### PR TITLE
apr-util: Update to 1.6.3

### DIFF
--- a/packages/a/apr-util/abi_used_symbols
+++ b/packages/a/apr-util/abi_used_symbols
@@ -15,6 +15,7 @@ libapr-1.so.0:apr_dso_sym
 libapr-1.so.0:apr_dso_unload
 libapr-1.so.0:apr_env_get
 libapr-1.so.0:apr_file_close
+libapr-1.so.0:apr_file_dup
 libapr-1.so.0:apr_file_flags_get
 libapr-1.so.0:apr_file_info_get
 libapr-1.so.0:apr_file_lock
@@ -97,7 +98,6 @@ libapr-1.so.0:apr_thread_cond_wait
 libapr-1.so.0:apr_thread_create
 libapr-1.so.0:apr_thread_data_get
 libapr-1.so.0:apr_thread_data_set
-libapr-1.so.0:apr_thread_detach
 libapr-1.so.0:apr_thread_exit
 libapr-1.so.0:apr_thread_join
 libapr-1.so.0:apr_thread_mutex_create
@@ -118,6 +118,7 @@ libc.so.6:__ctype_tolower_loc
 libc.so.6:__errno_location
 libc.so.6:__explicit_bzero_chk
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
 libc.so.6:__printf_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
@@ -152,7 +153,6 @@ libc.so.6:strncmp
 libc.so.6:strrchr
 libc.so.6:strstr
 libc.so.6:strtod
-libc.so.6:strtol
 libcrypt.so.2:crypt_r
 libcrypto.so.3:ENGINE_by_id
 libcrypto.so.3:ENGINE_finish

--- a/packages/a/apr-util/package.yml
+++ b/packages/a/apr-util/package.yml
@@ -1,8 +1,9 @@
 name       : apr-util
-version    : 1.6.1
-release    : 15
+version    : 1.6.3
+release    : 16
 source     :
-    - https://archive.apache.org/dist/apr/apr-util-1.6.1.tar.bz2 : d3e12f7b6ad12687572a3a39475545a072608f4ba03a6ce8a3778f607dd0035b
+    - https://dlcdn.apache.org//apr/apr-util-1.6.3.tar.bz2 : a41076e3710746326c3945042994ad9a4fcac0ce0277dd8fea076fec3c9772b5
+homepage   : https://apr.apache.org/
 license    : Apache-2.0
 component  : programming
 summary    : apr-util provides a number of abstractions for Apache apr

--- a/packages/a/apr-util/pspec_x86_64.xml
+++ b/packages/a/apr-util/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>apr-util</Name>
+        <Homepage>https://apr.apache.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">apr-util provides a number of abstractions for Apache apr</Summary>
         <Description xml:lang="en">apr-util provides a number of abstractions for Apache apr
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>apr-util</Name>
@@ -36,7 +37,7 @@
             <Path fileType="library">/usr/lib64/apr-util-1/apr_ldap.so</Path>
             <Path fileType="library">/usr/lib64/aprutil.exp</Path>
             <Path fileType="library">/usr/lib64/libaprutil-1.so.0</Path>
-            <Path fileType="library">/usr/lib64/libaprutil-1.so.0.6.1</Path>
+            <Path fileType="library">/usr/lib64/libaprutil-1.so.0.6.3</Path>
         </Files>
     </Package>
     <Package>
@@ -46,7 +47,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="15">apr-util</Dependency>
+            <Dependency release="16">apr-util</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/apr-1/apr_anylock.h</Path>
@@ -89,12 +90,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2023-08-20</Date>
-            <Version>1.6.1</Version>
+        <Update release="16">
+            <Date>2023-11-23</Date>
+            <Version>1.6.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/h/httpd/abi_symbols
+++ b/packages/h/httpd/abi_symbols
@@ -235,6 +235,7 @@ httpd:ap_get_mime_headers_core
 httpd:ap_get_module_config
 httpd:ap_get_module_flags
 httpd:ap_get_output_filter_handle
