### PR TITLE
Update libwebkit-gtk to 2.42.4

### DIFF
--- a/packages/l/libwebkit-gtk/abi_used_symbols
+++ b/packages/l/libwebkit-gtk/abi_used_symbols
@@ -442,6 +442,7 @@ libcairo.so.2:cairo_surface_flush
 libcairo.so.2:cairo_surface_get_content
 libcairo.so.2:cairo_surface_get_device_scale
 libcairo.so.2:cairo_surface_get_type
+libcairo.so.2:cairo_surface_get_user_data
 libcairo.so.2:cairo_surface_mark_dirty
 libcairo.so.2:cairo_surface_mark_dirty_rectangle
 libcairo.so.2:cairo_surface_reference
@@ -3357,14 +3358,12 @@ libtasn1.so.6:asn1_write_value
 libwayland-client.so.0:wl_display_connect
 libwayland-client.so.0:wl_display_disconnect
 libwayland-client.so.0:wl_display_roundtrip
-libwayland-client.so.0:wl_pointer_interface
 libwayland-client.so.0:wl_proxy_add_listener
 libwayland-client.so.0:wl_proxy_destroy
 libwayland-client.so.0:wl_proxy_get_version
 libwayland-client.so.0:wl_proxy_marshal_flags
 libwayland-client.so.0:wl_region_interface
 libwayland-client.so.0:wl_registry_interface
-libwayland-client.so.0:wl_surface_interface
 libwayland-server.so.0:wl_pointer_interface
 libwayland-server.so.0:wl_region_interface
 libwayland-server.so.0:wl_registry_interface

--- a/packages/l/libwebkit-gtk/package.yml
+++ b/packages/l/libwebkit-gtk/package.yml
@@ -1,8 +1,8 @@
 name       : libwebkit-gtk
-version    : 2.42.3
-release    : 110
+version    : 2.42.4
+release    : 111
 source     :
-    - https://webkitgtk.org/releases/webkitgtk-2.42.3.tar.xz : 0a1a4630045628b3a6fe95da72dc47852cff20d66be1ac6fd0d669c88c13d8e2
+    - https://webkitgtk.org/releases/webkitgtk-2.42.4.tar.xz : 52288b30bda22373442cecb86f9c9a569ad8d4769a1f97b352290ed92a67ed86
 homepage   : https://webkitgtk.org
 license    : LGPL-2.1-only
 component  : desktop.web

--- a/packages/l/libwebkit-gtk/pspec_x86_64.xml
+++ b/packages/l/libwebkit-gtk/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libwebkit-gtk</Name>
         <Homepage>https://webkitgtk.org</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Hans Kelson</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>LGPL-2.1-only</License>
         <PartOf>desktop.web</PartOf>
@@ -24,9 +24,9 @@
             <Path fileType="library">/usr/lib64/girepository-1.0/WebKit2-4.0.typelib</Path>
             <Path fileType="library">/usr/lib64/girepository-1.0/WebKit2WebExtension-4.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libjavascriptcoregtk-4.0.so.18</Path>
-            <Path fileType="library">/usr/lib64/libjavascriptcoregtk-4.0.so.18.23.12</Path>
+            <Path fileType="library">/usr/lib64/libjavascriptcoregtk-4.0.so.18.23.13</Path>
             <Path fileType="library">/usr/lib64/libwebkit2gtk-4.0.so.37</Path>
-            <Path fileType="library">/usr/lib64/libwebkit2gtk-4.0.so.37.67.6</Path>
+            <Path fileType="library">/usr/lib64/libwebkit2gtk-4.0.so.37.67.7</Path>
             <Path fileType="library">/usr/lib64/webkit2gtk-4.0/injected-bundle/libwebkit2gtkinjectedbundle.so</Path>
             <Path fileType="executable">/usr/libexec/webkit2gtk-4.0/MiniBrowser</Path>
             <Path fileType="executable">/usr/libexec/webkit2gtk-4.0/WebKitNetworkProcess</Path>
