### PR TITLE
gpxsee: Update to 13.13

### DIFF
--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.12'
-release    : 30
+version    : '13.13'
+release    : 31
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.12.tar.gz : 947d725d0d30fa827c2971174ab2244b4eaf0c491aed1bb9f0dd71de06237218
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.13.tar.gz : 83b462d209981cc2449b4479a5e39a8810837c79eb2847f7dc49bc62efd540a0
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -136,9 +136,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="30">
-            <Date>2023-12-12</Date>
-            <Version>13.12</Version>
+        <Update release="31">
+            <Date>2023-12-22</Date>
+            <Version>13.13</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Fixed broken map scale (ruler) on HiDPI maps.
- Limit the overzoom to not produce huge tiles which break map rendering.

**Test Plan**
- open map, zoom in and out

**Checklist**
- [X] Package was built and tested against unstable
