### PR TITLE
ci/package_checks: fix dependency order for `pkgconfig32`

### DIFF
--- a/common/CI/package_checks.py
+++ b/common/CI/package_checks.py
@@ -272,10 +272,13 @@ class PackageDependenciesOrder(PullRequestCheck):
         if isinstance(pkg, dict):
             pkg = list(pkg.keys())[0]
 
-        if pkg.startswith('pkgconfig('):
-            return 0, pkg.removeprefix('pkgconfig(')
+        if pkg.startswith('pkgconfig32('):
+            return 0, pkg.removeprefix('pkgconfig32(')
 
-        return 1, pkg
+        if pkg.startswith('pkgconfig('):
+            return 1, pkg.removeprefix('pkgconfig(')
+
+        return 2, pkg
 
 
 class PackageDirectory(PullRequestCheck):


### PR DESCRIPTION
**Summary**

Fix `pkgconfig32` entries not being sorted in a separate section by sorting them *before* `pkgconfig` (as that is currently most common).

Resolves #921

**Test Plan**

- Run checks against `packages/a/avahi/package.yml`, see no dependency order violation.
- Run checks against `packages/c/cups/package.yml`, see dependency order violation (it has `pkgconfig` before `pkgconfig32`).

**Checklist**

- [x] ~~Package was built and tested against unstable~~ n/a
