### PR TITLE
brother-dcp135c: homepage inclusion

### DIFF
--- a/packages/b/brother-dcp135c/abi_libs
+++ b/packages/b/brother-dcp135c/abi_libs
@@ -1,0 +1,1 @@
+brcupsconfpt1

--- a/packages/b/brother-dcp135c/abi_symbols
+++ b/packages/b/brother-dcp135c/abi_symbols
@@ -1,0 +1,1 @@
+brcupsconfpt1:stdout

--- a/packages/b/brother-dcp135c/abi_used_symbols
+++ b/packages/b/brother-dcp135c/abi_used_symbols
@@ -1,4 +1,5 @@
 libc.so.6:__libc_start_main
+libc.so.6:__stack_chk_fail
 libc.so.6:fflush
 libc.so.6:fgets
 libc.so.6:fopen
@@ -6,6 +7,7 @@ libc.so.6:fputs
 libc.so.6:sprintf
 libc.so.6:strchr
 libc.so.6:strcpy
+libc.so.6:strlen
 libc.so.6:strncpy
 libc.so.6:strstr
 libc.so.6:system

--- a/packages/b/brother-dcp135c/package.yml
+++ b/packages/b/brother-dcp135c/package.yml
@@ -1,9 +1,10 @@
 name       : brother-dcp135c
 version    : 1.0.1
-release    : 1
+release    : 2
 source     :
     - https://download.brother.com/welcome/dlf006675/ink3_GPL_src_101-1.tar.gz : 0b036f13182554e32952ef515a08a4d8415ccd35af3ab43c6fb331cb840b8cc3
     - https://download.brother.com/welcome/dlf005458/dcp135clpr-1.0.1-1.i386.rpm : aab731af656be017042d5f934d99fa5592e86db8b4141cfd5a614a0b6d3122de
+homepage   : https://global.brother/
 license    :
     - Distributable
     - GPL-2.0-or-later
@@ -17,8 +18,8 @@ builddeps  :
     - rpm
 rundeps    :
     - a2ps
-    - glibc-32bit
     - ghostscript
+    - glibc-32bit
     - psutils
 setup      : |
     # Extract rpms

--- a/packages/b/brother-dcp135c/pspec_x86_64.xml
+++ b/packages/b/brother-dcp135c/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>brother-dcp135c</Name>
+        <Homepage>https://global.brother/</Homepage>
         <Packager>
-            <Name>F. von Gellhorn</Name>
-            <Email>flinux@vongellhorn.ch</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>Distributable</License>
         <License>GPL-2.0-or-later</License>
@@ -12,7 +13,7 @@
         <Description xml:lang="en">Printer driver for Brother DCP-135C.
 Note that some portions are binary and provided for hardware enablement so may not meet typical Solus packaging standards for paths.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://solus-project.com/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>brother-dcp135c</Name>
@@ -43,12 +44,12 @@ Note that some portions are binary and provided for hardware enablement so may n
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2019-01-20</Date>
+        <Update release="2">
+            <Date>2023-12-19</Date>
             <Version>1.0.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>F. von Gellhorn</Name>
-            <Email>flinux@vongellhorn.ch</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable