### PR TITLE
calamares: Reenable automatic LUKS partitioning

### DIFF
--- a/packages/c/calamares/files/install/modules/partition.conf
+++ b/packages/c/calamares/files/install/modules/partition.conf
@@ -20,7 +20,7 @@ defaultFileSystemType:              "ext4"
 
 availableFileSystemTypes:           ["ext4","btrfs","f2fs"]
 
-enableLuksAutomatedPartitioning:    false
+enableLuksAutomatedPartitioning:    true
 
 # Doesn't seem to do anything
 # luksFsType                          "luks2"

--- a/packages/c/calamares/package.yml
+++ b/packages/c/calamares/package.yml
@@ -1,6 +1,6 @@
 name       : calamares
 version    : 3.2.62
-release    : 12
+release    : 13
 source     :
     - https://github.com/calamares/calamares/releases/download/v3.2.62/calamares-3.2.62.tar.gz : a0fbcec2a438693753fc174220356119ad7adb8a2b19c317518aa1cb025d6dd0
 homepage   : https://calamares.io

--- a/packages/c/calamares/pspec_x86_64.xml
+++ b/packages/c/calamares/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>calamares</Name>
         <Homepage>https://calamares.io</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <License>CC-BY-4.0</License>
@@ -284,7 +284,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="12">calamares</Dependency>
+            <Dependency release="13">calamares</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libcalamares/Branding.h</Path>
@@ -405,12 +405,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2023-12-21</Date>
+        <Update release="13">
+            <Date>2023-12-23</Date>
             <Version>3.2.62</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- It is now working again on BIOS since 5614c7fa149899998b28677eef76a94cd13a1a71 as we now always create a boot partition.

**Test Plan**

- GNOME, BIOS + LUKS + BTRFS + Swap partition <- OK (swap partition is encrypted as well)
- GNOME, BIOS + LUKS + EXT4 + Swapfile <- OK

(UEFI was known good working before disabling)

**Checklist**

- [x] Package was built and tested against unstable
