### PR TITLE
yaru-theme: update to 23.10.0

### DIFF
--- a/packages/y/yaru-theme/package.yml
+++ b/packages/y/yaru-theme/package.yml
@@ -1,13 +1,14 @@
 name       : yaru-theme
-version    : 23.04.4
-release    : 21
+version    : 23.10.0
+release    : 22
 source     :
-    - https://github.com/ubuntu/yaru/archive/refs/tags/23.04.4.tar.gz : be00296286426006851e2cdf63dfe8166439cdf2afa22d56035e449cc524412c
+    - https://github.com/ubuntu/yaru/archive/refs/tags/23.10.0-0ubuntu2.tar.gz : 2cc53cefb8f899bf7100dedad674799caf478115aafa5a8ea504770c75278108
 license    :
     - CC-BY-SA-4.0
     - GPL-3.0-or-later
     - LGPL-2.1-only
     - LGPL-3.0-only
+homepage   : https://github.com/ubuntu/yaru
 component  :
     - ^yaru-icon-theme : desktop.theme
     - ^yaru-gtk-theme : desktop.theme

--- a/packages/y/yaru-theme/pspec_x86_64.xml
+++ b/packages/y/yaru-theme/pspec_x86_64.xml
@@ -1,6 +1,7 @@
 <PISI>
     <Source>
         <Name>yaru-theme</Name>
+        <Homepage>https://github.com/ubuntu/yaru</Homepage>
         <Packager>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>
