### PR TITLE
grub2: Improve default resolution settings

### DIFF
--- a/packages/g/grub2/files/conf/grub
+++ b/packages/g/grub2/files/conf/grub
@@ -23,8 +23,12 @@ GRUB_COLOR_HIGHLIGHT="light-blue/white"
 # you can see them in real GRUB with the command `vbeinfo'
 #GRUB_GFXMODE=640x480
 
-# This is a reasonable default w/fallbacks for older laptops and VMs
-GRUB_GFXMODE=1366x768,1024x768x32,auto
+# Virt-Manager VMs will pick 1280x800 (which is also the default resolution
+# for virt-managers graphical session at the greeter), but because the
+# resolution is so uncommon, virtually nothing else will support it, and will
+# instead fall back to 'auto' and pick the largest resolution supported by
+# their GPU+Display combination.
+GRUB_GFXMODE=1280x800,auto
 
 # Uncomment if you don't want GRUB to pass "root=UUID=xxx" parameter to Linux
 #GRUB_DISABLE_LINUX_UUID=true

--- a/packages/g/grub2/package.yml
+++ b/packages/g/grub2/package.yml
@@ -1,6 +1,6 @@
 name       : grub2
 version    : '2.04'
-release    : 35
+release    : 36
 source     :
     - git|https://git.savannah.gnu.org/git/grub.git : e7b8856f8be3292afdb38d2e8c70ad8d62a61e10
 homepage   : https://www.gnu.org/software/grub/

--- a/packages/g/grub2/pspec_x86_64.xml
+++ b/packages/g/grub2/pspec_x86_64.xml
@@ -647,8 +647,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="35">
-            <Date>2023-12-07</Date>
+        <Update release="36">
+            <Date>2023-12-20</Date>
             <Version>2.04</Version>
             <Comment>Packaging update</Comment>
             <Name>Rune Morling</Name>


### PR DESCRIPTION
**Summary**
On BIOS-based virt-manager VMs, the grub2 graphics mode defaults to VGA 640x480 if no configuration changes are made to the `GRUB_GFXMODE` stanza in `/etc/default/grub`.

However, it turns out that the BIOS on the emulated VGA card supports the 1280x800 mode, which makes the default ter-32b font we use much more usable compared to when it is used in 640x480.

At the same time, 1280x800 is a resolution that is so unusual, that almost no physical displays and almost no real world VGA BIOSes support it.

And if -- against expectations -- a physical GPU+Display combination turns out to support 1280x800, the resolution is large enough that the ter-32b font will still yield a 80x25 display and look nice in doing so.

**Test Plan**

This was tested in both a virt-manager VM and two different PCs with different GPUs and Monitors.

**Checklist**

- [x] Package was built and tested against unstable
