### PR TITLE
blender: Enable CUDA and OptiX support

### DIFF
--- a/packages/b/blender/abi_used_symbols
+++ b/packages/b/blender/abi_used_symbols
@@ -1506,11 +1506,12 @@ libjack.so.0:jack_transport_locate
 libjack.so.0:jack_transport_query
 libjack.so.0:jack_transport_start
 libjack.so.0:jack_transport_stop
+libjemalloc.so.2:_ZdaPv
 libjemalloc.so.2:_ZdlPv
 libjemalloc.so.2:_ZdlPvSt11align_val_t
-libjemalloc.so.2:_Znam
 libjemalloc.so.2:_Znwm
 libjemalloc.so.2:calloc
+libjemalloc.so.2:free
 libjemalloc.so.2:malloc_usable_size
 libjemalloc.so.2:memalign
 libjemalloc.so.2:realloc
@@ -1832,10 +1833,11 @@ libosdGPU.so.3.6.0:_ZN10OpenSubdiv6v3_6_03Osd14GLVertexBuffer7BindVBOEPv
 libosdGPU.so.3.6.0:_ZN10OpenSubdiv6v3_6_03Osd14GLVertexBufferD1Ev
 libosdGPU.so.3.6.0:_ZN10OpenSubdiv6v3_6_03Osd21GLSLPatchShaderSource25GetPatchBasisShaderSourceB5cxx11Ev
 libosdGPU.so.3.6.0:_ZNK10OpenSubdiv6v3_6_03Osd14GLVertexBuffer14GetNumVerticesEv
-liboslcomp.so.1.13:_ZN9OSL_v1_1311OSLCompiler7compileEN16OpenImageIO_v2_517basic_string_viewIcSt11char_traitsIcEEERKSt6vectorINSt7__cxx1112basic_stringIcS4_SaIcEEESaISA_EES5_
 liboslcomp.so.1.13:_ZN9OSL_v1_1311OSLCompilerC1EPN16OpenImageIO_v2_512ErrorHandlerE
 liboslcomp.so.1.13:_ZN9OSL_v1_1311OSLCompilerD1Ev
+liboslexec.so.1.13:_ZN9OSL_v1_1311OSLCompiler7compileEN16OpenImageIO_v2_517basic_string_viewIcSt11char_traitsIcEEERKSt6vectorINSt7__cxx1112basic_stringIcS4_SaIcEEESaISA_EES5_
 liboslexec.so.1.13:_ZN9OSL_v1_1313ShadingSystem11get_contextEPNS_13PerThreadInfoEPN16OpenImageIO_v2_513TextureSystem9PerthreadE
+liboslexec.so.1.13:_ZN9OSL_v1_1313ShadingSystem12getattributeEPNS_11ShaderGroupEN16OpenImageIO_v2_517basic_string_viewIcSt11char_traitsIcEEENS3_8TypeDescEPv
 liboslexec.so.1.13:_ZN9OSL_v1_1313ShadingSystem14ConnectShadersEN16OpenImageIO_v2_517basic_string_viewIcSt11char_traitsIcEEES5_S5_S5_
 liboslexec.so.1.13:_ZN9OSL_v1_1313ShadingSystem14ShaderGroupEndEv
 liboslexec.so.1.13:_ZN9OSL_v1_1313ShadingSystem15release_contextEPNS_14ShadingContextE
@@ -2482,8 +2484,8 @@ libstdc++.so.6:_ZTv0_n24_NSoD0Ev
 libstdc++.so.6:_ZTv0_n24_NSoD1Ev
 libstdc++.so.6:_ZTv0_n24_NSt13basic_fstreamIcSt11char_traitsIcEED0Ev
 libstdc++.so.6:_ZTv0_n24_NSt13basic_fstreamIcSt11char_traitsIcEED1Ev
-libstdc++.so.6:_ZdaPv
 libstdc++.so.6:_ZdlPv
+libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
 libstdc++.so.6:_ZnwmRKSt9nothrow_t
 libstdc++.so.6:__cxa_allocate_exception

--- a/packages/b/blender/package.yml
+++ b/packages/b/blender/package.yml
@@ -1,10 +1,14 @@
 name       : blender
 version    : 4.1.0
-release    : 85
+release    : 86
 source     :
     - https://download.blender.org/source/blender-4.1.0.tar.xz : dc002d82e3c340c93855c6684730d01801b669a29b1cc6b75eeb990ba69e723f
     - https://download.blender.org/demo/test/BMW27.blend.zip : 08170de260488c14855a13db81c8d5ad844bc6162c3db13e1d9ba8094f55fe2b
-license    : GPL-2.0-or-later
+    - https://developer.download.nvidia.com/compute/cuda/12.3.0/local_installers/cuda_12.3.0_545.23.06_linux.run#cuda-sdk.run : 7c13face3af64d6e1648d6e3101d31c8111e747143acb0077d973c1690820422
+    - https://developer.download.nvidia.com/redist/optix/v7.6/OptiX-7.6-Include.zip : f4c6b2a33d8ed14af8ad6d0fea3a9d60e544fba540c05055a754e06c2f8097b3
+license    :
+    - GPL-2.0-or-later
+    - EULA # cuda/optix
 homepage   : https://blender.org/
 component  : multimedia.graphics
 summary    : A fully integrated 3D graphics creation suite
@@ -65,7 +69,22 @@ environment: |
     export HIP_CLANG_PATH=/usr/bin
     export DEVICE_LIB_PATH=/usr/lib64/amdgcn/bitcode
 setup      : |
+    mkdir cuda-sdk cuda-tmp optix-headers
+
+    pushd optix-headers
+    unzip $sources/OptiX-7.6-Include.zip
+    popd
+
+    pushd $sources
+    sh cuda-sdk.run --silent --toolkit --toolkitpath=$workdir/cuda-sdk --tmpdir=$workdir/cuda-tmp
+    popd
+
+    # Allow gcc-13 to work
+    sed -i "/.*unsupported GNU version.*/d" cuda-sdk/include/crt/host_config.h
+    sed -i "/.*unsupported clang version.*/d" cuda-sdk/include/crt/host_config.h
+
     %cmake_ninja \
+        -DCUDA_TOOLKIT_ROOT_DIR=$workdir/cuda-sdk/ \
         -DPYTHON_VERSION=%python3_version% \
         -DPYTHON_LIBPATH=%libdir% \
         -DPYTHON_LIBRARY=python%python3_version% \
@@ -73,15 +92,17 @@ setup      : |
         -DWITH_ALEMBIC=ON \
         -DWITH_CODEC_FFMPEG=ON \
         -DWITH_CODEC_SNDFILE=ON \
+        -DWITH_CYCLES_CUDA_BINARIES=ON \
         -DWITH_CYCLES_EMBREE=ON \
-        -DWITH_CYCLES_OSL=ON \
         -DWITH_CYCLES_HIP_BINARIES=ON \
+        -DWITH_CYCLES_OSL=ON \
         -DWITH_FFTW3=ON \
         -DWITH_HARU=ON \
         -DWITH_IMAGE_OPENJPEG=ON \
         -DWITH_INSTALL_PORTABLE=OFF \
         -DWITH_JACK=ON \
         -DWITH_LLVM=ON \
+        -DOPTIX_ROOT_DIR="$workdir/optix-headers" \
         -DWITH_OPENCOLORIO=ON \
         -DWITH_OPENIMAGEIO=ON \
         -DWITH_OPENSUBDIV=ON \

--- a/packages/b/blender/pspec_x86_64.xml
+++ b/packages/b/blender/pspec_x86_64.xml
@@ -7,6 +7,7 @@
             <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
+        <License>EULA</License>
         <PartOf>multimedia.graphics</PartOf>
         <Summary xml:lang="en">A fully integrated 3D graphics creation suite</Summary>
         <Description xml:lang="en">Blender is the free and open source 3D creation suite. It supports the entirety of the 3D pipeline&#x2014;modeling, rigging, animation, simulation, rendering, compositing and motion tracking, even video editing and game creation.
@@ -727,6 +728,7 @@
             <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/__pycache__/version_update.cpython-311.pyc</Path>
             <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/camera.py</Path>
             <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/engine.py</Path>
+            <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/lib/kernel_compute_75.ptx</Path>
             <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/lib/kernel_gfx1010.fatbin</Path>
             <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/lib/kernel_gfx1011.fatbin</Path>
             <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/lib/kernel_gfx1012.fatbin</Path>
@@ -750,6 +752,18 @@
             <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/lib/kernel_gfx908.fatbin</Path>
             <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/lib/kernel_gfx90a.fatbin</Path>
             <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/lib/kernel_gfx90c.fatbin</Path>
+            <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/lib/kernel_optix.ptx</Path>
+            <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/lib/kernel_optix_osl.ptx</Path>
+            <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/lib/kernel_optix_osl_services.ptx</Path>
+            <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/lib/kernel_optix_shader_raytrace.ptx</Path>
+            <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/lib/kernel_sm_50.cubin</Path>
+            <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/lib/kernel_sm_52.cubin</Path>
+            <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/lib/kernel_sm_60.cubin</Path>
+            <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/lib/kernel_sm_61.cubin</Path>
+            <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/lib/kernel_sm_70.cubin</Path>
+            <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/lib/kernel_sm_75.cubin</Path>
+            <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/lib/kernel_sm_86.cubin</Path>
+            <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/lib/kernel_sm_89.cubin</Path>
             <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/license/Apache2-license.txt</Path>
             <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/license/BSD-3-Clause-license.txt</Path>
             <Path fileType="data">/usr/share/blender/4.1/scripts/addons/cycles/license/MIT-license.txt</Path>
@@ -3752,8 +3766,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="85">
-            <Date>2024-05-20</Date>
+        <Update release="86">
+            <Date>2024-05-25</Date>
             <Version>4.1.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Joey Riches</Name>


### PR DESCRIPTION
**Summary**
- Add CUDA as a source to avoid redistributing CUDA in a separate package.
- Add OptiX headers as a source to avoid redistributing in a separate package.

**Test Plan**
- Run classroom with CUDA cycles renderer enabled. Verify the GPU is being used.
- Run classroom with OptiX cycles renderer enabled. Verify the GPU is being used.

**Checklist**

- [x] Package was built and tested against unstable
