### PR TITLE
mpc-qt: Fix missing icons

### DIFF
--- a/packages/m/mpc-qt/package.yml
+++ b/packages/m/mpc-qt/package.yml
@@ -1,8 +1,9 @@
 name       : mpc-qt
 version    : '23.02'
-release    : 7
+release    : 8
 source     :
     - https://github.com/mpc-qt/mpc-qt/archive/refs/tags/v23.02.tar.gz : c7bb48e53cf43e6705e67ae7de598d50f442ea73131d17142ea027042befd14c
+homepage   : https://mpc-qt.github.io
 license    : GPL-2.0-or-later
 component  : multimedia.video
 summary    : Media Player Classic Qute Theater
@@ -13,6 +14,8 @@ builddeps  :
     - pkgconfig(Qt5X11Extras)
     - pkgconfig(mpv)
     - pkgconfig(xcb)
+rundeps    :
+    - qt5-svg
 setup      : |
     %qmake MPCQT_VERSION=$version PREFIX=/usr
 build      : |

--- a/packages/m/mpc-qt/pspec_x86_64.xml
+++ b/packages/m/mpc-qt/pspec_x86_64.xml
@@ -2,8 +2,8 @@
     <Source>
         <Name>mpc-qt</Name>
         <Packager>
-            <Name>Alexander Vorobyev</Name>
-            <Email>avorobyev@protonmail.com</Email>
+            <Name>Wouter Horlings</Name>
+            <Email>wouter@horlin.gs</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>multimedia.video</PartOf>
@@ -33,12 +33,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2023-04-18</Date>
+        <Update release="8">
+            <Date>2023-10-03</Date>
             <Version>23.02</Version>
             <Comment>Packaging update</Comment>
-            <Name>Alexander Vorobyev</Name>
-            <Email>avorobyev@protonmail.com</Email>
+            <Name>Wouter Horlings</Name>
+            <Email>wouter@horlin.gs</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
## Summary

- Add qt5-svg run dependency.
- Add homepage to package.

Bugfixes:

- Fix missing icons

## Test Plan

- Launched the application
- Played some video file

## Checklist

- [x] Package was built and tested against unstable