### PR TITLE
allegro4: homepage inclusion

### DIFF
--- a/packages/a/allegro4/abi_used_symbols
+++ b/packages/a/allegro4/abi_used_symbols
@@ -263,10 +263,7 @@ libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
 libc.so.6:__isoc99_sscanf
 libc.so.6:__longjmp_chk
-libc.so.6:__memcpy_chk
-libc.so.6:__memset_chk
 libc.so.6:__open_2
-libc.so.6:__poll_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
@@ -312,6 +309,7 @@ libc.so.6:mkstemp
 libc.so.6:open
 libc.so.6:opendir
 libc.so.6:pclose
+libc.so.6:poll
 libc.so.6:popen
 libc.so.6:pthread_cond_destroy
 libc.so.6:pthread_cond_init

--- a/packages/a/allegro4/package.yml
+++ b/packages/a/allegro4/package.yml
@@ -1,8 +1,9 @@
 name       : allegro4
 version    : 4.4.3.1
-release    : 8
+release    : 9
 source     :
     - https://github.com/liballeg/allegro5/archive/4.4.3.1.tar.gz : 650fe3dfa2bdaa47ec89d012a60907cf02156b81f66fd3b503dc5d33a2e0563f
+homepage   : https://liballeg.org/
 license    : Giftware
 component  : programming
 summary    : Allegro is a cross-platform library mainly aimed at video game and multimedia programming.

--- a/packages/a/allegro4/pspec_x86_64.xml
+++ b/packages/a/allegro4/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>allegro4</Name>
+        <Homepage>https://liballeg.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>Giftware</License>
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Allegro is a cross-platform library mainly aimed at video game and multimedia programming.</Summary>
         <Description xml:lang="en">Allegro is a cross-platform library mainly aimed at video game and multimedia programming.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>allegro4</Name>
@@ -41,7 +42,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="8">allegro4</Dependency>
+            <Dependency release="9">allegro4</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/alleggl.h</Path>
@@ -161,12 +162,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2022-03-25</Date>
+        <Update release="9">
+            <Date>2023-11-14</Date>
             <Version>4.4.3.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable

**Comment**
Is there any reason we keep this package? it seems only `liberation-circuit` need this and already replaced by allegro5 (`allegro`)