### PR TITLE
fb2converter: Update to 1.72.1

### DIFF
--- a/packages/f/fb2converter/package.yml
+++ b/packages/f/fb2converter/package.yml
@@ -1,8 +1,9 @@
 name       : fb2converter
-version    : 1.71.0
-release    : 14
+version    : 1.72.1
+release    : 15
 source     :
-    - https://github.com/rupor-github/fb2converter/archive/refs/tags/v1.71.0.tar.gz : 23be09d16943c60e422fc10a61e9f33f82ff257116afec2415f1eca9edd7f444
+    - https://github.com/rupor-github/fb2converter/archive/refs/tags/v1.72.1.tar.gz : ecee765f512dd7f2f6758d9a99b8cf143daf638c866e145ebdec2b05e200b7c1
+homepage   : https://github.com/rupor-github/fb2converter
 license    : GPL-3.0-only
 component  : office.viewers
 summary    : Unified converter of FB2 files into epub2, kepub, mobi and azw3 formats.

--- a/packages/f/fb2converter/pspec_x86_64.xml
+++ b/packages/f/fb2converter/pspec_x86_64.xml
@@ -1,6 +1,7 @@
 <PISI>
     <Source>
         <Name>fb2converter</Name>
+        <Homepage>https://github.com/rupor-github/fb2converter</Homepage>
         <Packager>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>
@@ -10,7 +11,7 @@
         <Summary xml:lang="en">Unified converter of FB2 files into epub2, kepub, mobi and azw3 formats.</Summary>
         <Description xml:lang="en">CLI ebook format converter, a complete rewrite of fb2mobi. Aims to be faster than python implementation and much easier to maintain. Simpler configuration, zero dependencies, better diagnostics and no installation required.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>fb2converter</Name>
@@ -23,9 +24,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2023-08-10</Date>
-            <Version>1.71.0</Version>
+        <Update release="15">
+            <Date>2023-10-21</Date>
+            <Version>1.72.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Extending "synccovers" command to support writing thumbnails into specified directory.
- Using go 1.21 toolchain and updating all dependencies

**Test Plan**
- fb2c convert in.fb2
- skim through epub file

**Checklist**
- [X] Package was built and tested against unstable
