### PR TITLE
flask-cors: update to 4.0.0

### DIFF
--- a/packages/f/flask-cors/package.yml
+++ b/packages/f/flask-cors/package.yml
@@ -12,7 +12,6 @@ description: |
 builddeps  :
     - flask
     - python-nose
-    - python-packaging
     - python-pytest
     - python-wheel
 rundeps    :

--- a/packages/f/flask-cors/package.yml
+++ b/packages/f/flask-cors/package.yml
@@ -1,17 +1,20 @@
 name       : flask-cors
-version    : 3.1.01
-release    : 7
+version    : 4.0.0
+release    : 8
 source     :
-    - https://github.com/corydolphin/flask-cors/archive/refs/tags/3.1.01.tar.gz : bd5b6b31f4e0b2f698c790743b1db5553d447df2144ef0555e28914756d32c98
+    - https://github.com/corydolphin/flask-cors/archive/refs/tags/4.0.0.tar.gz : 8b1a009daf20410ddcfc19382af681245698b5079942285922efdcd3cd2d40ea
 license    : MIT
+homepage   : https://flask-cors.corydolphin.com/
 component  : programming.python
-summary    : Cross Origin Resource Sharing ( CORS ) support for Flask
+summary    : Cross Origin Resource Sharing (CORS) support for Flask
 description: |
     A Flask extension for handling Cross Origin Resource Sharing (CORS), making cross-origin AJAX possible.
 builddeps  :
     - flask
     - python-nose
     - python-packaging
+    - python-pytest
+    - python-wheel
 rundeps    :
     - flask
 build      : |

--- a/packages/f/flask-cors/pspec_x86_64.xml
+++ b/packages/f/flask-cors/pspec_x86_64.xml
@@ -1,30 +1,31 @@
 <PISI>
     <Source>
         <Name>flask-cors</Name>
+        <Homepage>https://flask-cors.corydolphin.com/</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
-        <Summary xml:lang="en">Cross Origin Resource Sharing ( CORS ) support for Flask</Summary>
+        <Summary xml:lang="en">Cross Origin Resource Sharing (CORS) support for Flask</Summary>
         <Description xml:lang="en">A Flask extension for handling Cross Origin Resource Sharing (CORS), making cross-origin AJAX possible.
 </Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
     </Source>
     <Package>
         <Name>flask-cors</Name>
-        <Summary xml:lang="en">Cross Origin Resource Sharing ( CORS ) support for Flask</Summary>
+        <Summary xml:lang="en">Cross Origin Resource Sharing (CORS) support for Flask</Summary>
         <Description xml:lang="en">A Flask extension for handling Cross Origin Resource Sharing (CORS), making cross-origin AJAX possible.
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/Flask_Cors-3.1.1-py3.10.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/Flask_Cors-3.1.1-py3.10.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/Flask_Cors-3.1.1-py3.10.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/Flask_Cors-3.1.1-py3.10.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/Flask_Cors-3.1.1-py3.10.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/Flask_Cors-3.1.1-py3.10.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/Flask_Cors-4.0.0-py3.10.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/Flask_Cors-4.0.0-py3.10.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/Flask_Cors-4.0.0-py3.10.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/Flask_Cors-4.0.0-py3.10.egg-info/not-zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/Flask_Cors-4.0.0-py3.10.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/Flask_Cors-4.0.0-py3.10.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/flask_cors/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/flask_cors/__pycache__/__init__.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/flask_cors/__pycache__/core.cpython-310.pyc</Path>
@@ -38,12 +39,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2023-09-16</Date>
-            <Version>3.1.01</Version>
+        <Update release="8">
+            <Date>2023-09-20</Date>
+            <Version>4.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
## Summary

**Changes:**
- Remove support for Python versions older than 3.8
- Remove dependency on six

## Test Plan

Ran some examples from the documentation

## Checklist

- [x] Package was built and tested against unstable
