### PR TITLE
c-ares: homepage inclusion

### DIFF
--- a/packages/c/c-ares/abi_used_symbols
+++ b/packages/c/c-ares/abi_used_symbols
@@ -3,7 +3,9 @@ libc.so.6:__ctype_tolower_loc
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoul
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__printf_chk
@@ -61,6 +63,4 @@ libc.so.6:strlen
 libc.so.6:strncasecmp
 libc.so.6:strncmp
 libc.so.6:strncpy
-libc.so.6:strtol
-libc.so.6:strtoul
 libc.so.6:writev

--- a/packages/c/c-ares/package.yml
+++ b/packages/c/c-ares/package.yml
@@ -1,8 +1,9 @@
 name       : c-ares
 version    : 1.19.1
-release    : 7
+release    : 8
 source     :
     - https://github.com/c-ares/c-ares/archive/refs/tags/cares-1_19_1.tar.gz : 9eadec0b34015941abdf3eb6aead694c8d96a192a792131186a7e0a86f2ad6d9
+homepage   : https://c-ares.org/
 license    : MIT
 component  : programming.library
 summary    : C library that performs DNS requests and name resolves asynchronously

--- a/packages/c/c-ares/pspec_x86_64.xml
+++ b/packages/c/c-ares/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>c-ares</Name>
+        <Homepage>https://c-ares.org/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.library</PartOf>
         <Summary xml:lang="en">C library that performs DNS requests and name resolves asynchronously</Summary>
         <Description xml:lang="en">This is c-ares, an asynchronous resolver library. It is intended for applications which need to perform DNS queries without blocking, or need to perform multiple DNS queries in parallel. The primary examples of such applications are servers which communicate with multiple clients and programs with graphical user interfaces.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>c-ares</Name>
@@ -36,7 +37,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="7">c-ares</Dependency>
+            <Dependency release="8">c-ares</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/ares.h</Path>
@@ -113,12 +114,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2023-09-01</Date>
+        <Update release="8">
+            <Date>2023-12-24</Date>
             <Version>1.19.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable

**Comment**

There is [newer version](https://c-ares.org/download/c-ares-1.24.0.tar.gz) of this. But it touches too many apps i am not familiar with. (bzflag, grpc,nodejs, wireshark)
