### PR TITLE
libxfce4ui: Fix Keyboard Shortcuts

### DIFF
--- a/packages/l/libxfce4ui/files/0001-libxfce4kbd-private-Add-shortcut-for-Whiskermenu.patch
+++ b/packages/l/libxfce4ui/files/0001-libxfce4kbd-private-Add-shortcut-for-Whiskermenu.patch
@@ -1,4 +1,4 @@
-From 8ffc6614d7fd12e2453a5be1bb56a573ab5feb8f Mon Sep 17 00:00:00 2001
+From d09d641687ccc71421586d9342880c5995941b13 Mon Sep 17 00:00:00 2001
 From: Evan Maddock <maddock.evan@vivaldi.net>
 Date: Thu, 14 Dec 2023 10:48:47 -0500
 Subject: [PATCH] libxfce4kbd-private: Add shortcut for Whiskermenu
@@ -9,14 +9,14 @@ Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
  1 file changed, 1 insertion(+)
 
 diff --git a/libxfce4kbd-private/xfce4-keyboard-shortcuts.xml b/libxfce4kbd-private/xfce4-keyboard-shortcuts.xml
-index 32901e3..5b04d93 100644
+index 32901e3..dbf3c32 100644
 --- a/libxfce4kbd-private/xfce4-keyboard-shortcuts.xml
 +++ b/libxfce4kbd-private/xfce4-keyboard-shortcuts.xml
 @@ -30,6 +30,7 @@
          <property name="startup-notify" type="bool" value="true"/>
        </property>
        <property name="&lt;Alt&gt;&lt;Super&gt;s" type="string" value="orca"/>
-+      <property name="Super_L" type="string" value="xfce4-popup-whiskermenu">
++      <property name="Super_L" type="string" value="xfce4-popup-whiskermenu"/>
      </property>
    </property>
    <property name="xfwm4" type="empty">

--- a/packages/l/libxfce4ui/package.yml
+++ b/packages/l/libxfce4ui/package.yml
@@ -1,6 +1,6 @@
 name       : libxfce4ui
 version    : 4.18.4
-release    : 5
+release    : 6
 source     :
     - https://archive.xfce.org/src/xfce/libxfce4ui/4.18/libxfce4ui-4.18.4.tar.bz2 : 87eefe797c6d26de3f754de48872faf131f1b5fc93fb88e22f5c7886a842cb4c
 homepage   : https://docs.xfce.org/xfce/libxfce4ui/start

--- a/packages/l/libxfce4ui/pspec_x86_64.xml
+++ b/packages/l/libxfce4ui/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libxfce4ui</Name>
         <Homepage>https://docs.xfce.org/xfce/libxfce4ui/start</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>desktop.xfce</PartOf>
@@ -111,7 +111,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="5">libxfce4ui</Dependency>
+            <Dependency release="6">libxfce4ui</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/xfce4/libxfce4kbd-private-3/libxfce4kbd-private/xfce-shortcut-dialog.h</Path>
@@ -180,12 +180,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2023-12-14</Date>
+        <Update release="6">
+            <Date>2023-12-16</Date>
             <Version>4.18.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Fix a malformed XML tag which was keeping XFCE from recognizing any of the window manager keyboard shortcuts

**Test Plan**

1. Open XFCE Window Manager settings
2. Go to the "Keyboard" tab
3. Click "Reset to defaults"
4. See that there are no configured keyboard shortcuts
5. Rebuild `libxfce4ui` against unstable with changes from this PR
6. Install the new package to your XFCE system
7. Reset window manager shortcuts to default again
8. See that keyboard shortcuts are configured now


**Checklist**

- [x] Package was built and tested against unstable
