### PR TITLE
bibtool: Update to 2.68

### DIFF
--- a/packages/b/bibtool/abi_libs
+++ b/packages/b/bibtool/abi_libs
@@ -1,0 +1,1 @@
+bibtool

--- a/packages/b/bibtool/abi_symbols
+++ b/packages/b/bibtool/abi_symbols
@@ -1,0 +1,15 @@
+bibtool:error
+bibtool:re_compile_fastmap
+bibtool:re_compile_pattern
+bibtool:re_match
+bibtool:re_match_2
+bibtool:re_max_failures
+bibtool:re_search
+bibtool:re_search_2
+bibtool:re_set_registers
+bibtool:re_set_syntax
+bibtool:re_syntax_options
+bibtool:regcomp
+bibtool:regerror
+bibtool:regexec
+bibtool:regfree

--- a/packages/b/bibtool/abi_used_symbols
+++ b/packages/b/bibtool/abi_used_symbols
@@ -1,7 +1,7 @@
-libc.so.6:_IO_getc
 libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_tolower_loc
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
@@ -16,11 +16,14 @@ libc.so.6:fputc
 libc.so.6:fputs
 libc.so.6:free
 libc.so.6:fwrite
+libc.so.6:getc
 libc.so.6:getenv
 libc.so.6:localtime
 libc.so.6:malloc
 libc.so.6:memcmp
 libc.so.6:memcpy
+libc.so.6:memmove
+libc.so.6:memset
 libc.so.6:realloc
 libc.so.6:stderr
 libc.so.6:stdin
@@ -33,5 +36,4 @@ libc.so.6:strftime
 libc.so.6:strlen
 libc.so.6:strncpy
 libc.so.6:strrchr
-libc.so.6:strtol
 libc.so.6:time

--- a/packages/b/bibtool/package.yml
+++ b/packages/b/bibtool/package.yml
@@ -1,9 +1,10 @@
 name       : bibtool
-version    : 2.67
-release    : 1
+version    : '2.68'
+release    : 2
 source     :
-    - https://github.com/ge-ne/bibtool/releases/download/BibTool_2_67/BibTool-2.67.tar.gz : 5b6c4160975a926356e8e59d0e5c01ac2a7be337ecace2494918fc2a46d9d784
-license    : GPL-2.0
+    - https://github.com/ge-ne/bibtool/releases/download/BibTool_2_68/BibTool-2.68.tar.gz : e1964d199b0726f431f9a1dc4ff7257bb3dba879b9fa221803e0aa7840dee0e0
+homepage   : https://www.gerd-neugebauer.de/software/TeX/BibTool/
+license    : GPL-2.0-or-later
 component  : editor
 summary    : A tool for manipulating BibTeX databases
 description: |
@@ -14,7 +15,7 @@ description: |
     manipulation of BibTeX files which goes beyond the possibilities and
     intentions of BibTeX.
 setup      : |
-    %configure
+    ./configure $(sed 's|--runstatedir=/run||g' <<< "%CONFOPTS%")
 build      : |
     %make
 install    : |

--- a/packages/b/bibtool/pspec_x86_64.xml
+++ b/packages/b/bibtool/pspec_x86_64.xml
@@ -1,11 +1,12 @@
 <PISI>
     <Source>
         <Name>bibtool</Name>
+        <Homepage>https://www.gerd-neugebauer.de/software/TeX/BibTool/</Homepage>
         <Packager>
-            <Name>Bryan T. Meyers</Name>
-            <Email>bmeyers@datadrake.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
-        <License>GPL-2.0</License>
+        <License>GPL-2.0-or-later</License>
         <PartOf>editor</PartOf>
         <Summary xml:lang="en">A tool for manipulating BibTeX databases</Summary>
         <Description xml:lang="en">BibTeX provides an easy to use means to integrate citations and
@@ -15,7 +16,7 @@ The program BibTool is intended to fill this gap. BibTool allows the
 manipulation of BibTeX files which goes beyond the possibilities and
 intentions of BibTeX.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://solus-project.com/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>bibtool</Name>
@@ -29,7 +30,7 @@ intentions of BibTeX.
 </Description>
         <PartOf>editor</PartOf>
         <Files>
-            <Path fileType="executable">/usr/bin</Path>
+            <Path fileType="executable">/usr/bin/bibtool</Path>
             <Path fileType="library">/usr/lib64/BibTool/biblatex.rsc</Path>
             <Path fileType="library">/usr/lib64/BibTool/braces.rsc</Path>
             <Path fileType="library">/usr/lib64/BibTool/check_y.rsc</Path>
@@ -46,12 +47,12 @@ intentions of BibTeX.
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2017-01-24</Date>
-            <Version>2.67</Version>
+        <Update release="2">
+            <Date>2023-12-01</Date>
+            <Version>2.68</Version>
             <Comment>Packaging update</Comment>
-            <Name>Bryan T. Meyers</Name>
-            <Email>bmeyers@datadrake.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Handling of extracting by aux file improved.
- Record extended by attribute `lineno`. This attribute carries the line number of the initiating @.
- The format of the error messages has been slightly streamlined. Double spaces are avoided; two colons in one message are avoided.
- The format of the messages of `check_rule` include file and line number.
- Warning for double fields added.
- The empty output file is used to signal that the output should be suppressed.
- The resources `check.warning.rule` and `check.error.rule` have been introduced to allow semantic checks to be classified as warning or error.
- The behaviour of the resource `check.double` has been generalized. The requirement that double entries to be adjacent has been dropped. This has the impact that the processing is slightly slower.
- New resource file `unique.field` introduced. With this resource it is possible to specify additional unique constraints for fields. If different records have the same value for one of those fields then a warning is issued.
- Static library renamed from `libbib.a` to `libbibtool.a`.
- Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

- Open `.bib` file
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable