### PR TITLE
scrcpy: update to 2.1.1

### DIFF
--- a/packages/s/scrcpy/abi_used_symbols
+++ b/packages/s/scrcpy/abi_used_symbols
@@ -130,7 +130,8 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__memmove_chk
@@ -190,7 +191,6 @@ libc.so.6:strncmp
 libc.so.6:strrchr
 libc.so.6:strspn
 libc.so.6:strtok_r
-libc.so.6:strtol
 libc.so.6:waitid
 libc.so.6:write
 libswresample.so.3:swr_alloc

--- a/packages/s/scrcpy/package.yml
+++ b/packages/s/scrcpy/package.yml
@@ -1,9 +1,10 @@
 name       : scrcpy
-version    : '2.0'
-release    : 22
+version    : 2.1.1
+release    : 23
 source     :
-    - https://github.com/Genymobile/scrcpy/archive/v2.0.tar.gz : a256241dd178ab103e4a119d0387f348c10ac513f25a7ca4859bd53ca5e7d43f
-    - https://github.com/Genymobile/scrcpy/releases/download/v2.0/scrcpy-server-v2.0 : 9e241615f578cd690bb43311000debdecf6a9c50a7082b001952f18f6f21ddc2
+    - https://github.com/Genymobile/scrcpy/archive/v2.1.1.tar.gz : 6f3d055159cb125eabe940a901bef8a69e14e2c25f0e47554f846e7f26a36c4d
+    - https://github.com/Genymobile/scrcpy/releases/download/v2.1.1/scrcpy-server-v2.1.1 : 9558db6c56743a1dc03b38f59801fb40e91cc891f8fc0c89e5b0b067761f148e
+homepage   : https://github.com/Genymobile/scrcpy
 license    : Apache-2.0
 component  : network.util
 summary    : Display and control your Android device

--- a/packages/s/scrcpy/pspec_x86_64.xml
+++ b/packages/s/scrcpy/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>scrcpy</Name>
+        <Homepage>https://github.com/Genymobile/scrcpy</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Mislav Čakarić</Name>
+            <Email>mcakaric@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>network.util</PartOf>
         <Summary xml:lang="en">Display and control your Android device</Summary>
         <Description xml:lang="en">This application provides display and control of Android devices connected on USB (or over TCP/IP). It does not require any root access.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>scrcpy</Name>
@@ -30,12 +31,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2023-03-12</Date>
-            <Version>2.0</Version>
+        <Update release="23">
+            <Date>2023-10-23</Date>
+            <Version>2.1.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Mislav Čakarić</Name>
+            <Email>mcakaric@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Bump scrcpy to new release version.

[2.0 -> 2.1 Changelog](https://github.com/Genymobile/scrcpy/releases/tag/v2.1)
[2.1 -> 2.1.1 Changelog](https://github.com/Genymobile/scrcpy/releases/tag/v2.1.1)

**Test Plan**

Connected to my Android phone with ADB enabled.
Started scrcpy and checked if i can control my phone from computer, using mouse and keyboard.
Checked that audio is also forwarded to computer.

**Checklist**

- [x] Package was built and tested against unstable
