### PR TITLE
ci/package_checks: add check for commit message ending in `]`

### DIFF
--- a/common/CI/package_checks.py
+++ b/common/CI/package_checks.py
@@ -145,6 +145,25 @@ class PullRequestCheck:
         return None
 
 
+class CommitMessage(PullRequestCheck):
+    def run(self) -> List[Result]:
+        return [result
+                for commit in self.commits
+                for result in self._check_commit(commit)]
+
+    def _check_commit(self, commit: str) -> List[Result]:
+        msg = self.git.commit_message(commit)
+        files = self.git.files_in_commit(commit)
+        file = files[0] if files else ''
+
+        results: List[Result] = []
+
+        if msg.strip().endswith(']'):
+            results.append(Result(message='commit ends with ]', level=Level.ERROR, file=file))
+
+        return results
+
+
 class Homepage(PullRequestCheck):
     _error = '`homepage` is not set'
     _level = Level.ERROR
@@ -341,6 +360,7 @@ class SummaryGenerator(PullRequestCheck):
 
 class Checker:
     checks = [
+        CommitMessage,
         Homepage,
         PackageBumped,
         PackageDependenciesOrder,


### PR DESCRIPTION
**Summary**

Adds a check for commit messages ending in a `]`. The comment is added on the first file of the commit if there is any.

**Test Plan**

See [this test pull request](https://github.com/silkeh/packages/pull/5/files#diff-fd36bdf870f06c81d1e087aca13513b1e87ec59e451f02eeee4e591e31a5992aR1)

**Checklist**

- [x] ~~Package was built and tested against unstable~~ n/a
