### PR TITLE
wildmidi: Update to 0.45

### DIFF
--- a/packages/m/mpd/abi_used_symbols
+++ b/packages/m/mpd/abi_used_symbols
@@ -254,7 +254,11 @@ libc.so.6:__assert_fail
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoll
+libc.so.6:__isoc23_strtoul
+libc.so.6:__isoc23_strtoull
 libc.so.6:__libc_single_threaded
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
@@ -385,10 +389,6 @@ libc.so.6:strrchr
 libc.so.6:strstr
 libc.so.6:strtod
 libc.so.6:strtof
-libc.so.6:strtol
-libc.so.6:strtoll
-libc.so.6:strtoul
-libc.so.6:strtoull
 libc.so.6:syscall
 libc.so.6:sysconf
 libc.so.6:time
@@ -985,7 +985,6 @@ libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE17find_firs
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEcm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE5rfindEcm
-libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7compareEPKc
 libstdc++.so.6:_ZNSt12system_errorD1Ev
 libstdc++.so.6:_ZNSt13random_device7_M_finiEv
 libstdc++.so.6:_ZNSt13random_device7_M_initERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
@@ -1023,8 +1022,6 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt8__detail15_List_node_base11_M_transferEPS0_S1_
 libstdc++.so.6:_ZNSt8__detail15_List_node_base7_M_hookEPS0_
 libstdc++.so.6:_ZNSt8__detail15_List_node_base9_M_unhookEv
-libstdc++.so.6:_ZNSt8ios_base4InitC1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitD1Ev
 libstdc++.so.6:_ZNSt9bad_allocD1Ev
 libstdc++.so.6:_ZNSt9exceptionD2Ev
 libstdc++.so.6:_ZSt11_Hash_bytesPKvmm

--- a/packages/m/mpd/package.yml
+++ b/packages/m/mpd/package.yml
@@ -1,8 +1,8 @@
 name       : mpd
-version    : 0.23.13
-release    : 84
+version    : 0.23.14
+release    : 85
 source     :
-    - https://github.com/MusicPlayerDaemon/MPD/archive/refs/tags/v0.23.13.tar.gz : c002fd15033d791c8ac3dcc009b728b0e8440ed483ba56e3ff8964587fe9f97d
+    - https://github.com/MusicPlayerDaemon/MPD/archive/refs/tags/v0.23.14.tar.gz : 3547237437368962c8a8bdec088a369a94ef66f7afc22f6fc0d643c1406bd533
 homepage   : https://www.musicpd.org
 license    : GPL-2.0-or-later
 component  : multimedia.audio

--- a/packages/m/mpd/pspec_x86_64.xml
+++ b/packages/m/mpd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mpd</Name>
         <Homepage>https://www.musicpd.org</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>multimedia.audio</PartOf>
@@ -34,12 +34,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="84">
-            <Date>2023-10-08</Date>
-            <Version>0.23.13</Version>
+        <Update release="85">
+            <Date>2023-11-02</Date>
+            <Version>0.23.14</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/w/wildmidi/abi_libs
+++ b/packages/w/wildmidi/abi_libs
@@ -1,1 +1,2 @@
 libWildMidi.so.2
+wildmidi

--- a/packages/w/wildmidi/abi_symbols
+++ b/packages/w/wildmidi/abi_symbols
@@ -19,3 +19,13 @@ libWildMidi.so.2:WildMidi_SetCvtOption
 libWildMidi.so.2:WildMidi_SetOption
 libWildMidi.so.2:WildMidi_Shutdown
 libWildMidi.so.2:WildMidi_SongSeek
+wildmidi:_IO_stdin_used
+wildmidi:__bss_start
+wildmidi:__data_start
+wildmidi:_edata
+wildmidi:_end
+wildmidi:_start
+wildmidi:_tty
+wildmidi:main
+wildmidi:wm_inittty
+wildmidi:wm_resetty

--- a/packages/w/wildmidi/abi_used_libs
+++ b/packages/w/wildmidi/abi_used_libs
@@ -1,2 +1,3 @@
+libasound.so.2
 libc.so.6
 libm.so.6

--- a/packages/w/wildmidi/abi_used_symbols
+++ b/packages/w/wildmidi/abi_used_symbols
@@ -1,3 +1,24 @@
+libasound.so.2:snd_pcm_bytes_to_frames
+libasound.so.2:snd_pcm_close
+libasound.so.2:snd_pcm_frames_to_bytes
+libasound.so.2:snd_pcm_hw_params
+libasound.so.2:snd_pcm_hw_params_any
+libasound.so.2:snd_pcm_hw_params_set_access
+libasound.so.2:snd_pcm_hw_params_set_buffer_time_near
+libasound.so.2:snd_pcm_hw_params_set_channels
+libasound.so.2:snd_pcm_hw_params_set_format
+libasound.so.2:snd_pcm_hw_params_set_period_time_near
+libasound.so.2:snd_pcm_hw_params_set_rate_near
+libasound.so.2:snd_pcm_hw_params_sizeof
+libasound.so.2:snd_pcm_open
+libasound.so.2:snd_pcm_prepare
+libasound.so.2:snd_pcm_start
+libasound.so.2:snd_pcm_state
+libasound.so.2:snd_pcm_sw_params
+libasound.so.2:snd_pcm_sw_params_current
+libasound.so.2:snd_pcm_sw_params_sizeof
+libasound.so.2:snd_pcm_writei
+libasound.so.2:snd_strerror
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
 libc.so.6:__libc_start_main
@@ -5,7 +26,6 @@ libc.so.6:__memcpy_chk
 libc.so.6:__printf_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
-libc.so.6:__strncpy_chk
 libc.so.6:__vfprintf_chk
 libc.so.6:__vsprintf_chk
 libc.so.6:calloc
@@ -19,7 +39,6 @@ libc.so.6:getenv
 libc.so.6:getopt_long
 libc.so.6:getpwuid
 libc.so.6:getuid
-libc.so.6:ioctl
 libc.so.6:isatty
 libc.so.6:lseek64
 libc.so.6:malloc
@@ -53,4 +72,3 @@ libm.so.6:pow
 libm.so.6:sin
 libm.so.6:sincos
 libm.so.6:sinh
-libm.so.6:sqrt

--- a/packages/w/wildmidi/files/wildmidi.cfg
+++ b/packages/w/wildmidi/files/wildmidi.cfg
@@ -1,0 +1,134 @@
+
+drumset 0
+
+ 25	/usr/share/soundfonts/freepats/Drum_000/025_Snare_Roll.pat 
+ 26	/usr/share/soundfonts/freepats/Drum_000/026_Snap.pat 
+ 27	/usr/share/soundfonts/freepats/Drum_000/027_High_Q.pat 
+ 31	/usr/share/soundfonts/freepats/Drum_000/031_Sticks.pat 
+ 32	/usr/share/soundfonts/freepats/Drum_000/032_Square_Click.pat 
+ 33	/usr/share/soundfonts/freepats/Drum_000/033_Metronome_Click.pat 
+ 34	/usr/share/soundfonts/freepats/Drum_000/034_Metronome_Bell.pat 
+ 35	/usr/share/soundfonts/freepats/Drum_000/035_Kick_1.pat amp=100
+ 36	/usr/share/soundfonts/freepats/Drum_000/036_Kick_2.pat amp=100
+ 37	/usr/share/soundfonts/freepats/Drum_000/037_Stick_Rim.pat 
+ 38	/usr/share/soundfonts/freepats/Drum_000/038_Snare_1.pat 
+ 39	/usr/share/soundfonts/freepats/Drum_000/039_Clap_Hand.pat amp=100
+ 40	/usr/share/soundfonts/freepats/Drum_000/040_Snare_2.pat 
+ 41	/usr/share/soundfonts/freepats/Drum_000/041_Tom_Low_2.pat amp=100
+ 42	/usr/share/soundfonts/freepats/Drum_000/042_Hi-Hat_Closed.pat 
+ 43	/usr/share/soundfonts/freepats/Drum_000/043_Tom_Low_1.pat amp=100
+ 44	/usr/share/soundfonts/freepats/Drum_000/044_Hi-Hat_Pedal.pat 
+ 45	/usr/share/soundfonts/freepats/Drum_000/045_Tom_Mid_2.pat amp=100
+ 46	/usr/share/soundfonts/freepats/Drum_000/046_Hi-Hat_Open.pat 
+ 47	/usr/share/soundfonts/freepats/Drum_000/047_Tom_Mid_1.pat amp=100
+ 48	/usr/share/soundfonts/freepats/Drum_000/048_Tom_High_2.pat amp=100
+ 49	/usr/share/soundfonts/freepats/Drum_000/049_Cymbal_Crash_1.pat 
+ 50	/usr/share/soundfonts/freepats/Drum_000/050_Tom_High_1.pat amp=100
+ 51	/usr/share/soundfonts/freepats/Drum_000/051_Cymbal_Ride_1.pat 
+ 52	/usr/share/soundfonts/freepats/Drum_000/052_Cymbal_Chinese.pat 
+ 53	/usr/share/soundfonts/freepats/Drum_000/053_Cymbal_Ride_Bell.pat amp=100
+ 54	/usr/share/soundfonts/freepats/Drum_000/054_Tombourine.pat 
+ 55	/usr/share/soundfonts/freepats/Drum_000/055_Cymbal_Splash.pat 
+ 56	/usr/share/soundfonts/freepats/Drum_000/056_Cow_Bell.pat 
+ 57	/usr/share/soundfonts/freepats/Drum_000/057_Cymbal_Crash_2.pat 
+ 58	/usr/share/soundfonts/freepats/Drum_000/058_Vibra-Slap.pat 
+ 59	/usr/share/soundfonts/freepats/Drum_000/059_Cymbal_Ride_2.pat 
+ 60	/usr/share/soundfonts/freepats/Drum_000/060_Bongo_High.pat 
+ 61	/usr/share/soundfonts/freepats/Drum_000/061_Bongo_Low.pat 
+ 62	/usr/share/soundfonts/freepats/Drum_000/062_Conga_High_1_Mute.pat 
+ 63	/usr/share/soundfonts/freepats/Drum_000/063_Conga_High_2_Open.pat 
+ 64	/usr/share/soundfonts/freepats/Drum_000/064_Conga_Low.pat 
+ 65	/usr/share/soundfonts/freepats/Drum_000/065_Timbale_High.pat 
+ 66	/usr/share/soundfonts/freepats/Drum_000/066_Timbale_Low.pat 
+ 67	/usr/share/soundfonts/freepats/Drum_000/067_Agogo_High.pat 
+ 68	/usr/share/soundfonts/freepats/Drum_000/068_Agogo_Low.pat 
+ 69	/usr/share/soundfonts/freepats/Drum_000/069_Cabasa.pat amp=100
+ 70	/usr/share/soundfonts/freepats/Drum_000/070_Maracas.pat 
+ 71	/usr/share/soundfonts/freepats/Drum_000/071_Whistle_1_High_Short.pat 
+ 72	/usr/share/soundfonts/freepats/Drum_000/072_Whistle_2_Low_Long.pat 
+ 73	/usr/share/soundfonts/freepats/Drum_000/073_Guiro_1_Short.pat 
+ 74	/usr/share/soundfonts/freepats/Drum_000/074_Guiro_2_Long.pat 
+ 75	/usr/share/soundfonts/freepats/Drum_000/075_Claves.pat amp=100
+ 76	/usr/share/soundfonts/freepats/Drum_000/076_Wood_Block_1_High.pat 
+ 77	/usr/share/soundfonts/freepats/Drum_000/077_Wood_Block_2_Low.pat 
+ 78	/usr/share/soundfonts/freepats/Drum_000/078_Cuica_1_Mute.pat amp=100
+ 79	/usr/share/soundfonts/freepats/Drum_000/079_Cuica_2_Open.pat amp=100
+ 80	/usr/share/soundfonts/freepats/Drum_000/080_Triangle_1_Mute.pat 
+ 81	/usr/share/soundfonts/freepats/Drum_000/081_Triangle_2_Open.pat 
+ 82	/usr/share/soundfonts/freepats/Drum_000/082_Shaker.pat 
+ 84	/usr/share/soundfonts/freepats/Drum_000/084_Belltree.pat 
+
+bank 0
+
+ 0	/usr/share/soundfonts/freepats/Tone_000/000_Acoustic_Grand_Piano.pat amp=120 pan=center
+ 1	/usr/share/soundfonts/freepats/Tone_000/001_Acoustic_Brite_Piano.pat 
+ 2	/usr/share/soundfonts/freepats/Tone_000/002_Electric_Grand_Piano.pat 
+ 4	/usr/share/soundfonts/freepats/Tone_000/004_Electric_Piano_1_Rhodes.pat 
+ 5	/usr/share/soundfonts/freepats/Tone_000/005_Electric_Piano_2_Chorused_Yamaha_DX.pat 
+ 6	/usr/share/soundfonts/freepats/Tone_000/006_Harpsichord.pat 
+ 7	/usr/share/soundfonts/freepats/Tone_000/007_Clavinet.pat 
+ 8	/usr/share/soundfonts/freepats/Tone_000/008_Celesta.pat 
+ 9	/usr/share/soundfonts/freepats/Tone_000/009_Glockenspiel.pat 
+ 13	/usr/share/soundfonts/freepats/Tone_000/013_Xylophone.pat 
+ 14	/usr/share/soundfonts/freepats/Tone_000/014_Tubular_Bells.pat 
+ 15	/usr/share/soundfonts/freepats/Tone_000/015_Dulcimer.pat 
+ 16	/usr/share/soundfonts/freepats/Tone_000/016_Hammond_Organ.pat 
+ 19	/usr/share/soundfonts/freepats/Tone_000/019_Church_Organ.pat 
+ 21	/usr/share/soundfonts/freepats/Tone_000/021_Accordion.pat 
+ 23	/usr/share/soundfonts/freepats/Tone_000/023_Tango_Accordion.pat 
+ 24	/usr/share/soundfonts/freepats/Tone_000/024_Nylon_Guitar.pat 
+ 25	/usr/share/soundfonts/freepats/Tone_000/025_Steel_Guitar.pat 
+ 26	/usr/share/soundfonts/freepats/Tone_000/026_Jazz_Guitar.pat 
+ 27	/usr/share/soundfonts/freepats/Tone_000/027_Clean_Electric_Guitar.pat 
+ 28	/usr/share/soundfonts/freepats/Tone_000/028_Muted_Electric_Guitar.pat 
+ 29	/usr/share/soundfonts/freepats/Tone_000/029_Overdriven_Guitar.pat 
+ 30	/usr/share/soundfonts/freepats/Tone_000/030_Distortion_Guitar.pat 
+ 32	/usr/share/soundfonts/freepats/Tone_000/032_Acoustic_Bass.pat 
+ 33	/usr/share/soundfonts/freepats/Tone_000/033_Finger_Bass.pat 
+ 34	/usr/share/soundfonts/freepats/Tone_000/034_Pick_Bass.pat 
+ 35	/usr/share/soundfonts/freepats/Tone_000/035_Fretless_Bass.pat 
+ 36	/usr/share/soundfonts/freepats/Tone_000/036_Slap_Bass_1.pat 
+ 37	/usr/share/soundfonts/freepats/Tone_000/037_Slap_Bass_2.pat 
+ 38	/usr/share/soundfonts/freepats/Tone_000/038_Synth_Bass_1.pat 
+ 40	/usr/share/soundfonts/freepats/Tone_000/040_Violin.pat 
+ 42	/usr/share/soundfonts/freepats/Tone_000/042_Cello.pat 
+ 44	/usr/share/soundfonts/freepats/Tone_000/044_Tremolo_Strings.pat 
+ 45	/usr/share/soundfonts/freepats/Tone_000/045_Pizzicato_Strings.pat 
+ 46	/usr/share/soundfonts/freepats/Tone_000/046_Harp.pat 
+ 47	/usr/share/soundfonts/freepats/Tone_000/047_Timpani.pat 
+ 48	/usr/share/soundfonts/freepats/Tone_000/048_String_Ensemble_1_Marcato.pat 
+ 53	/usr/share/soundfonts/freepats/Tone_000/053_Voice_Oohs.pat 
+ 56	/usr/share/soundfonts/freepats/Tone_000/056_Trumpet.pat 
+ 57	/usr/share/soundfonts/freepats/Tone_000/057_Trombone.pat 
+ 58	/usr/share/soundfonts/freepats/Tone_000/058_Tuba.pat 
+ 59	/usr/share/soundfonts/freepats/Tone_000/059_Muted_Trumpet.pat 
+ 60	/usr/share/soundfonts/freepats/Tone_000/060_French_Horn.pat 
+ 61	/usr/share/soundfonts/freepats/Tone_000/061_Brass_Section.pat 
+ 64	/usr/share/soundfonts/freepats/Tone_000/064_Soprano_Sax.pat 
+ 65	/usr/share/soundfonts/freepats/Tone_000/065_Alto_Sax.pat 
+ 66	/usr/share/soundfonts/freepats/Tone_000/066_Tenor_Sax.pat 
+ 67	/usr/share/soundfonts/freepats/Tone_000/067_Baritone_Sax.pat 
+ 68	/usr/share/soundfonts/freepats/Tone_000/068_Oboe.pat 
+ 69	/usr/share/soundfonts/freepats/Tone_000/069_English_Horn.pat 
+ 70	/usr/share/soundfonts/freepats/Tone_000/070_Bassoon.pat 
+ 71	/usr/share/soundfonts/freepats/Tone_000/071_Clarinet.pat 
+ 72	/usr/share/soundfonts/freepats/Tone_000/072_Piccolo.pat 
+ 73	/usr/share/soundfonts/freepats/Tone_000/073_Flute.pat 
+ 74	/usr/share/soundfonts/freepats/Tone_000/074_Recorder.pat 
+ 75	/usr/share/soundfonts/freepats/Tone_000/075_Pan_Flute.pat 
+ 76	/usr/share/soundfonts/freepats/Tone_000/076_Bottle_Blow.pat 
+ 79	/usr/share/soundfonts/freepats/Tone_000/079_Ocarina.pat 
+ 80	/usr/share/soundfonts/freepats/Tone_000/080_Square_Wave.pat 
+ 84	/usr/share/soundfonts/freepats/Tone_000/084_Charang.pat 
+ 88	/usr/share/soundfonts/freepats/Tone_000/088_New_Age.pat 
+ 94	/usr/share/soundfonts/freepats/Tone_000/094_Halo_Pad.pat 
+ 95	/usr/share/soundfonts/freepats/Tone_000/095_Sweep_Pad.pat 
+ 98	/usr/share/soundfonts/freepats/Tone_000/098_Crystal.pat 
+ 101	/usr/share/soundfonts/freepats/Tone_000/101_Goblins--Unicorn.pat 
+ 102	/usr/share/soundfonts/freepats/Tone_000/102_Echo_Voice.pat 
+ 104	/usr/share/soundfonts/freepats/Tone_000/104_Sitar.pat 
+ 114	/usr/share/soundfonts/freepats/Tone_000/114_Steel_Drums.pat 
+ 115	/usr/share/soundfonts/freepats/Tone_000/115_Wood_Block.pat 
+ 120	/usr/share/soundfonts/freepats/Tone_000/120_Guitar_Fret_Noise.pat 
+ 122	/usr/share/soundfonts/freepats/Tone_000/122_Seashore.pat 
+ 125	/usr/share/soundfonts/freepats/Tone_000/125_Helicopter.pat 

--- a/packages/w/wildmidi/package.yml
+++ b/packages/w/wildmidi/package.yml
@@ -1,8 +1,9 @@
 name       : wildmidi
-version    : 0.4.3
-release    : 3
+version    : 0.4.5
+release    : 4
 source     :
-    - https://github.com/Mindwerks/wildmidi/archive/wildmidi-0.4.3.tar.gz : 498e5a96455bb4b91b37188ad6dcb070824e92c44f5ed452b90adbaec8eef3c5
+    - https://github.com/Mindwerks/wildmidi/releases/download/wildmidi-0.4.5/wildmidi-0.4.5.tar.gz : d5e7bef00a7aa47534a53d43b1265f8d3d27f6a28e7f563c1cdf02ff4fa35b99
+homepage   : https://github.com/Mindwerks/wildmidi/
 license    :
     - GPL-3.0-or-later
     - LGPL-3.0-or-later
@@ -10,9 +11,16 @@ component  : programming.library
 summary    : WildMIDI is a simple software midi player which has a core softsynth library that can be use with other applications
 description: |
     WildMIDI is a simple software midi player which has a core softsynth library that can be use with other applications
+builddeps  :
+    - pkgconfig(alsa)
+rundeps    :
+    - freepats
 setup      : |
-    %cmake .
+    %cmake_ninja .
 build      : |
-    %make
+    %ninja_build
 install    : |
-    %make_install
+    %ninja_install
+
+    #Install configuraton files for wildimidi (take from freepats) so it poduces sound
+    install -Dm00644 $pkgfiles/wildmidi.cfg $installdir/etc/wildmidi/wildmidi.cfg

--- a/packages/w/wildmidi/pspec_x86_64.xml
+++ b/packages/w/wildmidi/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>wildmidi</Name>
+        <Homepage>https://github.com/Mindwerks/wildmidi/</Homepage>
         <Packager>
-            <Name>F. von Gellhorn</Name>
-            <Email>flinux@vongellhorn.ch</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <License>LGPL-3.0-or-later</License>
@@ -11,7 +12,7 @@
         <Summary xml:lang="en">WildMIDI is a simple software midi player which has a core softsynth library that can be use with other applications</Summary>
         <Description xml:lang="en">WildMIDI is a simple software midi player which has a core softsynth library that can be use with other applications
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>wildmidi</Name>
@@ -20,10 +21,31 @@
 </Description>
         <PartOf>programming.library</PartOf>
         <Files>
+            <Path fileType="config">/etc/wildmidi/wildmidi.cfg</Path>
             <Path fileType="executable">/usr/bin/wildmidi</Path>
-            <Path fileType="library">/usr/lib/libWildMidi.so.2</Path>
-            <Path fileType="library">/usr/lib/libWildMidi.so.2.1.0</Path>
+            <Path fileType="library">/usr/lib64/libWildMidi.so.2</Path>
+            <Path fileType="library">/usr/lib64/libWildMidi.so.2.1.0</Path>
             <Path fileType="man">/usr/share/man/man1/wildmidi.1</Path>
