### PR TITLE
common: Add Fish helper scripts

### DIFF
--- a/common/Scripts/helpers.fish
+++ b/common/Scripts/helpers.fish
@@ -1,0 +1,35 @@
+#!/usr/bin/env fish
+function __solus_package_dir
+    realpath (dirname (readlink (status -f)))/../..
+end
+
+function __solus_toplevel
+    git rev-parse --show-toplevel
+end
+
+function gotosoluspkgs -d "Go to the root of the Solus packages repository"
+    cd (__solus_package_dir)
+end
+
+function goroot -d "Go to the root of the current Git repository"
+    cd (__solus_toplevel)
+end
+
+function gotopkg -a package -d "Go to a package directory"
+    cd (__solus_toplevel)/packages/*/$package
+end
+
+function whatprovides -a library -d "Show packages that provide a certain library"
+    path basename (path dirname (grep $library (__solus_toplevel)/packages/*/*/abi_libs))
+end
+
+function whatuses -a library -d "Show packages that use a certain library"
+    path basename (path dirname (grep $library (__solus_toplevel)/packages/*/*/abi_used_libs))
+end
+
+complete -c gotosoluspkgs -f
+complete -c goroot -f
+complete -c gotopkg -f
+complete -c gotopkg -a "(path basename (__solus_toplevel)/packages/*/*)"
+complete -c whatprovides -f
+complete -c whatuses -f


### PR DESCRIPTION
**Summary**

This adds a Fish-based implementation of [the helper scripts](https://help.getsol.us/docs/packaging/prepare-for-packaging#set-up-monorepo-helper-functions-optional).

Resolves #506

**Test Plan**

Symlink the configuration and start a new shell:

```fish
mkdir -p ~/.config/fish/conf.d
ln -s (git rev-parse --show-toplevel)/common/Scripts/helpers.fish ~/.config/fish/conf.d/solus.fish
exec fish
```

**Checklist**

- [x] ~~Package was built and tested against unstable~~ n/a
