### PR TITLE
font-sarasa-gothic: Update to 0.42.3

### DIFF
--- a/packages/f/font-sarasa-gothic/package.yml
+++ b/packages/f/font-sarasa-gothic/package.yml
@@ -1,8 +1,8 @@
 name       : font-sarasa-gothic
-version    : '0.42.2'
-release    : 1
+version    : 0.42.3
+release    : 2
 source     :
-    - https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.42.2/sarasa-gothic-ttc-0.42.2.7z : 4643c794e3d742202cc2d7a4ace0a661c3cd94d4af72ac9a3388ee48727111e6
+    - https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.42.3/sarasa-gothic-ttc-0.42.3.7z : e6dcbbd772695c3599a9e5e760bd45e718af898b675b6c3d664179a650c382e7
 homepage   : https://github.com/be5invis/Sarasa-Gothic
 license    : OFL-1.1
 component  : desktop.font

--- a/packages/f/font-sarasa-gothic/pspec_x86_64.xml
+++ b/packages/f/font-sarasa-gothic/pspec_x86_64.xml
@@ -33,9 +33,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2023-10-15</Date>
-            <Version>0.42.2</Version>
+        <Update release="2">
+            <Date>2023-10-26</Date>
+            <Version>0.42.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Hertz Hwang</Name>
             <Email>hertz@26hz.com.cn</Email>


### PR DESCRIPTION
**Summary**
Update to 0.42.3

**Test Plan**
- Installed locally

**Checklist**
- [x] Package was built and tested against unstable

**Full release notes:**
- [v0.42.3](https://github.com/be5invis/Sarasa-Gothic/releases/tag/v0.42.3)