### PR TITLE
calamares: Enable hwclock and networkcfg

### DIFF
--- a/packages/c/calamares/files/install/settings.conf
+++ b/packages/c/calamares/files/install/settings.conf
@@ -56,9 +56,10 @@ sequence:
 #  - initcpiocfg
 #  - initcpio
   - displaymanager
-#  - networkcfg
-#  - hwclock
-#  - services-systemd
+  # This module will persist the network configuration from the live environment to the installed one
+  - networkcfg
+  # Sets the hardware clock to match the live installer. Not strictly needed since we enable NTP by default but helpful.
+  - hwclock
 #  - dracut
 #  - initramfs
 #  - grubcfg

--- a/packages/c/calamares/package.yml
+++ b/packages/c/calamares/package.yml
@@ -1,6 +1,6 @@
 name       : calamares
 version    : 3.2.62
-release    : 10
+release    : 11
 source     :
     - https://github.com/calamares/calamares/releases/download/v3.2.62/calamares-3.2.62.tar.gz : a0fbcec2a438693753fc174220356119ad7adb8a2b19c317518aa1cb025d6dd0
 homepage   : https://calamares.io

--- a/packages/c/calamares/pspec_x86_64.xml
+++ b/packages/c/calamares/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>calamares</Name>
         <Homepage>https://calamares.io</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Reilly Brogan</Name>
+            <Email>solus@reillybrogan.com</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <License>CC-BY-4.0</License>
@@ -284,7 +284,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">calamares</Dependency>
+            <Dependency release="11">calamares</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libcalamares/Branding.h</Path>
@@ -405,12 +405,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
+        <Update release="11">
             <Date>2023-12-20</Date>
             <Version>3.2.62</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Reilly Brogan</Name>
+            <Email>solus@reillybrogan.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
Enables the hwclock and networkcfg modules by default. Both do not have configuration or UI and do the following:

hwclock: Synchronizes the hardware clock with the current live environment time. Helpful since we enable systemd-timesyncd by default, so if a user connects to a network they will end up with accurate time being persisted.
networkcfg: If the user has setup a custom network configuration in the live environment (for instance connecting to wifi) then that will be copied to the installed system.