### PR TITLE
tailscale: Update to 1.56.1

### DIFF
--- a/packages/t/tailscale/abi_used_symbols
+++ b/packages/t/tailscale/abi_used_symbols
@@ -10,6 +10,7 @@ libc.so.6:getaddrinfo
 libc.so.6:getgrgid_r
 libc.so.6:getgrnam_r
 libc.so.6:getgrouplist
+libc.so.6:getnameinfo
 libc.so.6:getpwnam_r
 libc.so.6:getpwuid_r
 libc.so.6:malloc
@@ -31,6 +32,7 @@ libc.so.6:pthread_mutex_unlock
 libc.so.6:pthread_self
 libc.so.6:pthread_setspecific
 libc.so.6:pthread_sigmask
+libc.so.6:res_search
 libc.so.6:setegid
 libc.so.6:setenv
 libc.so.6:seteuid

--- a/packages/t/tailscale/package.yml
+++ b/packages/t/tailscale/package.yml
@@ -1,8 +1,8 @@
 name       : tailscale
-version    : 1.54.1
-release    : 6
+version    : 1.56.1
+release    : 7
 source     :
-    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.54.1.tar.gz : 56ef2e53fd42373b90a9ec5e057f61c2bb4455551dc13b74f49fbdd6b393ecdb
+    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.56.1.tar.gz : 56b7d25c704e3c22e9e20dcb55695cd9c816878d2c172a73c64aac42e460fd41
 homepage   : https://tailscale.com
 license    : BSD-3-Clause
 component  : network.clients

--- a/packages/t/tailscale/pspec_x86_64.xml
+++ b/packages/t/tailscale/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2023-12-03</Date>
-            <Version>1.54.1</Version>
+        <Update release="7">
+            <Date>2023-12-22</Date>
+            <Version>1.56.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Web interface redirects to the correct self IP known by source peer
- Usage of slices.Compact from app connector domains list
- improve responsiveness under load, especially with bidirectional traffic
- improve UPnP portmapping
- add tailscale whois subcommand to observe metadata associated with a Tailscale IP
- include tailnet name and profile ID in tailscale switch --list to disambiguate profiles with common login names
- make System policies beta
- improve tailscale web interface for configuring some device settings such as exit nodes, subnet routers, and Tailscale SSH
- improve containerboot to symlink its socket file if possible, making the tailscale CLI work without --socket=/tmp/tailscale.sock

**Test Plan**
- tailscale netcheck

**Checklist**
- [X] Package was built and tested against unstable
