### PR TITLE
sarasa-gothic font: add appstream metainfo

### DIFF
--- a/packages/f/font-sarasa-gothic/files/sarasa-gothic.metainfo.xml
+++ b/packages/f/font-sarasa-gothic/files/sarasa-gothic.metainfo.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023 Solus Developers <copyright@getsol.us -->
+<component type="font">
+  <id>font-sarasa-gothic</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>sarasa-gothic</name>
+  <url type="homepage">https://github.com/be5invis/Sarasa-Gothic</url>
+  <summary>This is SARASA GOTHIC, a CJK programming font based on Iosevka and Source Han Sans.</summary>
+  <summary xml:lang="ja">更紗ゴシック</summary>
+  <summary xml:lang="kr">사라사 고딕</summary>
+  <summary xml:lang="zh">更纱黑体</summary>
+  <description>
+    <p>
+      Sarasa-Gothic is a CJK programming font based on Iosevka and Source Han Sans.
+    </p>
+  </description>
+</component>

--- a/packages/f/font-sarasa-gothic/package.yml
+++ b/packages/f/font-sarasa-gothic/package.yml
@@ -1,6 +1,6 @@
 name       : font-sarasa-gothic
 version    : 0.42.3
-release    : 2
+release    : 3
 source     :
     - https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.42.3/sarasa-gothic-ttc-0.42.3.7z : e6dcbbd772695c3599a9e5e760bd45e718af898b675b6c3d664179a650c382e7
 homepage   : https://github.com/be5invis/Sarasa-Gothic
@@ -12,3 +12,4 @@ description: |
 install    : |
     install -d $installdir/usr/share/fonts/sarasa-gothic
     install -Dm00644 *.ttc $installdir/usr/share/fonts/sarasa-gothic/
+    install -Dm00644 $pkgfiles/sarasa-gothic.metainfo.xml $installdir/usr/share/metainfo/sarasa-gothic.metainfo.xml

--- a/packages/f/font-sarasa-gothic/pspec_x86_64.xml
+++ b/packages/f/font-sarasa-gothic/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>font-sarasa-gothic</Name>
         <Homepage>https://github.com/be5invis/Sarasa-Gothic</Homepage>
         <Packager>
-            <Name>Hertz Hwang</Name>
-            <Email>hertz@26hz.com.cn</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>OFL-1.1</License>
         <PartOf>desktop.font</PartOf>
@@ -30,15 +30,16 @@
             <Path fileType="data">/usr/share/fonts/sarasa-gothic/sarasa-regular.ttc</Path>
             <Path fileType="data">/usr/share/fonts/sarasa-gothic/sarasa-semibold.ttc</Path>
             <Path fileType="data">/usr/share/fonts/sarasa-gothic/sarasa-semibolditalic.ttc</Path>
+            <Path fileType="data">/usr/share/metainfo/sarasa-gothic.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2023-10-26</Date>
+        <Update release="3">
+            <Date>2023-10-27</Date>
             <Version>0.42.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Hertz Hwang</Name>
-            <Email>hertz@26hz.com.cn</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
## Summary:

Add appstream metainfo to sarasa-gothic as part of #449

## Test Plan:

Installed font eopkg. Verified fonts appear in Font Management
Ran `appstream-builder --packages-dir=. --include-failed -v` and verified there are no errors

**Checklist**

- [x] Package was built and tested against unstable
