### PR TITLE
wine: update to 8.18

### DIFF
--- a/packages/w/wine/abi_symbols
+++ b/packages/w/wine/abi_symbols
@@ -22,6 +22,7 @@ msv1_0.so:__wine_unix_call_wow64_funcs
 netapi32.so:__wine_unix_call_funcs
 netapi32.so:__wine_unix_call_wow64_funcs
 nsiproxy.so:__wine_unix_call_funcs
+nsiproxy.so:str_to_in6_addr
 ntdll.so:KeUserModeCallback
 ntdll.so:NtAcceptConnectPort
 ntdll.so:NtAccessCheck
@@ -343,6 +344,7 @@ win32u.so:NtGdiDdDDIEscape
 win32u.so:NtGdiDdDDIOpenAdapterFromDeviceName
 win32u.so:NtGdiDdDDIOpenAdapterFromHdc
 win32u.so:NtGdiDdDDIOpenAdapterFromLuid
+win32u.so:NtGdiDdDDIQueryAdapterInfo
 win32u.so:NtGdiDdDDIQueryStatistics
 win32u.so:NtGdiDdDDIQueryVideoMemoryInfo
 win32u.so:NtGdiDdDDISetQueuedLimit

--- a/packages/w/wine/abi_symbols32
+++ b/packages/w/wine/abi_symbols32
@@ -11,6 +11,7 @@ mountmgr.so:__wine_unix_call_funcs
 msv1_0.so:__wine_unix_call_funcs
 netapi32.so:__wine_unix_call_funcs
 nsiproxy.so:__wine_unix_call_funcs
+nsiproxy.so:str_to_in6_addr
 ntdll.so:KeUserModeCallback
 ntdll.so:NtAcceptConnectPort
 ntdll.so:NtAccessCheck
@@ -357,6 +358,7 @@ win32u.so:NtGdiDdDDIEscape
 win32u.so:NtGdiDdDDIOpenAdapterFromDeviceName
 win32u.so:NtGdiDdDDIOpenAdapterFromHdc
 win32u.so:NtGdiDdDDIOpenAdapterFromLuid
+win32u.so:NtGdiDdDDIQueryAdapterInfo
 win32u.so:NtGdiDdDDIQueryStatistics
 win32u.so:NtGdiDdDDIQueryVideoMemoryInfo
 win32u.so:NtGdiDdDDISetQueuedLimit

--- a/packages/w/wine/package.yml
+++ b/packages/w/wine/package.yml
@@ -1,8 +1,8 @@
 name       : wine
-version    : '8.17'
-release    : 161
+version    : '8.18'
+release    : 162
 source     :
-    - https://dl.winehq.org/wine/source/8.x/wine-8.17.tar.xz : f01785bd3162c74e65deb13aa0add711e37c484454719bedd0e8c2b1a3469b7e
+    - https://dl.winehq.org/wine/source/8.x/wine-8.18.tar.xz : 30faef14acf70fd5f739d2fece3432839f1f7dd2d3624bcc3662c3b1b83260db
 license    : LGPL-2.1-or-later
 component  : virt
 homepage   : https://www.winehq.org/

--- a/packages/w/wine/pspec_x86_64.xml
+++ b/packages/w/wine/pspec_x86_64.xml
@@ -11,7 +11,7 @@
         <Summary xml:lang="en">Wine is a compatibility layer for Windows applications</Summary>
         <Description xml:lang="en">Wine (originally an acronym for &quot;Wine Is Not an Emulator&quot;) is a compatibility layer capable of running Windows applications on several POSIX-compliant operating systems, such as Linux, Mac OSX, &amp; BSD. Instead of simulating internal Windows logic like a virtual machine or emulator, Wine translates Windows API calls into POSIX calls on-the-fly, eliminating the performance and memory penalties of other methods and allowing you to cleanly integrate Windows applications into your desktop.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>wine</Name>
@@ -673,10 +673,13 @@
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/windows.globalization.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/windows.media.devices.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/windows.media.dll</Path>
+            <Path fileType="library">/usr/lib64/wine/x86_64-windows/windows.media.mediacontrol.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/windows.media.speech.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/windows.networking.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/windows.networking.hostname.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/windows.perception.stub.dll</Path>
+            <Path fileType="library">/usr/lib64/wine/x86_64-windows/windows.security.credentials.ui.userconsentverifier.dll</Path>
+            <Path fileType="library">/usr/lib64/wine/x86_64-windows/windows.storage.applicationdata.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/windows.system.profile.systemmanufacturers.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/windows.ui.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/windowscodecs.dll</Path>
@@ -973,7 +976,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="161">wine</Dependency>
+            <Dependency release="162">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/wine</Path>
@@ -1656,10 +1659,13 @@
             <Path fileType="library">/usr/lib32/wine/i386-windows/windows.globalization.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/windows.media.devices.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/windows.media.dll</Path>
+            <Path fileType="library">/usr/lib32/wine/i386-windows/windows.media.mediacontrol.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/windows.media.speech.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/windows.networking.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/windows.networking.hostname.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/windows.perception.stub.dll</Path>
+            <Path fileType="library">/usr/lib32/wine/i386-windows/windows.security.credentials.ui.userconsentverifier.dll</Path>
+            <Path fileType="library">/usr/lib32/wine/i386-windows/windows.storage.applicationdata.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/windows.system.profile.systemmanufacturers.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/windows.ui.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/windowscodecs.dll</Path>
@@ -1797,7 +1803,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="161">wine</Dependency>
+            <Dependency release="162">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wine/debug.h</Path>
@@ -2519,6 +2525,7 @@
             <Path fileType="header">/usr/include/wine/windows/netcfgx.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/netcon.h</Path>
             <Path fileType="header">/usr/include/wine/windows/netcon.idl</Path>
+            <Path fileType="header">/usr/include/wine/windows/netevent.h</Path>
             <Path fileType="header">/usr/include/wine/windows/netfw.h</Path>
             <Path fileType="header">/usr/include/wine/windows/netfw.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/netioapi.h</Path>
@@ -2728,6 +2735,8 @@
             <Path fileType="header">/usr/include/wine/windows/structuredquerycondition.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/svrapi.h</Path>
             <Path fileType="header">/usr/include/wine/windows/synchapi.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/systemmediatransportcontrolsinterop.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/systemmediatransportcontrolsinterop.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/t2embapi.h</Path>
             <Path fileType="header">/usr/include/wine/windows/tapi.h</Path>
             <Path fileType="header">/usr/include/wine/windows/taskschd.h</Path>
@@ -2915,6 +2924,8 @@
             <Path fileType="header">/usr/include/wine/windows/windows.perception.spatial.surfaces.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.security.credentials.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.security.credentials.idl</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.security.credentials.ui.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.security.credentials.ui.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.security.cryptography.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.security.cryptography.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.security.isolation.h</Path>
@@ -2966,6 +2977,7 @@
             <Path fileType="header">/usr/include/wine/windows/winnt.h</Path>
             <Path fileType="header">/usr/include/wine/windows/winnt.rh</Path>
             <Path fileType="header">/usr/include/wine/windows/winperf.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/winppi.h</Path>
             <Path fileType="header">/usr/include/wine/windows/winreg.h</Path>
             <Path fileType="header">/usr/include/wine/windows/winresrc.h</Path>
             <Path fileType="header">/usr/include/wine/windows/winsafer.h</Path>
@@ -3071,9 +3083,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="161">
-            <Date>2023-09-29</Date>
-            <Version>8.17</Version>
+        <Update release="162">
+            <Date>2023-10-14</Date>
+            <Version>8.18</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Highlighted changes:
- Bundled FluidSynth library for DirectMusic
- More window management in the Wayland driver
- More effect support in Direct3D 10
- Various bug fixes

Full release notes available [here](https://www.winehq.org/announce/8.18)

**Test Plan**
- Launched and used several Wine tools (`winefile`, `winecfg`, `wineconsole`,...)
- Played Age of Empires I demo

**Checklist**

- [x] Package was built and tested against unstable