@@ -95,7 +95,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="110">libwebkit-gtk</Dependency>
+            <Dependency release="111">libwebkit-gtk</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/webkitgtk-4.0/JavaScriptCore/JSBase.h</Path>
@@ -325,12 +325,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="110">
-            <Date>2023-12-05</Date>
-            <Version>2.42.3</Version>
+        <Update release="111">
+            <Date>2023-12-17</Date>
+            <Version>2.42.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Hans Kelson</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/l/libwebkit-gtk41/abi_used_symbols
+++ b/packages/l/libwebkit-gtk41/abi_used_symbols
@@ -442,6 +442,7 @@ libcairo.so.2:cairo_surface_flush
 libcairo.so.2:cairo_surface_get_content
 libcairo.so.2:cairo_surface_get_device_scale
 libcairo.so.2:cairo_surface_get_type
+libcairo.so.2:cairo_surface_get_user_data
 libcairo.so.2:cairo_surface_mark_dirty
 libcairo.so.2:cairo_surface_mark_dirty_rectangle
 libcairo.so.2:cairo_surface_reference
@@ -3381,6 +3382,7 @@ libwayland-client.so.0:wl_proxy_add_listener
 libwayland-client.so.0:wl_proxy_destroy
 libwayland-client.so.0:wl_proxy_get_version
 libwayland-client.so.0:wl_proxy_marshal_flags
+libwayland-client.so.0:wl_surface_interface
 libwayland-server.so.0:wl_pointer_interface
 libwayland-server.so.0:wl_region_interface
 libwayland-server.so.0:wl_registry_interface

--- a/packages/l/libwebkit-gtk41/package.yml
+++ b/packages/l/libwebkit-gtk41/package.yml
@@ -1,8 +1,8 @@
 name       : libwebkit-gtk41
-version    : 2.42.3
-release    : 23
+version    : 2.42.4
+release    : 24
 source     :
-    - https://webkitgtk.org/releases/webkitgtk-2.42.3.tar.xz : 0a1a4630045628b3a6fe95da72dc47852cff20d66be1ac6fd0d669c88c13d8e2
+    - https://webkitgtk.org/releases/webkitgtk-2.42.4.tar.xz : 52288b30bda22373442cecb86f9c9a569ad8d4769a1f97b352290ed92a67ed86
 homepage   : https://webkitgtk.org
 license    : LGPL-2.1-only
 component  : desktop.web

--- a/packages/l/libwebkit-gtk41/pspec_x86_64.xml
+++ b/packages/l/libwebkit-gtk41/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libwebkit-gtk41</Name>
         <Homepage>https://webkitgtk.org</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>LGPL-2.1-only</License>
         <PartOf>desktop.web</PartOf>
@@ -24,9 +24,9 @@
             <Path fileType="library">/usr/lib64/girepository-1.0/WebKit2-4.1.typelib</Path>
             <Path fileType="library">/usr/lib64/girepository-1.0/WebKit2WebExtension-4.1.typelib</Path>
             <Path fileType="library">/usr/lib64/libjavascriptcoregtk-4.1.so.0</Path>
-            <Path fileType="library">/usr/lib64/libjavascriptcoregtk-4.1.so.0.4.12</Path>
+            <Path fileType="library">/usr/lib64/libjavascriptcoregtk-4.1.so.0.4.13</Path>
             <Path fileType="library">/usr/lib64/libwebkit2gtk-4.1.so.0</Path>
-            <Path fileType="library">/usr/lib64/libwebkit2gtk-4.1.so.0.12.6</Path>
+            <Path fileType="library">/usr/lib64/libwebkit2gtk-4.1.so.0.12.7</Path>
             <Path fileType="library">/usr/lib64/webkit2gtk-4.1/injected-bundle/libwebkit2gtkinjectedbundle.so</Path>
             <Path fileType="executable">/usr/libexec/webkit2gtk-4.1/MiniBrowser</Path>
             <Path fileType="executable">/usr/libexec/webkit2gtk-4.1/WebKitNetworkProcess</Path>
@@ -95,7 +95,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="23">libwebkit-gtk41</Dependency>
+            <Dependency release="24">libwebkit-gtk41</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/webkitgtk-4.1/JavaScriptCore/JSBase.h</Path>
@@ -325,12 +325,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2023-12-05</Date>
-            <Version>2.42.3</Version>
+        <Update release="24">
+            <Date>2023-12-17</Date>
+            <Version>2.42.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Update to 2.42.4 for https://seclists.org/oss-sec/2023/q4/290. @HarveyDevel updated `libwebkit-gtk5`.

**Test Plan**

Rebuilt, installs correctly

**Checklist**

- [x] Package was built and tested against unstable
