### PR TITLE
element: Use Wayland by default

### DIFF
--- a/packages/e/element/files/0001-Unpack-package.json.patch
+++ b/packages/e/element/files/0001-Unpack-package.json.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Reilly Brogan <reilly@reillybrogan.com>
+Date: Wed, 24 Apr 2024 16:25:14 -0500
+Subject: [PATCH] Unpack package.json
+
+---
+ electron-builder.ts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/electron-builder.ts b/electron-builder.ts
+index dedb5f7..8cc0570 100644
+--- a/electron-builder.ts
++++ b/electron-builder.ts
+@@ -55,7 +55,7 @@ interface Configuration extends BaseConfiguration {
+  */
+ const config: Writable<Configuration> = {
+     appId: "im.riot.app",
+-    asarUnpack: "**/*.node",
++    asarUnpack: [ "**/*.node", "package.json"],
+     afterPack: async (context: AfterPackContext) => {
+         if (context.electronPlatformName !== "darwin" || context.arch === Arch.universal) {
+             // Burn in electron fuses for proactive security hardening.

--- a/packages/e/element/files/Element.desktop
+++ b/packages/e/element/files/Element.desktop
@@ -1,10 +1,10 @@
 [Desktop Entry]
 Name=Element
 Comment=A glossy Matrix collaboration client for desktop
-Exec=env MESA_SHADER_CACHE_DISABLE=true element-desktop %U
+Exec=/usr/bin/element-desktop %U
 Terminal=false
 Type=Application
-Categories=GTK;Network;
+Categories=Network;InstantMessaging;Chat;VideoConference;
 Icon=element-desktop
-StartupWMClass=element
 MimeType=x-scheme-handler/riot;x-scheme-handler/element;
+Keywords=Matrix;matrix.org;chat;irc;communications;talk;riot;vector;

--- a/packages/e/element/files/autolaunch.patch
+++ b/packages/e/element/files/autolaunch.patch
@@ -1,0 +1,11 @@
+diff --git a/src/electron-main.ts b/src/electron-main.ts
+--- a/src/electron-main.ts
++++ b/src/electron-main.ts
+@@ -204,6 +204,7 @@ async function setupGlobals() {
+     global.launcher = new AutoLaunch({
+         name: global.vectorConfig.brand || 'Element',
+         isHidden: true,
++        path: "/usr/bin/element-desktop",
+         mac: {
+             useLaunchAgent: true,
+         },

--- a/packages/e/element/files/electron-desktop.sh
+++ b/packages/e/element/files/electron-desktop.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+# Launches element-desktop with flags specified in $XDG_CONFIG_HOME/element-desktop-flags.conf
+
+# Make script fail if `cat` fails for some reason
+set -e
+
+# Set default value if variable is unset/null
+XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-${HOME}/.config}"
+
+# Attempt to read a config file if it exists
+if [ -r "${XDG_CONFIG_HOME}/element-desktop-flags.conf" ]; then
+  ELEMENT_DESKTOP_FLAGS="$(cat "$XDG_CONFIG_HOME/element-desktop-flags.conf")"
+fi
+
+# Wayland auto-detection. If the session is a wayland session then this will launch as a Wayland window unless the ELEMENT_NO_WAYLAND variable is set
+if [ -z "${ELEMENT_NO_WAYLAND+set}" ]; then
+  ELEMENT_DESKTOP_FLAGS="$ELEMENT_DESKTOP_FLAGS --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations,WebRTCPipeWireCapturer"
+fi
+
+# shellcheck disable=SC2086
+exec /usr/share/element/element-desktop $ELEMENT_DESKTOP_FLAGS "$@"

--- a/packages/e/element/files/element.appdata.xml
+++ b/packages/e/element/files/element.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id type="desktop">Element.desktop</id>
+  <id>Element</id>
   <name>Element</name>
   <project_license>Apache-2.0</project_license>
   <developer_name>New Vector Ltd</developer_name>
@@ -58,5 +58,8 @@
     <content_attribute id="money-purchasing">none</content_attribute>
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
+  <provides>
+    <id>im.riot.Riot</id>
+  </provides>
   <update_contact>releng@getsol.us</update_contact>
 </component>

--- a/packages/e/element/package.yml
+++ b/packages/e/element/package.yml
@@ -1,6 +1,6 @@
 name       : element
 version    : 1.11.65
-release    : 166
+release    : 167
 homepage   : https://element.io/
 source     :
     - git|https://github.com/vector-im/element-desktop.git : v1.11.65
@@ -45,9 +45,15 @@ setup      : |
     jq '.update_base_url = null | .posthog = null | .show_labs_settings = true' \
         element.io/release/config.json > config.json
 
+    # Ensure that autolaunch files specify the direct path to the wrapper script
+    %patch -p1 -i $pkgfiles/autolaunch.patch
+
+    # Unpack the package.json so we can fix the Wayland AppID
+    %patch -p1 -i $pkgfiles/0001-Unpack-package.json.patch
+
     # Perform yarn install on both
-    yarn install
-    yarn --cwd element-web install
+    yarn install --frozen-lockfile --network-timeout 180000
+    yarn --cwd element-web install --frozen-lockfile --network-timeout 180000
 build      : |
     # Build element-web
     yarn --cwd element-web build
@@ -56,14 +62,18 @@ build      : |
     yarn run build:native
     yarn run build
 install    : |
-    install -dm00644 $installdir/usr/bin
-    install -dm00644 $installdir/usr/share/element
-    cp -Rv dist/linux-unpacked/* $installdir/usr/share/element
-    cp -Rv element-web/webapp $installdir/usr/share/element/resources/
-    ln -sv ../share/element/element-desktop $installdir/usr/bin/element-desktop
+    # Installdir for Element
+    element_installdir=$installdir/usr/share/element
+
+    install -dm00644 $element_installdir
+    cp -Rv dist/linux-unpacked/* $element_installdir
+    cp -Rv element-web/webapp $element_installdir/resources/
+
+    # Wrapper script
+    install -Dm00755 $pkgfiles/electron-desktop.sh $installdir/usr/bin/element-desktop
 
     # Install configuration
-    install -Dm00644 config.json $installdir/usr/share/element/resources/webapp/
+    install -Dm00644 config.json $element_installdir/resources/webapp/
 
     # Install Icons
     for icon_size in 16 24 48 64 96 128 256 512
@@ -73,8 +83,14 @@ install    : |
         ln -s element-desktop.png $installdir/usr/share/icons/hicolor/${icon_size}x${icon_size}/apps/element.png
     done
 
+    # Fix Wayland appid
+    package_json=$element_installdir/resources/app.asar.unpacked/package.json
+    tmp=$(mktemp)
+    jq ".desktopName = \"Element.desktop\"" $package_json > "$tmp" && mv "$tmp" $package_json
+    chmod 644 $package_json
+
     # Desktop File
     install -Dm00644 $pkgfiles/Element.desktop $installdir/usr/share/applications/Element.desktop
 
     # appstream data
-    install -Dm00644 $pkgfiles/element.metainfo.xml $installdir/usr/share/metainfo/element.appdata.xml
+    install -Dm00644 $pkgfiles/element.appdata.xml $installdir/usr/share/metainfo/element.appdata.xml

--- a/packages/e/element/pspec_x86_64.xml
+++ b/packages/e/element/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>element</Name>
         <Homepage>https://element.io/</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Reilly Brogan</Name>
+            <Email>solus@reillybrogan.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>network.im</PartOf>
@@ -95,6 +95,7 @@
             <Path fileType="data">/usr/share/element/resources/app.asar</Path>
             <Path fileType="data">/usr/share/element/resources/app.asar.unpacked/node_modules/keytar/build/Release/keytar.node</Path>
             <Path fileType="data">/usr/share/element/resources/app.asar.unpacked/node_modules/matrix-seshat/index.node</Path>
+            <Path fileType="data">/usr/share/element/resources/app.asar.unpacked/package.json</Path>
             <Path fileType="data">/usr/share/element/resources/img/element.ico</Path>
             <Path fileType="data">/usr/share/element/resources/img/element.png</Path>
             <Path fileType="data">/usr/share/element/resources/package-type</Path>
@@ -773,12 +774,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="166">
+        <Update release="167">
             <Date>2024-04-24</Date>
             <Version>1.11.65</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Reilly Brogan</Name>
+            <Email>solus@reillybrogan.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
Changes:
- Remove `MESA_SHADER_CACHE_DISABLE` which I assume is a workaround for that issue
- Syncs some changes from the flathub .desktop file to our one (keywords and categories mostly)
- Add a wrapper script to pick up user-configured flags
- Re-try enabling Wayland by default (newer Electron and all that)
- Fix an issue where selecting "launch on startup" would create a .desktop file with the wrong binary path (which is problematic with the wrapper script)