### PR TITLE
libinput: Disable quirk removing two-finger scrolling on HP Pavillion

### DIFF
--- a/packages/l/libinput/abi_used_symbols
+++ b/packages/l/libinput/abi_used_symbols
@@ -100,6 +100,7 @@ libc.so.6:write
 libevdev.so.2:libevdev_change_fd
 libevdev.so.2:libevdev_disable_event_code
 libevdev.so.2:libevdev_disable_event_type
+libevdev.so.2:libevdev_disable_property
 libevdev.so.2:libevdev_enable_event_code
 libevdev.so.2:libevdev_enable_event_type
 libevdev.so.2:libevdev_enable_property

--- a/packages/l/libinput/files/0001-quirks-Disable-quirk-removing-two-finger-scrolling-f.patch
+++ b/packages/l/libinput/files/0001-quirks-Disable-quirk-removing-two-finger-scrolling-f.patch
@@ -1,0 +1,39 @@
+From fd38b763a2d0af061b94301589004d09ea12ff46 Mon Sep 17 00:00:00 2001
+From: Joey Riches <josephriches@gmail.com>
+Date: Fri, 29 Sep 2023 23:38:17 +0100
+Subject: [PATCH 1/1] quirks: Disable quirk removing two-finger scrolling for
+ HP Pavillion
+
+Opiniated: Personally affected by this and I would much rather live with
+any potential bugginess than be forced to use edge-scrolling. I can't
+even replicate the original bug.
+
+Upstream bug: https://bugs.freedesktop.org/show_bug.cgi?id=91135
+---
+ quirks/50-system-hp.quirks | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/quirks/50-system-hp.quirks b/quirks/50-system-hp.quirks
+index 80e7b9b4..6b959141 100644
+--- a/quirks/50-system-hp.quirks
++++ b/quirks/50-system-hp.quirks
+@@ -14,10 +14,13 @@ MatchName=*SynPS/2 Synaptics TouchPad
+ MatchDMIModalias=dmi:*svnHewlett-Packard:*pnHPCompaq8510w*
+ AttrEventCode=-BTN_TOOL_DOUBLETAP;-BTN_TOOL_TRIPLETAP;
+
+-[HP Pavilion dmi4]
+-MatchName=*SynPS/2 Synaptics TouchPad
+-MatchDMIModalias=dmi:*svnHewlett-Packard:*pnHPPaviliondm4NotebookPC*
+-ModelHPPavilionDM4Touchpad=1
++# SOLUS: Downstream change
++# We will live with any potential bugginess rather than force
++# edge scrolling here.
++# [HP Pavilion dmi4]
++# MatchName=*SynPS/2 Synaptics TouchPad
++# MatchDMIModalias=dmi:*svnHewlett-Packard:*pnHPPaviliondm4NotebookPC*
++# ModelHPPavilionDM4Touchpad=1
+
+ # Touchpad is a clickpad but INPUT_PROP_BUTTONPAD is not set, see
+ # https://bugs.freedesktop.org/show_bug.cgi?id=97147
+--
+2.42.0

--- a/packages/l/libinput/package.yml
+++ b/packages/l/libinput/package.yml
@@ -1,6 +1,6 @@
 name       : libinput
 version    : 1.24.0
-release    : 43
+release    : 44
 source     :
     - https://gitlab.freedesktop.org/libinput/libinput/-/archive/1.24.0/libinput-1.24.0.tar.gz : 7413c3733b8c39dc38b8687950e0e0d9d38a73394539f9efa2a7c84a412cb505
 license    : MIT
@@ -16,6 +16,7 @@ builddeps  :
     - pyparsing
     - python-pytest
 setup      : |
+    %patch -p1 -i $pkgfiles/0001-quirks-Disable-quirk-removing-two-finger-scrolling-f.patch
     %meson_configure -Ddebug-gui=false \
         -Ddocumentation=false \
         -Dtests=false \

--- a/packages/l/libinput/pspec_x86_64.xml
+++ b/packages/l/libinput/pspec_x86_64.xml
@@ -2,8 +2,8 @@
     <Source>
         <Name>libinput</Name>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>desktop.library</PartOf>
@@ -116,7 +116,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="43">libinput</Dependency>
+            <Dependency release="44">libinput</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libinput.h</Path>
@@ -125,12 +125,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="43">
-            <Date>2023-09-22</Date>
+        <Update release="44">
+            <Date>2023-09-29</Date>
             <Version>1.24.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Personally affected by this quirk. Can't replicate the bug and i _hate_ _hate_ _hate_ edge scrolling.

**Test Plan**

Use two finger scrolling

**Checklist**

- [x] Package was built and tested against unstable
