### PR TITLE
JMESPath: initial inclusion in the repository

### DIFF
--- a/packages/a/ansible/package.yml
+++ b/packages/a/ansible/package.yml
@@ -1,6 +1,6 @@
 name       : ansible
 version    : 2.16.0
-release    : 42
+release    : 43
 source     :
     - https://github.com/ansible/ansible/archive/refs/tags/v2.16.0.tar.gz : 5daf596615765944b20c426775c31d8a232d42ae613e2b0b37ce492bc4e3b4e5
 license    : GPL-3.0-or-later
@@ -16,6 +16,7 @@ builddeps  :
     - python-jinja
 rundeps    :
     - python-jinja
+    - python-jmespath
     - python-paramiko
     - python-resolvelib
     - pyyaml

--- a/packages/a/ansible/pspec_x86_64.xml
+++ b/packages/a/ansible/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ansible</Name>
         <Homepage>https://www.ansible.com/</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Wouter Horlings</Name>
+            <Email>wouter@horlin.gs</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -1735,12 +1735,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="42">
-            <Date>2023-11-08</Date>
+        <Update release="43">
+            <Date>2023-11-22</Date>
             <Version>2.16.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Wouter Horlings</Name>
+            <Email>wouter@horlin.gs</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/py/python-jmespath/MAINTAINERS.md
+++ b/packages/py/python-jmespath/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Wouter Horlings
+  - Matrix: @achilleshiel:utwente.io
+  - Email: wouter@horlin.gs

--- a/packages/py/python-jmespath/package.yml
+++ b/packages/py/python-jmespath/package.yml
@@ -1,0 +1,18 @@
+name       : python-jmespath
+version    : 1.0.1
+release    : 1
+source     :
+    - https://github.com/jmespath/jmespath.py/archive/refs/tags/1.0.1.tar.gz : 6a02470b1716ec7a32abe89a873a4795c41c938468225f8a53d860980ec9e3c6
+homepage   : https://jmespath.org
+license    : MIT
+component  : programming.python
+summary    : JMESPath is a query language for JSON.
+description: |
+    JMESPath (pronounced "james path") allows you to declaratively specify how to extract elements from a JSON document.
+builddeps  :
+    - python-build
+    - python-installer
+build      : |
+    %python3_setup
+install    : |
+    %python3_install

--- a/packages/py/python-jmespath/pspec_x86_64.xml
+++ b/packages/py/python-jmespath/pspec_x86_64.xml
@@ -1,0 +1,55 @@
+<PISI>
+    <Source>
+        <Name>python-jmespath</Name>
+        <Homepage>https://jmespath.org</Homepage>
+        <Packager>
+            <Name>Wouter Horlings</Name>
+            <Email>wouter@horlin.gs</Email>
+        </Packager>
+        <License>MIT</License>
+        <PartOf>programming.python</PartOf>
+        <Summary xml:lang="en">JMESPath is a query language for JSON.</Summary>
+        <Description xml:lang="en">JMESPath (pronounced &quot;james path&quot;) allows you to declaratively specify how to extract elements from a JSON document.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>python-jmespath</Name>
+        <Summary xml:lang="en">JMESPath is a query language for JSON.</Summary>
+        <Description xml:lang="en">JMESPath (pronounced &quot;james path&quot;) allows you to declaratively specify how to extract elements from a JSON document.
+</Description>
+        <PartOf>programming.python</PartOf>
+        <Files>
+            <Path fileType="executable">/usr/bin/jp.py</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/jmespath-1.0.1-py3.10.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/jmespath-1.0.1-py3.10.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/jmespath-1.0.1-py3.10.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/jmespath-1.0.1-py3.10.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/jmespath/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/jmespath/__pycache__/__init__.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/jmespath/__pycache__/ast.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/jmespath/__pycache__/compat.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/jmespath/__pycache__/exceptions.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/jmespath/__pycache__/functions.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/jmespath/__pycache__/lexer.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/jmespath/__pycache__/parser.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/jmespath/__pycache__/visitor.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/jmespath/ast.py</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/jmespath/compat.py</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/jmespath/exceptions.py</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/jmespath/functions.py</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/jmespath/lexer.py</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/jmespath/parser.py</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/jmespath/visitor.py</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2023-11-16</Date>
+            <Version>1.0.1</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Wouter Horlings</Name>
+            <Email>wouter@horlin.gs</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**

Add the JMESPath python package, which allows you to build queries for json-documents.

This is a dependency for the `json_query` method in Ansible.

**Test Plan**

- Ran successfully a ansible run using `json_query`

**Checklist**

- [x] Package was built and tested against unstable