### PR TITLE
urw-core35-fonts: Update to 20200910

### DIFF
--- a/packages/u/urw-core35-fonts/package.yml
+++ b/packages/u/urw-core35-fonts/package.yml
@@ -1,8 +1,9 @@
 name       : urw-core35-fonts
-version    : '20170801'
-release    : 2
+version    : '20200910'
+release    : 3
 source     :
-    - https://github.com/ArtifexSoftware/urw-base35-fonts/archive/20170801.tar.gz : 38432cf683c39be23646f34107ad025aefd95d0bdc588bb4675c6d775996f2b0
+    - https://github.com/ArtifexSoftware/urw-base35-fonts/archive/refs/tags/20200910.tar.gz : e0d9b7f11885fdfdc4987f06b2aa0565ad2a4af52b22e5ebf79e1a98abd0ae2f
+homepage   : https://github.com/ArtifexSoftware/urw-base35-fonts
 license    : AGPL-3.0
 component  : desktop.font
 summary    : URW++ Postscript core35 fonts

--- a/packages/u/urw-core35-fonts/pspec_x86_64.xml
+++ b/packages/u/urw-core35-fonts/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>urw-core35-fonts</Name>
+        <Homepage>https://github.com/ArtifexSoftware/urw-base35-fonts</Homepage>
         <Packager>
-            <Name>Peter O&apos;Connor</Name>
-            <Email>peter@solus-project.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>AGPL-3.0</License>
         <PartOf>desktop.font</PartOf>
         <Summary xml:lang="en">URW++ Postscript core35 fonts</Summary>
         <Description xml:lang="en">URW++ Core Font Set. These 35 base fonts are provided freely by URW++ company, and are mainly utilized by Ghostscript, or other applications using it.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://solus-project.com/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>urw-core35-fonts</Name>
@@ -22,11 +23,12 @@
             <Path fileType="data">/usr/share/fontconfig/conf.avail/30-urw-bookman.conf</Path>
             <Path fileType="data">/usr/share/fontconfig/conf.avail/30-urw-c059.conf</Path>
             <Path fileType="data">/usr/share/fontconfig/conf.avail/30-urw-d050000l.conf</Path>
-            <Path fileType="data">/usr/share/fontconfig/conf.avail/30-urw-fallback.conf</Path>
+            <Path fileType="data">/usr/share/fontconfig/conf.avail/30-urw-fallback-backwards.conf</Path>
+            <Path fileType="data">/usr/share/fontconfig/conf.avail/30-urw-fallback-generics.conf</Path>
+            <Path fileType="data">/usr/share/fontconfig/conf.avail/30-urw-fallback-specifics.conf</Path>
             <Path fileType="data">/usr/share/fontconfig/conf.avail/30-urw-gothic.conf</Path>
             <Path fileType="data">/usr/share/fontconfig/conf.avail/30-urw-nimbus-mono-ps.conf</Path>
             <Path fileType="data">/usr/share/fontconfig/conf.avail/30-urw-nimbus-roman.conf</Path>
-            <Path fileType="data">/usr/share/fontconfig/conf.avail/30-urw-nimbus-sans-narrow.conf</Path>
             <Path fileType="data">/usr/share/fontconfig/conf.avail/30-urw-nimbus-sans.conf</Path>
             <Path fileType="data">/usr/share/fontconfig/conf.avail/30-urw-p052.conf</Path>
             <Path fileType="data">/usr/share/fontconfig/conf.avail/30-urw-standard-symbols-ps.conf</Path>
@@ -65,10 +67,10 @@
             <Path fileType="data">/usr/share/fonts/Type1/NimbusSans-Italic.t1</Path>
             <Path fileType="data">/usr/share/fonts/Type1/NimbusSans-Regular.afm</Path>
             <Path fileType="data">/usr/share/fonts/Type1/NimbusSans-Regular.t1</Path>
-            <Path fileType="data">/usr/share/fonts/Type1/NimbusSansNarrow-BdOblique.afm</Path>
-            <Path fileType="data">/usr/share/fonts/Type1/NimbusSansNarrow-BdOblique.t1</Path>
             <Path fileType="data">/usr/share/fonts/Type1/NimbusSansNarrow-Bold.afm</Path>
             <Path fileType="data">/usr/share/fonts/Type1/NimbusSansNarrow-Bold.t1</Path>
+            <Path fileType="data">/usr/share/fonts/Type1/NimbusSansNarrow-BoldOblique.afm</Path>
+            <Path fileType="data">/usr/share/fonts/Type1/NimbusSansNarrow-BoldOblique.t1</Path>
             <Path fileType="data">/usr/share/fonts/Type1/NimbusSansNarrow-Oblique.afm</Path>
             <Path fileType="data">/usr/share/fonts/Type1/NimbusSansNarrow-Oblique.t1</Path>
             <Path fileType="data">/usr/share/fonts/Type1/NimbusSansNarrow-Regular.afm</Path>
