### PR TITLE
font-ibm-plex: Update to 6.3.0

### DIFF
--- a/packages/f/font-ibm-plex/files/ibmplex.metainfo.xml
+++ b/packages/f/font-ibm-plex/files/ibmplex.metainfo.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <component type="font">
+  <id>font-ibm-plex-ttf</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>ibmplex</name>
+  <url type="homepage">https://www.ibm.com/plex/</url>
+  <summary>Meet the IBM Plex® typeface, our corporate typeface family.</summary>
+</component>

--- a/packages/f/font-ibm-plex/package.yml
+++ b/packages/f/font-ibm-plex/package.yml
@@ -1,8 +1,9 @@
 name       : font-ibm-plex
-version    : 6.1.1
-release    : 10
+version    : 6.3.0
+release    : 11
 source     :
-    - https://github.com/IBM/plex/archive/refs/tags/v6.1.1.tar.gz : 198936deddf38b1e108f6537790a6707650b69ba61371f8591f9d9a1ed6f9604
+    - https://github.com/IBM/plex/archive/refs/tags/v6.3.0.tar.gz : 079bc7182720719df90908a6519d4a9e998b580451960912ae16fe7b71e44261
+homepage   : https://www.ibm.com/plex/
 license    : OFL-1.1
 component  :
     - otf : desktop.font
@@ -14,7 +15,9 @@ description: |
     The package of IBM’s new typeface, IBM Plex in both OpenType and TrueType formats.
 patterns   :
     - otf : /usr/share/fonts/opentype
-    - ttf : /usr/share/fonts/truetype
+    - ttf :
+        - /usr/share/fonts/truetype
+        - /usr/share/metainfo
 replaces   :
     - ttf : font-ibm-plex
 install    : |
@@ -32,3 +35,6 @@ install    : |
 
     # No otf are shipped with this one
     install -D -m00644 IBM-Plex-Sans-Variable/fonts/complete/ttf/*.ttf -t $installdir/usr/share/fonts/truetype/ibmplex/
+
+    # metadata
+    install -Dm00644 $pkgfiles/ibmplex.metainfo.xml $installdir/usr/share/metainfo/ibmplex.metainfo.xml

--- a/packages/f/font-ibm-plex/pspec_x86_64.xml
+++ b/packages/f/font-ibm-plex/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>font-ibm-plex</Name>
+        <Homepage>https://www.ibm.com/plex/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Nazar Stasiv</Name>
+            <Email>nazar@autistici.org</Email>
         </Packager>
         <License>OFL-1.1</License>
         <PartOf>desktop.font</PartOf>
         <Summary xml:lang="en">IBM Plex Typeface (OTF)</Summary>
         <Description xml:lang="en">The package of IBM’s new typeface, IBM Plex in both OpenType and TrueType formats.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>font-ibm-plex-otf</Name>
@@ -148,6 +149,8 @@
 </Description>
         <PartOf>desktop.font</PartOf>
         <Files>
+            <Path fileType="data">/usr/share/fonts/truetype/ibmplex/IBM Plex Sans Var-Italic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ibmplex/IBM Plex Sans Var-Roman.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/ibmplex/IBMPlexMono-Bold.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/ibmplex/IBMPlexMono-BoldItalic.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/ibmplex/IBMPlexMono-ExtraLight.ttf</Path>
@@ -252,8 +255,6 @@
             <Path fileType="data">/usr/share/fonts/truetype/ibmplex/IBMPlexSansThaiLooped-SemiBold.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/ibmplex/IBMPlexSansThaiLooped-Text.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/ibmplex/IBMPlexSansThaiLooped-Thin.ttf</Path>
-            <Path fileType="data">/usr/share/fonts/truetype/ibmplex/IBMPlexSansVar-Italic.ttf</Path>
-            <Path fileType="data">/usr/share/fonts/truetype/ibmplex/IBMPlexSansVar-Roman.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/ibmplex/IBMPlexSerif-Bold.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/ibmplex/IBMPlexSerif-BoldItalic.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/ibmplex/IBMPlexSerif-ExtraLight.ttf</Path>
@@ -270,18 +271,19 @@
             <Path fileType="data">/usr/share/fonts/truetype/ibmplex/IBMPlexSerif-TextItalic.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/ibmplex/IBMPlexSerif-Thin.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/ibmplex/IBMPlexSerif-ThinItalic.ttf</Path>
+            <Path fileType="data">/usr/share/metainfo/ibmplex.metainfo.xml</Path>
         </Files>
         <Replaces>
             <Package>font-ibm-plex</Package>
         </Replaces>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2022-12-17</Date>
-            <Version>6.1.1</Version>
+        <Update release="11">
+            <Date>2023-12-09</Date>
+            <Version>6.3.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Nazar Stasiv</Name>
+            <Email>nazar@autistici.org</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

IBM PLEX SERIF
- Added support for monotonic Greek (74 glyphs per font)
- Replaced commaaccent with cedilla in glyphs /Tcedilla /tcedilla
- Disabled bit 38 (Mathematical Operators) from OS/2 UnicodeRanges
- Improved hinting
- Fixed FamilyClass value in OS/2 table
- Fixed STAT table; Roman and Italic styles are correctly linked in various environments now
- Fixed incorrect behaviour in Adobe InDesign
- Fixed inconsistencies in vertical alignment

IBM PLEX SANS
- Added new glyphs
- Fixed FamilyClass value in OS/2 table
- Fixed STAT table; Roman and Italic styles are correctly linked in various environments now
- Fixed incorrect behaviour in Adobe InDesign
- Fixed inconsistencies in vertical alignment
- Replaced commaaccent with cedilla in glyphs /Tcedilla /tcedilla
- Disabled bit 38 (Mathematical Operators) from OS/2 UnicodeRanges
- Improved hinting

**Test Plan**
- render serif font

**Checklist**
- [X] Package was built and tested against unstable
