### PR TITLE
calamares: More fixes

### DIFF
--- a/packages/c/calamares/files/install/modules/partition.conf
+++ b/packages/c/calamares/files/install/modules/partition.conf
@@ -4,6 +4,7 @@
 # When a user chooses "Erase"
 defaultPartitionTableType:          "gpt"
 
+bootPartitionName:                  "boot"
 efiSystemPartition:                 "/boot"
 efiSystemPartitionName:             "EFI"
 efiSystemPartitionSize:             1024M

--- a/packages/c/calamares/files/install/modules/shellprocess_postinstall.conf
+++ b/packages/c/calamares/files/install/modules/shellprocess_postinstall.conf
@@ -13,5 +13,10 @@ script:
     - "echo \"## The default console font on Solus is ter-v32b, if you would like to change that uncomment this and set it to your selection\" >> /etc/vconsole.conf"
     - "echo \"# FONT=ter-v32b\" >> /etc/vconsole.conf"
 
+    # If the ISO was generated from unstable then remove the local repo and switch back to shannon
+    # TODO: We could make a UI to configure this. Perhaps an advanced option to make the installed system run from unstable?
+    - "/usr/bin/eopkg rr Local || true"
+    - "/usr/bin/eopkg ar Solus https://cdn.getsol.us/repo/shannon/eopkg-index.xml.xz"
+
 i18n:
     name: "Running post install triggers"

--- a/packages/c/calamares/files/install/modules/users.conf
+++ b/packages/c/calamares/files/install/modules/users.conf
@@ -41,9 +41,10 @@ allowWeakPasswordsDefault: false
 
 userShell: /usr/bin/bash
 
-setHostname: EtcFile
-
-writeHostsFile: true
+hostname:
+    template: "${first}-solus"
+    location: EtcFile
+    writeHostsFile: true
 
 presets:
     fullName:

--- a/packages/c/calamares/files/patches/downstream/0001-Solus-Create-boot-partition-for-BIOS-installs.patch
+++ b/packages/c/calamares/files/patches/downstream/0001-Solus-Create-boot-partition-for-BIOS-installs.patch
@@ -1,0 +1,96 @@
+From bda04865b5d80b0edda8449e8fb0fa375cc1ee9b Mon Sep 17 00:00:00 2001
+From: Reilly Brogan <reilly@reillybrogan.com>
+Date: Wed, 13 Dec 2023 19:27:51 -0600
+Subject: [PATCH] Solus: Create boot partition for BIOS installs
+
+Signed-off-by: Reilly Brogan <reilly@reillybrogan.com>
+---
+ src/modules/partition/Config.cpp              |  5 +++++
+ src/modules/partition/core/KPMHelpers.h       |  1 +
+ .../partition/core/PartitionActions.cpp       | 20 +++++++++++++++----
+ src/modules/partition/partition.schema.yaml   |  1 +
+ 4 files changed, 23 insertions(+), 4 deletions(-)
+
+diff --git a/src/modules/partition/Config.cpp b/src/modules/partition/Config.cpp
+index 367c4ee38..ab2e19bc7 100644
+--- a/src/modules/partition/Config.cpp
++++ b/src/modules/partition/Config.cpp
+@@ -270,6 +270,11 @@ fillGSConfigurationEFI( Calamares::GlobalStorage* gs, const QVariantMap& configu
+     {
+         gs->insert( "efiSystemPartitionName", CalamaresUtils::getString( configurationMap, "efiSystemPartitionName" ) );
+     }
++    // Read and parse key bootPartitionName
++    if ( configurationMap.contains( "bootPartitionName" ) )
++    {
++        gs->insert( "bootPartitionName", CalamaresUtils::getString( configurationMap, "bootPartitionName" ) );
++    }
+ }
+ 
+ void
+diff --git a/src/modules/partition/core/KPMHelpers.h b/src/modules/partition/core/KPMHelpers.h
+index e059c934a..5f039555a 100644
+--- a/src/modules/partition/core/KPMHelpers.h
++++ b/src/modules/partition/core/KPMHelpers.h
+@@ -31,6 +31,7 @@ class PartitionRole;
+ #define KPM_PARTITION_FLAG( x ) PartitionTable::Flag::x
+ #define KPM_PARTITION_STATE( x ) Partition::State::x
+ #define KPM_PARTITION_FLAG_ESP PartitionTable::Flag::Boot
++#define KPM_PARTITION_FLAG_BOOT PartitionTable::Flag::Boot
+ #else
+ #define KPM_PARTITION_FLAG( x ) PartitionTable::Flag##x
+ #define KPM_PARTITION_STATE( x ) Partition::State##x
+diff --git a/src/modules/partition/core/PartitionActions.cpp b/src/modules/partition/core/PartitionActions.cpp
+index 0ce9ff4ed..05c4966f7 100644
+--- a/src/modules/partition/core/PartitionActions.cpp
++++ b/src/modules/partition/core/PartitionActions.cpp
+@@ -116,7 +116,8 @@ doAutopartition( PartitionCoreModule* core, Device* dev, Choices::AutoPartitionO
+ 
+     core->createPartitionTable( dev, partType );
+ 
+-    if ( isEfi )
++    // On Solus we always want to create a /boot partition
++    if ( true )
+     {
+         size_t uefisys_part_sizeB = PartUtils::efiFilesystemMinimumSize();
+         qint64 efiSectorCount = CalamaresUtils::bytesToSectors( uefisys_part_sizeB, dev->logicalSize() );
+@@ -136,11 +137,22 @@ doAutopartition( PartitionCoreModule* core, Device* dev, Choices::AutoPartitionO
+                                                                   KPM_PARTITION_FLAG( None ) );
+         PartitionInfo::setFormat( efiPartition, true );
+         PartitionInfo::setMountPoint( efiPartition, o.efiPartitionMountPoint );
+-        if ( gs->contains( "efiSystemPartitionName" ) )
++        if ( isEfi )
+         {
+-            efiPartition->setLabel( gs->value( "efiSystemPartitionName" ).toString() );
++            if ( gs->contains( "efiSystemPartitionName" ) )
++            {
++                efiPartition->setLabel( gs->value( "efiSystemPartitionName" ).toString() );
++            }
++            core->createPartition( dev, efiPartition, KPM_PARTITION_FLAG_ESP );
++        }
++        else
++        {
++            if ( gs->contains( "bootPartitionName" ) )
++            {
++                efiPartition->setLabel( gs->value( "bootPartitionName" ).toString() );
++            }
++            core->createPartition( dev, efiPartition, KPM_PARTITION_FLAG_BOOT );
+         }
+-        core->createPartition( dev, efiPartition, KPM_PARTITION_FLAG_ESP );
+         firstFreeSector = lastSector + 1;
+     }
+ 
+diff --git a/src/modules/partition/partition.schema.yaml b/src/modules/partition/partition.schema.yaml
+index 6c65e8ae7..6d5b7d1b3 100644
+--- a/src/modules/partition/partition.schema.yaml
++++ b/src/modules/partition/partition.schema.yaml
+@@ -9,6 +9,7 @@ properties:
+     efiSystemPartition: { type: string }  # Mount point
+     efiSystemPartitionSize: { type: string }
+     efiSystemPartitionName: { type: string }
++    bootPartitionName: { type: string }
+ 
+     userSwapChoices: { type: array, items: { type: string, enum: [ none, reuse, small, suspend, file ] } }
+     # ensureSuspendToDisk: { type: boolean, default: true }  # Legacy
+-- 
+2.43.0
+

--- a/packages/c/calamares/files/series
+++ b/packages/c/calamares/files/series
@@ -2,3 +2,4 @@ patches/downstream/0001-Don-t-spawn-a-new-shell-when-starting.patch
 patches/downstream/0001-bootloader-Add-clr-boot-manager-support.patch
 patches/downstream/0001-users-Use-libxcrypt-for-salt-generation-when-possibl.patch
 patches/downstream/0001-Solus-Skip-adding-boot-partition.patch
+patches/downstream/0001-Solus-Create-boot-partition-for-BIOS-installs.patch

--- a/packages/c/calamares/package.yml
+++ b/packages/c/calamares/package.yml
@@ -1,6 +1,6 @@
 name       : calamares
 version    : 3.2.62
-release    : 8
+release    : 9
 source     :
     - https://github.com/calamares/calamares/releases/download/v3.2.62/calamares-3.2.62.tar.gz : a0fbcec2a438693753fc174220356119ad7adb8a2b19c317518aa1cb025d6dd0
 homepage   : https://calamares.io

--- a/packages/c/calamares/pspec_x86_64.xml
+++ b/packages/c/calamares/pspec_x86_64.xml
@@ -283,7 +283,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="8">calamares</Dependency>
+            <Dependency release="9">calamares</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libcalamares/Branding.h</Path>
@@ -404,7 +404,7 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
+        <Update release="9">
             <Date>2023-12-14</Date>
             <Version>3.2.62</Version>
             <Comment>Packaging update</Comment>


### PR DESCRIPTION
Changes:
- Create a boot partition even with BIOS installs when auto-partitioning
- Set the default system hostname to `${first}-solus` instead of pulling from the platform
- Set the install back to stable if the ISO was built from unstable
