### PR TITLE
pisi: emit downloading event for packagekit

### DIFF
--- a/packages/p/pisi/files/emit-downloading-event.patch
+++ b/packages/p/pisi/files/emit-downloading-event.patch
@@ -1,0 +1,33 @@
+From 76e04b79097da5e7c335f035cce293e577f7cd0d Mon Sep 17 00:00:00 2001
+From: Joey Riches <josephriches@gmail.com>
+Date: Fri, 13 Oct 2023 14:40:45 +0100
+Subject: [PATCH] package: emit event when a package is downloading/cached
+
+PiSi currently emits events for other operations e.g. removing,
+installing; but crucially not for downloading packages.
+
+This is needed for packagekit so we can get a callback to know when
+the package is downloading in order to emit transaction events from
+a pisi.api.install call for example.
+---
+ pisi/package.py | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/pisi/package.py b/pisi/package.py
+index c018b7a..41e7177 100644
+--- a/pisi/package.py
++++ b/pisi/package.py
+@@ -94,8 +94,13 @@ def fetch_remote_file(self, url):
+         dest = ctx.config.cached_packages_dir()
+         self.filepath = os.path.join(dest, url.filename())
+ 
++        # So we can emit a notify event with the package info
++        pkg_name, pkg_version = pisi.util.parse_package_name(url.filename())
++        self.metadata, self.files, self.repo = pisi.api.info_name(pkg_name, False)
++
+         if not os.path.exists(self.filepath):
+             try:
++                ctx.ui.notify(pisi.ui.downloading, package=self.metadata.package, files=None)
+                 pisi.file.File.download(url, dest)
+             except pisi.fetcher.FetchError:
+                 # Bug 3465

--- a/packages/p/pisi/pspec.xml
+++ b/packages/p/pisi/pspec.xml
@@ -23,6 +23,7 @@
         <Patches>
             <Patch level="1">0001-Revert-cli-output-Truncate-if-it-doesn-t-fit-console.patch</Patch>
             <Patch level="1">0001-Add-Wl-z-pack-relative-relocs-to-default-linker-flag.patch</Patch>
+            <Patch level="1">emit-downloading-event.patch</Patch>
         </Patches>
     </Source>
 
@@ -62,6 +63,14 @@
     </Package>
 
     <History>
+        <Update release="108">
+            <Date>10-18-2023</Date>
+            <Version>3.10</Version>
+            <Comment>Package bump</Comment>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
+        </Update>
+
         <Update release="107">
             <Date>10-16-2023</Date>
             <Version>3.10</Version>


### PR DESCRIPTION
**Summary**

This is required by the latest packagekit work in order to get callbacks for which packages are currently downloading in an operation.

**Test Plan**

Dogfood the patch locally for a few days

**Checklist**

- [x] Package was built and tested against unstable
