### PR TITLE
python-orjson: update to 3.9.8

### DIFF
--- a/packages/py/python-orjson/abi_used_symbols
+++ b/packages/py/python-orjson/abi_used_symbols
@@ -7,6 +7,7 @@ UNKNOWN:PyCMethod_New
 UNKNOWN:PyCallable_Check
 UNKNOWN:PyCapsule_Import
 UNKNOWN:PyDict_New
+UNKNOWN:PyDict_Next
 UNKNOWN:PyErr_Clear
 UNKNOWN:PyErr_Fetch
 UNKNOWN:PyErr_NewException
@@ -44,7 +45,6 @@ UNKNOWN:PyUnicode_New
 UNKNOWN:_PyBytes_Resize
 UNKNOWN:_PyDict_Contains_KnownHash
 UNKNOWN:_PyDict_NewPresized
-UNKNOWN:_PyDict_Next
 UNKNOWN:_PyDict_SetItem_KnownHash
 UNKNOWN:_PyLong_AsByteArray
 UNKNOWN:_PyObject_MakeTpCall

--- a/packages/py/python-orjson/package.yml
+++ b/packages/py/python-orjson/package.yml
@@ -1,8 +1,8 @@
 name       : python-orjson
-version    : 3.9.7
-release    : 30
+version    : 3.9.8
+release    : 31
 source     :
-    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.9.7.tar.gz : 85e39198f78e2f7e054d296395f6c96f5e02892337746ef5b6a1bf3ed5910142
+    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.9.8.tar.gz : ed1adc6db9841974170a5195b827ee4e392b1e8ca385b19fcdc3248489844059
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-orjson/pspec_x86_64.xml
+++ b/packages/py/python-orjson/pspec_x86_64.xml
@@ -12,7 +12,7 @@
         <Summary xml:lang="en">Fast, correct Python JSON library</Summary>
         <Description xml:lang="en">Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>python-orjson</Name>
@@ -21,11 +21,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.7.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.7.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.7.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.7.dist-info/license_files/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.7.dist-info/license_files/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.8.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.8.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.8.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.8.dist-info/license_files/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.8.dist-info/license_files/LICENSE-MIT</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/orjson/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/orjson/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/orjson/__pycache__/__init__.cpython-310.opt-1.pyc</Path>
@@ -35,9 +35,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="30">
-            <Date>2023-09-17</Date>
-            <Version>3.9.7</Version>
+        <Update release="31">
+            <Date>2023-10-10</Date>
+            <Version>3.9.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Improve performance
- Drop support for Python 3.7

**Test Plan**
- Tested a number of examples from the project README

**Checklist**

- [x] Package was built and tested against unstable
