### PR TITLE
font-roboto-ttf: Inclusion of homepage and metainfo.xml

### DIFF
--- a/packages/f/font-roboto-ttf/files/roboto.metainfo.xml
+++ b/packages/f/font-roboto-ttf/files/roboto.metainfo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023 Solus Developers <copyright@getsol.us> -->
+<component type="font">
+  <id>roboto</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Roboto</name>
+  <url type ="homepage">https://fonts.google.com/specimen/Roboto</url>
+  <summary>The Roboto family of fonts</summary>
+</component>

--- a/packages/f/font-roboto-ttf/package.yml
+++ b/packages/f/font-roboto-ttf/package.yml
@@ -1,8 +1,9 @@
 name       : font-roboto-ttf
 version    : '2.138'
-release    : 5
+release    : 6
 source     :
     - https://github.com/google/roboto/releases/download/v2.138/roboto-unhinted.zip : 70f64c718510a601fbcf752aafe644314dacaeb85474dc689c89787c4a72a728
+homepage   : https://fonts.google.com/specimen/Roboto
 license    : Apache-2.0
 component  : desktop.font
 summary    : The Roboto family of fonts
@@ -13,3 +14,4 @@ install    : |
     install -dm644 $fontdir
     cp -R $workdir/*.ttf $fontdir
     chmod -R 00644 $installdir
+    install -Dm00644 $pkgfiles/roboto.metainfo.xml $installdir/usr/share/metainfo/roboto.metainfo.xml

--- a/packages/f/font-roboto-ttf/pspec_x86_64.xml
+++ b/packages/f/font-roboto-ttf/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>font-roboto-ttf</Name>
+        <Homepage>https://fonts.google.com/specimen/Roboto</Homepage>
         <Packager>
-            <Name>Bryan T. Meyers</Name>
-            <Email>bmeyers@datadrake.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>desktop.font</PartOf>
         <Summary xml:lang="en">The Roboto family of fonts</Summary>
         <Description xml:lang="en">The Roboto family of fonts
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://solus-project.com/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>font-roboto-ttf</Name>
@@ -39,15 +40,16 @@
             <Path fileType="data">/usr/share/fonts/truetype/roboto/RobotoCondensed-Medium.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/roboto/RobotoCondensed-MediumItalic.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/roboto/RobotoCondensed-Regular.ttf</Path>
+            <Path fileType="data">/usr/share/metainfo/roboto.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2018-12-30</Date>
+        <Update release="6">
+            <Date>2023-10-13</Date>
             <Version>2.138</Version>
             <Comment>Packaging update</Comment>
-            <Name>Bryan T. Meyers</Name>
-            <Email>bmeyers@datadrake.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Adding `homepage` key to `package.yml`( Part of #411)
- Including `metainfo.xml` (Part of #449)

**Test Plan**

- Build the package
- Run `appstream-builder --packages-dir=. --include-failed -v`
- Check that the package doesn't show up in the `example-failed.xml.gz`
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable