### PR TITLE
upx: Update to 4.1.0

### DIFF
--- a/packages/u/upx/abi_used_symbols
+++ b/packages/u/upx/abi_used_symbols
@@ -1,8 +1,10 @@
-libc.so.6:__assert_fail
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoll
+libc.so.6:__isoc23_strtoull
 libc.so.6:__libc_start_main
 libc.so.6:__memset_chk
 libc.so.6:__printf_chk
@@ -67,8 +69,6 @@ libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strrchr
 libc.so.6:strstr
-libc.so.6:strtol
-libc.so.6:strtoull
 libc.so.6:sysconf
 libc.so.6:time
 libc.so.6:tolower
@@ -79,7 +79,6 @@ libgcc_s.so.1:_Unwind_Resume
 libm.so.6:log10
 libstdc++.so.6:_ZNKSt12__basic_fileIcE7is_openEv
 libstdc++.so.6:_ZNKSt5ctypeIcE13_M_widen_initEv
-libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7compareEmmPKc
 libstdc++.so.6:_ZNKSt8__detail20_Prime_rehash_policy14_M_need_rehashEmmm
 libstdc++.so.6:_ZNKSt9exception4whatEv
 libstdc++.so.6:_ZNSdD2Ev
@@ -127,8 +126,6 @@ libstdc++.so.6:_ZNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE7_M_syncE
 libstdc++.so.6:_ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEEC1Ev
 libstdc++.so.6:_ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEED1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitC1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitD1Ev
 libstdc++.so.6:_ZNSt8ios_baseC2Ev
 libstdc++.so.6:_ZNSt8ios_baseD2Ev
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE4initEPSt15basic_streambufIcS1_E
@@ -143,10 +140,12 @@ libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt19uncaught_exceptionsv
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
+libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZSt28__throw_bad_array_new_lengthv
 libstdc++.so.6:_ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_
 libstdc++.so.6:_ZSt4cout
 libstdc++.so.6:_ZSt7getlineIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EES4_
+libstdc++.so.6:_ZSt9terminatev
 libstdc++.so.6:_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
 libstdc++.so.6:_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_c
 libstdc++.so.6:_ZTIPKc
@@ -156,6 +155,7 @@ libstdc++.so.6:_ZTISt15basic_streambufIcSt11char_traitsIcEE
 libstdc++.so.6:_ZTISt9bad_alloc
 libstdc++.so.6:_ZTISt9exception
 libstdc++.so.6:_ZTIi
+libstdc++.so.6:_ZTIm
 libstdc++.so.6:_ZTTNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEEE
 libstdc++.so.6:_ZTTNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEE
 libstdc++.so.6:_ZTTSt13basic_fstreamIcSt11char_traitsIcEE
@@ -177,7 +177,6 @@ libstdc++.so.6:_ZdlPvm
 libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
 libstdc++.so.6:__cxa_allocate_exception
-libstdc++.so.6:__cxa_bad_typeid
 libstdc++.so.6:__cxa_begin_catch
 libstdc++.so.6:__cxa_end_catch
 libstdc++.so.6:__cxa_guard_acquire

--- a/packages/u/upx/package.yml
+++ b/packages/u/upx/package.yml
@@ -1,8 +1,9 @@
 name       : upx
-version    : 4.0.2
-release    : 5
+version    : 4.1.0
+release    : 6
 source     :
-    - https://github.com/upx/upx/releases/download/v4.0.2/upx-4.0.2-src.tar.xz : 1221e725b1a89e06739df27fae394d6bc88aedbe12f137c630ec772522cbc76f
+    - https://github.com/upx/upx/releases/download/v4.1.0/upx-4.1.0-src.tar.xz : 0582f78b517ea87ba1caa6e8c111474f58edd167e5f01f074d7d9ca2f81d47d0
+homepage   : https://upx.github.io/
 license    : GPL-2.0-or-later
 component  : system.utils
 summary    : Ultimate Packer for eXecutables.

--- a/packages/u/upx/pspec_x86_64.xml
+++ b/packages/u/upx/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>upx</Name>
+        <Homepage>https://upx.github.io/</Homepage>
         <Packager>
-            <Name>Mislav Čakarić</Name>
-            <Email>mcakaric@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">Ultimate Packer for eXecutables.</Summary>
         <Description xml:lang="en">Free, portable, extendable, high-performance executable packer for several executable formats. UPX achieves an excellent compression ratio and offers very fast decompression. Your executables suffer no memory overhead or other drawbacks for most of the formats supported, because of in-place decompression.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>upx</Name>
@@ -24,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2023-05-30</Date>
-            <Version>4.0.2</Version>
+        <Update release="6">
+            <Date>2023-10-18</Date>
+            <Version>4.1.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Mislav Čakarić</Name>
-            <Email>mcakaric@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Changelog can be found [here](https://github.com/upx/upx/blob/master/NEWS)
- Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

- Install `upx` and try to use it on few executables
- Try build simple C and golang program into binary executable
- Compress it with `upx` and run it
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable