### PR TITLE
xfce4-panel: Enable icon scaling in the system tray by default

### DIFF
--- a/packages/x/xfce4-panel/files/0001-Use-Solus-defaults.patch
+++ b/packages/x/xfce4-panel/files/0001-Use-Solus-defaults.patch
@@ -1,15 +1,15 @@
-From a43f73d53d6090ec8d546721c51083674f55a0e9 Mon Sep 17 00:00:00 2001
+From 6b3be9ae26cfe4778f8e236c7dad3dc37fc15c23 Mon Sep 17 00:00:00 2001
 From: Evan Maddock <maddock.evan@vivaldi.net>
 Date: Mon, 27 Nov 2023 15:12:54 -0500
 Subject: [PATCH] Use Solus defaults
 
 Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
 ---
- migrate/default.xml.in | 98 ++++++++++++++++++------------------------
- 1 file changed, 43 insertions(+), 55 deletions(-)
+ migrate/default.xml.in | 99 +++++++++++++++++++-----------------------
+ 1 file changed, 44 insertions(+), 55 deletions(-)
 
 diff --git a/migrate/default.xml.in b/migrate/default.xml.in
-index 46344203..38050911 100644
+index 46344203..f458a26c 100644
 --- a/migrate/default.xml.in
 +++ b/migrate/default.xml.in
 @@ -4,14 +4,13 @@
@@ -31,7 +31,7 @@ index 46344203..38050911 100644
        <property name="plugin-ids" type="array">
          <value type="int" value="1"/>
          <value type="int" value="2"/>
-@@ -27,79 +26,68 @@
+@@ -27,79 +26,69 @@
          <value type="int" value="12"/>
          <value type="int" value="13"/>
          <value type="int" value="14"/>
@@ -136,6 +136,7 @@ index 46344203..38050911 100644
 +      <property name="known-legacy-items" type="array">
 +        <value type="string" value="ethernet network connection “wired connection 1” active"/>
 +      </property>
++      <property name="icon-size" type="int" value="0"/>
 +    </property>
 +    <property name="plugin-13" type="string" value="pulseaudio">
 +      <property name="enable-keyboard-shortcuts" type="bool" value="true"/>

--- a/packages/x/xfce4-panel/package.yml
+++ b/packages/x/xfce4-panel/package.yml
@@ -1,6 +1,6 @@
 name       : xfce4-panel
 version    : 4.18.5
-release    : 9
+release    : 10
 source     :
     - https://archive.xfce.org/src/xfce/xfce4-panel/4.18/xfce4-panel-4.18.5.tar.bz2 : b20e0d10cc5149a601d8eee07373efb446ea3e179dd032ed8ddb5782e3f9e7cb
 homepage   : https://docs.xfce.org/xfce/xfce4-panel/start

--- a/packages/x/xfce4-panel/pspec_x86_64.xml
+++ b/packages/x/xfce4-panel/pspec_x86_64.xml
@@ -223,7 +223,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="9">xfce4-panel</Dependency>
+            <Dependency release="10">xfce4-panel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/xfce4/libxfce4panel-2.0/libxfce4panel/libxfce4panel-config.h</Path>
@@ -281,8 +281,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2023-12-03</Date>
+        <Update release="10">
+            <Date>2023-12-15</Date>
             <Version>4.18.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**

- Enable icon scaling in the system tray by default

Ref https://github.com/getsolus/packages/issues/305

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Created a new user and saw that the network-manager-applet icon now scales with the other icons

**Checklist**

- [x] Package was built and tested against unstable
