### PR TITLE
godot: update to 3.5.3

### DIFF
--- a/packages/g/godot-cpp/package.yml
+++ b/packages/g/godot-cpp/package.yml
@@ -1,16 +1,17 @@
 name       : godot-cpp
-version    : 3.5.2
-release    : 8
+version    : 3.5.3
+release    : 9
 source     :
-    - https://github.com/godotengine/godot-cpp/archive/refs/tags/godot-3.5.2-stable.tar.gz : 73748396b0ad3789b7fcff815dfead47b022902199c8708341c263402f263f19
+    - https://github.com/godotengine/godot-cpp/archive/refs/tags/godot-3.5.3-stable.tar.gz : 8455d08cdd75ad19254a9ac89b63569d46b5238cd8b7f8771930ba4c68ceeef4
 license    : MIT
+homepage   : https://github.com/godotengine/godot-cpp/
 component  : programming.devel
 summary    : C++ bindings for the Godot script API
 description: |
     The C++ bindings for GDNative are built on top of the NativeScript GDNative API and provide a nicer way to "extend" nodes in Godot using C++. This is equivalent to writing scripts in GDScript, but in C++ instead.
 clang      : yes
 builddeps  :
-    - godot-headers
+    - pkgconfig(godot)
     - scons
 rundeps    :
     - godot-headers

--- a/packages/g/godot-cpp/pspec_x86_64.xml
+++ b/packages/g/godot-cpp/pspec_x86_64.xml
@@ -1,6 +1,7 @@
 <PISI>
     <Source>
         <Name>godot-cpp</Name>
+        <Homepage>https://github.com/godotengine/godot-cpp/</Homepage>
         <Packager>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>
@@ -731,9 +732,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2023-04-22</Date>
-            <Version>3.5.2</Version>
+        <Update release="9">
+            <Date>2023-09-26</Date>
+            <Version>3.5.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>

--- a/packages/g/godot-headers/package.yml
+++ b/packages/g/godot-headers/package.yml
@@ -1,9 +1,10 @@
 name       : godot-headers
-version    : 3.5.2
-release    : 7
+version    : 3.5.3
+release    : 8
 source     :
-    - https://github.com/godotengine/godot-headers/archive/refs/tags/godot-3.5.2-stable.tar.gz : 42e97953d3f193db01cccd856dff0430a6737d47b8496a70e7df34387d870a6e
+    - https://github.com/godotengine/godot-headers/archive/refs/tags/godot-3.5.3-stable.tar.gz : 98bf368ab07cac91b864e983bffa50757aabf2a8156d3e9f4d81ecbcea77ebd7
 license    : MIT
+homepage   : https://github.com/godotengine/godot-headers
 component  : programming.devel
 summary    : Headers for the Godot API supplied by the GDNative module
 description: |

--- a/packages/g/godot-headers/pspec_x86_64.xml
+++ b/packages/g/godot-headers/pspec_x86_64.xml
@@ -1,6 +1,7 @@
 <PISI>
     <Source>
         <Name>godot-headers</Name>
+        <Homepage>https://github.com/godotengine/godot-headers</Homepage>
         <Packager>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>
@@ -55,9 +56,9 @@ NativeScript uses GDNative to implement scripts backed by native code.
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2023-04-22</Date>
-            <Version>3.5.2</Version>
+        <Update release="8">
+            <Date>2023-09-26</Date>
+            <Version>3.5.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>

--- a/packages/g/godot/abi_used_libs
+++ b/packages/g/godot/abi_used_libs
@@ -25,7 +25,6 @@ libopus.so.0
 libopusfile.so.0
 libpcre2-32.so.0
 libpng16.so.16
-libsharpyuv.so.0
 libtheora.so.0
 libtheoradec.so.1
 libvorbis.so.0

--- a/packages/g/godot/package.yml
+++ b/packages/g/godot/package.yml
@@ -1,8 +1,8 @@
 name       : godot-classic
-version    : 3.5.2
-release    : 49
+version    : 3.5.3
+release    : 50
 source     :
-    - https://github.com/godotengine/godot/archive/3.5.2-stable.tar.gz : f40652a1343d060d5e3f53957c27205f39c2bfe54b7701d1b6c133c0a90f1f34
+    - https://github.com/godotengine/godot/archive/3.5.3-stable.tar.gz : 643366a288fc529564d8bb42a42093d72071c8186f57ff03cae6d5929f81bd1d
 homepage   : https://godotengine.org/
 license    :
     - CC-BY-3.0

--- a/packages/g/godot/pspec_x86_64.xml
+++ b/packages/g/godot/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>godot-classic</Name>
         <Homepage>https://godotengine.org/</Homepage>
         <Packager>
-            <Name>Alexander Vorobyev</Name>
-            <Email>avorobyev@protonmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>CC-BY-3.0</License>
         <License>MIT</License>
@@ -21,7 +21,7 @@
 </Description>
         <PartOf>games</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="49">godot-common</Dependency>
+            <Dependency releaseFrom="50">godot-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/godot</Path>
@@ -51,7 +51,7 @@
 </Description>
         <PartOf>games</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="49">godot-common</Dependency>
+            <Dependency releaseFrom="50">godot-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/godot.mono</Path>
@@ -100,12 +100,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="49">
-            <Date>2023-05-10</Date>
-            <Version>3.5.2</Version>
+        <Update release="50">
+            <Date>2023-09-25</Date>
+            <Version>3.5.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Alexander Vorobyev</Name>
-            <Email>avorobyev@protonmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Release notes available [here](https://godotengine.org/article/maintenance-release-godot-3-5-3/)

**Test Plan**
- Opened and edited a test project with classic and mono version

**Checklist**

- [x] Package was built and tested against unstable
