### PR TITLE
gpxsee: Update to 13.11

### DIFF
--- a/packages/g/gpxsee/abi_used_symbols
+++ b/packages/g/gpxsee/abi_used_symbols
@@ -208,6 +208,7 @@ libQt5Core.so.5:_ZN7QObjectD2Ev
 libQt5Core.so.5:_ZN7QString11reallocDataEjb
 libQt5Core.so.5:_ZN7QString13toUtf8_helperERKS_
 libQt5Core.so.5:_ZN7QString14compare_helperEPK5QChariPKciN2Qt15CaseSensitivityE
+libQt5Core.so.5:_ZN7QString14compare_helperEPK5QChariS2_iN2Qt15CaseSensitivityE
 libQt5Core.so.5:_ZN7QString14toLower_helperERS_
 libQt5Core.so.5:_ZN7QString14toUpper_helperERS_
 libQt5Core.so.5:_ZN7QString14trimmed_helperERKS_
@@ -457,6 +458,7 @@ libQt5Core.so.5:_ZNK7QString3midEii
 libQt5Core.so.5:_ZNK7QString4leftEi
 libQt5Core.so.5:_ZNK7QString5rightEi
 libQt5Core.so.5:_ZNK7QString5splitE5QChar6QFlagsIN2Qt18SplitBehaviorFlagsEENS2_15CaseSensitivityE
+libQt5Core.so.5:_ZNK7QString5splitERK18QRegularExpression6QFlagsIN2Qt18SplitBehaviorFlagsEE
 libQt5Core.so.5:_ZNK7QString5splitERKS_6QFlagsIN2Qt18SplitBehaviorFlagsEENS3_15CaseSensitivityE
 libQt5Core.so.5:_ZNK7QString5toIntEPbi
 libQt5Core.so.5:_ZNK7QString6toUIntEPbi
@@ -532,7 +534,6 @@ libQt5Core.so.5:_ZTI18QFutureWatcherBase
 libQt5Core.so.5:_ZTI20QFutureInterfaceBase
 libQt5Core.so.5:_ZTI7QObject
 libQt5Core.so.5:_ZTI9QIODevice
-libQt5Core.so.5:_ZTV18QFutureWatcherBase
 libQt5Core.so.5:_Zeq13QLatin1StringRK10QStringRef
 libQt5Core.so.5:_ZeqRK7QStringS1_
 libQt5Core.so.5:_ZlsR11QDataStreamRK9QTimeZone
@@ -795,7 +796,6 @@ libQt5Gui.so.5:_ZNK6QImage4sizeEv
 libQt5Gui.so.5:_ZNK6QImage5widthEv
 libQt5Gui.so.5:_ZNK6QImage6heightEv
 libQt5Gui.so.5:_ZNK6QImage6isNullEv
-libQt5Gui.so.5:_ZNK6QImage6metricEN12QPaintDevice17PaintDeviceMetricE
 libQt5Gui.so.5:_ZNK7QCursor5shapeEv
 libQt5Gui.so.5:_ZNK7QPixmap5widthEv
 libQt5Gui.so.5:_ZNK7QPixmap6heightEv
@@ -864,7 +864,6 @@ libQt5Sql.so.5:_ZN12QSqlDatabaseaSERKS_
 libQt5Sql.so.5:_ZN9QSqlErrorD1Ev
 libQt5Sql.so.5:_ZN9QSqlFieldD1Ev
 libQt5Sql.so.5:_ZN9QSqlQuery4execEv
-libQt5Sql.so.5:_ZN9QSqlQuery4nextEv
 libQt5Sql.so.5:_ZN9QSqlQuery5firstEv
 libQt5Sql.so.5:_ZN9QSqlQuery7prepareERK7QString
 libQt5Sql.so.5:_ZN9QSqlQuery9bindValueERK7QStringRK8QVariant6QFlagsIN4QSql13ParamTypeFlagEE
@@ -1131,6 +1130,7 @@ libQt5Widgets.so.5:_ZN5QMenu10insertMenuEP7QActionPS_
 libQt5Widgets.so.5:_ZN5QMenu12addSeparatorEv
 libQt5Widgets.so.5:_ZN5QMenu7addMenuEPS_
 libQt5Widgets.so.5:_ZN5QMenu7addMenuERK7QString
+libQt5Widgets.so.5:_ZN5QMenu7setIconERK5QIcon
 libQt5Widgets.so.5:_ZN5QMenuC1ERK7QStringP7QWidget
 libQt5Widgets.so.5:_ZN6QFrame10paintEventEP11QPaintEvent
 libQt5Widgets.so.5:_ZN6QFrame11changeEventEP6QEvent
@@ -1432,6 +1432,7 @@ libQt5Widgets.so.5:_ZNK19QGraphicsSceneEvent6widgetEv
 libQt5Widgets.so.5:_ZNK23QGraphicsSceneHelpEvent8scenePosEv
 libQt5Widgets.so.5:_ZNK23QGraphicsSceneHelpEvent9screenPosEv
 libQt5Widgets.so.5:_ZNK24QGraphicsSceneMouseEvent9screenPosEv
