### PR TITLE
blosc: homepage inclusion

### DIFF
--- a/packages/b/blosc/package.yml
+++ b/packages/b/blosc/package.yml
@@ -1,11 +1,12 @@
 name       : blosc
 version    : 1.21.1
-release    : 4
+release    : 5
 source     :
     - https://github.com/Blosc/c-blosc/archive/refs/tags/v1.21.1.tar.gz : f387149eab24efa01c308e4cba0f59f64ccae57292ec9c794002232f7903b55b
+homepage   : https://www.blosc.org/
 license    :
-    - BSD-2-CLAUSE
-    - BSD-3-CLAUSE
+    - BSD-2-Clause
+    - BSD-3-Clause
     - MIT
     - Zlib
 component  : programming.library

--- a/packages/b/blosc/pspec_x86_64.xml
+++ b/packages/b/blosc/pspec_x86_64.xml
@@ -1,19 +1,20 @@
 <PISI>
     <Source>
         <Name>blosc</Name>
+        <Homepage>https://www.blosc.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
-        <License>BSD-2-CLAUSE</License>
-        <License>BSD-3-CLAUSE</License>
+        <License>BSD-2-Clause</License>
+        <License>BSD-3-Clause</License>
         <License>MIT</License>
         <License>Zlib</License>
         <PartOf>programming.library</PartOf>
         <Summary xml:lang="en">A blocking, shuffling and loss-less compression library that can be faster than `memcpy()`</Summary>
         <Description xml:lang="en">Blosc is a high performance compressor optimized for binary data. It has been designed to transmit data to the processor cache faster than the traditional, non-compressed, direct memory fetch approach via a memcpy() OS call.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>blosc</Name>
@@ -33,7 +34,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="4">blosc</Dependency>
+            <Dependency release="5">blosc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/blosc-export.h</Path>
@@ -43,12 +44,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2022-03-28</Date>
+        <Update release="5">
+            <Date>2023-12-01</Date>
             <Version>1.21.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable

**Comment**

There is new version of this at [1.21.5](https://github.com/Blosc/c-blosc/releases/tag/v1.21.5). another sidenote `openvdb` (a revdep of this package) also has new release at [11.0.0](https://github.com/AcademySoftwareFoundation/openvdb/releases/tag/v11.0.0) but it removes `python2` support. Those touch many things, it scares me. Cheers!
