### PR TITLE
budgie-desktop-branding: Swap to Calamares

### DIFF
--- a/packages/b/budgie-desktop-branding/package.yml
+++ b/packages/b/budgie-desktop-branding/package.yml
@@ -1,8 +1,8 @@
 name       : budgie-desktop-branding
 version    : '22.1'
-release    : 69
+release    : 70
 source     :
-    - https://github.com/getsolus/budgie-desktop-branding/releases/download/v22.1/budgie-desktop-branding-v22.1.tar.xz : ce9b1dde4c51c7f4644b0cfd75fb16996cb00aeb40b1dbecc2ceb39e094cc40c
+    - git|https://github.com/getsolus/budgie-desktop-branding.git : 4ff6b914082b8e6cff7ff12fee43585b70982487
 homepage   : https://github.com/getsolus/budgie-desktop-branding
 license    : GPL-2.0-only
 summary    :

--- a/packages/b/budgie-desktop-branding/pspec_x86_64.xml
+++ b/packages/b/budgie-desktop-branding/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>budgie-desktop-branding</Name>
         <Homepage>https://github.com/getsolus/budgie-desktop-branding</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>desktop.budgie</PartOf>
@@ -36,7 +36,7 @@
         <Description xml:lang="en">Budgie LiveCD-specific Configuration</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="69">budgie-desktop-branding</Dependency>
+            <Dependency releaseFrom="70">budgie-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/glib-2.0/schemas/50_budgie_settings.gschema.override</Path>
@@ -44,12 +44,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="69">
-            <Date>2023-10-27</Date>
+        <Update release="70">
+            <Date>2023-12-03</Date>
             <Version>22.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Switch installer to Calamares in the livecd panel

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See Calamares icon on the livecd panel

**Checklist**

- [ ] Package was built and tested against unstable
