### PR TITLE
kinfocenter: Add dependency on fwupd

### DIFF
--- a/packages/k/kinfocenter/abi_used_symbols
+++ b/packages/k/kinfocenter/abi_used_symbols
@@ -766,7 +766,6 @@ libc.so.6:getnameinfo
 libc.so.6:malloc
 libc.so.6:memcpy
 libc.so.6:memmove
-libc.so.6:memset
 libc.so.6:open
 libc.so.6:read
 libc.so.6:setenv
@@ -775,10 +774,9 @@ libc.so.6:strlen
 libc.so.6:sysinfo
 libc.so.6:uname
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE6resizeEmw
-libstdc++.so.6:_ZNSt8ios_base4InitC1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitD1Ev
 libstdc++.so.6:_ZSt16__ostream_insertIwSt11char_traitsIwEERSt13basic_ostreamIT_T0_ES6_PKS3_l
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
+libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
 libstdc++.so.6:_ZSt5wcout
 libstdc++.so.6:_ZTVN10__cxxabiv117__class_type_infoE

--- a/packages/k/kinfocenter/package.yml
+++ b/packages/k/kinfocenter/package.yml
@@ -1,6 +1,6 @@
 name       : kinfocenter
 version    : 5.27.8
-release    : 96
+release    : 97
 source     :
     - https://cdn.download.kde.org/stable/plasma/5.27.8/kinfocenter-5.27.8.tar.xz : af6f629f68bab369721977f0e1749cf1d2d1b11234dfd4c7329a42120faad9cc
 homepage   : https://www.kde.org/workspaces/plasmadesktop/
@@ -26,6 +26,7 @@ builddeps  :
 rundeps    :
     - aha
     - clinfo
+    - fwupd
     - kirigami2
     - plasma-disks
     - vulkan-tools

--- a/packages/k/kinfocenter/pspec_x86_64.xml
+++ b/packages/k/kinfocenter/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>kinfocenter</Name>
         <Homepage>https://www.kde.org/workspaces/plasmadesktop/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GFDL-1.2-only</License>
         <License>GPL-2.0-or-later</License>
@@ -13,7 +13,7 @@
         <Summary xml:lang="en">KDE Info Center</Summary>
         <Description xml:lang="en">KInfoCenter is a utility that provides information about a computer system.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>kinfocenter</Name>
@@ -937,12 +937,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="96">
-            <Date>2023-09-27</Date>
+        <Update release="97">
+            <Date>2023-12-06</Date>
             <Version>5.27.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add dependency on fwupd. This enables the Firmware Security section to work.

Fixes https://github.com/getsolus/packages/issues/307

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install the updated package in a Plasma VM and see that the Info Center panel no longer complains about missing dependencies.

**Checklist**

- [x] Package was built and tested against unstable
