### PR TITLE
slick-greeter: Make greeter box much more opaque

### DIFF
--- a/packages/s/slick-greeter/files/series
+++ b/packages/s/slick-greeter/files/series
@@ -1,1 +1,2 @@
 0001-Apply-Solus-branding.patch
+solus-change-greeter-box-opacity.patch

--- a/packages/s/slick-greeter/files/solus-change-greeter-box-opacity.patch
+++ b/packages/s/slick-greeter/files/solus-change-greeter-box-opacity.patch
@@ -1,0 +1,20 @@
+Make text in the login greeter box easier to read on bright backgrounds.
+by making the greeter box background more opaque.
+
+diff --git a/src/dash-box.vala b/src/dash-box.vala
+index 889ba41..b91886c 100644
+--- a/src/dash-box.vala
++++ b/src/dash-box.vala
+@@ -216,10 +216,10 @@ public class DashBox : Gtk.Box
+ 
+         CairoUtils.rounded_rectangle (c, 0, box_y, box_w, box_h, box_r);
+ 
+-        c.set_source_rgba (0.1, 0.1, 0.1, 0.4);
++        c.set_source_rgba (0.1, 0.1, 0.1, 0.9);
+         c.fill_preserve ();
+ 
+-        c.set_source_rgba (0.4, 0.4, 0.4, 0.4);
++        c.set_source_rgba (0.4, 0.4, 0.4, 0.9);
+         c.set_line_width (1);
+         c.stroke ();
+ 

--- a/packages/s/slick-greeter/package.yml
+++ b/packages/s/slick-greeter/package.yml
@@ -1,6 +1,6 @@
 name       : slick-greeter
 version    : 2.0.1
-release    : 29
+release    : 30
 source     :
     - https://github.com/linuxmint/slick-greeter/archive/refs/tags/2.0.1.tar.gz : 24ddfb1a01e3f49ad96618b946d15cc7ab7629f6238a93c9e8d4a1b362be2882
 homepage   : https://github.com/linuxmint/slick-greeter

--- a/packages/s/slick-greeter/pspec_x86_64.xml
+++ b/packages/s/slick-greeter/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>slick-greeter</Name>
         <Homepage>https://github.com/linuxmint/slick-greeter</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop.lightdm</PartOf>
@@ -278,12 +278,12 @@
         </Conflicts>
     </Package>
     <History>
-        <Update release="29">
-            <Date>2023-12-04</Date>
+        <Update release="30">
+            <Date>2023-12-19</Date>
             <Version>2.0.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
This solves the issue where greeter text is hard to read when using bright backgrounds.

**Test Plan**
- Spun up an XFCE VM and took screenshots of the unmodified and the modified greeter.
- Saw that the modified greeter had a darker background as expected.

**Checklist**

- [x] Package was built and tested against unstable
