### PR TITLE
font-droid-ttf: Inclusion of metainfo.xml

### DIFF
--- a/packages/f/font-droid-ttf/files/droid.metainfo.xml
+++ b/packages/f/font-droid-ttf/files/droid.metainfo.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023 Solus Developers <copyright@getsol.us> -->
+<component type="font">
+  <id>font-droid-ttf</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Droid</name>
+  <summary>Droid fonts. Includes Fallback and Japanese support.</summary>
+</component>

--- a/packages/f/font-droid-ttf/package.yml
+++ b/packages/f/font-droid-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : font-droid-ttf
-version    : '1.00'
-release    : 7
+version    : '20121017'
+release    : 8
 source     :
-    - https://getsol.us/sources/font-droid-ttf.tar.xz : 2f8fc432fa9aa2702a305a8687822a987ba3c69c2ab12643be7fa00c94d0819a
+    - https://sources.archlinux.org/other/packages/ttf-droid/ttf-droid-20121017.tar.xz : f068efec9e8201fe0d1be75b1a4751c98d14dc44267b2237f549403b2a8069e3
 license    : Apache-2.0
 component  : desktop.font
 summary    : Droid fonts. Includes Fallback and Japanese support.
@@ -11,5 +11,6 @@ description: |
 install    : |
     fontdir=$installdir/usr/share/fonts/truetype/droid/
     install -dm644 $fontdir
-    cp -R $workdir/Droid*/*.ttf $fontdir
+    cp -R $workdir/*.ttf $fontdir
     chmod -R 00644 $installdir
+    install -Dm00644 $pkgfiles/droid.metainfo.xml $installdir/usr/share/metainfo/droid.metainfo.xml

--- a/packages/f/font-droid-ttf/pspec_x86_64.xml
+++ b/packages/f/font-droid-ttf/pspec_x86_64.xml
@@ -2,15 +2,15 @@
     <Source>
         <Name>font-droid-ttf</Name>
         <Packager>
-            <Name>F. von Gellhorn</Name>
-            <Email>flinux@vongellhorn.ch</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>desktop.font</PartOf>
         <Summary xml:lang="en">Droid fonts. Includes Fallback and Japanese support.</Summary>
         <Description xml:lang="en">Droid fonts. Includes Fallback and Japanese support.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>font-droid-ttf</Name>
@@ -19,23 +19,43 @@
 </Description>
         <PartOf>desktop.font</PartOf>
         <Files>
+            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidKufi-Bold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidKufi-Regular.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidNaskh-Bold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidNaskh-Regular-SystemUI.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidNaskh-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSans-Bold.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSans.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSansArabic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSansArmenian.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSansDevanagari-Regular.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSansEthiopic-Bold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSansEthiopic-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSansFallback.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSansFallbackFull.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSansFallbackLegacy.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSansGeorgian.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSansHebrew-Bold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSansHebrew-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSansJapanese.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSansMono.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSansTamil-Bold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSansTamil-Regular.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSansThai.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSerif-Bold.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSerif-BoldItalic.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSerif-Italic.ttf</Path>
-            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSerif.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/droid/DroidSerif-Regular.ttf</Path>
+            <Path fileType="data">/usr/share/metainfo/droid.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2019-05-20</Date>
-            <Version>1.00</Version>
+        <Update release="8">
+            <Date>2023-10-14</Date>
+            <Version>20121017</Version>
             <Comment>Packaging update</Comment>
-            <Name>F. von Gellhorn</Name>
-            <Email>flinux@vongellhorn.ch</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Change source to a new one (old one no longer works)
- Including `metainfo.xml` (Part of #449)

**Test Plan**

- Build the package
- Run `appstream-builder --packages-dir=. --include-failed -v`
- Check that the package doesn't show up in the `example-failed.xml.gz`
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable