### PR TITLE
ci: Add PR and Python linters

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/.github/workflows/package_lint.yml
+++ b/.github/workflows/package_lint.yml
@@ -1,0 +1,18 @@
+---
+name: Package Lint
+on:
+  pull_request:
+    paths:
+      - packages/**
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  Checks:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+    - run: common/CI/package_checks.py --base=origin/${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/script_lint.yml
+++ b/.github/workflows/script_lint.yml
@@ -1,0 +1,24 @@
+---
+name: Script Lint
+on:
+  pull_request:
+    paths:
+      - 'common/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  Python:
+    name: Python Linting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v4
+      - name: Set up Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: flake8 Lint
+        uses: py-actions/flake8@v2
+        with:
+           path: "common/CI"

--- a/common/CI/package_checks.py
+++ b/common/CI/package_checks.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+import argparse
+import os.path
+import re
+import subprocess
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Optional, TextIO
+from xml.etree import ElementTree
+
+import yaml
+
+
+class Level(str, Enum):
+    __str__ = Enum.__str__
+    ERROR = 'error'
+    WARNING = 'warning'
+
+
+@dataclass
+class Result:
+    message: str
+    file: str
+    line: Optional[int]
+    level: Level
+
+    def __str__(self) -> str:
+        if self.file:
+            if self.line:
+                return f'::{self.level} file={self.file},line={self.line}::{self.message}'
+            return f'::{self.level} file={self.file}::{self.message}'
+
+        return f'::{self.level}::{self.message}'
+
+
+class PullRequestCheck:
+    _package_files = ['package.yml']
+
+    def run(self, files: List[str]) -> List[Result]:
+        raise NotImplementedError
+
+    @staticmethod
+    def _filter_packages(files: List[str]) -> List[str]:
+        return [f for f in files if os.path.basename(f) in PullRequestCheck._package_files]
+
+    @staticmethod
+    def _root() -> str:
+        return _git(['rev-parse', '--show-toplevel'])
+
+    @staticmethod
+    def _path(path: str) -> str:
+        return os.path.join(PullRequestCheck._root(), path)
+
+    @staticmethod
+    def _open(path: str) -> TextIO:
+        return open(PullRequestCheck._path(path), 'r')
+
+
+class Homepage(PullRequestCheck):
+    _error = '`homepage` is not set'
+    _level = Level.ERROR
+
+    def run(self, files: List[str]) -> List[Result]:
+        return [Result(self._error, f, None, self._level)
+                for f in self._filter_packages(files)
+                if not self._includes_homepage(f)]
+
+    @staticmethod
+    def _includes_homepage(file: str) -> bool:
+        with PullRequestCheck._open(file) as f:
+            return 'homepage' in yaml.safe_load(f)
+
+
+class PackageDirectory(PullRequestCheck):
+    _two_letter_dirs = ['py']
+    _error = 'Package not in correct directory'
+    _level = Level.ERROR
+
+    def run(self, files: List[str]) -> List[Result]:
+        paths = [os.path.dirname(f) for f in self._filter_packages(files)]
+
+        return [Result(self._error, path, None, self._level) for path in paths
+                if not self._check_path(path)]
+
+    def _check_path(self, path: str) -> bool:
+        pkg = os.path.basename(os.path.realpath(path))
+        exp = ['packages', self._dir(pkg), pkg]
+
+        return path.split('/') == exp
+
+    def _dir(self, package: str):
+        for two in self._two_letter_dirs:
+            if package.startswith(two):
+                return two
+
+        return package[0]
+
+
+class Patch(PullRequestCheck):
+    _regex = r'patch -p1 <'
+    _error = 'Uses `patch <`, use `patch -i` instead'
+    _level = Level.ERROR
+
+    def run(self, files: List[str]) -> List[Result]:
+        return [r for f in self._filter_packages(files)
+                for r in self._wrong_patch(f)]
+
+    def _wrong_patch(self, file: str) -> List[Result]:
+        results: List[Result] = []
+
+        with self._open(file) as f:
+            for i, line in enumerate(f.readlines()):
+                if re.search(self._regex, line):
+                    results.append(Result(self._error, file, i + 1, self._level))
+
+        return results
+
+
+class UnwantedFiles(PullRequestCheck):
+    _patterns = ['Makefile^', r'.*\.eopkg^', r'.*\.tar\..*', r'^packages/[^/]+(/[^/]+)?$']
+    _error = 'This file should not be included'
+    _level = Level.ERROR
+
+    def run(self, files: List[str]) -> List[Result]:
+        return [Result(self._error, f, None, self._level)
+                for f in files
+                for p in self._patterns
+                if not os.path.isdir(f) and re.match(p, f)]
+
+
+class Pspec(PullRequestCheck):
+    _error = '`package.yml` and `pspec_x86_64.xml` are not consistent'
+    _level = Level.ERROR
+
+    def run(self, files: List[str]) -> List[Result]:
+        paths = [os.path.dirname(f) for f in self._filter_packages(files)]
+
+        return [Result(self._error, self._xml_file(path), None, self._level)
+                for path in paths
+                if not self._check_consistent(path)]
+
+    @staticmethod
+    def _check_consistent(package_dir: str) -> bool:
+        xml = Pspec._xml_file(package_dir)
+        xml_release = int(ElementTree.parse(xml).findall('.//Update')[0].attrib['release'])
+
+        with open(Pspec._yml_file(package_dir), 'r') as f:
+            yml_release = yaml.safe_load(f)['release']
+
+        return yml_release == xml_release
+
+    @staticmethod
+    def _yml_file(package_dir: str) -> str:
+        return PullRequestCheck._path(os.path.join(package_dir, 'package.yml'))
+
+    @staticmethod
+    def _xml_file(package_dir: str) -> str:
+        return PullRequestCheck._path(os.path.join(package_dir, 'pspec_x86_64.xml'))
+
+
+def run_checks(files: List[str]):
+    print(f'Checking files: {", ".join(files)}')
+
+    checks = [Homepage(), PackageDirectory(), Patch(), UnwantedFiles(), Pspec()]
+    results = [result for check in checks for result in check.run(files)]
+    errors = [r for r in results if r.level == Level.ERROR]
+
+    print(f"Found {len(results)} issue(s)")
+
+    for result in results:
+        print(result)
+
+    if len(errors) > 0:
+        exit(1)
+
+
+def _git(args: List[str]) -> str:
+    res = subprocess.run(['git'] + args, capture_output=True, text=True)
+    if res.returncode != 0:
+        raise Exception("git error: " + res.stderr)
+
+    return res.stdout.strip()
+
+
+def _ref_to_fetch(ref: str) -> List[str]:
+    return ref.split('..')[0].split('/')
+
+
+def files_from_ref(base: str, head: str) -> List[str]:
+    _git(['fetch'] + _ref_to_fetch(base))
+
+    merge_base = _git(['merge-base', head, base])
+
+    return _git(['diff', '--name-only', '--diff-filter=AM', merge_base, head]).split("\n")
+
+
+def repo_relative_paths(files: List[str]) -> List[str]:
+    root = _git(['rev-parse', '--show-toplevel'])
+
+    return [os.path.relpath(os.path.realpath(f), root) for f in files]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--base', type=str,
+                        help='Optional reference to the base branch')
+    parser.add_argument('--head', type=str, default='HEAD',
+                        help='Optional reference to the current branch head')
+    parser.add_argument('filename', type=str, nargs="*",
+                        help='Additional files to check')
+    args = parser.parse_args()
+    args.filename = repo_relative_paths(args.filename)
+
+    if args.base:
+        args.filename += files_from_ref(args.base, args.head)
+
+    run_checks(args.filename)

--- a/common/Taskfile.yml
+++ b/common/Taskfile.yml
@@ -182,6 +182,12 @@ tasks:
       - ssh build-controller@build.getsol.us build "{{ .SOURCE }}" "{{ .TAG }}" "{{ .PATH }}" "{{ .REF }}"
 
   # Other utilities
+  check:
+    desc: Run package sanity checks
+    dir: '{{ .USER_WORKING_DIR }}'
+    cmds:
+      - "{{ .TASKFILE_DIR }}/common/CI/package_checks.py --base origin/main {{.CLI_ARGS}}"
+
   clean:
     desc: Clean current tree
     dir: '{{ .USER_WORKING_DIR }}'


### PR DESCRIPTION
**Summary**

This PR adds some initial linters for for pull requests. Checks are mostly focussed on common packaging mistakes:

- `homepage` not set
- Incorrect directory
- `patch <` instead of `patch -i`
- Various unwanted files (including in incorrect directories)
- Inconsistent `package.yml` and `pspec_x86_64.yml`.

**Test Plan**

This PR!

**Checklist**

- [ ] ~~Package was built and tested against unstable~~ n/a
