### PR TITLE
ci: Check shell scripts in common with shellcheck

### DIFF
--- a/.github/workflows/script_lint.yml
+++ b/.github/workflows/script_lint.yml
@@ -28,3 +28,23 @@ jobs:
           path: common/CI common/Hooks common/Scripts/worklog.py
           python_version: "3.10"
           requirements: types-PyYAML
+  ShellCheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: common
+          check_together: 'yes'
+          ignore_paths: >-
+            common/Legacy/**
+            common/Scripts/package-publish-safety-catches.sh
+            common/Scripts/helpers.zsh
+            common/Scripts/sync_licenses.sh
+            common/Scripts/new-package.sh
+            common/Scripts/find-old.sh
+            common/Scripts/rebuild-template-script.sh
+            common/Scripts/buildserver-notification.sh
+            common/Scripts/update_stateless.sh

--- a/common/Scripts/helpers.sh
+++ b/common/Scripts/helpers.sh
@@ -5,27 +5,27 @@
 # This function will only work if this script is sourced
 # by your bash shell.
 function gotosoluspkgs() {
-    cd $(dirname $(readlink "${BASH_SOURCE[0]}"))/../../
+    cd "$(dirname "$(readlink "${BASH_SOURCE[0]}")")/../../" || exit 1
 }
 
 # Goes to the root directory of the git repository
 function goroot() {
-    cd $(git rev-parse --show-toplevel)
+    cd "$(git rev-parse --show-toplevel)" || exit 1
 }
 
 # Push into a package directory
 function gotopkg() {
-    cd $(git rev-parse --show-toplevel)/packages/*/$1
+    cd "$(git rev-parse --show-toplevel)"/packages/*/"$1" || exit 1
 }
 
 # What provides a lib
 function whatprovides() {
-    grep $1 $(git rev-parse --show-toplevel)/packages/*/*/abi_libs
+    grep "$1" "$(git rev-parse --show-toplevel)"/packages/*/*/abi_libs
 }
 
 # What uses a lib
 function whatuses() {
-    grep $1 $(git rev-parse --show-toplevel)/packages/*/*/abi_used_libs
+    grep "$1" "$(git rev-parse --show-toplevel)"/packages/*/*/abi_used_libs
 }
 
 
@@ -33,15 +33,14 @@ function whatuses() {
 _gotopkg()
 {
 
-    _list=$(ls $(git rev-parse --show-toplevel)/packages/*/)
+    _list=$(ls "$(git rev-parse --show-toplevel)"/packages/*/)
 
-    local cur prev
+    local cur
     COMPREPLY=()
     cur=${COMP_WORDS[COMP_CWORD]}
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     if [[ $COMP_CWORD -eq 1 ]] ; then
-        COMPREPLY=( $(compgen -W "${_list}" -- ${cur}) )
+        readarray -t COMPREPLY < <(compgen -W "${_list}" -- "${cur}")
         return 0
     fi
 }


### PR DESCRIPTION
**Summary**

Add shellcheck action to the GitHub workflow to reduce the amount of bugs in shell scripts.
Currently failing scripts (and one zsh script) have been excluded.
These can be removed from the ignored scripts when they have been fixed.

Resolves https://github.com/getsolus/packages/issues/968

**Test Plan**

This PR!

**Checklist**

- [x] CI checks pass
