### PR TITLE
noto-sans-ttf: add appstream metainfo

### DIFF
--- a/packages/n/noto-sans-ttf/files/noto-sans-ttf.metainfo.xml
+++ b/packages/n/noto-sans-ttf/files/noto-sans-ttf.metainfo.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023 Solus Developers <copyright@getsol.us -->
+<component type="font">
+  <id>noto-sans-ttf</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>noto-sans-ttf</name>
+  <url type="homepage">https://fonts.google.com/noto/</url>
+  <summary>A sans-serif variant of the Noto family created by Google.</summary>
+  <description>
+    <p>
+      Noto's goal is to provide a beautiful reading experience for all languages. It is a free, professionally-designed, open-source collection of fonts with a harmonious look and feel in multiple weights and styles.
+    </p>
+  </description>
+</component>

--- a/packages/n/noto-sans-ttf/files/noto-serif-ttf.metainfo.xml
+++ b/packages/n/noto-sans-ttf/files/noto-serif-ttf.metainfo.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023 Solus Developers <copyright@getsol.us -->
+<component type="font">
+  <id>noto-serif-ttf</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>noto-serif-ttf</name>
+  <url type="homepage">https://fonts.google.com/noto/</url>
+  <summary>A serif variant of the Noto family created by Google.</summary>
+  <description>
+    <p>
+      Noto's goal is to provide a beautiful reading experience for all languages. It is a free, professionally-designed, open-source collection of fonts with a harmonious look and feel in multiple weights and styles.
+    </p>
+  </description>
+</component>

--- a/packages/n/noto-sans-ttf/package.yml
+++ b/packages/n/noto-sans-ttf/package.yml
@@ -1,6 +1,6 @@
 name       : noto-sans-ttf
 version    : '20201206'
-release    : 21
+release    : 22
 source     :
     - https://github.com/googlefonts/noto-fonts/archive/refs/tags/v20201206-phase3.tar.gz : 18a513b6cfb99209d9ffe88f31659a514845e34ee8e7a0b534e37aa19e2c4270
     - https://github.com/googlefonts/noto-emoji/archive/refs/tags/v2.038.tar.gz : 47d8b39733a1e82efced7dee96e30cb31d205b150dc3ca44d59abbb22d027195
@@ -41,5 +41,10 @@ install    : |
 
     install -dm00755 $installdir/usr/share/fonts/conf.d
     ln -sv /usr/share/fontconfig/conf.avail/66-noto-color-emoji.conf $installdir/usr/share/fonts/conf.d/66-noto-color-emoji.conf
+
+    install -Dm00644 $pkgfiles/noto-sans-ttf.metainfo.xml $installdir/usr/share/metainfo/noto-sans-ttf.metainfo.xml
+    install -Dm00644 $pkgfiles/noto-serif-ttf.metainfo.xml $installdir/usr/share/metainfo/noto-serif-ttf.metainfo.xml
 patterns   :
-    - ^noto-serif-ttf : /usr/share/fonts/truetype/noto-sans-ttf/NotoSerif*
+    - ^noto-serif-ttf :
+      - /usr/share/fonts/truetype/noto-sans-ttf/NotoSerif*
+      - /usr/share/metainfo/noto-serif-ttf.metainfo.xml

--- a/packages/n/noto-sans-ttf/pspec_x86_64.xml
+++ b/packages/n/noto-sans-ttf/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>noto-sans-ttf</Name>
         <Homepage>https://fonts.google.com/noto</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>OFL-1.1</License>
         <PartOf>desktop.font</PartOf>
         <Summary xml:lang="en">Noto Sans Fonts (Multi-lingual and Emoji)</Summary>
         <Description xml:lang="en">Noto&apos;s goal is to provide a beautiful reading experience for all languages. It is a free, professionally-designed, open-source collection of fonts with a harmonious look and feel in multiple weights and styles.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>noto-sans-ttf</Name>
@@ -1150,6 +1150,7 @@
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansYi-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansZanabazarSquare-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoTraditionalNushu-Regular.ttf</Path>
+            <Path fileType="data">/usr/share/metainfo/noto-sans-ttf.metainfo.xml</Path>
         </Files>
     </Package>
     <Package>
@@ -1618,15 +1619,16 @@
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifYezidi-Medium.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifYezidi-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifYezidi-SemiBold.ttf</Path>
+            <Path fileType="data">/usr/share/metainfo/noto-serif-ttf.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2022-10-21</Date>
+        <Update release="22">
+            <Date>2023-11-10</Date>
             <Version>20201206</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
## Summary:

Add appstream metainfo to noto-sans-ttf as part of #449

## Test Plan:

Installed font eopkgs. Verified fonts appear in Font Management - noto sans, noto serif, noto color emoji Verified /usr/share/fonts/conf.d/66-noto-color-emoji.conf created as valid symlink Ran `appstream-builder --packages-dir=. --include-failed -v`

**Checklist**

- [x] Package was built and tested against unstable
