### PR TITLE
gpodder: update to 3.11.4

### DIFF
--- a/packages/g/gpodder/package.yml
+++ b/packages/g/gpodder/package.yml
@@ -1,8 +1,8 @@
 name       : gpodder
-version    : 3.11.2
-release    : 24
+version    : 3.11.4
+release    : 25
 source     :
-    - https://github.com/gpodder/gpodder/archive/refs/tags/3.11.2.tar.gz : a8e7eb3778698c63e9ff2066253746644428573654edcfd21e46bebdc57f5d28
+    - https://github.com/gpodder/gpodder/archive/refs/tags/3.11.4.tar.gz : 8022a6c29157dc287b5661f8915d04404767c33b6858e8d1a6c728904f8dae55
 homepage   : https://gpodder.github.io/
 license    : GPL-3.0-or-later
 component  : multimedia.audio
@@ -13,8 +13,6 @@ builddeps  :
     - python-html5lib
     - python-mygpoclient
     - python-podcastparser
-    - python-pytest
-    - python-pytest-httpserver
     - python-requests
 rundeps    :
     - python-gobject
@@ -24,6 +22,9 @@ rundeps    :
     - python-requests
     - python3-dbus
     - yt-dlp
+checkdeps  :
+    - python-pytest
+    - python-pytest-httpserver
 install    : |
     %make_install
 

--- a/packages/g/gpodder/pspec_x86_64.xml
+++ b/packages/g/gpodder/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>gpodder</Name>
         <Homepage>https://gpodder.github.io/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>multimedia.audio</PartOf>
         <Summary xml:lang="en">The gPodder podcast client</Summary>
         <Description xml:lang="en">gPodder is a simple, open source podcast client written in Python using GTK+. In development since 2005 with a proven, mature codebase.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>gpodder</Name>
@@ -23,10 +23,10 @@
             <Path fileType="executable">/usr/bin/gpo</Path>
             <Path fileType="executable">/usr/bin/gpodder</Path>
             <Path fileType="executable">/usr/bin/gpodder-migrate2tres</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/gpodder-3.11.2-py3.10.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/gpodder-3.11.2-py3.10.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/gpodder-3.11.2-py3.10.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/gpodder-3.11.2-py3.10.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/gpodder-3.11.4-py3.10.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/gpodder-3.11.4-py3.10.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/gpodder-3.11.4-py3.10.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/gpodder-3.11.4-py3.10.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/gpodder/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/gpodder/__pycache__/__init__.cpython-310.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/gpodder/__pycache__/__init__.cpython-310.pyc</Path>
@@ -312,12 +312,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2023-09-14</Date>
-            <Version>3.11.2</Version>
+        <Update release="25">
+            <Date>2023-10-27</Date>
+            <Version>3.11.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- add setting to toggle sync filesize comparisons (disable if your device adds metadata)
- show remaining duration for each download in progress tab
- make file size units translatable
- add plural form of rename downloads translation string
- expand ~ and ~user in GPODDER_HOME and GPODDER_DOWNLOAD_DIR
- find channel ID in YouTube "watch" URLs
- replace deprecated Gdk.Screen methods
- update dependencies
- catch errors for directories inside sync device
- fix YouTube GDPR issues by setting consent cookie in get_channel_id_url()

**Packaging changes:** Use `checkdeps`

**Test Plan**

- Added a new podcast, downloaded and watched an episode

**Checklist**

- [x] Package was built and tested against unstable
