### PR TITLE
grub2: Update default config to set font to ter-32b

### DIFF
--- a/packages/g/grub2/files/conf/grub
+++ b/packages/g/grub2/files/conf/grub
@@ -10,9 +10,6 @@ GRUB_BACKGROUND=""
 GRUB_COLOR_NORMAL="black/white"
 GRUB_COLOR_HIGHLIGHT="light-blue/white"
 
-# Use large 16x32 terminus fonts to help people on HiDPI monitors
-GRUB_FONT="/boot/grub/fonts/ter-32b.pf2"
-
 # Uncomment to enable BadRAM filtering, modify to suit your needs
 # This works with Linux (no patch required) and with any kernel that obtains
 # the memory map information from GRUB (GNU Mach, kernel of FreeBSD ...)
@@ -25,6 +22,8 @@ GRUB_FONT="/boot/grub/fonts/ter-32b.pf2"
 # note that you can use only modes which your graphic card supports via VBE
 # you can see them in real GRUB with the command `vbeinfo'
 #GRUB_GFXMODE=640x480
+
+# This is a reasonable default w/fallbacks for older laptops and VMs
 GRUB_GFXMODE=1366x768,1024x768x32,auto
 
 # Uncomment if you don't want GRUB to pass "root=UUID=xxx" parameter to Linux

--- a/packages/g/grub2/package.yml
+++ b/packages/g/grub2/package.yml
@@ -1,6 +1,6 @@
 name       : grub2
 version    : '2.04'
-release    : 34
+release    : 35
 source     :
     - git|https://git.savannah.gnu.org/git/grub.git : e7b8856f8be3292afdb38d2e8c70ad8d62a61e10
 homepage   : https://www.gnu.org/software/grub/
@@ -43,11 +43,16 @@ install    : |
     install -Dm00755 $pkgfiles/update-grub2 -t $installdir/usr/sbin
     install -Dm00644 $pkgfiles/conf/grub    -t $installdir/etc/default
     install -Dm00644 $pkgfiles/splash.tga   -t $installdir/usr/share/backgrounds
-    install -Dm00644 $pkgfiles/unicode.pf2  -t $installdir/usr/share/grub
     rm $installdir/etc/grub.d/30_uefi-firmware
 
     # build grub-compatible PF2 fonts from BDF format terminus fonts in 16x32
     $installdir/usr/bin/grub-mkfont $pkgfiles/font-terminus-bdf/ter-u32b.bdf -o $installdir/usr/share/grub/ter-32b.pf2
     $installdir/usr/bin/grub-mkfont $pkgfiles/font-terminus-bdf/ter-u32n.bdf -o $installdir/usr/share/grub/ter-32n.pf2
-    install -Dm00644 $installdir/usr/share/grub/ter-32b.pf2 $installdir/boot/grub/fonts/ter-32b.pf2
-    install -Dm00644 $installdir/usr/share/grub/ter-32n.pf2 $installdir/boot/grub/fonts/ter-32n.pf2
+
+    # grub installs /usr/share/grub/unicode.pf2 to /boot/grub/fonts/ by default
+    # if grub-install invocations do not specify a --fonts="font1 font2 (...)" argument.
+    # Hence, the simplest way to override the default unicode.pf2 font (which is ugly)
+    # is to rename it and copy in the font we want to be the default as unicode.pf2
+    # This allows users to still use the original font if they so desire.
+    install -Dm00644 $pkgfiles/unicode.pf2 $installdir/usr/share/grub/unicode-8x16.pf2
+    install -Dm00644 $installdir/usr/share/grub/ter-32b.pf2 $installdir/usr/share/grub/unicode.pf2

--- a/packages/g/grub2/pspec_x86_64.xml
+++ b/packages/g/grub2/pspec_x86_64.xml
@@ -21,8 +21,6 @@
 </Description>
         <PartOf>system.boot</PartOf>
         <Files>
-            <Path fileType="data">/boot/grub/fonts/ter-32b.pf2</Path>
-            <Path fileType="data">/boot/grub/fonts/ter-32n.pf2</Path>
             <Path fileType="config">/etc/bash_completion.d/grub</Path>
             <Path fileType="config">/etc/default/grub</Path>
             <Path fileType="config">/etc/grub.d/00_header</Path>
@@ -640,6 +638,7 @@
             <Path fileType="data">/usr/share/grub/grub-mkconfig_lib</Path>
             <Path fileType="data">/usr/share/grub/ter-32b.pf2</Path>
             <Path fileType="data">/usr/share/grub/ter-32n.pf2</Path>
+            <Path fileType="data">/usr/share/grub/unicode-8x16.pf2</Path>
             <Path fileType="data">/usr/share/grub/unicode.pf2</Path>
             <Path fileType="info">/usr/share/info/grub-dev.info</Path>
             <Path fileType="info">/usr/share/info/grub.info</Path>
@@ -648,7 +647,7 @@
         </Files>
     </Package>
     <History>
-        <Update release="34">
+        <Update release="35">
             <Date>2023-12-07</Date>
             <Version>2.04</Version>
             <Comment>Packaging update</Comment>


### PR DESCRIPTION
**Summary**
Increase default font size to 32px (terminus bold) to help with legibility on HiDPI displays.

Additionally, set GRUB_GFXMODE 1366x768, with a 1024x768 fallback, and auto for when VM gfx adapters are genuinely clueless. This appears to be a decent setting for everything from VMs and older laptops to modern high resolution displays with the added bonus that the font itself is cleaner looking than the one upstream ships by default.

Part of #826

**Test Plan**
- Update grub2
- run `sudo mv /etc/default/grub.newconfig /etc/default/grub`
- run `sudo grub-install /dev/<my root device>` # this copies in the new unicode font like on a new ISO
- run `sudo clr-update-wrapper`
- reboot and check that new font is displayed in grub bootloader menu

**Checklist**
- [x] Package was built and tested against unstable
