### PR TITLE
bandwhich: Update to 0.21.1

### DIFF
--- a/packages/b/bandwhich/package.yml
+++ b/packages/b/bandwhich/package.yml
@@ -1,8 +1,9 @@
 name       : bandwhich
-version    : 0.21.0
-release    : 2
+version    : 0.21.1
+release    : 3
 source     :
-    - https://github.com/imsnif/bandwhich/archive/refs/tags/v0.21.0.tar.gz : f9c50c340372593bf4c54fcf2608ef37c2c56a37367b2f430c27cce3ea947828
+    - https://github.com/imsnif/bandwhich/archive/refs/tags/v0.21.1.tar.gz : 8ba9bf6469834ad498b9fd17f86759a16793b00a6ef44edd6e525ec40adcb0b0
+homepage   : https://github.com/imsnif/bandwhich
 license    : MIT
 component  : system.utils
 summary    : Terminal bandwidth utilization tool

--- a/packages/b/bandwhich/pspec_x86_64.xml
+++ b/packages/b/bandwhich/pspec_x86_64.xml
@@ -1,6 +1,7 @@
 <PISI>
     <Source>
         <Name>bandwhich</Name>
+        <Homepage>https://github.com/imsnif/bandwhich</Homepage>
         <Packager>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>
@@ -10,7 +11,7 @@
         <Summary xml:lang="en">Terminal bandwidth utilization tool</Summary>
         <Description xml:lang="en">This is a CLI utility for displaying current network utilization by process, connection and remote IP/hostname
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>bandwhich</Name>
@@ -24,9 +25,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2023-09-24</Date>
-            <Version>0.21.0</Version>
+        <Update release="3">
+            <Date>2023-10-16</Date>
+            <Version>0.21.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
## Summary
- Various codestyle changes
- Handle IPv4-mapped IPv6 addresses when resolving connection owner
- Bump dependencies to fix a memory leak
- Logging infrastructure added
- Version flag added
- [changelog](https://raw.githubusercontent.com/imsnif/bandwhich/v0.21.1/CHANGELOG.md)

## Test Plan
- watch traffic on different network interfaces

## Checklist
- [X] Package was built and tested against unstable
