### PR TITLE
wayland-utils: Update to 1.2.0

### DIFF
--- a/packages/w/wayland-utils/abi_used_symbols
+++ b/packages/w/wayland-utils/abi_used_symbols
@@ -14,10 +14,15 @@ libc.so.6:malloc
 libc.so.6:memcpy
 libc.so.6:mmap64
 libc.so.6:munmap
+libc.so.6:perror
 libc.so.6:stderr
 libc.so.6:strcmp
 libc.so.6:strdup
 libc.so.6:strerror
+libc.so.6:strstr
+libdrm.so.2:drmFreeDevice
+libdrm.so.2:drmGetDeviceFromDevId
+libdrm.so.2:drmGetDeviceNameFromFd
 libdrm.so.2:drmGetFormatModifierName
 libdrm.so.2:drmGetFormatModifierVendor
 libwayland-client.so.0:wl_array_copy

--- a/packages/w/wayland-utils/package.yml
+++ b/packages/w/wayland-utils/package.yml
@@ -1,8 +1,9 @@
 name       : wayland-utils
-version    : 1.1.0
-release    : 1
+version    : 1.2.0
+release    : 2
 source     :
-    - https://gitlab.freedesktop.org/wayland/wayland-utils/-/archive/1.1.0/wayland-utils-1.1.0.tar.gz : 736fae5eb93e7eb6cdaa2374583b82912d2a497853ee8a1b3aeec0109ddd82dc
+    - https://gitlab.freedesktop.org/wayland/wayland-utils/-/archive/1.2.0/wayland-utils-1.2.0.tar.gz : 2ccc0d31c7327f3739322d643e13c1346f2485ae860e837cf58524346d89566c
+homepage   : https://gitlab.freedesktop.org/wayland/wayland-utils
 license    :
     - X11
     - MIT

--- a/packages/w/wayland-utils/pspec_x86_64.xml
+++ b/packages/w/wayland-utils/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>wayland-utils</Name>
+        <Homepage>https://gitlab.freedesktop.org/wayland/wayland-utils</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>X11</License>
         <License>MIT</License>
@@ -11,7 +12,7 @@
         <Summary xml:lang="en">wayland-info is a utility for displaying information about the Wayland protocols supported by a Wayland compositor.</Summary>
         <Description xml:lang="en">wayland-info is a utility for displaying information about the Wayland protocols supported by a Wayland compositor. It can be used to check which Wayland protocols and versions are advertised by the Wayland compositor. wayland-info also provides additional information for a subset of Wayland protocols it knows about, namely Linux DMABUF, presentation time, tablet and XDG output protocols.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>wayland-utils</Name>
@@ -25,12 +26,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2023-05-02</Date>
-            <Version>1.1.0</Version>
+        <Update release="2">
+            <Date>2023-10-31</Date>
+            <Version>1.2.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Fix spurious tab/space
- Adds a command line option `--interface` (`-i`) which prints the information only for the given interface
- Full changelog can be found [here](https://gitlab.freedesktop.org/wayland/wayland-utils/-/compare/1.1...1.2?from_project_id=7032&straight=false)
- Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

- Run `wayland-info -i 'wl_compositor'`
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable