### PR TITLE
mu: Update to 1.10.8

### DIFF
--- a/packages/m/mu/abi_used_symbols
+++ b/packages/m/mu/abi_used_symbols
@@ -5,6 +5,9 @@ UNKNOWN:_ZTIN6Xapian8KeyMakerE
 libc.so.6:__assert_fail
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoll
+libc.so.6:__isoc23_strtoull
 libc.so.6:__libc_single_threaded
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
@@ -65,10 +68,7 @@ libc.so.6:strftime
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strptime
-libc.so.6:strtol
 libc.so.6:strtold
-libc.so.6:strtoll
-libc.so.6:strtoull
 libc.so.6:symlink
 libc.so.6:time
 libc.so.6:tolower
@@ -312,6 +312,7 @@ libstdc++.so.6:_ZNKSt10filesystem7__cxx114path5_List13_Impl_deleterclEPNS2_5_Imp
 libstdc++.so.6:_ZNKSt12__basic_fileIcE7is_openEv
 libstdc++.so.6:_ZNKSt13runtime_error4whatEv
 libstdc++.so.6:_ZNKSt5ctypeIcE13_M_widen_initEv
+libstdc++.so.6:_ZNKSt6locale2id5_M_idEv
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12find_last_ofEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE13find_first_ofEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE16find_last_not_ofEcm
@@ -321,7 +322,6 @@ libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEcm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE5rfindEcm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6substrEmm
-libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7compareEPKc
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7compareEmmPKc
 libstdc++.so.6:_ZNKSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE3strEv
 libstdc++.so.6:_ZNKSt8__detail20_Prime_rehash_policy11_M_next_bktEm
@@ -360,6 +360,7 @@ libstdc++.so.6:_ZNSt18condition_variable10notify_oneEv
 libstdc++.so.6:_ZNSt18condition_variableC1Ev
 libstdc++.so.6:_ZNSt18condition_variableD1Ev
 libstdc++.so.6:_ZNSt3_V215system_categoryEv
+libstdc++.so.6:_ZNSt5ctypeIcE2idE
 libstdc++.so.6:_ZNSt6chrono3_V212steady_clock3nowEv
 libstdc++.so.6:_ZNSt6locale6globalERKS_
 libstdc++.so.6:_ZNSt6localeC1EPKc
@@ -395,8 +396,6 @@ libstdc++.so.6:_ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEC1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt8ios_base13_M_grow_wordsEib
 libstdc++.so.6:_ZNSt8ios_base15sync_with_stdioEb
-libstdc++.so.6:_ZNSt8ios_base4InitC1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitD1Ev
 libstdc++.so.6:_ZNSt8ios_base6xallocEv
 libstdc++.so.6:_ZNSt8ios_baseC2Ev
 libstdc++.so.6:_ZNSt8ios_baseD2Ev
@@ -415,6 +414,7 @@ libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt20__throw_out_of_rangePKc
 libstdc++.so.6:_ZSt20__throw_system_errori
+libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZSt24__throw_invalid_argumentPKc
 libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
 libstdc++.so.6:_ZSt25__throw_bad_function_callv
@@ -427,7 +427,6 @@ libstdc++.so.6:_ZSt4clog
 libstdc++.so.6:_ZSt4cout
 libstdc++.so.6:_ZSt7getlineIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EES4_
 libstdc++.so.6:_ZSt9terminatev
-libstdc++.so.6:_ZSt9use_facetISt5ctypeIcEERKT_RKSt6locale
 libstdc++.so.6:_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
 libstdc++.so.6:_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_c
 libstdc++.so.6:_ZTINSt6thread6_StateE

--- a/packages/m/mu/package.yml
+++ b/packages/m/mu/package.yml
@@ -1,8 +1,8 @@
 name       : mu
-version    : 1.10.7
-release    : 19
+version    : 1.10.8
+release    : 20
 source     :
-    - https://github.com/djcb/mu/releases/download/v1.10.7/mu-1.10.7.tar.xz : eaaac9ba515da232295b03f2797eed13552fdd29a30122134dd382a64d0d3c21
+    - https://github.com/djcb/mu/releases/download/v1.10.8/mu-1.10.8.tar.xz : 6b11d8add2a7eeb0ebc4a5c7a6b9a9b3e1be8c5175c0c1c019a7ad8d7e363589
 license    : GPL-3.0-only
 homepage   : https://www.djcbsoftware.nl/code/mu/
 component  : editor

--- a/packages/m/mu/pspec_x86_64.xml
+++ b/packages/m/mu/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>mu</Name>
         <Homepage>https://www.djcbsoftware.nl/code/mu/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Nazar Stasiv</Name>
+            <Email>nazar@autistici.org</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <PartOf>editor</PartOf>
         <Summary xml:lang="en">maildir indexer/searcher + emacs mail client + guile bindings</Summary>
         <Description xml:lang="en">mu is a tool for dealing with e-mail messages stored in the Maildir-format. mu’s purpose in life is to help you to quickly find the messages you need; in addition, it allows you to view messages, extract attachments, create new maildirs, and so on. See the mu cheatsheet for some examples. mu is fully documented.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>mu</Name>
@@ -78,7 +78,7 @@
             <Path fileType="data">/usr/share/emacs/site-lisp/mu4e/mu4e-window.elc</Path>
             <Path fileType="data">/usr/share/emacs/site-lisp/mu4e/mu4e.el</Path>
             <Path fileType="data">/usr/share/emacs/site-lisp/mu4e/mu4e.elc</Path>
-            <Path fileType="info">/usr/share/info/mu4e.info.gz</Path>
+            <Path fileType="info">/usr/share/info/mu4e.info</Path>
             <Path fileType="man">/usr/share/man/man1/mu-add.1</Path>
             <Path fileType="man">/usr/share/man/man1/mu-cfind.1</Path>
             <Path fileType="man">/usr/share/man/man1/mu-extract.1</Path>
@@ -100,12 +100,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2023-09-29</Date>
-            <Version>1.10.7</Version>
+        <Update release="20">
+            <Date>2023-11-11</Date>
+            <Version>1.10.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Nazar Stasiv</Name>
+            <Email>nazar@autistici.org</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- guile: fix module installation path
- infodir: allow passing absolute path
- mu4e-view: assign gnus-article-buffer
- mu4e: fix completion with non-quick keys

**Test Plan**
- mu index; search for and view message with mu4e

**Checklist**
- [X] Package was built and tested against unstable
