### PR TITLE
tailscale: Update to 1.52.1

### DIFF
--- a/packages/t/tailscale/package.yml
+++ b/packages/t/tailscale/package.yml
@@ -1,8 +1,8 @@
 name       : tailscale
-version    : 1.50.1
-release    : 3
+version    : 1.52.1
+release    : 4
 source     :
-    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.50.1.tar.gz : 183a7d559590a759dd77aa9c2b65486ab6e13c26f3c07fad0b536e318ad5e233
+    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.52.1.tar.gz : 297d01584104dde7d1e5d2e99ee57c6a60579dc4f494ed9d2306716e031af19a
 homepage   : https://tailscale.com
 license    : BSD-3-Clause
 component  : network.clients

--- a/packages/t/tailscale/pspec_x86_64.xml
+++ b/packages/t/tailscale/pspec_x86_64.xml
@@ -11,7 +11,7 @@
         <Summary xml:lang="en">Private WireGuard® networks made easy</Summary>
         <Description xml:lang="en">The easiest, most secure way to use WireGuard and 2FA.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>tailscale</Name>
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2023-10-06</Date>
-            <Version>1.50.1</Version>
+        <Update release="4">
+            <Date>2023-11-05</Date>
+            <Version>1.52.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- tailscale cert command renews in the background. The current certificate only displays if it has expired.
- tailscale status command displays a message about client updates when newer versions are available
- tailscale up command displays a message about client updates when newer versions are available
- Taildrop now resumes file transfers after partial transfers are interrupted
- Taildrop prevents file duplication
- Taildrop detects conflicting file transfers and only proceeds with one transfer
- Wake on LAN (WoL) is now supported for peer node wake-ups
- TCP DNS queries are speculatively started if UDP hasn’t responded quickly enough
- Truncated UDP DNS results are properly retried using TCP
- Go is updated to version 1.21.3
- tailscale set command flag --auto-update is added to opt in to automatic client updates (beta)
- tailscale serve and tailscale funnel commands are updated for improved usability
- tailscale update command for manual updates is now in beta
- Taildrop file transfer displays a progress meter
- nftables auto-detection is improved when TS_DEBUG_FIREWALL_MODE=auto is used
- DNS detection of NetworkManager with configured but absent systemd-resolved, such as EndeavourOS
- DNS detection for Debian resolvconf version 1.90 or later

**Test Plan**
- tailscale netcheck; tailscale status

**Checklist**
- [X] Package was built and tested against unstable
