### PR TITLE
gnome-shell-extension-speedinator: Initial inclusion

### DIFF
--- a/packages/g/gnome-shell-extension-speedinator/package.yml
+++ b/packages/g/gnome-shell-extension-speedinator/package.yml
@@ -1,0 +1,15 @@
+name       : gnome-shell-extension-speedinator
+version    : 0.1
+release    : 1
+source     :
+    - git|https://github.com/tehsquidge/speedinator.git : 368c7e711b08d5edadfe58c8d9b480417949af33
+homepage   : https://github.com/tehsquidge/speedinator
+license    : GPL-3.0-or-later
+component  : desktop.gnome
+summary    : Control the speed of gnome-shell animations
+description: |
+    speedinator - For speeding up Gnome Shell animations. This is a reworking of Impatience but for Gnome 45+.
+install    : |
+    install -dm00644 $installdir/usr/share/gnome-shell/extensions/speedinator@liam.moe/
+    install -Dm00644 schemas/org.gnome.shell.extensions.moe.liam.speedinator.gschema.xml $installdir/usr/share/glib-2.0/schemas/org.gnome.shell.extensions.moe.liam.speedinator.gschema.xml
+    cp extension.js metadata.json prefs.js $installdir/usr/share/gnome-shell/extensions/speedinator@liam.moe/

--- a/packages/g/gnome-shell-extension-speedinator/pspec_x86_64.xml
+++ b/packages/g/gnome-shell-extension-speedinator/pspec_x86_64.xml
@@ -1,0 +1,38 @@
+<PISI>
+    <Source>
+        <Name>gnome-shell-extension-speedinator</Name>
+        <Homepage>https://github.com/tehsquidge/speedinator</Homepage>
+        <Packager>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
+        </Packager>
+        <License>GPL-3.0-or-later</License>
+        <PartOf>desktop.gnome</PartOf>
+        <Summary xml:lang="en">Control the speed of gnome-shell animations</Summary>
+        <Description xml:lang="en">speedinator - For speeding up Gnome Shell animations. This is a reworking of Impatience but for Gnome 45+.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>gnome-shell-extension-speedinator</Name>
+        <Summary xml:lang="en">Control the speed of gnome-shell animations</Summary>
+        <Description xml:lang="en">speedinator - For speeding up Gnome Shell animations. This is a reworking of Impatience but for Gnome 45+.
+</Description>
+        <PartOf>desktop.gnome</PartOf>
+        <Files>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.shell.extensions.moe.liam.speedinator.gschema.xml</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/speedinator@liam.moe/extension.js</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/speedinator@liam.moe/metadata.json</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/speedinator@liam.moe/prefs.js</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2023-10-27</Date>
+            <Version>0.1</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**

- Replacement for gnome-shell-extension-impatience, resolves #680.

**Test Plan**

- Install, relog, enable extension. Visibly see animation speedups.

**Checklist**

- [x] Package was built and tested against unstable
