### PR TITLE
jet: Inclusion of homepage

### DIFF
--- a/packages/j/jet/package.yml
+++ b/packages/j/jet/package.yml
@@ -1,8 +1,9 @@
 name       : jet
 version    : 0.7.27
-release    : 5
+release    : 6
 source     :
     - https://github.com/borkdude/jet/archive/refs/tags/v0.7.27.tar.gz : 3e473b00acd80c2caf3eeb314b7d5db4c8553d301354d0647a68c8a5082ed8d2
+homepage   : https://github.com/borkdude/jet
 license    : EPL-1.0
 networking : yes
 component  : programming.tools

--- a/packages/j/jet/pspec_x86_64.xml
+++ b/packages/j/jet/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>jet</Name>
+        <Homepage>https://github.com/borkdude/jet</Homepage>
         <Packager>
-            <Name>Oliver Marks</Name>
-            <Email>oly@digitaloctave.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>EPL-1.0</License>
         <PartOf>programming.tools</PartOf>
         <Summary xml:lang="en">Transform EDN transit and json from the command line.</Summary>
         <Description xml:lang="en">CLI to transform between JSON, EDN and Transit, powered with a minimal query language.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>jet</Name>
@@ -23,12 +24,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2023-08-14</Date>
+        <Update release="6">
+            <Date>2023-10-11</Date>
             <Version>0.7.27</Version>
             <Comment>Packaging update</Comment>
-            <Name>Oliver Marks</Name>
-            <Email>oly@digitaloctave.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Adding `homepage` key to `package.yml`
- Part of #411

**Test Plan**

- Run package
- Test with example:
        - echo '{"a": 1}' | jet --from json --to edn 
        - echo '{"a": "hello there"}' | jet --from json --keywordize -t ":a symbol" --to edn
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built against unstable