### PR TITLE
thunar-shares-plugin: Replace gnome-fs-share with folder-publicshare

### DIFF
--- a/packages/t/thunar-shares-plugin/files/0001-tsp-page-Replace-gnome-fs-share-with-folder-publicsh.patch
+++ b/packages/t/thunar-shares-plugin/files/0001-tsp-page-Replace-gnome-fs-share-with-folder-publicsh.patch
@@ -1,0 +1,30 @@
+From 5379a62709d93c87a1354c5f0acb9d1e64d76df6 Mon Sep 17 00:00:00 2001
+From: Joey Riches <josephriches@gmail.com>
+Date: Mon, 18 Dec 2023 21:06:57 +0000
+Subject: [PATCH 1/1] tsp-page: Replace gnome-fs-share with folder-publicshare
+ icon
+
+gnome-fs-share was removed with nautilus 3.1 many years ago, as such
+icon themes have begun to stop providing this icon.
+
+Replace with a modern suitable alternative.
+---
+ thunar-plugin/tsp-page.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/thunar-plugin/tsp-page.c b/thunar-plugin/tsp-page.c
+index 33c397b..afd3b02 100644
+--- a/thunar-plugin/tsp-page.c
++++ b/thunar-plugin/tsp-page.c
+@@ -143,7 +143,7 @@ tsp_page_init (TspPage *page)
+   gtk_box_pack_start (GTK_BOX (vbox1), hbox1, FALSE, TRUE, 0);
+ 
+   widget = gtk_image_new ();
+-  gtk_image_set_from_icon_name (GTK_IMAGE (widget), "gnome-fs-share", GTK_ICON_SIZE_DIALOG);
++  gtk_image_set_from_icon_name (GTK_IMAGE (widget), "folder-publicshare", GTK_ICON_SIZE_DIALOG);
+   gtk_widget_set_halign (widget, GTK_ALIGN_START);
+   gtk_box_pack_start (GTK_BOX (hbox1), widget, FALSE, FALSE, 0);
+ 
+-- 
+2.43.0
+

--- a/packages/t/thunar-shares-plugin/package.yml
+++ b/packages/t/thunar-shares-plugin/package.yml
@@ -1,6 +1,6 @@
 name       : thunar-shares-plugin
 version    : 0.3.2
-release    : 1
+release    : 2
 source     :
     - https://archive.xfce.org/src/thunar-plugins/thunar-shares-plugin/0.3/thunar-shares-plugin-0.3.2.tar.bz2 : 1009d5e6c91534fa49a69090c53c54ab9da2e0428d08d8e687528f63a4ac3f07
 homepage   : https://docs.xfce.org/xfce/thunar/thunar-shares-plugin
@@ -12,6 +12,7 @@ description: |
 builddeps  :
     - pkgconfig(thunarx-3)
 setup      : |
+    %patch -p1 -i $pkgfiles/0001-tsp-page-Replace-gnome-fs-share-with-folder-publicsh.patch
     %configure
 build      : |
     %make

--- a/packages/t/thunar-shares-plugin/pspec_x86_64.xml
+++ b/packages/t/thunar-shares-plugin/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>thunar-shares-plugin</Name>
         <Homepage>https://docs.xfce.org/xfce/thunar/thunar-shares-plugin</Homepage>
         <Packager>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.xfce</PartOf>
@@ -80,12 +80,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2023-10-26</Date>
+        <Update release="2">
+            <Date>2023-12-18</Date>
             <Version>0.3.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- As icon themes have begun to stop providing this icon

**Packager's Notes**
- This patch has been submitted upstream

**Test Plan**

- Verify icon gets picked from user theme

**Checklist**

- [x] Package was built and tested against unstable
