### PR TITLE
python-maturin: update to 1.3.1

### DIFF
--- a/packages/py/python-maturin/abi_used_symbols
+++ b/packages/py/python-maturin/abi_used_symbols
@@ -29,6 +29,7 @@ libc.so.6:fstat64
 libc.so.6:fstatat64
 libc.so.6:getcwd
 libc.so.6:getenv
+libc.so.6:getpid
 libc.so.6:getpwuid_r
 libc.so.6:getuid
 libc.so.6:gnu_get_libc_version
@@ -82,6 +83,9 @@ libc.so.6:readlink
 libc.so.6:readv
 libc.so.6:realloc
 libc.so.6:realpath
+libc.so.6:recv
+libc.so.6:recvmsg
+libc.so.6:sendmsg
 libc.so.6:setenv
 libc.so.6:setgid
 libc.so.6:setgroups
@@ -92,6 +96,7 @@ libc.so.6:sigaddset
 libc.so.6:sigaltstack
 libc.so.6:sigemptyset
 libc.so.6:signal
+libc.so.6:socketpair
 libc.so.6:stat64
 libc.so.6:strlen
 libc.so.6:syscall

--- a/packages/py/python-maturin/package.yml
+++ b/packages/py/python-maturin/package.yml
@@ -1,8 +1,8 @@
 name       : python-maturin
-version    : 1.3.0
-release    : 37
+version    : 1.3.1
+release    : 38
 source     :
-    - https://github.com/PyO3/maturin/archive/refs/tags/v1.3.0.tar.gz : bee17a7c744d1f4a30477d4437adba5c97e31e989388a7946be205d0e9bcb9bf
+    - https://github.com/PyO3/maturin/archive/refs/tags/v1.3.1.tar.gz : 9e4f6cf2b5127103042d7319e9cbeee3df5b429c3c29b930fd360cbf8da84828
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-maturin/pspec_x86_64.xml
+++ b/packages/py/python-maturin/pspec_x86_64.xml
@@ -12,7 +12,7 @@
         <Summary xml:lang="en">Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages</Summary>
         <Description xml:lang="en">Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>python-maturin</Name>
@@ -22,12 +22,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/maturin</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.0-py3.10.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.0-py3.10.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.0-py3.10.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.0-py3.10.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.0-py3.10.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.0-py3.10.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.1-py3.10.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.1-py3.10.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.1-py3.10.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.1-py3.10.egg-info/not-zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.1-py3.10.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.1-py3.10.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/maturin/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/maturin/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/maturin/__pycache__/__init__.cpython-310.pyc</Path>
@@ -37,9 +37,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="37">
-            <Date>2023-10-07</Date>
-            <Version>1.3.0</Version>
+        <Update release="38">
+            <Date>2023-10-24</Date>
+            <Version>1.3.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Use external `uniffi-bindgen` if no root package is configured
- Fix wheel filename for GraalPy
- Pytest skeleton in mixed template
- Keep trailing newlines from templates
- Auto-detect Python 3.13
- Fix missing `workspace.members` in sdist
- Don't set `MACOSX_DEPLOYMENT_TARGET` for editable builds by default
- Dependency updates

**Test Plan**

Successfully built `python-orjson`

**Checklist**

- [x] Package was built and tested against unstable
