### PR TITLE
python-moddb: update to 0.10.0

### DIFF
--- a/packages/py/python-moddb/package.yml
+++ b/packages/py/python-moddb/package.yml
@@ -1,8 +1,8 @@
 name       : python-moddb
-version    : 0.9.0
-release    : 3
+version    : 0.10.0
+release    : 4
 source     :
-    - https://pypi.io/packages/source/m/moddb/moddb-0.9.0.tar.gz : c78f94d69062e5f12098e7bcecb1b1479cbab359b157d75225461d7af3750e8e
+    - https://pypi.io/packages/source/m/moddb/moddb-0.10.0.tar.gz : 42784e1b34328a87113ad2a51e8ba5c99e6169657a4117d2be37d61b26aaadb5
 homepage   : https://github.com/ClementJ18/moddb
 license    : MIT
 component  : programming.python

--- a/packages/py/python-moddb/pspec_x86_64.xml
+++ b/packages/py/python-moddb/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-moddb</Name>
         <Homepage>https://github.com/ClementJ18/moddb</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,11 +20,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/moddb-0.9.0-py3.10.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/moddb-0.9.0-py3.10.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/moddb-0.9.0-py3.10.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/moddb-0.9.0-py3.10.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/moddb-0.9.0-py3.10.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/moddb-0.10.0-py3.10.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/moddb-0.10.0-py3.10.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/moddb-0.10.0-py3.10.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/moddb-0.10.0-py3.10.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/moddb-0.10.0-py3.10.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/moddb/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/moddb/__pycache__/__init__.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/moddb/__pycache__/base.cpython-310.pyc</Path>
@@ -70,12 +70,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2023-10-15</Date>
-            <Version>0.9.0</Version>
+        <Update release="4">
+            <Date>2023-10-22</Date>
+            <Version>0.10.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Pinned major releases of all dependencies
- Fixed improper parsing of not yet released pages
- Fixed improper parsing of get_tags when page did not have more tags
- Documented more of the utility functions
- Some enum members have been renamed to better fit with the naming pattern of the website
- Tests now produce cassettes for easy re-use

**Test Plan**

Tested a number of examples from the documentation

**Checklist**

- [x] Package was built and tested against unstable
