### PR TITLE
gpxsee: Update to 13.10

### DIFF
--- a/packages/g/gpxsee/abi_used_symbols
+++ b/packages/g/gpxsee/abi_used_symbols
@@ -574,7 +574,6 @@ libQt5Gui.so.5:_ZN12QKeySequenceD1Ev
 libQt5Gui.so.5:_ZN12QPaintDeviceC2Ev
 libQt5Gui.so.5:_ZN12QPainterPath10addPolygonERK9QPolygonF
 libQt5Gui.so.5:_ZN12QPainterPath12closeSubpathEv
-libQt5Gui.so.5:_ZN12QPainterPath20setElementPositionAtEidd
 libQt5Gui.so.5:_ZN12QPainterPath6lineToERK7QPointF
 libQt5Gui.so.5:_ZN12QPainterPath6moveToERK7QPointF
 libQt5Gui.so.5:_ZN12QPainterPath6quadToERK7QPointFS2_
@@ -623,6 +622,9 @@ libQt5Gui.so.5:_ZN5QFont9setWeightEi
 libQt5Gui.so.5:_ZN5QFontC1ERKS_
 libQt5Gui.so.5:_ZN5QFontC1Ev
 libQt5Gui.so.5:_ZN5QFontD1Ev
+libQt5Gui.so.5:_ZN5QIcon20setFallbackThemeNameERK7QString
+libQt5Gui.so.5:_ZN5QIcon9fromThemeERK7QString
+libQt5Gui.so.5:_ZN5QIcon9fromThemeERK7QStringRKS_
 libQt5Gui.so.5:_ZN5QIconC1ERK7QPixmap
 libQt5Gui.so.5:_ZN5QIconC1ERK7QString
 libQt5Gui.so.5:_ZN5QIconC1Ev

--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.9'
-release    : 27
+version    : '13.10'
+release    : 28
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.9.tar.gz : 86079c7d8053a64837042695e666cd4f4aac7fb01b19e76106cf9b124653b22f
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.10.tar.gz : 29c1ca028bb3faf18147c95aa6e9d70ad80ce7011b275c3c25c6628e097b8898
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -11,7 +11,7 @@
         <Summary xml:lang="en">a Qt-based GPS log file viewer and analyzer that supports all common GPS log file formats.</Summary>
         <Description xml:lang="en">a Qt-based GPS log file viewer and analyzer that supports all common GPS log file formats.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>gpxsee</Name>
@@ -130,9 +130,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2023-09-28</Date>
-            <Version>13.9</Version>
+        <Update release="28">
+            <Date>2023-10-29</Date>
+            <Version>13.10</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- New GUI icons that fit the current platform styles.
- Added "Open directory" action for desktop systems.
- Fixed/improved vector maps path label layout algorithm.

**Test Plan**
- open map file; zoom in and out

**Checklist**
- [X] Package was built and tested against unstable
