### PR TITLE
amtk: homepage inclusion

### DIFF
--- a/packages/a/amtk/package.yml
+++ b/packages/a/amtk/package.yml
@@ -1,8 +1,9 @@
 name       : amtk
 version    : 5.6.1
-release    : 9
+release    : 10
 source     :
     - https://download.gnome.org/sources/amtk/5.6/amtk-5.6.1.tar.xz : d50115b85c872aac296934b5ee726a3fa156c6f5ad96d27e0edd0aa5ad173228
+homepage   : https://gedit-technology.net/
 license    : LGPL-2.1-or-later
 component  : programming.library
 summary    : Actions, Menus and Toolbars Kit for GTK+ applications

--- a/packages/a/amtk/pspec_x86_64.xml
+++ b/packages/a/amtk/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>amtk</Name>
+        <Homepage>https://gedit-technology.net/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>programming.library</PartOf>
         <Summary xml:lang="en">Actions, Menus and Toolbars Kit for GTK+ applications</Summary>
         <Description xml:lang="en">Actions, Menus and Toolbars Kit for GTK+ applications
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>amtk</Name>
@@ -60,7 +61,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="9">amtk</Dependency>
+            <Dependency release="10">amtk</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/amtk-5/amtk/amtk-action-info-central-store.h</Path>
@@ -120,12 +121,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2023-05-02</Date>
+        <Update release="10">
+            <Date>2023-11-18</Date>
             <Version>5.6.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable

**Comment**

Shouldn't this be deprecated? This package is replaced by `libgedit-amtk`. I also noticed that it doesn't show on `eopkg info amtk`.