### PR TITLE
syncthing: update to 1.26.0

### DIFF
--- a/packages/s/syncthing/files/syncthing.metainfo.xml
+++ b/packages/s/syncthing/files/syncthing.metainfo.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id type="desktop">syncthing.desktop</id>
+  <name>syncthing</name>
+  <project_license>MPL-2.0</project_license>
+  <developer_name>The Syncthing Project</developer_name>
+  <summary>Syncthing is an open-source file synchronization client/server application</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <url type="homepage">https://syncthing.net</url>
+  <url type="help">https://docs.syncthing.net/</url>
+  <description>
+    <p>Syncthing is an open-source file synchronization client/server application, written in Go, implementing its own, equally free Block Exchange Protocol. All transit communications between syncthing nodes are encrypted, and all nodes are uniquely identified with cryptographic certificates.</p>
+  </description>
+  <screenshots>
+    <screenshot>
+      <caption>Syncthing UI</caption>
+      <image type="source">https://docs.syncthing.net/_images/gui1.png</image>
+    </screenshot>
+  </screenshots>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="violence-desecration">none</content_attribute>
+    <content_attribute id="violence-slavery">none</content_attribute>
+    <content_attribute id="violence-worship">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="sex-homosexuality">none</content_attribute>
+    <content_attribute id="sex-prostitution">none</content_attribute>
+    <content_attribute id="sex-adultery">none</content_attribute>
+    <content_attribute id="sex-appearance">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+  <update_contact>releng@getsol.us</update_contact>
+</component>

--- a/packages/s/syncthing/package.yml
+++ b/packages/s/syncthing/package.yml
@@ -1,9 +1,9 @@
 name       : syncthing
-version    : 1.25.0
-release    : 86
+version    : 1.26.0
+release    : 87
 homepage   : https://syncthing.net
 source     :
-    - https://github.com/syncthing/syncthing/releases/download/v1.25.0/syncthing-source-v1.25.0.tar.gz : e25199e870236216b8409f4c30735c177c83d9eb7f77474c8a9d0c6739789ea1
+    - https://github.com/syncthing/syncthing/releases/download/v1.26.0/syncthing-source-v1.26.0.tar.gz : bfb4ce711b09c15671b3e43d02c7ae20b5a380483cf0a7bcb414222d827d4e30
 license    : MPL-2.0
 component  : network.util
 networking : yes
@@ -12,11 +12,7 @@ description: |
     Syncthing is an open-source file synchronization client/server application, written in Go, implementing its own, equally free Block Exchange Protocol. All transit communications between syncthing nodes are encrypted, and all nodes are uniquely identified with cryptographic certificates.
 builddeps  :
     - git
-    # - golang # re-add for build after 1.23.7
-# remove for build after 1.23.7
-setup      : |
-    curl -sSL https://go.dev/dl/go1.20.7.linux-amd64.tar.gz | tar xz
-# remove for build after 1.23.7
+    - golang
 environment: |
     export PATH="$PATH:$PWD/go/bin"
 build      : |

--- a/packages/s/syncthing/pspec_x86_64.xml
+++ b/packages/s/syncthing/pspec_x86_64.xml
@@ -11,7 +11,7 @@
         <Summary xml:lang="en">Syncthing is an open-source file synchronization client/server application</Summary>
         <Description xml:lang="en">Syncthing is an open-source file synchronization client/server application, written in Go, implementing its own, equally free Block Exchange Protocol. All transit communications between syncthing nodes are encrypted, and all nodes are uniquely identified with cryptographic certificates.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>syncthing</Name>
@@ -49,9 +49,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="86">
-            <Date>2023-10-03</Date>
-            <Version>1.25.0</Version>
+        <Update release="87">
+            <Date>2023-11-07</Date>
+            <Version>1.26.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Tracey Clark</Name>
             <Email>traceyc.dev@tlcnet.info</Email>


### PR DESCRIPTION
**Summary**

Bugfixes:

- Omitting %s from LDAP search filter results in corrupt search filter
- Posting config with invalid versioner type causes panic
- Deduplicated files on Windows aren't treated as regular files any more (Go 1.21)
- Syncthing Docker container fails to start if underlying filesystem doesn't support `chown`
- traefik no longer url escape X-Forwarded-Tls-Client-Cert header
- Favicon is stuck in notify state

Enhancements:

 - Use a real login screen + sessions instead of HTTP basic auth

**Full release notes:**
- [1.26.0](https://github.com/syncthing/syncthing/releases/tag/v1.26.0)

Solus:

- Add appdata metainfo file

**Test Plan**

- Loaded the syncthing web UI, verified I can see shares and UI works normally
- Exercised Syncthing-GTK
- Verified that a file shared between the local machine and a remote machine syncs

**Checklist**

- [x] Package was built and tested against unstable
