### PR TITLE
common: Parse build page json in buildserver-notification.sh

### DIFF
--- a/common/Scripts/buildserver-notification.sh
+++ b/common/Scripts/buildserver-notification.sh
@@ -4,7 +4,7 @@
 # Additionally, if a package successfully builds it will then check if it gets successfully indexed into the repo.
 
 # Check requirements before starting
-REQUIREMENTS="curl unxz notify-send paplay"
+REQUIREMENTS="curl unxz notify-send paplay jq"
 for i in $REQUIREMENTS; do
     if ! which $i &> /dev/null; then
         echo "Missing requirement: $i. Install it to continue."
@@ -18,38 +18,47 @@ if [[ ! -z "${DISABLE_BUILD_SUCCESS_NOTIFY}" ]]; then
 fi
 
 if [ -f "package.yml" ]; then
-    TAG=$($(git rev-parse --show-toplevel)/common/Scripts/gettag.py package.yml)
+    # Read the file from the latest commit in directory. Not from any potential unstaged changes
+    SPECFILEREF=$(git show $(git rev-list -1 HEAD .):./package.yml > /tmp/tmp.yml)
+    TAG=$($(git rev-parse --show-toplevel)/common/Scripts/gettag.py /tmp/tmp.yml)
+    rm /tmp/tmp.yml
+elif [ -f "pspec.xml" ]; then
+    # Read the file from the latest commit in directory. Not from any potential unstaged changes
+    SPECFILEREF=$(git show $(git rev-list -1 HEAD .):./pspec.xml > /tmp/tmp.xml)
+    TAG=$($(git rev-parse --show-toplevel)/common/Scripts/gettag.py /tmp/tmp.xml)
+    rm /tmp/tmp.xml
 else
-    TAG=$($(git rev-parse --show-toplevel)/common/Scripts/gettag.py pspec.xml)
+    echo "No valid package.yml or pspec.xml file found"
+    exit 1
 fi
 
-BUILDSERVER_URL="https://build.getsol.us"
-BUILDPAGE="/tmp/buildpage.html"
+BUILDSERVER_JSON_URL="https://build.getsol.us/builds.json"
+JSONPAGE="/tmp/builds.json"
 
 # Download the page
-curl -s $BUILDSERVER_URL -o $BUILDPAGE
+curl -sSL $BUILDSERVER_JSON_URL -o $JSONPAGE
 
 # Check it's actually been published first.
-if [[ ! $(grep "${TAG}" "${BUILDPAGE}" ) ]] ; then
+if [[ ! $(jq '.[] | select(.tag == $ARGS.positional[0])' "${JSONPAGE}" --args "${TAG}") ]] ; then
     echo "${TAG} not found on build queue, has it been published?"
     exit 1
 fi
 
 # Get the latest build-id for the $TAG
-BUILDID=$(grep -B 1 "${TAG}" "${BUILDPAGE}" | grep -o '[0-9]*' | sort -nr | head -1)
+BUILDID=$(jq '.[] | select(.tag == $ARGS.positional[0]) | .id' "${JSONPAGE}" --args "${TAG}" | grep -o '[0-9]*' | sort -nr | head -1)
 echo "Build ID: ${BUILDID} | Tag: ${TAG}"
 
 # Look for build-ok from the build id
-while [[ ! $(grep -A 6 "${BUILDID}" "${BUILDPAGE}" | grep ">ok<") ]] ; do
+while [[ ! $(jq '.[] | select(.tag == $ARGS.positional[0]) | .status' "${JSONPAGE}" --args "${TAG}" | grep "OK") ]]; do
 
     # Don't DoS the server
     sleep 20
 
     # Download new build page if-modified-since (-z)
-    curl -s -z $BUILDPAGE $BUILDSERVER_URL -o $BUILDPAGE
+    curl -sSL -z $JSONPAGE $BUILDSERVER_JSON_URL -o $JSONPAGE
 
     # Check if the build has failed
-    if [[ $(grep -A 4 "${BUILDID}" "${BUILDPAGE}" | grep ">failed<") ]] ; then
+    if [[ $(jq '.[] | select(.tag == $ARGS.positional[0]) | .status' "${JSONPAGE}" --args "${TAG}" | grep "FAILED") ]] ; then
         echo "Failed on the build server!"
         notify-send -u critical "${TAG} failed on the build server!" -t 0
         paplay /usr/share/sounds/freedesktop/stereo/suspend-error.oga
@@ -58,7 +67,7 @@ while [[ ! $(grep -A 6 "${BUILDID}" "${BUILDPAGE}" | grep ">ok<") ]] ; do
 done
 
 echo "Build succeeded on the buildserver! Waiting for it to be indexed..."
-rm ${BUILDPAGE}
+if [ -f "${JSONPAGE}" ]; then rm ${JSONPAGE}; fi
 
 ### Now that it's built ensure we find it indexed into the repo.
 
@@ -66,8 +75,9 @@ rm ${BUILDPAGE}
 INDEX_SHA_URL="https://cdn.getsol.us/repo/unstable/eopkg-index.xml.xz.sha1sum"
 INDEX_XZ_URL="https://cdn.getsol.us/repo/unstable/eopkg-index.xml.xz"
 INDEX_SHA=$(curl -s $INDEX_SHA_URL)
-curl -s $INDEX_XZ_URL -o /tmp/unstable-index.xml.xz
-unxz /tmp/unstable-index.xml.xz -f
+INDEX_XML="/tmp/unstable-index.xml"
+curl -s $INDEX_XZ_URL -o ${INDEX_XML}.xz
+unxz ${INDEX_XML}.xz -f
 
 # Downloads and extracts the new index if the sha sum has changed.
 update_index_if_changed() {
@@ -77,29 +87,29 @@ update_index_if_changed() {
     if [[ $NEW_INDEX_SHA != $INDEX_SHA ]]; then
         INDEX_SHA=$NEW_INDEX_SHA
         echo "index sha: ${INDEX_SHA}"
-        rm /tmp/unstable-index.xml
-        curl -s $INDEX_XZ_URL -o /tmp/unstable-index.xml.xz
-        unxz /tmp/unstable-index.xml.xz -f
+        rm ${INDEX_XML}
+        curl -s $INDEX_XZ_URL -o ${INDEX_XML}.xz
+        unxz ${INDEX_XML}.xz -f
     # Same sha, do nothing
     elif [[ $NEW_INDEX_SHA = $INDEX_SHA ]]; then
         echo "index sha: ${INDEX_SHA}"
     else
         echo "Unknown error occured."
-        rm /tmp/unstable-index.xml.xz /tmp/unstable-index.xml
+        if [ -f "${INDEX_XML}" ]; then rm ${INDEX_XML}; fi
         exit 1
     fi
 }
 
 # Look for the tag in the index
 # FIXME: some packages like libreoffice do not output a eopkg file matching the tag
-while [[ $(grep ${TAG} < /tmp/unstable-index.xml | wc -l) -lt 1 ]] ; do
+while [[ $(grep ${TAG} < ${INDEX_XML} | wc -l) -lt 1 ]] ; do
     var=$((var+1))
     # Wait up to 1m:30s (90 / (sleep) 5 = 18) before bailing
     if [[ $var == 18 ]]; then
         echo "Successfully built but hasn't been found in the index yet, please manually check."
         notify-send -u low "${TAG} successfully built but hasen't been found in the index yet, please manually check." -t 0
         paplay /usr/share/sounds/freedesktop/stereo/dialog-warning.oga
-        rm /tmp/unstable-index.xml
+        if [ -f "${INDEX_XML}" ]; then rm ${INDEX_XML}; fi
         exit 1
     fi
     sleep 5
@@ -113,4 +123,5 @@ if [[ -z "${DISABLE_BUILD_SUCCESS_NOTIFY}" ]]; then
     notify-send "${TAG} indexed into the repo!" -t 0
     paplay /usr/share/sounds/freedesktop/stereo/complete.oga
 fi
-rm /tmp/unstable-index.xml
+
+if [ -f "${INDEX_XML}" ]; then rm ${INDEX_XML}; fi


### PR DESCRIPTION
**Summary**
Make use of the new json output from the build page in order to obtain more reliable results.

Additionally, get the tag from the package.yml stored in the latest commit instead potentially tagging from any unstaged changes.

Lastly, take this opportunity to cleanup the script a little.

**Test Plan**

go-task notify-complete
go-task bump
go-task notify-complete <- verify the correct tag is used.

**Checklist**

- [ ] Package was built and tested against unstable N/A
