### PR TITLE
zsh-autosuggestions: Inclusion of homepage

### DIFF
--- a/packages/z/zsh-autosuggestions/package.yml
+++ b/packages/z/zsh-autosuggestions/package.yml
@@ -1,8 +1,9 @@
 name       : zsh-autosuggestions
 version    : 0.7.0
-release    : 5
+release    : 6
 source     :
     - https://github.com/zsh-users/zsh-autosuggestions/archive/v0.7.0.tar.gz : ccd97fe9d7250b634683c651ef8a2fe3513ea917d1b491e8696a2a352b714f08
+homepage   : https://github.com/zsh-users/zsh-autosuggestions
 license    : MIT
 component  : system.utils
 summary    : Fish-like autosuggestions for zsh

--- a/packages/z/zsh-autosuggestions/pspec_x86_64.xml
+++ b/packages/z/zsh-autosuggestions/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>zsh-autosuggestions</Name>
+        <Homepage>https://github.com/zsh-users/zsh-autosuggestions</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">Fish-like autosuggestions for zsh</Summary>
         <Description xml:lang="en">Fish-like fast/unobtrusive autosuggestions for zsh. It suggests commands as you type, based on command history.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>zsh-autosuggestions</Name>
@@ -25,12 +26,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2021-08-22</Date>
+        <Update release="6">
+            <Date>2023-10-10</Date>
             <Version>0.7.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Adding `homepage` key to `package.yml`
- Part of #411

**Test Plan**

- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built against unstable