### PR TITLE
python-orjson: update to 3.9.9

### DIFF
--- a/packages/py/python-orjson/package.yml
+++ b/packages/py/python-orjson/package.yml
@@ -1,8 +1,8 @@
 name       : python-orjson
-version    : 3.9.8
-release    : 31
+version    : 3.9.9
+release    : 32
 source     :
-    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.9.8.tar.gz : ed1adc6db9841974170a5195b827ee4e392b1e8ca385b19fcdc3248489844059
+    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.9.9.tar.gz : 02e693843c2959befdd82d1ebae8b05ed12d1cb821605d5f9fe9f98ca5c9fd2b
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-orjson/pspec_x86_64.xml
+++ b/packages/py/python-orjson/pspec_x86_64.xml
@@ -21,11 +21,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.8.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.8.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.8.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.8.dist-info/license_files/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.8.dist-info/license_files/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.9.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.9.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.9.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.9.dist-info/license_files/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.9.dist-info/license_files/LICENSE-MIT</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/orjson/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/orjson/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/orjson/__pycache__/__init__.cpython-310.opt-1.pyc</Path>
@@ -35,9 +35,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2023-10-10</Date>
-            <Version>3.9.8</Version>
+        <Update release="32">
+            <Date>2023-10-13</Date>
+            <Version>3.9.9</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- `orjson` module metadata explicitly marks subinterpreters as not supported

**Test Plan**

Ran a number of examples from the project README

**Checklist**

- [x] Package was built and tested against unstable
