### PR TITLE
cd-discid: homepage inclusion

### DIFF
--- a/packages/c/cd-discid/package.yml
+++ b/packages/c/cd-discid/package.yml
@@ -1,8 +1,9 @@
 name       : cd-discid
-version    : 1.4
-release    : 1
+version    : '1.4'
+release    : 2
 source     :
     - https://github.com/taem/cd-discid/archive/1.4.tar.gz : 6f07df25ebf17b8336c17a50092ed288cc5a6b86f85705db7e1aa35ba26683cf
+homepage   : https://linukz.org/cd-discid.shtml
 license    : GPL-2.0-or-later
 component  : multimedia.audio
 summary    : Utility to get CDDB discid information

--- a/packages/c/cd-discid/pspec_x86_64.xml
+++ b/packages/c/cd-discid/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>cd-discid</Name>
+        <Homepage>https://linukz.org/cd-discid.shtml</Homepage>
         <Packager>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>multimedia.audio</PartOf>
         <Summary xml:lang="en">Utility to get CDDB discid information</Summary>
         <Description xml:lang="en">cd-discid is a backend utility to get CDDB discid information from a CD-ROM disc
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://solus-project.com/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>cd-discid</Name>
@@ -24,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2018-08-16</Date>
+        <Update release="2">
+            <Date>2023-12-25</Date>
             <Version>1.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable

**Comment**

This is an old package, unmaintained since 2013. Still works though.