+httpd:ap_get_pollfd_from_conn
 httpd:ap_get_protocol
 httpd:ap_get_protocol_upgrades
 httpd:ap_get_read_buf_size
@@ -441,6 +442,7 @@ httpd:ap_hack_ap_get_mime_headers_core
 httpd:ap_hack_ap_get_module_config
 httpd:ap_hack_ap_get_module_flags
 httpd:ap_hack_ap_get_output_filter_handle
+httpd:ap_hack_ap_get_pollfd_from_conn
 httpd:ap_hack_ap_get_protocol
 httpd:ap_hack_ap_get_protocol_upgrades
 httpd:ap_hack_ap_get_read_buf_size
@@ -523,6 +525,7 @@ httpd:ap_hack_ap_hook_get_fixups
 httpd:ap_hack_ap_hook_get_force_authn
 httpd:ap_hack_ap_hook_get_generate_log_id
 httpd:ap_hack_ap_hook_get_get_mgmt_items
+httpd:ap_hack_ap_hook_get_get_pollfd_from_conn
 httpd:ap_hack_ap_hook_get_get_suexec_identity
 httpd:ap_hack_ap_hook_get_handler
 httpd:ap_hack_ap_hook_get_header_parser
@@ -542,6 +545,7 @@ httpd:ap_hack_ap_hook_get_note_auth_failure
 httpd:ap_hack_ap_hook_get_open_htaccess
 httpd:ap_hack_ap_hook_get_open_logs
 httpd:ap_hack_ap_hook_get_optional_fn_retrieve
+httpd:ap_hack_ap_hook_get_pollfd_from_conn
 httpd:ap_hack_ap_hook_get_post_config
 httpd:ap_hack_ap_hook_get_post_perdir_config
 httpd:ap_hack_ap_hook_get_post_read_request
@@ -837,6 +841,7 @@ httpd:ap_hack_ap_run_fixups
 httpd:ap_hack_ap_run_force_authn
 httpd:ap_hack_ap_run_generate_log_id
 httpd:ap_hack_ap_run_get_mgmt_items
+httpd:ap_hack_ap_run_get_pollfd_from_conn
 httpd:ap_hack_ap_run_get_suexec_identity
 httpd:ap_hack_ap_run_handler
 httpd:ap_hack_ap_run_header_parser
@@ -1938,6 +1943,7 @@ httpd:ap_hook_get_fixups
 httpd:ap_hook_get_force_authn
 httpd:ap_hook_get_generate_log_id
 httpd:ap_hook_get_get_mgmt_items
+httpd:ap_hook_get_get_pollfd_from_conn
 httpd:ap_hook_get_get_suexec_identity
 httpd:ap_hook_get_handler
 httpd:ap_hook_get_header_parser
@@ -1957,6 +1963,7 @@ httpd:ap_hook_get_note_auth_failure
 httpd:ap_hook_get_open_htaccess
 httpd:ap_hook_get_open_logs
 httpd:ap_hook_get_optional_fn_retrieve
+httpd:ap_hook_get_pollfd_from_conn
 httpd:ap_hook_get_post_config
 httpd:ap_hook_get_post_perdir_config
 httpd:ap_hook_get_post_read_request
@@ -2287,6 +2294,7 @@ httpd:ap_run_fixups
 httpd:ap_run_force_authn
 httpd:ap_run_generate_log_id
 httpd:ap_run_get_mgmt_items
+httpd:ap_run_get_pollfd_from_conn
 httpd:ap_run_get_suexec_identity
 httpd:ap_run_handler
 httpd:ap_run_header_parser

--- a/packages/h/httpd/abi_used_symbols
+++ b/packages/h/httpd/abi_used_symbols
@@ -883,7 +883,8 @@ libc.so.6:__ctype_toupper_loc
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__printf_chk
@@ -979,7 +980,6 @@ libc.so.6:strrchr
 libc.so.6:strspn
 libc.so.6:strstr
 libc.so.6:strtod
-libc.so.6:strtol
 libc.so.6:syscall
 libc.so.6:sysconf
 libc.so.6:time
@@ -1083,6 +1083,7 @@ libcrypto.so.3:EVP_DigestInit_ex
 libcrypto.so.3:EVP_DigestUpdate
 libcrypto.so.3:EVP_EncryptInit_ex
 libcrypto.so.3:EVP_MAC_CTX_set_params
+libcrypto.so.3:EVP_MD_CTX_free
 libcrypto.so.3:EVP_MD_CTX_new
 libcrypto.so.3:EVP_PKEY_free
 libcrypto.so.3:EVP_PKEY_get1_EC_KEY
@@ -1230,6 +1231,7 @@ libcrypto.so.3:i2d_OCSP_REQUEST
 libcrypto.so.3:i2d_OCSP_RESPONSE
 libcrypto.so.3:i2d_PrivateKey
 liblber-2.4.so.2:ber_pvt_opt_on
+libldap-2.4.so.2:ldap_bind_s
 libldap-2.4.so.2:ldap_compare_s
 libldap-2.4.so.2:ldap_count_entries
 libldap-2.4.so.2:ldap_err2string
@@ -1243,6 +1245,7 @@ libldap-2.4.so.2:ldap_parse_result
 libldap-2.4.so.2:ldap_result
 libldap-2.4.so.2:ldap_search_ext_s
 libldap-2.4.so.2:ldap_set_option
+libldap-2.4.so.2:ldap_set_rebind_proc
 libldap-2.4.so.2:ldap_simple_bind
 libldap-2.4.so.2:ldap_unbind_s
 libldap-2.4.so.2:ldap_value_free
@@ -1252,6 +1255,7 @@ libnghttp2.so.14:nghttp2_option_del
 libnghttp2.so.14:nghttp2_option_new
 libnghttp2.so.14:nghttp2_option_set_no_auto_window_update
 libnghttp2.so.14:nghttp2_option_set_no_closed_streams
+libnghttp2.so.14:nghttp2_option_set_no_rfc9113_leading_and_trailing_ws_validation
 libnghttp2.so.14:nghttp2_option_set_peer_max_concurrent_streams
 libnghttp2.so.14:nghttp2_priority_spec_init
 libnghttp2.so.14:nghttp2_session_callbacks_del

--- a/packages/h/httpd/package.yml
+++ b/packages/h/httpd/package.yml
@@ -1,8 +1,9 @@
 name       : httpd
-version    : 2.4.57
-release    : 27
+version    : 2.4.58
+release    : 28
 source     :
-    - http://archive.apache.org/dist/httpd/httpd-2.4.57.tar.bz2 : dbccb84aee95e095edfbb81e5eb926ccd24e6ada55dcd83caecb262e5cf94d2a
+    - https://dlcdn.apache.org/httpd/httpd-2.4.58.tar.bz2 : fa16d72a078210a54c47dd5bef2f8b9b8a01d94909a51453956b3ec6442ea4c5
+homepage   : https://httpd.apache.org/
 license    : Apache-2.0
 component  : programming
 summary    : A secure, efficient and extensible server that provides HTTP services in sync with the current HTTP standards
@@ -20,7 +21,7 @@ builddeps  :
 setup      : |
     %apply_patches
     cat $pkgfiles/solus.layout >> config.layout
-    %configure \
+    ./configure $(sed 's|--runstatedir=/run||g' <<< "%CONFOPTS%") \
         --datadir=/usr/share/httpd \
         --disable-static \
         --enable-alias \

--- a/packages/h/httpd/pspec_x86_64.xml
+++ b/packages/h/httpd/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>httpd</Name>
+        <Homepage>https://httpd.apache.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">A secure, efficient and extensible server that provides HTTP services in sync with the current HTTP standards</Summary>
         <Description xml:lang="en">A secure, efficient and extensible server that provides HTTP services in sync with the current HTTP standards.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>httpd</Name>
@@ -1605,7 +1606,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="27">httpd</Dependency>
+            <Dependency release="28">httpd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/httpd/ap_compat.h</Path>
@@ -1676,12 +1677,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2023-08-20</Date>
-            <Version>2.4.57</Version>
+        <Update release="28">
+            <Date>2023-11-23</Date>
+            <Version>2.4.58</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/t/tomcat-connectors/abi_symbols
+++ b/packages/t/tomcat-connectors/abi_symbols
@@ -70,7 +70,6 @@ mod_jk.so:jk_b_reset
 mod_jk.so:jk_b_set_buffer
 mod_jk.so:jk_b_set_buffer_size
 mod_jk.so:jk_canonenc
-mod_jk.so:jk_check_attribute_length
 mod_jk.so:jk_check_buffer_size
 mod_jk.so:jk_clone_sockaddr
 mod_jk.so:jk_close_file_logger
@@ -239,6 +238,9 @@ mod_jk.so:jk_shm_close
 mod_jk.so:jk_shm_lock
 mod_jk.so:jk_shm_name
 mod_jk.so:jk_shm_open
+mod_jk.so:jk_shm_str_copy
+mod_jk.so:jk_shm_str_init
+mod_jk.so:jk_shm_str_init_ne
 mod_jk.so:jk_shm_unlock
 mod_jk.so:jk_shutdown_socket
 mod_jk.so:jk_sleep

--- a/packages/t/tomcat-connectors/abi_used_symbols
+++ b/packages/t/tomcat-connectors/abi_used_symbols
@@ -83,7 +83,8 @@ libc.so.6:__ctype_tolower_loc
 libc.so.6:__ctype_toupper_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__memcpy_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__sprintf_chk
@@ -161,7 +162,6 @@ libc.so.6:strspn
 libc.so.6:strstr
 libc.so.6:strtod
 libc.so.6:strtok_r
-libc.so.6:strtol
 libc.so.6:time
 libc.so.6:unlink
 libc.so.6:write

--- a/packages/t/tomcat-connectors/package.yml
+++ b/packages/t/tomcat-connectors/package.yml
@@ -1,8 +1,9 @@
 name       : tomcat-connectors
-version    : 1.2.48
-release    : 6
+version    : 1.2.49
+release    : 7
 source     :
-    - https://github.com/apache/tomcat-connectors/archive/JK_1_2_48.tar.gz : 74d0139ce6ba44c87ce136a063b246adc61369f7afd11a3e857903068d18dd61
+    - https://github.com/apache/tomcat-connectors/archive/refs/tags/JK_1_2_49.tar.gz : dea2f0d62c685472b98fd5fdaddad73169dbb790e028a59eb8d52b260df0fa7b
+homepage   : https://tomcat.apache.org/
 license    : Apache-2.0
 component  : programming
 summary    : Provides mod_jk for connecting httpd to a Tomcat container

--- a/packages/t/tomcat-connectors/pspec_x86_64.xml
+++ b/packages/t/tomcat-connectors/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>tomcat-connectors</Name>
+        <Homepage>https://tomcat.apache.org/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Provides mod_jk for connecting httpd to a Tomcat container</Summary>
         <Description xml:lang="en">mod_jk is an Apache module used to connect the Tomcat servlet container with web servers such as Apache, iPlanet, Sun ONE (formerly Netscape) and even IIS using the Apache JServ Protocol.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>tomcat-connectors</Name>
@@ -23,12 +24,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2022-03-27</Date>
-            <Version>1.2.48</Version>
+        <Update release="7">
+            <Date>2023-11-23</Date>
+            <Version>1.2.49</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Changelog can be found [here](https://downloads.apache.org/apr/CHANGES-APR-UTIL-1.6)
- Added `homepage` key to `package.yml` (Part of https://github.com/getsolus/packages/issues/411)

**Test Plan**

- Rebuild `httpd` against this package
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable