### PR TITLE
papirus-icon-theme: Update to 20231101

### DIFF
--- a/packages/p/papirus-icon-theme/package.yml
+++ b/packages/p/papirus-icon-theme/package.yml
@@ -1,8 +1,8 @@
 name       : papirus-icon-theme
-version    : '20230901'
-release    : 83
+version    : '20231101'
+release    : 84
 source     :
-    - https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/archive/refs/tags/20230901.tar.gz : 6bac89403270111572b808a69c6bdaa28a13609822dd2448b95a147c0e1c0c31
+    - https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/archive/refs/tags/20231101.tar.gz : b42c2cb0beb066e01c6611aa4427dc46fe89ab7ae6cbbcbe4a606afbb2bdaaf0
 license    : GPL-3.0-or-later
 homepage   : https://git.io/papirus-icon-theme
 component  :
@@ -23,8 +23,7 @@ replaces   :
 setup      : |
     %patch -p1 -i $pkgfiles/0001-Revert-redesign-System-Software-Install.patch
 install    : |
-    rm -r ePapirus*
-    %make_install
+    EXCLUDE="ePapirus ePapirus-Dark" %make_install
     scDir=$installdir/usr/share/icons/solus-sc
     thirdPartyIcons=(
         "android-studio"


### PR DESCRIPTION
**Summary**

Release notes can be found [here](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/releases/tag/20231101)

**Test Plan**

- Set icon theme to Papirus, browsed through system folders and menu
- Checked icons in Software Center

**Checklist**

- [x] Package was built and tested against unstable
