### PR TITLE
xfce4-panel: Update defaults patch

### DIFF
--- a/packages/x/xfce4-panel/files/0001-Use-Solus-defaults.patch
+++ b/packages/x/xfce4-panel/files/0001-Use-Solus-defaults.patch
@@ -1,18 +1,18 @@
-From 3fb95666ca5d2d39a479916a259f0e6ec4de3ef7 Mon Sep 17 00:00:00 2001
+From a43f73d53d6090ec8d546721c51083674f55a0e9 Mon Sep 17 00:00:00 2001
 From: Evan Maddock <maddock.evan@vivaldi.net>
 Date: Mon, 27 Nov 2023 15:12:54 -0500
 Subject: [PATCH] Use Solus defaults
 
 Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
 ---
- migrate/default.xml.in | 102 +++++++++++------------------------------
- 1 file changed, 28 insertions(+), 74 deletions(-)
+ migrate/default.xml.in | 98 ++++++++++++++++++------------------------
+ 1 file changed, 43 insertions(+), 55 deletions(-)
 
 diff --git a/migrate/default.xml.in b/migrate/default.xml.in
-index 46344203..b57703aa 100644
+index 46344203..38050911 100644
 --- a/migrate/default.xml.in
 +++ b/migrate/default.xml.in
-@@ -4,102 +4,56 @@
+@@ -4,14 +4,13 @@
    <property name="configver" type="int" value="@XFCE4_PANEL_CONFIG_VERSION@"/>
    <property name="panels" type="array">
      <value type="int" value="1"/>
@@ -26,22 +26,15 @@ index 46344203..b57703aa 100644
 +      <property name="length" type="double" value="100"/>
        <property name="position-locked" type="bool" value="true"/>
 -      <property name="icon-size" type="uint" value="16"/>
-       <property name="size" type="uint" value="26"/>
+-      <property name="size" type="uint" value="26"/>
++      <property name="size" type="uint" value="36"/>
        <property name="plugin-ids" type="array">
--        <value type="int" value="1"/>
--        <value type="int" value="2"/>
--        <value type="int" value="3"/>
--        <value type="int" value="4"/>
--        <value type="int" value="5"/>
--        <value type="int" value="6"/>
-         <value type="int" value="7"/>
--        <value type="int" value="8"/>
--        <value type="int" value="9"/>
--        <value type="int" value="10"/>
--        <value type="int" value="11"/>
--        <value type="int" value="12"/>
--        <value type="int" value="13"/>
--        <value type="int" value="14"/>
+         <value type="int" value="1"/>
+         <value type="int" value="2"/>
+@@ -27,79 +26,68 @@
+         <value type="int" value="12"/>
+         <value type="int" value="13"/>
+         <value type="int" value="14"/>
 -      </property>
 -    </property>
 -    <property name="panel-2" type="empty">
@@ -51,22 +44,14 @@ index 46344203..b57703aa 100644
 -      <property name="position-locked" type="bool" value="true"/>
 -      <property name="size" type="uint" value="48"/>
 -      <property name="plugin-ids" type="array">
--        <value type="int" value="15"/>
--        <value type="int" value="16"/>
--        <value type="int" value="17"/>
--        <value type="int" value="18"/>
+         <value type="int" value="15"/>
+         <value type="int" value="16"/>
+         <value type="int" value="17"/>
+         <value type="int" value="18"/>
 -        <value type="int" value="19"/>
-         <value type="int" value="20"/>
-         <value type="int" value="21"/>
-         <value type="int" value="22"/>
-+        <value type="int" value="23"/>
-+        <value type="int" value="24"/>
-+        <value type="int" value="25"/>
-+        <value type="int" value="26"/>
-+        <value type="int" value="27"/>
-+        <value type="int" value="28"/>
-+        <value type="int" value="29"/>
-+        <value type="int" value="30"/>
+-        <value type="int" value="20"/>
+-        <value type="int" value="21"/>
+-        <value type="int" value="22"/>
        </property>
      </property>
    </property>
