### PR TITLE
clr-boot-manager: Add patch for BTRFS subvolumes

### DIFF
--- a/packages/c/clr-boot-manager/abi_used_symbols
+++ b/packages/c/clr-boot-manager/abi_used_symbols
@@ -30,7 +30,9 @@ libc.so.6:__ctype_toupper_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
 libc.so.6:__getdelim
-libc.so.6:__isoc99_fscanf
+libc.so.6:__isoc23_fscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
@@ -104,7 +106,6 @@ libc.so.6:strncmp
 libc.so.6:strncpy
 libc.so.6:strndup
 libc.so.6:strstr
-libc.so.6:strtol
 libc.so.6:symlink
 libc.so.6:sync
 libc.so.6:system

--- a/packages/c/clr-boot-manager/files/0001-grub2-Fix-loading-kernel-and-initramfs-on-BTRFS-subv.patch
+++ b/packages/c/clr-boot-manager/files/0001-grub2-Fix-loading-kernel-and-initramfs-on-BTRFS-subv.patch
@@ -1,0 +1,76 @@
+From 92ebb5328431275928260cf4a35fcb562f2bc8cf Mon Sep 17 00:00:00 2001
+From: Evan Maddock <maddock.evan@vivaldi.net>
+Date: Mon, 11 Dec 2023 11:19:07 -0500
+Subject: [PATCH] grub2: Fix loading kernel and initramfs on BTRFS subvolumes
+
+Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
+---
+ src/bootloaders/grub2.c | 18 ++++++++++++++----
+ 1 file changed, 14 insertions(+), 4 deletions(-)
+
+diff --git a/src/bootloaders/grub2.c b/src/bootloaders/grub2.c
+index 644a8aa..dc7af62 100644
+--- a/src/bootloaders/grub2.c
++++ b/src/bootloaders/grub2.c
+@@ -174,12 +174,22 @@ bool grub2_write_kernel(const Grub2Config *config, const Kernel *kernel)
+         const char *tab = config->submenu ? "\t\t" : "\t";
+         const char *root_tab = config->submenu ? "\t" : "";
+         NcHashmapIter iter = { 0 };
++        char *boot_prefix = NULL;
+         char *initrd_name = NULL;
+         char *ucode_initrd = NULL;
+         autofree(char) *initrd_paths = NULL;
+         initrd_paths = malloc(1);
+         initrd_paths[0] = '\0';
+ 
++        /* If /boot is on a BTRFS subvolume, Grub will fail to find it without
++         * the subvolume prefix being at the start of the path
++         */
++        if (config->root_dev->btrfs_sub) {
++                boot_prefix = string_printf("/%s/%s", config->root_dev->btrfs_sub, BOOT_DIRECTORY);
++        } else {
++                boot_prefix = BOOT_DIRECTORY;
++        }
++
+         /* Write the start of the entry
+          * e.g. menuentry 'Some Linux OS (4.4.9-12.lts)' --class some-linux-os --class gnu-linux
+          * --class gnu --class os
+@@ -231,7 +241,7 @@ bool grub2_write_kernel(const Grub2Config *config, const Kernel *kernel)
+                 cbm_writer_append_printf(config->writer,
+                                          "echo \"%slinux %s/%s root=UUID=%s ",
+                                          tab,
+-                                         BOOT_DIRECTORY, /* i.e. /boot */
++                                         boot_prefix, /* i.e. /boot */
+                                          kernel->target.legacy_path,
+                                          config->root_dev->uuid);
+         }
+@@ -256,7 +266,7 @@ bool grub2_write_kernel(const Grub2Config *config, const Kernel *kernel)
+                 char *tmp = initrd_paths;
+                 initrd_paths = string_printf("%s %s/%s",
+                                          initrd_paths,
+-                                         (!config->is_separate) ? BOOT_DIRECTORY : "", /* i.e. /boot */
++                                         (!config->is_separate) ? boot_prefix : "", /* i.e. /boot */
+                                          ucode_initrd);
+                 free(tmp);
+         }
+@@ -266,7 +276,7 @@ bool grub2_write_kernel(const Grub2Config *config, const Kernel *kernel)
+                 char *tmp = initrd_paths;
+                 initrd_paths = string_printf("%s %s/%s",
+                                          initrd_paths,
+-                                         (!config->is_separate) ? BOOT_DIRECTORY : "", /* i.e. /boot */
++                                         (!config->is_separate) ? boot_prefix : "", /* i.e. /boot */
+                                          kernel->target.initrd_path);
+                 free(tmp);
+         }
+@@ -280,7 +290,7 @@ bool grub2_write_kernel(const Grub2Config *config, const Kernel *kernel)
+                 }
+                 initrd_paths = string_printf("%s %s/%s",
+                                          initrd_paths,
+-                                         (!config->is_separate) ? BOOT_DIRECTORY : "", /* i.e. /boot */
++                                         (!config->is_separate) ? boot_prefix : "", /* i.e. /boot */
+                                          initrd_name);
+                 free(tmp);
+         }
+-- 
+2.43.0
+

--- a/packages/c/clr-boot-manager/files/series
+++ b/packages/c/clr-boot-manager/files/series
@@ -11,3 +11,4 @@
 0011-shim-systemd-Don-t-exit-if-we-can-t-parse-efivars.patch
 0012-shim-systemd-Don-t-hardcode-vendor-name.patch
 0013-shim-systemd-Support-for-shim-s-fallback-efi-loader.patch
+0001-grub2-Fix-loading-kernel-and-initramfs-on-BTRFS-subv.patch

--- a/packages/c/clr-boot-manager/package.yml
+++ b/packages/c/clr-boot-manager/package.yml
@@ -1,8 +1,9 @@
 name       : clr-boot-manager
 version    : 3.3.0
-release    : 32
+release    : 33
 source     :
     - https://github.com/clearlinux/clr-boot-manager/releases/download/v3.3.0/clr-boot-manager-3.3.0.tar.xz : d049112b0a87d8be4919386d869122451b18b77fc11438a4f0154dc51f64f12a
+homepage   : https://www.clearlinux.org
 license    : LGPL-2.1-or-later
 component  : system.base
 summary    : Kernel & Boot Loader Management

--- a/packages/c/clr-boot-manager/pspec_x86_64.xml
+++ b/packages/c/clr-boot-manager/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>clr-boot-manager</Name>
+        <Homepage>https://www.clearlinux.org</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>system.base</PartOf>
@@ -14,7 +15,7 @@ Special care is taken to ensure the ESP is handled gracefully, and in the instan
 
 Most importantly, clr-boot-manager provides a simple mechanism to provide kernel updates, with the ability for users to rollback to an older kernel should the new update be problematic. This is achieved through the use of strict namespace policies, permanent source paths, and clr-boot-manager&apos;s own internal logic, without the need for &quot;meta packages&quot; or undue complexity on the distribution side.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>clr-boot-manager</Name>
@@ -37,12 +38,12 @@ Most importantly, clr-boot-manager provides a simple mechanism to provide kernel
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2023-05-31</Date>
+        <Update release="33">
+            <Date>2023-12-08</Date>
             <Version>3.3.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fix booting with Grub on BTRFS subvolumes

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Built a fresh ISO and installed using Grub on a default BTRFS layout, and rebooted successfully post-installation.

**Checklist**

- [x] Package was built and tested against unstable
