### PR TITLE
tailscale: Update to 1.50.0

### DIFF
--- a/packages/t/tailscale/abi_used_symbols
+++ b/packages/t/tailscale/abi_used_symbols
@@ -10,7 +10,6 @@ libc.so.6:getaddrinfo
 libc.so.6:getgrgid_r
 libc.so.6:getgrnam_r
 libc.so.6:getgrouplist
-libc.so.6:getnameinfo
 libc.so.6:getpwnam_r
 libc.so.6:getpwuid_r
 libc.so.6:malloc
@@ -32,7 +31,6 @@ libc.so.6:pthread_mutex_unlock
 libc.so.6:pthread_self
 libc.so.6:pthread_setspecific
 libc.so.6:pthread_sigmask
-libc.so.6:res_search
 libc.so.6:setegid
 libc.so.6:setenv
 libc.so.6:seteuid

--- a/packages/t/tailscale/package.yml
+++ b/packages/t/tailscale/package.yml
@@ -1,8 +1,8 @@
 name       : tailscale
-version    : 1.48.2
-release    : 1
+version    : 1.50.0
+release    : 2
 source     :
-    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.48.2.tar.gz : 1c34c5c2c3b78e59ffb824b356418ff828653c62885b126d0d05f300218b36b5
+    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.50.0.tar.gz : a7e024577854c07b793c4bbd81a497250e6a1b4536e303351a388810f13b7316
 homepage   : https://tailscale.com
 license    : BSD-3-Clause
 component  : network.clients

--- a/packages/t/tailscale/pspec_x86_64.xml
+++ b/packages/t/tailscale/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2023-09-21</Date>
-            <Version>1.48.2</Version>
+        <Update release="2">
+            <Date>2023-09-28</Date>
+            <Version>1.50.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
## Summary
- update to Go 1.21.1.
- tailscale ping now sends an ICMP Ping code of 0.
- UPnP falls back to a permanent lease if a limited lease fails, some servers only support permanent.
- Adds support for Wikimedia DNS using DNS-over-HTTPS.
- Unhide tailscale update CLI command on most platforms.
- tailscale web updated to use React and be more awesome.
- Add --log-http option to tailscale debug portmap.
- tailscale netcheck now works even if the OS platform lacks CA certificates.
- nftables support now interoperates with ufw

## Test Plan
- tailscale netcheck
- tailscale status

## Checklist
- [X] Package was built and tested against unstable
