### PR TITLE
qemu: update to 7.2.6

### DIFF
--- a/packages/q/qemu/package.yml
+++ b/packages/q/qemu/package.yml
@@ -1,8 +1,8 @@
 name       : qemu
-version    : 7.2.5
-release    : 59
+version    : 7.2.6
+release    : 60
 source     :
-    - https://download.qemu.org/qemu-7.2.5.tar.xz : 172042aa37609240130fe03f5925001e717d74dbd0799adf15b15dc038aef9d1
+    - https://download.qemu.org/qemu-7.2.6.tar.xz : 61f6c6efc442f36d1c13ead336aaea3b8a77830094e86f87e45c18ab7a6e4c26
 license    : GPL-2.0-only
 homepage   : https://wiki.qemu.org/Main_Page
 component  : virt

--- a/packages/q/qemu/pspec_x86_64.xml
+++ b/packages/q/qemu/pspec_x86_64.xml
@@ -170,9 +170,9 @@ When used as a virtualizer, QEMU achieves near native performances by executing 
         </Files>
     </Package>
     <History>
-        <Update release="59">
-            <Date>2023-09-17</Date>
-            <Version>7.2.5</Version>
+        <Update release="60">
+            <Date>2023-10-03</Date>
+            <Version>7.2.6</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Release notes available [here](https://www.mail-archive.com/qemu-devel@nongnu.org/msg991183.html)

**Test Plan**
- Launched my Solus VMs
- Created and launched a number of VMs (x64, aarch64) in `gnome-boxes` and `virt-manager`

**Checklist**

- [x] Package was built and tested against unstable
