### PR TITLE
gpxsee: Update to 13.12

### DIFF
--- a/packages/g/gpxsee/abi_used_symbols
+++ b/packages/g/gpxsee/abi_used_symbols
@@ -564,7 +564,6 @@ libQt5Gui.so.5:_ZN12QFontMetricsD1Ev
 libQt5Gui.so.5:_ZN12QImageReader13setScaledSizeERK5QSize
 libQt5Gui.so.5:_ZN12QImageReader16setAutoTransformEb
 libQt5Gui.so.5:_ZN12QImageReader21supportedImageFormatsEv
-libQt5Gui.so.5:_ZN12QImageReader4readEP6QImage
 libQt5Gui.so.5:_ZN12QImageReader4readEv
 libQt5Gui.so.5:_ZN12QImageReaderC1EP9QIODeviceRK10QByteArray
 libQt5Gui.so.5:_ZN12QImageReaderC1ERK7QStringRK10QByteArray
@@ -672,10 +671,10 @@ libQt5Gui.so.5:_ZN7QCursorC1EN2Qt11CursorShapeE
 libQt5Gui.so.5:_ZN7QCursorC1Ev
 libQt5Gui.so.5:_ZN7QCursorD1Ev
 libQt5Gui.so.5:_ZN7QPixmap12loadFromDataEPKhjPKc6QFlagsIN2Qt19ImageConversionFlagEE
-libQt5Gui.so.5:_ZN7QPixmap16convertFromImageERK6QImage6QFlagsIN2Qt19ImageConversionFlagEE
 libQt5Gui.so.5:_ZN7QPixmap16fromImageInPlaceER6QImage6QFlagsIN2Qt19ImageConversionFlagEE
 libQt5Gui.so.5:_ZN7QPixmap19setDevicePixelRatioEd
 libQt5Gui.so.5:_ZN7QPixmap4fillERK6QColor
+libQt5Gui.so.5:_ZN7QPixmap4loadERK7QStringPKc6QFlagsIN2Qt19ImageConversionFlagEE
 libQt5Gui.so.5:_ZN7QPixmap9fromImageERK6QImage6QFlagsIN2Qt19ImageConversionFlagEE
 libQt5Gui.so.5:_ZN7QPixmapC1ERK5QSize
 libQt5Gui.so.5:_ZN7QPixmapC1ERK7QStringPKc6QFlagsIN2Qt19ImageConversionFlagEE

--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.11'
-release    : 29
+version    : '13.12'
+release    : 30
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.11.tar.gz : 85c65db7f8d3b100c82fcef521b72145b2c5146b0a5ea22316fae72b8d05dcbf
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.12.tar.gz : 947d725d0d30fa827c2971174ab2244b4eaf0c491aed1bb9f0dd71de06237218
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -136,9 +136,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="29">
-            <Date>2023-11-20</Date>
-            <Version>13.11</Version>
+        <Update release="30">
+            <Date>2023-12-12</Date>
+            <Version>13.12</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Added support for overzoom in MVT vector maps (MBTiles/online).
- Vector (MVT) online maps now rendered asynchronous.
- Fixed vector MBTiles not loading in Qt6 builds issue.
- [changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

**Test Plan**
- open map file; zoom in and out

**Checklist**
- [X] Package was built and tested against unstable
