### PR TITLE
libheif: update to 1.17.1

### DIFF
--- a/packages/l/libheif/abi_symbols
+++ b/packages/l/libheif/abi_symbols
@@ -16,6 +16,7 @@ heif-info:optarg
 heif-info:optind
 heif-info:stderr
 heif-thumbnailer:_ZSt4cerr
+heif-thumbnailer:_ZSt4cout
 heif-thumbnailer:__libc_single_threaded
 heif-thumbnailer:optarg
 heif-thumbnailer:optind
@@ -91,11 +92,14 @@ libheif.so.1:heif_encoder_set_parameter_integer
 libheif.so.1:heif_encoder_set_parameter_string
 libheif.so.1:heif_encoding_options_alloc
 libheif.so.1:heif_encoding_options_free
+libheif.so.1:heif_error_success
 libheif.so.1:heif_fourcc_to_brand
 libheif.so.1:heif_free_list_of_compatible_brands
+libheif.so.1:heif_free_plugin_directories
 libheif.so.1:heif_get_decoder_descriptors
 libheif.so.1:heif_get_encoder_descriptors
 libheif.so.1:heif_get_file_mime_type
+libheif.so.1:heif_get_plugin_directories
 libheif.so.1:heif_get_version
 libheif.so.1:heif_get_version_number
 libheif.so.1:heif_get_version_number_maintenance
@@ -133,6 +137,7 @@ libheif.so.1:heif_image_handle_get_auxiliary_image_handle
 libheif.so.1:heif_image_handle_get_auxiliary_type
 libheif.so.1:heif_image_handle_get_chroma_bits_per_pixel
 libheif.so.1:heif_image_handle_get_color_profile_type
+libheif.so.1:heif_image_handle_get_context
 libheif.so.1:heif_image_handle_get_depth_image_handle
 libheif.so.1:heif_image_handle_get_depth_image_representation_info
 libheif.so.1:heif_image_handle_get_height
@@ -147,6 +152,7 @@ libheif.so.1:heif_image_handle_get_list_of_thumbnail_IDs
 libheif.so.1:heif_image_handle_get_luma_bits_per_pixel
 libheif.so.1:heif_image_handle_get_metadata
 libheif.so.1:heif_image_handle_get_metadata_content_type
+libheif.so.1:heif_image_handle_get_metadata_item_uri_type
 libheif.so.1:heif_image_handle_get_metadata_size
 libheif.so.1:heif_image_handle_get_metadata_type
 libheif.so.1:heif_image_handle_get_nclx_color_profile
@@ -155,6 +161,7 @@ libheif.so.1:heif_image_handle_get_number_of_depth_images
 libheif.so.1:heif_image_handle_get_number_of_metadata_blocks
 libheif.so.1:heif_image_handle_get_number_of_region_items
 libheif.so.1:heif_image_handle_get_number_of_thumbnails
+libheif.so.1:heif_image_handle_get_preferred_decoding_colorspace
 libheif.so.1:heif_image_handle_get_raw_color_profile
 libheif.so.1:heif_image_handle_get_raw_color_profile_size
 libheif.so.1:heif_image_handle_get_thumbnail
@@ -200,6 +207,9 @@ libheif.so.1:heif_property_user_description_release
 libheif.so.1:heif_read_main_brand
 libheif.so.1:heif_region_get_ellipse
 libheif.so.1:heif_region_get_ellipse_transformed
+libheif.so.1:heif_region_get_inline_mask_data
+libheif.so.1:heif_region_get_inline_mask_data_len
+libheif.so.1:heif_region_get_mask_image
 libheif.so.1:heif_region_get_point
 libheif.so.1:heif_region_get_point_transformed
 libheif.so.1:heif_region_get_polygon_num_points
@@ -210,12 +220,16 @@ libheif.so.1:heif_region_get_polyline_points
 libheif.so.1:heif_region_get_polyline_points_transformed
 libheif.so.1:heif_region_get_rectangle
 libheif.so.1:heif_region_get_rectangle_transformed
+libheif.so.1:heif_region_get_referenced_mask_ID
 libheif.so.1:heif_region_get_type
 libheif.so.1:heif_region_item_add_region_ellipse
+libheif.so.1:heif_region_item_add_region_inline_mask
+libheif.so.1:heif_region_item_add_region_inline_mask_data
 libheif.so.1:heif_region_item_add_region_point
 libheif.so.1:heif_region_item_add_region_polygon
 libheif.so.1:heif_region_item_add_region_polyline
 libheif.so.1:heif_region_item_add_region_rectangle
+libheif.so.1:heif_region_item_add_region_referenced_mask
 libheif.so.1:heif_region_item_get_id
 libheif.so.1:heif_region_item_get_list_of_regions
 libheif.so.1:heif_region_item_get_number_of_regions

--- a/packages/l/libheif/abi_used_symbols
+++ b/packages/l/libheif/abi_used_symbols
@@ -30,6 +30,8 @@ libaom.so.3:aom_img_free
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoul
 libc.so.6:__libc_single_threaded
 libc.so.6:__libc_start_main
 libc.so.6:__longjmp_chk
@@ -71,8 +73,6 @@ libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strncpy
-libc.so.6:strtol
-libc.so.6:strtoul
 libc.so.6:tolower
 libc.so.6:write
 libdav1d.so.7:dav1d_close
@@ -123,6 +123,7 @@ libjpeg.so.8:jpeg_destroy_decompress
 libjpeg.so.8:jpeg_finish_compress
 libjpeg.so.8:jpeg_finish_decompress
 libjpeg.so.8:jpeg_read_header
+libjpeg.so.8:jpeg_read_raw_data
 libjpeg.so.8:jpeg_read_scanlines
 libjpeg.so.8:jpeg_save_markers
 libjpeg.so.8:jpeg_set_defaults
@@ -144,6 +145,7 @@ libpng16.so.16:png_create_write_struct
 libpng16.so.16:png_destroy_read_struct
 libpng16.so.16:png_destroy_write_struct
 libpng16.so.16:png_get_IHDR
+libpng16.so.16:png_get_channels
 libpng16.so.16:png_get_eXIf_1
 libpng16.so.16:png_get_iCCP
 libpng16.so.16:png_get_io_ptr
@@ -158,10 +160,11 @@ libpng16.so.16:png_read_update_info
 libpng16.so.16:png_set_IHDR
 libpng16.so.16:png_set_compression_level
 libpng16.so.16:png_set_eXIf_1
-libpng16.so.16:png_set_expand
+libpng16.so.16:png_set_expand_gray_1_2_4_to_8
 libpng16.so.16:png_set_iCCP
 libpng16.so.16:png_set_longjmp_fn
 libpng16.so.16:png_set_packing
+libpng16.so.16:png_set_palette_to_rgb
 libpng16.so.16:png_set_read_fn
 libpng16.so.16:png_set_text
 libpng16.so.16:png_write_end
@@ -187,16 +190,14 @@ libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEcm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE5rfindEcm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6substrEmm
-libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7compareEPKc
-libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7compareEmmRKS4_
 libstdc++.so.6:_ZNKSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE3strEv
 libstdc++.so.6:_ZNKSt8__detail20_Prime_rehash_policy14_M_need_rehashEmmm
 libstdc++.so.6:_ZNSdD2Ev
 libstdc++.so.6:_ZNSi4readEPcl
 libstdc++.so.6:_ZNSi5seekgElSt12_Ios_Seekdir
 libstdc++.so.6:_ZNSi5tellgEv
-libstdc++.so.6:_ZNSiC2Ev
 libstdc++.so.6:_ZNSo3putEc
