### PR TITLE
kitty: Update to 0.31.0

### DIFF
--- a/packages/k/kitty/abi_used_libs
+++ b/packages/k/kitty/abi_used_libs
@@ -1,6 +1,7 @@
 UNKNOWN
 libX11-xcb.so.1
 libX11.so.6
+libXcursor.so.1
 libc.so.6
 libcrypto.so.3
 libdbus-1.so.3

--- a/packages/k/kitty/abi_used_symbols
+++ b/packages/k/kitty/abi_used_symbols
@@ -76,7 +76,6 @@ UNKNOWN:regfree
 UNKNOWN:round
 UNKNOWN:roundf
 UNKNOWN:send
-UNKNOWN:sendfile64
 UNKNOWN:setsid
 UNKNOWN:setsockopt
 UNKNOWN:shutdown
@@ -184,10 +183,12 @@ libX11.so.6:XrmGetStringDatabase
 libX11.so.6:XrmInitialize
 libX11.so.6:XrmUniqueQuark
 libX11.so.6:Xutf8SetWMProperties
+libXcursor.so.1:XcursorLibraryLoadCursor
 libc.so.6:__ctype_b_loc
 libc.so.6:__environ
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
 libc.so.6:__longjmp_chk
@@ -282,6 +283,7 @@ libc.so.6:read
 libc.so.6:realloc
 libc.so.6:realpath
 libc.so.6:regexec
+libc.so.6:sendfile64
 libc.so.6:setenv
 libc.so.6:setutxent
 libc.so.6:shm_open
@@ -467,7 +469,9 @@ libpython3.10.so.1.0:PyConfig_SetBytesArgv
 libpython3.10.so.1.0:PyConfig_SetBytesString
 libpython3.10.so.1.0:PyDict_GetItemString
 libpython3.10.so.1.0:PyDict_New
+libpython3.10.so.1.0:PyDict_Next
 libpython3.10.so.1.0:PyDict_SetItemString
+libpython3.10.so.1.0:PyDict_Size
 libpython3.10.so.1.0:PyDict_Type
 libpython3.10.so.1.0:PyErr_Clear
 libpython3.10.so.1.0:PyErr_Format

--- a/packages/k/kitty/package.yml
+++ b/packages/k/kitty/package.yml
@@ -1,8 +1,8 @@
 name       : kitty
-version    : 0.30.1
-release    : 57
+version    : 0.31.0
+release    : 58
 source     :
-    - https://github.com/kovidgoyal/kitty/releases/download/v0.30.1/kitty-0.30.1.tar.xz : 42c4ccfb601f830fbf42b7cb23d545f0f775010f26abe1b969b8346290e9d68b
+    - https://github.com/kovidgoyal/kitty/releases/download/v0.31.0/kitty-0.31.0.tar.xz : d122497134abab8e25dfcb6b127af40cfe641980e007f696732f70ed298198f5
 license    : GPL-3.0-only
 component  : system.utils
 homepage   : https://sw.kovidgoyal.net/kitty/

--- a/packages/k/kitty/pspec_x86_64.xml
+++ b/packages/k/kitty/pspec_x86_64.xml
@@ -93,14 +93,6 @@ Kitty is designed from the ground up to support all modern terminal features, su
             <Path fileType="library">/usr/lib/kitty/kittens/icat/__pycache__/main.cpython-310.opt-2.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kittens/icat/__pycache__/main.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kittens/icat/main.py</Path>
-            <Path fileType="library">/usr/lib/kitty/kittens/mouse_demo/__init__.py</Path>
-            <Path fileType="library">/usr/lib/kitty/kittens/mouse_demo/__pycache__/__init__.cpython-310.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/kitty/kittens/mouse_demo/__pycache__/__init__.cpython-310.opt-2.pyc</Path>
-            <Path fileType="library">/usr/lib/kitty/kittens/mouse_demo/__pycache__/__init__.cpython-310.pyc</Path>
-            <Path fileType="library">/usr/lib/kitty/kittens/mouse_demo/__pycache__/main.cpython-310.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/kitty/kittens/mouse_demo/__pycache__/main.cpython-310.opt-2.pyc</Path>
-            <Path fileType="library">/usr/lib/kitty/kittens/mouse_demo/__pycache__/main.cpython-310.pyc</Path>
-            <Path fileType="library">/usr/lib/kitty/kittens/mouse_demo/main.py</Path>
             <Path fileType="library">/usr/lib/kitty/kittens/panel/__init__.py</Path>
             <Path fileType="library">/usr/lib/kitty/kittens/panel/__pycache__/__init__.cpython-310.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kittens/panel/__pycache__/__init__.cpython-310.opt-2.pyc</Path>
@@ -697,9 +689,9 @@ Kitty is designed from the ground up to support all modern terminal features, su
         </Files>
     </Package>
     <History>
-        <Update release="57">
-            <Date>2023-10-08</Date>
-            <Version>0.30.1</Version>
+        <Update release="58">
+            <Date>2023-11-11</Date>
+            <Version>0.31.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Allow easily running arbitrarily complex remote control scripts without needing to turn on remote control
- A new escape code that can be used by programs running in the terminal to change the shape of the mouse pointer
- Graphics protocol: Support for positioning images relative to other images
- A new option single_window_padding_width to use a different padding when only a single window is visible
- A new mouse action mouse_selection word_and_line_from_point to select the current word under the mouse cursor and extend to end of line
- A new option underline_hyperlinks to control when hyperlinks are underlined
- Allow using the full range of standard mouse cursor shapes when customizing the mouse cursor
- kitten @ set-background-opacity --toggle - a new flag to easily switch opacity between the specified value and the default
- Fix a regression caused by rewrite of kittens to Go that made various kittens reset colors in a terminal when the colors were changed by escape code
- Fix trailing bracket not ignored when detecting a multi-line URL with the trailing bracket as the first character on the last line
- Fix the kitten @ launch --copy-env option not copying current environment variables
- Fix a regression that broke kitten update-self
- Two new event types for watchers, on_title_change and on_set_user_var
- When pasting, if the text contains terminal control codes ask the user for permission
- Render Private Use Unicode symbols using two cells if the second cell contains an en-space as well as a normal space
- Allow applications sending notifications to specify that the notification should only be displayed if the window is currently unfocused
- unicode_input kitten: Fix a regression that broke the “Emoticons” tab
- Shell integration: Fix sudo --edit not working and also fix completions for sudo not working in zsh
- A new action set_window_title to interactively change the title of the active window
- ssh kitten: Fix a regression that broken ctrl+space mapping in zsh
- Wayland: Fix primary selections not working with the river compositor
- [changelog](https://sw.kovidgoyal.net/kitty/changelog/#id1)

**Test Plan**
- kitty -v; ctrl+shift+g to view output in pager

**Checklist**
- [X] Package was built and tested against unstable
