### PR TITLE
autofs: Update to 5.1.9

### DIFF
--- a/packages/a/autofs/abi_symbols
+++ b/packages/a/autofs/abi_symbols
@@ -15,9 +15,11 @@ automount:close_lookup
 automount:close_mount
 automount:close_mount_fds
 automount:close_parse
+automount:cmd_pipe_mutex_lock
+automount:cmd_pipe_mutex_unlock
+automount:cmd_pipe_name
 automount:confdir
 automount:count_mounts
-automount:destroy_logpri_fifo
 automount:do_expire
 automount:do_force_unlink
 automount:do_lookup_mount
@@ -30,9 +32,10 @@ automount:expire_cleanup
 automount:expire_proc_cleanup
 automount:expire_proc_direct
 automount:expire_proc_indirect
-automount:fifodir
+automount:finish_cmd_pipe_handler
 automount:global_negative_timeout
 automount:global_options
+automount:global_positive_timeout
 automount:global_selection_options
 automount:handle_mounts
 automount:handle_mounts_exit
@@ -62,6 +65,11 @@ automount:lookup_source_close_ioctlfd
 automount:lookup_source_mapent
 automount:lookup_source_valid_mapent
 automount:main
+automount:map_module_lock_cleanup
+automount:map_module_readlock
+automount:map_module_try_writelock
+automount:map_module_unlock
+automount:map_module_writelock
 automount:mapdir
 automount:master__create_buffer
 automount:master__delete_buffer
@@ -80,6 +88,7 @@ automount:master_char
 automount:master_done
 automount:master_find_map_source
 automount:master_find_mapent
+automount:master_find_mapent_by_devid
 automount:master_find_source_instance
 automount:master_free
 automount:master_free_autofs_point
@@ -116,7 +125,6 @@ automount:master_notify_submount
 automount:master_out
 automount:master_parse
 automount:master_parse_entry
-automount:master_partial_match_mapent
 automount:master_pop_buffer_state
 automount:master_push_buffer_state
 automount:master_read_master
@@ -129,8 +137,6 @@ automount:master_set_lineno
 automount:master_set_out
 automount:master_set_scan_buffer
 automount:master_show_mounts
-automount:master_source_current_signal
-automount:master_source_current_wait
 automount:master_source_lock_cleanup
 automount:master_source_readlock
 automount:master_source_unlock
@@ -144,7 +150,6 @@ automount:mount_autofs_offset
 automount:mp_mode
 automount:mrc
 automount:my_yyinput
-automount:nextstate
 automount:nfs_mount_uses_string_options
 automount:open_fd
 automount:open_fd_mode
@@ -184,6 +189,7 @@ automount:st_remove_tasks
 automount:st_start_handler
 automount:st_wait_state
 automount:st_wait_task
+automount:start_cmd_pipe_handler
 automount:stderr
 automount:stdin
 automount:stdout
@@ -298,6 +304,8 @@ libautofs.so:defaults_get_mount_nfs_default_proto
 libautofs.so:defaults_get_mount_verbose
 libautofs.so:defaults_get_mount_wait
 libautofs.so:defaults_get_negative_timeout
+libautofs.so:defaults_get_open_file_limit
+libautofs.so:defaults_get_positive_timeout
 libautofs.so:defaults_get_schema
 libautofs.so:defaults_get_searchdns
 libautofs.so:defaults_get_sss_master_map_wait
@@ -329,10 +337,13 @@ libautofs.so:get_exp_timeout
 libautofs.so:get_ioctl_ops
 libautofs.so:get_kver_major
 libautofs.so:get_kver_minor
+libautofs.so:get_log_debug_level
 libautofs.so:get_mnt_list
 libautofs.so:get_network_proximity
 libautofs.so:get_proximity
 libautofs.so:get_selector
+libautofs.so:have_log_debug
+libautofs.so:have_log_verbose
 libautofs.so:in_network
 libautofs.so:init_ioctl_ctl
 libautofs.so:is_mounted
@@ -363,6 +374,7 @@ libautofs.so:make_mnt_name_string
 libautofs.so:make_options_string
 libautofs.so:match_cached_key
 libautofs.so:merge_options
+libautofs.so:mnt_find_submount_by_devid
 libautofs.so:mnts_add_amdmount
 libautofs.so:mnts_add_mount
 libautofs.so:mnts_add_submount
@@ -422,6 +434,7 @@ libautofs.so:nss_set_out
 libautofs.so:nss_text
 libautofs.so:nss_wrap
 libautofs.so:nsswitch_parse
+libautofs.so:open_ioctlfd
 libautofs.so:open_log
 libautofs.so:parse_map_type_info
 libautofs.so:query_kproto_ver
@@ -457,6 +470,7 @@ libautofs.so:set_log_verbose_ap
 libautofs.so:set_tsd_user_vars
 libautofs.so:skipspace
 libautofs.so:span_space
+libautofs.so:starts_with_null_opt
 libautofs.so:strmcmp
 libautofs.so:t_direct
 libautofs.so:t_indirect
@@ -491,6 +505,7 @@ lookup_file.so:lookup_read_map
 lookup_file.so:lookup_read_master
 lookup_file.so:lookup_reinit
 lookup_file.so:lookup_version
+lookup_hosts.so:entries_cleanup
 lookup_hosts.so:hostent_mutex
 lookup_hosts.so:lookup_done
 lookup_hosts.so:lookup_init
@@ -502,6 +517,9 @@ lookup_hosts.so:lookup_version
 lookup_ldap.so:__unbind_ldap_connection
 lookup_ldap.so:_krb5_princ_realm
 lookup_ldap.so:authtype_requires_creds
+lookup_ldap.so:autofs_ldap_sasl_defaults
+lookup_ldap.so:autofs_ldap_sasl_freedefs
+lookup_ldap.so:autofs_ldap_sasl_interact
 lookup_ldap.so:autofs_sasl_bind
 lookup_ldap.so:autofs_sasl_client_init
 lookup_ldap.so:autofs_sasl_dispose
@@ -510,6 +528,7 @@ lookup_ldap.so:autofs_sasl_unbind
 lookup_ldap.so:base64_decode
 lookup_ldap.so:base64_encode
 lookup_ldap.so:bind_ldap_simple
+lookup_ldap.so:defaults_mutex
 lookup_ldap.so:do_sasl_bind
 lookup_ldap.so:do_sasl_extern
 lookup_ldap.so:free_dclist

--- a/packages/a/autofs/abi_used_symbols
+++ b/packages/a/autofs/abi_used_symbols
@@ -2,7 +2,9 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_tolower_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoul
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__memmove_chk
@@ -34,7 +36,6 @@ libc.so.6:chmod
 libc.so.6:clearerr
 libc.so.6:clock_gettime
 libc.so.6:close
-libc.so.6:closedir
 libc.so.6:closelog
 libc.so.6:connect
 libc.so.6:dirname
@@ -70,7 +71,9 @@ libc.so.6:getaddrinfo
 libc.so.6:getc
 libc.so.6:getenv
 libc.so.6:geteuid
+libc.so.6:getgid
 libc.so.6:getgrgid_r
+libc.so.6:getgrouplist
 libc.so.6:gethostent
 libc.so.6:gethostname
 libc.so.6:getifaddrs
@@ -81,11 +84,13 @@ libc.so.6:getpgrp
 libc.so.6:getpid
 libc.so.6:getprotobynumber
 libc.so.6:getpwnam
+libc.so.6:getpwuid
 libc.so.6:getpwuid_r
 libc.so.6:getrlimit64
 libc.so.6:getrpcbyname
 libc.so.6:getservbyname
 libc.so.6:getsockopt
+libc.so.6:getuid
 libc.so.6:in6addr_any
 libc.so.6:inet_ntop
 libc.so.6:innetgr
@@ -106,11 +111,11 @@ libc.so.6:mkfifo
 libc.so.6:mount
 libc.so.6:nanosleep
 libc.so.6:open64
-libc.so.6:opendir
 libc.so.6:openlog
 libc.so.6:pipe
 libc.so.6:pipe2
 libc.so.6:poll
+libc.so.6:ppoll
 libc.so.6:pthread_attr_destroy
 libc.so.6:pthread_attr_init
 libc.so.6:pthread_attr_setdetachstate
@@ -152,7 +157,6 @@ libc.so.6:raise
 libc.so.6:rand
 libc.so.6:random
 libc.so.6:read
-libc.so.6:readdir64
 libc.so.6:readlink
 libc.so.6:realloc
 libc.so.6:res_query
@@ -186,6 +190,7 @@ libc.so.6:strcat
 libc.so.6:strchr
 libc.so.6:strcmp
 libc.so.6:strcpy
+libc.so.6:strcspn
 libc.so.6:strdup
 libc.so.6:strerror
 libc.so.6:strerror_r
@@ -202,8 +207,6 @@ libc.so.6:strspn
 libc.so.6:strstr
 libc.so.6:strtok
 libc.so.6:strtok_r
-libc.so.6:strtol
-libc.so.6:strtoul
 libc.so.6:symlink
 libc.so.6:sysconf
 libc.so.6:time
@@ -223,6 +226,7 @@ libkrb5.so.3:krb5_cc_destroy
 libkrb5.so.3:krb5_cc_get_principal
 libkrb5.so.3:krb5_cc_initialize
 libkrb5.so.3:krb5_cc_resolve
+libkrb5.so.3:krb5_cc_retrieve_cred
 libkrb5.so.3:krb5_cc_store_cred
 libkrb5.so.3:krb5_free_context
 libkrb5.so.3:krb5_free_cred_contents
@@ -234,7 +238,10 @@ libkrb5.so.3:krb5_parse_name
 libkrb5.so.3:krb5_sname_to_principal
 libkrb5.so.3:krb5_unparse_name
 liblber-2.4.so.2:ber_bvfree
+liblber-2.4.so.2:ber_memalloc
 liblber-2.4.so.2:ber_memfree
+liblber-2.4.so.2:ber_set_option
+liblber-2.4.so.2:ber_strdup
 libldap-2.4.so.2:ldap_control_free
 libldap-2.4.so.2:ldap_controls_free
 libldap-2.4.so.2:ldap_count_values
@@ -259,6 +266,7 @@ libldap-2.4.so.2:ldap_parse_result
 libldap-2.4.so.2:ldap_parse_sasl_bind_result
 libldap-2.4.so.2:ldap_result
 libldap-2.4.so.2:ldap_sasl_bind
+libldap-2.4.so.2:ldap_sasl_interactive_bind
 libldap-2.4.so.2:ldap_sasl_interactive_bind_s
 libldap-2.4.so.2:ldap_search_ext_s
 libldap-2.4.so.2:ldap_search_s
@@ -275,8 +283,8 @@ libsasl2.so.3:sasl_client_new
 libsasl2.so.3:sasl_client_start
 libsasl2.so.3:sasl_client_step
 libsasl2.so.3:sasl_dispose
-libsasl2.so.3:sasl_done
 libsasl2.so.3:sasl_errdetail
+libsasl2.so.3:sasl_getprop
 libsasl2.so.3:sasl_set_mutex
 libsystemd.so.0:sd_notify
 libtirpc.so.3:authunix_create_default

--- a/packages/a/autofs/package.yml
+++ b/packages/a/autofs/package.yml
@@ -1,8 +1,9 @@
 name       : autofs
-version    : 5.1.8
-release    : 10
+version    : 5.1.9
+release    : 11
 source     :
-    - https://mirrors.edge.kernel.org/pub/linux/daemons/autofs/v5/autofs-5.1.8.tar.xz : b33d1059855664b20eeda26f3e28ff518fb0c3d58f565570af2ae569dc73c0fd
+    - https://mirrors.edge.kernel.org/pub/linux/daemons/autofs/v5/autofs-5.1.9.tar.xz : 87e6af6a03794b9462ea519781e50e7d23b5f7c92cd59e1142c85d2493b3c24b
+homepage   : https://git.kernel.org/pub/scm/linux/storage/autofs/autofs.git/
 license    : GPL-2.0-or-later
 component  : system.utils
 summary    : Kernel based automounter

--- a/packages/a/autofs/pspec_x86_64.xml
+++ b/packages/a/autofs/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>autofs</Name>
+        <Homepage>https://git.kernel.org/pub/scm/linux/storage/autofs/autofs.git/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">Kernel based automounter</Summary>
         <Description xml:lang="en">Kernel based automounter
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>autofs</Name>
@@ -59,12 +60,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2023-08-22</Date>
-            <Version>5.1.8</Version>
+        <Update release="11">
+            <Date>2023-11-27</Date>
+            <Version>5.1.9</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Full changelog can be found [here](https://git.kernel.org/pub/scm/linux/storage/autofs/autofs.git/plain/CHANGELOG?h=release_5_1_9&id=8c348df3dc4509e87dff6615ba7d295ca28fab63)
- Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

- Set up simple autofs mount
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable