### PR TITLE
urlscan: Update to 1.0.1

### DIFF
--- a/packages/u/urlscan/package.yml
+++ b/packages/u/urlscan/package.yml
@@ -1,15 +1,20 @@
 name       : urlscan
-version    : 0.9.4
-release    : 7
+version    : 1.0.1
+release    : 8
 source     :
-    - https://github.com/firecat53/urlscan/archive/0.9.4.tar.gz : fc76c3c8a852f1fbdde69faa336184b7f060b33e8e4573d6ffa8790ed6f429b6
+    - https://files.pythonhosted.org/packages/source/u/urlscan/urlscan-1.0.1.tar.gz : e0ec986e5aa2da57dd2face8692116d80af173d4eb56a78e4fd881731113307f
+homepage   : https://github.com/firecat53/urlscan
 license    : GPL-2.0-or-later
 component  : network.mail
 summary    : Mutt and terminal url selector (similar to urlview)
 description: |
     Urlscan is a small program that is designed to integrate with the "mutt" mailreader to allow you to easily launch a Web browser for URLs contained in email messages. It is a replacement for the "urlview" program.
 builddeps  :
-    - pkgconfig(python3)
+    - python-build
+    - python-hatchling
+    - python-hatch-vcs
+    - python-installer
+    - python-wheel
 rundeps    :
     - python3-urwid
 build      : |

--- a/packages/u/urlscan/pspec_x86_64.xml
+++ b/packages/u/urlscan/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>urlscan</Name>
+        <Homepage>https://github.com/firecat53/urlscan</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>network.mail</PartOf>
         <Summary xml:lang="en">Mutt and terminal url selector (similar to urlview)</Summary>
         <Description xml:lang="en">Urlscan is a small program that is designed to integrate with the &quot;mutt&quot; mailreader to allow you to easily launch a Web browser for URLs contained in email messages. It is a replacement for the &quot;urlview&quot; program.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>urlscan</Name>
@@ -20,30 +21,39 @@
         <PartOf>network.mail</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/urlscan</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan-0.9.4-py3.10.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan-0.9.4-py3.10.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan-0.9.4-py3.10.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan-0.9.4-py3.10.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan-0.9.4-py3.10.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan-1.0.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan-1.0.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan-1.0.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan-1.0.1.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan-1.0.1.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan/__main__.py</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan/__pycache__/__init__.cpython-310.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan/__pycache__/__init__.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan/__pycache__/__main__.cpython-310.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan/__pycache__/__main__.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan/__pycache__/_version.cpython-310.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan/__pycache__/_version.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan/__pycache__/urlchoose.cpython-310.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan/__pycache__/urlchoose.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan/__pycache__/urlscan.cpython-310.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan/__pycache__/urlscan.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan/_version.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan/assets/tlds-alpha-by-domain.txt</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan/urlchoose.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/urlscan/urlscan.py</Path>
-            <Path fileType="doc">/usr/share/doc/urlscan/COPYING</Path>
-            <Path fileType="doc">/usr/share/doc/urlscan/README.rst</Path>
+            <Path fileType="doc">/usr/share/doc/urlscan/LICENSE</Path>
+            <Path fileType="doc">/usr/share/doc/urlscan/README.md</Path>
             <Path fileType="man">/usr/share/man/man1/urlscan.1</Path>
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2022-04-12</Date>
-            <Version>0.9.4</Version>
+        <Update release="8">
+            <Date>2023-10-21</Date>
+            <Version>1.0.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Changes can be found [here](https://github.com/firecat53/urlscan/releases)
- Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

- Ran it successufully on test file
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable