### PR TITLE
sof-firmware: update to 2.7.2

### DIFF
--- a/packages/s/sof-firmware/files/sof-firmware.metainfo.xml
+++ b/packages/s/sof-firmware/files/sof-firmware.metainfo.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="driver">
+  <id>sof-firmware</id>
+  <name>Sound Open Firmware</name>
+  <project_license>BSD-3-Clause, ISC</project_license>
+  <developer_name>SOF Project</developer_name>
+  <summary>Sound Open Firmware</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <url type="homepage">https://github.com/thesofproject</url>
+  <url type="help">https://thesofproject.github.io</url>
+  <description>
+    <p>Sound Open Firmware. This package provides Firmware and topology binaries.</p>
+  </description>
+  <update_contact>releng@getsol.us</update_contact>
+</component>

--- a/packages/s/sof-firmware/package.yml
+++ b/packages/s/sof-firmware/package.yml
@@ -1,9 +1,9 @@
 name       : sof-firmware
 homepage   : https://github.com/thesofproject/sof-bin
-version    : 2.7.1
-release    : 13
+version    : 2.7.2
+release    : 14
 source     :
-    - https://github.com/thesofproject/sof-bin/releases/download/v2023.09.1/sof-bin-2023.09.1.tar.gz : 583233652a298cb754c03f47c33a58c9b97770498aa0db03141f11ef705d191d
+    - https://github.com/thesofproject/sof-bin/releases/download/v2023.09.2/sof-bin-2023.09.2.tar.gz : 23063a3e447497bbb2683d0c5f3a0fbb248dabfb24544138be0e73e9e15e0f63
 license    :
     - BSD-3-Clause
     - ISC
@@ -17,3 +17,4 @@ install    : |
     cp -a sof-ace-tplg "$installdir/lib/firmware/intel/sof-ace-tplg"
     cp -a sof-ipc4 "$installdir/lib/firmware/intel/sof-ipc4"
     cp -a sof-tplg "$installdir/lib/firmware/intel/sof-tplg"
+    install -Dm00644 $pkgfiles/sof-firmware.metainfo.xml $installdir/usr/share/metainfo/sof-firmware.metainfo.xml

--- a/packages/s/sof-firmware/pspec_x86_64.xml
+++ b/packages/s/sof-firmware/pspec_x86_64.xml
@@ -33,6 +33,8 @@
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-rt711-4ch.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-rt711-l0-rt1316-l23-rt714-l1.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-rt712-l0-rt1712-l3.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-rt713-l0-rt1316-l12-rt1713-l3.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-rt713-l0-rt1316-l12.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-sdw-cs42l42-l0-max98363-l2.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ipc4/mtl/community/sof-mtl.ri</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ipc4/mtl/intel-signed/sof-mtl.ri</Path>
@@ -391,12 +393,13 @@
             <Path fileType="data">/lib/firmware/intel/sof/sof-tgl-h.ri</Path>
             <Path fileType="data">/lib/firmware/intel/sof/sof-tgl.ldc</Path>
             <Path fileType="data">/lib/firmware/intel/sof/sof-tgl.ri</Path>
+            <Path fileType="data">/usr/share/metainfo/sof-firmware.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2023-11-04</Date>
-            <Version>2.7.1</Version>
+        <Update release="14">
+            <Date>2023-11-17</Date>
+            <Version>2.7.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Tracey Clark</Name>
             <Email>traceyc.dev@tlcnet.info</Email>


### PR DESCRIPTION
**Summary**

For v2.7 series, topologies from 2.7.2 release have been added, including following new/updated files:

v2.7.x/sof-ace-tplg-v2.7.2
├── sof-mtl-max98357a-rt5682-ssp2-ssp0-2ch-pdm1.tplg
├── sof-mtl-max98357a-rt5682-ssp2-ssp0.tplg
├── sof-mtl-max98357a-rt5682.tplg
├── sof-mtl-rt713-l0-rt1316-l12-rt1713-l3.tplg
└── sof-mtl-rt713-l0-rt1316-l12.tplg

Full release notes [here](https://github.com/thesofproject/sof-bin/releases/tag/v2023.09.2)

**Test Plan**

Verified firmware files were installed to correct paths. Restarted pipewire.
    systemctl --user restart pipewire.service
Listened to music and triggered system sounds to verify that sound still works.

**Checklist**

- [x] Package was built and tested against unstable