### PR TITLE
ci/package_checks: exclude merge commits from checks/changelog

### DIFF
--- a/common/CI/package_checks.py
+++ b/common/CI/package_checks.py
@@ -37,7 +37,7 @@ class Git:
         return self.run('log', '-1', '--format=%B', ref)
 
     def commit_refs(self, base: str, head: str) -> List[str]:
-        return self.run_lines('log', '--pretty=%H', base + '..' + head)
+        return self.run_lines('log', '--no-merges', '--pretty=%H', base + '..' + head)
 
     def fetch(self, remote: List[str]) -> None:
         self.run('fetch', *remote)


### PR DESCRIPTION
**Summary**

Exclude merge commits from the changelog generation. See, for example, [this changelog](https://github.com/getsolus/packages/actions/runs/6975160174), which includes an entry for the merge commit.

**Test Plan**

See [this changelog](https://github.com/silkeh/packages/actions/runs/6989475137).

**Checklist**

- [x] ~~Package was built and tested against unstable~~ n/a.
