### PR TITLE
Update syncthing to 1.25.0

### DIFF
--- a/packages/s/syncthing/package.yml
+++ b/packages/s/syncthing/package.yml
@@ -1,9 +1,9 @@
 name       : syncthing
-version    : 1.24.0
-release    : 85
+version    : 1.25.0
+release    : 86
 homepage   : https://syncthing.net
 source     :
-    - https://github.com/syncthing/syncthing/releases/download/v1.24.0/syncthing-source-v1.24.0.tar.gz : 4a9459667f9b70a7d1e7d572c7c9d02431ef8f055679eef368300ce1a826608f
+    - https://github.com/syncthing/syncthing/releases/download/v1.25.0/syncthing-source-v1.25.0.tar.gz : e25199e870236216b8409f4c30735c177c83d9eb7f77474c8a9d0c6739789ea1
 license    : MPL-2.0
 component  : network.util
 networking : yes

--- a/packages/s/syncthing/pspec_x86_64.xml
+++ b/packages/s/syncthing/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>syncthing</Name>
         <Homepage>https://syncthing.net</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>MPL-2.0</License>
         <PartOf>network.util</PartOf>
@@ -49,12 +49,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="85">
-            <Date>2023-09-20</Date>
-            <Version>1.24.0</Version>
+        <Update release="86">
+            <Date>2023-10-03</Date>
+            <Version>1.25.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
## Summary

Bugfixes:

 - Usage report transport type is wrong for QUIC
 - Discovery server keeps duplicate entries
 - Web GUI loses config changes when doing multiple modifications (e.g. on slow hardware or remotely)
 - panic: counter cannot decrease in value
 - Hashed passwords via API are hashed again

Enhancements:

 - Use multiple simultaneous TCP connections
 - Move footer links to header

**Full release notes:**
- [1.25.0](https://github.com/syncthing/syncthing/releases/tag/v1.25.0)

## Test Plan:

- Loaded the syncthing web UI, verified I can see shares and UI works normally
- Exercised Syncthing-GTK
- Verified that a file shared between the local machine and a remote machine syncs

## Checklist

- [x] Package was built and tested against unstable
