### PR TITLE
cava: update to 0.9.1

### DIFF
--- a/packages/c/cava/abi_used_symbols
+++ b/packages/c/cava/abi_used_symbols
@@ -60,6 +60,7 @@ libc.so.6:optarg
 libc.so.6:pthread_create
 libc.so.6:pthread_exit
 libc.so.6:pthread_join
+libc.so.6:pthread_mutex_init
 libc.so.6:pthread_mutex_lock
 libc.so.6:pthread_mutex_unlock
 libc.so.6:raise
@@ -71,6 +72,7 @@ libc.so.6:signal
 libc.so.6:snprintf
 libc.so.6:stderr
 libc.so.6:stdout
+libc.so.6:strcat
 libc.so.6:strcmp
 libc.so.6:strcpy
 libc.so.6:strdup

--- a/packages/c/cava/package.yml
+++ b/packages/c/cava/package.yml
@@ -1,8 +1,8 @@
 name       : cava
-version    : 0.8.3
-release    : 11
+version    : 0.9.1
+release    : 12
 source     :
-    - https://github.com/karlstav/cava/archive/refs/tags/0.8.3.tar.gz : ce7378ababada5a20fa8250c6b3fe6412bc1a7dd31301a52b8b4a71d362875b9
+    - https://github.com/karlstav/cava/archive/refs/tags/0.9.1.tar.gz : 483f571d5fba5fb8aa81511c4dcf8ce0949c7c503ec6c743c2914cd78e6faf03
 homepage   : https://github.com/karlstav/cava
 license    : MIT
 component  : multimedia.audio
@@ -15,7 +15,6 @@ builddeps  :
     - pkgconfig(iniparser)
     - pkgconfig(libpulse)
 setup      : |
-    sed -i "s|local/lib|lib64|g" Makefile.am
     %autogen --disable-static
 build      : |
     %make

--- a/packages/c/cava/pspec_x86_64.xml
+++ b/packages/c/cava/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>cava</Name>
         <Homepage>https://github.com/karlstav/cava</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>multimedia.audio</PartOf>
@@ -25,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2023-07-25</Date>
-            <Version>0.8.3</Version>
+        <Update release="12">
+            <Date>2023-09-30</Date>
+            <Version>0.9.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- glsl shader output
- pipewire input support
- gradient support in sdl output
- some config options are now `0-100` instead of `0-1`
- fix default input wrongly being set to alsa instead of pulseaudio/pipewire

**Test Plan**
- Listened to some music while watching the visualizer
- Configured different colours and bar widths/sensitivities

**Checklist**

- [x] Package was built and tested against unstable
