### PR TITLE
font-ubuntu-ttf: Inclusion of homepage and metainfo.xml

### DIFF
--- a/packages/f/font-ubuntu-ttf/files/ubuntu.metainfo.xml
+++ b/packages/f/font-ubuntu-ttf/files/ubuntu.metainfo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023 Solus Developers <copyright@getsol.us> -->
+<component type="font">
+  <id>font-ubuntu-ttf</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Ubuntu</name>
+  <url type="homepage">https://design.ubuntu.com/font</url>
+  <summary>Ubuntu font family</summary>
+</component>

--- a/packages/f/font-ubuntu-ttf/package.yml
+++ b/packages/f/font-ubuntu-ttf/package.yml
@@ -1,14 +1,16 @@
 name       : font-ubuntu-ttf
-version    : 0.83
-release    : 2
+version    : '0.83'
+release    : 3
 source     :
-    - http://font.ubuntu.com/download/ubuntu-font-family-0.83.zip : 456d7d42797febd0d7d4cf1b782a2e03680bb4a5ee43cc9d06bda172bac05b42
+    - https://assets.ubuntu.com/v1/0cef8205-ubuntu-font-family-0.83.zip : 61a2b342526fd552f19fef438bb9211a8212de19ad96e32a1209c039f1d68ecf
+homepage   : https://design.ubuntu.com/font
 license    : Ubuntu Font License-1.0
 component  : desktop.font
 summary    : Ubuntu font family
 description: |
     Ubuntu font family
 install    : |
-      fontDir=$installdir/usr/share/fonts/truetype/ubuntu
-      install -dm755 $fontDir
-      mv $workdir/*.ttf $fontDir/
+    fontDir=$installdir/usr/share/fonts/truetype/ubuntu
+    install -dm644 $fontDir
+    mv $workdir/*/*.ttf $fontDir/
+    install -Dm00644 $pkgfiles/ubuntu.metainfo.xml $installdir/usr/share/metainfo/ubuntu.metainfo.xml

--- a/packages/f/font-ubuntu-ttf/pspec_x86_64.xml
+++ b/packages/f/font-ubuntu-ttf/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>font-ubuntu-ttf</Name>
+        <Homepage>https://design.ubuntu.com/font</Homepage>
         <Packager>
-            <Name>Joshua Strobl</Name>
-            <Email>joshua@stroblindustries.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>Ubuntu Font License-1.0</License>
         <PartOf>desktop.font</PartOf>
         <Summary xml:lang="en">Ubuntu font family</Summary>
         <Description xml:lang="en">Ubuntu font family
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://solus-project.com/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>font-ubuntu-ttf</Name>
@@ -28,19 +29,21 @@
             <Path fileType="data">/usr/share/fonts/truetype/ubuntu/Ubuntu-MI.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/ubuntu/Ubuntu-R.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/ubuntu/Ubuntu-RI.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu/Ubuntu-Th.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/ubuntu/UbuntuMono-B.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/ubuntu/UbuntuMono-BI.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/ubuntu/UbuntuMono-R.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/ubuntu/UbuntuMono-RI.ttf</Path>
+            <Path fileType="data">/usr/share/metainfo/ubuntu.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2017-02-25</Date>
+        <Update release="3">
+            <Date>2023-10-14</Date>
             <Version>0.83</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joshua Strobl</Name>
-            <Email>joshua@stroblindustries.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Change to new source (old one no longer works)
- Adding `homepage` key to `package.yml`( Part of #411)
- Including `metainfo.xml` (Part of #449)

**Test Plan**

- Build the package
- Run `appstream-builder --packages-dir=. --include-failed -v`
- Check that the package doesn't show up in the `example-failed.xml.gz`
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable