### PR TITLE
acpid2: Update to 2.0.34

### DIFF
--- a/packages/a/acpid2/abi_used_symbols
+++ b/packages/a/acpid2/abi_used_symbols
@@ -3,8 +3,8 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
-libc.so.6:__fread_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__printf_chk
@@ -66,6 +66,7 @@ libc.so.6:optarg
 libc.so.6:perror
 libc.so.6:poll
 libc.so.6:puts
+libc.so.6:qsort
 libc.so.6:read
 libc.so.6:readdir
 libc.so.6:realloc
@@ -97,7 +98,6 @@ libc.so.6:strlen
 libc.so.6:strncpy
 libc.so.6:strnlen
 libc.so.6:strrchr
-libc.so.6:strtol
 libc.so.6:time
 libc.so.6:umask
 libc.so.6:unlink

--- a/packages/a/acpid2/package.yml
+++ b/packages/a/acpid2/package.yml
@@ -1,8 +1,9 @@
 name       : acpid2
-version    : 2.0.33
-release    : 5
+version    : 2.0.34
+release    : 6
 source     :
-    - https://downloads.sourceforge.net/project/acpid2/acpid-2.0.33.tar.xz : 0856f71b3eb34a1b663d0a8e6363dfcbc519e63d847330498898658e2972dbe8
+    - https://sourceforge.net/projects/acpid2/files/acpid-2.0.34.tar.xz/download : 2d095c8cfcbc847caec746d62cdc8d0bff1ec1bc72ef7c674c721e04da6ab333
+homepage   : https://sourceforge.net/projects/acpid2/
 license    : GPL-2.0-or-later
 component  : system.utils
 summary    : acpid with netlink and input layer support

--- a/packages/a/acpid2/pspec_x86_64.xml
+++ b/packages/a/acpid2/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>acpid2</Name>
+        <Homepage>https://sourceforge.net/projects/acpid2/</Homepage>
         <Packager>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">acpid with netlink and input layer support</Summary>
         <Description xml:lang="en">acpid with netlink and input layer support
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>acpid2</Name>
@@ -31,12 +32,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2022-01-04</Date>
-            <Version>2.0.33</Version>
+        <Update release="6">
+            <Date>2023-11-10</Date>
+            <Version>2.0.34</Version>
             <Comment>Packaging update</Comment>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Add `MSG_CMSG_CLOEXEC` for systems that are missing it.
- Fix a bug with input layer event table not working on 32-bit builds with 64-bit time types.
- Use binary search to find input layer events in the table.
- Use AC_PROG_CC instead of the obsolete AC_PROG_CC_STDC.
- Add support for more input layer events.

**Test Plan**

- Question : How do I test this?

**Checklist**

- [x] Package was built and tested against unstable
