### PR TITLE
bash: Support user ~/.bashrc.d/* script sourcing

### DIFF
--- a/packages/b/bash/files/profile/profile
+++ b/packages/b/bash/files/profile/profile
@@ -19,5 +19,14 @@ if [ -d /etc/profile.d ] ; then
     unset script
 fi
 
+# User specific aliases and functions
+if [ -d ~/.bashrc.d ]; then
+    for rc in ~/.bashrc.d/*; do
+        if [ -f "$rc" ]; then
+            . "$rc"
+        fi
+    done
+    unset rc
+fi
 
 # End /usr/share/defaults/etc/profile

--- a/packages/b/bash/package.yml
+++ b/packages/b/bash/package.yml
@@ -1,6 +1,6 @@
 name       : bash
 version    : 5.1.16
-release    : 68
+release    : 69
 source     :
     - https://ftp.gnu.org/gnu/bash/bash-5.1.tar.gz : cc012bc860406dcf42f64431bcd3d2fa7560c02915a601aba9cd597a39329baa
 license    :

--- a/packages/b/bash/pspec_x86_64.xml
+++ b/packages/b/bash/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>bash</Name>
         <Homepage>https://www.gnu.org/software/bash</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -95,19 +95,19 @@
 </Description>
         <PartOf>system.boot</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="68">bash</Dependency>
+            <Dependency releaseFrom="69">bash</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/bash.recovery</Path>
         </Files>
     </Package>
     <History>
-        <Update release="68">
-            <Date>2023-08-26</Date>
+        <Update release="69">
+            <Date>2023-09-24</Date>
             <Version>5.1.16</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Any files in `~/.bashrc.d/` are sourced after all other /usr/share/defaults/etc/profile.d/ and /etc/profile.d/ scripts are sourced.

This in effect makes it simple to perform per-user changes to override system settings, by copying changed files into `~/.bashrc.d/` and editing them there as per user requirements.

Additionally, this feature also has the nice side-effect that it becomes simpler and easier to save and restore user shell customisations across installs without having to edit the default `~/.bashrc` file.

**Test Plan**

Open a new shell and check that `~/.bashrc.d/*` were correctly sourced.

**Checklist**

- [x] Package was built and tested against unstable
