### PR TITLE
fftw: Ensure missing `FFTW3LibraryDepends.cmake` file is provided

### DIFF
--- a/packages/f/fftw/package.yml
+++ b/packages/f/fftw/package.yml
@@ -1,6 +1,6 @@
 name       : fftw
 version    : 3.3.8
-release    : 12
+release    : 13
 source     :
     - http://fftw.org/fftw-3.3.8.tar.gz : 6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303
 license    : GPL-2.0-or-later
@@ -12,9 +12,16 @@ avx2       : yes
 builddeps  :
     - gfortran
     - libpth-devel
+environment: |
+    if [[ ! -z "${AVX2BUILD}" ]]; then
+        export CFLAGS="$CFLAGS -mtune=haswell -march=haswell"
+        export TO_BUILD="fftw-single-avx2 fftw-double-avx2"
+    else
+        export TO_BUILD="fftw-single fftw-double fftw-long-double"
+    fi
 setup      : |
     export CONFOPTS="$CONFOPTS --prefix=/usr --libdir=%libdir% --disable-static --enable-shared --enable-openmp --enable-threads"
-    export avxflags="--libdir=%libdir%/haswell --enable-sse2 --enable-fma --enable-avx2"
+    export avxflags="--enable-sse2 --enable-fma --enable-avx2"
 
     mkdir .fftw && mv * .fftw/
 
@@ -49,16 +56,24 @@ setup      : |
         popd
     fi
 build      : |
-    if [[ ! -z "${AVX2BUILD}" ]]; then
-        export CFLAGS="$CFLAGS -mtune=haswell -march=haswell"
-        export TO_BUILD="fftw-single-avx2 fftw-double-avx2"
-    else
-        export TO_BUILD="fftw-single fftw-double fftw-long-double"
-    fi
-
     for dir in $TO_BUILD; do
         pushd $dir
         %make
+        popd
+    done
+install    : |
+    for dir in $TO_BUILD; do
+        pushd $dir
         %make_install
         popd
     done
+
+    if [[ -z "${AVX2BUILD}" ]]; then
+        pushd fftw-double
+        # install missing FFTW3LibraryDepends.cmake
+        export CMAKE_OPTS="-DENABLE_OPENMP=ON -DENABLE_THREADS=ON -DENABLE_FLOAT=ON -DENABLE_LONG_DOUBLE=ON -DENABLE_QUAD_PRECISION=ON -DENABLE_SSE=ON -DENABLE_SSE2=ON -DENABLE_AVX=ON -DENABLE_AVX2=ON"
+        %cmake_ninja ${CMAKE_OPTS}
+        # https://github.com/FFTW/fftw3/issues/130#issuecomment-1030280157
+        sed -e 's|\(IMPORTED_LOCATION_NONE\).*|\1 "/usr/lib64/libfftw3.so.3"|' -i solusBuildDir/FFTW3LibraryDepends.cmake
+        install -vDm 00644 solusBuildDir/FFTW3LibraryDepends.cmake -t $installdir/usr/lib64/cmake/fftw3/
+    fi

--- a/packages/f/fftw/pspec_x86_64.xml
+++ b/packages/f/fftw/pspec_x86_64.xml
@@ -2,8 +2,8 @@
     <Source>
         <Name>fftw</Name>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>programming</PartOf>
@@ -69,7 +69,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="12">fftw</Dependency>
+            <Dependency release="13">fftw</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/fftw3.f</Path>
@@ -79,6 +79,7 @@
             <Path fileType="header">/usr/include/fftw3q.f03</Path>
             <Path fileType="library">/usr/lib64/cmake/fftw3/FFTW3Config.cmake</Path>
             <Path fileType="library">/usr/lib64/cmake/fftw3/FFTW3ConfigVersion.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/fftw3/FFTW3LibraryDepends.cmake</Path>
             <Path fileType="library">/usr/lib64/cmake/fftw3/FFTW3fConfig.cmake</Path>
             <Path fileType="library">/usr/lib64/cmake/fftw3/FFTW3fConfigVersion.cmake</Path>
             <Path fileType="library">/usr/lib64/cmake/fftw3/FFTW3lConfig.cmake</Path>
@@ -98,12 +99,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2022-03-25</Date>
+        <Update release="13">
+            <Date>2023-10-02</Date>
             <Version>3.3.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Upstream issue: https://github.com/FFTW/fftw3/issues/130

**Packaging Notes**
- Due to fakeroot only being allowed during the install step these days, rework the package a bit without resorting to enabling fatfakeroot.

**Test Plan**
Fixes finding fftw when building `krita`

**Checklist**

- [x] Package was built and tested against unstable
