### PR TITLE
budgie rebuilds for gnome 45

### DIFF
--- a/packages/b/budgie-calendar-applet/package.yml
+++ b/packages/b/budgie-calendar-applet/package.yml
@@ -1,6 +1,6 @@
 name       : budgie-calendar-applet
 version    : '5.3'
-release    : 6
+release    : 7
 source     :
     - https://github.com/danielpinto8zz6/budgie-calendar-applet/archive/refs/tags/5.3.tar.gz : 921ad0d698ab7afea2c7e29351027013049f381f4e866fea1e0fa84982a8bb70
 homepage   : https://github.com/danielpinto8zz6/budgie-calendar-applet

--- a/packages/b/budgie-calendar-applet/pspec_x86_64.xml
+++ b/packages/b/budgie-calendar-applet/pspec_x86_64.xml
@@ -11,7 +11,7 @@
         <Summary xml:lang="en">Calendar applet for the Budgie Desktop</Summary>
         <Description xml:lang="en">A budgie-desktop applet to show hours and when click show a calendar in a popover.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>budgie-calendar-applet</Name>
@@ -38,8 +38,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2023-07-18</Date>
+        <Update release="7">
+            <Date>2023-10-18</Date>
             <Version>5.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>

--- a/packages/b/budgie-control-center/abi_used_symbols
+++ b/packages/b/budgie-control-center/abi_used_symbols
@@ -1145,6 +1145,7 @@ libgobject-2.0.so.0:g_boxed_type_register_static
 libgobject-2.0.so.0:g_cclosure_marshal_VOID__BOOLEAN
 libgobject-2.0.so.0:g_cclosure_marshal_VOID__OBJECT
 libgobject-2.0.so.0:g_cclosure_marshal_VOID__POINTER
+libgobject-2.0.so.0:g_cclosure_marshal_VOID__STRING
 libgobject-2.0.so.0:g_cclosure_marshal_VOID__UINT
 libgobject-2.0.so.0:g_cclosure_marshal_VOID__VOID
 libgobject-2.0.so.0:g_cclosure_marshal_generic
@@ -1258,6 +1259,7 @@ libgobject-2.0.so.0:g_value_get_uint64
 libgobject-2.0.so.0:g_value_get_ulong
 libgobject-2.0.so.0:g_value_get_variant
 libgobject-2.0.so.0:g_value_init
+libgobject-2.0.so.0:g_value_peek_pointer
 libgobject-2.0.so.0:g_value_set_boolean
 libgobject-2.0.so.0:g_value_set_double
 libgobject-2.0.so.0:g_value_set_enum

--- a/packages/b/budgie-control-center/package.yml
+++ b/packages/b/budgie-control-center/package.yml
@@ -1,8 +1,9 @@
 name       : budgie-control-center
 version    : 1.3.0
-release    : 20
+release    : 21
 source     :
     - https://github.com/BuddiesOfBudgie/budgie-control-center/releases/download/v1.3.0/budgie-control-center-1.3.0.tar.xz : d526a22f22cc5ae0fd7a6c6ce4460bb368e93cb6c1b09300f76b97144aab3819
+homepage   : https://buddiesofbudgie.org
 license    : GPL-2.0-or-later
 component  : desktop.budgie
 summary    : Budgie Control Center is a fork of GNOME Control Center for the Budgie 10 Series

--- a/packages/b/budgie-control-center/pspec_x86_64.xml
+++ b/packages/b/budgie-control-center/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>budgie-control-center</Name>
+        <Homepage>https://buddiesofbudgie.org</Homepage>
         <Packager>
-            <Name>Rune Morling</Name>
-            <Email>ermo@serpentos.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.budgie</PartOf>
         <Summary xml:lang="en">Budgie Control Center is a fork of GNOME Control Center for the Budgie 10 Series</Summary>
         <Description xml:lang="en">Budgie Control Center is a fork of GNOME Settings / GNOME Control Center with the intent of providing a simplified list of settings that are applicable to the Budgie 10 series, along with any small quality-of-life settings.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>budgie-control-center</Name>
@@ -316,12 +317,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2023-09-06</Date>
+        <Update release="21">
+            <Date>2023-10-18</Date>
             <Version>1.3.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Rune Morling</Name>
-            <Email>ermo@serpentos.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/b/budgie-cputemp-applet/package.yml
+++ b/packages/b/budgie-cputemp-applet/package.yml
@@ -1,8 +1,9 @@
 name       : budgie-cputemp-applet
 version    : 1.2.0
-release    : 2
+release    : 3
 source     :
     - https://github.com/tarkah/budgie-cputemp-applet/archive/refs/tags/1.2.0.tar.gz : f3c897dc47a08398f1da0b1bb020d7fe07d01b93666ea6f48623990184a8325a
+homepage   : https://github.com/tarkah/budgie-cputemp-applet
 license    : GPL-2.0-only
 component  : desktop.budgie
 summary    : Applet to monitor CPU Temperature

--- a/packages/b/budgie-cputemp-applet/pspec_x86_64.xml
+++ b/packages/b/budgie-cputemp-applet/pspec_x86_64.xml
@@ -1,6 +1,7 @@
 <PISI>
     <Source>
         <Name>budgie-cputemp-applet</Name>
+        <Homepage>https://github.com/tarkah/budgie-cputemp-applet</Homepage>
         <Packager>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>
@@ -10,7 +11,7 @@
         <Summary xml:lang="en">Applet to monitor CPU Temperature</Summary>
         <Description xml:lang="en">An applet that monitors and displays CPU Temperature. Sensor can be chosen in the applet popover menu.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>budgie-cputemp-applet</Name>
@@ -26,8 +27,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2023-07-18</Date>
+        <Update release="3">
+            <Date>2023-10-18</Date>
             <Version>1.2.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>

--- a/packages/b/budgie-desktop-view/abi_used_symbols
+++ b/packages/b/budgie-desktop-view/abi_used_symbols
@@ -6,6 +6,7 @@ libc.so.6:strcmp
 libc.so.6:strlen
 libgdk-3.so.0:gdk_app_launch_context_set_screen
 libgdk-3.so.0:gdk_app_launch_context_set_timestamp
+libgdk-3.so.0:gdk_cursor_get_type
 libgdk-3.so.0:gdk_cursor_new_for_display
 libgdk-3.so.0:gdk_cursor_new_from_name
 libgdk-3.so.0:gdk_display_get_app_launch_context
@@ -13,9 +14,14 @@ libgdk-3.so.0:gdk_display_get_default
 libgdk-3.so.0:gdk_display_get_primary_monitor
 libgdk-3.so.0:gdk_monitor_get_scale_factor
 libgdk-3.so.0:gdk_monitor_get_workarea
+libgdk-3.so.0:gdk_rectangle_get_type
 libgdk-3.so.0:gdk_screen_get_default
 libgdk-3.so.0:gdk_screen_get_rgba_visual
+libgdk-3.so.0:gdk_screen_get_root_window
+libgdk-3.so.0:gdk_window_add_filter
 libgdk-3.so.0:gdk_window_set_cursor
+libgdk-3.so.0:gdk_window_set_events
+libgdk-3.so.0:gdk_x11_get_xatom_by_name
 libgdk_pixbuf-2.0.so.0:gdk_pixbuf_copy
 libgdk_pixbuf-2.0.so.0:gdk_pixbuf_get_width
 libgdk_pixbuf-2.0.so.0:gdk_pixbuf_new_from_file_at_scale
@@ -24,7 +30,6 @@ libgdk_pixbuf-2.0.so.0:gdk_pixbuf_scale_simple
 libgio-2.0.so.0:g_app_info_get_default_for_type
 libgio-2.0.so.0:g_app_info_get_display_name
 libgio-2.0.so.0:g_app_info_get_icon
