### PR TITLE
pam: Set more tolerable failed login defaults

### DIFF
--- a/packages/p/pam/files/faillock.conf
+++ b/packages/p/pam/files/faillock.conf
@@ -1,0 +1,62 @@
+# Configuration for locking the user after multiple failed
+# authentication attempts.
+#
+# The directory where the user files with the failure records are kept.
+# The default is /var/run/faillock.
+# dir = /var/run/faillock
+#
+# Will log the user name into the system log if the user is not found.
+# Enabled if option is present.
+# audit
+#
+# Don't print informative messages.
+# Enabled if option is present.
+# silent
+#
+# Don't log informative messages via syslog.
+# Enabled if option is present.
+# no_log_info
+#
+# Only track failed user authentications attempts for local users
+# in /etc/passwd and ignore centralized (AD, IdM, LDAP, etc.) users.
+# The `faillock` command will also no longer track user failed
+# authentication attempts. Enabling this option will prevent a
+# double-lockout scenario where a user is locked out locally and
+# in the centralized mechanism.
+# Enabled if option is present.
+# local_users_only
+#
+# Deny access if the number of consecutive authentication failures
+# for this user during the recent interval exceeds n tries.
+# The default is 3.
+deny = 10
+#
+# The length of the interval during which the consecutive
+# authentication failures must happen for the user account
+# lock out is <replaceable>n</replaceable> seconds.
+# The default is 900 (15 minutes).
+# fail_interval = 900
+#
+# The access will be re-enabled after n seconds after the lock out.
+# The value 0 has the same meaning as value `never` - the access
+# will not be re-enabled without resetting the faillock
+# entries by the `faillock` command.
+# The default is 600 (10 minutes).
+# unlock_time = 600
+#
+# Root account can become locked as well as regular accounts.
+# Enabled if option is present.
+# even_deny_root
+#
+# This option implies the `even_deny_root` option.
+# Allow access after n seconds to root account after the
+# account is locked. In case the option is not specified
+# the value is the same as of the `unlock_time` option.
+# root_unlock_time = 900
+#
+# If a group name is specified with this option, members
+# of the group will be handled by this module the same as
+# the root account (the options `even_deny_root>` and
+# `root_unlock_time` will apply to them.
+# By default, the option is not set.
+# admin_group = <admin_group_name>

--- a/packages/p/pam/package.yml
+++ b/packages/p/pam/package.yml
@@ -1,6 +1,6 @@
 name       : pam
 version    : 1.5.3
-release    : 29
+release    : 30
 source     :
     - https://github.com/linux-pam/linux-pam/releases/download/v1.5.3/Linux-PAM-1.5.3.tar.xz : 7ac4b50feee004a9fa88f1dfd2d2fa738a82896763050cd773b3c54b0a818283
 license    : GPL-3.0-or-later
@@ -51,6 +51,9 @@ install    : |
     mv $installdir/etc/environment $installdir/usr/share/defaults/etc/environment
 
     install -Dm00644 $pkgfiles/shells $installdir/usr/share/defaults/etc/shells
+
+    # increase amount of mistyped password attemps before lockout
+    install -Dm00644 $pkgfiles/faillock.conf $installdir/usr/share/defaults/etc/security/faillock.conf
 
     # Stateless
     find $installdir -type d -empty -delete

--- a/packages/p/pam/pspec_x86_64.xml
+++ b/packages/p/pam/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pam</Name>
         <Homepage>https://github.com/linux-pam/linux-pam</Homepage>
         <Packager>
-            <Name>Oliver Marks</Name>
-            <Email>oly@digitaloctave.com</Email>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -238,7 +238,7 @@
         <Description xml:lang="en">The Linux PAM package contains Pluggable Authentication Modules used to enable the local system administrator to choose how applications authenticate users.</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="29">pam</Dependency>
+            <Dependency release="30">pam</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpam.so.0</Path>
@@ -295,8 +295,8 @@
         <Description xml:lang="en">The Linux PAM package contains Pluggable Authentication Modules used to enable the local system administrator to choose how applications authenticate users.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="29">pam-32bit</Dependency>
-            <Dependency release="29">pam-devel</Dependency>
+            <Dependency release="30">pam-32bit</Dependency>
+            <Dependency release="30">pam-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpam.so</Path>
@@ -313,7 +313,7 @@
         <Description xml:lang="en">The Linux PAM package contains Pluggable Authentication Modules used to enable the local system administrator to choose how applications authenticate users.</Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="29">pam</Dependency>
+            <Dependency release="30">pam</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/security/_pam_compat.h</Path>
@@ -388,12 +388,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="29">
-            <Date>2023-12-05</Date>
+        <Update release="30">
+            <Date>2023-12-07</Date>
             <Version>1.5.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Oliver Marks</Name>
-            <Email>oly@digitaloctave.com</Email>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

This commit tweaks the defaults before an account is locked from:

3 unsuccessful tries within 15 minutes => 10 minute account lockout

To:

10 unsuccesful tries within 15 minutes => 10 minute account lockout

The goal is to make fat-finger typos less punishing and frustrating. The hope is that allowing more consecutive tries before locking the user out will not punish legimate mistakes, but will still punish an attacker trying to brute-force the user's password.

Note that the NIST recommends allowing at least 10 tries here:

https://pages.nist.gov/800-63-3/sp800-63b.html#sec10

**Test Plan**

- Install the package with the new defaults
- Make the required number of unsuccessful login attempts on a virtual console
- Note how `login` helpfully mentions that the account is now locked for the specified duration
- After the specified minutes have passed, log in successfully with correct password.

**Checklist**

- [x] Package was built and tested against unstable
