### PR TITLE
gnome-desktop-branding: Sync with git

### DIFF
--- a/packages/g/gnome-desktop-branding/package.yml
+++ b/packages/g/gnome-desktop-branding/package.yml
@@ -1,8 +1,8 @@
 name       : gnome-desktop-branding
 version    : '19'
-release    : 49
+release    : 50
 source     :
-    - git|https://github.com/getsolus/gnome-desktop-branding.git : v19
+    - git|https://github.com/getsolus/gnome-desktop-branding.git : 40fbfcb8a1cc95bc0753f429252f534466ebc355
 homepage   : https://github.com/getsolus/gnome-desktop-branding
 license    : GPL-2.0-only
 component  :

--- a/packages/g/gnome-desktop-branding/pspec_x86_64.xml
+++ b/packages/g/gnome-desktop-branding/pspec_x86_64.xml
@@ -34,15 +34,15 @@
         <Description xml:lang="en">Solus 4.0 LiveCD configuration.</Description>
         <PartOf>desktop.gnome</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="49">gnome-desktop-branding</Dependency>
+            <Dependency releaseFrom="50">gnome-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/glib-2.0/schemas/50_gnome_livecd.gschema.override</Path>
         </Files>
     </Package>
     <History>
-        <Update release="49">
-            <Date>2023-12-13</Date>
+        <Update release="50">
+            <Date>2023-12-18</Date>
             <Version>19</Version>
             <Comment>Packaging update</Comment>
             <Name>Joey Riches</Name>


### PR DESCRIPTION
**Summary**
- Change background to rivers and mountains
- Slightly increase mono font size
- Merge in defaults from gsettings-desktop-schemas

**Test Plan**

Spin a smoketest ISO with this package, verify changes

**Checklist**

- [x] Package was built and tested against unstable
