### PR TITLE
Add metadata to nerd-fonts

### DIFF
--- a/packages/f/font-firacode-nerd/files/nerd-fonts.metainfo.xml
+++ b/packages/f/font-firacode-nerd/files/nerd-fonts.metainfo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023 Solus Developers <copyright@getsol.us -->
+<component type="font">
+  <id>font-firacode-nerd</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>nerd-fonts</name>
+  <url type="homepage">https://www.nerdfonts.com/</url>
+  <summary>firacode font with nerdfonts patcher</summary>
+</component>

--- a/packages/f/font-firacode-nerd/package.yml
+++ b/packages/f/font-firacode-nerd/package.yml
@@ -1,6 +1,6 @@
 name       : font-firacode-nerd
 version    : 3.0.2
-release    : 1
+release    : 2
 source     :
     - https://github.com/ryanoasis/nerd-fonts/releases/download/v3.0.2/FiraCode.tar.xz : 76c1d691cea44b0cae4d6add56bb3ef52b83cedebb1c5f519b62d068f8586b93
 homepage   : https://www.nerdfonts.com/
@@ -12,3 +12,4 @@ description: |
 install    : |
     install -d $installdir/usr/share/fonts/nerd-fonts
     install -Dm00644 *.ttf $installdir/usr/share/fonts/nerd-fonts/
+    install -Dm00644 $pkgfiles/nerd-fonts.metainfo.xml $installdir/usr/share/metainfo/nerd-fonts.metainfo.xml

--- a/packages/f/font-firacode-nerd/pspec_x86_64.xml
+++ b/packages/f/font-firacode-nerd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>font-firacode-nerd</Name>
         <Homepage>https://www.nerdfonts.com/</Homepage>
         <Packager>
-            <Name>Hertz Hwang</Name>
-            <Email>hertz@26hz.com.cn</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>desktop.font</PartOf>
@@ -38,15 +38,16 @@
             <Path fileType="data">/usr/share/fonts/nerd-fonts/FiraCodeNerdFontPropo-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/nerd-fonts/FiraCodeNerdFontPropo-Retina.ttf</Path>
             <Path fileType="data">/usr/share/fonts/nerd-fonts/FiraCodeNerdFontPropo-SemiBold.ttf</Path>
+            <Path fileType="data">/usr/share/metainfo/nerd-fonts.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2023-10-15</Date>
+        <Update release="2">
+            <Date>2023-10-26</Date>
             <Version>3.0.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Hertz Hwang</Name>
-            <Email>hertz@26hz.com.cn</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
## Summary:

Add appstream metainfo to nerd-fonts as part of #449

## Test Plan:

Installed font eopkg. Verified fonts appear in Font Management Ran `appstream-builder --packages-dir=. --include-failed -v`

**Checklist**

- [x] Package was built and tested against unstable
