### PR TITLE
fontconfig: Fix defaults

### DIFF
--- a/packages/f/fontconfig/abi_used_symbols
+++ b/packages/f/fontconfig/abi_used_symbols
@@ -2,7 +2,9 @@ libc.so.6:__assert_fail
 libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoull
 libc.so.6:__libc_start_main
 libc.so.6:__open_2
 libc.so.6:__printf_chk
@@ -88,8 +90,6 @@ libc.so.6:strpbrk
 libc.so.6:strrchr
 libc.so.6:strstr
 libc.so.6:strtod
-libc.so.6:strtol
-libc.so.6:strtoull
 libc.so.6:symlink
 libc.so.6:time
 libc.so.6:unlink

--- a/packages/f/fontconfig/abi_used_symbols32
+++ b/packages/f/fontconfig/abi_used_symbols32
@@ -2,7 +2,9 @@ libc.so.6:__assert_fail
 libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoull
 libc.so.6:__open64_2
 libc.so.6:__printf_chk
 libc.so.6:__realpath_chk
@@ -80,8 +82,6 @@ libc.so.6:strpbrk
 libc.so.6:strrchr
 libc.so.6:strstr
 libc.so.6:strtod
-libc.so.6:strtol
-libc.so.6:strtoull
 libc.so.6:symlink
 libc.so.6:time
 libc.so.6:unlink

--- a/packages/f/fontconfig/files/0002-Enforce-sane-defaults-for-Solus.patch
+++ b/packages/f/fontconfig/files/0002-Enforce-sane-defaults-for-Solus.patch
@@ -14,22 +14,6 @@ diff --git a/conf.d/60-latin.conf b/conf.d/60-latin.conf
 index ff933af..c817753 100644
 --- a/conf.d/60-latin.conf
 +++ b/conf.d/60-latin.conf
-@@ -5,6 +5,7 @@
- 	<alias>
- 		<family>serif</family>
- 		<prefer>
-+			<family>Clear Sans</family>
- 			<family>Noto Serif</family>
- 			<family>DejaVu Serif</family>
- 			<family>Times New Roman</family>
-@@ -18,6 +19,7 @@
- 	<alias>
- 		<family>sans-serif</family>
- 		<prefer>
-+			<family>Clear Sans</family>
- 			<family>Noto Sans</family>
- 			<family>DejaVu Sans</family>
- 			<family>Verdana</family>
 @@ -35,6 +37,7 @@
  	<alias>
  		<family>monospace</family>

--- a/packages/f/fontconfig/package.yml
+++ b/packages/f/fontconfig/package.yml
@@ -1,6 +1,6 @@
 name       : fontconfig
 version    : 2.14.2
-release    : 38
+release    : 39
 source     :
     - https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.14.2.tar.xz : dba695b57bce15023d2ceedef82062c2b925e51f5d4cc4aef736cf13f60a468b
 homepage   : https://www.freedesktop.org/wiki/Software/fontconfig/

--- a/packages/f/fontconfig/pspec_x86_64.xml
+++ b/packages/f/fontconfig/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>fontconfig</Name>
         <Homepage>https://www.freedesktop.org/wiki/Software/fontconfig/</Homepage>
         <Packager>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>MIT</License>
         <License>HPND</License>
@@ -129,7 +129,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="38">fontconfig</Dependency>
+            <Dependency release="39">fontconfig</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libfontconfig.so.1</Path>
@@ -143,8 +143,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="38">fontconfig-devel</Dependency>
-            <Dependency release="38">fontconfig-32bit</Dependency>
+            <Dependency release="39">fontconfig-devel</Dependency>
+            <Dependency release="39">fontconfig-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libfontconfig.so</Path>
@@ -158,7 +158,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="38">fontconfig</Dependency>
+            <Dependency release="39">fontconfig</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/fontconfig/fcfreetype.h</Path>
@@ -388,12 +388,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="38">
-            <Date>2023-10-08</Date>
+        <Update release="39">
+            <Date>2023-10-25</Date>
             <Version>2.14.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
This PR updates our Solus fontconfig defaults patch to reflect the agreed-upon change from Clear Sans to Noto Sans. In addition, this changes the default Serifed font from Clear Sans to Noto Serif. 

**Test Plan**
1. Test `font-face: serif;` in a web browser on Solus, see that the displayed font is Sans Serif
2. Build fontconfig with the changes in this PR
3. Repeat the above test after restarting your browser, see that the displayed font is correctly serifed

**Checklist**

- [x] Package was built and tested against unstable
