### PR TITLE
languagetool: Update to 6.3

### DIFF
--- a/packages/l/languagetool/package.yml
+++ b/packages/l/languagetool/package.yml
@@ -1,8 +1,9 @@
 name       : languagetool
-version    : '6.2'
-release    : 7
+version    : '6.3'
+release    : 8
 source     :
-    - git|https://github.com/languagetool-org/languagetool.git : v6.2
+    - https://github.com/languagetool-org/languagetool/archive/refs/tags/v6.3-branch.tar.gz : c15c0dbb9ef889e40e7d88129f90e1570319904214f27d707c92577ab8865c86
+homepage   : https://languagetool.org
 license    : LGPL-2.1-only
 component  : office.viewers
 summary    : Style and Grammar Checker for 25+ Languages
@@ -18,7 +19,7 @@ environment: |
     JAVA_HOME=/usr/lib64/openjdk-17
     PATH=$JAVA_HOME/bin:$PATH
 build      : |
-    $workdir/build.sh languagetool-standalone package -DskipTests -Dmaven.repo.local=$workdir/.m2
+    $workdir/build.sh languagetool-standalone package -DskipTests -Dmaven.repo.local=$workdir/.m2 -Dmaven.gitcommitid.skip=true
 install    : |
     install -dDm00755 $installdir/usr/share/languagetool/{libs,META-INF,org}
     cp $workdir/languagetool-standalone/target/LanguageTool-$version/LanguageTool-$version/*.jar $installdir/usr/share/languagetool/

--- a/packages/l/languagetool/pspec_x86_64.xml
+++ b/packages/l/languagetool/pspec_x86_64.xml
@@ -1,6 +1,7 @@
 <PISI>
     <Source>
         <Name>languagetool</Name>
+        <Homepage>https://languagetool.org</Homepage>
         <Packager>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>
@@ -10,7 +11,7 @@
         <Summary xml:lang="en">Style and Grammar Checker for 25+ Languages</Summary>
         <Description xml:lang="en">LanguageTool is an Open Source proofreading software for English, French, German, Polish, Russian, and more than 20 other languages. It finds many errors that a simple spell checker cannot detect.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>languagetool</Name>
@@ -108,6 +109,7 @@
             <Path fileType="data">/usr/share/languagetool/libs/commons-pool2.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/commons-text.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/commons-validator.jar</Path>
+            <Path fileType="data">/usr/share/languagetool/libs/dutch-pos-dict.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/ecs-logging-core.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/emoji-java.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/error_prone_annotations.jar</Path>
@@ -137,21 +139,10 @@
             <Path fileType="data">/usr/share/languagetool/libs/java-diff-utils.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/javax.activation-api.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/javax.annotation-api.jar</Path>
-            <Path fileType="data">/usr/share/languagetool/libs/javax.servlet-api.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/jaxb-api.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/jaxb-core.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/jaxb-runtime.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/jcommander.jar</Path>
-            <Path fileType="data">/usr/share/languagetool/libs/jetty-client.jar</Path>
-            <Path fileType="data">/usr/share/languagetool/libs/jetty-http.jar</Path>
-            <Path fileType="data">/usr/share/languagetool/libs/jetty-io.jar</Path>
-            <Path fileType="data">/usr/share/languagetool/libs/jetty-security.jar</Path>
-            <Path fileType="data">/usr/share/languagetool/libs/jetty-server.jar</Path>
-            <Path fileType="data">/usr/share/languagetool/libs/jetty-servlet.jar</Path>
-            <Path fileType="data">/usr/share/languagetool/libs/jetty-util-ajax.jar</Path>
-            <Path fileType="data">/usr/share/languagetool/libs/jetty-util.jar</Path>
-            <Path fileType="data">/usr/share/languagetool/libs/jetty-webapp.jar</Path>
-            <Path fileType="data">/usr/share/languagetool/libs/jetty-xml.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/jna-platform.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/jna.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/json.jar</Path>
@@ -219,7 +210,6 @@
             <Path fileType="data">/usr/share/languagetool/libs/simpleclient_tracer_otel_agent.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/slf4j-api.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/spanish-pos-dict.jar</Path>
-            <Path fileType="data">/usr/share/languagetool/libs/spark-core.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/stax-ex.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/trove4j.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/txw2.jar</Path>
@@ -227,11 +217,6 @@
             <Path fileType="data">/usr/share/languagetool/libs/uom-lib-common.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/vavr-match.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/vavr.jar</Path>
-            <Path fileType="data">/usr/share/languagetool/libs/websocket-api.jar</Path>
-            <Path fileType="data">/usr/share/languagetool/libs/websocket-client.jar</Path>
-            <Path fileType="data">/usr/share/languagetool/libs/websocket-common.jar</Path>
-            <Path fileType="data">/usr/share/languagetool/libs/websocket-server.jar</Path>
-            <Path fileType="data">/usr/share/languagetool/libs/websocket-servlet.jar</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/MessagesBundle_ar.properties</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/MessagesBundle_ast.properties</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/MessagesBundle_be.properties</Path>
@@ -283,10 +268,12 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/BalearicCatalan.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/Belarusian.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/BelgianDutch.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/language/BelgianFrench.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/BrazilianPortuguese.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/Breton.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/BritishEnglish.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/CanadianEnglish.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/language/CanadianFrench.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/Catalan.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/Chinese.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/Danish.class</Path>
@@ -319,6 +306,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/Spanish.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/SpanishVoseo.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/Swedish.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/language/SwissFrench.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/SwissGerman.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/Tagalog.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/Tamil.class</Path>
@@ -409,6 +397,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ca/compounds.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ca/disambiguation.xml</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ca/do-not-synthesize.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ca/entities.ent</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ca/hunspell/ignore.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ca/hunspell/prohibit.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ca/multiwords.txt</Path>
@@ -439,6 +428,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/case_rule_exceptions.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/common_words.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/compound-cities.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/compound_exceptions.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/compounds.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/confusion_set_candidates.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/confusion_sets.txt</Path>
@@ -483,6 +473,8 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/spelling_correction_model.bin</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/tagset.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/word_definitions.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/words_infix_s.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/words_no_infix_s.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/el/README.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/el/added.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/el/added_custom.txt</Path>
@@ -590,6 +582,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/confusion_set_candidates.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/confusion_sets.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/disambiguation.xml</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/entities.ent</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/es.sor</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/etiquetas-eagles.md</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/hunspell/prohibit.txt</Path>
@@ -700,27 +693,18 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/km/removed.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/km/removed_custom.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/km/tagset.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/README.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/added.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/added_custom.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/common_words.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/compounds.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/confusion_sets.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/disambiguation.xml</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/dutch.dict</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/dutch.info</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/dutch_synth.dict</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/dutch_synth.info</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/dutch_tags.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/multipartcompounds.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/nl.sor</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/preferredwords.csv</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/removed.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/removed_custom.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/spelling/README.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/spelling/ignore.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/spelling/nl_NL.dict</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/spelling/nl_NL.info</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/spelling/prohibit.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/spelling/spelling.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/tagset.csv</Path>
@@ -749,9 +733,19 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/added_custom.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/blacklist.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/common_words.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/compound_colours.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/confusion_set_candidates.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/confusion_sets.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/disambiguation.xml</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/entities/abbrev.ent</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/entities/datetime.ent</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/entities/hyphenised.ent</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/entities/languages.ent</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/entities/messages.ent</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/entities/misc.ent</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/entities/paronyms.ent</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/entities/postal.ent</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/entities/verbs.ent</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/hunspell/README_pt_AO.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/hunspell/README_pt_BR.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/hunspell/README_pt_MZ.txt</Path>
@@ -864,16 +858,22 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/sv/added_custom.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/sv/common_words.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/sv/compounds.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/sv/disambiguation.xml</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/sv/hunspell/LICENSE_en_US.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/sv/hunspell/LICENSE_sv_SE.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/sv/hunspell/ignore.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/sv/hunspell/spelling.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/sv/hunspell/sv_SE.aff</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/sv/hunspell/sv_SE.dic</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/sv/multiwords.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/sv/removed.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/sv/removed_custom.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/sv/sv.sor</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/sv/swedish.dict</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/sv/swedish.info</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/sv/swedish_synth.dict</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/sv/swedish_synth.dict_tags.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/sv/swedish_synth.info</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/sv/tagset.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ta/README.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ta/added.txt</Path>
@@ -908,6 +908,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/uk/dash_left_master.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/uk/dash_prefixes.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/uk/dash_prefixes_invalid.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/uk/derivats.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/uk/disambig_dups.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/uk/disambig_remove.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/uk/disambiguation.xml</Path>
@@ -980,6 +981,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/AbstractSimpleReplaceLemmasRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/AdjustPronounsFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/AdvancedSynthesizerFilter.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/AnarASuggestionsFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/CatalanNumberInWordFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/CatalanNumberSpellerFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/CatalanRepeatedWordsRule.class</Path>
@@ -996,13 +998,17 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/DateCheckFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/DateFilterHelper.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/DiacriticsCheckFilter.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/DonarTempsSuggestionsFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/FindSuggestionsEsFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/FindSuggestionsFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/MorfologikCatalanSpellerRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/NewYearDateFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/OblidarseSugestionsFilter.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/PortarTempsSuggestionsFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/PostponedAdjectiveConcordanceFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/PronomFebleDuplicateRule.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/PronomsFeblesHelper$PronounPosition.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/PronomsFeblesHelper.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/ReplaceOperationNamesRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/SimpleReplaceAdverbsMent.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/SimpleReplaceAnglicism.class</Path>
@@ -1018,6 +1024,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/SimpleReplaceRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/SimpleReplaceVerbsRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/SuppressIfAnyRuleMatchesFilter.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/SynthesizeWithDeterminerFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/TextToNumberFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/ca-ES-valencia/grammar.xml</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/check_case.txt</Path>
@@ -1100,8 +1107,8 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/PotentialCompoundFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/PrepositionToCases$Case.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/PrepositionToCases.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/ProhibitedCompoundRule$1.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/ProhibitedCompoundRule$Pair.class</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/ProhibitedCompoundRule$SpecificIdRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/ProhibitedCompoundRule$WeightedRuleMatch.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/ProhibitedCompoundRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/RecentYearFilter.class</Path>
@@ -1170,10 +1177,10 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/CompoundRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/ConsistentApostrophesRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/ContractionSpellingRule.class</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/ConvertToSentenceCaseFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/DateCheckFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/DateFilterHelper.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/EnglishConfusionProbabilityRule.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/EnglishConvertToSentenceCaseFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/EnglishDashRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/EnglishDiacriticsRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/EnglishForDutchmenFalseFriendRule.class</Path>
@@ -1300,7 +1307,6 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/fa/replace.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/fr/AdvancedSynthesizerFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/fr/CompoundRule.class</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/fr/ConvertToSentenceCaseFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/fr/DMYDateCheckFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/fr/DateCheckFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/fr/DateFilterHelper.class</Path>
@@ -1442,6 +1448,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/PortugueseArchaismsRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/PortugueseBarbarismsRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/PortugueseClicheRule.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/PortugueseColourHyphenationRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/PortugueseConfusionProbabilityRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/PortugueseDiacriticsRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/PortugueseFillerWordsRule.class</Path>
@@ -1463,17 +1470,12 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/PreReformPortugueseCompoundRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/PreReformPortugueseDashRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/RegularIrregularParticipleFilter.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/RomanNumeralFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/YMDDateCheckFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/YMDNewYearDateFilter.class</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/archaisms-pt-BR.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/archaisms-pt-PT.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/archaisms-pt.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/barbarisms-pt-BR.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/barbarisms-pt-PT.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/barbarisms-pt.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/cliches-pt-BR.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/cliches-pt-PT.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/cliches-pt.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/archaisms.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/barbarisms.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/cliches.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/coherency.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/confusion_pairs.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/diacritics.txt</Path>
@@ -1482,16 +1484,28 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/indent.sh</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/not_optimized_regexps.lib</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-AO/grammar.xml</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-BR/archaisms.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-BR/barbarisms.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-BR/cliches.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-BR/confusion_pairs.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-BR/grammar.xml</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-BR/redundancies.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-BR/replace.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-BR/style.xml</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-BR/wikipedia.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-BR/wordiness.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-MZ/grammar.xml</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-PT/archaisms.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-PT/barbarisms.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-PT/cliches.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-PT/confusion_pairs.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-PT/grammar.xml</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-PT/redundancies.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-PT/replace.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-PT/style.xml</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/redundancies-pt-BR.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/redundancies-pt-PT.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/redundancies-pt.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-PT/wikipedia.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/pt-PT/wordiness.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/redundancies.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/remote-rule-filters.xml</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/replace.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/style.xml</Path>
@@ -1499,12 +1513,8 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/verbos_sem_acento_adj_com_acento.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/verbos_sem_acento_nomes_com_acento.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/weaselwords.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/wikipedia-pt-BR.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/wikipedia-pt-PT.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/wikipedia-pt.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/wordiness-pt-BR.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/wordiness-pt-PT.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/wordiness-pt.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/wikipedia.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/wordiness.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/wrongWordInContext.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ro/CompoundRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ro/MorfologikRomanianSpellerRule.class</Path>
@@ -1547,6 +1557,8 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/sl/MorfologikSlovenianSpellerRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/sl/grammar.xml</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/sv/CompoundRule.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/sv/WordCoherencyRule.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/sv/coherency.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/sv/grammar.xml</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ta/grammar.xml</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/tl/grammar.xml</Path>
@@ -1628,6 +1640,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/synthesis/ro/RomanianSynthesizer.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/synthesis/ru/RussianSynthesizer.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/synthesis/sk/SlovakSynthesizer.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/synthesis/sv/SwedishSynthesizer.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/synthesis/uk/UkrainianSynthesizer.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/ar/ArabicHybridDisambiguator.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/ar/ArabicTagManager.class</Path>
@@ -1662,6 +1675,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/disambiguation/ru/RussianHybridDisambiguator.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/disambiguation/rules/de/GermanRuleDisambiguator.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/disambiguation/rules/it/ItalianRuleDisambiguator.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/disambiguation/sv/SwedishHybridDisambiguator.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/disambiguation/uk/SimpleDisambiguator$MatcherEntry.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/disambiguation/uk/SimpleDisambiguator$TokenMatcher.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/disambiguation/uk/SimpleDisambiguator.class</Path>
@@ -1732,9 +1746,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2023-07-02</Date>
-            <Version>6.2</Version>
+        <Update release="8">
+            <Date>2023-10-08</Date>
+            <Version>6.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
## Summary
- added and improved Catalan rules
- added and improved Dutch rules
- added and improved English rules
- updated [en_GB spellchecker](https://github.com/marcoagpinto/aoo-mozilla-en-dict) to v.3.2.1
- added and improved French rules
- added and improved German rules
- extended German dictionary
- added and improved Portuguese rules
- added and improved Spanish rules
- Ukrainian tagging and disambiguation improvements
- new rules and words in Ukrainian POS dictionary
- [changelog](https://raw.githubusercontent.com/languagetool-org/languagetool/v6.3-branch/languagetool-standalone/CHANGES.md)

## Test Plan
JAVA_HOME=/usr/lib64/openjdk-17 languagetool

## Checklist
- [X] Package was built and tested against unstable
- [X] Release [announcement](https://forum.languagetool.org/t/ann-languagetool-6-3/9358)