-libgio-2.0.so.0:g_app_info_get_id
 libgio-2.0.so.0:g_app_info_launch
 libgio-2.0.so.0:g_app_info_launch_default_for_uri
 libgio-2.0.so.0:g_app_info_launch_uris
@@ -187,6 +192,8 @@ libglib-2.0.so.0:g_utf8_collate_key_for_filename
 libglib-2.0.so.0:g_variant_builder_end
 libglib-2.0.so.0:g_variant_builder_init
 libglib-2.0.so.0:g_variant_iter_init
+libgobject-2.0.so.0:g_boxed_copy
+libgobject-2.0.so.0:g_boxed_free
 libgobject-2.0.so.0:g_cclosure_marshal_VOID__OBJECT
 libgobject-2.0.so.0:g_cclosure_marshal_VOID__VOID
 libgobject-2.0.so.0:g_cclosure_new
@@ -240,7 +247,6 @@ libgtk-3.so.0:gtk_drag_dest_set
 libgtk-3.so.0:gtk_drag_finish
 libgtk-3.so.0:gtk_event_box_new
 libgtk-3.so.0:gtk_flow_box_child_get_type
-libgtk-3.so.0:gtk_flow_box_get_child_at_index
 libgtk-3.so.0:gtk_flow_box_get_selected_children
 libgtk-3.so.0:gtk_flow_box_invalidate_sort
 libgtk-3.so.0:gtk_flow_box_new
@@ -280,6 +286,7 @@ libgtk-3.so.0:gtk_widget_get_name
 libgtk-3.so.0:gtk_widget_get_style_context
 libgtk-3.so.0:gtk_widget_get_window
 libgtk-3.so.0:gtk_widget_hide
+libgtk-3.so.0:gtk_widget_is_visible
 libgtk-3.so.0:gtk_widget_queue_draw
 libgtk-3.so.0:gtk_widget_set_can_focus
 libgtk-3.so.0:gtk_widget_set_events

--- a/packages/b/budgie-desktop-view/package.yml
+++ b/packages/b/budgie-desktop-view/package.yml
@@ -1,8 +1,9 @@
 name       : budgie-desktop-view
-version    : 1.2.1
-release    : 25
+version    : '1.3'
+release    : 26
 source     :
-    - https://github.com/BuddiesOfBudgie/budgie-desktop-view/archive/refs/tags/v1.2.1.tar.gz : c81cc27b83be2a2d1325c9d7bf01bafe7fc8186fbb5dfb2806d54b5669f92ff5
+    - https://github.com/BuddiesOfBudgie/budgie-desktop-view/releases/download/v1.3/budgie-desktop-view-v1.3.tar.xz : acf47e478fa6df75308c1a553668d236a484bd5fb1b60deba4b7744de0445411
+homepage   : https://buddiesofbudgie.org
 license    : Apache-2.0
 component  : desktop.budgie
 summary    : Budgie Desktop View is the official Budgie desktop icons implementation, developed by Solus.

--- a/packages/b/budgie-desktop-view/pspec_x86_64.xml
+++ b/packages/b/budgie-desktop-view/pspec_x86_64.xml
@@ -1,6 +1,7 @@
 <PISI>
     <Source>
         <Name>budgie-desktop-view</Name>
+        <Homepage>https://buddiesofbudgie.org</Homepage>
         <Packager>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>
@@ -10,7 +11,7 @@
         <Summary xml:lang="en">Budgie Desktop View is the official Budgie desktop icons implementation, developed by Solus.</Summary>
         <Description xml:lang="en">Budgie Desktop View is the official Budgie desktop icons implementation, developed by Solus.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>budgie-desktop-view</Name>
