### PR TITLE
powerline-fonts: Inclusion of homepage and metainfo.xml

### DIFF
--- a/packages/p/powerline-fonts/files/powerline-fonts.metainfo.xml
+++ b/packages/p/powerline-fonts/files/powerline-fonts.metainfo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023 Solus Developers <copyright@getsol.us> -->
+<component type="font">
+  <id>powerline-fonts</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Powerline Fonts</name>
+  <url type ="homepage">https://github.com/powerline/fonts/</url>
+  <summary>Patched fonts for Powerline users.</summary>
+</component>

--- a/packages/p/powerline-fonts/package.yml
+++ b/packages/p/powerline-fonts/package.yml
@@ -1,8 +1,9 @@
 name       : powerline-fonts
 version    : 2015.12.04
-release    : 3
+release    : 4
 source     :
     - https://github.com/powerline/fonts/archive/2015-12-04.tar.gz : 3a0b73abca6334b5e6bddefab67f6eb1b2fac1231817d95fc79126c8998c4844
+homepage   : https://github.com/powerline/fonts/
 license    :
     - Apache-2.0
     - DejaVu Fonts License
@@ -37,3 +38,4 @@ install    : |
     rm -r install.sh install.ps1 samples
     mkdir -p $installdir/usr/share/fonts/powerline
     cp -r * $installdir/usr/share/fonts/powerline
+    install -Dm00644 $pkgfiles/powerline-fonts.metainfo.xml $installdir/usr/share/metainfo/powerline-fonts.metainfo.xml

--- a/packages/p/powerline-fonts/pspec_x86_64.xml
+++ b/packages/p/powerline-fonts/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>powerline-fonts</Name>
+        <Homepage>https://github.com/powerline/fonts/</Homepage>
         <Packager>
-            <Name>F. von Gellhorn</Name>
-            <Email>flinux@vongellhorn.ch</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>DejaVu Fonts License</License>
@@ -34,7 +35,7 @@ Terminess Powerline
 Tinos Powerline
 Fura Powerline
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>powerline-fonts</Name>
@@ -258,15 +259,16 @@ Fura Powerline
             <Path fileType="data">/usr/share/fonts/powerline/UbuntuMono/Ubuntu Mono derivative Powerline.ttf</Path>
             <Path fileType="data">/usr/share/fonts/powerline/UbuntuMono/fonts.dir</Path>
             <Path fileType="data">/usr/share/fonts/powerline/UbuntuMono/fonts.scale</Path>
+            <Path fileType="data">/usr/share/metainfo/powerline-fonts.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2020-02-23</Date>
+        <Update release="4">
+            <Date>2023-10-13</Date>
             <Version>2015.12.04</Version>
             <Comment>Packaging update</Comment>
-            <Name>F. von Gellhorn</Name>
-            <Email>flinux@vongellhorn.ch</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Adding `homepage` key to `package.yml`( Part of getsolus#411)
- Including `metainfo.xml` (Part of getsolus#449)

**Test Plan**

- Build the package
- Run `appstream-builder --packages-dir=. --include-failed -v`
- Check that the package doesn't show up in the `example-failed.xml.gz`
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable
