### PR TITLE
font-overpass-otf: Inclusion of homepage and metainfo.xml

### DIFF
--- a/packages/f/font-overpass-otf/files/overpass.metainfo.xml
+++ b/packages/f/font-overpass-otf/files/overpass.metainfo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023 Solus Developers <copyright@getsol.us> -->
+<component type="font">
+  <id>overpass</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Overpass</name>
+  <url type ="homepage">http://overpassfont.org/</url>
+  <summary> An open source font family inspired by Highway Gothic.</summary>
+</component>

--- a/packages/f/font-overpass-otf/package.yml
+++ b/packages/f/font-overpass-otf/package.yml
@@ -1,8 +1,9 @@
 name       : font-overpass-otf
 version    : 3.0.5
-release    : 4
+release    : 5
 source     :
     - https://github.com/RedHatOfficial/Overpass/archive/refs/tags/v3.0.5.tar.gz : beb7528f1e9adf3decf841f02510a3752820561a06842f9097d9f2565fe41f34
+homepage   : http://overpassfont.org/
 license    :
     - OFL-1.1
     - LGPL-2.1-or-later
@@ -14,3 +15,4 @@ install    : |
     install -dm00755 $installdir/usr/share/fonts/opentype/overpass{,-mono}
     install -m00644 desktop-fonts/overpass/*.otf $installdir/usr/share/fonts/opentype/overpass/.
     install -m00644 desktop-fonts/overpass-mono/*.otf $installdir/usr/share/fonts/opentype/overpass-mono/.
+    install -Dm00644 $pkgfiles/overpass.metainfo.xml $installdir/usr/share/metainfo/overpass.metainfo.xml

--- a/packages/f/font-overpass-otf/pspec_x86_64.xml
+++ b/packages/f/font-overpass-otf/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>font-overpass-otf</Name>
+        <Homepage>http://overpassfont.org/</Homepage>
         <Packager>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>OFL-1.1</License>
         <License>LGPL-2.1-or-later</License>
@@ -11,7 +12,7 @@
         <Summary xml:lang="en">Overpass font family</Summary>
         <Description xml:lang="en">An open source font family inspired by Highway Gothic.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>font-overpass-otf</Name>
@@ -40,15 +41,16 @@
             <Path fileType="data">/usr/share/fonts/opentype/overpass/overpass-semibold.otf</Path>
             <Path fileType="data">/usr/share/fonts/opentype/overpass/overpass-thin-italic.otf</Path>
             <Path fileType="data">/usr/share/fonts/opentype/overpass/overpass-thin.otf</Path>
+            <Path fileType="data">/usr/share/metainfo/overpass.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2021-10-07</Date>
+        <Update release="5">
+            <Date>2023-10-13</Date>
             <Version>3.0.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Adding `homepage` key to `package.yml`( Part of getsolus#411)
- Including `metainfo.xml` (Part of getsolus#449)

**Test Plan**

- Build the package
- Run `appstream-builder --packages-dir=. --include-failed -v`
- Check that the package doesn't show up in the `example-failed.xml.gz`
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable