### PR TITLE
gnome-desktop-branding: Update to v18

### DIFF
--- a/packages/g/gnome-desktop-branding/package.yml
+++ b/packages/g/gnome-desktop-branding/package.yml
@@ -1,8 +1,8 @@
 name       : gnome-desktop-branding
-version    : '17'
-release    : 46
+version    : '18'
+release    : 47
 source     :
-    - git|https://github.com/getsolus/gnome-desktop-branding.git : 47616d76922ad69fcb1709987442ca7679450df2
+    - git|https://github.com/getsolus/gnome-desktop-branding.git : v18
 homepage   : https://github.com/getsolus/gnome-desktop-branding
 license    : GPL-2.0-only
 component  :
@@ -29,6 +29,7 @@ rundeps    :
     - gnome-browser-connector
     - gnome-shell
     - gnome-shell-extension-appindicator
+    - gnome-shell-extension-speedinator
     - gnome-shell-extensions
     - noto-sans-ttf
     - noto-serif-ttf

--- a/packages/g/gnome-desktop-branding/pspec_x86_64.xml
+++ b/packages/g/gnome-desktop-branding/pspec_x86_64.xml
@@ -34,16 +34,16 @@
         <Description xml:lang="en">Solus 4.0 LiveCD configuration.</Description>
         <PartOf>desktop.gnome</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="46">gnome-desktop-branding</Dependency>
+            <Dependency releaseFrom="47">gnome-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/glib-2.0/schemas/50_gnome_livecd.gschema.override</Path>
         </Files>
     </Package>
     <History>
-        <Update release="46">
-            <Date>2023-10-27</Date>
-            <Version>17</Version>
+        <Update release="47">
+            <Date>2023-10-28</Date>
+            <Version>18</Version>
             <Comment>Packaging update</Comment>
             <Name>Joey Riches</Name>
             <Email>josephriches@gmail.com</Email>


### PR DESCRIPTION
**Functional Changelog**
- Enable speedinator by default to replace impatience

**Test Plan**

Verify changes took place in a gnome session.

**Checklist**

- [x] Package was built and tested against unstable