+libQt5Widgets.so.5:_ZNK5QMenu10menuActionEv
 libQt5Widgets.so.5:_ZNK5QMenu7isEmptyEv
 libQt5Widgets.so.5:_ZNK6QFrame10frameStyleEv
 libQt5Widgets.so.5:_ZNK6QFrame10frameWidthEv
@@ -1442,6 +1443,7 @@ libQt5Widgets.so.5:_ZNK6QLabel14heightForWidthEi
 libQt5Widgets.so.5:_ZNK6QLabel15minimumSizeHintEv
 libQt5Widgets.so.5:_ZNK6QLabel8sizeHintEv
 libQt5Widgets.so.5:_ZNK7QAction4dataEv
+libQt5Widgets.so.5:_ZNK7QAction4textEv
 libQt5Widgets.so.5:_ZNK7QAction9isCheckedEv
 libQt5Widgets.so.5:_ZNK7QAction9isEnabledEv
 libQt5Widgets.so.5:_ZNK7QDialog15minimumSizeHintEv
@@ -1545,9 +1547,13 @@ libgcc_s.so.1:_Unwind_Resume
 libm.so.6:asin
 libm.so.6:atan
 libm.so.6:atan2
+libm.so.6:ceil
 libm.so.6:cos
 libm.so.6:exp
+libm.so.6:exp2
+libm.so.6:floor
 libm.so.6:hypot
+libm.so.6:ldexp
 libm.so.6:log
 libm.so.6:log10
 libm.so.6:log2
@@ -1555,16 +1561,16 @@ libm.so.6:pow
 libm.so.6:remainder
 libm.so.6:round
 libm.so.6:sin
-libm.so.6:sincos
 libm.so.6:sqrt
 libm.so.6:tan
 libstdc++.so.6:_ZSt7nothrow
+libstdc++.so.6:_ZSt9terminatev
 libstdc++.so.6:_ZTISt9bad_alloc
 libstdc++.so.6:_ZTVN10__cxxabiv117__class_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv120__si_class_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv121__vmi_class_type_infoE
 libstdc++.so.6:_ZdaPv
-libstdc++.so.6:_ZdlPvm
+libstdc++.so.6:_ZdlPv
 libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
 libstdc++.so.6:_ZnwmRKSt9nothrow_t
@@ -1573,7 +1579,7 @@ libstdc++.so.6:__cxa_end_catch
 libstdc++.so.6:__cxa_guard_abort
 libstdc++.so.6:__cxa_guard_acquire
 libstdc++.so.6:__cxa_guard_release
+libstdc++.so.6:__cxa_pure_virtual
 libstdc++.so.6:__cxa_rethrow
-libstdc++.so.6:__cxa_throw_bad_array_new_length
 libstdc++.so.6:__dynamic_cast
 libstdc++.so.6:__gxx_personality_v0

--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.10'
-release    : 28
+version    : '13.11'
+release    : 29
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.10.tar.gz : 29c1ca028bb3faf18147c95aa6e9d70ad80ce7011b275c3c25c6628e097b8898
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.11.tar.gz : 85c65db7f8d3b100c82fcef521b72145b2c5146b0a5ea22316fae72b8d05dcbf
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -56,12 +56,14 @@
             <Path fileType="data">/usr/share/gpxsee/symbols/Dam.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Drinking Water.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Fastfood.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Ferry.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Fishing Area.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Flag, Blue.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Flag, Green.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Flag, Red.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Flag.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Forest.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Funicular.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Furbearer.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Gas Station.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Geocache Found.png</Path>
@@ -75,6 +77,7 @@
             <Path fileType="data">/usr/share/gpxsee/symbols/Information.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Library.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Live Theater.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Lodge.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Lodging.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Marina.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Medical Facility.png</Path>
@@ -88,10 +91,12 @@
             <Path fileType="data">/usr/share/gpxsee/symbols/Parking Area.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Pharmacy.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Picnic Area.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Pizza.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Police Station.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Post Office.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/RV Park.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Radio Beacon.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Railway.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Residence.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Restaurant.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Restroom.png</Path>
@@ -99,6 +104,7 @@
             <Path fileType="data">/usr/share/gpxsee/symbols/School.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Shipwreck.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Shopping Center.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Shower.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Ski Resort.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Skiing Area.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Skull and Crossbones.png</Path>
@@ -130,9 +136,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2023-10-29</Date>
-            <Version>13.10</Version>
+        <Update release="29">
+            <Date>2023-11-20</Date>
+            <Version>13.11</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Added support for GPSDump WPT files.
- Added "Open recent" menu.
- Huge MBTiles maps now load in a "geologically short" time.
- Vector MBTiles maps now rendered asynchronous.
- Fixed map bounds limiting.
- [changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

**Test Plan**
- open map file; zoom in and out

**Checklist**
- [X] Package was built and tested against unstable
