### PR TITLE
Fixes for amtk

### DIFF
--- a/packages/d/devhelp/package.yml
+++ b/packages/d/devhelp/package.yml
@@ -1,6 +1,6 @@
 name       : devhelp
 version    : '43.0'
-release    : 33
+release    : 34
 source     :
     - git|https://gitlab.gnome.org/GNOME/devhelp : 43.0
 homepage   : https://wiki.gnome.org/Apps/Devhelp
@@ -10,7 +10,6 @@ summary    : API documentation browser for GNOME
 description: |
     Devhelp is an API documentation browser for GTK+ and GNOME. It works natively with GTK-Doc (the API reference system developed for GTK+ and used throughout GNOME for API documentation). If you use GTK-Doc with your project, you can use Devhelp to browse the documentation.
 builddeps  :
-    - pkgconfig(amtk-5)
     - pkgconfig(gi-docgen)
     - pkgconfig(gsettings-desktop-schemas)
     - pkgconfig(gtk+-3.0)

--- a/packages/d/devhelp/pspec_x86_64.xml
+++ b/packages/d/devhelp/pspec_x86_64.xml
@@ -450,7 +450,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="33">devhelp</Dependency>
+            <Dependency release="34">devhelp</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/devhelp-3/devhelp/devhelp.h</Path>
@@ -482,8 +482,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2023-10-17</Date>
+        <Update release="34">
+            <Date>2023-10-18</Date>
             <Version>43.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Zach Bacon</Name>

--- a/packages/l/libgedit-amtk/package.yml
+++ b/packages/l/libgedit-amtk/package.yml
@@ -1,6 +1,6 @@
 name       : libgedit-amtk
 version    : 5.8.0
-release    : 1
+release    : 2
 source     :
     - https://gedit-technology.net/tarballs/libgedit-amtk/libgedit-amtk-5.8.0.tar.xz : 64017ae100ef588e01ef54d79c13c4b9767fd37e4365d7e4afd924f751460ecc
 homepage   : https://gedit-technology.net/
@@ -12,6 +12,10 @@ description: |
 builddeps  :
     - pkgconfig(gtk+-3.0)
     - gtk-doc
+replaces   :
+    - amtk
+    - devel: amtk-devel
+    - dbginfo: amtk-dbginfo
 setup      : |
     %meson_configure
 build      : |

--- a/packages/l/libgedit-amtk/pspec_x86_64.xml
+++ b/packages/l/libgedit-amtk/pspec_x86_64.xml
@@ -53,6 +53,9 @@
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/libgedit-amtk-5.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/libgedit-amtk-5.mo</Path>
         </Files>
+        <Replaces>
+            <Package>amtk</Package>
+        </Replaces>
     </Package>
     <Package>
         <Name>libgedit-amtk-devel</Name>
@@ -61,7 +64,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="1">libgedit-amtk</Dependency>
+            <Dependency release="2">libgedit-amtk</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libgedit-amtk-5/amtk/amtk-action-info-central-store.h</Path>
@@ -81,6 +84,9 @@
             <Path fileType="library">/usr/lib64/libgedit-amtk-5.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/libgedit-amtk-5.pc</Path>
         </Files>
+        <Replaces>
+            <Package>amtk-devel</Package>
+        </Replaces>
     </Package>
     <Package>
         <Name>libgedit-amtk-docs</Name>
@@ -121,8 +127,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2023-10-17</Date>
+        <Update release="2">
+            <Date>2023-10-18</Date>
             <Version>5.8.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Zach Bacon</Name>


### PR DESCRIPTION
**Summary**

Removes dep from devhelp and causes libgedit-amtk to replace the amtk package

**Test Plan**

Ensured that libgedit-amtk removed amtk when it's installed.

**Checklist**

- [x] Package was built and tested against unstable
