### PR TITLE
libtimezonemap: update data files to fix installer issues

### DIFF
--- a/packages/l/libtimezonemap/package.yml
+++ b/packages/l/libtimezonemap/package.yml
@@ -1,6 +1,6 @@
 name       : libtimezonemap
 version    : 0.4.5.2
-release    : 15
+release    : 16
 source     :
     - https://github.com/dashea/timezonemap/archive/refs/tags/0.4.5.2.tar.gz : 80f631f79754c772ccbb80f5b6f9d232766f5706089bcfa7897bdf093323b6be
 homepage   : https://github.com/dashea/timezonemap
@@ -16,6 +16,7 @@ builddeps  :
     - pkgconfig(libsoup-2.4)
     - vala
 setup      : |
+    %patch -p1 -i $pkgfiles/0001-Import-latest-data-from-geonames.org.patch
     %reconfigure
 build      : |
     %make

--- a/packages/l/libtimezonemap/pspec_x86_64.xml
+++ b/packages/l/libtimezonemap/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libtimezonemap</Name>
         <Homepage>https://github.com/dashea/timezonemap</Homepage>
         <Packager>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop.library</PartOf>
@@ -40,7 +40,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="15">libtimezonemap</Dependency>
+            <Dependency release="16">libtimezonemap</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/timezonemap/timezonemap/cc-timezone-location.h</Path>
@@ -52,12 +52,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2023-07-16</Date>
+        <Update release="16">
+            <Date>2023-09-18</Date>
             <Version>0.4.5.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary:**
This updates the data files for `libtimezonemap` using the latest info from geonames.org As this dataset was outdated it caused issues with e.g. selecting Kyiv in the installer

**Test Plan:**
Successfully selected Kyiv on the timezone map in `os-installer`

## Checklist

- [x] Package was built and tested against unstable
