### PR TITLE
kitty: Update to 0.30.1

### DIFF
--- a/packages/k/kitty/package.yml
+++ b/packages/k/kitty/package.yml
@@ -1,8 +1,8 @@
 name       : kitty
-version    : 0.30.0
-release    : 56
+version    : 0.30.1
+release    : 57
 source     :
-    - https://github.com/kovidgoyal/kitty/releases/download/v0.30.0/kitty-0.30.0.tar.xz : aac6b6a593ef55a41b93bb87eff551042a68046f8dbe6909b6a7522853be06a6
+    - https://github.com/kovidgoyal/kitty/releases/download/v0.30.1/kitty-0.30.1.tar.xz : 42c4ccfb601f830fbf42b7cb23d545f0f775010f26abe1b969b8346290e9d68b
 license    : GPL-3.0-only
 component  : system.utils
 homepage   : https://sw.kovidgoyal.net/kitty/

--- a/packages/k/kitty/pspec_x86_64.xml
+++ b/packages/k/kitty/pspec_x86_64.xml
@@ -13,7 +13,7 @@
 
 Kitty is designed from the ground up to support all modern terminal features, such as unicode, true color, bold/italic fonts, text formatting, etc. It even extends existing text formatting escape codes, to add support for features not available elsewhere, such as colored and styled (curly) underlines. One of the design goals of Kitty is to be easily extensible so that new features can be added in the future with relatively less effort.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>kitty</Name>
@@ -697,9 +697,9 @@ Kitty is designed from the ground up to support all modern terminal features, su
         </Files>
     </Package>
     <History>
-        <Update release="56">
-            <Date>2023-09-28</Date>
-            <Version>0.30.0</Version>
+        <Update release="57">
+            <Date>2023-10-08</Date>
+            <Version>0.30.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
## Summary
- Shell integration: Automatically alias sudo to make the kitty terminfo files available in the sudo environment. Can be turned off via shell_integration
- ssh kitten: Fix a regression in 0.28.0 that caused using --kitten to override ssh.conf not inheriting settings from ssh.conf
- themes kitten: Allow absolute paths for --config-file-name
- Expand environment variables in the shell option
- X11: Fix a crash on startup when the ibus service returns errors and the GLFW_IM_MODULE env var is set to ibus
- [changelog](https://sw.kovidgoyal.net/kitty/changelog/#id1)

## Test Plan
- run htop

## Checklist
- [X] Package was built and tested against unstable
