### PR TITLE
font-terminus-console: Initial inclusion

### DIFF
--- a/packages/f/font-terminus-console/package.yml
+++ b/packages/f/font-terminus-console/package.yml
@@ -1,0 +1,25 @@
+name       : font-terminus-console
+version    : 4.49.1
+release    : 1
+source     :
+    - http://netix.dl.sourceforge.net/project/terminus-font/terminus-font-4.49/terminus-font-4.49.1.tar.gz : d961c1b781627bf417f9b340693d64fc219e0113ad3a3af1a3424c7aa373ef79
+license    : OFL-1.1
+homepage   : https://terminus-font.sourceforge.net/
+component  : desktop.font
+summary    : Monospaced font designed for long (8+ hours per day) work with computers.
+description: |
+    Monospaced font designed for long (8+ hours per day) work with computers.
+
+    Contains 1326 characters, supports about 120 language sets, many IBM, Windows and Macintosh code pages, IBM VGA / vt100 / xterm pseudographic characters and Esperanto.
+
+    NB: This package *only* contains the terminus console font versions.
+builddeps  :
+    - bdftopcf
+setup      : |
+    %configure
+build      : |
+    %make
+install    : |
+    %make_install
+    # only want /usr/share/consolefonts
+    rm -rf $installdir/usr/share/fonts

--- a/packages/f/font-terminus-console/pspec_x86_64.xml
+++ b/packages/f/font-terminus-console/pspec_x86_64.xml
@@ -1,0 +1,280 @@
+<PISI>
+    <Source>
+        <Name>font-terminus-console</Name>
+        <Homepage>https://terminus-font.sourceforge.net/</Homepage>
+        <Packager>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
+        </Packager>
+        <License>OFL-1.1</License>
+        <PartOf>desktop.font</PartOf>
+        <Summary xml:lang="en">Monospaced font designed for long (8+ hours per day) work with computers.</Summary>
+        <Description xml:lang="en">Monospaced font designed for long (8+ hours per day) work with computers.
+
+Contains 1326 characters, supports about 120 language sets, many IBM, Windows and Macintosh code pages, IBM VGA / vt100 / xterm pseudographic characters and Esperanto.
+
+NB: This package *only* contains the terminus console font versions.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>font-terminus-console</Name>
+        <Summary xml:lang="en">Monospaced font designed for long (8+ hours per day) work with computers.</Summary>
+        <Description xml:lang="en">Monospaced font designed for long (8+ hours per day) work with computers.
+
+Contains 1326 characters, supports about 120 language sets, many IBM, Windows and Macintosh code pages, IBM VGA / vt100 / xterm pseudographic characters and Esperanto.
+
+NB: This package *only* contains the terminus console font versions.
+</Description>
+        <PartOf>desktop.font</PartOf>
+        <Files>
+            <Path fileType="data">/usr/share/consolefonts/ter-112n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-114b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-114n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-116b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-116n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-118b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-118n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-120b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-120n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-122b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-122n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-124b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-124n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-128b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-128n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-132b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-132n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-212n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-214b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-214n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-216b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-216n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-218b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-218n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-220b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-220n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-222b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-222n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-224b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-224n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-228b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-228n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-232b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-232n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-712n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-714b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-714n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-716b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-716n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-718b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-718n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-720b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-720n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-722b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-722n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-724b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-724n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-728b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-728n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-732b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-732n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-912n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-914b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-914n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-916b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-916n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-918b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-918n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-920b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-920n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-922b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-922n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-924b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-924n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-928b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-928n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-932b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-932n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-c12n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-c14b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-c14n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-c16b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-c16n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-c18b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-c18n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-c20b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-c20n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-c22b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-c22n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-c24b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-c24n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-c28b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-c28n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-c32b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-c32n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-d12n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-d14b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-d14n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-d16b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-d16n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-d18b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-d18n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-d20b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-d20n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-d22b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-d22n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-d24b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-d24n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-d28b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-d28n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-d32b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-d32n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-g12n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-g14b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-g14n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-g16b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-g16n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-g18b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-g18n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-g20b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-g20n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-g22b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-g22n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-g24b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-g24n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-g28b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-g28n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-g32b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-g32n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-h12n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-h14b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-h14n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-h16b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-h16n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-h18b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-h18n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-h20b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-h20n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-h22b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-h22n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-h24b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-h24n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-h28b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-h28n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-h32b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-h32n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-i12n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-i14b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-i14n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-i16b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-i16n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-i18b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-i18n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-i20b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-i20n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-i22b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-i22n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-i24b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-i24n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-i28b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-i28n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-i32b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-i32n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-k12n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-k14b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-k14n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-k16b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-k16n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-k18b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-k18n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-k20b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-k20n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-k22b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-k22n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-k24b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-k24n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-k28b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-k28n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-k32b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-k32n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-m12n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-m14b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-m14n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-m16b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-m16n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-m18b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-m18n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-m20b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-m20n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-m22b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-m22n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-m24b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-m24n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-m28b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-m28n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-m32b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-m32n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-p12n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-p14b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-p14n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-p16b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-p16n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-p18b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-p18n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-p20b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-p20n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-p22b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-p22n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-p24b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-p24n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-p28b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-p28n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-p32b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-p32n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-u12n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-u14b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-u14n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-u16b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-u16n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-u18b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-u18n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-u20b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-u20n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-u22b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-u22n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-u24b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-u24n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-u28b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-u28n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-u32b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-u32n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-v12n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-v14b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-v14n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-v16b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-v16n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-v18b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-v18n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-v20b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-v20n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-v22b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-v22n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-v24b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-v24n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-v28b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-v28n.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-v32b.psf.gz</Path>
+            <Path fileType="data">/usr/share/consolefonts/ter-v32n.psf.gz</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2023-11-14</Date>
+            <Version>4.49.1</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**
Add the console version of the terminus monospaced font.

The intent is for this to be used in the bootloader, the kernel and by default in the linux console (ter-vXXn), which will make things look particularly sleek.

**Test Plan**
Install font-terminus-console locally and use setfont to switch to ter-v32n and observe that it looks nice on a 32" 4K monitor.

**Checklist**

- [x] Package was built and tested against unstable
