### PR TITLE
Update sof-firmware to 2.7

### DIFF
--- a/packages/s/sof-firmware/package.yml
+++ b/packages/s/sof-firmware/package.yml
@@ -1,8 +1,8 @@
 name       : sof-firmware
-version    : 2.2.6
-release    : 11
+version    : '2.7'
+release    : 12
 source     :
-    - https://github.com/thesofproject/sof-bin/releases/download/v2.2.6/sof-bin-v2.2.6.tar.gz : 9322c2a7636d02845c3b26984d58ab8f78d63ff4c766d084c3196a585e000905
+    - https://github.com/thesofproject/sof-bin/releases/download/v2023.09/sof-bin-2023.09.tar.gz : 4bcc75c6642348e1a516db7ff9d050b6ea1b8672983542c6952562fa8c1c7b63
 license    :
     - BSD-3-Clause
     - ISC
@@ -12,5 +12,7 @@ description: |
     Sound Open Firmware
 install    : |
     install -dm00755 $installdir/lib/firmware/intel
-    cp -a sof-v$version "$installdir/lib/firmware/intel/sof"
-    cp -a sof-tplg-v$version "$installdir/lib/firmware/intel/sof-tplg"
+    cp -a sof "$installdir/lib/firmware/intel/sof"
+    cp -a sof-ace-tplg "$installdir/lib/firmware/intel/sof-ace-tplg"
+    cp -a sof-ipc4 "$installdir/lib/firmware/intel/sof-ipc4"
+    cp -a sof-tplg "$installdir/lib/firmware/intel/sof-tplg"

--- a/packages/s/sof-firmware/pspec_x86_64.xml
+++ b/packages/s/sof-firmware/pspec_x86_64.xml
@@ -20,6 +20,22 @@
 </Description>
         <PartOf>kernel</PartOf>
         <Files>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-hda-generic-2ch.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-hda-generic-4ch.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-hda-generic-idisp.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-hda-generic.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-max98357a-rt5682-ssp2-ssp0-2ch-pdm1.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-max98357a-rt5682-ssp2-ssp0.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-max98357a-rt5682.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-rt1019-rt5682.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-rt1318-l12-rt714-l0.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-rt711-4ch.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-rt711-l0-rt1316-l23-rt714-l1.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-rt712-l0-rt1712-l3.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-sdw-cs42l42-l0-max98363-l2.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ipc4/mtl/community/sof-mtl.ri</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ipc4/mtl/intel-signed/sof-mtl.ri</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ipc4/mtl/sof-mtl.ri</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-acp.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-cs35l41.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-es8336-dmic2ch-ssp0.tplg</Path>
@@ -39,6 +55,7 @@
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-max98357a-rt5682-waves-2way.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-max98357a-rt5682-waves.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-max98357a-rt5682.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-max98360a-da7219.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-max98360a-nau8825.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-max98360a-rt5682-2way.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-max98360a-rt5682-4ch.tplg</Path>
@@ -51,6 +68,7 @@
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-max98390-rt5682-rtnr.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-max98390-rt5682.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-max98390-ssp2-rt5682-ssp0.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-nau8318-nau8825.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-nau8825.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-nocodec-ci.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-nocodec-hdmi-ssp02.tplg</Path>
@@ -62,6 +80,7 @@
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-rt1316-l12-rt714-l0.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-rt1316-l2-mono-rt714-l0.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-rt1316-l2-mono-rt714-l3.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-rt5650.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-rt5682.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-rt711-4ch.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-adl-rt711-l0-rt1308-l12-rt715-l3.tplg</Path>
@@ -258,6 +277,7 @@
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-rpl-rt1316-l12-rt714-l0.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-rpl-rt711-4ch.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-rpl-rt711-l0-rt1316-l12-rt714-l3.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-rpl-rt711-l0-rt1316-l12.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-rpl-rt711-l0-rt1318-l12-rt714-l3.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-rpl-rt711-l0-rt1318-l12.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-tplg/sof-rpl-rt711-l0.tplg</Path>
@@ -373,9 +393,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2023-07-22</Date>
-            <Version>2.2.6</Version>
+        <Update release="12">
+            <Date>2023-10-01</Date>
+            <Version>2.7</Version>
             <Comment>Packaging update</Comment>
             <Name>Tracey Clark</Name>
             <Email>tracey_dev@tlcnet.info</Email>


### PR DESCRIPTION
## Summary

Add prebuilt binaries for Intel Meteor Lake hardware

Packaging: Update to match new directory structure and include new directories.

Full release notes [here](https://github.com/thesofproject/sof-bin/releases/tag/v2023.09)

## Test Plan:

Verified firmware files were installed to correct paths, including new ones: /lib/firmware/intel/sof /lib/firmware/intel/sof-tplg /lib/firmware/intel Listened to music and triggered system sounds to verify that sound still works.

## Checklist

- [x] Package was built and tested against unstable