### PR TITLE
botan2: homepage inclusion

### DIFF
--- a/packages/b/botan2/abi_used_symbols
+++ b/packages/b/botan2/abi_used_symbols
@@ -42,9 +42,12 @@ libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtoul
+libc.so.6:__isoc23_strtoull
 libc.so.6:__libc_single_threaded
 libc.so.6:__libc_start_main
 libc.so.6:__longjmp_chk
+libc.so.6:__memcpy_chk
 libc.so.6:__sigsetjmp
 libc.so.6:__stack_chk_fail
 libc.so.6:accept
@@ -109,8 +112,6 @@ libc.so.6:strcmp
 libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strtod
-libc.so.6:strtoul
-libc.so.6:strtoull
 libc.so.6:sysconf
 libc.so.6:tcgetattr
 libc.so.6:tcsetattr
@@ -130,7 +131,6 @@ libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE16find_last
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE17find_first_not_ofEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEcm
-libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7compareEPKc
 libstdc++.so.6:_ZNKSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE3strEv
 libstdc++.so.6:_ZNKSt8__detail20_Prime_rehash_policy11_M_next_bktEm
 libstdc++.so.6:_ZNKSt8__detail20_Prime_rehash_policy14_M_need_rehashEmmm
@@ -165,7 +165,6 @@ libstdc++.so.6:_ZNSt13basic_filebufIcSt11char_traitsIcEED1Ev
 libstdc++.so.6:_ZNSt13runtime_errorC2EPKc
 libstdc++.so.6:_ZNSt13runtime_errorC2ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
 libstdc++.so.6:_ZNSt13runtime_errorD2Ev
-libstdc++.so.6:_ZNSt14basic_ifstreamIcSt11char_traitsIcEEC1ERKNSt7__cxx1112basic_stringIcS1_SaIcEEESt13_Ios_Openmode
 libstdc++.so.6:_ZNSt14basic_ifstreamIcSt11char_traitsIcEED1Ev
 libstdc++.so.6:_ZNSt14basic_ofstreamIcSt11char_traitsIcEED1Ev
 libstdc++.so.6:_ZNSt15__exception_ptr13exception_ptr10_M_releaseEv
@@ -191,6 +190,7 @@ libstdc++.so.6:_ZNSt6thread15_M_start_threadESt10unique_ptrINS_6_StateESt14defau
 libstdc++.so.6:_ZNSt6thread20hardware_concurrencyEv
 libstdc++.so.6:_ZNSt6thread4joinEv
 libstdc++.so.6:_ZNSt6thread6_StateD2Ev
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_disposeEv
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructEmc
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE14_M_replace_auxEmmmc
@@ -204,6 +204,7 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_appendEP
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_assignERKS4_
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createERmm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_mutateEmmPKcm
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9push_backEc
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1EOS4_
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE7_M_syncEPcmm
@@ -212,10 +213,9 @@ libstdc++.so.6:_ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEC1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEED1Ev
+libstdc++.so.6:_ZNSt7__cxx117collateIcE2idE
 libstdc++.so.6:_ZNSt8__detail15_List_node_base7_M_hookEPS0_
 libstdc++.so.6:_ZNSt8__detail15_List_node_base9_M_unhookEv
-libstdc++.so.6:_ZNSt8ios_base4InitC1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitD1Ev
 libstdc++.so.6:_ZNSt8ios_baseC2Ev
 libstdc++.so.6:_ZNSt8ios_baseD2Ev
 libstdc++.so.6:_ZNSt9bad_allocD1Ev
@@ -242,6 +242,7 @@ libstdc++.so.6:_ZSt20__throw_future_errori
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt20__throw_out_of_rangePKc
 libstdc++.so.6:_ZSt20__throw_system_errori
+libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZSt24__throw_invalid_argumentPKc
 libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
 libstdc++.so.6:_ZSt25__throw_bad_function_callv
@@ -253,8 +254,6 @@ libstdc++.so.6:_ZSt4cerr
 libstdc++.so.6:_ZSt4cout
 libstdc++.so.6:_ZSt7getlineIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EES4_
 libstdc++.so.6:_ZSt9terminatev
-libstdc++.so.6:_ZSt9use_facetINSt7__cxx117collateIcEEERKT_RKSt6locale
-libstdc++.so.6:_ZSt9use_facetISt5ctypeIcEERKT_RKSt6locale
 libstdc++.so.6:_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
 libstdc++.so.6:_ZStrsIcSt11char_traitsIcEERSt13basic_istreamIT_T0_ES6_RS3_
 libstdc++.so.6:_ZStrsIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EE

--- a/packages/b/botan2/package.yml
+++ b/packages/b/botan2/package.yml
@@ -1,8 +1,9 @@
 name       : botan2
 version    : 2.19.3
-release    : 19
+release    : 20
 source     :
     - https://github.com/randombit/botan/archive/refs/tags/2.19.3.tar.gz : 8f568bf74c2e476d92ac8a1cfc2ba8407ec038fe9458bd0a11e7da827a9b8199
+homepage   : https://botan.randombit.net/
 license    : BSD-2-Clause
 component  : programming.library
 summary    : Crypto and TLS library for C++11

--- a/packages/b/botan2/pspec_x86_64.xml
+++ b/packages/b/botan2/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>botan2</Name>
+        <Homepage>https://botan.randombit.net/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>programming.library</PartOf>
         <Summary xml:lang="en">Crypto and TLS library for C++11</Summary>
         <Description xml:lang="en">Botan&apos;s goal is to be the best option for cryptography in C++ by offering the tools necessary to implement a range of practical systems, such as TLS protocol, X.509 certificates, modern AEAD ciphers, PKCS#11 and TPM hardware support, password hashing, and post quantum crypto schemes. A Python binding is included.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>botan2</Name>
@@ -32,7 +33,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="19">botan2</Dependency>
+            <Dependency release="20">botan2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/botan-2/botan/adler32.h</Path>
@@ -348,12 +349,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2022-12-14</Date>
+        <Update release="20">
+            <Date>2023-12-01</Date>
             <Version>2.19.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>ems1000.syahrin@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable

**Comment**

I am sure the staffs already aware that [`botan3`](https://botan.randombit.net/releases/Botan-3.2.0.tar.xz) is available. I also want to note that of all revdeps of this packages (`corectrl`, `keepassxc`, and `thunderbird`), only `keepassxc`  supports botan3. Cheers!