### PR TITLE
veracrypt: Update to 1.26.7

### DIFF
--- a/packages/v/veracrypt/abi_used_symbols
+++ b/packages/v/veracrypt/abi_used_symbols
@@ -12,6 +12,7 @@ libc.so.6:__memcpy_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__syslog_chk
+libc.so.6:__vsnprintf_chk
 libc.so.6:_exit
 libc.so.6:_setjmp
 libc.so.6:chown
@@ -109,6 +110,7 @@ libc.so.6:waitpid
 libc.so.6:wcsdup
 libc.so.6:wcslen
 libc.so.6:wcsrtombs
+libc.so.6:wcstombs
 libc.so.6:wmemcmp
 libc.so.6:wmemcpy
 libc.so.6:write
@@ -146,6 +148,7 @@ libstdc++.so.6:_ZNSdD2Ev
 libstdc++.so.6:_ZNSi10_M_extractIjEERSiRT_
 libstdc++.so.6:_ZNSi10_M_extractImEERSiRT_
 libstdc++.so.6:_ZNSo3putEc
+libstdc++.so.6:_ZNSo9_M_insertIlEERSoT_
 libstdc++.so.6:_ZNSo9_M_insertImEERSoT_
 libstdc++.so.6:_ZNSolsEi
 libstdc++.so.6:_ZNSt13basic_istreamIwSt11char_traitsIwEE10_M_extractIjEERS2_RT_
@@ -164,9 +167,11 @@ libstdc++.so.6:_ZNSt6localeC1Ev
 libstdc++.so.6:_ZNSt6localeD1Ev
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_disposeEv
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructEmc
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE13_S_copy_charsEPcPKcS7_
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE14_M_replace_auxEmmmc
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6appendEPKc
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6resizeEmc
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_appendEPKcm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_assignERKS4_
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createERmm
@@ -292,6 +297,7 @@ libwx_baseu-3.2.so.0:_Z28wxGet_wxConvWhateverWorksPtrv
 libwx_baseu-3.2.so.0:_Z4endlR18wxTextOutputStream
 libwx_baseu-3.2.so.0:_Z7wxEntryRiPPc
 libwx_baseu-3.2.so.0:_Z7wxMkdirRK8wxStringi
+libwx_baseu-3.2.so.0:_Z8wxSetEnvRK8wxStringS1_
 libwx_baseu-3.2.so.0:_Z9wxExecuteRK8wxStringiP9wxProcessPK12wxExecuteEnv
 libwx_baseu-3.2.so.0:_ZN10wxDateTime13TIME_T_FACTORE
 libwx_baseu-3.2.so.0:_ZN10wxDateTime8TimeZoneC1ENS_2TZE
@@ -422,6 +428,7 @@ libwx_baseu-3.2.so.0:_ZNK10wxFileName10FileExistsEv
 libwx_baseu-3.2.so.0:_ZNK10wxFileName11GetFullPathE12wxPathFormat
 libwx_baseu-3.2.so.0:_ZNK10wxFileName6ExistsEi
 libwx_baseu-3.2.so.0:_ZNK10wxFileName7GetPathEi12wxPathFormat
+libwx_baseu-3.2.so.0:_ZNK10wxFileName7GetSizeEv
 libwx_baseu-3.2.so.0:_ZNK10wxFileType14GetOpenCommandERK8wxString
 libwx_baseu-3.2.so.0:_ZNK10wxListBase4FindERK9wxListKey
 libwx_baseu-3.2.so.0:_ZNK11wxCondition4IsOkEv
@@ -445,6 +452,7 @@ libwx_baseu-3.2.so.0:_ZNK17wxStringTokenizer13HasMoreTokensEv
 libwx_baseu-3.2.so.0:_ZNK20wxArgNormalizerWcharIRK10wxCStrDataE3getEv
 libwx_baseu-3.2.so.0:_ZNK20wxArgNormalizerWcharIRK8wxStringE3getEv
 libwx_baseu-3.2.so.0:_ZNK23wxSingleInstanceChecker18DoIsAnotherRunningEv
+libwx_baseu-3.2.so.0:_ZNK8wxMBConv14DoConvertMB2WCEPKcm
 libwx_baseu-3.2.so.0:_ZNK8wxObject12CloneRefDataEPK12wxRefCounter
 libwx_baseu-3.2.so.0:_ZNK8wxObject12GetClassInfoEv
 libwx_baseu-3.2.so.0:_ZNK8wxObject13CreateRefDataEv
@@ -484,6 +492,7 @@ libwx_baseu-3.2.so.0:wxDefaultDateTimeFormat
 libwx_baseu-3.2.so.0:wxEVT_NULL
 libwx_baseu-3.2.so.0:wxEVT_TIMER
 libwx_baseu-3.2.so.0:wxEmptyString
+libwx_baseu-3.2.so.0:wxInvalidSize
 libwx_baseu-3.2.so.0:wxTheAssertHandler
 libwx_baseu-3.2.so.0:wxTrapInAssert
 libwx_gtk3u_core-3.2.so.0:_Z11wxSafeYieldP8wxWindowb

--- a/packages/v/veracrypt/package.yml
+++ b/packages/v/veracrypt/package.yml
@@ -1,17 +1,22 @@
 name       : veracrypt
-version    : 1.25.9
-release    : 21
+version    : 1.26.7
+release    : 22
 source     :
-    - https://launchpad.net/veracrypt/trunk/1.25.9/+download/VeraCrypt_1.25.9_Source.tar.bz2 : 76b6e18184bc21a41d2949ff63d721d49054a716ceff3a4bd77b5c3510b794af
+    - https://launchpad.net/veracrypt/trunk/1.26.7/+download/VeraCrypt_1.26.7_Source.tar.bz2 : f76d27b182414e0d4fd9b6b59fbea28b25db6fa69f2bbcffa2ec269b1a865f65
+homepage   : https://veracrypt.fr 
 license    :
     - TrueCrypt-3.0
     - Apache-2.0
 component  : security.crypto
 summary    : Disk encryption software based on TrueCrypt
-description: Disk encryption software based on TrueCrypt
+description: |
+  VeraCrypt is a software for establishing and maintaining an on-the-fly-encrypted volume (data storage device). 
+  No data stored on an encrypted volume can be read without using the correct encryption keys/files. 
+  Files can be copied to and from a mounted VeraCrypt volume just like they are copied to/from any normal disk.
 builddeps  :
     - pkgconfig(ayatana-appindicator3-0.1)
     - pkgconfig(fuse)
+    - pkgconfig(libpcsclite)
     - wxwidgets-devel
     - yasm
 setup      : |

--- a/packages/v/veracrypt/pspec_x86_64.xml
+++ b/packages/v/veracrypt/pspec_x86_64.xml
@@ -24,9 +24,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
+        <Update release="22">
             <Date>2023-10-02</Date>
-            <Version>1.25.9</Version>
+            <Version>1.26.7</Version>
             <Comment>Packaging update</Comment>
             <Name>Wouter Horlings</Name>
             <Email>wouter@horlin.gs</Email>


### PR DESCRIPTION
## Summary

- Add pcsc-lite builddeb for smart card support.
- Update homepage and description of package.

**Full release notes:**
- [1.26.7](https://github.com/veracrypt/VeraCrypt/releases/tag/VeraCrypt_1.26.7)

## Test Plan

- Launched the application
- Encrypted and decrypted some files

## Checklist

- [x] Package was built and tested against unstable
