### PR TITLE
font-opendyslexic-otf: Inclusion of homepage and metainfo.xml

### DIFF
--- a/packages/f/font-opendyslexic-otf/files/opendyslexic.metainfo.xml
+++ b/packages/f/font-opendyslexic-otf/files/opendyslexic.metainfo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023 Solus Developers <copyright@getsol.us> -->
+<component type="font">
+  <id>opendyslexic</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>OpenDyslexic</name>
+  <url type ="homepage">https://opendyslexic.org/</url>
+  <summary> a typeface that uses typeface shapes & features to help offset some visual symptoms of Dyslexia.</summary>
+</component>

--- a/packages/f/font-opendyslexic-otf/package.yml
+++ b/packages/f/font-opendyslexic-otf/package.yml
@@ -1,8 +1,9 @@
 name       : font-opendyslexic-otf
 version    : 0.91.12
-release    : 1
+release    : 2
 source     :
     - https://github.com/antijingoist/opendyslexic/archive/v0.91.12.tar.gz : d20d182fb7069023b8dbdf131bbe232093b4147dd4900e27c95b86d3ddfca34b
+homepage   : https://opendyslexic.org/
 license    : OFL-1.1
 summary    : OpenDyslexic, a typeface that uses typeface shapes & features to help offset some visual symptoms of Dyslexia.
 component  : desktop.font
@@ -13,3 +14,5 @@ install    : |
     install -dm644 $fontdir
     cp -R $workdir/compiled/*.otf $fontdir
     chmod -R 00644 $installdir
+
+    install -Dm00644 $pkgfiles/opendyslexic.metainfo.xml $installdir/usr/share/metainfo/opendyslexic.metainfo.xml

--- a/packages/f/font-opendyslexic-otf/pspec_x86_64.xml
+++ b/packages/f/font-opendyslexic-otf/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>font-opendyslexic-otf</Name>
+        <Homepage>https://opendyslexic.org/</Homepage>
         <Packager>
-            <Name>Kévin Bergue</Name>
-            <Email>kevin@be-ta.art</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>OFL-1.1</License>
         <PartOf>desktop.font</PartOf>
         <Summary xml:lang="en">OpenDyslexic, a typeface that uses typeface shapes &amp; features to help offset some visual symptoms of Dyslexia.</Summary>
         <Description xml:lang="en">OpenDyslexic, a typeface that uses typeface shapes &amp; features to help offset some visual symptoms of Dyslexia.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>font-opendyslexic-otf</Name>
@@ -23,15 +24,16 @@
             <Path fileType="data">/usr/share/fonts/opentype/opendyslexic/OpenDyslexic-Bold.otf</Path>
             <Path fileType="data">/usr/share/fonts/opentype/opendyslexic/OpenDyslexic-Italic.otf</Path>
             <Path fileType="data">/usr/share/fonts/opentype/opendyslexic/OpenDyslexic-Regular.otf</Path>
+            <Path fileType="data">/usr/share/metainfo/opendyslexic.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2019-11-19</Date>
+        <Update release="2">
+            <Date>2023-10-13</Date>
             <Version>0.91.12</Version>
             <Comment>Packaging update</Comment>
-            <Name>Kévin Bergue</Name>
-            <Email>kevin@be-ta.art</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Adding `homepage` key to `package.yml`( Part of #411)
- Including `metainfo.xml` (Part of #449)

**Test Plan**

- Build the package
- Run `appstream-builder --packages-dir=. --include-failed -v`
- Check that the package doesn't show up in the `example-failed.xml.gz`
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable