### PR TITLE
weechat: Update 4.1.1

### DIFF
--- a/packages/w/weechat/package.yml
+++ b/packages/w/weechat/package.yml
@@ -1,8 +1,8 @@
 name       : weechat
-version    : 4.1.0
-release    : 73
+version    : 4.1.1
+release    : 74
 source     :
-    - https://github.com/weechat/weechat/archive/refs/tags/v4.1.0.tar.gz : 789a7a225dcdaf9b104bf661a8dcd0209f8a976f90388bb7f4d298562a12a329
+    - https://github.com/weechat/weechat/archive/refs/tags/v4.1.1.tar.gz : 1571021731e658d47edb2159a00fa48e6df7272de4f4a57b9e971592433db9a3
 homepage   : https://weechat.org
 license    : GPL-3.0-or-later
 summary    : WeeChat is a fast, light and extensible chat client.

--- a/packages/w/weechat/pspec_x86_64.xml
+++ b/packages/w/weechat/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>weechat</Name>
         <Homepage>https://weechat.org</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.irc</PartOf>
@@ -72,7 +72,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="73">weechat</Dependency>
+            <Dependency release="74">weechat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/weechat/weechat-plugin.h</Path>
@@ -80,12 +80,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="73">
-            <Date>2023-10-22</Date>
-            <Version>4.1.0</Version>
+        <Update release="74">
+            <Date>2023-10-31</Date>
+            <Version>4.1.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Fix crash when a custom bar item name is already used by a default bar item
- Fix random timeouts when a lot of concurrent processes are launched with hook_process
- Revert compute of nick colors to case sensitive way, deprecate again infos `irc_nick_color` and `irc_nick_color_name`

**Test Plan**

- Connect irc.libera.chat
- Join #solus channel and chat to void

**Checklist**

- [x] Package was built and tested against unstable