### PR TITLE
wine: Update to 8.19

### DIFF
--- a/packages/w/wine/abi_used_symbols
+++ b/packages/w/wine/abi_used_symbols
@@ -1009,7 +1009,6 @@ libwayland-client.so.0:wl_display_dispatch_queue_pending
 libwayland-client.so.0:wl_display_flush
 libwayland-client.so.0:wl_display_roundtrip_queue
 libwayland-client.so.0:wl_event_queue_destroy
-libwayland-client.so.0:wl_list_empty
 libwayland-client.so.0:wl_list_init
 libwayland-client.so.0:wl_list_insert
 libwayland-client.so.0:wl_list_remove

--- a/packages/w/wine/abi_used_symbols32
+++ b/packages/w/wine/abi_used_symbols32
@@ -947,7 +947,6 @@ libwayland-client.so.0:wl_display_dispatch_queue_pending
 libwayland-client.so.0:wl_display_flush
 libwayland-client.so.0:wl_display_roundtrip_queue
 libwayland-client.so.0:wl_event_queue_destroy
-libwayland-client.so.0:wl_list_empty
 libwayland-client.so.0:wl_list_init
 libwayland-client.so.0:wl_list_insert
 libwayland-client.so.0:wl_list_remove

--- a/packages/w/wine/package.yml
+++ b/packages/w/wine/package.yml
@@ -1,8 +1,8 @@
 name       : wine
-version    : '8.18'
-release    : 164
+version    : '8.19'
+release    : 165
 source     :
-    - https://dl.winehq.org/wine/source/8.x/wine-8.18.tar.xz : 30faef14acf70fd5f739d2fece3432839f1f7dd2d3624bcc3662c3b1b83260db
+    - https://dl.winehq.org/wine/source/8.x/wine-8.19.tar.xz : 9253f81c8880ddcc9b7914974c2fc198485457a476683fa27a71fe73522ed31d
 license    : LGPL-2.1-or-later
 component  : virt
 homepage   : https://www.winehq.org/

--- a/packages/w/wine/pspec_x86_64.xml
+++ b/packages/w/wine/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>wine</Name>
         <Homepage>https://www.winehq.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>virt</PartOf>
@@ -976,7 +976,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="164">wine</Dependency>
+            <Dependency release="165">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/wine</Path>
@@ -1615,7 +1615,6 @@
             <Path fileType="library">/usr/lib32/wine/i386-windows/vcomp140.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/vcomp90.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/vcruntime140.dll</Path>
-            <Path fileType="library">/usr/lib32/wine/i386-windows/vcruntime140_1.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/vdhcp.vxd</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/vdmdbg.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/ver.dll16</Path>
@@ -1803,7 +1802,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="164">wine</Dependency>
+            <Dependency release="165">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wine/debug.h</Path>
@@ -2037,10 +2036,12 @@
             <Path fileType="header">/usr/include/wine/windows/d3d10_1.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/d3d10_1shader.h</Path>
             <Path fileType="header">/usr/include/wine/windows/d3d10effect.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/d3d10effect.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/d3d10misc.h</Path>
             <Path fileType="header">/usr/include/wine/windows/d3d10sdklayers.h</Path>
             <Path fileType="header">/usr/include/wine/windows/d3d10sdklayers.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/d3d10shader.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/d3d10shader.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/d3d11.h</Path>
             <Path fileType="header">/usr/include/wine/windows/d3d11.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/d3d11_1.h</Path>
@@ -3083,12 +3084,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="164">
-            <Date>2023-10-21</Date>
-            <Version>8.18</Version>
+        <Update release="165">
+            <Date>2023-10-30</Date>
+            <Version>8.19</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Highlighted changes:
- Mono engine updated to version 8.1.0
- More DirectMusic implementation
- Various bug fixes

Full release notes available [here](https://www.winehq.org/announce/8.19)

**Test Plan**

- Used several Wine apps like `winecfg`, `winefile`, `wineconsole`
- Played Age of Empires 1 Demo using `wine`

**Checklist**

- [x] Package was built and tested against unstable
