### PR TITLE
font-util: update to 1.4.1

### DIFF
--- a/packages/f/font-util/package.yml
+++ b/packages/f/font-util/package.yml
@@ -1,14 +1,14 @@
 name       : font-util
-version    : 1.4.0
-release    : 7
+version    : 1.4.1
+release    : 8
 source     :
-    - https://www.x.org/releases/individual/font/font-util-1.4.0.tar.gz : 30b90fe52347916be9b08f95f717f17c9c1f58bef8cabb49014d0fdd2b0df643
+    - https://www.x.org/releases/individual/font/font-util-1.4.1.tar.gz : f029ae80cdd75d89bee7f7af61c21e07982adfb9f72344a158b99f91f77ef5ed
 license    :
-    - MIT
-    - BSD-2-Clause-NetBSD
-    - BSD-2-Clause
-    - MIT-open-group
-    - Unicode-TOU
+    - BSD-2-Clause # bdftruncate.c
+    - BSD-2-Clause-NetBSD # ucs2any
+    - MIT # fontutil.m4.in
+    - MIT-open-group # fontutil.m4.in, Makefile.am, configure.ac
+    - Unicode-TOU # character maps
 component  : xorg.fonts
 homepage   : https://xorg.freedesktop.org
 summary    : X.Org fonts font-util

--- a/packages/f/font-util/pspec_x86_64.xml
+++ b/packages/f/font-util/pspec_x86_64.xml
@@ -6,9 +6,9 @@
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
-        <License>MIT</License>
-        <License>BSD-2-Clause-NetBSD</License>
         <License>BSD-2-Clause</License>
+        <License>BSD-2-Clause-NetBSD</License>
+        <License>MIT</License>
         <License>MIT-open-group</License>
         <License>Unicode-TOU</License>
         <PartOf>xorg.fonts</PartOf>
@@ -54,7 +54,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="7">font-util</Dependency>
+            <Dependency release="8">font-util</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/lib64/pkgconfig/fontutil.pc</Path>
@@ -62,9 +62,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2023-02-22</Date>
-            <Version>1.4.0</Version>
+        <Update release="8">
+            <Date>2023-10-07</Date>
+            <Version>1.4.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

This release contains no functional changes, only license clarifications

Release notes available [here](https://lists.x.org/archives/xorg-announce/2023-September/003418.html)

Packaging change: Sorted licenses and added comments

**Test Plan**
- Truncated the GNU Unifont .bdf using `bdftruncate`

**Checklist**

- [x] Package was built and tested against unstable