@@ -13,7 +14,7 @@
         <Summary xml:lang="en">Yaru default ubuntu theme</Summary>
         <Description xml:lang="en">Yaru is a theme entirely backed by the Ubuntu community
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>yaru-gtk-theme</Name>
@@ -3445,13 +3446,16 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/checkbox-off-blue-dark.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/checkbox-off-focused-blue-dark.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/dash-placeholder.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/gnome-shell-high-contrast.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/pad-osd.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/process-working.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/toggle-off-blue-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/toggle-off-hc-blue-dark.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/toggle-on-blue-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/toggle-on-hc-blue-dark.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/workspace-placeholder.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue/calendar-today-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue/calendar-today.svg</Path>
@@ -3700,15 +3704,12 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/checkbox-off-focused-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/checkbox-off-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/dash-placeholder.svg</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/gnome-shell-high-contrast.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/pad-osd.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/process-working.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/running-indicator.svg</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/toggle-off-hc-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/toggle-off-light.svg</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/toggle-on-hc-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/toggle-on-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/workspace-placeholder.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/gnome-shell</Path>
@@ -8277,7 +8278,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/16x16/actions/mail_forward.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/actions/mail_new.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/actions/mail_reply.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/16x16/actions/printer.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/actions/printers.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/actions/process-stop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/actions/redo.png</Path>
@@ -8319,6 +8319,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/16x16/actions/system-shutdown.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/actions/system-switch-user.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/actions/undo.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/16x16/actions/view-app-grid.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/actions/view-zoom-in.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/actions/view-zoom-out.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/actions/window-close.png</Path>
@@ -8335,7 +8336,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/16x16/apps/accessories-dictionary.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/apps/accessories-text-editor.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/apps/address-book-app.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/16x16/apps/amazon-store.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/apps/applets-screenshooter.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/apps/applications-multimedia.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/apps/applications-office.png</Path>
@@ -8564,7 +8564,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/16x16/apps/workspace-switcher-right-top.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/apps/workspace-switcher-top-left.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/apps/x-office-address-book.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/16x16/categories/application-x-addon.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/categories/applications-accessories.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/categories/applications-development.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/categories/applications-games.png</Path>
@@ -8677,7 +8676,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/16x16/devices/phone.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/devices/printer-network.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/devices/printer.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/16x16/emblems/config-users.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/emblems/emblem-danger.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/emblems/emblem-default.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/emblems/emblem-dialog-question.png</Path>
@@ -9058,6 +9056,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/16x16/mimetypes/application-x-wine-extension-ini.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/mimetypes/application-x-xpinstall.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/mimetypes/application-x-yaml.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/16x16/mimetypes/application-x-zerosize.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/mimetypes/application-x-zip.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/mimetypes/application-xml.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/mimetypes/application-zip.png</Path>
@@ -9242,6 +9241,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/16x16/places/insync-folder.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/places/network-server.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/places/network-workgroup.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/16x16/places/start-here.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/places/user-desktop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/places/user-home.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/places/user-trash.png</Path>
@@ -9402,7 +9402,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/actions/mail_forward.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/actions/mail_new.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/actions/mail_reply.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/actions/printer.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/actions/printers.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/actions/process-stop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/actions/redo.png</Path>
@@ -9444,6 +9443,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/actions/system-shutdown.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/actions/system-switch-user.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/actions/undo.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/actions/view-app-grid.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/actions/view-zoom-in.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/actions/view-zoom-out.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/actions/window-close.png</Path>
@@ -9460,7 +9460,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/apps/accessories-dictionary.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/apps/accessories-text-editor.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/apps/address-book-app.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/apps/amazon-store.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/apps/applets-screenshooter.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/apps/applications-multimedia.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/apps/applications-office.png</Path>
@@ -9689,7 +9688,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/apps/workspace-switcher-right-top.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/apps/workspace-switcher-top-left.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/apps/x-office-address-book.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/categories/application-x-addon.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/categories/applications-accessories.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/categories/applications-development.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/categories/applications-games.png</Path>
@@ -9802,7 +9800,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/devices/phone.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/devices/printer-network.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/devices/printer.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/emblems/config-users.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/emblems/emblem-danger.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/emblems/emblem-default.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/emblems/emblem-dialog-question.png</Path>
@@ -9975,6 +9972,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/mimetypes/application-x-wine-extension-ini.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/mimetypes/application-x-xpinstall.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/mimetypes/application-x-yaml.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/mimetypes/application-x-zerosize.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/mimetypes/application-x-zip.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/mimetypes/application-xml.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/mimetypes/application-zip.png</Path>
@@ -10159,6 +10157,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/places/insync-folder.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/places/network-server.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/places/network-workgroup.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/places/start-here.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/places/user-desktop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/places/user-home.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/places/user-trash.png</Path>
@@ -10311,7 +10310,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/22x22/actions/mail_forward.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22/actions/mail_new.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22/actions/mail_reply.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/22x22/actions/printer.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22/actions/printers.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22/actions/process-stop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22/actions/redo.png</Path>
@@ -10347,6 +10345,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/22x22/actions/system-shut-down.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22/actions/system-shutdown.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22/actions/undo.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/22x22/actions/view-app-grid.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22/actions/view-zoom-in.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22/actions/view-zoom-out.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22/actions/window-close.png</Path>
@@ -10356,12 +10355,20 @@
             <Path fileType="data">/usr/share/icons/Yaru/22x22/actions/zoom-best-fit.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22/actions/zoom-in.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22/actions/zoom-out.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/22x22/apps/address-book-app.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/22x22/apps/gnome-contacts.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/22x22/apps/office-address-book.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/22x22/apps/office-addressbook.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/22x22/apps/org.gnome.Contacts.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22/apps/ubiquity.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/22x22/apps/x-office-address-book.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22/categories/preferences-system-bluetooth.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22/legacy/document-export.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22/legacy/document-import.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22/legacy/list-add.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22/legacy/list-remove.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/22x22/places/folder-recent.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/22x22/places/start-here.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22@2x/actions/address-book-new.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22@2x/actions/appointment-new.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22@2x/actions/blueman-trust.png</Path>
@@ -10421,14 +10428,17 @@
             <Path fileType="data">/usr/share/icons/Yaru/22x22@2x/actions/system-log-out.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22@2x/actions/system-reboot.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22@2x/actions/system-shutdown.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/22x22@2x/actions/view-app-grid.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22@2x/actions/zoom-in.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22@2x/actions/zoom-out.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/22x22@2x/apps/address-book-app.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22@2x/apps/ubiquity.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22@2x/categories/preferences-system-bluetooth.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22@2x/legacy/document-export.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22@2x/legacy/document-import.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22@2x/legacy/list-add.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/22x22@2x/legacy/list-remove.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/22x22@2x/places/start-here.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/actions/address-book-new.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/actions/application-exit.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/actions/appointment-new.png</Path>
@@ -10554,7 +10564,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/24x24/actions/mail_forward.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/actions/mail_new.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/actions/mail_reply.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/24x24/actions/printer.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/actions/printers.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/actions/process-stop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/actions/redo.png</Path>
@@ -10596,6 +10605,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/24x24/actions/system-shutdown.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/actions/system-switch-user.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/actions/undo.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/24x24/actions/view-app-grid.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/actions/view-zoom-in.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/actions/view-zoom-out.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/actions/window-close.png</Path>
@@ -10612,7 +10622,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/24x24/apps/accessories-dictionary.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/apps/accessories-text-editor.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/apps/address-book-app.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/24x24/apps/amazon-store.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/apps/applets-screenshooter.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/apps/applications-multimedia.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/apps/applications-office.png</Path>
@@ -10841,7 +10850,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/24x24/apps/workspace-switcher-right-top.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/apps/workspace-switcher-top-left.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/apps/x-office-address-book.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/24x24/categories/application-x-addon.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/categories/applications-accessories.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/categories/applications-development.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/categories/applications-games.png</Path>
@@ -10954,7 +10962,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/24x24/devices/phone.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/devices/printer-network.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/devices/printer.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/24x24/emblems/config-users.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/emblems/emblem-danger.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/emblems/emblem-default.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/emblems/emblem-dialog-question.png</Path>
@@ -11178,6 +11185,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/24x24/mimetypes/application-x-wine-extension-ini.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/mimetypes/application-x-xpinstall.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/mimetypes/application-x-yaml.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/24x24/mimetypes/application-x-zerosize.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/mimetypes/application-x-zip.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/mimetypes/application-xml.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/mimetypes/application-zip.png</Path>
@@ -11362,6 +11370,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/24x24/places/insync-folder.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/places/network-server.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/places/network-workgroup.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/24x24/places/start-here.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/places/user-desktop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/places/user-home.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/places/user-trash.png</Path>
@@ -11522,7 +11531,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/actions/mail_forward.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/actions/mail_new.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/actions/mail_reply.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/actions/printer.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/actions/printers.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/actions/process-stop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/actions/redo.png</Path>
@@ -11564,6 +11572,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/actions/system-shutdown.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/actions/system-switch-user.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/actions/undo.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/actions/view-app-grid.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/actions/view-zoom-in.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/actions/view-zoom-out.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/actions/window-close.png</Path>
@@ -11580,7 +11589,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/apps/accessories-dictionary.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/apps/accessories-text-editor.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/apps/address-book-app.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/apps/amazon-store.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/apps/applets-screenshooter.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/apps/applications-multimedia.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/apps/applications-office.png</Path>
@@ -11809,7 +11817,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/apps/workspace-switcher-right-top.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/apps/workspace-switcher-top-left.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/apps/x-office-address-book.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/categories/application-x-addon.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/categories/applications-accessories.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/categories/applications-development.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/categories/applications-games.png</Path>
@@ -11922,7 +11929,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/devices/phone.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/devices/printer-network.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/devices/printer.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/emblems/config-users.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/emblems/emblem-danger.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/emblems/emblem-default.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/emblems/emblem-dialog-question.png</Path>
@@ -12095,6 +12101,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/mimetypes/application-x-wine-extension-ini.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/mimetypes/application-x-xpinstall.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/mimetypes/application-x-yaml.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/mimetypes/application-x-zerosize.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/mimetypes/application-x-zip.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/mimetypes/application-xml.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/mimetypes/application-zip.png</Path>
@@ -12279,6 +12286,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/places/insync-folder.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/places/network-server.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/places/network-workgroup.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/places/start-here.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/places/user-desktop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/places/user-home.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/places/user-trash.png</Path>
@@ -12439,7 +12447,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/256x256/actions/mail_forward.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/actions/mail_new.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/actions/mail_reply.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/256x256/actions/printer.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/actions/printers.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/actions/process-stop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/actions/redo.png</Path>
@@ -12481,6 +12488,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/256x256/actions/system-shutdown.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/actions/system-switch-user.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/actions/undo.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/256x256/actions/view-app-grid.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/actions/view-zoom-in.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/actions/view-zoom-out.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/actions/window-close.png</Path>
@@ -12497,7 +12505,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/256x256/apps/accessories-dictionary.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/apps/accessories-text-editor.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/apps/address-book-app.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/256x256/apps/amazon-store.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/apps/applets-screenshooter.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/apps/applications-multimedia.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/apps/applications-office.png</Path>
@@ -12726,7 +12733,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/256x256/apps/workspace-switcher-right-top.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/apps/workspace-switcher-top-left.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/apps/x-office-address-book.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/256x256/categories/application-x-addon.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/categories/applications-accessories.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/categories/applications-development.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/categories/applications-games.png</Path>
@@ -12839,7 +12845,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/256x256/devices/phone.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/devices/printer-network.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/devices/printer.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/256x256/emblems/config-users.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/emblems/emblem-danger.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/emblems/emblem-default.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/emblems/emblem-dialog-question.png</Path>
@@ -13012,6 +13017,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/256x256/mimetypes/application-x-wine-extension-ini.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/mimetypes/application-x-xpinstall.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/mimetypes/application-x-yaml.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/256x256/mimetypes/application-x-zerosize.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/mimetypes/application-x-zip.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/mimetypes/application-xml.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/mimetypes/application-zip.png</Path>
@@ -13196,6 +13202,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/256x256/places/insync-folder.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/places/network-server.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/places/network-workgroup.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/256x256/places/start-here.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/places/user-desktop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/places/user-home.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/places/user-trash.png</Path>
@@ -13356,7 +13363,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/actions/mail_forward.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/actions/mail_new.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/actions/mail_reply.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/actions/printer.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/actions/printers.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/actions/process-stop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/actions/redo.png</Path>
@@ -13398,6 +13404,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/actions/system-shutdown.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/actions/system-switch-user.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/actions/undo.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/actions/view-app-grid.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/actions/view-zoom-in.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/actions/view-zoom-out.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/actions/window-close.png</Path>
@@ -13414,7 +13421,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/apps/accessories-dictionary.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/apps/accessories-text-editor.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/apps/address-book-app.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/apps/amazon-store.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/apps/applets-screenshooter.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/apps/applications-multimedia.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/apps/applications-office.png</Path>
@@ -13643,7 +13649,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/apps/workspace-switcher-right-top.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/apps/workspace-switcher-top-left.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/apps/x-office-address-book.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/categories/application-x-addon.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/categories/applications-accessories.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/categories/applications-development.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/categories/applications-games.png</Path>
@@ -13756,7 +13761,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/devices/phone.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/devices/printer-network.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/devices/printer.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/emblems/config-users.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/emblems/emblem-danger.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/emblems/emblem-default.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/emblems/emblem-dialog-question.png</Path>
@@ -13929,6 +13933,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/mimetypes/application-x-wine-extension-ini.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/mimetypes/application-x-xpinstall.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/mimetypes/application-x-yaml.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/mimetypes/application-x-zerosize.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/mimetypes/application-x-zip.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/mimetypes/application-xml.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/mimetypes/application-zip.png</Path>
@@ -14113,6 +14118,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/places/insync-folder.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/places/network-server.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/places/network-workgroup.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/places/start-here.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/places/user-desktop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/places/user-home.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/places/user-trash.png</Path>
@@ -14273,7 +14279,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/32x32/actions/mail_forward.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/actions/mail_new.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/actions/mail_reply.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/32x32/actions/printer.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/actions/printers.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/actions/process-stop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/actions/redo.png</Path>
@@ -14315,6 +14320,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/32x32/actions/system-shutdown.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/actions/system-switch-user.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/actions/undo.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/32x32/actions/view-app-grid.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/actions/view-zoom-in.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/actions/view-zoom-out.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/actions/window-close.png</Path>
@@ -14331,7 +14337,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/32x32/apps/accessories-dictionary.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/apps/accessories-text-editor.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/apps/address-book-app.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/32x32/apps/amazon-store.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/apps/applets-screenshooter.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/apps/applications-multimedia.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/apps/applications-office.png</Path>
@@ -14560,7 +14565,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/32x32/apps/workspace-switcher-right-top.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/apps/workspace-switcher-top-left.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/apps/x-office-address-book.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/32x32/categories/application-x-addon.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/categories/applications-accessories.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/categories/applications-development.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/categories/applications-games.png</Path>
@@ -14673,7 +14677,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/32x32/devices/phone.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/devices/printer-network.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/devices/printer.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/32x32/emblems/config-users.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/emblems/emblem-danger.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/emblems/emblem-default.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/emblems/emblem-dialog-question.png</Path>
@@ -14846,6 +14849,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/32x32/mimetypes/application-x-wine-extension-ini.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/mimetypes/application-x-xpinstall.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/mimetypes/application-x-yaml.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/32x32/mimetypes/application-x-zerosize.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/mimetypes/application-x-zip.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/mimetypes/application-xml.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/mimetypes/application-zip.png</Path>
@@ -15030,6 +15034,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/32x32/places/insync-folder.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/places/network-server.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/places/network-workgroup.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/32x32/places/start-here.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/places/user-desktop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/places/user-home.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/places/user-trash.png</Path>
@@ -15190,7 +15195,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/actions/mail_forward.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/actions/mail_new.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/actions/mail_reply.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/actions/printer.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/actions/printers.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/actions/process-stop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/actions/redo.png</Path>
@@ -15232,6 +15236,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/actions/system-shutdown.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/actions/system-switch-user.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/actions/undo.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/actions/view-app-grid.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/actions/view-zoom-in.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/actions/view-zoom-out.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/actions/window-close.png</Path>
@@ -15248,7 +15253,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/apps/accessories-dictionary.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/apps/accessories-text-editor.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/apps/address-book-app.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/apps/amazon-store.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/apps/applets-screenshooter.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/apps/applications-multimedia.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/apps/applications-office.png</Path>
@@ -15477,7 +15481,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/apps/workspace-switcher-right-top.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/apps/workspace-switcher-top-left.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/apps/x-office-address-book.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/categories/application-x-addon.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/categories/applications-accessories.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/categories/applications-development.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/categories/applications-games.png</Path>
@@ -15590,7 +15593,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/devices/phone.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/devices/printer-network.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/devices/printer.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/emblems/config-users.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/emblems/emblem-danger.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/emblems/emblem-default.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/emblems/emblem-dialog-question.png</Path>
@@ -15763,6 +15765,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/mimetypes/application-x-wine-extension-ini.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/mimetypes/application-x-xpinstall.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/mimetypes/application-x-yaml.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/mimetypes/application-x-zerosize.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/mimetypes/application-x-zip.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/mimetypes/application-xml.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/mimetypes/application-zip.png</Path>
@@ -15947,6 +15950,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/places/insync-folder.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/places/network-server.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/places/network-workgroup.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/places/start-here.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/places/user-desktop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/places/user-home.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/places/user-trash.png</Path>
@@ -16107,7 +16111,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/48x48/actions/mail_forward.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/actions/mail_new.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/actions/mail_reply.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/48x48/actions/printer.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/actions/printers.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/actions/process-stop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/actions/redo.png</Path>
@@ -16149,6 +16152,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/48x48/actions/system-shutdown.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/actions/system-switch-user.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/actions/undo.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/48x48/actions/view-app-grid.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/actions/view-zoom-in.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/actions/view-zoom-out.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/actions/window-close.png</Path>
@@ -16165,7 +16169,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/48x48/apps/accessories-dictionary.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/apps/accessories-text-editor.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/apps/address-book-app.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/48x48/apps/amazon-store.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/apps/applets-screenshooter.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/apps/applications-multimedia.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/apps/applications-office.png</Path>
@@ -16394,7 +16397,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/48x48/apps/workspace-switcher-right-top.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/apps/workspace-switcher-top-left.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/apps/x-office-address-book.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/48x48/categories/application-x-addon.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/categories/applications-accessories.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/categories/applications-development.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/categories/applications-games.png</Path>
@@ -16507,7 +16509,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/48x48/devices/phone.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/devices/printer-network.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/devices/printer.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/48x48/emblems/config-users.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/emblems/emblem-danger.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/emblems/emblem-default.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/emblems/emblem-dialog-question.png</Path>
@@ -16680,6 +16681,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/48x48/mimetypes/application-x-wine-extension-ini.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/mimetypes/application-x-xpinstall.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/mimetypes/application-x-yaml.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/48x48/mimetypes/application-x-zerosize.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/mimetypes/application-x-zip.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/mimetypes/application-xml.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/mimetypes/application-zip.png</Path>
@@ -16864,6 +16866,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/48x48/places/insync-folder.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/places/network-server.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/places/network-workgroup.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/48x48/places/start-here.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/places/user-desktop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/places/user-home.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/places/user-trash.png</Path>
@@ -17024,7 +17027,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/actions/mail_forward.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/actions/mail_new.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/actions/mail_reply.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/actions/printer.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/actions/printers.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/actions/process-stop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/actions/redo.png</Path>
@@ -17066,6 +17068,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/actions/system-shutdown.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/actions/system-switch-user.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/actions/undo.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/actions/view-app-grid.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/actions/view-zoom-in.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/actions/view-zoom-out.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/actions/window-close.png</Path>
@@ -17082,7 +17085,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/apps/accessories-dictionary.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/apps/accessories-text-editor.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/apps/address-book-app.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/apps/amazon-store.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/apps/applets-screenshooter.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/apps/applications-multimedia.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/apps/applications-office.png</Path>
@@ -17311,7 +17313,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/apps/workspace-switcher-right-top.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/apps/workspace-switcher-top-left.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/apps/x-office-address-book.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/categories/application-x-addon.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/categories/applications-accessories.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/categories/applications-development.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/categories/applications-games.png</Path>
@@ -17424,7 +17425,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/devices/phone.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/devices/printer-network.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/devices/printer.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/emblems/config-users.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/emblems/emblem-danger.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/emblems/emblem-default.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/emblems/emblem-dialog-question.png</Path>
@@ -17597,6 +17597,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/mimetypes/application-x-wine-extension-ini.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/mimetypes/application-x-xpinstall.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/mimetypes/application-x-yaml.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/mimetypes/application-x-zerosize.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/mimetypes/application-x-zip.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/mimetypes/application-xml.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/mimetypes/application-zip.png</Path>
@@ -17781,6 +17782,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/places/insync-folder.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/places/network-server.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/places/network-workgroup.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/places/start-here.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/places/user-desktop.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/places/user-home.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/places/user-trash.png</Path>
@@ -17838,7 +17840,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/8x8/categories/system-lock-screen.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/8x8/categories/system-users.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/8x8/categories/unity-screen-panel.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/8x8/emblems/config-users.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/8x8/emblems/emblem-danger.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/8x8/emblems/emblem-default.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/8x8/emblems/emblem-dialog-question.png</Path>
@@ -17896,7 +17897,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/8x8@2x/categories/system-lock-screen.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/8x8@2x/categories/system-users.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/8x8@2x/categories/unity-screen-panel.png</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/8x8@2x/emblems/config-users.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/8x8@2x/emblems/emblem-danger.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/8x8@2x/emblems/emblem-default.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/8x8@2x/emblems/emblem-dialog-question.png</Path>
@@ -18234,7 +18234,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/action-unavailable-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/address-book-new-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/adw-entry-apply-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/adw-expander-arrow-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/adw-mail-send-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/annotations-squiggly-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/annotations-text-symbolic.svg</Path>
@@ -18357,7 +18356,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/go-previous-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/go-top-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/go-up-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/hdy-expander-arrow-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/help-about-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/image-adjust-color-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/image-auto-adjust-symbolic.svg</Path>
@@ -18509,7 +18507,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/accessories-character-map-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/accessories-text-editor-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/address-book-app-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/amazon-store-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/applets-screenshooter-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/application-x-executable-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/applications-system-symbolic.svg</Path>
@@ -18699,6 +18696,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/seahorse-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/session-properties-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/settings-app-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/settings-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/shotwell-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/sm.puri.Chatty-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/snap-symbolic.svg</Path>
@@ -18767,10 +18765,12 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/applications-other-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/applications-science-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/applications-utilities-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/bolt-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/calendar-month-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/calendar-today-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/calendar-week-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/calendar-year-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/camera-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/characters-arrow-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/characters-bullet-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/characters-currency-symbolic.svg</Path>
@@ -18793,36 +18793,32 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/emoji-travel-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/goa-panel-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/hearing-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/location-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/lock-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/microphone-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/multitasking-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-about-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-accessibility-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-appearance-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-applications-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-bluetooth-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-camera-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-color-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-default-apps-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-diagnostics-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-display-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-file-history-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-keyboard-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-location-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-microphone-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-mobile-network-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-mouse-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-multitasking-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-network-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-notifications-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-online-accounts-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-power-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-printers-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-privacy-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-region-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-removable-media-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-search-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-sharing-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-sound-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-system-lock-screen-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-thunderbolt-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-time-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-users-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-wacom-symbolic.svg</Path>
@@ -18841,6 +18837,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/preferences-system-parental-controls-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/preferences-ubuntu-panel-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/seeing-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/trash-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/typing-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/view-tasks-today-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/view-tasks-week-symbolic.svg</Path>
@@ -19053,7 +19050,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/mimetypes/package-x-generic-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/mimetypes/text-x-generic-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/mimetypes/video-x-generic-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/mimetypes/x-office-address-book-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/mimetypes/x-office-calendar-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/mimetypes/x-office-document-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/mimetypes/x-office-drawing-symbolic.svg</Path>
@@ -19442,9 +19438,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2023-04-24</Date>
-            <Version>23.04.4</Version>
+        <Update release="22">
+            <Date>2023-10-16</Date>
+            <Version>23.10.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Release notes available [here](https://raw.githubusercontent.com/ubuntu/yaru/23.10.0-0ubuntu2/debian/changelog)

**Test Plan**

Changed icon and gtk theme to Yaru and navigated around my system to check things were alright

**Checklist**

- [x] Package was built and tested against unstable
