### PR TITLE
Add infra namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,3 @@
 common/Go/yabi/yabi
 common/Go/ypkg/ypkg-tools
 common/switch_repo_domains
-
-# Team tooling
-/infrastructure-tooling

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 common/Go/yabi/yabi
 common/Go/ypkg/ypkg-tools
 common/switch_repo_domains
+
+# Team tooling
+/infrastructure-tooling

--- a/common/Taskfile.yml
+++ b/common/Taskfile.yml
@@ -2,8 +2,7 @@ version : '3'
 
 includes:
   infra:
-    dir: "{{ .TASKFILE_DIR }}"
-    taskfile: infrastructure-tooling/Infra.yml
+    taskfile: ./infrastructure-tooling/Infra.yml
     optional: true
 
 set: [pipefail]

--- a/common/Taskfile.yml
+++ b/common/Taskfile.yml
@@ -1,5 +1,11 @@
 version : '3'
 
+includes:
+  infra:
+    dir: "{{ .TASKFILE_DIR }}"
+    taskfile: infrastructure-tooling/Infra.yml
+    optional: true
+
 set: [pipefail]
 
 vars:

--- a/common/Taskfile.yml
+++ b/common/Taskfile.yml
@@ -2,7 +2,8 @@ version : '3'
 
 includes:
   infra:
-    taskfile: ./infrastructure-tooling/Infra.yml
+    dir: ../infrastructure-tooling
+    taskfile: ../infrastructure-tooling/Infra.yml
     optional: true
 
 set: [pipefail]


### PR DESCRIPTION
## Summary

Add infra name space as an optional include for infrastructure-tooling

This is currently needed for the tram file generator that has already been committed.

## Test Plan

Generate tram file using `go-task infra:gen-tram`

## Checklist

- [ ] Package was built and tested against unstable N/A
