### PR TITLE
grub2: Update default config to set font to ter-32b

### DIFF
--- a/packages/g/grub2/files/conf/grub
+++ b/packages/g/grub2/files/conf/grub
@@ -10,6 +10,9 @@ GRUB_BACKGROUND=""
 GRUB_COLOR_NORMAL="black/white"
 GRUB_COLOR_HIGHLIGHT="light-blue/white"
 
+# Use large 16x32 terminus fonts to help people on HiDPI monitors
+GRUB_FONT="/boot/grub/fonts/ter-32b.pf2"
+
 # Uncomment to enable BadRAM filtering, modify to suit your needs
 # This works with Linux (no patch required) and with any kernel that obtains
 # the memory map information from GRUB (GNU Mach, kernel of FreeBSD ...)
@@ -22,6 +25,7 @@ GRUB_COLOR_HIGHLIGHT="light-blue/white"
 # note that you can use only modes which your graphic card supports via VBE
 # you can see them in real GRUB with the command `vbeinfo'
 #GRUB_GFXMODE=640x480
+GRUB_GFXMODE=1366x768,1024x768x32,auto
 
 # Uncomment if you don't want GRUB to pass "root=UUID=xxx" parameter to Linux
 #GRUB_DISABLE_LINUX_UUID=true

--- a/packages/g/grub2/package.yml
+++ b/packages/g/grub2/package.yml
@@ -1,6 +1,6 @@
 name       : grub2
 version    : '2.04'
-release    : 32
+release    : 34
 source     :
     - git|https://git.savannah.gnu.org/git/grub.git : e7b8856f8be3292afdb38d2e8c70ad8d62a61e10
 homepage   : https://www.gnu.org/software/grub/
@@ -49,3 +49,5 @@ install    : |
     # build grub-compatible PF2 fonts from BDF format terminus fonts in 16x32
     $installdir/usr/bin/grub-mkfont $pkgfiles/font-terminus-bdf/ter-u32b.bdf -o $installdir/usr/share/grub/ter-32b.pf2
     $installdir/usr/bin/grub-mkfont $pkgfiles/font-terminus-bdf/ter-u32n.bdf -o $installdir/usr/share/grub/ter-32n.pf2
+    install -Dm00644 $installdir/usr/share/grub/ter-32b.pf2 $installdir/boot/grub/fonts/ter-32b.pf2
+    install -Dm00644 $installdir/usr/share/grub/ter-32n.pf2 $installdir/boot/grub/fonts/ter-32n.pf2

--- a/packages/g/grub2/pspec_x86_64.xml
+++ b/packages/g/grub2/pspec_x86_64.xml
@@ -21,6 +21,8 @@
 </Description>
         <PartOf>system.boot</PartOf>
         <Files>
+            <Path fileType="data">/boot/grub/fonts/ter-32b.pf2</Path>
+            <Path fileType="data">/boot/grub/fonts/ter-32n.pf2</Path>
             <Path fileType="config">/etc/bash_completion.d/grub</Path>
             <Path fileType="config">/etc/default/grub</Path>
             <Path fileType="config">/etc/grub.d/00_header</Path>
@@ -646,8 +648,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2023-11-23</Date>
+        <Update release="34">
+            <Date>2023-12-07</Date>
             <Version>2.04</Version>
             <Comment>Packaging update</Comment>
             <Name>Rune Morling</Name>


### PR DESCRIPTION
**Summary**
Increase default font size to 32px (terminus bold) to help with legibility on HiDPI displays.

Additionally, set GRUB_GFXMODE 1366x768, with a 1024x768 fallback, and auto for when VM gfx adapters are genuinely clueless. This will probably work in VMs and on (most) older laptops.

Shout out to @TraceyC77 and sheepman4267 for the suggestions and valuable QA work on this.

Part of #826

**Test Plan**
- Update grub2
- run `sudo mv /etc/default/grub.newconfig /etc/default/grub`
- run `sudo clr-update-wrapper`
- reboot and check that new font is displayed in grub bootloader menu

**Checklist**

- [x] Package was built and tested against unstable
