### PR TITLE
autoconf-archive: Update to 2023.02.20

### DIFF
--- a/packages/a/autoconf-archive/package.yml
+++ b/packages/a/autoconf-archive/package.yml
@@ -1,9 +1,10 @@
 name       : autoconf-archive
-version    : 2019.01.06
-release    : 7
+version    : 2023.02.20
+release    : 8
 source     :
-    - https://ftp.gnu.org/gnu/autoconf-archive/autoconf-archive-2019.01.06.tar.xz : 17195c833098da79de5778ee90948f4c5d90ed1a0cf8391b4ab348e2ec511e3f
-license    : GPL-3.0-with-autoconf-exception
+    - https://ftp.gnu.org/gnu/autoconf-archive/autoconf-archive-2023.02.20.tar.xz : 71d4048479ae28f1f5794619c3d72df9c01df49b1c628ef85fde37596dc31a33
+homepage   : https://www.gnu.org/software/autoconf-archive/
+license    : GPL-3.0-or-later WITH Autoconf-exception-3.0
 component  : programming.devel
 summary    : A collection of macros for Autoconf
 description: |

--- a/packages/a/autoconf-archive/pspec_x86_64.xml
+++ b/packages/a/autoconf-archive/pspec_x86_64.xml
@@ -1,17 +1,18 @@
 <PISI>
     <Source>
         <Name>autoconf-archive</Name>
+        <Homepage>https://www.gnu.org/software/autoconf-archive/</Homepage>
         <Packager>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
-        <License>GPL-3.0-with-autoconf-exception</License>
+        <License>GPL-3.0-or-later WITH Autoconf-exception-3.0</License>
         <PartOf>programming.devel</PartOf>
         <Summary xml:lang="en">A collection of macros for Autoconf</Summary>
         <Description xml:lang="en">The GNU Autoconf Archive is a collection of more than 500 macros for [GNU Autoconf](http://www.gnu.org/software/autoconf) that have been contributed as free software by friendly supporters of the cause from all over the Internet. Every single one of those macros can be re-used without imposing any restrictions whatsoever on the licensing of the generated configure script. In particular, it is possible to use all those macros in configure scripts that are meant for non-free software. This policy is unusual for a Free Software Foundation project. The FSF firmly believes that software ought to be free, and software licenses like the GPL are specifically designed to ensure that derivative work based on free software must be free as well.
 In case of Autoconf, however, an exception has been made, because Autoconf is at such a pivotal position in the software development tool chain that the benefits from having this tool available as widely as possible outweigh the disadvantage that some authors may choose to use it, too, for proprietary software.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>autoconf-archive</Name>
@@ -48,6 +49,7 @@ In case of Autoconf, however, an exception has been made, because Autoconf is at
             <Path fileType="data">/usr/share/aclocal/ax_blas.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_blas_f77_func.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_boost_asio.m4</Path>
+            <Path fileType="data">/usr/share/aclocal/ax_boost_atomic.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_boost_base.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_boost_chrono.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_boost_context.m4</Path>
@@ -55,11 +57,14 @@ In case of Autoconf, however, an exception has been made, because Autoconf is at
             <Path fileType="data">/usr/share/aclocal/ax_boost_date_time.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_boost_filesystem.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_boost_iostreams.m4</Path>
+            <Path fileType="data">/usr/share/aclocal/ax_boost_json.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_boost_locale.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_boost_log.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_boost_log_setup.m4</Path>
+            <Path fileType="data">/usr/share/aclocal/ax_boost_process.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_boost_program_options.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_boost_python.m4</Path>
+            <Path fileType="data">/usr/share/aclocal/ax_boost_random.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_boost_regex.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_boost_serialization.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_boost_signals.m4</Path>
@@ -78,6 +83,7 @@ In case of Autoconf, however, an exception has been made, because Autoconf is at
             <Path fileType="data">/usr/share/aclocal/ax_c_float_words_bigendian.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_c_long_long.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_c_referenceable_passed_va_list.m4</Path>
+            <Path fileType="data">/usr/share/aclocal/ax_c_restrict.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_c_var_func.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_cache_size.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_caolan_check_package.m4</Path>
@@ -179,6 +185,7 @@ In case of Autoconf, however, an exception has been made, because Autoconf is at
             <Path fileType="data">/usr/share/aclocal/ax_check_page_aligned_malloc.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_check_pathfind.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_check_pathname_style.m4</Path>
+            <Path fileType="data">/usr/share/aclocal/ax_check_pcre2.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_check_pgsql_db.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_check_posix_regcomp.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_check_posix_sysinfo.m4</Path>
@@ -376,6 +383,7 @@ In case of Autoconf, however, an exception has been made, because Autoconf is at
             <Path fileType="data">/usr/share/aclocal/ax_have_select.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_include_strcasecmp.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_install_files.m4</Path>
+            <Path fileType="data">/usr/share/aclocal/ax_int128.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_is_release.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_java_check_class.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_java_options.m4</Path>
@@ -424,6 +432,7 @@ In case of Autoconf, however, an exception has been made, because Autoconf is at
             <Path fileType="data">/usr/share/aclocal/ax_missing_prog.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_mpi.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_mpip.m4</Path>
+            <Path fileType="data">/usr/share/aclocal/ax_ms_cpprest.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_need_awk.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_normalize_path.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_not_enable_frame_pointer.m4</Path>
@@ -446,6 +455,7 @@ In case of Autoconf, however, an exception has been made, because Autoconf is at
             <Path fileType="data">/usr/share/aclocal/ax_pkg_mico.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_pkg_swig.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_prefix_config_h.m4</Path>
+            <Path fileType="data">/usr/share/aclocal/ax_prepend_flag.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_print_to_file.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_printf_size_t.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_prog_apache.m4</Path>
@@ -499,6 +509,7 @@ In case of Autoconf, however, an exception has been made, because Autoconf is at
             <Path fileType="data">/usr/share/aclocal/ax_prog_perl_version.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_prog_pgclient.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_prog_python_version.m4</Path>
+            <Path fileType="data">/usr/share/aclocal/ax_prog_robot.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_prog_ruby_version.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_prog_scala.m4</Path>
             <Path fileType="data">/usr/share/aclocal/ax_prog_scalac.m4</Path>
@@ -598,15 +609,19 @@ In case of Autoconf, however, an exception has been made, because Autoconf is at
             <Path fileType="doc">/usr/share/doc/autoconf-archive/COPYING.EXCEPTION</Path>
             <Path fileType="doc">/usr/share/doc/autoconf-archive/README</Path>
             <Path fileType="info">/usr/share/info/autoconf-archive.info</Path>
+            <Path fileType="info">/usr/share/info/autoconf-archive.info-1</Path>
+            <Path fileType="info">/usr/share/info/autoconf-archive.info-2</Path>
+            <Path fileType="info">/usr/share/info/autoconf-archive.info-3</Path>
+            <Path fileType="info">/usr/share/info/autoconf-archive.info-4</Path>
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2020-02-10</Date>
-            <Version>2019.01.06</Version>
+        <Update release="8">
+            <Date>2023-12-18</Date>
+            <Version>2023.02.20</Version>
             <Comment>Packaging update</Comment>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Full changelog can be found inside source [tarball](http://ftp.wayne.edu/gnu/autoconf-archive/autoconf-archive-2023.02.20.tar.xz)
- Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

- Rebuild `mate-desktop` against this package locally
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable