### PR TITLE
helpers.sh: Robustify functions and don't exit 1

### DIFF
--- a/common/Scripts/helpers.sh
+++ b/common/Scripts/helpers.sh
@@ -1,30 +1,49 @@
 #!/usr/bin/env bash
 
+# shellcheck wants to add '|| exit 1' willy nilly, so let's
+# build a nice 'failmsg' function instead.
+function failmsg() {
+    echo "$*"
+    return 1
+}
+
 # Goes to the root directory of the solus packages
 # git repository from anywhere on the filesystem.
 # This function will only work if this script is sourced
 # by your bash shell.
 function gotosoluspkgs() {
-    cd "$(dirname "$(readlink "${BASH_SOURCE[0]}")")/../../" || exit 1
+    cd "$(dirname "$(readlink "${BASH_SOURCE[0]}")")/../../" || \
+        failmsg "Unable to find the solus packages git dir."
 }
 
 # Goes to the root directory of the git repository
 function goroot() {
-    cd "$(git rev-parse --show-toplevel)" || exit 1
+    local pkgroot="$(git rev-parse --show-toplevel)"
+    [[ -n "${pkgroot}" ]] && cd "${pkgroot}" || \
+        failmsg "If you're not somewhere in the solus packages git dir, use gotosoluspkgs instead."
 }
 
 # Push into a package directory
 function gotopkg() {
-    cd "$(git rev-parse --show-toplevel)"/packages/*/"$1" || exit 1
+    local arg="$1"
+    gotosoluspkgs
+    if [[ -n "$arg" ]]; then
+        cd "$(git rev-parse --show-toplevel)"/packages/*/"$arg" || \
+            failmsg "Something went wrong."
+    else
+        failmsg "No package specified, going to the root of the solus packages git dir instead."
+    fi
 }
 
 # What provides a lib
 function whatprovides() {
+    gotosoluspkgs
     grep "$1" "$(git rev-parse --show-toplevel)"/packages/*/*/abi_libs
 }
 
 # What uses a lib
 function whatuses() {
+    gotosoluspkgs
     grep "$1" "$(git rev-parse --show-toplevel)"/packages/*/*/abi_used_libs
 }
 


### PR DESCRIPTION
**Summary**
Shellcheck recklessly introduced a bug that will make functions `exit 1` which causes the shell to exit, if the function in question doesn not complete successfully.

This commit fixes this "small" oversight.

In addition, this commit also makes the `gotopkg` and `goroot` functions more robust and yields hopefully useful error messages as necessary.

**Test Plan**
```
ermo@solbox:~
$ goroot
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
If you're not somewhere in the solus packages git dir, use gotosoluspkgs instead.
ermo@solbox:~/
$ gotosoluspkgs
ermo@solbox:~/repos/getsolus/solpkgs
$ cd
ermo@solbox:~
$ gotopkg
No package specified, going to the root of the solus packages git dir instead.
ermo@solbox:~/repos/getsolus/solpkgs
$ cd
ermo@solbox:~
$ gotopkg grub2
ermo@solbox:~/repos/getsolus/solpkgs/packages/g/grub2
$
```