### PR TITLE
gnome-desktop-branding: Update to v19

### DIFF
--- a/packages/g/gnome-desktop-branding/package.yml
+++ b/packages/g/gnome-desktop-branding/package.yml
@@ -1,8 +1,8 @@
 name       : gnome-desktop-branding
-version    : '18'
-release    : 48
+version    : '19'
+release    : 49
 source     :
-    - git|https://github.com/getsolus/gnome-desktop-branding.git : v18
+    - git|https://github.com/getsolus/gnome-desktop-branding.git : v19
 homepage   : https://github.com/getsolus/gnome-desktop-branding
 license    : GPL-2.0-only
 component  :

--- a/packages/g/gnome-desktop-branding/pspec_x86_64.xml
+++ b/packages/g/gnome-desktop-branding/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-desktop-branding</Name>
         <Homepage>https://github.com/getsolus/gnome-desktop-branding</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>desktop.gnome</PartOf>
@@ -34,19 +34,19 @@
         <Description xml:lang="en">Solus 4.0 LiveCD configuration.</Description>
         <PartOf>desktop.gnome</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="48">gnome-desktop-branding</Dependency>
+            <Dependency releaseFrom="49">gnome-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/glib-2.0/schemas/50_gnome_livecd.gschema.override</Path>
         </Files>
     </Package>
     <History>
-        <Update release="48">
-            <Date>2023-11-01</Date>
-            <Version>18</Version>
+        <Update release="49">
+            <Date>2023-12-13</Date>
+            <Version>19</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Center new windows in mutter by default
- Enable solus logo distributor icon in GDM
- livecd: Pin calamares to default apps

Exception for ISO freeze due to regression where the installer was not pinned to the default apps.

**Test Plan**

**Checklist**

- [x] Package was built and tested against unstable
