### PR TITLE
font-fira-ttf: Inclusion of homepage and metainfo.xml

### DIFF
--- a/packages/f/font-fira-ttf/files/fira.metainfo.xml
+++ b/packages/f/font-fira-ttf/files/fira.metainfo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023 Solus Developers <copyright@getsol.us> -->
+<component type="font">
+  <id>fira</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Fira</name>
+  <url type ="homepage">http://mozilla.github.io/Fira</url>
+  <summary>Mozilla's new typeface, used in Firefox OS.</summary>
+</component>

--- a/packages/f/font-fira-ttf/package.yml
+++ b/packages/f/font-fira-ttf/package.yml
@@ -1,8 +1,9 @@
 name       : font-fira-ttf
 version    : 4.202
-release    : 3
+release    : 4
 source     :
     - https://github.com/mozilla/Fira/archive/4.202.tar.gz : d86269657387f144d77ba12011124f30f423f70672e1576dc16f918bb16ddfe4
+homepage   : http://mozilla.github.io/Fira/
 license    : OFL-1.1
 component  : desktop.font
 summary    : Mozilla's new typeface, used in Firefox OS
@@ -12,3 +13,4 @@ install    : |
     fontdir=$installdir/usr/share/fonts/truetype/fira/
     install -dm644 $fontdir
     cp -R $workdir/ttf/*.ttf $fontdir
+    install -Dm00644 $pkgfiles/fira.metainfo.xml $installdir/usr/share/metainfo/fira.metainfo.xml

--- a/packages/f/font-fira-ttf/pspec_x86_64.xml
+++ b/packages/f/font-fira-ttf/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>font-fira-ttf</Name>
+        <Homepage>http://mozilla.github.io/Fira/</Homepage>
         <Packager>
-            <Name>Bryan T. Meyers</Name>
-            <Email>bmeyers@datadrake.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>OFL-1.1</License>
         <PartOf>desktop.font</PartOf>
         <Summary xml:lang="en">Mozilla&apos;s new typeface, used in Firefox OS</Summary>
         <Description xml:lang="en">Mozilla&apos;s new typeface, used in Firefox OS
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://solus-project.com/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>font-fira-ttf</Name>
@@ -54,15 +55,16 @@
             <Path fileType="data">/usr/share/fonts/truetype/fira/FiraSans-UltraItalic.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/fira/FiraSans-UltraLight.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/fira/FiraSans-UltraLightItalic.ttf</Path>
+            <Path fileType="data">/usr/share/metainfo/fira.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2018-12-12</Date>
+        <Update release="4">
+            <Date>2023-10-12</Date>
             <Version>4.202</Version>
             <Comment>Packaging update</Comment>
-            <Name>Bryan T. Meyers</Name>
-            <Email>bmeyers@datadrake.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Adding `homepage` key to `package.yml`( Part of #411)
- Including metainfo.xml (Part of #449)

**Test Plan**

- Build the package
- Run `appstream-builder --packages-dir=. --include-failed -v`
- Check that the package doesn't show up in the `example-failed.xml.gz`
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable