### PR TITLE
font-tlwg-ttf: Update to 0.7.3

### DIFF
--- a/packages/f/font-tlwg-ttf/files/tlwg.metainfo.xml
+++ b/packages/f/font-tlwg-ttf/files/tlwg.metainfo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023 Solus Developers <copyright@getsol.us> -->
+<component type="font">
+  <id>fonts-tlwg</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Fonts-TLWG</name>
+  <url type ="homepage">https://linux.thai.net/projects/fonts-tlwg/</url>
+  <summary>A collection of Thai scalable fonts available in free licenses.</summary>
+</component>

--- a/packages/f/font-tlwg-ttf/package.yml
+++ b/packages/f/font-tlwg-ttf/package.yml
@@ -1,8 +1,9 @@
 name       : font-tlwg-ttf
-version    : 0.7.1
-release    : 3
+version    : 0.7.3
+release    : 4
 source     :
-    - https://github.com/tlwg/fonts-tlwg/releases/download/v0.7.1/ttf-tlwg-0.7.1.tar.xz : cfae0305b1a78a0dfc780d37586b42709a41d14b5aab5e3e84e2746995f457a2
+    - https://github.com/tlwg/fonts-tlwg/releases/download/v0.7.3/ttf-tlwg-0.7.3.tar.xz : 34052a3332e4f717e218a6b266e3c289ae6b1edb350140383239948e16d8e390
+homepage   : https://linux.thai.net/projects/fonts-tlwg
 license    :
     - GPL-2.0-only
     - MIT # Waree
@@ -15,3 +16,4 @@ install    : |
     cp *.ttf $installdir/usr/share/fonts/truetype/thai
     mv fontconfig/conf.avail $installdir/usr/share/fonts/conf.d
     chmod 00644 -R $installdir/usr/share/fonts
+    install -Dm00644 $pkgfiles/tlwg.metainfo.xml $installdir/usr/share/metainfo/tlwg.metainfo.xml

--- a/packages/f/font-tlwg-ttf/pspec_x86_64.xml
+++ b/packages/f/font-tlwg-ttf/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>font-tlwg-ttf</Name>
+        <Homepage>https://linux.thai.net/projects/fonts-tlwg</Homepage>
         <Packager>
-            <Name>Bryan T. Meyers</Name>
-            <Email>bmeyers@datadrake.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <License>MIT</License>
@@ -11,7 +12,7 @@
         <Summary xml:lang="en">Fonts-TLWG is a collection of Thai scalable fonts available under free licenses.</Summary>
         <Description xml:lang="en">Fonts-TLWG is a collection of Thai scalable fonts available under free licenses.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://solus-project.com/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>font-tlwg-ttf</Name>
@@ -92,15 +93,16 @@
             <Path fileType="data">/usr/share/fonts/truetype/thai/Waree-BoldOblique.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/thai/Waree-Oblique.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/thai/Waree.ttf</Path>
+            <Path fileType="data">/usr/share/metainfo/tlwg.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2018-12-30</Date>
-            <Version>0.7.1</Version>
+        <Update release="4">
+            <Date>2023-10-13</Date>
+            <Version>0.7.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Bryan T. Meyers</Name>
-            <Email>bmeyers@datadrake.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- 0.7.3 changelog: 
   * Purisa, Sawasdee: now can be embeded as installable in PDF. 
  * TlwgTypo, TlwgTypist: fix uneven widths of some glyphs.
  * TlwgTypo, TlwgTypist, TlwgMono, TlwgTypewriter: clear PANOSE to use calculated values, so as to get listed in gvim. (Thanks Chaiwat Suttipongsakul for the report.) 
  * Norasi: add 'onum' and 'smcp' OpenType features for access to old style figures and small caps glyphs. * LaTeX: Add old style figures and small caps supports for Norasi. 
  * [changelog](https://github.com/tlwg/fonts-tlwg/releases/tag/v0.7.3)
- Adding `homepage` key to `package.yml` (Part of #411)
- Including `metainfo.xml` (Part of #449)

**Test Plan**

- Render text with the font
- Build the package
- Run `appstream-builder --packages-dir=. --include-failed -v`
- Check that the package doesn't show up in the `example-failed.xml.gz`

**Checklist**

- [x] Package was built and tested against unstable