### PR TITLE
calamares: Hide LVM buttons

### DIFF
--- a/packages/c/calamares/files/patches/downstream/0001-partition-Hide-Volume-Group-buttons.patch
+++ b/packages/c/calamares/files/patches/downstream/0001-partition-Hide-Volume-Group-buttons.patch
@@ -1,0 +1,29 @@
+From 48a18ee87cc0f83ffc82b9a0d9fd36488f4605c8 Mon Sep 17 00:00:00 2001
+From: Evan Maddock <maddock.evan@vivaldi.net>
+Date: Thu, 21 Dec 2023 11:51:42 -0500
+Subject: [PATCH] partition: Hide Volume Group buttons
+
+Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
+---
+ src/modules/partition/gui/PartitionPage.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/modules/partition/gui/PartitionPage.cpp b/src/modules/partition/gui/PartitionPage.cpp
+index 0b3cf2478..11b078554 100644
+--- a/src/modules/partition/gui/PartitionPage.cpp
++++ b/src/modules/partition/gui/PartitionPage.cpp
+@@ -213,6 +213,11 @@ PartitionPage::updateButtons()
+     m_ui->resizeVolumeGroupButton->setEnabled( currentDeviceIsVG && !isVGdeactivated );
+     m_ui->deactivateVolumeGroupButton->setEnabled( currentDeviceIsVG && isDeactivable && !isVGdeactivated );
+     m_ui->removeVolumeGroupButton->setEnabled( currentDeviceIsVG && isRemovable );
++
++    m_ui->newVolumeGroupButton->hide();
++    m_ui->resizeVolumeGroupButton->hide();
++    m_ui->deactivateVolumeGroupButton->hide();
++    m_ui->removeVolumeGroupButton->hide();
+ }
+ 
+ void
+-- 
+2.43.0
+

--- a/packages/c/calamares/files/series
+++ b/packages/c/calamares/files/series
@@ -3,3 +3,4 @@ patches/downstream/0001-bootloader-Add-clr-boot-manager-support.patch
 patches/downstream/0001-users-Use-libxcrypt-for-salt-generation-when-possibl.patch
 patches/downstream/0001-Solus-Skip-adding-boot-partition.patch
 patches/downstream/0001-Solus-Create-boot-partition-for-BIOS-installs.patch
+patches/downstream/0001-partition-Hide-Volume-Group-buttons.patch

--- a/packages/c/calamares/package.yml
+++ b/packages/c/calamares/package.yml
@@ -1,6 +1,6 @@
 name       : calamares
 version    : 3.2.62
-release    : 11
+release    : 12
 source     :
     - https://github.com/calamares/calamares/releases/download/v3.2.62/calamares-3.2.62.tar.gz : a0fbcec2a438693753fc174220356119ad7adb8a2b19c317518aa1cb025d6dd0
 homepage   : https://calamares.io

--- a/packages/c/calamares/pspec_x86_64.xml
+++ b/packages/c/calamares/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>calamares</Name>
         <Homepage>https://calamares.io</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <License>CC-BY-4.0</License>
@@ -284,7 +284,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="11">calamares</Dependency>
+            <Dependency release="12">calamares</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libcalamares/Branding.h</Path>
@@ -405,12 +405,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2023-12-20</Date>
+        <Update release="12">
+            <Date>2023-12-21</Date>
             <Version>3.2.62</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Hide LVM buttons to prevent crashes

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Update Calamares in a live session and choose manual partitioning; observed that the LVM buttons are no longer shown.

**Checklist**

- [x] Package was built and tested against unstable
