### PR TITLE
gpxsee: Update to 13.9

### DIFF
--- a/packages/g/gpxsee/abi_used_symbols
+++ b/packages/g/gpxsee/abi_used_symbols
@@ -464,11 +464,13 @@ libQt5Core.so.5:_ZNK7QString7compareERKS_N2Qt15CaseSensitivityE
 libQt5Core.so.5:_ZNK7QString7indexOfE5QChariN2Qt15CaseSensitivityE
 libQt5Core.so.5:_ZNK7QString7indexOfERKS_iN2Qt15CaseSensitivityE
 libQt5Core.so.5:_ZNK7QString8containsERK18QRegularExpression
+libQt5Core.so.5:_ZNK7QString8endsWithERKS_N2Qt15CaseSensitivityE
 libQt5Core.so.5:_ZNK7QString8toDoubleEPb
 libQt5Core.so.5:_ZNK7QStringeqE13QLatin1String
 libQt5Core.so.5:_ZNK8QVariant10toLongLongEPb
 libQt5Core.so.5:_ZNK8QVariant11toByteArrayEv
 libQt5Core.so.5:_ZNK8QVariant3cmpERKS_
+libQt5Core.so.5:_ZNK8QVariant4typeEv
 libQt5Core.so.5:_ZNK8QVariant5toIntEPb
 libQt5Core.so.5:_ZNK8QVariant5toMapEv
 libQt5Core.so.5:_ZNK8QVariant6toBoolEv

--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.8'
-release    : 26
+version    : '13.9'
+release    : 27
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.8.tar.gz : cdfeeb500405a86f2e32e7ba0eb5b3063f96329889239f65513474a5dbd3d283
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.9.tar.gz : 86079c7d8053a64837042695e666cd4f4aac7fb01b19e76106cf9b124653b22f
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -130,9 +130,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2023-09-14</Date>
-            <Version>13.8</Version>
+        <Update release="27">
+            <Date>2023-09-28</Date>
+            <Version>13.9</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
## Summary
- Fixed storing of WMTS tiles with file system incompatible tile matrix names.
- Improved/fixed TrekBuddy maps/atlases support.
- Improved ENC maps rendering style.

## Test Plan
- open garmin map
- zoom in and out

## Checklist
- [X] Package was built and tested against unstable
- 