### PR TITLE
udftools: Update to 2.3

### DIFF
--- a/packages/u/udftools/abi_used_symbols
+++ b/packages/u/udftools/abi_used_symbols
@@ -6,7 +6,6 @@ libc.so.6:__fprintf_chk
 libc.so.6:__isoc99_fscanf
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
-libc.so.6:__mbstowcs_chk
 libc.so.6:__memcpy_chk
 libc.so.6:__memmove_chk
 libc.so.6:__open_2
@@ -18,7 +17,6 @@ libc.so.6:__strncat_chk
 libc.so.6:__timezone
 libc.so.6:__vfprintf_chk
 libc.so.6:_exit
-libc.so.6:alarm
 libc.so.6:calloc
 libc.so.6:chdir
 libc.so.6:close
@@ -80,6 +78,7 @@ libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strncpy
+libc.so.6:strnlen
 libc.so.6:strrchr
 libc.so.6:strtol
 libc.so.6:strtoll

--- a/packages/u/udftools/package.yml
+++ b/packages/u/udftools/package.yml
@@ -1,8 +1,9 @@
 name       : udftools
-version    : '2.2'
-release    : 5
+version    : '2.3'
+release    : 6
 source     :
-    - https://github.com/pali/udftools/releases/download/2.2/udftools-2.2.tar.gz : d67ce203d71d828619d6d3791ab33eefab4bc506e0ee73355ab6c2f91d52448e
+    - https://github.com/pali/udftools/releases/download/2.3/udftools-2.3.tar.gz : 750dcf5c797765eb42265e0a56d1a99f97f94b7f6f4534263a5410503f0caf59
+homepage   : https://github.com/pali/udftools
 license    : GPL-2.0-or-later
 component  : system.utils
 summary    : Linux UDF Filesystem userspace utilities

--- a/packages/u/udftools/pspec_x86_64.xml
+++ b/packages/u/udftools/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>udftools</Name>
+        <Homepage>https://github.com/pali/udftools</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">Linux UDF Filesystem userspace utilities</Summary>
         <Description xml:lang="en">Linux tools for UDF filesystems and DVD/CD-R(W) drives
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>udftools</Name>
@@ -25,6 +26,7 @@
             <Path fileType="library">/usr/lib/udev/rules.d/80-pktsetup.rules</Path>
             <Path fileType="executable">/usr/sbin/mkfs.udf</Path>
             <Path fileType="executable">/usr/sbin/mkudffs</Path>
+            <Path fileType="executable">/usr/sbin/pktcdvd-check</Path>
             <Path fileType="executable">/usr/sbin/pktsetup</Path>
             <Path fileType="executable">/usr/sbin/udflabel</Path>
             <Path fileType="doc">/usr/share/doc/udftools/AUTHORS</Path>
@@ -43,12 +45,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2022-03-24</Date>
-            <Version>2.2</Version>
+        <Update release="6">
+            <Date>2023-10-17</Date>
+            <Version>2.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Changes in 2.3 
  - mkudffs: 
    - Added support for creating Multisession UDF disc images via new `--startblock` option 
    - Added new options for specifying owner, organization and contact information 
    - Added new option `--bootarea=mbr:sec-size` to allow specifying MBR sector size 
    - Added udftools version string into Application Identifier 
    - Fixed default value of Packet Length in Sparable Partition for UDF 1.50 and 2.00 rev to 32 blocks 
    - Fixed detecting all 33 types of optical discs defined in all versions of SCSI MMC specifications 
    - Fixed filling CHS sector number into MBR partition table 
    - Fixed alignment of VAT block for CD-R, DVD-R and BD-R disc 
    - Fixed alignment for CD-R discs 
    - Fixed generating unclosed CD-R image with blocks more than 3072 
  - udfinfo & udflabel: 
    - Added support for Multisession UDF optical discs via new `--startblock` and `--lastblock` options 
    - Added support for showing and changing owner, organization, contact, appid and impid UDF identifiers 
    - Added more checks to validation of UDF structures 
    - Throw error when trying to modify UDF disc with unsupported Pseudo OverWrite partition 
  - pktsetup: 
    - Added new option `-i` to ignore errors when device is already mapped or unmapped 
    - Added new tool `pktcdvd-check` which checks if optical disc can be used by kernel `pktcdvd.ko` driver for write operations 
    - Update udev rule to map only optical discs which are supported for write operation (check done by pktcdvd-check tool) - cdrwtool: 
    - Fixed formatting of CD-RW disc in modern optical drives according to MMC-6 standard (via Format Code 1) - Fixed support for progress bar
- Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

- Checked the availabilty of function on gparted
- Verified the added homepage loads information about the package

**Checklist**

[x] Package was built and tested against unstable