@@ -31,9 +32,11 @@
             <Path fileType="localedata">/usr/share/locale/he/LC_MESSAGES/budgie-desktop-view.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/budgie-desktop-view.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja_JP/LC_MESSAGES/budgie-desktop-view.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/budgie-desktop-view.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ko/LC_MESSAGES/budgie-desktop-view.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lt/LC_MESSAGES/budgie-desktop-view.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ms_MY/LC_MESSAGES/budgie-desktop-view.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/oc/LC_MESSAGES/budgie-desktop-view.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/budgie-desktop-view.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt_PT/LC_MESSAGES/budgie-desktop-view.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ru/LC_MESSAGES/budgie-desktop-view.mo</Path>
@@ -47,9 +50,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="25">
-            <Date>2023-07-18</Date>
-            <Version>1.2.1</Version>
+        <Update release="26">
+            <Date>2023-10-18</Date>
+            <Version>1.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>

--- a/packages/b/budgie-desktop/abi_used_symbols
+++ b/packages/b/budgie-desktop/abi_used_symbols
@@ -916,6 +916,7 @@ libgtk-3.so.0:gtk_icon_theme_has_icon
 libgtk-3.so.0:gtk_icon_theme_load_icon
 libgtk-3.so.0:gtk_icon_theme_lookup_by_gicon
 libgtk-3.so.0:gtk_icon_theme_lookup_icon
+libgtk-3.so.0:gtk_icon_theme_new
 libgtk-3.so.0:gtk_icon_theme_prepend_search_path
 libgtk-3.so.0:gtk_image_get_gicon
 libgtk-3.so.0:gtk_image_get_icon_name

--- a/packages/b/budgie-desktop/package.yml
+++ b/packages/b/budgie-desktop/package.yml
@@ -1,8 +1,8 @@
 name       : budgie-desktop
-version    : 10.8.1
-release    : 265
+version    : 10.8.2
+release    : 266
 source     :
-    - https://github.com/BuddiesOfBudgie/budgie-desktop/releases/download/v10.8.1/budgie-desktop-v10.8.1.tar.xz : b12d4b5bc3da3363c766535cf8e8e64003afac46f84d040ad7d7d996090f2ca7
+    - https://github.com/BuddiesOfBudgie/budgie-desktop/releases/download/v10.8.2/budgie-desktop-v10.8.2.tar.xz : a8f88a253a787bb51f122923456103b1dfd4b880c3c6be6cb08e6c70624f9673
 homepage   : https://blog.buddiesofbudgie.org
 license    :
     - GPL-2.0-only

--- a/packages/b/budgie-desktop/pspec_x86_64.xml
+++ b/packages/b/budgie-desktop/pspec_x86_64.xml
@@ -12,7 +12,7 @@
         <Summary xml:lang="en">Budgie Desktop is the flagship desktop experience developed by the Solus team.</Summary>
         <Description xml:lang="en">Budgie Desktop is the flagship desktop experience developed by the Solus team.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>budgie-desktop</Name>
@@ -246,7 +246,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="265">budgie-desktop</Dependency>
+            <Dependency release="266">budgie-desktop</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/budgie-desktop/applet-info.h</Path>
@@ -305,9 +305,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="265">
-            <Date>2023-10-01</Date>
-            <Version>10.8.1</Version>
+        <Update release="266">
+            <Date>2023-10-18</Date>
+            <Version>10.8.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>

--- a/packages/b/budgie-extras/package.yml
+++ b/packages/b/budgie-extras/package.yml
@@ -1,6 +1,6 @@
 name       : budgie-extras
 version    : 1.7.0
-release    : 26
+release    : 27
 source     :
     - https://github.com/UbuntuBudgie/budgie-extras/releases/download/v1.7.0/budgie-extras-1.7.0.tar.xz : 9605a79006dadc293ea7e4dbbf01dbf411c732a7fa82252ba29664fbd962d89c
 homepage   : https://github.com/UbuntuBudgie/budgie-extras

