### PR TITLE
coreutils: Update to 9.4

### DIFF
--- a/packages/c/coreutils/abi_used_symbols
+++ b/packages/c/coreutils/abi_used_symbols
@@ -21,6 +21,7 @@ libc.so.6:__errno_location
 libc.so.6:__explicit_bzero_chk
 libc.so.6:__fpending
 libc.so.6:__fprintf_chk
+libc.so.6:__fpurge
 libc.so.6:__fread_unlocked_chk
 libc.so.6:__freading
 libc.so.6:__getdelim
@@ -157,14 +158,12 @@ libc.so.6:getxattr
 libc.so.6:gmtime_r
 libc.so.6:hasmntopt
 libc.so.6:iconv
-libc.so.6:iconv_close
 libc.so.6:iconv_open
 libc.so.6:inotify_add_watch
 libc.so.6:inotify_init
 libc.so.6:inotify_rm_watch
 libc.so.6:ioctl
 libc.so.6:isatty
-libc.so.6:iswalnum
 libc.so.6:iswcntrl
 libc.so.6:iswprint
 libc.so.6:iswspace
@@ -173,12 +172,14 @@ libc.so.6:lchmod
 libc.so.6:lchown
 libc.so.6:link
 libc.so.6:linkat
+libc.so.6:listxattr
 libc.so.6:localeconv
 libc.so.6:localtime
 libc.so.6:localtime_r
 libc.so.6:lseek
 libc.so.6:lstat
 libc.so.6:malloc
+libc.so.6:mbrtoc32
 libc.so.6:mbrtowc
 libc.so.6:mbsinit
 libc.so.6:mbstowcs
@@ -253,6 +254,7 @@ libc.so.6:rewinddir
 libc.so.6:rmdir
 libc.so.6:rpmatch
 libc.so.6:sched_getaffinity
+libc.so.6:secure_getenv
 libc.so.6:setenv
 libc.so.6:setgid
 libc.so.6:setgroups
@@ -282,7 +284,6 @@ libc.so.6:stderr
 libc.so.6:stdin
 libc.so.6:stdout
 libc.so.6:stpcpy
-libc.so.6:stpncpy
 libc.so.6:strchr
 libc.so.6:strcmp
 libc.so.6:strcoll
@@ -292,7 +293,6 @@ libc.so.6:strdup
 libc.so.6:strftime
 libc.so.6:strlen
 libc.so.6:strncmp
-libc.so.6:strncpy
 libc.so.6:strnlen
 libc.so.6:strpbrk
 libc.so.6:strrchr
@@ -322,7 +322,7 @@ libc.so.6:timegm
 libc.so.6:timer_create
 libc.so.6:timer_delete
 libc.so.6:timer_settime
-libc.so.6:tmpfile
+libc.so.6:timespec_get
 libc.so.6:towlower
 libc.so.6:ttyname
 libc.so.6:tzset

--- a/packages/c/coreutils/files/0001-Disable-tests-that-fail-in-chroot.patch
+++ b/packages/c/coreutils/files/0001-Disable-tests-that-fail-in-chroot.patch
@@ -28,12 +28,12 @@ index a0c0249..77118b3 100644
 --- a/tests/local.mk
 +++ b/tests/local.mk
 @@ -180,8 +180,6 @@ all_tests =					\
-   tests/tail-2/F-headers.sh			\
-   tests/tail-2/descriptor-vs-rename.sh		\
-   tests/tail-2/inotify-rotate.sh		\
--  tests/tail-2/inotify-rotate-resources.sh	\
--  tests/tail-2/inotify-dir-recreate.sh		\
-   tests/tail-2/inotify-only-regular.sh		\
+   tests/tail/F-headers.sh			\
+   tests/tail/descriptor-vs-rename.sh		\
+   tests/tail/inotify-rotate.sh			\
+-  tests/tail/inotify-rotate-resources.sh	\
+-  tests/tail/inotify-dir-recreate.sh		\
+   tests/tail/inotify-only-regular.sh		\
    tests/chmod/no-x.sh				\
    tests/chgrp/basic.sh				\
 @@ -476,7 +474,6 @@ all_tests =					\

--- a/packages/c/coreutils/package.yml
+++ b/packages/c/coreutils/package.yml
@@ -1,8 +1,8 @@
 name       : coreutils
-version    : '9.3'
-release    : 30
+version    : '9.4'
+release    : 31
 source     :
-    - https://ftp.gnu.org/gnu/coreutils/coreutils-9.3.tar.xz : adbcfcfe899235b71e8768dcf07cd532520b7f54f9a8064843f8d199a904bbaa
+    - https://ftp.gnu.org/gnu/coreutils/coreutils-9.4.tar.xz : ea613a4cf44612326e917201bbbcdfbd301de21ffc3b59b6e5c07e040b275e52
 license    : GPL-3.0-or-later
 component  : system.base
 summary    : GNU core utilities

--- a/packages/c/coreutils/pspec_x86_64.xml
+++ b/packages/c/coreutils/pspec_x86_64.xml
@@ -2,8 +2,8 @@
     <Source>
         <Name>coreutils</Name>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -238,6 +238,8 @@
             <Path fileType="localedata">/usr/share/locale/sr/LC_TIME/coreutils.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/coreutils.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sv/LC_TIME/coreutils.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ta/LC_MESSAGES/coreutils.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ta/LC_TIME/coreutils.mo</Path>
             <Path fileType="localedata">/usr/share/locale/tr/LC_MESSAGES/coreutils.mo</Path>
             <Path fileType="localedata">/usr/share/locale/tr/LC_TIME/coreutils.mo</Path>
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/coreutils.mo</Path>
@@ -354,12 +356,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="30">
-            <Date>2023-09-09</Date>
-            <Version>9.3</Version>
+        <Update release="31">
+            <Date>2023-09-29</Date>
+            <Version>9.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

[Changelog](https://lists.gnu.org/archive/html/info-gnu/2023-08/msg00007.html)

**Test Plan**

Use some common utilities as normal, e.g. cp, mv, etc.

**Checklist**

- [x] Package was built and tested against unstable
