### PR TITLE
wireless-regdb: Update to 2023.09.01

### DIFF
--- a/packages/w/wireless-regdb/package.yml
+++ b/packages/w/wireless-regdb/package.yml
@@ -1,8 +1,9 @@
 name       : wireless-regdb
-version    : 2020.04.29
-release    : 2
+version    : 2023.09.01
+release    : 3
 source     :
-    - https://mirrors.edge.kernel.org/pub/software/network/wireless-regdb/wireless-regdb-2020.04.29.tar.xz : 89fd031aed5977c219a71501e144375a10e7c90d1005d5d086ea7972886a2c7a
+    - https://mirrors.edge.kernel.org/pub/software/network/wireless-regdb/wireless-regdb-2023.09.01.tar.xz : 26d4c2a727cc59239b84735aad856b7c7d0b04e30aa5c235c4f7f47f5f053491
+homepage   : https://wireless.wiki.kernel.org/en/developers/regulatory/wireless-regdb
 license    : ISC
 component  : system.base
 summary    : This package contains the wireless regulatory database used by all cfg80211 based Linux wireless drivers.

--- a/packages/w/wireless-regdb/pspec_x86_64.xml
+++ b/packages/w/wireless-regdb/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>wireless-regdb</Name>
+        <Homepage>https://wireless.wiki.kernel.org/en/developers/regulatory/wireless-regdb</Homepage>
         <Packager>
-            <Name>Joshua Strobl</Name>
-            <Email>joshua@streambits.io</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>ISC</License>
         <PartOf>system.base</PartOf>
         <Summary xml:lang="en">This package contains the wireless regulatory database used by all cfg80211 based Linux wireless drivers.</Summary>
         <Description xml:lang="en">This package contains the wireless regulatory database used by all cfg80211 based Linux wireless drivers.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>wireless-regdb</Name>
@@ -28,12 +29,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2020-07-16</Date>
-            <Version>2020.04.29</Version>
+        <Update release="3">
+            <Date>2023-11-02</Date>
+            <Version>2023.09.01</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joshua Strobl</Name>
-            <Email>joshua@streambits.io</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Add support for US S1G channels
- Remove PTMP-ONLY from 5850-5895 MHz for US
- Update regulatory rules for: 
  - Australia
  - Turkiye
  - Egypt 
  - Philipines 
  - Hong Kong 
  - India 
  - Russia 
  - Japan 
  - Switzerland 
  - Brazil 
  - Bulgaria 
  - Israel 
  - Netherlands
- Full `git` commit can be found [here](https://git.kernel.org/pub/scm/linux/kernel/git/sforshee/wireless-regdb.git//log/?h=master-2023-09-01)
- Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable