### PR TITLE
osinfo-db: Update to 20231027

### DIFF
--- a/packages/o/osinfo-db/package.yml
+++ b/packages/o/osinfo-db/package.yml
@@ -1,8 +1,8 @@
 name       : osinfo-db
-version    : '20230719'
-release    : 13
+version    : '20231027'
+release    : 14
 source     :
-    - https://releases.pagure.org/libosinfo/osinfo-db-20230719.tar.xz : 13d1c97fc7d67137935dcc97778c08bb079a4f0fe312d479786cea1411e4845a
+    - https://releases.pagure.org/libosinfo/osinfo-db-20231027.tar.xz : 84a3dd050786ad52215fa3ec6531573ee6b3c3a56ca20b1ba75b2d85e0f0ba1a
 homepage   : https://libosinfo.org
 license    : GPL-2.0-or-later
 component  : virt

--- a/packages/o/osinfo-db/pspec_x86_64.xml
+++ b/packages/o/osinfo-db/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>osinfo-db</Name>
         <Homepage>https://libosinfo.org</Homepage>
         <Packager>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>virt</PartOf>
@@ -445,6 +445,7 @@
             <Path fileType="data">/usr/share/osinfo/os/mageia.org/mageia-6.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/mageia.org/mageia-7.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/mageia.org/mageia-8.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/mageia.org/mageia-9.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/mandriva.com/mandrake-10.0.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/mandriva.com/mandrake-10.1.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/mandriva.com/mandrake-10.2.xml</Path>
@@ -993,12 +994,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2023-10-17</Date>
-            <Version>20230719</Version>
+        <Update release="14">
+            <Date>2023-11-07</Date>
+            <Version>20231027</Version>
             <Comment>Packaging update</Comment>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Added Mageia 9
- Fixed incorrect kernel/initrd entries
- Fixed/updated ISO links

Full commit log available [here](https://gitlab.com/libosinfo/osinfo-db/-/compare/v20230719...v20231027?from_project_id=1414771&straight=false)

**Test Plan**

Checked "Mageia 9" was available as an option in `gnome-boxes`

**Checklist**

- [x] Package was built and tested against unstable
