### PR TITLE
vnstat: Update 2.11

### DIFF
--- a/packages/v/vnstat/abi_libs
+++ b/packages/v/vnstat/abi_libs
@@ -1,0 +1,1 @@
+vnstati

--- a/packages/v/vnstat/abi_symbols
+++ b/packages/v/vnstat/abi_symbols
@@ -1,0 +1,3 @@
+vnstati:__bss_start
+vnstati:_edata
+vnstati:_end

--- a/packages/v/vnstat/abi_used_symbols
+++ b/packages/v/vnstat/abi_used_symbols
@@ -101,10 +101,12 @@ libgd.so.3:gdImageColorTransparent
 libgd.so.3:gdImageCreate
 libgd.so.3:gdImageDashedLine
 libgd.so.3:gdImageDestroy
+libgd.so.3:gdImageFile
 libgd.so.3:gdImageFill
 libgd.so.3:gdImageFilledArc
 libgd.so.3:gdImageFilledRectangle
 libgd.so.3:gdImageLine
+libgd.so.3:gdImagePaletteToTrueColor
 libgd.so.3:gdImagePng
 libgd.so.3:gdImageRectangle
 libgd.so.3:gdImageScale
@@ -112,6 +114,7 @@ libgd.so.3:gdImageSetInterpolationMethod
 libgd.so.3:gdImageSetPixel
 libgd.so.3:gdImageString
 libgd.so.3:gdImageStringUp
+libgd.so.3:gdSupportsFileType
 libm.so.6:lrint
 libm.so.6:lrintf
 libm.so.6:pow
@@ -128,6 +131,7 @@ libsqlite3.so.0:sqlite3_exec
 libsqlite3.so.0:sqlite3_finalize
 libsqlite3.so.0:sqlite3_get_autocommit
 libsqlite3.so.0:sqlite3_last_insert_rowid
+libsqlite3.so.0:sqlite3_libversion
 libsqlite3.so.0:sqlite3_open_v2
 libsqlite3.so.0:sqlite3_prepare_v2
 libsqlite3.so.0:sqlite3_snprintf

--- a/packages/v/vnstat/package.yml
+++ b/packages/v/vnstat/package.yml
@@ -1,8 +1,9 @@
 name       : vnstat
-version    : '2.8'
-release    : 9
+version    : '2.11'
+release    : 10
 source     :
-    - https://github.com/vergoh/vnstat/releases/download/v2.8/vnstat-2.8.tar.gz : 03f858a7abf6bd85bb8cd595f3541fc3bd31f8f400ec092ef3034825ccb77c25
+    - https://github.com/vergoh/vnstat/releases/download/v2.11/vnstat-2.11.tar.gz : babc3f1583cc40e4e8ffb2f53296d93d308cb5a5043e85054f6eaf7b4ae57856
+homepage   : https://humdi.net/vnstat/
 license    : GPL-2.0-or-later
 component  : system.utils
 summary    : A network traffic monitor for Linux and BSD

--- a/packages/v/vnstat/pspec_x86_64.xml
+++ b/packages/v/vnstat/pspec_x86_64.xml
@@ -1,31 +1,22 @@
 <PISI>
     <Source>
         <Name>vnstat</Name>
+        <Homepage>https://humdi.net/vnstat/</Homepage>
         <Packager>
-            <Name>Solène Rapenne</Name>
-            <Email>solene@perso.pw</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">A network traffic monitor for Linux and BSD</Summary>
-        <Description xml:lang="en">vnStat is a console-based network traffic monitor that uses the network interface statistics
-provided by the kernel as information source. This means that vnStat will not actually be
-sniffing any traffic and also ensures light use of system resources.
-Traffic statistics are stored on a hourly level for the last 24 hours, on a daily level for the
-last 30 days and on a monthly level for the last 12 months. Total seen traffic and a top 10
-days listing is also provided.
+        <Description xml:lang="en">vnStat is a console-based network traffic monitor that uses the network interface statistics provided by the kernel as information source. This means that vnStat will not actually be sniffing any traffic and also ensures light use of system resources. Traffic statistics are stored on a hourly level for the last 24 hours, on a daily level for the last 30 days and on a monthly level for the last 12 months. Total seen traffic and a top 10 days listing is also provided.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>vnstat</Name>
         <Summary xml:lang="en">A network traffic monitor for Linux and BSD</Summary>
-        <Description xml:lang="en">vnStat is a console-based network traffic monitor that uses the network interface statistics
-provided by the kernel as information source. This means that vnStat will not actually be
-sniffing any traffic and also ensures light use of system resources.
-Traffic statistics are stored on a hourly level for the last 24 hours, on a daily level for the
-last 30 days and on a monthly level for the last 12 months. Total seen traffic and a top 10
-days listing is also provided.
+        <Description xml:lang="en">vnStat is a console-based network traffic monitor that uses the network interface statistics provided by the kernel as information source. This means that vnStat will not actually be sniffing any traffic and also ensures light use of system resources. Traffic statistics are stored on a hourly level for the last 24 hours, on a daily level for the last 30 days and on a monthly level for the last 12 months. Total seen traffic and a top 10 days listing is also provided.
 </Description>
         <PartOf>system.utils</PartOf>
         <Files>
@@ -41,12 +32,12 @@ days listing is also provided.
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2021-11-11</Date>
-            <Version>2.8</Version>
+        <Update release="10">
+            <Date>2023-10-29</Date>
+            <Version>2.11</Version>
             <Comment>Packaging update</Comment>
-            <Name>Solène Rapenne</Name>
-            <Email>solene@perso.pw</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Full changelog can be found here:
   - [2.11](https://github.com/vergoh/vnstat/releases/tag/v2.11)
   - [2.10](https://github.com/vergoh/vnstat/releases/tag/v2.10)
   - [2.9](https://github.com/vergoh/vnstat/releases/tag/v2.9) 
- Added `homepage` key to `package.yml` part of #411

**Test Plan**

- Monitor network speed and make log of it
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable