### PR TITLE
 cantarell-fonts: Replace homepage to more representative one

### DIFF
--- a/packages/c/cantarell-fonts/package.yml
+++ b/packages/c/cantarell-fonts/package.yml
@@ -1,11 +1,11 @@
 name       : cantarell-fonts
 version    : '0.303.1'
-release    : 11
+release    : 12
 source     :
     - https://download.gnome.org/sources/cantarell-fonts/0.303/cantarell-fonts-0.303.1.tar.xz : f9463a0659c63e57e381fdd753cf1929225395c5b49135989424761830530411
+homepage   : https://cantarell.gnome.org/
 license    : OFL-1.1
 component  : desktop.gnome.core
-homepage   : https://gitlab.gnome.org/GNOME/cantarell-fonts
 summary    : GNOME Cantarell fonts
 description: |
     GNOME Cantarell fonts - required for GNOME 3

--- a/packages/c/cantarell-fonts/pspec_x86_64.xml
+++ b/packages/c/cantarell-fonts/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>cantarell-fonts</Name>
-        <Homepage>https://gitlab.gnome.org/GNOME/cantarell-fonts</Homepage>
+        <Homepage>https://cantarell.gnome.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>OFL-1.1</License>
         <PartOf>desktop.gnome.core</PartOf>
@@ -25,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2023-12-21</Date>
+        <Update release="12">
+            <Date>2023-12-24</Date>
             <Version>0.303.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Replaced homepage to more representative one

**Test Plan**

Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable

**Comment**

This package is already include metainfo.xml but there is no preview in software center. Why?