### PR TITLE
xfce4-desktop-branding: sync with latest git

### DIFF
--- a/packages/x/xfce4-desktop-branding/package.yml
+++ b/packages/x/xfce4-desktop-branding/package.yml
@@ -1,8 +1,8 @@
 name       : xfce4-desktop-branding
 version    : 1.0.0
-release    : 7
+release    : 8
 source     :
-    - git|https://github.com/getsolus/xfce4-desktop-branding.git : 6205ddcc11d38e115752e82ceb7f9adf9bef59e9
+    - git|https://github.com/getsolus/xfce4-desktop-branding.git : f870cd2a3c6923cd2f4b4323581d7534ce9d8820
 homepage   : https://github.com/getsolus/xfce4-desktop-branding
 license    : GPL-2.0-only
 component  :

--- a/packages/x/xfce4-desktop-branding/pspec_x86_64.xml
+++ b/packages/x/xfce4-desktop-branding/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xfce4-desktop-branding</Name>
         <Homepage>https://github.com/getsolus/xfce4-desktop-branding</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>desktop.xfce</PartOf>
@@ -23,6 +23,7 @@
             <Path fileType="data">/usr/share/xdg/xfce4/xfconf/xfce-perchannel-xml/thunar.xml</Path>
             <Path fileType="data">/usr/share/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-appfinder.xml</Path>
             <Path fileType="data">/usr/share/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml</Path>
+            <Path fileType="data">/usr/share/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-notifyd.xml</Path>
             <Path fileType="data">/usr/share/xdg/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml</Path>
         </Files>
     </Package>
@@ -32,19 +33,19 @@
         <Description xml:lang="en">Defaults for the XFCE4 Desktop.</Description>
         <PartOf>desktop.xfce</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="7">xfce4-desktop-branding</Dependency>
+            <Dependency releaseFrom="8">xfce4-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/lightdm/lightdm.conf.d/xfce_config.conf</Path>
         </Files>
     </Package>
     <History>
-        <Update release="7">
+        <Update release="8">
             <Date>2023-12-20</Date>
             <Version>1.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Update default bg image for desktop and greeter
- Move notifyd text boxes to bottom right
- Remove deprecated [SeatDefaults] config section

**Test Plan**
Build an ungodly number of XFCE smoketest ISOs and test that they work as advertised above.

**Checklist**

- [x] Package was built and tested against unstable
