### PR TITLE
font-iosevka-ttf: Update to 27.3.1

### DIFF
--- a/packages/f/font-iosevka-ttf/package.yml
+++ b/packages/f/font-iosevka-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : font-iosevka-ttf
-version    : 27.2.0
-release    : 45
+version    : 27.3.1
+release    : 46
 source     :
-    - https://github.com/be5invis/Iosevka/releases/download/v27.2.0/ttf-iosevka-27.2.0.zip : c503f10ddb124be03793b70b7f6245945eefeea456b1fcd3a4b3b8434eadc839
+    - https://github.com/be5invis/Iosevka/releases/download/v27.3.1/ttf-iosevka-27.3.1.zip : 981c8f88bd937a47b15243ab8ae8a35eb935cfbc87af0fa63964735441efe779
 homepage   : https://typeof.net/Iosevka
 license    : OFL-1.1
 component  : desktop.font

--- a/packages/f/font-iosevka-ttf/pspec_x86_64.xml
+++ b/packages/f/font-iosevka-ttf/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>font-iosevka-ttf</Name>
         <Homepage>https://typeof.net/Iosevka</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Nazar Stasiv</Name>
+            <Email>nazar@autistici.org</Email>
         </Packager>
         <License>OFL-1.1</License>
         <PartOf>desktop.font</PartOf>
@@ -78,12 +78,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="45">
-            <Date>2023-10-12</Date>
-            <Version>27.2.0</Version>
+        <Update release="46">
+            <Date>2023-10-28</Date>
+            <Version>27.3.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Nazar Stasiv</Name>
+            <Email>nazar@autistici.org</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
## Summary
- Fix mark placement for U+024F.
- Make the tailed variants of i and l use the fully-tailed shape even when upright, as is consistent with t = bent-hook
- The old, slightly-curly variants for i, l, iota (ι) and tau (τ) are moved to semi-tailed variants.
- Make Cyrillic Yat to follow Yeri variants. Italic Yat will also respond to variants of n.
- Add short-tailed lowercase tau (τ)
- Fix tailed variants for U+02A0.
- Stylistic set fixes
- Refine shape of flat 5
- Add tailed lower lambda
- Add Chancery and Semi-Chancery variants for lowercase x and Greek Chi
- Add arrow-lr ligation group for C-like's spaceship operators
- Add raised cap-height cent sign (¢) variants to VSAM
- [changelog](https://raw.githubusercontent.com/be5invis/Iosevka/v27.3.1/CHANGELOG.md)

## Test Plan
- render text with the font

## Checklist
- [X] Package was built and tested against unstable
