### PR TITLE
font-jetbrainsmono-ttf: Inclusion of metainfo.xml

### DIFF
--- a/packages/f/font-jetbrainsmono-ttf/files/jetbrainsmono.metainfo.xml
+++ b/packages/f/font-jetbrainsmono-ttf/files/jetbrainsmono.metainfo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023 Solus Developers <copyright@getsol.us> -->
+<component type="font">
+  <id>jetbrainsmono</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>JetBrains Mono</name>
+  <url type ="homepage">https://www.jetbrains.com/lp/mono/</url>
+  <summary>A free and open-source typeface for developers</summary>
+</component>

--- a/packages/f/font-jetbrainsmono-ttf/package.yml
+++ b/packages/f/font-jetbrainsmono-ttf/package.yml
@@ -1,6 +1,6 @@
 name       : font-jetbrainsmono-ttf
 version    : '2.304'
-release    : 11
+release    : 12
 source     :
     - https://github.com/JetBrains/JetBrainsMono/releases/download/v2.304/JetBrainsMono-2.304.zip : 6f6376c6ed2960ea8a963cd7387ec9d76e3f629125bc33d1fdcd7eb7012f7bbf
 license    : OFL-1.1
@@ -11,3 +11,4 @@ description: |
     JetBrains Mono is a free and open-source monospace font from JetBrains, designed for developers. Like Fira Code, it features over a hundred code-specific ligatures, with support for over 140 languages.
 install    : |
     install -Dm00644 fonts/ttf/*.ttf -t $installdir/usr/share/fonts/truetype/jetbrainsmono/
+    install -Dm00644 $pkgfiles/jetbrainsmono.metainfo.xml $installdir/usr/share/metainfo/jetbrainsmono.metainfo.xml

--- a/packages/f/font-jetbrainsmono-ttf/pspec_x86_64.xml
+++ b/packages/f/font-jetbrainsmono-ttf/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>font-jetbrainsmono-ttf</Name>
         <Homepage>https://www.jetbrains.com/lp/mono/</Homepage>
         <Packager>
-            <Name>Fabian Mettler</Name>
-            <Email>fabian@mettler.cc</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>OFL-1.1</License>
         <PartOf>desktop.font</PartOf>
         <Summary xml:lang="en">A free and open-source typeface for developers</Summary>
         <Description xml:lang="en">JetBrains Mono is a free and open-source monospace font from JetBrains, designed for developers. Like Fira Code, it features over a hundred code-specific ligatures, with support for over 140 languages.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>font-jetbrainsmono-ttf</Name>
@@ -52,15 +52,16 @@
             <Path fileType="data">/usr/share/fonts/truetype/jetbrainsmono/JetBrainsMonoNL-SemiBoldItalic.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/jetbrainsmono/JetBrainsMonoNL-Thin.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/jetbrainsmono/JetBrainsMonoNL-ThinItalic.ttf</Path>
+            <Path fileType="data">/usr/share/metainfo/jetbrainsmono.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2023-07-09</Date>
+        <Update release="12">
+            <Date>2023-10-13</Date>
             <Version>2.304</Version>
             <Comment>Packaging update</Comment>
-            <Name>Fabian Mettler</Name>
-            <Email>fabian@mettler.cc</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Including `metainfo.xml` (Part of #449)

**Test Plan**

- Build the package
- Run `appstream-builder --packages-dir=. --include-failed -v`
- Check that the package doesn't show up in the `example-failed.xml.gz`

**Checklist**

- [x] Package was built against unstable