### PR TITLE
bluez: update to 5.70

### DIFF
--- a/packages/b/bluez/abi_symbols
+++ b/packages/b/bluez/abi_symbols
@@ -521,6 +521,7 @@ obexd:bt_compidtostr
 obexd:bt_error
 obexd:bt_free
 obexd:bt_io_accept
+obexd:bt_io_bcast_accept
 obexd:bt_io_connect
 obexd:bt_io_error_quark
 obexd:bt_io_get
@@ -1021,6 +1022,8 @@ obexd:sdp_uuid_to_uuid128
 obexd:str2ba
 obexd:strdelimit
 obexd:string_read
+obexd:strisutf8
+obexd:strstrip
 obexd:strsuffix
 obexd:strtoba
 obexd:sync_exit

--- a/packages/b/bluez/abi_used_symbols
+++ b/packages/b/bluez/abi_used_symbols
@@ -6,6 +6,7 @@ libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
 libc.so.6:__getdelim
+libc.so.6:__isoc99_fscanf
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
@@ -58,6 +59,7 @@ libc.so.6:fcntl64
 libc.so.6:fdatasync
 libc.so.6:fdopen
 libc.so.6:fdopendir
+libc.so.6:fflush
 libc.so.6:fgets
 libc.so.6:fileno
 libc.so.6:flock
@@ -83,6 +85,7 @@ libc.so.6:getsockopt
 libc.so.6:gettimeofday
 libc.so.6:gmtime
 libc.so.6:if_nametoindex
+libc.so.6:index
 libc.so.6:inet_addr
 libc.so.6:ioctl
 libc.so.6:isatty
@@ -110,9 +113,11 @@ libc.so.6:opendir
 libc.so.6:openlog
 libc.so.6:optarg
 libc.so.6:optind
+libc.so.6:pclose
 libc.so.6:perror
 libc.so.6:pipe
 libc.so.6:poll
+libc.so.6:popen
 libc.so.6:prctl
 libc.so.6:putchar
 libc.so.6:puts

--- a/packages/b/bluez/package.yml
+++ b/packages/b/bluez/package.yml
@@ -1,15 +1,16 @@
 name       : bluez
-version    : '5.68'
-release    : 43
+version    : '5.70'
+release    : 44
 source     :
-    - https://mirrors.edge.kernel.org/pub/linux/bluetooth/bluez-5.68.tar.xz : fc505e6445cb579a55cacee6821fe70d633921522043d322b696de0a175ff933
+    - https://mirrors.edge.kernel.org/pub/linux/bluetooth/bluez-5.70.tar.xz : 37e372e916955e144cb882f888e4be40898f10ae3b7c213ddcdd55ee9c009278
 license    :
     - GPL-2.0-or-later
     - LGPL-2.1-or-later
+homepage   : http://www.bluez.org/
 component  : system.utils
 summary    : Official Linux Bluetooth protocol stack.
 description: |
-    The Bluetooth wireless technology is a worldwide specification for a small-form factor, low-cost radio solution that provides links between mobile computers, mobile phones, other portable handheld devices, and connectivity to the Internet. The specification is developed, published and promoted by the Bluetooth Special Interest Group (SIG).f BlueZ provides support for the core Bluetooth layers and protocols. It is flexible, efficient and uses a modular implementation.
+    The Bluetooth wireless technology is a worldwide specification for a small-form factor, low-cost radio solution that provides links between mobile computers, mobile phones, other portable handheld devices, and connectivity to the Internet. The specification is developed, published and promoted by the Bluetooth Special Interest Group (SIG). BlueZ provides support for the core Bluetooth layers and protocols. It is flexible, efficient and uses a modular implementation.
 builddeps  :
     - pkgconfig(libical)
     - cups-devel
@@ -28,8 +29,8 @@ build      : |
     %make
 install    : |
     %make_install
-    install -D -m 00755 src/main.conf $installdir/usr/share/defaults/bluetooth/main.conf
-    install -D -d -m 00755 $installdir/usr/lib/systemd/system/bluetooth.target.wants
+    install -Dm00755 src/main.conf $installdir/usr/share/defaults/bluetooth/main.conf
+    install -dm00755 $installdir/usr/lib/systemd/system/bluetooth.target.wants
     ln -sv bluetooth.service  $installdir/usr/lib/systemd/system/dbus-org.bluez.service
     ln -sv ../bluetooth.service  $installdir/usr/lib/systemd/system/bluetooth.target.wants/bluetooth.service
     ln -sv obex.service $installdir/usr/lib/systemd/user/dbus-org.bluez.obex.service

--- a/packages/b/bluez/pspec_x86_64.xml
+++ b/packages/b/bluez/pspec_x86_64.xml
@@ -1,6 +1,7 @@
 <PISI>
     <Source>
         <Name>bluez</Name>
+        <Homepage>http://www.bluez.org/</Homepage>
         <Packager>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>
@@ -9,14 +10,14 @@
         <License>LGPL-2.1-or-later</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">Official Linux Bluetooth protocol stack.</Summary>
-        <Description xml:lang="en">The Bluetooth wireless technology is a worldwide specification for a small-form factor, low-cost radio solution that provides links between mobile computers, mobile phones, other portable handheld devices, and connectivity to the Internet. The specification is developed, published and promoted by the Bluetooth Special Interest Group (SIG).f BlueZ provides support for the core Bluetooth layers and protocols. It is flexible, efficient and uses a modular implementation.
+        <Description xml:lang="en">The Bluetooth wireless technology is a worldwide specification for a small-form factor, low-cost radio solution that provides links between mobile computers, mobile phones, other portable handheld devices, and connectivity to the Internet. The specification is developed, published and promoted by the Bluetooth Special Interest Group (SIG). BlueZ provides support for the core Bluetooth layers and protocols. It is flexible, efficient and uses a modular implementation.
 </Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
     </Source>
     <Package>
         <Name>bluez</Name>
         <Summary xml:lang="en">Official Linux Bluetooth protocol stack.</Summary>
-        <Description xml:lang="en">The Bluetooth wireless technology is a worldwide specification for a small-form factor, low-cost radio solution that provides links between mobile computers, mobile phones, other portable handheld devices, and connectivity to the Internet. The specification is developed, published and promoted by the Bluetooth Special Interest Group (SIG).f BlueZ provides support for the core Bluetooth layers and protocols. It is flexible, efficient and uses a modular implementation.
+        <Description xml:lang="en">The Bluetooth wireless technology is a worldwide specification for a small-form factor, low-cost radio solution that provides links between mobile computers, mobile phones, other portable handheld devices, and connectivity to the Internet. The specification is developed, published and promoted by the Bluetooth Special Interest Group (SIG). BlueZ provides support for the core Bluetooth layers and protocols. It is flexible, efficient and uses a modular implementation.
 </Description>
         <PartOf>system.utils</PartOf>
         <Files>
@@ -42,12 +43,15 @@
             <Path fileType="library">/usr/lib64/bluez/bluetooth/obexd</Path>
             <Path fileType="library">/usr/lib64/cups/backend/bluetooth</Path>
             <Path fileType="library">/usr/lib64/libbluetooth.so.3</Path>
-            <Path fileType="library">/usr/lib64/libbluetooth.so.3.19.9</Path>
+            <Path fileType="library">/usr/lib64/libbluetooth.so.3.19.10</Path>
             <Path fileType="data">/usr/share/dbus-1/services/org.bluez.obex.service</Path>
             <Path fileType="data">/usr/share/dbus-1/system-services/org.bluez.service</Path>
             <Path fileType="data">/usr/share/dbus-1/system.d/bluetooth.conf</Path>
             <Path fileType="data">/usr/share/defaults/bluetooth/main.conf</Path>
+            <Path fileType="man">/usr/share/man/man1/bluetoothctl-mgmt.1</Path>
+            <Path fileType="man">/usr/share/man/man1/bluetoothctl-monitor.1</Path>
             <Path fileType="man">/usr/share/man/man1/btattach.1</Path>
+            <Path fileType="man">/usr/share/man/man1/btmgmt.1</Path>
             <Path fileType="man">/usr/share/man/man1/btmon.1</Path>
             <Path fileType="man">/usr/share/man/man1/hid2hci.1</Path>
             <Path fileType="man">/usr/share/man/man1/isotest.1</Path>
@@ -60,11 +64,11 @@
     <Package>
         <Name>bluez-devel</Name>
         <Summary xml:lang="en">Development files for bluez</Summary>
-        <Description xml:lang="en">The Bluetooth wireless technology is a worldwide specification for a small-form factor, low-cost radio solution that provides links between mobile computers, mobile phones, other portable handheld devices, and connectivity to the Internet. The specification is developed, published and promoted by the Bluetooth Special Interest Group (SIG).f BlueZ provides support for the core Bluetooth layers and protocols. It is flexible, efficient and uses a modular implementation.
+        <Description xml:lang="en">The Bluetooth wireless technology is a worldwide specification for a small-form factor, low-cost radio solution that provides links between mobile computers, mobile phones, other portable handheld devices, and connectivity to the Internet. The specification is developed, published and promoted by the Bluetooth Special Interest Group (SIG). BlueZ provides support for the core Bluetooth layers and protocols. It is flexible, efficient and uses a modular implementation.
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="43">bluez</Dependency>
+            <Dependency release="44">bluez</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/bluetooth/bluetooth.h</Path>
@@ -83,9 +87,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="43">
-            <Date>2023-07-12</Date>
-            <Version>5.68</Version>
+        <Update release="44">
+            <Date>2023-09-30</Date>
+            <Version>5.70</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fix issue with not sending GATT confirmations
- Fix issue with not handling initiator properly
- Fix issue with not checking PBAP counter length
- Add support for MICP profile and MICS service
- Fix issue with BAP enabling state correctly when resuming
- Fix issue with detaching source ASEs only after Stop Ready
- Fix issue with handling VCP audio location and descriptor
- Fix issue with generating IRK for adapter with privacy enabled
- Add support for BAP broadcast sink

Full commit log available [here](https://github.com/bluez/bluez/compare/5.68...5.70)

Packaging changes: added homepage, minor cleanups

**Test Plan**
- Connected both my Bluetooth headphones and earbuds
- Changed Bluetooth audio codecs
- Re-paired my earbuds using `bluetoothctl`

**Checklist**

- [x] Package was built and tested against unstable
