### PR TITLE
font-freefont-ttf: Inclusion of homepage and metainfo.xml

### DIFF
--- a/packages/f/font-freefont-ttf/files/freefont.metainfo.xml
+++ b/packages/f/font-freefont-ttf/files/freefont.metainfo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023 Solus Developers <copyright@getsol.us> -->
+<component type="font">
+  <id>freefont</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>FreeFont</name>
+  <url type="homepage">https://www.gnu.org/software/freefont/</url>
+  <summary>A free family of scalable outline fonts, suitable for general use on computers and for desktop publishing.</summary>
+</component>

--- a/packages/f/font-freefont-ttf/package.yml
+++ b/packages/f/font-freefont-ttf/package.yml
@@ -1,8 +1,9 @@
 name       : font-freefont-ttf
 version    : 5.3.12
-release    : 1
+release    : 2
 source     :
     - http://ftp.gnu.org/gnu/freefont/freefont-ttf-20120503.zip : 7c85baf1bf82a1a1845d1322112bc6ca982221b484e3b3925022e25b5cae89af
+homepage   : https://www.gnu.org/software/freefont/
 license    : GPL-3.0-or-later
 component  : desktop.font
 summary    : GNU FreeFont is a free family of scalable outline fonts, suitable for general use on computers and for desktop publishing. It is Unicode-encoded for compatibility with all modern operating systems.
@@ -12,3 +13,4 @@ install    : |
     fontdir=$installdir/usr/share/fonts/truetype/freefont/
     install -dm644 $fontdir
     cp -R $workdir/*.ttf $fontdir
+    install -Dm00644 $pkgfiles/freefont.metainfo.xml $installdir/usr/share/metainfo/freefont.metainfo.xml

--- a/packages/f/font-freefont-ttf/pspec_x86_64.xml
+++ b/packages/f/font-freefont-ttf/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>font-freefont-ttf</Name>
+        <Homepage>https://www.gnu.org/software/freefont/</Homepage>
         <Packager>
-            <Name>TeenCorn</Name>
-            <Email>TeenCorn@protonmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop.font</PartOf>
         <Summary xml:lang="en">GNU FreeFont is a free family of scalable outline fonts, suitable for general use on computers and for desktop publishing. It is Unicode-encoded for compatibility with all modern operating systems.</Summary>
         <Description xml:lang="en">GNU FreeFont is a free family of scalable outline fonts, suitable for general use on computers and for desktop publishing. It is Unicode-encoded for compatibility with all modern operating systems.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://solus-project.com/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>font-freefont-ttf</Name>
@@ -31,15 +32,16 @@
             <Path fileType="data">/usr/share/fonts/truetype/freefont/FreeSerifBold.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/freefont/FreeSerifBoldItalic.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/freefont/FreeSerifItalic.ttf</Path>
+            <Path fileType="data">/usr/share/metainfo/freefont.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2018-10-30</Date>
+        <Update release="2">
+            <Date>2023-10-12</Date>
             <Version>5.3.12</Version>
             <Comment>Packaging update</Comment>
-            <Name>TeenCorn</Name>
-            <Email>TeenCorn@protonmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Adding `homepage` key to `package.yml`( Part of #411)
- Including `metainfo.xml` (Part of #449)

**Test Plan**

- Build the package
- Run `appstream-builder --packages-dir=. --include-failed -v`
- Check that the package doesn't show up in the `example-failed.xml.gz`
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable