### PR TITLE
wireguard-tools: Update to 1.0.20210914

### DIFF
--- a/packages/w/wireguard-tools/abi_used_symbols
+++ b/packages/w/wireguard-tools/abi_used_symbols
@@ -1,6 +1,9 @@
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
 libc.so.6:__getdelim
+libc.so.6:__isoc23_strtoll
+libc.so.6:__isoc23_strtoul
+libc.so.6:__isoc23_strtoull
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
@@ -65,12 +68,10 @@ libc.so.6:strdup
 libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncasecmp
+libc.so.6:strncmp
 libc.so.6:strncpy
 libc.so.6:strrchr
 libc.so.6:strsep
-libc.so.6:strtoll
-libc.so.6:strtoul
-libc.so.6:strtoull
 libc.so.6:syscall
 libc.so.6:sysconf
 libc.so.6:time

--- a/packages/w/wireguard-tools/package.yml
+++ b/packages/w/wireguard-tools/package.yml
@@ -1,8 +1,9 @@
 name       : wireguard-tools
-version    : 1.0.20210424
-release    : 7
+version    : 1.0.20210914
+release    : 8
 source     :
-    - https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-1.0.20210424.tar.xz : b288b0c43871d919629d7e77846ef0b47f8eeaa9ebc9cedeee8233fc6cc376ad
+    - https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-1.0.20210914.tar.xz : 97ff31489217bb265b7ae850d3d0f335ab07d2652ba1feec88b734bc96bd05ac
+homepage   : https://www.wireguard.com/
 license    : GPL-2.0-only
 component  : network.util
 summary    : Required tools for WireGuard, such as wg(8) and wg-quick(8)

--- a/packages/w/wireguard-tools/pspec_x86_64.xml
+++ b/packages/w/wireguard-tools/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>wireguard-tools</Name>
+        <Homepage>https://www.wireguard.com/</Homepage>
         <Packager>
-            <Name>F. von Gellhorn</Name>
-            <Email>flinux@vongellhorn.ch</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>network.util</PartOf>
         <Summary xml:lang="en">Required tools for WireGuard, such as wg(8) and wg-quick(8)</Summary>
         <Description xml:lang="en">This supplies the main userspace tooling for using and configuring WireGuard tunnels, including the wg(8) and wg-quick(8) utilities.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>wireguard-tools</Name>
@@ -30,12 +31,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2021-06-20</Date>
-            <Version>1.0.20210424</Version>
+        <Update release="8">
+            <Date>2023-11-02</Date>
+            <Version>1.0.20210914</Version>
             <Comment>Packaging update</Comment>
-            <Name>F. von Gellhorn</Name>
-            <Email>flinux@vongellhorn.ch</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- The `git` commit can be found [here](https://git.zx2c4.com/wireguard-tools/log/?h=v1.0.20210914)
- Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

- Start a connection using `wg-quick`
- Start connection using `gnome-control-center`
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable