### PR TITLE
Add a go task for creating new packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.tgz
 *~
 *.vscode
+**.kate-swp
 
 # Go binaries
 common/Go/yabi/yabi

--- a/common/Scripts/new-package.sh
+++ b/common/Scripts/new-package.sh
@@ -4,14 +4,18 @@
 
 set -euo pipefail
 
-if [ $# -ne 2 ]
-then
+if [[ $# -eq 2 ]]; then
+    PACKAGE="$1"
+    TARBALL="$2"
+elif [[ $# -gt 0 && $# -ne 2 ]]; then
     echo "Usage: $0 <package name> <tarball>"
     exit 1
+else
+    read -p "Package name: " prompt
+    PACKAGE=${prompt}
+    read -p "Tarball URL: " prompt
+    TARBALL=${prompt}
 fi
-
-PACKAGE="$1"
-TARBALL="$2"
 
 # Basic repo name linting check
 if [[ ! "${PACKAGE}" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then

--- a/common/Scripts/new-package.sh
+++ b/common/Scripts/new-package.sh
@@ -17,6 +17,8 @@ else
     TARBALL=${prompt}
 fi
 
+YAUTO=$(git rev-parse --show-toplevel)/common/Scripts/yauto.py
+
 # Basic repo name linting check
 if [[ ! "${PACKAGE}" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
     echo "Package names are restricted to US ASCII lowercase letters, numbers and dashes."
@@ -30,9 +32,9 @@ else
     DIR="packages/${PACKAGE:0:1}/${PACKAGE}"
 fi
 
-mkdir -p ${DIR}
+mkdir -p $(git rev-parse --show-toplevel)/${DIR}
 
-pushd ${DIR}
-../../../common/Scripts/yauto.py ${TARBALL}
+pushd $(git rev-parse --show-toplevel)/${DIR}
+$YAUTO ${TARBALL}
 
 printf "\npackage.yml created in ${DIR}\n"

--- a/common/Scripts/new-package.sh
+++ b/common/Scripts/new-package.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Creates a new package from the package name and tarball
+
+set -euo pipefail
+
+if [ $# -ne 2 ]
+then
+    echo "Usage: $0 <package name> <tarball>"
+    exit 1
+fi
+
+PACKAGE="$1"
+TARBALL="$2"
+
+# Basic repo name linting check
+if [[ ! "${PACKAGE}" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+    echo "Package names are restricted to US ASCII lowercase letters, numbers and dashes."
+    exit 1
+fi
+
+# FIXME: Don't hardcode this case
+if [[ ${PACKAGE:0:2} == "py" ]]; then
+    DIR="packages/py/${PACKAGE}"
+else
+    DIR="packages/${PACKAGE:0:1}/${PACKAGE}"
+fi
+
+mkdir -p ${DIR}
+
+pushd ${DIR}
+../../../common/Scripts/yauto.py ${TARBALL}
+
+printf "\npackage.yml created in ${DIR}\n"

--- a/common/Taskfile.yml
+++ b/common/Taskfile.yml
@@ -132,8 +132,3 @@ tasks:
       - test -d .git
     cmds:
       - git pull --rebase
-
-  switch-domains:
-    desc: Update local repositories to use correct hostname
-    cmds:
-      - go run "{{ .TASKFILE_DIR }}/common/Go/switch_repo_domains.go"

--- a/common/Taskfile.yml
+++ b/common/Taskfile.yml
@@ -136,6 +136,8 @@ tasks:
   new:
     desc: Create a new package
     dir: '{{ .USER_WORKING_DIR }}'
+    vars:
+      NEWPKG: "{{ .TASKFILE_DIR }}/common/Scripts/new-package.sh"
     cmds:
       - |
-        "{{ .TASKFILE_DIR }}"/common/Scripts/new-package.sh {{.CLI_ARGS}}
+        {{ .NEWPKG }} {{.CLI_ARGS}}

--- a/common/Taskfile.yml
+++ b/common/Taskfile.yml
@@ -132,3 +132,10 @@ tasks:
       - test -d .git
     cmds:
       - git pull --rebase
+
+  new:
+    desc: Create a new package
+    dir: '{{ .USER_WORKING_DIR }}'
+    cmds:
+      - |
+        "{{ .TASKFILE_DIR }}"/common/Scripts/new-package.sh {{.CLI_ARGS}}


### PR DESCRIPTION
## Summary

Adds a new package command

Usage: `go-task new -- python-zzzbar https://www.nano-editor.org/dist/v7/nano-7.2.tar.xz`

Also removes unneeded switch-repo-domains from taskfile

## Test Plan

`go-task new -- python-zzzbar https://www.nano-editor.org/dist/v7/nano-7.2.tar.xz`
`go-task new -- zzzbar https://www.nano-editor.org/dist/v7/nano-7.2.tar.xz`

Verify the package.yml was created in the correct directory.

## Checklist

- [ ] Package was built and tested against unstable n/a
