### PR TITLE
common/Taskfile: Add clean-all action to remove _all_ eopkgs

### DIFF
--- a/common/Taskfile.yml
+++ b/common/Taskfile.yml
@@ -196,6 +196,12 @@ tasks:
     cmds:
       - rm *.eopkg -fv
 
+  clean-all:
+    desc: WARNING - Clean ALL eopkgs found in the monorepo
+    dir: '{{ .TASKFILE_DIR }}'
+    cmds:
+      - find $(git rev-parse --show-toplevel) -type f -name '*.eopkg' -delete
+
   pull:
     desc: Pull/rebase latest changes
     dir: '{{ .USER_WORKING_DIR }}'


### PR DESCRIPTION
**Summary**

Add `go-task clean-all` action to remove _all_ eopkgs found in the monorepo

**Test Plan**

`go-task clean-all`

**Checklist**

- [ ] Package was built and tested against unstable N/A
