### PR TITLE
font-iosevka-ttf: Update to 27.0.2

### DIFF
--- a/packages/f/font-iosevka-ttf/package.yml
+++ b/packages/f/font-iosevka-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : font-iosevka-ttf
-version    : 26.3.3
-release    : 42
+version    : 27.0.2
+release    : 43
 source     :
-    - https://github.com/be5invis/Iosevka/releases/download/v26.3.3/ttf-iosevka-26.3.3.zip : 8722ba67202d684fefbac873b5dd49af4a0f9edfab424d1ecf3113d123c58f3a
+    - https://github.com/be5invis/Iosevka/releases/download/v27.0.2/ttf-iosevka-27.0.2.zip : bcc44527ea04ef30e6c02a861d4ce895ae74be3e4fc02332d9fbd578596d1d08
 homepage   : https://typeof.net/Iosevka
 license    : OFL-1.1
 component  : desktop.font

--- a/packages/f/font-iosevka-ttf/pspec_x86_64.xml
+++ b/packages/f/font-iosevka-ttf/pspec_x86_64.xml
@@ -77,9 +77,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="42">
-            <Date>2023-09-14</Date>
-            <Version>26.3.3</Version>
+        <Update release="43">
+            <Date>2023-09-24</Date>
+            <Version>27.0.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
 ## Summary
 - Added Characters
 - Add variants for Cyrillic lower Ef (ф) with a split bowl
 - Add Bulgarian local variants for Cyrillic Ef (Ф,ф)
 - Fix serifs in U+01A6
 - Improve serifs of Turn M (U+019C, U+026F) under quasi-proportional.
 - Make Turn h (U+0265) and Turn M with Long Leg (U+0270) follow serif variants of u.
 - Optimize geometry for U+A65A and U+A65B under extended width.
 - Variants for π, τ and « are inserted into the main tag sequence.
 - Reordered variants of Eszet.
 - Change of variant names
 - Add bottom-right and top-left bottom-right serifed variants of R.
 - Add bottom-left motion serifed variants of Cyrillic Ya (Я,я).
 - Add cursive variants for Cyrillic Capital/Small Zhe (Ж,ж)
 - Allow R Rotunda (U+A75A, U+A75B) and Indian Rupee Sign (U+20B9) to have a bottom-right serif.
 - Add OpenType zero feature
 - Fix broken geometry of U+AB3A under condensed width.
 - Improve bowl shape of Latin Phi (U+0278).
 - Fix dot radius of U+20DB, U+20DC and U+20D8
 - [changelog](https://raw.githubusercontent.com/be5invis/Iosevka/v27.0.2/CHANGELOG.md)

 ## Test Plan
 M-x set-frame-font

 ## Checklist
 - [X] Package was built and tested against unstable