### PR TITLE
sof-firmware: update to 2.7.1

### DIFF
--- a/packages/s/sof-firmware/package.yml
+++ b/packages/s/sof-firmware/package.yml
@@ -1,8 +1,9 @@
 name       : sof-firmware
-version    : '2.7'
-release    : 12
+homepage   : https://github.com/thesofproject/sof-bin
+version    : 2.7.1
+release    : 13
 source     :
-    - https://github.com/thesofproject/sof-bin/releases/download/v2023.09/sof-bin-2023.09.tar.gz : 4bcc75c6642348e1a516db7ff9d050b6ea1b8672983542c6952562fa8c1c7b63
+    - https://github.com/thesofproject/sof-bin/releases/download/v2023.09.1/sof-bin-2023.09.1.tar.gz : 583233652a298cb754c03f47c33a58c9b97770498aa0db03141f11ef705d191d
 license    :
     - BSD-3-Clause
     - ISC

--- a/packages/s/sof-firmware/pspec_x86_64.xml
+++ b/packages/s/sof-firmware/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>sof-firmware</Name>
+        <Homepage>https://github.com/thesofproject/sof-bin</Homepage>
         <Packager>
             <Name>Tracey Clark</Name>
-            <Email>tracey_dev@tlcnet.info</Email>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>ISC</License>
@@ -11,7 +12,7 @@
         <Summary xml:lang="en">Sound Open Firmware</Summary>
         <Description xml:lang="en">Sound Open Firmware
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>sof-firmware</Name>
@@ -393,12 +394,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2023-10-01</Date>
-            <Version>2.7</Version>
+        <Update release="13">
+            <Date>2023-11-04</Date>
+            <Version>2.7.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Tracey Clark</Name>
-            <Email>tracey_dev@tlcnet.info</Email>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

The SOF v2.7.1 contains important fixes to Intel Meteor Lake platforms.

Full release notes [here](https://github.com/thesofproject/sof-bin/releases/tag/v2023.09.1)

**Test Plan**

Verified firmware files were installed to correct paths. Restarted pipewire.
    systemctl --user restart pipewire.service
Listened to music and triggered system sounds to verify that sound still works.

**Checklist**

- [x] Package was built and tested against unstable


