### PR TITLE
libvirt: Enable firewalld support

### DIFF
--- a/packages/l/libvirt/abi_used_symbols
+++ b/packages/l/libvirt/abi_used_symbols
@@ -309,6 +309,7 @@ libgio-2.0.so.0:g_dbus_connection_close_sync
 libgio-2.0.so.0:g_dbus_connection_flush_sync
 libgio-2.0.so.0:g_dbus_connection_new_for_address_sync
 libgio-2.0.so.0:g_dbus_connection_signal_subscribe
+libgio-2.0.so.0:g_dbus_connection_signal_unsubscribe
 libgio-2.0.so.0:g_dbus_error_get_remote_error
 libgio-2.0.so.0:g_dbus_error_is_remote_error
 libgio-2.0.so.0:g_dbus_message_get_interface

--- a/packages/l/libvirt/package.yml
+++ b/packages/l/libvirt/package.yml
@@ -1,6 +1,6 @@
 name       : libvirt
 version    : 9.7.0
-release    : 61
+release    : 62
 source     :
     - https://libvirt.org/sources/libvirt-9.7.0.tar.xz : d8c758fe7db640f572489caa8ea6dd8262d169a4372326c23a3a013cdc40b8ce
 license    :
@@ -45,7 +45,7 @@ setup      : |
         -Ddriver_libvirtd=enabled \
         -Ddriver_network=enabled \
         -Ddriver_qemu=enabled \
-        -Dfirewalld=disabled \
+        -Dfirewalld=enabled \
         -Dinit_script='systemd' \
         -Drunstatedir='/run' \
         -Dselinux=disabled \

--- a/packages/l/libvirt/pspec_x86_64.xml
+++ b/packages/l/libvirt/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libvirt</Name>
         <Homepage>https://libvirt.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -12,7 +12,7 @@
         <Summary xml:lang="en">Library providing a simple virtualization API</Summary>
         <Description xml:lang="en">A toolkit to interact with the virtualization capabilities of recent versions of Linux
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>libvirt</Name>
@@ -99,6 +99,11 @@
             <Path fileType="executable">/usr/bin/virt-qemu-sev-validate</Path>
             <Path fileType="executable">/usr/bin/virt-ssh-helper</Path>
             <Path fileType="executable">/usr/bin/virt-xml-validate</Path>
+            <Path fileType="library">/usr/lib/firewalld/policies/libvirt-routed-in.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/policies/libvirt-routed-out.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/policies/libvirt-to-host.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/zones/libvirt-routed.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/zones/libvirt.xml</Path>
             <Path fileType="library">/usr/lib/sysctl.d/60-libvirtd.conf</Path>
             <Path fileType="library">/usr/lib/sysctl.d/60-qemu-postcopy-migration.conf</Path>
             <Path fileType="library">/usr/lib/systemd/system/libvirt-guests.service</Path>
@@ -473,7 +478,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="61">libvirt</Dependency>
+            <Dependency release="62">libvirt</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libvirt/libvirt-admin.h</Path>
@@ -505,12 +510,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="61">
-            <Date>2023-09-17</Date>
+        <Update release="62">
+            <Date>2023-10-10</Date>
             <Version>9.7.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Enables support for Firewalld

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Create a new VM with virt-manager using the NAT network option

**Checklist**

- [x] Package was built and tested against unstable
