### PR TITLE
ci: cleanup and add check for bumped packages

### DIFF
--- a/.github/workflows/package_lint.yml
+++ b/.github/workflows/package_lint.yml
@@ -14,5 +14,5 @@ jobs:
     - name: Check out repository code
       uses: actions/checkout@v4
       with:
-        fetch-depth: 2
+        fetch-depth: 0
     - run: common/CI/package_checks.py --base=origin/${{ github.event.pull_request.base.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ common/switch_repo_domains
 
 # Python caches
 .mypy_cache
+venv

--- a/common/CI/package_checks.py
+++ b/common/CI/package_checks.py
@@ -150,6 +150,7 @@ class Homepage(PullRequestCheck):
 
 class PackageBumped(PullRequestCheck):
     _msg = 'Package release is not incremented by 1'
+    _msg_new = 'Package release is not 1'
     _level = Level.WARNING
 
     def run(self) -> List[Result]:
@@ -159,16 +160,19 @@ class PackageBumped(PullRequestCheck):
         return [result for result in results if result is not None]
 
     def _check_commit(self, base: str, file: str) -> Optional[Result]:
+        new = self.load_package_yml(file)
+
         try:
             old = self.load_package_yml_from_commit(base, file)
-            new = self.load_package_yml(file)
-
             if int(old['release']) + 1 != int(new['release']):
                 return Result(level=self._level, file=file, message=self._msg)
 
             return None
         except Exception as e:
             if 'exists on disk, but not in' in str(e):
+                if int(new['release']) != 1:
+                    return Result(level=self._level, file=file, message=self._msg_new)
+
                 return None
 
             raise e

--- a/common/CI/package_checks.py
+++ b/common/CI/package_checks.py
@@ -102,9 +102,13 @@ class PullRequestCheck:
     def run(self) -> List[Result]:
         raise NotImplementedError
 
-    @staticmethod
-    def _filter_packages(files: List[str]) -> List[str]:
-        return [f for f in files if os.path.basename(f) in PullRequestCheck._package_files]
+    @property
+    def package_files(self) -> List[str]:
+        return self._filter_packages(self.files)
+
+    def _filter_packages(self, files: List[str]) -> List[str]:
+        return [f for f in files
+                if os.path.basename(f) in self._package_files]
 
     def _path(self, path: str) -> str:
         return os.path.join(self.git.root, path)
@@ -119,7 +123,7 @@ class Homepage(PullRequestCheck):
 
     def run(self) -> List[Result]:
         return [Result(message=self._error, file=f, level=self._level)
-                for f in self._filter_packages(self.files)
+                for f in self.package_files
                 if not self._includes_homepage(f)]
 
     def _includes_homepage(self, file: str) -> bool:
@@ -133,7 +137,7 @@ class PackageDirectory(PullRequestCheck):
     _level = Level.ERROR
 
     def run(self) -> List[Result]:
-        paths = [os.path.dirname(f) for f in self._filter_packages(self.files)]
+        paths = [os.path.dirname(f) for f in self.package_files]
 
         return [Result(message=self._error, file=path, level=self._level) for path in paths
                 if not self._check_path(path)]
@@ -158,7 +162,7 @@ class Patch(PullRequestCheck):
     _level = Level.ERROR
 
     def run(self) -> List[Result]:
-        return [r for f in self._filter_packages(self.files)
+        return [r for f in self.package_files
                 for r in self._wrong_patch(f)]
 
     def _wrong_patch(self, file: str) -> List[Result]:
@@ -189,7 +193,7 @@ class Pspec(PullRequestCheck):
     _level = Level.ERROR
 
     def run(self) -> List[Result]:
-        paths = [os.path.dirname(f) for f in self._filter_packages(self.files)]
+        paths = [os.path.dirname(f) for f in self.package_files]
 
         return [Result(message=self._error, file=os.path.join(path, 'pspec_x86_64.xml'), level=self._level)
                 for path in paths


### PR DESCRIPTION
**Summary**

- Perform an extensive cleanup of the package checks script
- Add a linter to check if a package has been bumped *once*. This is set as a warning, so it doesn't interfere with PRs that do not require rebuilds.

**Test Plan**

See [this test PR](https://github.com/silkeh/packages/pull/4/files#diff-fd36bdf870f06c81d1e087aca13513b1e87ec59e451f02eeee4e591e31a5992a).

**Checklist**

- [x] ~~Package was built and tested against unstable~~ n/a
