### PR TITLE
osinfo-db-tools: Update to 1.11.0

### DIFF
--- a/packages/o/osinfo-db-tools/package.yml
+++ b/packages/o/osinfo-db-tools/package.yml
@@ -1,8 +1,8 @@
 name       : osinfo-db-tools
-version    : 1.10.0
-release    : 10
+version    : 1.11.0
+release    : 11
 source     :
-    - https://gitlab.com/libosinfo/osinfo-db-tools/-/archive/v1.10.0/osinfo-db-tools-v1.10.0.tar.gz : 3677ee201cfebcb673b543b9f6fe43d67bc6fb1b55a2540c1af8ce13358c7e6f
+    - https://gitlab.com/libosinfo/osinfo-db-tools/-/archive/v1.11.0/osinfo-db-tools-v1.11.0.tar.gz : b03429cad1dadf5e20bd2d24c4b130df35882ed22ebfbadb5f7acd50c6218ee2
 homepage   : https://libosinfo.org/
 license    : GPL-2.0-or-later
 component  : programming.tools

--- a/packages/o/osinfo-db-tools/pspec_x86_64.xml
+++ b/packages/o/osinfo-db-tools/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>osinfo-db-tools</Name>
         <Homepage>https://libosinfo.org/</Homepage>
         <Packager>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>programming.tools</PartOf>
@@ -32,6 +32,7 @@
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/osinfo-db-tools.mo</Path>
             <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/osinfo-db-tools.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/osinfo-db-tools.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/osinfo-db-tools.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ko/LC_MESSAGES/osinfo-db-tools.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pl/LC_MESSAGES/osinfo-db-tools.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/osinfo-db-tools.mo</Path>
@@ -47,12 +48,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2023-10-17</Date>
-            <Version>1.10.0</Version>
+        <Update release="11">
+            <Date>2023-11-07</Date>
+            <Version>1.11.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Added `--nightly` option to osinfo-db-import
- Several translation improvements

**Test Plan**

Built `osinfo-db`

**Checklist**

- [x] Package was built and tested against unstable
