### PR TITLE
calamares: Enable the displaymanager module for autologin

### DIFF
--- a/packages/c/calamares/files/install/modules/displaymanager.conf
+++ b/packages/c/calamares/files/install/modules/displaymanager.conf
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: no
+# SPDX-License-Identifier: CC0-1.0
+#
+# Configure one or more display managers (e.g. SDDM)
+# with a "best effort" approach.
+#
+# This module also sets up autologin, if the feature is enabled in
+# globalstorage (where it would come from the users page).
+---
+# The DM module attempts to set up all the DMs found in this list, in the
+# precise order listed. The displaymanagers list can also be set in
+# globalstorage, and in that case it overrides the setting here.
+#
+# If *sysconfigSetup* is set to *true* (see below, only relevant for
+# openSUSE derivatives) then this list is ignored and only sysconfig
+# is attempted. You can also list "sysconfig" in this list instead.
+#
+displaymanagers:
+  - sddm
+  - lightdm
+  - gdm
+
+# Enable the following settings to force a desktop environment
+# in your displaymanager configuration file. This will attempt
+# to configure the given DE (without checking if it is installed).
+# The DM configuration for each potential DM may **or may not**
+# support configuring a default DE, so the keys are mandatory
+# but their interpretation is up to the DM configuration.
+#
+# Subkeys of *defaultDesktopEnvironment* are (all mandatory):
+#  - *executable* a full path to an executable
+#  - *desktopFile* a .desktop filename
+#
+# If this is **not** set, then Calamares will look for installed
+# DE's and pick the first one it finds that is actually installed.
+#
+# If this **is** set, and the *executable* key doesn't point to
+# an installed file, then the .desktop file's TryExec key is
+# used instead.
+#
+
+#defaultDesktopEnvironment:
+#    executable: "startkde"
+#    desktopFile: "plasma"
+
+#If true, try to ensure that the user, group, /var directory etc. for the
+#display manager are set up correctly. This is normally done by the distribution
+#packages, and best left to them. Therefore, it is disabled by default.
+basicSetup: false
+
+# If true, setup autologin for openSUSE. This only makes sense on openSUSE
+# derivatives or other systems where /etc/sysconfig/displaymanager exists.
+#
+# The preferred way to pick sysconfig is to just list it in the
+# *displaymanagers* list (as the only one).
+#
+sysconfigSetup: false
+
+# Some DMs have specific settings. These can be customized here.
+#
+# greetd has configurable user and group; the user and group is created if it
+# does not exist, and the user is set as default-session user.
+#
+# lightdm has a list of greeters to look for, preferring them in order if
+# they are installed (if not, picks the alphabetically first greeter that is installed).
+#
+greetd:
+  greeter_user: "tom_bombadil"
+  greeter_group: "wheel"
+lightdm:
+  preferred_greeters: ["slick-greeter.desktop", "lightdm-greeter.desktop"]

--- a/packages/c/calamares/files/install/settings.conf
+++ b/packages/c/calamares/files/install/settings.conf
@@ -55,7 +55,7 @@ sequence:
 #  - plymouthcfg
 #  - initcpiocfg
 #  - initcpio
-#  - displaymanager
+  - displaymanager
 #  - networkcfg
 #  - hwclock
 #  - services-systemd

--- a/packages/c/calamares/package.yml
+++ b/packages/c/calamares/package.yml
@@ -1,6 +1,6 @@
 name       : calamares
 version    : 3.2.62
-release    : 9
+release    : 10
 source     :
     - https://github.com/calamares/calamares/releases/download/v3.2.62/calamares-3.2.62.tar.gz : a0fbcec2a438693753fc174220356119ad7adb8a2b19c317518aa1cb025d6dd0
 homepage   : https://calamares.io

--- a/packages/c/calamares/pspec_x86_64.xml
+++ b/packages/c/calamares/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>calamares</Name>
         <Homepage>https://calamares.io</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <License>CC-BY-4.0</License>
@@ -190,6 +190,7 @@
             <Path fileType="data">/usr/share/calamares/branding/solus/stylesheet.qss</Path>
             <Path fileType="data">/usr/share/calamares/modules/bootloader.conf</Path>
             <Path fileType="data">/usr/share/calamares/modules/contextualprocess_packageoptions.conf</Path>
+            <Path fileType="data">/usr/share/calamares/modules/displaymanager.conf</Path>
             <Path fileType="data">/usr/share/calamares/modules/fstab.conf</Path>
             <Path fileType="data">/usr/share/calamares/modules/locale.conf</Path>
             <Path fileType="data">/usr/share/calamares/modules/mount.conf</Path>
@@ -283,7 +284,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="9">calamares</Dependency>
+            <Dependency release="10">calamares</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libcalamares/Branding.h</Path>
@@ -404,12 +405,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2023-12-14</Date>
+        <Update release="10">
+            <Date>2023-12-20</Date>
             <Version>3.2.62</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Enable autologin support

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install the system with the user set to be automatically logged in on Budgie and XFCE.

**Checklist**

- [x] Package was built and tested against unstable
