### PR TITLE
syncthing: update to 1.27.0

### DIFF
--- a/packages/s/syncthing/MAINTAINERS.md
+++ b/packages/s/syncthing/MAINTAINERS.md
@@ -2,3 +2,4 @@ This file is used to indicate primary maintainership for this package. A package
 
 - Tracey Clark
   - Email: traceyc.dev@tlcnet.info
+  - Matrix: @traceyc:matrix.org

--- a/packages/s/syncthing/package.yml
+++ b/packages/s/syncthing/package.yml
@@ -1,9 +1,9 @@
 name       : syncthing
-version    : 1.26.1
-release    : 90
+version    : 1.27.0
+release    : 91
 homepage   : https://syncthing.net
 source     :
-    - https://github.com/syncthing/syncthing/releases/download/v1.26.1/syncthing-source-v1.26.1.tar.gz : c14de7df16f33db6e77442ee298dd836aeb40ae08339ebe27e418a1bb0ebe7bd
+    - https://github.com/syncthing/syncthing/releases/download/v1.27.0/syncthing-source-v1.27.0.tar.gz : 8675dcf90eabe713e1b570c029f2196c607921f851430ae67745e2216e6bfa0d
 license    : MPL-2.0
 component  : network.util
 networking : yes

--- a/packages/s/syncthing/pspec_x86_64.xml
+++ b/packages/s/syncthing/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>syncthing</Name>
         <Homepage>https://syncthing.net</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>MPL-2.0</License>
         <PartOf>network.util</PartOf>
@@ -50,12 +50,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="90">
-            <Date>2023-11-21</Date>
-            <Version>1.26.1</Version>
+        <Update release="91">
+            <Date>2023-12-05</Date>
+            <Version>1.27.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Bugfixes:

- spurious log file in $XDG_CONFIG_HOME
- Discovery Returns IP
- Display error in 1.26 with login screen

Enhancements:

- Default config (state) dir on Unixes should be ~/.local/state/syncthing ($XDG_STATE_HOME/syncthing)
- Login form: login button should have an id attribute

**Test Plan**
- Restart Syncthing-GTK and verify it can connect to the syncthing backend, all folders sync
- View syncthing gui in web browser, ensure everything looks good

**Checklist**

- [x] Package was built and tested against unstable