### PR TITLE
font-hack-ttf: Inclusion of homepage and metainfo.xml

### DIFF
--- a/packages/f/font-hack-ttf/files/hack.metainfo.xml
+++ b/packages/f/font-hack-ttf/files/hack.metainfo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023 Solus Developers <copyright@getsol.us> -->
+<component type="font">
+  <id>hack</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Hack</name>
+  <url type="homepage">https://sourcefoundry.org/hack/</url>
+  <summary>A typeface designed for source code</summary>
+</component>

--- a/packages/f/font-hack-ttf/package.yml
+++ b/packages/f/font-hack-ttf/package.yml
@@ -1,16 +1,18 @@
 name       : font-hack-ttf
 version    : '3.003'
-release    : 4
+release    : 5
 source     :
     - https://github.com/source-foundry/Hack/releases/download/v3.003/Hack-v3.003-ttf.tar.xz : d9ed5d0a07525c7e7bd587b4364e4bc41021dd668658d09864453d9bb374a78d
+homepage   : https://sourcefoundry.org/hack/
 license    :
     - MIT
     - Copyright
 component  : desktop.font
 summary    : A typeface designed for source code
 description: |
-    A typeface designed for source code
+    Hack is designed to be a workhorse typeface for source code. It has deep roots in the free, open source typeface community and expands upon the contributions of the Bitstream Vera & DejaVu projects.
 install    : |
     fontDir=$installdir/usr/share/fonts/truetype/hack
     install -dm00644 $fontDir
     mv $workdir/*.ttf $fontDir/
+    install -Dm00644 $pkgfiles/hack.metainfo.xml $installdir/usr/share/metainfo/hack.metainfo.xml

--- a/packages/f/font-hack-ttf/pspec_x86_64.xml
+++ b/packages/f/font-hack-ttf/pspec_x86_64.xml
@@ -1,22 +1,23 @@
 <PISI>
     <Source>
         <Name>font-hack-ttf</Name>
+        <Homepage>https://sourcefoundry.org/hack/</Homepage>
         <Packager>
-            <Name>Bryan T. Meyers</Name>
-            <Email>bmeyers@datadrake.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <License>Copyright</License>
         <PartOf>desktop.font</PartOf>
         <Summary xml:lang="en">A typeface designed for source code</Summary>
-        <Description xml:lang="en">A typeface designed for source code
+        <Description xml:lang="en">Hack is designed to be a workhorse typeface for source code. It has deep roots in the free, open source typeface community and expands upon the contributions of the Bitstream Vera &amp; DejaVu projects.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://solus-project.com/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>font-hack-ttf</Name>
         <Summary xml:lang="en">A typeface designed for source code</Summary>
-        <Description xml:lang="en">A typeface designed for source code
+        <Description xml:lang="en">Hack is designed to be a workhorse typeface for source code. It has deep roots in the free, open source typeface community and expands upon the contributions of the Bitstream Vera &amp; DejaVu projects.
 </Description>
         <PartOf>desktop.font</PartOf>
         <Files>
@@ -24,15 +25,16 @@
             <Path fileType="data">/usr/share/fonts/truetype/hack/Hack-BoldItalic.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/hack/Hack-Italic.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/hack/Hack-Regular.ttf</Path>
+            <Path fileType="data">/usr/share/metainfo/hack.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2018-08-21</Date>
+        <Update release="5">
+            <Date>2023-10-12</Date>
             <Version>3.003</Version>
             <Comment>Packaging update</Comment>
-            <Name>Bryan T. Meyers</Name>
-            <Email>bmeyers@datadrake.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Adding `homepage` key to `package.yml`( Part of getsolus#411)
- Including `metainfo.xml` (Part of getsolus#449)

**Test Plan**

- Build the package
- Run `appstream-builder --packages-dir=. --include-failed -v`
- Check that the package doesn't show up in the `example-failed.xml.gz`
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable