### PR TITLE
ci/package_checks: add check for package version being a string

### DIFF
--- a/common/CI/package_checks.py
+++ b/common/CI/package_checks.py
@@ -295,6 +295,22 @@ class PackageDirectory(PullRequestCheck):
         return path.split('/') == exp
 
 
+class PackageVersion(PullRequestCheck):
+    _error = 'Package version is not a string'
+    _level = Level.ERROR
+
+    def run(self) -> List[Result]:
+        return [Result(message=self._error, level=self._level,
+                       file=path, line=self.file_line(path, r'^version\s*:'),)
+                for path in self.package_files
+                if not self._check_version(path)]
+
+    def _check_version(self, path: str) -> bool:
+        version = self.load_package_yml(path)['version']
+
+        return isinstance(version, str)
+
+
 class Patch(PullRequestCheck):
     _regex = r'patch -p1 <'
     _error = 'Uses `patch <`, use `patch -i` instead'
@@ -485,6 +501,7 @@ class Checker:
         PackageBumped,
         PackageDependenciesOrder,
         PackageDirectory,
+        PackageVersion,
         Patch,
         Pspec,
         SPDXLicense,


### PR DESCRIPTION
**Summary**

Ensure that package versions are always strings and not numbers, as might happen with versions like '1.2' and '20230102'.

**Test Plan**

Manually run check against repo:

```shell
$ ./common/CI/package_checks.py **/package.yml
Checking files: <snip>
Found 234 result(s), 234 error(s)
::error file=packages/a/a2jmidid/package.yml,line=2::Package version is not a string
::error file=packages/a/accounts-qml-module/package.yml,line=2::Package version is not a string
<etc>
```

**Checklist**

- [x] ~~Package was built and tested against unstable~~ n/a
