### PR TITLE
xpra: Update to 5.0.2

### DIFF
--- a/packages/x/xpra/package.yml
+++ b/packages/x/xpra/package.yml
@@ -1,8 +1,8 @@
 name       : xpra
-version    : 5.0.1
-release    : 6
+version    : 5.0.2
+release    : 7
 source     :
-    - https://github.com/Xpra-org/xpra/archive/refs/tags/v5.0.1.tar.gz : bf7b112e6518a000ac974149f6e71f8f4eb7918f87b049f0c7a59ba3841752de
+    - https://github.com/Xpra-org/xpra/archive/refs/tags/v5.0.2.tar.gz : 99b52399ab01ca75d8634a38ab32259986d2723461bcab1e1cb19877efbe8449
 homepage   : https://xpra.org
 license    : GPL-2.0-or-later
 component  : desktop

--- a/packages/x/xpra/pspec_x86_64.xml
+++ b/packages/x/xpra/pspec_x86_64.xml
@@ -4,7 +4,7 @@
         <Homepage>https://xpra.org</Homepage>
         <Packager>
             <Name>Maik Wöhl</Name>
-            <Email>mail@maikwoehl.de</Email>
+            <Email>maik.woehl@outlook.de</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop</PartOf>
@@ -25,10 +25,10 @@
             <Path fileType="executable">/usr/bin/xpra_Xdummy</Path>
             <Path fileType="executable">/usr/bin/xpra_launcher</Path>
             <Path fileType="library">/usr/lib/cups/backend/xpraforwarder</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/xpra-5.0.1-py3.10.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/xpra-5.0.1-py3.10.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/xpra-5.0.1-py3.10.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/xpra-5.0.1-py3.10.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/xpra-5.0.2-py3.10.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/xpra-5.0.2-py3.10.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/xpra-5.0.2-py3.10.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/xpra-5.0.2-py3.10.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/xpra/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/xpra/__pycache__/__init__.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/xpra/__pycache__/build_info.cpython-310.pyc</Path>
@@ -553,6 +553,8 @@
             <Path fileType="library">/usr/lib/python3.10/site-packages/xpra/net/ssh/util.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/xpra/net/subprocess_wrapper.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/xpra/net/upnp.py</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/xpra/net/vsock/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/xpra/net/vsock/__pycache__/__init__.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/xpra/net/vsock/vsock.cpython-310-x86_64-linux-gnu.so</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/xpra/net/websockets/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/xpra/net/websockets/__pycache__/__init__.cpython-310.pyc</Path>
@@ -1283,12 +1285,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2023-09-10</Date>
-            <Version>5.0.1</Version>
+        <Update release="7">
+            <Date>2023-09-28</Date>
+            <Version>5.0.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Maik Wöhl</Name>
-            <Email>mail@maikwoehl.de</Email>
+            <Email>maik.woehl@outlook.de</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Bugfixes:

- missing x264 encoder in DEB packages
- unusable vsock module
- start-after-connect was broken
- Overflow error in MS Windows hooks + fixup
- notification packet errors due to missing icon

Enhancements:

- pactl improve detection of monitor devices
- microphone support for Chromium

**Full release notes:**
- [5.0.2](https://github.com/Xpra-org/xpra/releases/tag/v5.0.2)

**Test Plan**

Command line tests used from https://wiki.archlinux.org/title/xpra

- [x] Shadow mode
- [x] Seamless mode (main use)

##### Shadow mode
```
xpra shadow ssh:<some-client>:0
```

##### Seamless mode
Start xpra server on your remote machine:

```
$ xpra start :4
```

Attach to xpra session on your local machine:

```
$ xpra attach ssh:<some-ip>:4
```

Start an application on your remote machine:

```
$ DISPLAY=:4 firefox
```

Firefox should appear on your local machine.

**Checklist**

- [x] Package was built and tested against unstable
