### PR TITLE
whois: Update to 5.5.19

### DIFF
--- a/packages/w/whois/abi_used_symbols
+++ b/packages/w/whois/abi_used_symbols
@@ -2,7 +2,8 @@ libc.so.6:__ctype_tolower_loc
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk

--- a/packages/w/whois/package.yml
+++ b/packages/w/whois/package.yml
@@ -1,8 +1,9 @@
 name       : whois
-version    : 5.5.6
-release    : 23
+version    : 5.5.19
+release    : 24
 source     :
-    - https://github.com/rfc1036/whois/archive/v5.5.6.tar.gz : fa86a9da4b6e79b6a04b0110f7f4f46214d038a051fef3d0767a09b44e49e8c8
+    - https://github.com/rfc1036/whois/archive/refs/tags/v5.5.19.tar.gz : 58602ce405a0d1f62fc99cd9e9e8cb3fb1ce05451a45a8d5b532bab5120d070e
+homepage   : https://github.com/rfc1036/whois
 license    : GPL-2.0-or-later
 component  : network.clients
 summary    : whois client

--- a/packages/w/whois/pspec_x86_64.xml
+++ b/packages/w/whois/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>whois</Name>
+        <Homepage>https://github.com/rfc1036/whois</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>network.clients</PartOf>
         <Summary xml:lang="en">whois client</Summary>
         <Description xml:lang="en">whois client - perform DNS lookups on remote hosts
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>whois</Name>
@@ -21,6 +22,8 @@
         <Files>
             <Path fileType="executable">/usr/bin/mkpasswd</Path>
             <Path fileType="executable">/usr/bin/whois</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/mkpasswd</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/whois</Path>
             <Path fileType="doc">/usr/share/doc/whois/whois.conf</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/whois.mo</Path>
             <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/whois.mo</Path>
@@ -32,10 +35,11 @@
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/whois.mo</Path>
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/whois.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/whois.mo</Path>
-            <Path fileType="localedata">/usr/share/locale/nb/LC_MESSAGES/whois.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/whois.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pl/LC_MESSAGES/whois.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/whois.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ru/LC_MESSAGES/whois.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/tr/LC_MESSAGES/whois.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/whois.mo</Path>
             <Path fileType="man">/usr/share/man/man1/mkpasswd.1</Path>
             <Path fileType="man">/usr/share/man/man1/whois.1</Path>
@@ -43,12 +47,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2022-11-15</Date>
-            <Version>5.5.6</Version>
+        <Update release="24">
+            <Date>2023-10-31</Date>
+            <Version>5.5.19</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Full changelog can be found [here](https://raw.githubusercontent.com/rfc1036/whois/v5.5.19/debian/changelog)
- Added `homepage` key to `package.yml` part of #411

**Test Plan**

- Run `whois getsol.us` and get expected information
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable 