### PR TITLE
gimp-help: update to  2.10.34 and added the homepage

### DIFF
--- a/packages/g/gimp-help/package.yml
+++ b/packages/g/gimp-help/package.yml
@@ -1,72 +1,169 @@
 name       : gimp-help
-version    : 2.10.0
-release    : 1
+version    : 2.10.34
+release    : 2
 source     :
-    - https://download.gimp.org/pub/gimp/help/gimp-help-2.10.0.tar.bz2 : 03804fed071b49e5810edd8327868659dfd9932fbf34d34189d56bd0ad539118
+    - https://download.gimp.org/pub/gimp/help/gimp-help-2.10.34.tar.bz2 : cae0adea6ffe47776f42dfc3a38f35d28e31893004e01812117af6f7fc897dc8
+homepage   : https://www.gimp.org/docs/
 license    :
     - GFDL-1.2-or-later
     - GPL-2.0-or-later
 component  :
     - multimedia.graphics
     - ca : multimedia.graphics
+    - cs : multimedia.graphics 
     - da : multimedia.graphics
     - de : multimedia.graphics
     - el : multimedia.graphics
+    - en_gb : multimedia.graphics
     - es : multimedia.graphics
+    - fa : multimedia.graphics
     - fi : multimedia.graphics
     - fr : multimedia.graphics
+    - hr : multimedia.graphics
+    - hu : multimedia.graphics
     - it : multimedia.graphics
     - ja : multimedia.graphics
     - ko : multimedia.graphics
+    - lt : multimedia.graphics
     - nl : multimedia.graphics
     - nn : multimedia.graphics
+    - pt : multimedia.graphics
     - pt_br : multimedia.graphics
     - ro : multimedia.graphics
     - ru : multimedia.graphics
+    - sl : multimedia.graphics
+    - sv : multimedia.graphics
+    - uk : multimedia.graphics
     - zh_cn : multimedia.graphics
-summary    :
-    - English help files for GIMP
+summary    :    
+    - English (US) help files for GIMP
     - ca : Catalan help files for GIMP
+    - cs : Czech help files for GIMP
     - da : Danish help files for GIMP
     - de : German help files for GIMP
     - el : Greek help files for GIMP
+    - en_gb : English (British) help files for GIMP
     - es : Spanish help files for GIMP
+    - fa : Persian help files for GIMP
     - fi : Finnish help files for GIMP
     - fr : French help files for GIMP
+    - hr : Croatian help files for GIMP
+    - hu : Hungarian help files for GIMP
     - it : Italian help files for GIMP
     - ja : Japanese help files for GIMP
     - ko : Korean help files for GIMP
+    - lt : Lithuanian help files for GIMP
     - nl : Dutch help files for GIMP
     - nn : Norwegian help files for GIMP
+    - pt : Portuguese help files for GIMP
     - pt_br : Brazilian Portuguese help files for GIMP
     - ro : Romanian help files for GIMP
     - ru : Russian help files for GIMP
-    - zn_cn : Simplified Chinese help files for GIMP
-description: |
-    Help files for GIMP
+    - sl : Slovenian help files for GIMP
+    - sv : Swedish help files for GIMP
+    - uk : Ukrainian help files for GIMP
+    - zh_cn : Simplified Chinese help files for GIMP
+description : |
+     Offline help files for GIMP. In the folder /usr/share/gimp/2.0/help/pdf you can find the Gimp Quickreferences. Not all translations are complete, Turkish and Polish are only present online.
 patterns   :