@@ -104,11 +106,12 @@
             <Path fileType="data">/usr/share/fonts/conf.d/30-urw-bookman.conf</Path>
             <Path fileType="data">/usr/share/fonts/conf.d/30-urw-c059.conf</Path>
             <Path fileType="data">/usr/share/fonts/conf.d/30-urw-d050000l.conf</Path>
-            <Path fileType="data">/usr/share/fonts/conf.d/30-urw-fallback.conf</Path>
+            <Path fileType="data">/usr/share/fonts/conf.d/30-urw-fallback-backwards.conf</Path>
+            <Path fileType="data">/usr/share/fonts/conf.d/30-urw-fallback-generics.conf</Path>
+            <Path fileType="data">/usr/share/fonts/conf.d/30-urw-fallback-specifics.conf</Path>
             <Path fileType="data">/usr/share/fonts/conf.d/30-urw-gothic.conf</Path>
             <Path fileType="data">/usr/share/fonts/conf.d/30-urw-nimbus-mono-ps.conf</Path>
             <Path fileType="data">/usr/share/fonts/conf.d/30-urw-nimbus-roman.conf</Path>
-            <Path fileType="data">/usr/share/fonts/conf.d/30-urw-nimbus-sans-narrow.conf</Path>
             <Path fileType="data">/usr/share/fonts/conf.d/30-urw-nimbus-sans.conf</Path>
             <Path fileType="data">/usr/share/fonts/conf.d/30-urw-p052.conf</Path>
             <Path fileType="data">/usr/share/fonts/conf.d/30-urw-standard-symbols-ps.conf</Path>
@@ -130,8 +133,8 @@
             <Path fileType="data">/usr/share/fonts/opentype/urw-core35/NimbusSans-BoldItalic.otf</Path>
             <Path fileType="data">/usr/share/fonts/opentype/urw-core35/NimbusSans-Italic.otf</Path>
             <Path fileType="data">/usr/share/fonts/opentype/urw-core35/NimbusSans-Regular.otf</Path>
-            <Path fileType="data">/usr/share/fonts/opentype/urw-core35/NimbusSansNarrow-BdOblique.otf</Path>
             <Path fileType="data">/usr/share/fonts/opentype/urw-core35/NimbusSansNarrow-Bold.otf</Path>
+            <Path fileType="data">/usr/share/fonts/opentype/urw-core35/NimbusSansNarrow-BoldOblique.otf</Path>
             <Path fileType="data">/usr/share/fonts/opentype/urw-core35/NimbusSansNarrow-Oblique.otf</Path>
             <Path fileType="data">/usr/share/fonts/opentype/urw-core35/NimbusSansNarrow-Regular.otf</Path>
             <Path fileType="data">/usr/share/fonts/opentype/urw-core35/P052-Bold.otf</Path>
@@ -165,8 +168,8 @@
             <Path fileType="data">/usr/share/fonts/truetype/urw-core35/NimbusSans-BoldItalic.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/urw-core35/NimbusSans-Italic.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/urw-core35/NimbusSans-Regular.ttf</Path>
-            <Path fileType="data">/usr/share/fonts/truetype/urw-core35/NimbusSansNarrow-BdOblique.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/urw-core35/NimbusSansNarrow-Bold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/urw-core35/NimbusSansNarrow-BoldOblique.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/urw-core35/NimbusSansNarrow-Oblique.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/urw-core35/NimbusSansNarrow-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/urw-core35/P052-Bold.ttf</Path>
@@ -188,7 +191,6 @@
             <Path fileType="data">/usr/share/metainfo/de.urwpp.NimbusMonoPS.metainfo.xml</Path>
             <Path fileType="data">/usr/share/metainfo/de.urwpp.NimbusRoman.metainfo.xml</Path>
             <Path fileType="data">/usr/share/metainfo/de.urwpp.NimbusSans.metainfo.xml</Path>
-            <Path fileType="data">/usr/share/metainfo/de.urwpp.NimbusSansNarrow.metainfo.xml</Path>
             <Path fileType="data">/usr/share/metainfo/de.urwpp.P052.metainfo.xml</Path>
             <Path fileType="data">/usr/share/metainfo/de.urwpp.StandardSymbolsPS.metainfo.xml</Path>
             <Path fileType="data">/usr/share/metainfo/de.urwpp.URWBookman.metainfo.xml</Path>
@@ -198,12 +200,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2018-08-03</Date>
-            <Version>20170801</Version>
+        <Update release="3">
+            <Date>2023-10-13</Date>
+            <Version>20200910</Version>
             <Comment>Packaging update</Comment>
-            <Name>Peter O&apos;Connor</Name>
-            <Email>peter@solus-project.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Mainly to fix letter te (afii10084) in Nimbus Sans Bold(Italic)
- Adding `homepage` key to `package.yml`( Part of getsolus#411)

**Test Plan**

- Render text with the fonts
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable