### PR TITLE
python-maturin: update to 1.3.0

### DIFF
--- a/packages/py/python-maturin/package.yml
+++ b/packages/py/python-maturin/package.yml
@@ -1,8 +1,8 @@
 name       : python-maturin
-version    : 1.2.3
-release    : 36
+version    : 1.3.0
+release    : 37
 source     :
-    - https://github.com/PyO3/maturin/archive/refs/tags/v1.2.3.tar.gz : 61e119a3d9b8f8083b7765236bc52afe779a0c2ae8c3aebc9e52d36560733772
+    - https://github.com/PyO3/maturin/archive/refs/tags/v1.3.0.tar.gz : bee17a7c744d1f4a30477d4437adba5c97e31e989388a7946be205d0e9bcb9bf
 license    :
     - Apache-2.0
     - MIT
@@ -17,7 +17,6 @@ builddeps  :
     - python-setuptools-rust
     - python-tomli
 build      : |
-    export MATURIN_SETUP_ARGS="--features full,rustls"
     %python3_setup
 install    : |
     %python3_install

--- a/packages/py/python-maturin/pspec_x86_64.xml
+++ b/packages/py/python-maturin/pspec_x86_64.xml
@@ -22,12 +22,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/maturin</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.2.3-py3.10.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.2.3-py3.10.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.2.3-py3.10.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.2.3-py3.10.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.2.3-py3.10.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.2.3-py3.10.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.0-py3.10.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.0-py3.10.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.0-py3.10.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.0-py3.10.egg-info/not-zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.0-py3.10.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.0-py3.10.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/maturin/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/maturin/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/maturin/__pycache__/__init__.cpython-310.pyc</Path>
@@ -37,9 +37,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2023-09-17</Date>
-            <Version>1.2.3</Version>
+        <Update release="37">
+            <Date>2023-10-07</Date>
+            <Version>1.3.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Better cross-compilation interpreter error
- Refactor Cargo sdist generator to avoid rewriting local dependencie
- Ignore sdist output files when building sdist
- Don't require `uniffi-bindgen` to be installed for uniffi bindings
- Fix python 3.7 compatibility
- Added `--pip-path` argument to `develop`
- Disable user site when running `get_interpreter_metadata.py`
- Fix platform tag for graalpy
- Always set minor version to 0 when major version >= 11 for macOS
- Warn about incorrect version in `build-system.requires`

**Test Plan**

- Built `python-orjson`

**Checklist**

- [x] Package was built and tested against unstable
