### PR TITLE
veracrypt: Fix missing app indicator

### DIFF
--- a/packages/v/veracrypt/abi_used_libs
+++ b/packages/v/veracrypt/abi_used_libs
@@ -1,6 +1,9 @@
+libayatana-appindicator3.so.1
 libc.so.6
 libfuse.so.2
 libgcc_s.so.1
+libgobject-2.0.so.0
+libgtk-3.so.0
 libstdc++.so.6
 libwx_baseu-3.2.so.0
 libwx_gtk3u_core-3.2.so.0

--- a/packages/v/veracrypt/abi_used_symbols
+++ b/packages/v/veracrypt/abi_used_symbols
@@ -1,3 +1,6 @@
+libayatana-appindicator3.so.1:app_indicator_new
+libayatana-appindicator3.so.1:app_indicator_set_menu
+libayatana-appindicator3.so.1:app_indicator_set_status
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__isoc99_sscanf
@@ -9,7 +12,6 @@ libc.so.6:__memcpy_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__syslog_chk
-libc.so.6:__wmemcpy_chk
 libc.so.6:_exit
 libc.so.6:_setjmp
 libc.so.6:chown
@@ -113,11 +115,20 @@ libc.so.6:write
 libfuse.so.2:fuse_get_context
 libfuse.so.2:fuse_main_real_compat25
 libgcc_s.so.1:_Unwind_Resume
+libgobject-2.0.so.0:g_signal_connect_data
+libgtk-3.so.0:gtk_menu_item_new_with_label
+libgtk-3.so.0:gtk_menu_item_set_label
+libgtk-3.so.0:gtk_menu_new
+libgtk-3.so.0:gtk_menu_shell_append
+libgtk-3.so.0:gtk_separator_menu_item_new
+libgtk-3.so.0:gtk_widget_set_sensitive
+libgtk-3.so.0:gtk_widget_show_all
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12find_last_ofEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE13find_first_ofEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE16find_last_not_ofEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE16find_last_not_ofEcm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE17find_first_not_ofEPKcmm
+libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEPKcm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEcm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE5rfindEcm
@@ -440,6 +451,7 @@ libwx_baseu-3.2.so.0:_ZNK8wxObject13CreateRefDataEv
 libwx_baseu-3.2.so.0:_ZNK8wxString11BeforeFirstE9wxUniCharPS_
 libwx_baseu-3.2.so.0:_ZNK8wxString3MidEmm
 libwx_baseu-3.2.so.0:_ZNK8wxString4LeftEm
+libwx_baseu-3.2.so.0:_ZNK8wxString6AsCharERK8wxMBConv
 libwx_baseu-3.2.so.0:_ZNK8wxString6ToLongEPli
 libwx_baseu-3.2.so.0:_ZNK8wxString7ToULongEPmi
 libwx_baseu-3.2.so.0:_ZNK8wxString7compareEPKw
@@ -596,7 +608,6 @@ libwx_gtk3u_core-3.2.so.0:_ZN13wxTaskBarIcon7SetIconERK14wxBitmapBundleRK8wxStri
 libwx_gtk3u_core-3.2.so.0:_ZN13wxTaskBarIcon9PopupMenuEP6wxMenu
 libwx_gtk3u_core-3.2.so.0:_ZN13wxTaskBarIconC2E17wxTaskBarIconType
 libwx_gtk3u_core-3.2.so.0:_ZN13wxTaskBarIconD2Ev
-libwx_gtk3u_core-3.2.so.0:_ZN14wxBitmapBundleC1ERK6wxIcon
 libwx_gtk3u_core-3.2.so.0:_ZN14wxBitmapBundleC1ERK8wxBitmap
 libwx_gtk3u_core-3.2.so.0:_ZN14wxBitmapBundleC1Ev
 libwx_gtk3u_core-3.2.so.0:_ZN14wxBitmapBundleD1Ev

--- a/packages/v/veracrypt/package.yml
+++ b/packages/v/veracrypt/package.yml
@@ -1,6 +1,6 @@
 name       : veracrypt
 version    : 1.25.9
-release    : 20
+release    : 21
 source     :
     - https://launchpad.net/veracrypt/trunk/1.25.9/+download/VeraCrypt_1.25.9_Source.tar.bz2 : 76b6e18184bc21a41d2949ff63d721d49054a716ceff3a4bd77b5c3510b794af
 license    :
@@ -10,6 +10,7 @@ component  : security.crypto
 summary    : Disk encryption software based on TrueCrypt
 description: Disk encryption software based on TrueCrypt
 builddeps  :
+    - pkgconfig(ayatana-appindicator3-0.1)
     - pkgconfig(fuse)
     - wxwidgets-devel
     - yasm
@@ -19,7 +20,8 @@ build      : |
     %make -C src \
         TC_EXTRA_CFLAGS="${CFLAGS}" \
         TC_EXTRA_CXXFLAGS="${CXXFLAGS}" \
-        TC_EXTRA_LFLAGS+="-ldl ${LDFLAGS}"
+        TC_EXTRA_LFLAGS+="-ldl ${LDFLAGS}" \
+        INDICATOR=1
 install    : |
     install -Dm00755 src/Main/veracrypt $installdir/usr/bin/veracrypt
     install -Dm00644 src/Resources/Icons/VeraCrypt-256x256.xpm $installdir/usr/share/pixmaps/veracrypt.xpm

--- a/packages/v/veracrypt/pspec_x86_64.xml
+++ b/packages/v/veracrypt/pspec_x86_64.xml
@@ -2,8 +2,8 @@
     <Source>
         <Name>veracrypt</Name>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Wouter Horlings</Name>
+            <Email>wouter@horlin.gs</Email>
         </Packager>
         <License>TrueCrypt-3.0</License>
         <License>Apache-2.0</License>
@@ -24,12 +24,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2023-07-22</Date>
+        <Update release="21">
+            <Date>2023-10-02</Date>
             <Version>1.25.9</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Wouter Horlings</Name>
+            <Email>wouter@horlin.gs</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
## Changes:

- Add `ayatana-appindicator3` as build dependency.
- Set `INDICATOR` build option.

Fixes #393

## Testplan:

- Create a new file with an encrypted filesystem.
- Store files in the filesystem.
- Remount the filesystem to access the files.
- Use trayicon to hide and unhide the application.

## Checklist

- [x] Package was built and tested against unstable