--- a/packages/b/budgie-extras/pspec_x86_64.xml
+++ b/packages/b/budgie-extras/pspec_x86_64.xml
@@ -3,14 +3,14 @@
         <Name>budgie-extras</Name>
         <Homepage>https://github.com/UbuntuBudgie/budgie-extras</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop.budgie</PartOf>
         <Summary xml:lang="en">Budgie-extras is a shared component with translations required by various applets</Summary>
         <Description xml:lang="en">Budgie-extras is a shared component with translations required by various applets.</Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>budgie-extras</Name>
@@ -46,7 +46,7 @@
         <Description xml:lang="en">The brightness controller applet allows controlling of the screen levels via xrandr (fallback) or via gnome-settings-daemon (if available).</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="26">budgie-extras</Dependency>
+            <Dependency releaseFrom="27">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-brightness-controller/brightnesscontroller.plugin</Path>
@@ -60,7 +60,7 @@
         <Description xml:lang="en">A count down applet with the following options; ring a bell, flash the (panel) icon, display a message window or run a (any) command.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="26">budgie-extras</Dependency>
+            <Dependency releaseFrom="27">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-countdown/CountDown.plugin</Path>
@@ -80,7 +80,7 @@
         <Description xml:lang="en">This on logon process manages keyboard shortcuts delivered via .bde files for various extras-plugins.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="26">budgie-extras</Dependency>
+            <Dependency releaseFrom="27">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/budgie-extras-daemon</Path>
@@ -104,8 +104,8 @@
         <Description xml:lang="en">The hotcorners applet allow user defined commands to be executed when the mouse cursor is pushed into a corner of the main desktop.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="26">budgie-previews</Dependency>
-            <Dependency releaseFrom="26">budgie-window-shuffler</Dependency>
+            <Dependency releaseFrom="27">budgie-previews</Dependency>
+            <Dependency releaseFrom="27">budgie-window-shuffler</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-hotcorners/HotCorners.plugin</Path>
@@ -130,7 +130,7 @@
         <Description xml:lang="en">The kangaroo applet allows for quick and easy browsing, across (possibly) many directory layers, without having to do a single mouse click.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="26">budgie-extras</Dependency>
+            <Dependency releaseFrom="27">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-kangaroo/BudgieKangaroo.plugin</Path>
@@ -144,7 +144,7 @@
         <Description xml:lang="en">Set previews to show an overview of windows in an expose like way.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="26">budgie-extras-daemon</Dependency>
+            <Dependency releaseFrom="27">budgie-extras-daemon</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-previews/previews_controls</Path>
@@ -177,7 +177,7 @@
         <Description xml:lang="en">The quicknote applet allows a user to record a text based note. The applet autosaves the text while writing and supports multiple undo and redo capabilities.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="26">budgie-extras</Dependency>
+            <Dependency releaseFrom="27">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-quicknote/QuickNoteApplet.plugin</Path>
@@ -192,7 +192,7 @@
         <Description xml:lang="en">Budgie Showtime is a digital desktop clock, showing time, and optionally, date. Text color of both can be set separately from the applet&apos;s menu.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="26">budgie-extras</Dependency>
+            <Dependency releaseFrom="27">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-showtime/ShowTime.plugin</Path>
@@ -208,7 +208,7 @@
         <Description xml:lang="en">Budgie TakeaBreak is a pomodoro like applet, to make sure to take regular breaks from working. Options from Budgie Settings include turning the screen upside down, dim the screen, lock screen or show a countdown message on break time. The applet can be accessed quickly from the panel to temporarily switch it off.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="26">budgie-extras</Dependency>
+            <Dependency releaseFrom="27">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-takeabreak/BudgieTakeaBreak.plugin</Path>
@@ -226,7 +226,7 @@
         <Description xml:lang="en">The visualspace applet shows as a stylish compact workspace on the budgie panel. Choosing windows in the applet popup moves to the workspace where the window is located and gives it focus. The number of Workspace can also be changed though the applet popup.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="26">budgie-extras</Dependency>
+            <Dependency releaseFrom="27">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-visualspace/VisualSpace.plugin</Path>
@@ -243,7 +243,7 @@
         <Description xml:lang="en">The weathershow applet displays daily and three hourly weather forecasts on both the desktop and a Popover.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="26">budgie-extras</Dependency>
+            <Dependency releaseFrom="27">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-weathershow/WeatherShow.plugin</Path>
@@ -328,7 +328,7 @@
         <Description xml:lang="en">The window shuffler is an easy to use windows tiling capability driven primarily through the keyboard to place and move window in a grid format.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="26">budgie-extras-daemon</Dependency>
+            <Dependency releaseFrom="27">budgie-extras-daemon</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-window-shuffler/ShufflerAPplet.plugin</Path>
@@ -406,12 +406,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2023-08-22</Date>
+        <Update release="27">
+            <Date>2023-10-18</Date>
             <Version>1.7.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/b/budgie-haste-applet/package.yml
+++ b/packages/b/budgie-haste-applet/package.yml
@@ -1,8 +1,9 @@
 name       : budgie-haste-applet
 version    : 0.3.0
-release    : 24
+release    : 25
 source     :
     - https://github.com/cybre/budgie-haste-applet/archive/v0.3.0.tar.gz : 69edb1efb700b1f5fd86b0e2e27a18261b375af85a46075c41dc41eab2a37494
+homepage   : https://github.com/cybre/budgie-haste-applet
 license    : GPL-2.0-or-later
 component  : desktop.budgie
 summary    : Post any text, be it code or prose, to various services directly from your desktop

--- a/packages/b/budgie-haste-applet/pspec_x86_64.xml
+++ b/packages/b/budgie-haste-applet/pspec_x86_64.xml
@@ -1,6 +1,7 @@
 <PISI>
     <Source>
         <Name>budgie-haste-applet</Name>
+        <Homepage>https://github.com/cybre/budgie-haste-applet</Homepage>
         <Packager>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>
@@ -10,7 +11,7 @@
         <Summary xml:lang="en">Post any text, be it code or prose, to various services directly from your desktop</Summary>
         <Description xml:lang="en">Post any text, be it code or prose, to various services directly from your desktop
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>budgie-haste-applet</Name>
@@ -38,8 +39,8 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2023-07-18</Date>
+        <Update release="25">
+            <Date>2023-10-18</Date>
             <Version>0.3.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>

--- a/packages/b/budgie-screensaver/package.yml
+++ b/packages/b/budgie-screensaver/package.yml
@@ -1,6 +1,6 @@
 name       : budgie-screensaver
 version    : 5.1.0
-release    : 26
+release    : 27
 source     :
     - https://github.com/BuddiesOfBudgie/budgie-screensaver/releases/download/v5.1.0/budgie-screensaver-v5.1.0.tar.xz : 563ac3f845729e9e6d184d2dbf036ab3f51ff244c27f5b286cfcb89acc147f0c
 license    :

--- a/packages/b/budgie-screensaver/pspec_x86_64.xml
+++ b/packages/b/budgie-screensaver/pspec_x86_64.xml
@@ -12,7 +12,7 @@
         <Summary xml:lang="en">Budgie Screensaver is a fork of gnome-screensaver intended for use with Budgie Desktop and is similar in purpose to other screensavers such as MATE Screensaver.</Summary>
         <Description xml:lang="en">Budgie Screensaver is a fork of gnome-screensaver intended for use with Budgie Desktop and is similar in purpose to other screensavers such as MATE Screensaver.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>budgie-screensaver</Name>
@@ -125,8 +125,8 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2023-07-18</Date>
+        <Update release="27">
+            <Date>2023-10-18</Date>
             <Version>5.1.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>

--- a/packages/b/budgie-screenshot-applet/package.yml
+++ b/packages/b/budgie-screenshot-applet/package.yml
@@ -1,8 +1,9 @@
 name       : budgie-screenshot-applet
 version    : 0.4.3
-release    : 30
+release    : 31
 source     :
     - git|https://github.com/cybre/budgie-screenshot-applet.git : 9e79e58419d42ba4f338a5cd84fa35d2c5ddb5da
+homepage   : https://github.com/cybre/budgie-screenshot-applet
 license    : GPL-2.0-or-later
 component  : desktop.budgie
 summary    : Take a screenshot of your desktop, a window or region; save to disk and upload.

--- a/packages/b/budgie-screenshot-applet/pspec_x86_64.xml
+++ b/packages/b/budgie-screenshot-applet/pspec_x86_64.xml
@@ -1,6 +1,7 @@
 <PISI>
     <Source>
         <Name>budgie-screenshot-applet</Name>
+        <Homepage>https://github.com/cybre/budgie-screenshot-applet</Homepage>
         <Packager>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>
@@ -10,7 +11,7 @@
         <Summary xml:lang="en">Take a screenshot of your desktop, a window or region; save to disk and upload.</Summary>
         <Description xml:lang="en">Take a screenshot of your desktop, a window or region; save to disk and upload.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>budgie-screenshot-applet</Name>
@@ -45,8 +46,8 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="30">
-            <Date>2023-07-18</Date>
+        <Update release="31">
+            <Date>2023-10-18</Date>
             <Version>0.4.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>

--- a/packages/b/budgie-shutdown-timer/package.yml
+++ b/packages/b/budgie-shutdown-timer/package.yml
@@ -1,6 +1,6 @@
 name       : budgie-shutdown-timer
 version    : 1.0
-release    : 3
+release    : 4
 source     :
     - git|https://github.com/gkr09/budgie-shutdown-timer : d0cabf8ec85584ba305b6dc6eadc9ffecd739006
 homepage   : https://github.com/gkr09/budgie-shutdown-timer

--- a/packages/b/budgie-shutdown-timer/pspec_x86_64.xml
+++ b/packages/b/budgie-shutdown-timer/pspec_x86_64.xml
@@ -11,7 +11,7 @@
         <Summary xml:lang="en">Schedule Shutdown/Restart etc. from your Budgie Desktop</Summary>
         <Description xml:lang="en">Automatically Shutdown/Reboot/Hibernate/Suspend after a set time.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>budgie-shutdown-timer</Name>
@@ -27,8 +27,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2023-07-18</Date>
+        <Update release="4">
+            <Date>2023-10-18</Date>
             <Version>1.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>

--- a/packages/b/budgie-user-indicator-redux-applet/package.yml
+++ b/packages/b/budgie-user-indicator-redux-applet/package.yml
@@ -1,6 +1,6 @@
 name       : budgie-user-indicator-redux-applet
 version    : 1.0.2
-release    : 3
+release    : 4
 source     :
     - https://github.com/EbonJaeger/budgie-user-indicator-redux/archive/refs/tags/v1.0.2.tar.gz : 7853476f7813ccafcbecf95eb4745bc1cf41f6851d1c0c60ab9a85a72f3b2da2
 homepage   : https://github.com/EbonJaeger/budgie-user-indicator-redux

--- a/packages/b/budgie-user-indicator-redux-applet/pspec_x86_64.xml
+++ b/packages/b/budgie-user-indicator-redux-applet/pspec_x86_64.xml
@@ -11,7 +11,7 @@
         <Summary xml:lang="en">Manage your user session from the Budgie panel</Summary>
         <Description xml:lang="en">Recreates the old user indicator applet functionality of Budgie Desktop to manage your user session directly from the panel menu, instead of opening the Power Dialog.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>budgie-user-indicator-redux-applet</Name>
@@ -46,8 +46,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2023-08-25</Date>
+        <Update release="4">
+            <Date>2023-10-18</Date>
             <Version>1.0.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>

--- a/packages/m/magpie/abi_used_symbols
+++ b/packages/m/magpie/abi_used_symbols
@@ -304,7 +304,9 @@ libatk-1.0.so.0:atk_util_get_type
 libatk-1.0.so.0:atk_window_get_type
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoul
 libc.so.6:__open64_2
 libc.so.6:__snprintf_chk
 libc.so.6:__sprintf_chk
@@ -334,7 +336,6 @@ libc.so.6:gettimeofday
 libc.so.6:getuid
 libc.so.6:ioctl
 libc.so.6:kill
-libc.so.6:memchr
 libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memfd_create
@@ -368,8 +369,6 @@ libc.so.6:strncmp
 libc.so.6:strncpy
 libc.so.6:strrchr
 libc.so.6:strstr
-libc.so.6:strtol
-libc.so.6:strtoul
 libc.so.6:unlink
 libc.so.6:unsetenv
 libcairo-gobject.so.2:cairo_gobject_context_get_type
@@ -1223,8 +1222,9 @@ libgobject-2.0.so.0:g_boxed_free
 libgobject-2.0.so.0:g_boxed_type_register_static
 libgobject-2.0.so.0:g_cclosure_marshal_VOID__BOOLEAN
 libgobject-2.0.so.0:g_cclosure_marshal_VOID__OBJECT
+libgobject-2.0.so.0:g_cclosure_marshal_VOID__UINT
+libgobject-2.0.so.0:g_cclosure_marshal_VOID__VARIANT
 libgobject-2.0.so.0:g_cclosure_marshal_VOID__VOID
-libgobject-2.0.so.0:g_cclosure_marshal_generic
 libgobject-2.0.so.0:g_cclosure_new
 libgobject-2.0.so.0:g_closure_invoke
 libgobject-2.0.so.0:g_closure_ref

--- a/packages/m/magpie/package.yml
+++ b/packages/m/magpie/package.yml
@@ -1,8 +1,9 @@
 name       : magpie
 version    : 0.9.3
-release    : 2
+release    : 3
 source     :
     - https://github.com/BuddiesOfBudgie/magpie/releases/download/v0.9.3/magpie-0.9.3.tar.xz : 99060cefe4684be05daf8e82b414b78d15cbe2c723993db902681ab4017bbbe9
+homepage   : https://buddiesofbudgie.org
 license    : GPL-2.0-or-later
 component  : desktop.budgie
 summary    : Magpie is a softish fork of Mutter 43.x

--- a/packages/m/magpie/pspec_x86_64.xml
+++ b/packages/m/magpie/pspec_x86_64.xml
@@ -1,6 +1,7 @@
 <PISI>
     <Source>
         <Name>magpie</Name>
+        <Homepage>https://buddiesofbudgie.org</Homepage>
         <Packager>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>
@@ -12,7 +13,7 @@
 
 It contains functionality related to, among other things, window management, window compositing, focus tracking, workspace management, keybindings and monitor configuration.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>magpie</Name>
@@ -152,7 +153,7 @@ It contains functionality related to, among other things, window management, win
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">magpie</Dependency>
+            <Dependency release="3">magpie</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/magpie-0/clutter/cally/cally-actor.h</Path>
@@ -375,8 +376,8 @@ It contains functionality related to, among other things, window management, win
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2023-08-26</Date>
+        <Update release="3">
+            <Date>2023-10-18</Date>
             <Version>0.9.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**

- magpie: Safety rebuild for GNOME 45
- budgie-screensaver: Safety rebuild for GNOME 45
- budgie-desktop-view: Update to 1.3
- budgie-desktop: Update to 10.8.2
- budgie-extras: Safety rebuild for GNOME 45
- budgie-haste-applet: Safety rebuild for GNOME 45
- budgie-screenshot-applet: Safety rebuild for GNOME 45
- budgie-user-indicator-redux-applet: Safety rebuild for GNOME 45
- budgie-calendar-applet: Safety rebuild for GNOME 45
- budgie-shutdown-timer: Safety rebuild for GNOME 45
- budgie-control-center: Safety rebuild for GNOME 45
- budgie-cputemp-applet: Safety rebuild for GNOME 45

**Test Plan**

Update fully and restart the system.

**Checklist**

- [x] Package was built and tested against unstable
