### PR TITLE
jtreg: Inclusion of homepage

### DIFF
--- a/packages/j/jtreg/package.yml
+++ b/packages/j/jtreg/package.yml
@@ -1,8 +1,9 @@
 name       : jtreg
 version    : 6.1.3
-release    : 3
+release    : 4
 source     :
     - https://github.com/openjdk/jtreg/archive/refs/tags/jtreg-6.1+3.tar.gz : 38a7a3f8d48d50eac8e09eb2f9880c7792fa198ec44d246df88492d45d6ee4cf
+homepage   : https://openjdk.org/projects/code-tools/jtreg/
 license    : GPL-2.0-only WITH Classpath-exception-2.0
 summary    : Test harness for testing the JDK
 description: |

--- a/packages/j/jtreg/pspec_x86_64.xml
+++ b/packages/j/jtreg/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>jtreg</Name>
+        <Homepage>https://openjdk.org/projects/code-tools/jtreg/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-only WITH Classpath-exception-2.0</License>
         <PartOf>programming.java</PartOf>
         <Summary xml:lang="en">Test harness for testing the JDK</Summary>
         <Description xml:lang="en">Test harness for testing the JDK, version 6.x for JDK 17
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>jtreg</Name>
@@ -47,12 +48,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2023-09-24</Date>
+        <Update release="4">
+            <Date>2023-10-16</Date>
             <Version>6.1.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Adding `homepage` key to `package.yml` (Part of #411)

**Test Plan**

- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable