### PR TITLE
wxsqlite3: Update to 4.9.5 

### DIFF
--- a/packages/g/guayadeque/abi_used_symbols
+++ b/packages/g/guayadeque/abi_used_symbols
@@ -1,5 +1,6 @@
 UNKNOWN:_ZTI18wxSQLite3Exception
 libc.so.6:__cxa_atexit
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_single_threaded
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
@@ -27,7 +28,6 @@ libc.so.6:strdup
 libc.so.6:strlen
 libc.so.6:strncpy
 libc.so.6:strstr
-libc.so.6:strtol
 libc.so.6:time
 libc.so.6:towupper
 libc.so.6:umask
@@ -300,16 +300,17 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE9_M_appendEP
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE9_M_assignERKS4_
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE9_M_createERmm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE9_M_mutateEmmPKwm
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE9push_backEw
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEEC1EOS4_
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEEC1ERKS4_
 libstdc++.so.6:_ZNSt8__detail15_List_node_base7_M_hookEPS0_
-libstdc++.so.6:_ZNSt8ios_base4InitC1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitD1Ev
 libstdc++.so.6:_ZSt17__throw_bad_allocv
 libstdc++.so.6:_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_incrementPKSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
+libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
 libstdc++.so.6:_ZSt28_Rb_tree_rebalance_for_erasePSt18_Rb_tree_node_baseRS_
 libstdc++.so.6:_ZSt28__throw_bad_array_new_lengthv

--- a/packages/g/guayadeque/package.yml
+++ b/packages/g/guayadeque/package.yml
@@ -1,6 +1,6 @@
 name       : guayadeque
 version    : 0.4.7
-release    : 10
+release    : 11
 source     :
     - https://github.com/anonbeat/guayadeque/archive/refs/tags/v0.4.7.tar.gz : 38d6ab8a1820e8c205b8f07d86fee912263dfdb982f5c08086e897600e0771b2
 license    : GPL-3.0-or-later

--- a/packages/g/guayadeque/pspec_x86_64.xml
+++ b/packages/g/guayadeque/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>guayadeque</Name>
         <Homepage>https://www.guayadeque.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>multimedia.audio</PartOf>
         <Summary xml:lang="en">Guayadeque Music Player</Summary>
         <Description xml:lang="en">Guayadeque is a music management program designed for all music enthusiasts. It is Full Featured Linux media player that can easily manage large collections and uses the Gstreamer media framework.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>guayadeque</Name>
@@ -58,12 +58,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2023-07-22</Date>
+        <Update release="11">
+            <Date>2023-11-03</Date>
             <Version>0.4.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/w/wxsqlite3/abi_symbols
+++ b/packages/w/wxsqlite3/abi_symbols
@@ -781,6 +781,7 @@ libwxcode_gtk3u_wxsqlite3-3.2.so.0:sqlite3_status
 libwxcode_gtk3u_wxsqlite3-3.2.so.0:sqlite3_status64
 libwxcode_gtk3u_wxsqlite3-3.2.so.0:sqlite3_step
 libwxcode_gtk3u_wxsqlite3-3.2.so.0:sqlite3_stmt_busy
+libwxcode_gtk3u_wxsqlite3-3.2.so.0:sqlite3_stmt_explain
 libwxcode_gtk3u_wxsqlite3-3.2.so.0:sqlite3_stmt_isexplain
 libwxcode_gtk3u_wxsqlite3-3.2.so.0:sqlite3_stmt_readonly
 libwxcode_gtk3u_wxsqlite3-3.2.so.0:sqlite3_stmt_status

--- a/packages/w/wxsqlite3/abi_used_symbols
+++ b/packages/w/wxsqlite3/abi_used_symbols
@@ -4,6 +4,8 @@ libc.so.6:__ctype_toupper_loc
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoll
 libc.so.6:__memcpy_chk
 libc.so.6:__memset_chk
 libc.so.6:__stack_chk_fail
@@ -80,11 +82,10 @@ libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strncpy
 libc.so.6:strrchr
+libc.so.6:strspn
 libc.so.6:strstr
 libc.so.6:strtod
-libc.so.6:strtol
 libc.so.6:strtold
-libc.so.6:strtoll
 libc.so.6:symlink
 libc.so.6:syscall
 libc.so.6:sysconf
@@ -123,10 +124,9 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE9_M_appendEP
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE9_M_assignERKS4_
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE9_M_createERmm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEEC1ERKS4_
-libstdc++.so.6:_ZNSt8ios_base4InitC1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitD1Ev
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
+libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZTVN10__cxxabiv117__class_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv120__si_class_type_infoE
 libstdc++.so.6:_ZdlPvm

--- a/packages/w/wxsqlite3/package.yml
+++ b/packages/w/wxsqlite3/package.yml
@@ -1,8 +1,9 @@
 name       : wxsqlite3
-version    : 4.9.4
-release    : 8
+version    : 4.9.6
+release    : 9
 source     :
-    - https://github.com/utelle/wxsqlite3/archive/refs/tags/v4.9.4.tar.gz : 020f05951bc46e59967bb48825799549cd8b79704c05358e972b86d4656c10e4
+    - https://github.com/utelle/wxsqlite3/archive/refs/tags/v4.9.6.tar.gz : e086b116667edfdc115e081cb4b32408bc834315f457fb6a9eb87de8218fbf77
+homepage   : https://utelle.github.io/wxsqlite3
 license    : LGPL-3.0-or-later WITH WxWindows-exception-3.1
 component  : programming
 summary    : wxSQLite3 is a C++ wrapper around the public domain SQLite 3.x database

--- a/packages/w/wxsqlite3/pspec_x86_64.xml
+++ b/packages/w/wxsqlite3/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>wxsqlite3</Name>
+        <Homepage>https://utelle.github.io/wxsqlite3</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>LGPL-3.0-or-later WITH WxWindows-exception-3.1</License>
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">wxSQLite3 is a C++ wrapper around the public domain SQLite 3.x database</Summary>
         <Description xml:lang="en">wxSQLite3 is a C++ wrapper around the public domain SQLite 3.x database.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>wxsqlite3</Name>
@@ -30,7 +31,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="8">wxsqlite3</Dependency>
+            <Dependency release="9">wxsqlite3</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wx/wxsqlite3.h</Path>
@@ -41,12 +42,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2023-07-22</Date>
-            <Version>4.9.4</Version>
+        <Update release="9">
+            <Date>2023-11-03</Date>
+            <Version>4.9.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Upgrade to SQLite3 Multiple Ciphers version 1.7.0 (SQLite version 3.43.1)
- [Changelog](https://github.com/utelle/wxsqlite3/blob/v4.9.6/readme.md)
- Added `homepage` key to `package.yml` (Part of https://github.com/getsolus/packages/issues/411)

**Test Plan**

- Rebulid `guayadeque` against this package
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable