### PR TITLE
font-lato-ttf: Inclusion of homepage and metainfo.xml

### DIFF
--- a/packages/f/font-lato-ttf/files/lato.metainfo.xml
+++ b/packages/f/font-lato-ttf/files/lato.metainfo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023 Solus Developers <copyright@getsol.us> -->
+<component type="font">
+  <id>lato</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Lato</name>
+  <url type ="homepage">https://www.latofonts.com</url>
+  <summary>A sanserif typeface family</summary>
+</component>

--- a/packages/f/font-lato-ttf/package.yml
+++ b/packages/f/font-lato-ttf/package.yml
@@ -1,8 +1,9 @@
 name       : font-lato-ttf
 version    : 2.015
-release    : 1
+release    : 2
 source     :
     - http://www.latofonts.com/download/Lato2OFL.zip : 42b54e96c07e299d967fc3227c7bd63a20d6cfb1dc8fd6dae83628091e20a5b8
+homepage   : http://www.latofonts.com
 license    : OFL-1.1
 component  : desktop.font
 summary    : A sanserif typeface family
@@ -18,3 +19,4 @@ install    : |
     
     ln -s /usr/share/fontconfig/conf.avail/69-lato.conf $installdir/usr/share/fonts/conf.d/69-lato.conf
 
+    install -Dm 00644 $pkgfiles/lato.metainfo.xml $installdir/usr/share/metainfo/lato.metainfo.xml

--- a/packages/f/font-lato-ttf/pspec_x86_64.xml
+++ b/packages/f/font-lato-ttf/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>font-lato-ttf</Name>
+        <Homepage>http://www.latofonts.com</Homepage>
         <Packager>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>OFL-1.1</License>
         <PartOf>desktop.font</PartOf>
         <Summary xml:lang="en">A sanserif typeface family</Summary>
         <Description xml:lang="en">Lato is a sanserif type­face fam­ily designed in the Sum­mer 2010 by Warsaw-​​based designer Łukasz Dziedzic (“Lato” means “Sum­mer” in Pol­ish).
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://solus-project.com/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>font-lato-ttf</Name>
@@ -39,15 +40,16 @@
             <Path fileType="data">/usr/share/fonts/truetype/lato/Lato-SemiboldItalic.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/lato/Lato-Thin.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/lato/Lato-ThinItalic.ttf</Path>
+            <Path fileType="data">/usr/share/metainfo/lato.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2017-08-21</Date>
+        <Update release="2">
+            <Date>2023-10-13</Date>
             <Version>2.015</Version>
             <Comment>Packaging update</Comment>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Adding `homepage` key to `package.yml`( Part of #411)
- Including `metainfo.xml` (Part of #449)

**Test Plan**

- Build the package
- Run `appstream-builder --packages-dir=. --include-failed -v`
- Check that the package doesn't show up in the `example-failed.xml.gz`
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built against unstable