### PR TITLE
.github: Change wording in "Request Package Update"

### DIFF
--- a/.github/ISSUE_TEMPLATE/request-package-update.yml
+++ b/.github/ISSUE_TEMPLATE/request-package-update.yml
@@ -23,6 +23,8 @@ body:
   - type: textarea
     id: other
     attributes:
-      label: Other comments
+      label: Reason for updating
       description: |
-        Anything about this release that would help.
+        Anything specific about this release that you need, or would benefit Solus users. This helps us prioritize updates.
+    validations:
+      required: true


### PR DESCRIPTION
This is meant to deter package update request with no specific reason other than "tHiS Is ThE nEwEst vErsIoN".