+            <Path fileType="man">/usr/share/man/man5/wildmidi.cfg.5</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>wildmidi-devel</Name>
+        <Summary xml:lang="en">Development files for wildmidi</Summary>
+        <Description xml:lang="en">WildMIDI is a simple software midi player which has a core softsynth library that can be use with other applications
+</Description>
+        <PartOf>programming.devel</PartOf>
+        <RuntimeDependencies>
+            <Dependency release="4">wildmidi</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="header">/usr/include/wildmidi_lib.h</Path>
+            <Path fileType="library">/usr/lib64/cmake/WildMidi/WildMidiConfig.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/WildMidi/WildMidiConfigVersion.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/WildMidi/WildMidiTargets-relwithdebinfo.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/WildMidi/WildMidiTargets.cmake</Path>
+            <Path fileType="library">/usr/lib64/libWildMidi.so</Path>
+            <Path fileType="data">/usr/lib64/pkgconfig/wildmidi.pc</Path>
             <Path fileType="man">/usr/share/man/man3/WildMidi_ClearError.3</Path>
             <Path fileType="man">/usr/share/man/man3/WildMidi_Close.3</Path>
             <Path fileType="man">/usr/share/man/man3/WildMidi_ConvertBufferToMidi.3</Path>
@@ -45,31 +67,15 @@
             <Path fileType="man">/usr/share/man/man3/WildMidi_SetOption.3</Path>
             <Path fileType="man">/usr/share/man/man3/WildMidi_Shutdown.3</Path>
             <Path fileType="man">/usr/share/man/man3/WildMidi_SongSeek.3</Path>
-            <Path fileType="man">/usr/share/man/man5/wildmidi.cfg.5</Path>
-        </Files>
-    </Package>
-    <Package>
-        <Name>wildmidi-devel</Name>
-        <Summary xml:lang="en">Development files for wildmidi</Summary>
-        <Description xml:lang="en">WildMIDI is a simple software midi player which has a core softsynth library that can be use with other applications
-</Description>
-        <PartOf>programming.devel</PartOf>
-        <RuntimeDependencies>
-            <Dependency release="3">wildmidi</Dependency>
-        </RuntimeDependencies>
-        <Files>
-            <Path fileType="header">/usr/include/wildmidi_lib.h</Path>
-            <Path fileType="library">/usr/lib/libWildMidi.so</Path>
-            <Path fileType="data">/usr/lib/pkgconfig/wildmidi.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2021-06-20</Date>
-            <Version>0.4.3</Version>
+        <Update release="4">
+            <Date>2023-11-01</Date>
+            <Version>0.4.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>F. von Gellhorn</Name>
-            <Email>flinux@vongellhorn.ch</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Changelog:
  - 0.45: 
    - Fixed MUS drum channels 9 and 15 being swapped if the same file is played twice from the same memory buffer 
    - Player: Fixed save midi reading wrong argv if there are no paths separators
  - 0.44:
    - Fixed integer overflow in midi parser sample count calculation
    - Fixed 8 bit ping pong GUS patch loaders - Fixed wrong variable use in reverb code - Reset block status of tty after playback - Fixed broken file name handling for 'save as midi' command during playback
    - Clamp MUS volume commands - CMake project improvements - `cmake` version 3.1 or newer is now required
- Added `homepage` key to `package.yml` (Part of #411)
- Added `freepats` to `rundeps` and `pkgconfig(alsa)` to `builddeps`

**Test Plan**

- Run `wildimidi -t` to run sample midi
- Play several midi files to test playback control
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable