### PR TITLE
czkawka: update to version 6.1.0

### DIFF
--- a/packages/c/czkawka/abi_used_symbols
+++ b/packages/c/czkawka/abi_used_symbols
@@ -30,9 +30,11 @@ libc.so.6:fstatat64
 libc.so.6:getcwd
 libc.so.6:getenv
 libc.so.6:getmntent
+libc.so.6:getpid
 libc.so.6:getpwuid_r
 libc.so.6:getuid
 libc.so.6:gnu_get_libc_version
+libc.so.6:isatty
 libc.so.6:kill
 libc.so.6:linkat
 libc.so.6:lseek64
@@ -45,7 +47,6 @@ libc.so.6:memmove
 libc.so.6:memrchr
 libc.so.6:memset
 libc.so.6:mkdir
-libc.so.6:mmap
 libc.so.6:mmap64
 libc.so.6:mprotect
 libc.so.6:munmap

--- a/packages/c/czkawka/package.yml
+++ b/packages/c/czkawka/package.yml
@@ -1,8 +1,8 @@
 name       : czkawka
-version    : 6.0.0
-release    : 4
+version    : 6.1.0
+release    : 5
 source     :
-    - https://github.com/qarmin/czkawka/archive/refs/tags/6.0.0.tar.gz : 32dc1d8a55bc3ce478246830a1f81679affa85735e69aa049fd83e30271e368f
+    - https://github.com/qarmin/czkawka/archive/refs/tags/6.1.0.tar.gz : 63e64c717a93b3d5210d6a4718833fdbf3ad7b28c9b74a243d9de3ab1ee6ad5a
 homepage   : https://qarmin.github.io/czkawka/
 license    :
     - CC-BY-4.0

--- a/packages/c/czkawka/pspec_x86_64.xml
+++ b/packages/c/czkawka/pspec_x86_64.xml
@@ -13,7 +13,7 @@
         <Description xml:lang="en">Czkawka is a simple, fast and free app to remove unnecessary files from your computer.
 It&apos;s an alternative for fslint.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>czkawka</Name>
@@ -33,9 +33,9 @@ It&apos;s an alternative for fslint.
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2023-07-29</Date>
-            <Version>6.0.0</Version>
+        <Update release="5">
+            <Date>2023-10-15</Date>
+            <Version>6.1.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>


### PR DESCRIPTION
**Changelog**

- BREAKING CHANGE - Changed cache saving method, deduplicated, optimized and simplified procedure(all files needs to be hashed again)
- Remove up to 340ms of delay when waiting for results
- Added logger with useful info when debugging app (level can be adjusted via e.g. RUST_LOG=debug env)
- Core code cleanup
- Updated list of bad extensions and support for finding invalid jar files
- More default excluded items on Windows(like pagefile)
- Unified printing/saving method to files/terminal and fixed some differences/bugs
- Uses fun_time library to print how much functions take time
- Added exporting results into json file format
- Added new test/regression suite for CI
- Added ability to use relative paths
- Allowed removing similar images/videos/music from cli
- Added info about saving/loading items to cache in duplicate and music mode
- Fixed number of files to check in duplicate mode
- Added support for qoi image format(without preview yet) - e92a
- Fixed stability problem, that could remove invalid file in CLI
- Fix Windows gui crashes by using gtk 4.6 instead 4.8 or 4.10
- Fixed printing info about duplicated music files
- Fixed printing info about duplicated video files

**Testplan**

- Tried searches for duplicate files and pictures, for temp files and broken symlinks.

**Checklist**

- [X] Package was built and tested against unstable
