### PR TITLE
buildserver-notification: also use tags from pspec.xml

### DIFF
--- a/common/Scripts/buildserver-notification.sh
+++ b/common/Scripts/buildserver-notification.sh
@@ -17,7 +17,12 @@ if [[ ! -z "${DISABLE_BUILD_SUCCESS_NOTIFY}" ]]; then
     echo "Notification and sound ping for build success disabled due to DISABLE_BUILD_SUCCESS_NOTIFY being set."
 fi
 
-TAG=$($(git rev-parse --show-toplevel)/common/Scripts/gettag.py package.yml)
+if [ -f "package.yml" ]; then
+    TAG=$($(git rev-parse --show-toplevel)/common/Scripts/gettag.py package.yml)
+else
+    TAG=$($(git rev-parse --show-toplevel)/common/Scripts/gettag.py pspec.xml)
+fi
+
 BUILDSERVER_URL="https://build.getsol.us"
 BUILDPAGE="/tmp/buildpage.html"
 


### PR DESCRIPTION
**Summary**

This makes the notification script create a tag from `pspec.xml` if `package.yml` doesn't exist, so it works for legacy packages.
(one of the two is guaranteed to exist by the notify-complete go-task precondition

**Test Plan**
- Tested with a `package.yml`
- Tested with a `pspec.xml`

**Checklist**

- [N/A] Package was built and tested against unstable
