### PR TITLE
gnome-mahjongg: backport patch to fix excessive resource usage

### DIFF
--- a/packages/g/gnome-mahjongg/files/only-create-a-single-timer.patch
+++ b/packages/g/gnome-mahjongg/files/only-create-a-single-timer.patch
@@ -1,0 +1,35 @@
+From 575a3aa37c0a1a5f993cb49d1477fb3a0ff05152 Mon Sep 17 00:00:00 2001
+From: Mat <mail@mathias.is>
+Date: Thu, 10 Aug 2023 05:03:31 +0300
+Subject: [PATCH] game: Only create a single timer
+
+A new, redundant timer was created each time tile pairs were removed
+or hints were shown, leading to excessive resource usage over time.
+
+Fixes #27
+Fixes #39
+
+Part-of: <https://gitlab.gnome.org/GNOME/gnome-mahjongg/-/merge_requests/36>
+---
+ src/game.vala | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/game.vala b/src/game.vala
+index 87d0fc5..8f1ae27 100644
+--- a/src/game.vala
++++ b/src/game.vala
+@@ -445,8 +445,9 @@ public class Game : Object
+ 
+     private void start_clock ()
+     {
+-        if (clock == null)
+-            clock = new Timer ();
++        if (clock != null)
++            return;
++        clock = new Timer ();
+         timeout_cb ();
+     }
+ 
+-- 
+GitLab
+

--- a/packages/g/gnome-mahjongg/package.yml
+++ b/packages/g/gnome-mahjongg/package.yml
@@ -1,9 +1,10 @@
 name       : gnome-mahjongg
 version    : 3.40.0
-release    : 9
+release    : 10
 source     :
     - https://gitlab.gnome.org/GNOME/gnome-mahjongg/-/archive/3.40.0/gnome-mahjongg-3.40.0.tar.bz2 : 04ba63008fa67b31a7705e28718f5e3dcc8ac3bba83e2ea695094a36ffe7c2f9
 license    : GPL-2.0-or-later
+homepage   : https://wiki.gnome.org/Apps/Mahjongg
 component  : games.card
 summary    : Mahjongg is a solitaire (one player) version of the classic Eastern tile game, Mahjongg.
 description: |
@@ -15,6 +16,7 @@ builddeps  :
     - itstool
     - vala
 setup      : |
+    %patch -p1 -i $pkgfiles/only-create-a-single-timer.patch
     %meson_configure
 build      : |
     %ninja_build

--- a/packages/g/gnome-mahjongg/pspec_x86_64.xml
+++ b/packages/g/gnome-mahjongg/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>gnome-mahjongg</Name>
+        <Homepage>https://wiki.gnome.org/Apps/Mahjongg</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>games.card</PartOf>
@@ -703,12 +704,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2023-07-30</Date>
+        <Update release="10">
+            <Date>2023-09-23</Date>
             <Version>3.40.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Backport a patch to fix excessive resource usage over time

Should fix this issue: https://discuss.getsol.us/d/9774-has-anyone-else-noticed-bad-behavior-from-gnome-mahjongg

Packaging change: added homepage

**Test Plan**
- Played a couple of games
- Pressed the "Hint" button repeatedly to see if game increasingly slows down

**Checklist**

- [x] Package was built and tested against unstable
