### PR TITLE
bdwgc: don't move man file to weird place

### DIFF
--- a/packages/b/bdwgc/package.yml
+++ b/packages/b/bdwgc/package.yml
@@ -1,6 +1,6 @@
 name       : bdwgc
 version    : 8.2.4
-release    : 17
+release    : 18
 source     :
     - https://github.com/ivmai/bdwgc/archive/v8.2.4.tar.gz : 18e63ab1428bd52e691da107a6a56651c161210b11fbe22e2aa3c31f7fa00ca5
 homepage   : http://www.hpl.hp.com/personal/Hans_Boehm/gc
@@ -18,5 +18,3 @@ build      : |
     %make
 install    : |
     %make_install
-    install -Dm00644 doc/gc.man $installdir/usr/share/man/manman/gc.man
-    rm -rf $installdir/usr/share/gc

--- a/packages/b/bdwgc/pspec_x86_64.xml
+++ b/packages/b/bdwgc/pspec_x86_64.xml
@@ -63,8 +63,6 @@
             <Path fileType="doc">/usr/share/doc/gc/scale.md</Path>
             <Path fileType="doc">/usr/share/doc/gc/simple_example.md</Path>
             <Path fileType="doc">/usr/share/doc/gc/tree.md</Path>
-            <Path fileType="man">/usr/share/man/man3/gc.3</Path>
-            <Path fileType="man">/usr/share/man/manman/gc.man</Path>
         </Files>
     </Package>
     <Package>
@@ -74,7 +72,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="17">bdwgc</Dependency>
+            <Dependency release="18">bdwgc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libcord.so.1</Path>
@@ -94,8 +92,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="17">bdwgc-devel</Dependency>
-            <Dependency release="17">bdwgc-32bit</Dependency>
+            <Dependency release="18">bdwgc-devel</Dependency>
+            <Dependency release="18">bdwgc-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libcord.so</Path>
@@ -112,7 +110,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="17">bdwgc</Dependency>
+            <Dependency release="18">bdwgc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gc.h</Path>
@@ -140,11 +138,12 @@
             <Path fileType="library">/usr/lib64/libgccpp.so</Path>
             <Path fileType="library">/usr/lib64/libgctba.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/bdw-gc.pc</Path>
+            <Path fileType="man">/usr/share/man/man3/gc.3</Path>
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2023-06-07</Date>
+        <Update release="18">
+            <Date>2023-10-01</Date>
             <Version>8.2.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>


### PR DESCRIPTION
**Summary**

Don't move the man file for `bdwgc` into a weird and lonely `manman` folder

Also remove another leftover packaging instructions that's no longer necessary

**Test Plan**

Checked man file was put into correct place

**Checklist**

- [x] Package was built and tested against unstable