-    - ca : /usr/share/gimp/*/help/ca
-    - da : /usr/share/gimp/*/help/da
-    - de : /usr/share/gimp/*/help/de
-    - el : /usr/share/gimp/*/help/el
-    - es : /usr/share/gimp/*/help/es
-    - fi : /usr/share/gimp/*/help/fi
-    - fr : /usr/share/gimp/*/help/fr
-    - it : /usr/share/gimp/*/help/it
-    - ja : /usr/share/gimp/*/help/ja
-    - ko : /usr/share/gimp/*/help/ko
-    - nl : /usr/share/gimp/*/help/nl
-    - nn : /usr/share/gimp/*/help/nn
-    - pt_br : /usr/share/gimp/*/help/pt_BR
-    - ro : /usr/share/gimp/*/help/ro
-    - ru : /usr/share/gimp/*/help/ru
-    - zh_cn : /usr/share/gimp/*/help/zhC_N
+    - ca :
+          - /usr/share/gimp/*/help/ca
+          - /usr/share/gimp/*/help/pdf/gimp-keys-ca.pdf
+    - cs : 
+          - /usr/share/gimp/*/help/cs
+          - /usr/share/gimp/*/help/pdf/gimp-keys-cs.pdf
+    - da : 
+          - /usr/share/gimp/*/help/da
+          - /usr/share/gimp/*/help/pdf/gimp-keys-da.pdf
+    - de : 
+          - /usr/share/gimp/*/help/de
+          - /usr/share/gimp/*/help/pdf/gimp-keys-de.pdf
+    - el : 
+          - /usr/share/gimp/*/help/el
+          - /usr/share/gimp/*/help/pdf/gimp-keys-el.pdf
+    - en_gb : 
+          - /usr/share/gimp/*/help/en_GB
+          - /usr/share/gimp/*/help/pdf/gimp-keys-en_GB.pdf
+    - es :
+          - /usr/share/gimp/*/help/es
+          - /usr/share/gimp/*/help/pdf/gimp-keys-es.pdf
+    - fa :
+          - /usr/share/gimp/*/help/fa
+          - /usr/share/gimp/*/help/pdf/gimp-keys-fa.pdf
+    - fi : 
+          - /usr/share/gimp/*/help/fi
+          - /usr/share/gimp/*/help/pdf/gimp-keys-fi.pdf
+    - fr : 
+          - /usr/share/gimp/*/help/fr
+          - /usr/share/gimp/*/help/pdf/gimp-keys-fr.pdf
+    - hr :
+          - /usr/share/gimp/*/help/hr
+          - /usr/share/gimp/*/help/pdf/gimp-keys-hr.pdf
+    - hu : 
+          - /usr/share/gimp/*/help/hu
+          - /usr/share/gimp/*/help/pdf/gimp-keys-hu.pdf
+    - it :
+          - /usr/share/gimp/*/help/it
+          - /usr/share/gimp/*/help/pdf/gimp-keys-it.pdf
+    - ja : 
+          - /usr/share/gimp/*/help/ja
+          - /usr/share/gimp/*/help/pdf/gimp-keys-ja.pdf
+    - ko : 
+          - /usr/share/gimp/*/help/ko
+          - /usr/share/gimp/*/help/pdf/gimp-keys-ko.pdf
+    - lt : 
+          - /usr/share/gimp/*/help/lt
+          - /usr/share/gimp/*/help/pdf/gimp-keys-lt.pdf
+    - nl : 
+          - /usr/share/gimp/*/help/nl
+          - /usr/share/gimp/*/help/pdf/gimp-keys-nl.pdf
+    - nn : 
+          - /usr/share/gimp/*/help/nn
+          - /usr/share/gimp/*/help/pdf/gimp-keys-nn.pdf
+    #- pl : in 2.10.34 there is only the gimp-keys-pl
+    #      - /usr/share/gimp/*/help/pl
+    #      - /usr/share/gimp/*/help/pdf/gimp-keys-pl.pdf    
+    - pt :
+          - /usr/share/gimp/*/help/pt
+          - /usr/share/gimp/*/help/pdf/gimp-keys-pt.pdf
+    - pt_br :
+          - /usr/share/gimp/*/help/pt_BR
+          - /usr/share/gimp/*/help/pdf/gimp-keys-pt_BR.pdf
+    - ro : 
+          - /usr/share/gimp/*/help/ro
+          - /usr/share/gimp/*/help/pdf/gimp-keys-ro.pdf
+    - ru :
+          - /usr/share/gimp/*/help/ru
+          - /usr/share/gimp/*/help/pdf/gimp-keys-ru.pdf
+    - sl :
+          - /usr/share/gimp/*/help/sl
+          - /usr/share/gimp/*/help/pdf/gimp-keys-sl.pdf
+    - sv :
+          - /usr/share/gimp/*/help/sv
+          - /usr/share/gimp/*/help/pdf/gimp-keys-sv.pdf
+    - uk :
+          - /usr/share/gimp/*/help/uk
+          - /usr/share/gimp/*/help/pdf/gimp-keys-uk.pdf
+    - zh_cn :
+          - /usr/share/gimp/*/help/zh_CN
+          - /usr/share/gimp/*/help/pdf/gimp-keys-zh_CN.pdf
 builddeps  :
     - pkgconfig(gimp-2.0)
     - docbook-xml
+    #The following have been added to populate the Quickreferences
+    - pkgconfig(librsvg-2.0)
+    - font-noto-cjk
 setup      : |
     %configure
 build      : |
-    %make
+    # The memory demands for this build are very high. -j16 was observed consuming ~80GB of memory, more than the build server has.
+    # Limit the jobs to 8 so as to not overwhelm the build server.
+    MAX_JOBS=%YJOBS%
+    if [ $MAX_JOBS -gt 8 ]; then
+        MAX_JOBS=8
+    fi
+    make -j$MAX_JOBS
 install    : |
     %make_install
+    rm $installdir/usr/share/gimp/*/help/pdf/gimp-keys-pl.pdf
+


### PR DESCRIPTION
**Summary**  
- The inclusion of "homepage" to package.yml
- Part of https://github.com/getsolus/packages/issues/411
- Update to new  source version
- Added quickreferences in pdf format
- Added new languages
- Limit the jobs to 8 so as to not overwhelm the build server

**Test Plan**

- Launched with Gimp, checked the folder /usr/share/gimp/*/help/pdf/

**Checklist**

- [x] Packages was built and tested against unstable
