### PR TITLE
common: Allow dots in package names in new-package.sh

### DIFF
--- a/common/Scripts/new-package.sh
+++ b/common/Scripts/new-package.sh
@@ -20,8 +20,8 @@ fi
 YAUTO=$(git rev-parse --show-toplevel)/common/Scripts/yauto.py
 
 # Basic repo name linting check
-if [[ ! "${PACKAGE}" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
-    echo "Package names are restricted to US ASCII lowercase letters, numbers and dashes."
+if [[ ! "${PACKAGE}" =~ ^[a-z0-9.]+(-[a-z0-9.]+)*$ ]]; then
+    echo "Package names are restricted to US ASCII lowercase letters, numbers, dashes, and, dots."
     exit 1
 fi
 


### PR DESCRIPTION
**Summary**

Allows dots in package names when creating a new package

**Test Plan**

`go-task new cairomm-1.16 https://penisland.com/foobar.tar.gz`

**Checklist**

- [ ] Package was built and tested against unstable n/a
