### PR TITLE
tailscale: Update to 1.54.0

### DIFF
--- a/packages/t/tailscale/package.yml
+++ b/packages/t/tailscale/package.yml
@@ -1,8 +1,8 @@
 name       : tailscale
-version    : 1.52.1
-release    : 4
+version    : 1.54.0
+release    : 5
 source     :
-    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.52.1.tar.gz : 297d01584104dde7d1e5d2e99ee57c6a60579dc4f494ed9d2306716e031af19a
+    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.54.0.tar.gz : c895a0f489706535ed400b0599d7d932d9eebc5f1bad2c236408a1e4b86620e7
 homepage   : https://tailscale.com
 license    : BSD-3-Clause
 component  : network.clients
@@ -11,8 +11,8 @@ description: |
     The easiest, most secure way to use WireGuard and 2FA.
 networking : yes
 builddeps  :
-    - golang
     - git
+    - golang
 environment: |
     export VERSION_LONG=%version%
     export VERSION_SHORT=%version%

--- a/packages/t/tailscale/pspec_x86_64.xml
+++ b/packages/t/tailscale/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2023-11-05</Date>
-            <Version>1.52.1</Version>
+        <Update release="5">
+            <Date>2023-11-19</Date>
+            <Version>1.54.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- update to Go 1.21.4
- improve throughput substantially for UDP packets over TUN device with recent Linux kernels

**Test Plan**
- tailscale status

**Checklist**
- [X] Package was built and tested against unstable