### PR TITLE
archivemount: homepage inclusion

### DIFF
--- a/packages/a/archivemount/abi_used_symbols
+++ b/packages/a/archivemount/abi_used_symbols
@@ -113,7 +113,6 @@ libc.so.6:strcmp
 libc.so.6:strdup
 libc.so.6:strerror
 libc.so.6:strlen
-libc.so.6:strncmp
 libc.so.6:strncpy
 libc.so.6:strrchr
 libc.so.6:tcgetattr

--- a/packages/a/archivemount/package.yml
+++ b/packages/a/archivemount/package.yml
@@ -1,8 +1,9 @@
 name       : archivemount
 version    : 0.9.1
-release    : 4
+release    : 5
 source     :
-    - https://www.cybernoia.de/software/archivemount/archivemount-0.9.1.tar.gz : c529b981cacb19541b48ddafdafb2ede47a40fcaf16c677c1e2cd198b159c5b3
+    - http://mirror.sobukus.de/files/grimoire/archive/archivemount-0.9.1.tar.gz : c529b981cacb19541b48ddafdafb2ede47a40fcaf16c677c1e2cd198b159c5b3
+homepage   : https://www.cybernoia.de/software/archivemount.html
 license    : GPL-2.0-or-later
 component  : system.utils
 summary    : FUSE based filesystem for mounting compressed archives

--- a/packages/a/archivemount/pspec_x86_64.xml
+++ b/packages/a/archivemount/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>archivemount</Name>
+        <Homepage>https://www.cybernoia.de/software/archivemount.html</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">FUSE based filesystem for mounting compressed archives</Summary>
         <Description xml:lang="en">FUSE based filesystem for mounting compressed archives
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>archivemount</Name>
@@ -24,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2022-03-30</Date>
+        <Update release="5">
+            <Date>2023-11-27</Date>
             <Version>0.9.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Change source to working one
- Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable

**Comment**

Please put this tarball [archivemount-0.9.1.tar.gz](https://github.com/getsolus/packages/files/13473834/archivemount-0.9.1.tar.gz) in source repo, the [official](https://www.cybernoia.de/software/archivemount/archivemount-0.9.1.tar.gz) one doesn't work with `go-task`.