### PR TITLE
repo-wide: update two more %patch commands to preferred syntax

### DIFF
--- a/packages/i/intel-media-driver/package.yml
+++ b/packages/i/intel-media-driver/package.yml
@@ -16,7 +16,7 @@ builddeps  :
     - pkgconfig(libva)
     - pkgconfig(pciaccess)
 setup      : |
-    %patch -Np1 < "$pkgfiles/0001-Set-BUILD_TYPE-to-CMAKE_BUILD_TYPE-if-undefined.patch"
+    %patch -Np1 -i $pkgfiles/0001-Set-BUILD_TYPE-to-CMAKE_BUILD_TYPE-if-undefined.patch
     rm -f Tools/MediaDriverTools/UMDPerfProfiler/MediaPerfParser
 
     export CXXFLAGS="$(echo "$CXXFLAGS" | sed -e 's/-Wall //')"

--- a/packages/l/libdispatch/package.yml
+++ b/packages/l/libdispatch/package.yml
@@ -12,7 +12,7 @@ description: |
     Comprehensive support for concurrent code execution on multicore hardware.
 clang      : yes
 setup      : |
-    %patch -p0 < "$pkgfiles/remove-werror.patch"
+    %patch -p0 -i $pkgfiles/remove-werror.patch
     %cmake_ninja -DBlocksRuntime_INCLUDE_DIR=/usr/include -DBlocksRuntime_LIBRARIES=/usr/lib64/libBlocksRuntime.so
 build      : |
     %ninja_build


### PR DESCRIPTION
**Summary**

Updates two more (last?) %patch commands to the new preferred syntax.
They weren't caught in the mass conversion due to surrounding quotes.

**Test Plan**

Built the two affected packages (I didn't include the resulting changes to reduce scope of PR but can do so if desired)

**Checklist**

- [x] Package was built and tested against unstable
