### PR TITLE
android-tools: update to 34.0.4

### DIFF
--- a/packages/a/android-tools/abi_used_symbols
+++ b/packages/a/android-tools/abi_used_symbols
@@ -17,6 +17,11 @@ libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
 libc.so.6:__getdelim
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoll
+libc.so.6:__isoc23_strtoul
+libc.so.6:__isoc23_strtoull
 libc.so.6:__isoc99_fscanf
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_single_threaded
@@ -47,6 +52,7 @@ libc.so.6:calloc
 libc.so.6:cfmakeraw
 libc.so.6:chdir
 libc.so.6:chmod
+libc.so.6:clock_gettime
 libc.so.6:close
 libc.so.6:closedir
 libc.so.6:connect
@@ -115,7 +121,6 @@ libc.so.6:getsockname
 libc.so.6:getsockopt
 libc.so.6:gettimeofday
 libc.so.6:getuid
-libc.so.6:gmtime_r
 libc.so.6:hasmntopt
 libc.so.6:in6addr_any
 libc.so.6:in6addr_loopback
@@ -126,7 +131,6 @@ libc.so.6:isalnum
 libc.so.6:isatty
 libc.so.6:isprint
 libc.so.6:isspace
-libc.so.6:isxdigit
 libc.so.6:kill
 libc.so.6:link
 libc.so.6:listen
@@ -239,7 +243,6 @@ libc.so.6:strtod
 libc.so.6:strtok
 libc.so.6:strtok_r
 libc.so.6:strtol
-libc.so.6:strtoll
 libc.so.6:strtoul
 libc.so.6:strtoull
 libc.so.6:syscall
@@ -373,18 +376,20 @@ libstdc++.so.6:_ZNSt6thread15_M_start_threadESt10unique_ptrINS_6_StateESt14defau
 libstdc++.so.6:_ZNSt6thread4joinEv
 libstdc++.so.6:_ZNSt6thread6_StateD2Ev
 libstdc++.so.6:_ZNSt6thread6detachEv
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE15_M_replace_coldEPcmPKcmm
 libstdc++.so.6:_ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEEC1Ev
 libstdc++.so.6:_ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEEC1EONS_12basic_stringIcS2_S3_EESt13_Ios_Openmode
 libstdc++.so.6:_ZNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEC1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEED1Ev
+libstdc++.so.6:_ZNSt7__cxx117collateIcE2idE
+libstdc++.so.6:_ZNSt7__cxx118numpunctIcE2idE
+libstdc++.so.6:_ZNSt7__cxx118numpunctIwE2idE
 libstdc++.so.6:_ZNSt8__detail15_List_node_base11_M_transferEPS0_S1_
 libstdc++.so.6:_ZNSt8__detail15_List_node_base4swapERS0_S1_
 libstdc++.so.6:_ZNSt8__detail15_List_node_base7_M_hookEPS0_
 libstdc++.so.6:_ZNSt8__detail15_List_node_base9_M_unhookEv
-libstdc++.so.6:_ZNSt8ios_base4InitC1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitD1Ev
 libstdc++.so.6:_ZNSt8ios_baseD2Ev
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE5clearESt12_Ios_Iostate
 libstdc++.so.6:_ZNSt9exceptionD2Ev
@@ -402,6 +407,7 @@ libstdc++.so.6:_ZSt19__throw_regex_errorNSt15regex_constants10error_typeE
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt20__throw_out_of_rangePKc
 libstdc++.so.6:_ZSt20__throw_system_errori
+libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZSt24__throw_invalid_argumentPKc
 libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
 libstdc++.so.6:_ZSt25__throw_bad_function_callv
@@ -416,10 +422,6 @@ libstdc++.so.6:_ZSt7getlineIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7
 libstdc++.so.6:_ZSt7getlineIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EES4_
 libstdc++.so.6:_ZSt7nothrow
 libstdc++.so.6:_ZSt9terminatev
-libstdc++.so.6:_ZSt9use_facetINSt7__cxx117collateIcEEERKT_RKSt6locale
-libstdc++.so.6:_ZSt9use_facetINSt7__cxx118numpunctIcEEERKT_RKSt6locale
-libstdc++.so.6:_ZSt9use_facetINSt7__cxx118numpunctIwEEERKT_RKSt6locale
-libstdc++.so.6:_ZSt9use_facetISt5ctypeIcEERKT_RKSt6locale
 libstdc++.so.6:_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
 libstdc++.so.6:_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_c
 libstdc++.so.6:_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_h
@@ -447,7 +449,6 @@ libstdc++.so.6:_Znam
 libstdc++.so.6:_ZnamRKSt9nothrow_t
 libstdc++.so.6:_Znwm
 libstdc++.so.6:__cxa_allocate_exception
-libstdc++.so.6:__cxa_bad_cast
 libstdc++.so.6:__cxa_begin_catch
 libstdc++.so.6:__cxa_end_catch
 libstdc++.so.6:__cxa_free_exception

--- a/packages/a/android-tools/package.yml
+++ b/packages/a/android-tools/package.yml
@@ -1,9 +1,9 @@
 name       : android-tools
-version    : 34.0.1
-release    : 21
+version    : 34.0.4
+release    : 22
 source     :
-    - git|https://github.com/nmeum/android-tools : 34.0.1
-    - git|https://github.com/M0Rf30/android-udev-rules : 20230303
+    - git|https://github.com/nmeum/android-tools : 34.0.4
+    - git|https://github.com/M0Rf30/android-udev-rules : 20230614
 license    :
     - Apache-2.0
     - GPL-3.0-or-later

--- a/packages/a/android-tools/pspec_x86_64.xml
+++ b/packages/a/android-tools/pspec_x86_64.xml
@@ -12,7 +12,7 @@
         <Summary xml:lang="en">Android development tools (adb and fastboot)</Summary>
         <Description xml:lang="en">Android development tools, this includes adb (android debug bridge) and fastboot (diagnostic protocol for androids fastboot bootloader)
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>android-tools</Name>
@@ -49,9 +49,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2023-05-30</Date>
-            <Version>34.0.1</Version>
+        <Update release="22">
+            <Date>2023-10-24</Date>
+            <Version>34.0.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Mislav Čakarić</Name>
             <Email>mcakaric@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Update android-tools to latest release 34.0.4
Changelog can be found [here](https://developer.android.com/tools/releases/platform-tools#3404_july_2023)

**Test Plan**

Tried few adb commands, like `adb shell` and `adb install`

**Checklist**

- [x] Package was built and tested against unstable
