### PR TITLE
PR template: switch to asterisk bolding to fix SC changelogs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,11 @@
-## Summary
+**Summary**
 
 <!-- Info on what this pull request updates/changes/etc -->
 
-## Test Plan
+**Test Plan**
 
 <!-- Short description of how the package was tested -->
 
-## Checklist
+**Checklist**
 
 - [ ] Package was built and tested against unstable


### PR DESCRIPTION
## Summary

Switches the PR template to asterisk bolding instead of H2. The (current) Software Center has no support for rendering H2 and this makes changelogs look worse (IMO at least)

H2:
![](https://i.imgur.com/Uqax8lA.png)

Asterisk bolding:
![](https://i.imgur.com/tMQ9lrj.png)

## Test Plan

Looked at changelogs with asterisk bolding and H2 formatting in SC and compared. 

## Checklist

- [x] Package was built and tested against unstable
