### PR TITLE
syncthing: update to 1.26.1

### DIFF
--- a/packages/s/syncthing/package.yml
+++ b/packages/s/syncthing/package.yml
@@ -1,9 +1,9 @@
 name       : syncthing
-version    : 1.26.0
-release    : 88
+version    : 1.26.1
+release    : 89
 homepage   : https://syncthing.net
 source     :
-    - https://github.com/syncthing/syncthing/releases/download/v1.26.0/syncthing-source-v1.26.0.tar.gz : bfb4ce711b09c15671b3e43d02c7ae20b5a380483cf0a7bcb414222d827d4e30
+    - https://github.com/syncthing/syncthing/releases/download/v1.26.1/syncthing-source-v1.26.1.tar.gz : c14de7df16f33db6e77442ee298dd836aeb40ae08339ebe27e418a1bb0ebe7bd
 license    : MPL-2.0
 component  : network.util
 networking : yes

--- a/packages/s/syncthing/pspec_x86_64.xml
+++ b/packages/s/syncthing/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>syncthing</Name>
         <Homepage>https://syncthing.net</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>MPL-2.0</License>
         <PartOf>network.util</PartOf>
@@ -50,12 +50,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="88">
+        <Update release="89">
             <Date>2023-11-16</Date>
-            <Version>1.26.0</Version>
+            <Version>1.26.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Bugfixes:

- Display error in 1.26 with login screen

**Full release notes:**
- [1.26.1](https://github.com/syncthing/syncthing/releases/tag/v1.26.1)

**Test Plan**

- Loaded the syncthing web UI, verified I can see shares and UI works normally
- Exercised Syncthing-GTK
- Verified that a file shared between the local machine and a remote machine syncs

**Checklist**

- [x] Package was built and tested against unstable
