### PR TITLE
man-pages: update to 6.05.01

### DIFF
--- a/packages/m/man-pages/package.yml
+++ b/packages/m/man-pages/package.yml
@@ -1,13 +1,14 @@
 name       : man-pages
-version    : '6.04'
-release    : 17
+version    : 6.05.01
+release    : 18
 source     :
-    - https://mirrors.edge.kernel.org/pub/linux/docs/man-pages/man-pages-6.04.tar.xz : c2c0b9329955df81af45ee80ebc84c47291f95df5157db1fab988199f9371af1
+    - https://mirrors.edge.kernel.org/pub/linux/docs/man-pages/man-pages-6.05.01.tar.xz : b96ab6b44a688c91d1b572e52fece519e1cfd2bb4c33fe7014fc3fd1ef3f9cae
 license    :
     - BSD-3-Clause
     - GPL-1.0-or-later
     - GPL-2.0-or-later
     - MIT
+homepage   : https://www.kernel.org/doc/man-pages/
 component  : system.utils
 summary    : Linux manual pages
 description: |
@@ -21,4 +22,6 @@ install    : |
     # Remove conflicting files
     while read -r conflict; do
         rm -v $installdir/usr/share/man/$conflict
-    done -i $pkgfiles/man_conflicts
+    done < $pkgfiles/man_conflicts
+patterns  :
+    - /*

--- a/packages/m/man-pages/pspec_x86_64.xml
+++ b/packages/m/man-pages/pspec_x86_64.xml
@@ -1,6 +1,7 @@
 <PISI>
     <Source>
         <Name>man-pages</Name>
+        <Homepage>https://www.kernel.org/doc/man-pages/</Homepage>
         <Packager>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>
@@ -209,6 +210,7 @@
             <Path fileType="man">/usr/share/man/man2/ioctl_getfsmap.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/ioctl_iflags.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/ioctl_ns.2.gz</Path>
+            <Path fileType="man">/usr/share/man/man2/ioctl_pipe.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/ioctl_tty.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/ioctl_userfaultfd.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/ioperm.2.gz</Path>
@@ -2356,6 +2358,7 @@
             <Path fileType="man">/usr/share/man/man5/core.5.gz</Path>
             <Path fileType="man">/usr/share/man/man5/dir_colors.5.gz</Path>
             <Path fileType="man">/usr/share/man/man5/elf.5.gz</Path>
+            <Path fileType="man">/usr/share/man/man5/erofs.5.gz</Path>
             <Path fileType="man">/usr/share/man/man5/filesystems.5.gz</Path>
             <Path fileType="man">/usr/share/man/man5/fs.5.gz</Path>
             <Path fileType="man">/usr/share/man/man5/ftpusers.5.gz</Path>
@@ -2576,9 +2579,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2023-04-20</Date>
-            <Version>6.04</Version>
+        <Update release="18">
+            <Date>2023-10-06</Date>
+            <Version>6.05.01</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Release notes:
- [6.05](https://www.spinics.net/lists/kernel/msg4883220.html)
- [6.05.01](https://www.spinics.net/lists/kernel/msg4885689.html)

Packaging changes: Added homepage, added pattern so `man3` folder isn't split off, fixed issue with redirection

**Test Plan**
- Looked at a number of man pages

**Checklist**

- [x] Package was built and tested against unstable
