### PR TITLE
gnome-shell-extension-speedinator: Match impatience defaults

### DIFF
--- a/packages/g/gnome-shell-extension-speedinator/files/0001-prefs.js-Add-a-0.75-option-in-animation-scale.patch
+++ b/packages/g/gnome-shell-extension-speedinator/files/0001-prefs.js-Add-a-0.75-option-in-animation-scale.patch
@@ -1,0 +1,34 @@
+From b30fa07b737dd81b538db364c122772330a48dc5 Mon Sep 17 00:00:00 2001
+From: Joey Riches <josephriches@gmail.com>
+Date: Sat, 28 Oct 2023 12:26:15 +0100
+Subject: [PATCH 1/1] prefs.js: Add a 0.75 option in animation scale
+
+Impatience used 0.75 by default, provide that value on the scale to
+help users move over.
+---
+ prefs.js | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/prefs.js b/prefs.js
+index 73c525f..edc7725 100644
+--- a/prefs.js
++++ b/prefs.js
+@@ -49,7 +49,7 @@ export default class SpeedinatorPreferences extends ExtensionPreferences {
+ 		group.add(hbox);
+ 		page.add(group);
+ 
+-		[0.25, 0.5, 1.0, 2.0].forEach(
++		[0.25, 0.5, 0.75, 1.0, 2.0].forEach(
+ 			mark => scale.add_mark(mark, Gtk.PositionType.TOP, "<small>" + mark + "</small>")
+ 		);
+ 		scale.set_value(settings.get_double("speed"));
+@@ -57,4 +57,4 @@ export default class SpeedinatorPreferences extends ExtensionPreferences {
+ 			settings.set_double("speed", sw.get_value());
+ 		});
+     }
+-}
+\ No newline at end of file
++}
+-- 
+2.42.0
+

--- a/packages/g/gnome-shell-extension-speedinator/files/0001-schemas-Set-the-default-value-to-0.75-to-match-impat.patch
+++ b/packages/g/gnome-shell-extension-speedinator/files/0001-schemas-Set-the-default-value-to-0.75-to-match-impat.patch
@@ -1,0 +1,20 @@
+diff --git a/schemas/org.gnome.shell.extensions.moe.liam.speedinator.gschema.xml b/schemas/org.gnome.shell.extensions.moe.liam.speedinator.gschema.xml
+index 1e40cab..5a3c649 100644
+--- a/schemas/org.gnome.shell.extensions.moe.liam.speedinator.gschema.xml
++++ b/schemas/org.gnome.shell.extensions.moe.liam.speedinator.gschema.xml
+@@ -2,9 +2,9 @@
+ <schemalist>
+ 	<schema id="org.gnome.shell.extensions.moe.liam.speedinator" path="/org/gnome/shell/extensions/moe/liam/speedinator/">
+ 		<key type="d" name="speed">
+-			<default>0.5</default>
++			<default>0.75</default>
+ 			<summary>speed</summary>
+ 			<description/>
+ 		</key>
+ 	</schema>
+-</schemalist>
+\ No newline at end of file
++</schemalist>
+-- 
+2.42.0
+

--- a/packages/g/gnome-shell-extension-speedinator/package.yml
+++ b/packages/g/gnome-shell-extension-speedinator/package.yml
@@ -1,6 +1,6 @@
 name       : gnome-shell-extension-speedinator
 version    : 0.1
-release    : 1
+release    : 2
 source     :
     - git|https://github.com/tehsquidge/speedinator.git : 368c7e711b08d5edadfe58c8d9b480417949af33
 homepage   : https://github.com/tehsquidge/speedinator
@@ -9,6 +9,9 @@ component  : desktop.gnome
 summary    : Control the speed of gnome-shell animations
 description: |
     speedinator - For speeding up Gnome Shell animations. This is a reworking of Impatience but for Gnome 45+.
+setup      : |
+    %patch -p1 -i $pkgfiles/0001-prefs.js-Add-a-0.75-option-in-animation-scale.patch
+    %patch -p1 -i $pkgfiles/0001-schemas-Set-the-default-value-to-0.75-to-match-impat.patch
 install    : |
     install -dm00644 $installdir/usr/share/gnome-shell/extensions/speedinator@liam.moe/
     install -Dm00644 schemas/org.gnome.shell.extensions.moe.liam.speedinator.gschema.xml $installdir/usr/share/glib-2.0/schemas/org.gnome.shell.extensions.moe.liam.speedinator.gschema.xml

--- a/packages/g/gnome-shell-extension-speedinator/pspec_x86_64.xml
+++ b/packages/g/gnome-shell-extension-speedinator/pspec_x86_64.xml
@@ -27,8 +27,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2023-10-27</Date>
+        <Update release="2">
+            <Date>2023-10-28</Date>
             <Version>0.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Joey Riches</Name>


### PR DESCRIPTION
**Summary**
- To provide a better seamless upgrade.

**Test Plan**

On a VM, install the extension and verify the new defaults took place.

**Checklist**

- [x] Package was built and tested against unstable
