### PR TITLE
xfce4-desktop-branding: Sync with git

### DIFF
--- a/packages/x/xfce4-desktop-branding/package.yml
+++ b/packages/x/xfce4-desktop-branding/package.yml
@@ -1,8 +1,8 @@
 name       : xfce4-desktop-branding
 version    : 1.0.0
-release    : 6
+release    : 7
 source     :
-    - git|https://github.com/getsolus/xfce4-desktop-branding.git : 844a1128136c288d7feac60a33afc2864239a71d
+    - git|https://github.com/getsolus/xfce4-desktop-branding.git : 6205ddcc11d38e115752e82ceb7f9adf9bef59e9
 homepage   : https://github.com/getsolus/xfce4-desktop-branding
 license    : GPL-2.0-only
 component  :

--- a/packages/x/xfce4-desktop-branding/pspec_x86_64.xml
+++ b/packages/x/xfce4-desktop-branding/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xfce4-desktop-branding</Name>
         <Homepage>https://github.com/getsolus/xfce4-desktop-branding</Homepage>
         <Packager>
-            <Name>Hans K</Name>
-            <Email>hans@communitycomputing.net</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>desktop.xfce</PartOf>
@@ -18,7 +18,7 @@
         <Description xml:lang="en">Defaults for the XFCE4 Desktop.</Description>
         <PartOf>desktop.xfce</PartOf>
         <Files>
-            <Path fileType="data">/usr/share/lightdm/lightdm-gtk-greeter.conf.d/10_xfce.conf</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/30_xfce_settings.gschema.override</Path>
             <Path fileType="data">/usr/share/xdg/xfce4/xfconf/xfce-perchannel-xml/thunar-volman.xml</Path>
             <Path fileType="data">/usr/share/xdg/xfce4/xfconf/xfce-perchannel-xml/thunar.xml</Path>
             <Path fileType="data">/usr/share/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-appfinder.xml</Path>
@@ -32,19 +32,19 @@
         <Description xml:lang="en">Defaults for the XFCE4 Desktop.</Description>
         <PartOf>desktop.xfce</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="6">xfce4-desktop-branding</Dependency>
+            <Dependency releaseFrom="7">xfce4-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/lightdm/lightdm.conf.d/xfce_config.conf</Path>
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2023-12-15</Date>
+        <Update release="7">
+            <Date>2023-12-20</Date>
             <Version>1.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Hans K</Name>
-            <Email>hans@communitycomputing.net</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- slick greeter overrides are now correctly applied.

**Test Plan**

- install, logout, verify slick greeter defaults were changed

**Checklist**

- [x] Package was built and tested against unstable
