### PR TITLE
vis: Update to 0.8

### DIFF
--- a/packages/v/vis/abi_used_symbols
+++ b/packages/v/vis/abi_used_symbols
@@ -5,8 +5,6 @@ libc.so.6:__fprintf_chk
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
 libc.so.6:__longjmp_chk
-libc.so.6:__memcpy_chk
-libc.so.6:__memmove_chk
 libc.so.6:__printf_chk
 libc.so.6:__sigsetjmp
 libc.so.6:__snprintf_chk

--- a/packages/v/vis/package.yml
+++ b/packages/v/vis/package.yml
@@ -1,8 +1,9 @@
 name       : vis
-version    : '0.7'
-release    : 8
+version    : '0.8'
+release    : 9
 source     :
-    - https://github.com/martanne/vis/releases/download/v0.7/vis-0.7.tar.gz : 359ebb12a986b2f4e2a945567ad7587eb7d354301a5050ce10d51544570635eb
+    - https://github.com/martanne/vis/releases/download/v0.8/vis-0.8.tar.gz : 61b10d40f15c4db2ce16e9acf291dbb762da4cbccf0cf2a80b28d9ac998a39bd
+homepage   : https://github.com/martanne/vis
 license    : ISC
 component  : editor
 summary    : vi-like editor based on Plan 9's structural regular expressions

--- a/packages/v/vis/pspec_x86_64.xml
+++ b/packages/v/vis/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>vis</Name>
+        <Homepage>https://github.com/martanne/vis</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>ISC</License>
         <PartOf>editor</PartOf>
         <Summary xml:lang="en">vi-like editor based on Plan 9&apos;s structural regular expressions</Summary>
         <Description xml:lang="en">vi-like editor based on Plan 9&apos;s structural regular expressions
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>vis</Name>
@@ -198,12 +199,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2022-04-19</Date>
-            <Version>0.7</Version>
+        <Update release="9">
+            <Date>2023-10-25</Date>
+            <Version>0.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Full changelog can be found [here](https://github.com/martanne/vis/releases/tag/v0.8)
- Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

- Edit text file and try to get out
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable