### PR TITLE
font-iosevka-ttf: Update to 27.3.4

### DIFF
--- a/packages/f/font-iosevka-ttf/package.yml
+++ b/packages/f/font-iosevka-ttf/package.yml
@@ -1,14 +1,14 @@
 name       : font-iosevka-ttf
-version    : 27.3.1
-release    : 46
+version    : 27.3.4
+release    : 47
 source     :
-    - https://github.com/be5invis/Iosevka/releases/download/v27.3.1/ttf-iosevka-27.3.1.zip : 981c8f88bd937a47b15243ab8ae8a35eb935cfbc87af0fa63964735441efe779
+    - https://github.com/be5invis/Iosevka/releases/download/v27.3.4/ttf-iosevka-27.3.4.zip : 43b8871dcf66200d485c88345da7219231c1a04cc02febd224cef694f71fadac
 homepage   : https://typeof.net/Iosevka
 license    : OFL-1.1
 component  : desktop.font
 summary    : Versatile typeface for code, from code.
 description: |
-    Iosevka is an open-source, sans-serif + slab-serif, monospace + quasi‑proportional typeface family, designed for writing code, using in terminals, and preparing technical documents.
+    Iosevka is an open-source, sans-serif + slab-serif, monospace + quasi-proportional typeface family, designed for writing code, using in terminals, and preparing technical documents.
 install    : |
-    install -D -m00644 *.ttf -t $installdir/usr/share/fonts/truetype/iosevka/
+    install -Dm00644 *.ttf -t $installdir/usr/share/fonts/truetype/iosevka/
     install -Dm00644 $pkgfiles/iosevka.metainfo.xml $installdir/usr/share/metainfo/iosevka.metainfo.xml

--- a/packages/f/font-iosevka-ttf/pspec_x86_64.xml
+++ b/packages/f/font-iosevka-ttf/pspec_x86_64.xml
@@ -78,9 +78,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="46">
-            <Date>2023-10-28</Date>
-            <Version>27.3.1</Version>
+        <Update release="47">
+            <Date>2023-11-08</Date>
+            <Version>27.3.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Disunify anonymous untagged variant selectors for Cyrillic Capital Yeri/Yery for consistency in style-driven configurations.
- Make LATIN CAPITAL LETTER Y WITH LOOP (U+1EFE) follow variants of capital Y (cv24) for a more balanced slab-italic form like that of Cyrillic Capital U.
- Remove base-serifed-only variants for CYRILLIC SMALL LETTER STRAIGHT U (U+04AF, U+04B1).
- Add characters: LEFTWARDS HARPOON WITH BARB UP TO BAR (U+2952) DOWNWARDS HARPOON WITH BARB LEFT FROM BAR (U+2961)
- Fix overlapping serifs of italic Yat
- Fix width of VERY MUCH GREATER-THAN (U+22D9)
- Remove duplicate variants for U+0181, U+018A, U+01A4, and U+2C64.
- Remove asymmetric variants for small capital B (U+0299, U+1D03) and Cyrillic Lower Ve (U+0432)

**Test Plan**
- render text with the font

**Checklist**
- [X] Package was built and tested against unstable