@@ -76,71 +61,93 @@ index 46344203..b57703aa 100644
 -      <property name="grouping" type="uint" value="1"/>
 -    </property>
 -    <property name="plugin-3" type="string" value="separator">
-+    <property name="plugin-7" type="string" value="whiskermenu"/>
-+    <property name="plugin-20" type="string" value="tasklist"/>
-+    <property name="plugin-21" type="string" value="separator">
-       <property name="expand" type="bool" value="true"/>
-       <property name="style" type="uint" value="0"/>
-     </property>
+-      <property name="expand" type="bool" value="true"/>
+-      <property name="style" type="uint" value="0"/>
+-    </property>
 -    <property name="plugin-4" type="string" value="pager"/>
 -    <property name="plugin-5" type="string" value="separator">
-+    <property name="plugin-22" type="string" value="pager"/>
-+    <property name="plugin-23" type="string" value="separator">
-         <property name="style" type="uint" value="0"/>
-+        <property name="expand" type="bool" value="false"/>
-     </property>
+-        <property name="style" type="uint" value="0"/>
+-    </property>
 -    <property name="plugin-6" type="string" value="systray">
 -        <property name="square-icons" type="bool" value="true"/>
-+    <property name="plugin-24" type="string" value="systray">
-+      <property name="known-legacy-items" type="array">
-+        <value type="string" value="ethernet network connection “wired connection 1” active"/>
-+      </property>
-     </property>
+-    </property>
 -    <property name="plugin-8" type="string" value="pulseaudio">
-+    <property name="plugin-25" type="string" value="pulseaudio">
-       <property name="enable-keyboard-shortcuts" type="bool" value="true"/>
+-      <property name="enable-keyboard-shortcuts" type="bool" value="true"/>
 -      <property name="show-notifications" type="bool" value="true"/>
 -    </property>
 -    <property name="plugin-9" type="string" value="power-manager-plugin"/>
 -    <property name="plugin-10" type="string" value="notification-plugin"/>
 -    <property name="plugin-11" type="string" value="separator">
--      <property name="style" type="uint" value="0"/>
-+      <property name="known-players" type="string" value="Rhythmbox"/>
++    <property name="plugin-1" type="string" value="whiskermenu"/>
++    <property name="plugin-2" type="string" value="separator">
+       <property name="style" type="uint" value="0"/>
      </property>
 -    <property name="plugin-12" type="string" value="clock"/>
 -    <property name="plugin-13" type="string" value="separator">
-+    <property name="plugin-26" type="string" value="power-manager-plugin"/>
-+    <property name="plugin-27" type="string" value="notification-plugin"/>
-+    <property name="plugin-28" type="string" value="clock"/>
-+    <property name="plugin-29" type="string" value="separator">
-       <property name="style" type="uint" value="0"/>
-     </property>
+-      <property name="style" type="uint" value="0"/>
+-    </property>
 -    <property name="plugin-14" type="string" value="actions"/>
 -    <property name="plugin-15" type="string" value="showdesktop"/>
 -    <property name="plugin-16" type="string" value="separator"/>
 -    <property name="plugin-17" type="string" value="launcher">
--      <property name="items" type="array">
++    <property name="plugin-3" type="string" value="launcher">
+       <property name="items" type="array">
 -        <value type="string" value="xfce4-terminal-emulator.desktop"/>
--      </property>
--    </property>
++        <value type="string" value="xfce4-web-browser.desktop"/>
+       </property>
+     </property>
 -    <property name="plugin-18" type="string" value="launcher">
--      <property name="items" type="array">
--        <value type="string" value="xfce4-file-manager.desktop"/>
--      </property>
--    </property>
++    <property name="plugin-4" type="string" value="launcher">
+       <property name="items" type="array">
+         <value type="string" value="xfce4-file-manager.desktop"/>
+       </property>
+     </property>
 -    <property name="plugin-19" type="string" value="launcher">
--      <property name="items" type="array">
++    <property name="plugin-5" type="string" value="launcher">
+       <property name="items" type="array">
 -        <value type="string" value="xfce4-web-browser.desktop"/>
--      </property>
--    </property>
++        <value type="string" value="xfce4-terminal-emulator.desktop"/>
++      </property>
++    </property>
++    <property name="plugin-6" type="string" value="launcher">
++      <property name="items" type="array">
++        <value type="string" value="solus-sc.desktop"/>
+       </property>
+     </property>
 -    <property name="plugin-20" type="string" value="launcher">
--      <property name="items" type="array">
--        <value type="string" value="xfce4-appfinder.desktop"/>
--      </property>
--    </property>
++    <property name="plugin-7" type="string" value="launcher">
+       <property name="items" type="array">
+         <value type="string" value="xfce4-appfinder.desktop"/>
+       </property>
+     </property>
 -    <property name="plugin-21" type="string" value="separator"/>
 -    <property name="plugin-22" type="string" value="directorymenu"/>
-+    <property name="plugin-30" type="string" value="actions"/>
++    <property name="plugin-8" type="string" value="tasklist"/>
++    <property name="plugin-9" type="string" value="separator">
++      <property name="expand" type="bool" value="true"/>
++      <property name="style" type="uint" value="0"/>
++    </property>
++    <property name="plugin-10" type="string" value="pager"/>
++    <property name="plugin-11" type="string" value="separator">
++        <property name="style" type="uint" value="0"/>
++        <property name="expand" type="bool" value="false"/>
++    </property>
++    <property name="plugin-12" type="string" value="systray">
++      <property name="known-legacy-items" type="array">
++        <value type="string" value="ethernet network connection “wired connection 1” active"/>
++      </property>
++    </property>
++    <property name="plugin-13" type="string" value="pulseaudio">
++      <property name="enable-keyboard-shortcuts" type="bool" value="true"/>
++      <property name="known-players" type="string" value="Rhythmbox"/>
++    </property>
++    <property name="plugin-14" type="string" value="power-manager-plugin"/>
++    <property name="plugin-15" type="string" value="notification-plugin"/>
++    <property name="plugin-16" type="string" value="clock"/>
++    <property name="plugin-17" type="string" value="separator">
++      <property name="style" type="uint" value="0"/>
++    </property>
++    <property name="plugin-18" type="string" value="actions"/>
    </property>
  </channel>
 -- 

--- a/packages/x/xfce4-panel/package.yml
+++ b/packages/x/xfce4-panel/package.yml
@@ -1,6 +1,6 @@
 name       : xfce4-panel
 version    : 4.18.5
-release    : 8
+release    : 9
 source     :
     - https://archive.xfce.org/src/xfce/xfce4-panel/4.18/xfce4-panel-4.18.5.tar.bz2 : b20e0d10cc5149a601d8eee07373efb446ea3e179dd032ed8ddb5782e3f9e7cb
 homepage   : https://docs.xfce.org/xfce/xfce4-panel/start
@@ -12,8 +12,8 @@ description: |
 builddeps  :
     - pkgconfig(exo-2)
     - pkgconfig(garcon-gtk3-1)
-    - pkgconfig(libxfce4ui-2)
     - pkgconfig(libwnck-3.0)
+    - pkgconfig(libxfce4ui-2)
 rundeps    :
     - network-manager-applet
 setup      : |

--- a/packages/x/xfce4-panel/pspec_x86_64.xml
+++ b/packages/x/xfce4-panel/pspec_x86_64.xml
@@ -223,7 +223,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="8">xfce4-panel</Dependency>
+            <Dependency release="9">xfce4-panel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/xfce4/libxfce4panel-2.0/libxfce4panel/libxfce4panel-config.h</Path>
@@ -281,8 +281,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2023-12-02</Date>
+        <Update release="9">
+            <Date>2023-12-03</Date>
             <Version>4.18.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
- Add the following launchers to the default layout:
  - Web browser
  - File manager
  - Terminal
  - Software Center
  - App Finder
- Increase default panel size to 36

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install the package and create a new user to observe the new defaults.

**Checklist**

- [x] Package was built and tested against unstable