+libstdc++.so.6:_ZNSo5flushEv
 libstdc++.so.6:_ZNSo5writeEPKcl
 libstdc++.so.6:_ZNSo9_M_insertIbEERSoT_
 libstdc++.so.6:_ZNSo9_M_insertIdEERSoT_
@@ -248,8 +249,6 @@ libstdc++.so.6:_ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEC1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEED1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitC1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitD1Ev
 libstdc++.so.6:_ZNSt8ios_baseC2Ev
 libstdc++.so.6:_ZNSt8ios_baseD2Ev
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE4initEPSt15basic_streambufIcS1_E
@@ -270,6 +269,7 @@ libstdc++.so.6:_ZSt20__throw_future_errori
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt20__throw_out_of_rangePKc
 libstdc++.so.6:_ZSt20__throw_system_errori
+libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZSt24__throw_invalid_argumentPKc
 libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
 libstdc++.so.6:_ZSt25__throw_bad_function_callv
@@ -277,6 +277,7 @@ libstdc++.so.6:_ZSt28_Rb_tree_rebalance_for_erasePSt18_Rb_tree_node_baseRS_
 libstdc++.so.6:_ZSt28__throw_bad_array_new_lengthv
 libstdc++.so.6:_ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_
 libstdc++.so.6:_ZSt4cerr
+libstdc++.so.6:_ZSt4cout
 libstdc++.so.6:_ZSt7getlineIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EES4_
 libstdc++.so.6:_ZSt9terminatev
 libstdc++.so.6:_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc

--- a/packages/l/libheif/package.yml
+++ b/packages/l/libheif/package.yml
@@ -1,14 +1,14 @@
 name       : libheif
-version    : 1.16.2
-release    : 34
+version    : 1.17.1
+release    : 35
 source     :
-    - https://github.com/strukturag/libheif/releases/download/v1.16.2/libheif-1.16.2.tar.gz : 7f97e4205c0bd9f9b8560536c8bd2e841d1c9a6d610401eb3eb87ed9cdfe78ea
+    - https://github.com/strukturag/libheif/releases/download/v1.17.1/libheif-1.17.1.tar.gz : 97d74c58a346887c1bbf98dcf0322c13b728286153d0f1be2b350f7107e49dba
 license    : LGPL-3.0-or-later
+homepage   : https://github.com/strukturag/libheif
 component  : multimedia.codecs
 summary    : libheif is an ISO/IEC 23008-12:2017 HEIF and AVIF (AV1 Image File Format) file format decoder and encoder
 description: |
     HEIF is a new image file format employing HEVC (h.265) or AV1 image coding, respectively, for the best compression ratios currently possible.
-
     libheif makes use of libde265 for the actual image decoding and x265 for encoding. For AVIF, libaom, dav1d, rav1e, or SVT-AV1 are used as codecs.
 builddeps  :
     - pkgconfig(SvtAv1Enc)
@@ -21,10 +21,13 @@ builddeps  :
     - pkgconfig(rav1e)
     - pkgconfig(x265)
 setup      : |
-    %cmake_ninja -DWITH_RAV1E_PLUGIN=OFF -DWITH_SvtEnc_PLUGIN=OFF
+    %cmake_ninja -DWITH_DAV1D=ON \
+                 -DWITH_DAV1D_PLUGIN=OFF \
+                 -DWITH_RAV1E=ON \
+                 -DWITH_RAV1E_PLUGIN=OFF \
+                 -DWITH_SvtEnc=ON \
+                 -DWITH_SvtEnc_PLUGIN=OFF
 build      : |
     %ninja_build
 install    : |
     %ninja_install
-    # Remove empty dir
-    rmdir $installdir/usr/lib64/libheif

--- a/packages/l/libheif/pspec_x86_64.xml
+++ b/packages/l/libheif/pspec_x86_64.xml
@@ -1,15 +1,15 @@
 <PISI>
     <Source>
         <Name>libheif</Name>
