### PR TITLE
Update msmtp to 1.8.25

### DIFF
--- a/packages/m/msmtp/abi_used_symbols
+++ b/packages/m/msmtp/abi_used_symbols
@@ -3,6 +3,7 @@ libc.so.6:__ctype_toupper_loc
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
@@ -105,9 +106,9 @@ libc.so.6:strncasecmp
 libc.so.6:strncmp
 libc.so.6:strncpy
 libc.so.6:strndup
+libc.so.6:strnlen
 libc.so.6:strrchr
 libc.so.6:strstr
-libc.so.6:strtol
 libc.so.6:textdomain
 libc.so.6:time
 libc.so.6:tmpfile

--- a/packages/m/msmtp/package.yml
+++ b/packages/m/msmtp/package.yml
@@ -1,8 +1,8 @@
 name       : msmtp
-version    : 1.8.22
-release    : 8
+version    : 1.8.25
+release    : 9
 source     :
-    - https://marlam.de/msmtp/releases/msmtp-1.8.22.tar.xz : 1b04206286a5b82622335e4eb09e17074368b7288e53d134543cbbc6b79ea3e7
+    - https://marlam.de/msmtp/releases/msmtp-1.8.25.tar.xz : 2dfe1dbbb397d26fe0b0b6b2e9cd2efdf9d72dd42d18e70d7f363ada2652d738
 homepage   : https://marlam.de/msmtp
 license    : GPL-3.0-or-later
 component  : network.clients

--- a/packages/m/msmtp/pspec_x86_64.xml
+++ b/packages/m/msmtp/pspec_x86_64.xml
@@ -11,7 +11,7 @@
         <Summary xml:lang="en">msmtp is an SMTP client</Summary>
         <Description xml:lang="en">msmtp is an easy to use SMTP client with fairly complete sendmail compatibility and supports profiles for use with different SMTP servers.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>msmtp</Name>
@@ -27,7 +27,10 @@
             <Path fileType="localedata">/usr/share/locale/eo/LC_MESSAGES/msmtp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/msmtp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/msmtp.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ro/LC_MESSAGES/msmtp.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ru/LC_MESSAGES/msmtp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sr/LC_MESSAGES/msmtp.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/msmtp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ta/LC_MESSAGES/msmtp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/msmtp.mo</Path>
             <Path fileType="man">/usr/share/man/man1/msmtp.1</Path>
@@ -35,9 +38,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2022-08-14</Date>
-            <Version>1.8.22</Version>
+        <Update release="9">
+            <Date>2023-11-05</Date>
+            <Version>1.8.25</Version>
             <Comment>Packaging update</Comment>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>


### PR DESCRIPTION
**Summary**

Bugfixes:

- Generation of Message-ID headers was improved to avoid problems with rspamd assigning SPAM points
- Documentation of ignored options was fixed
- The combination of envelope from addresses with wildcards and automatic account selection was fixed
- Fixes the allow_from_override command
- Fixes XOAUTH2 authentication with some servers

Enhancements:

- Add the from_full_name command
- msmtpq script updates
- Translation updates

Full release notes:

- [msmtp news](https://marlam.de/msmtp/news/)

**Test Plan**

Installed and sent a test email.

**Checklist**

- [X] Package was built and tested against unstable
