### PR TITLE
packagekit: sync with git

### DIFF
--- a/packages/p/packagekit/abi_used_symbols
+++ b/packages/p/packagekit/abi_used_symbols
@@ -25,9 +25,11 @@ libc.so.6:fopen64
 libc.so.6:fork
 libc.so.6:free
 libc.so.6:getc
+libc.so.6:geteuid
 libc.so.6:getpid
 libc.so.6:getppid
 libc.so.6:getpwuid
+libc.so.6:getuid
 libc.so.6:ioctl
 libc.so.6:isatty
 libc.so.6:kill
@@ -58,6 +60,7 @@ libc.so.6:strftime
 libc.so.6:strlen
 libc.so.6:strtol
 libc.so.6:symlink
+libc.so.6:sync
 libc.so.6:tcgetattr
 libc.so.6:tcsetattr
 libc.so.6:textdomain
@@ -198,6 +201,7 @@ libglib-2.0.so.0:g_file_get_contents
 libglib-2.0.so.0:g_file_read_link
 libglib-2.0.so.0:g_file_set_contents
 libglib-2.0.so.0:g_file_test
+libglib-2.0.so.0:g_find_program_in_path
 libglib-2.0.so.0:g_free
 libglib-2.0.so.0:g_get_current_time
 libglib-2.0.so.0:g_get_environ
@@ -321,6 +325,7 @@ libglib-2.0.so.0:g_source_set_static_name
 libglib-2.0.so.0:g_source_unref
 libglib-2.0.so.0:g_spawn_async
 libglib-2.0.so.0:g_spawn_async_with_pipes
+libglib-2.0.so.0:g_spawn_command_line_async
 libglib-2.0.so.0:g_str_equal
 libglib-2.0.so.0:g_str_has_prefix
 libglib-2.0.so.0:g_str_has_suffix
@@ -495,6 +500,7 @@ libsqlite3.so.0:sqlite3_free
 libsqlite3.so.0:sqlite3_open
 libsqlite3.so.0:sqlite3_prepare_v2
 libsqlite3.so.0:sqlite3_step
+libsystemd.so.0:sd_journal_print_with_location
 libsystemd.so.0:sd_notify
 libsystemd.so.0:sd_pid_get_owner_uid
 libsystemd.so.0:sd_pid_get_session

--- a/packages/p/packagekit/files/0001-data-Tweak-systemd-network-targets-to-get-offline-up.patch
+++ b/packages/p/packagekit/files/0001-data-Tweak-systemd-network-targets-to-get-offline-up.patch
@@ -1,0 +1,45 @@
+From f8364104fa7266735fb08e50d988f6e80acadf7a Mon Sep 17 00:00:00 2001
+From: Joey Riches <josephriches@gmail.com>
+Date: Sun, 22 Oct 2023 10:31:23 +0100
+Subject: [PATCH 1/1] data: Tweak systemd network targets to get offline update
+ working reliably
+
+Solus, downstream only.
+
+Even when an offline transation is pre-downloaded pk still wants network :(
+
+We were hitting an issue where pk offline update would try to start
+the transaction before networking was up.
+---
+ data/packagekit-offline-update.service.in | 1 +
+ data/packagekit.service.in                | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/data/packagekit-offline-update.service.in b/data/packagekit-offline-update.service.in
+index 23096058f..b2c19cd03 100644
+--- a/data/packagekit-offline-update.service.in
++++ b/data/packagekit-offline-update.service.in
+@@ -7,6 +7,7 @@ After=sysinit.target dbus.socket systemd-journald.socket system-update-pre.targe
+ Before=shutdown.target system-update.target
+ # See packagekit.service
+ ConditionPathExists=!/run/ostree-booted
++Wants=network-online.target
+ 
+ [Service]
+ Type=oneshot
+diff --git a/data/packagekit.service.in b/data/packagekit.service.in
+index 52884589a..0a01d3a0c 100644
+--- a/data/packagekit.service.in
++++ b/data/packagekit.service.in
+@@ -4,7 +4,7 @@ Description=PackageKit Daemon
+ # currently the design is to have dedicated daemons like
+ # eos-updater and rpm-ostree, and gnome-software talks to those.
+ ConditionPathExists=!/run/ostree-booted
+-Wants=network-online.target
++After=network-online.target
+ 
+ [Service]
+ Type=dbus
+-- 
+2.42.0
+

--- a/packages/p/packagekit/package.yml
+++ b/packages/p/packagekit/package.yml
@@ -1,8 +1,8 @@
 name       : packagekit
 version    : 1.2.6
-release    : 16
+release    : 17
 source     :
-    - git|https://github.com/joebonrichie/PackageKit.git : 51138a22d2a4a7f2888feed4eba2f1bca3112564
+    - git|https://github.com/joebonrichie/PackageKit.git : 7c59db788ae2d84753c15c546a87616f1ce80964
 license    : GPL-2.0-or-later
 component  : programming.library
 homepage   : https://www.freedesktop.org/software/PackageKit/
@@ -23,10 +23,10 @@ builddeps  :
     - docbook-xml
     - vala
 setup      : |
+    %patch -p1 -i $pkgfiles/0001-data-Tweak-systemd-network-targets-to-get-offline-up.patch
     %meson_configure \
         -Dpackaging_backend=pisi \
         -Dpythonpackagedir=/usr/lib/python2.7/site-packages/ \
-        -Doffline_update=false \
         -Dbash_command_not_found=false
 build      : |
     %ninja_build

--- a/packages/p/packagekit/pspec_x86_64.xml
+++ b/packages/p/packagekit/pspec_x86_64.xml
@@ -36,7 +36,9 @@ PackageKit is a DBUS abstraction layer that allows the session user to manage pa
             <Path fileType="library">/usr/lib/python2.7/site-packages/packagekit/misc.py</Path>
             <Path fileType="library">/usr/lib/python2.7/site-packages/packagekit/package.py</Path>
             <Path fileType="library">/usr/lib/python2.7/site-packages/packagekit/progress.py</Path>
+            <Path fileType="library">/usr/lib/systemd/system/packagekit-offline-update.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/packagekit.service</Path>
+            <Path fileType="library">/usr/lib/systemd/system/system-update.target.wants/packagekit-offline-update.service</Path>
             <Path fileType="library">/usr/lib64/girepository-1.0/PackageKitGlib-1.0.typelib</Path>
             <Path fileType="library">/usr/lib64/gnome-settings-daemon-3.0/gtk-modules/pk-gtk-module.desktop</Path>
             <Path fileType="library">/usr/lib64/gtk-3.0/modules/libpk-gtk-module.so</Path>
@@ -52,6 +54,7 @@ PackageKit is a DBUS abstraction layer that allows the session user to manage pa
             <Path fileType="library">/usr/lib64/packagekit/packagekit-direct</Path>
             <Path fileType="library">/usr/lib64/packagekit/packagekitd</Path>
             <Path fileType="library">/usr/lib64/packagekit/pk-gstreamer-install</Path>
+            <Path fileType="library">/usr/lib64/packagekit/pk-offline-update</Path>
             <Path fileType="data">/usr/share/PackageKit/helpers/pisi/pisiBackend.py</Path>
             <Path fileType="data">/usr/share/PackageKit/helpers/test_spawn/search-name.sh</Path>
             <Path fileType="data">/usr/share/PackageKit/pk-upgrade-distro.sh</Path>
@@ -146,7 +149,7 @@ PackageKit is a DBUS abstraction layer that allows the session user to manage pa
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="16">packagekit</Dependency>
+            <Dependency release="17">packagekit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/PackageKit/packagekit-glib2/packagekit.h</Path>
@@ -193,8 +196,8 @@ PackageKit is a DBUS abstraction layer that allows the session user to manage pa
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2023-10-13</Date>
+        <Update release="17">
+            <Date>2023-10-26</Date>
             <Version>1.2.6</Version>
             <Comment>Packaging update</Comment>
             <Name>Joey Riches</Name>


### PR DESCRIPTION
**Summary**

Depends on #549.

- Removing and installing packages in gnome-software now works reliably.
- Gnome-software now installs updates offline.
- Getting updates is now significantly quicker.
- Getting package details is now significantly quicker.

**Test Plan**

Tested by running pisibackend.py commands manually and dogfooding gnome-software

**Checklist**

- [x] Package was built and tested against unstable
