### PR TITLE
calamares: Fix for partitioning

### DIFF
--- a/packages/c/calamares/files/install/modules/partition.conf
+++ b/packages/c/calamares/files/install/modules/partition.conf
@@ -1,8 +1,11 @@
 # Reference: https://github.com/calamares/calamares/blob/3.2.x-stable/src/modules/partition/partition.conf
 
 ---
+# When a user chooses "Erase"
+defaultPartitionTableType:          "gpt"
 
 efiSystemPartition:                 "/boot"
+efiSystemPartitionName:             "EFI"
 efiSystemPartitionSize:             1024M
 
 userSwapChoices:
@@ -16,5 +19,7 @@ defaultFileSystemType:              "ext4"
 
 availableFileSystemTypes:           ["ext4","btrfs","f2fs"]
 
-enableLuksAutomatedPartitioning:    true
-luksFsType                          "luks2"
+enableLuksAutomatedPartitioning:    false
+
+# Doesn't seem to do anything
+# luksFsType                          "luks2"

--- a/packages/c/calamares/files/install/modules/shellprocess_postinstall.conf
+++ b/packages/c/calamares/files/install/modules/shellprocess_postinstall.conf
@@ -8,6 +8,8 @@ dontChroot: false
 script:
     - command: "/usr/sbin/usysconf run"
       timeout: 300
+
+    # Add a comment to the vconsole conf about how to change the font in the future
     - "echo \"## The default console font on Solus is ter-v32b, if you would like to change that uncomment this and set it to your selection\" >> /etc/vconsole.conf"
     - "echo \"# FONT=ter-v32b\" >> /etc/vconsole.conf"
 

--- a/packages/c/calamares/files/patches/downstream/0001-Solus-Skip-adding-boot-partition.patch
+++ b/packages/c/calamares/files/patches/downstream/0001-Solus-Skip-adding-boot-partition.patch
@@ -1,0 +1,30 @@
+From c192d49568cba4eabd6e3059103648b4f2f88114 Mon Sep 17 00:00:00 2001
+From: Reilly Brogan <reilly@reillybrogan.com>
+Date: Wed, 13 Dec 2023 18:08:53 -0600
+Subject: [PATCH] Solus: Skip adding boot partition
+
+Signed-off-by: Reilly Brogan <reilly@reillybrogan.com>
+---
+ src/modules/fstab/main.py | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/modules/fstab/main.py b/src/modules/fstab/main.py
+index 1fd1d695a..0a25e2bb6 100755
+--- a/src/modules/fstab/main.py
++++ b/src/modules/fstab/main.py
+@@ -256,6 +256,12 @@ class FstabGenerator(object):
+         disk_name = disk_name_for_partition(partition)
+         is_ssd = disk_name in self.ssd_disks
+ 
++        # On Solus we want to skip adding the boot partition to fstab if installing on UEFI
++        # clr-boot-manager will mount it as needed.
++        fw_type = libcalamares.globalstorage.value("firmwareType")
++        if mount_point == "/boot" and fw_type == "efi":
++            return None
++
+         # Swap partitions are called "linuxswap" by parted.
+         # That "fs" is visible in GS, but that gets mapped
+         # to "swap", above, because that's the spelling needed in /etc/fstab
+-- 
+2.43.0
+

--- a/packages/c/calamares/files/series
+++ b/packages/c/calamares/files/series
@@ -1,3 +1,4 @@
 patches/downstream/0001-Don-t-spawn-a-new-shell-when-starting.patch
 patches/downstream/0001-bootloader-Add-clr-boot-manager-support.patch
 patches/downstream/0001-users-Use-libxcrypt-for-salt-generation-when-possibl.patch
+patches/downstream/0001-Solus-Skip-adding-boot-partition.patch

--- a/packages/c/calamares/package.yml
+++ b/packages/c/calamares/package.yml
@@ -1,6 +1,6 @@
 name       : calamares
 version    : 3.2.62
-release    : 7
+release    : 8
 source     :
     - https://github.com/calamares/calamares/releases/download/v3.2.62/calamares-3.2.62.tar.gz : a0fbcec2a438693753fc174220356119ad7adb8a2b19c317518aa1cb025d6dd0
 homepage   : https://calamares.io

--- a/packages/c/calamares/pspec_x86_64.xml
+++ b/packages/c/calamares/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>calamares</Name>
         <Homepage>https://calamares.io</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Reilly Brogan</Name>
+            <Email>solus@reillybrogan.com</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <License>CC-BY-4.0</License>
@@ -283,7 +283,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="7">calamares</Dependency>
+            <Dependency release="8">calamares</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libcalamares/Branding.h</Path>
@@ -404,12 +404,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2023-12-12</Date>
+        <Update release="8">
+            <Date>2023-12-14</Date>
             <Version>3.2.62</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Reilly Brogan</Name>
+            <Email>solus@reillybrogan.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
Changes:
- Name EFI partition "EFI", which matches the os-installer naming
- Use GPT as the default partition table type
- Disable automated LUKS partitioning as it is currently broken on BIOS systems
- Comment out /boot from fstab if present. Note that this breaks BIOS installs with a dedicated boot partition.
