### PR TITLE
font-iosevka-ttf: Update to 27.2.0

### DIFF
--- a/packages/f/font-iosevka-ttf/files/iosevka.metainfo.xml
+++ b/packages/f/font-iosevka-ttf/files/iosevka.metainfo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023 Solus Developers <copyright@getsol.us> -->
+<component type="font">
+  <id>iosevka</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Iosevka</name>
+  <url type="homepage">https://typeof.net/Iosevka/</url>
+  <summary>Versatile typeface for code, from code.</summary>
+</component>

--- a/packages/f/font-iosevka-ttf/package.yml
+++ b/packages/f/font-iosevka-ttf/package.yml
@@ -1,13 +1,14 @@
 name       : font-iosevka-ttf
-version    : 27.1.0
-release    : 44
+version    : 27.2.0
+release    : 45
 source     :
-    - https://github.com/be5invis/Iosevka/releases/download/v27.1.0/ttf-iosevka-27.1.0.zip : 958bb0140d0fd49e3f4331d804d65d509c7c7ccac89ac575a5adb4ec0617885e
+    - https://github.com/be5invis/Iosevka/releases/download/v27.2.0/ttf-iosevka-27.2.0.zip : c503f10ddb124be03793b70b7f6245945eefeea456b1fcd3a4b3b8434eadc839
 homepage   : https://typeof.net/Iosevka
 license    : OFL-1.1
 component  : desktop.font
-summary    : Slender typeface for code, from code (default shape)
+summary    : Versatile typeface for code, from code.
 description: |
-    Iosevka is a slender monospace sans-serif and slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono, designed to be the ideal font for programming.
+    Iosevka is an open-source, sans-serif + slab-serif, monospace + quasi‑proportional typeface family, designed for writing code, using in terminals, and preparing technical documents.
 install    : |
     install -D -m00644 *.ttf -t $installdir/usr/share/fonts/truetype/iosevka/
+    install -Dm00644 $pkgfiles/iosevka.metainfo.xml $installdir/usr/share/metainfo/iosevka.metainfo.xml

--- a/packages/f/font-iosevka-ttf/pspec_x86_64.xml
+++ b/packages/f/font-iosevka-ttf/pspec_x86_64.xml
@@ -3,20 +3,20 @@
         <Name>font-iosevka-ttf</Name>
         <Homepage>https://typeof.net/Iosevka</Homepage>
         <Packager>
-            <Name>Nazar Stasiv</Name>
-            <Email>nazar@autistici.org</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>OFL-1.1</License>
         <PartOf>desktop.font</PartOf>
-        <Summary xml:lang="en">Slender typeface for code, from code (default shape)</Summary>
-        <Description xml:lang="en">Iosevka is a slender monospace sans-serif and slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono, designed to be the ideal font for programming.
+        <Summary xml:lang="en">Versatile typeface for code, from code.</Summary>
+        <Description xml:lang="en">Iosevka is an open-source, sans-serif + slab-serif, monospace + quasi‑proportional typeface family, designed for writing code, using in terminals, and preparing technical documents.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>font-iosevka-ttf</Name>
-        <Summary xml:lang="en">Slender typeface for code, from code (default shape)</Summary>
-        <Description xml:lang="en">Iosevka is a slender monospace sans-serif and slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono, designed to be the ideal font for programming.
+        <Summary xml:lang="en">Versatile typeface for code, from code.</Summary>
+        <Description xml:lang="en">Iosevka is an open-source, sans-serif + slab-serif, monospace + quasi‑proportional typeface family, designed for writing code, using in terminals, and preparing technical documents.
 </Description>
         <PartOf>desktop.font</PartOf>
         <Files>
@@ -74,15 +74,16 @@
             <Path fileType="data">/usr/share/fonts/truetype/iosevka/iosevka-thin.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/iosevka/iosevka-thinitalic.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/iosevka/iosevka-thinoblique.ttf</Path>
+            <Path fileType="data">/usr/share/metainfo/iosevka.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="44">
-            <Date>2023-10-06</Date>
-            <Version>27.1.0</Version>
+        <Update release="45">
+            <Date>2023-10-12</Date>
+            <Version>27.2.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Nazar Stasiv</Name>
-            <Email>nazar@autistici.org</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Add characters
  * TELEPHONE RECORDER (`U+2315`) (#2020).
  * COUNTERSINK (`U+2335`) (#2020).
  * BROKEN CIRCLE WITH NORTHWEST ARROW (`U+238B`) (#2020).
  * TRIPLE PLUS (`U+29FB`) (#2020).
- Correction of letter assignments for stylistic styles:
  * Fix `cv10` and `cv30` for `ss14`.
  * Fix `cv12`, `cv36`, and `cv82` for `ss16`.
  * Fix `cv22`, `cv31`, `cv47`, and `cv91` for `ss07`.
  * Fix `cv26` for `ss07`, `ss14`, and `ss15`.
  * Fix `cv28`, `cv43`, and `cv70` for `ss01`, `ss04`, `ss05`, `ss06`, `ss07`, `ss13`, and `ss16`.
  * Fix `cv55` for `ss03`, `ss09`, `cv12`, and `ss14`.
  * Fix `cv53` and `cv84` for `ss10`.
  * Fix `cv58` for `ss06` and `ss10`.
  * Fix `cv59` for `ss09` and `ss18`.
  * Fix `cv61` for `ss08` and `ss20`.
  * Fix `cv62` for `ss01`.
  * Fix `cv63` for `ss02`, `ss05`, and `ss12`.
  * Fix `cv68` for `ss03`.
  * Fix `cv72` for `ss03`, `ss05`, `ss06`, `cv07`, and `ss13`.
  * Fix `cv77` for `ss03`, `ss04`, `ss06`, `ss07`, `ss08`, `ss12`, `ss13`, and `ss18`.
  * Fix `cv79` and `cv80` for `ss01`, `ss02`, `ss04`, `ss05`, `ss06`, `ss07`, `ss09`, `ss12`, `ss13`, `ss14`, `ss16`, `ss18`, and Aile.
  * Fix `cv88` for `ss18`.
  * Fix `vsAA` and `vsAM` for `ss06`.
  * Fix `vsAG` for `ss03` and Etoile.
  * [changelog](https://raw.githubusercontent.com/be5invis/Iosevka/v27.2.0/CHANGELOG.md)
- Including `metainfo.xml` (Part of getsolus#449)

**Test Plan**

- Render text with the font
- Build the package
- Run `appstream-builder --packages-dir=. --include-failed -v`
- Check that the package doesn't show up in the `example-failed.xml.gz`

**Checklist**

- [x] Package was built and tested against unstable