+        <Homepage>https://github.com/strukturag/libheif</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>LGPL-3.0-or-later</License>
         <PartOf>multimedia.codecs</PartOf>
         <Summary xml:lang="en">libheif is an ISO/IEC 23008-12:2017 HEIF and AVIF (AV1 Image File Format) file format decoder and encoder</Summary>
         <Description xml:lang="en">HEIF is a new image file format employing HEVC (h.265) or AV1 image coding, respectively, for the best compression ratios currently possible.
-
 libheif makes use of libde265 for the actual image decoding and x265 for encoding. For AVIF, libaom, dav1d, rav1e, or SVT-AV1 are used as codecs.
 </Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
@@ -18,7 +18,6 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
         <Name>libheif</Name>
         <Summary xml:lang="en">libheif is an ISO/IEC 23008-12:2017 HEIF and AVIF (AV1 Image File Format) file format decoder and encoder</Summary>
         <Description xml:lang="en">HEIF is a new image file format employing HEVC (h.265) or AV1 image coding, respectively, for the best compression ratios currently possible.
-
 libheif makes use of libde265 for the actual image decoding and x265 for encoding. For AVIF, libaom, dav1d, rav1e, or SVT-AV1 are used as codecs.
 </Description>
         <PartOf>multimedia.codecs</PartOf>
@@ -28,8 +27,9 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
             <Path fileType="executable">/usr/bin/heif-info</Path>
             <Path fileType="executable">/usr/bin/heif-thumbnailer</Path>
             <Path fileType="library">/usr/lib64/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-heif.so</Path>
+            <Path fileType="library">/usr/lib64/libheif</Path>
             <Path fileType="library">/usr/lib64/libheif.so.1</Path>
-            <Path fileType="library">/usr/lib64/libheif.so.1.16.2</Path>
+            <Path fileType="library">/usr/lib64/libheif.so.1.17.1</Path>
             <Path fileType="man">/usr/share/man/man1/heif-convert.1</Path>
             <Path fileType="man">/usr/share/man/man1/heif-enc.1</Path>
             <Path fileType="man">/usr/share/man/man1/heif-info.1</Path>
@@ -41,17 +41,18 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
         <Name>libheif-devel</Name>
         <Summary xml:lang="en">Development files for libheif</Summary>
         <Description xml:lang="en">HEIF is a new image file format employing HEVC (h.265) or AV1 image coding, respectively, for the best compression ratios currently possible.
-
 libheif makes use of libde265 for the actual image decoding and x265 for encoding. For AVIF, libaom, dav1d, rav1e, or SVT-AV1 are used as codecs.
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="34">libheif</Dependency>
+            <Dependency release="35">libheif</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libheif/heif.h</Path>
             <Path fileType="header">/usr/include/libheif/heif_cxx.h</Path>
             <Path fileType="header">/usr/include/libheif/heif_plugin.h</Path>
+            <Path fileType="header">/usr/include/libheif/heif_properties.h</Path>
+            <Path fileType="header">/usr/include/libheif/heif_regions.h</Path>
             <Path fileType="header">/usr/include/libheif/heif_version.h</Path>
             <Path fileType="library">/usr/lib64/cmake/libheif/libheif-config-relwithdebinfo.cmake</Path>
             <Path fileType="library">/usr/lib64/cmake/libheif/libheif-config-version.cmake</Path>
@@ -61,12 +62,12 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
         </Files>
     </Package>
     <History>
-        <Update release="34">
-            <Date>2023-10-07</Date>
-            <Version>1.16.2</Version>
+        <Update release="35">
+            <Date>2023-10-22</Date>
+            <Version>1.17.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Release notes:
- [1.17.1](https://github.com/strukturag/libheif/releases/tag/v1.17.1)
- [1.17.0](https://github.com/strukturag/libheif/releases/tag/v1.17.0)

**Test Plan**

Encoded and converted a couple of images from and to HEIF and AVIF

**Checklist**

- [x] Package was built and tested against unstable
