### PR TITLE
gamemode: Update to 1.8.1, disable examples

### DIFF
--- a/packages/g/gamemode/abi_libs32
+++ b/packages/g/gamemode/abi_libs32
@@ -1,4 +1,6 @@
+cpucorectl
 cpugovctl
 gpuclockctl
 libgamemode.so.0
 libgamemodeauto.so.0
+procsysctl

--- a/packages/g/gamemode/abi_symbols32
+++ b/packages/g/gamemode/abi_symbols32
@@ -1,3 +1,4 @@
+cpucorectl:_IO_stdin_used
 cpugovctl:_IO_stdin_used
 gpuclockctl:_IO_stdin_used
 libgamemode.so.0:open_fdinfo_dir
@@ -12,3 +13,4 @@ libgamemode.so.0:real_gamemode_request_start
 libgamemode.so.0:real_gamemode_request_start_for
 libgamemodeauto.so.0:gamemode_request_end
 libgamemodeauto.so.0:gamemode_request_start
+procsysctl:_IO_stdin_used

--- a/packages/g/gamemode/abi_used_symbols
+++ b/packages/g/gamemode/abi_used_symbols
@@ -7,6 +7,7 @@ libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
+libc.so.6:__getdelim
 libc.so.6:__isoc23_sscanf
 libc.so.6:__isoc23_strtol
 libc.so.6:__isoc23_strtoll
@@ -15,7 +16,11 @@ libc.so.6:__isoc23_strtoull
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__realpath_chk
+libc.so.6:__sched_cpualloc
+libc.so.6:__sched_cpucount
+libc.so.6:__sched_cpufree
 libc.so.6:__snprintf_chk
+libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__syslog_chk
 libc.so.6:__vsnprintf_chk
@@ -38,6 +43,7 @@ libc.so.6:fdopen
 libc.so.6:fgets
 libc.so.6:fopen64
 libc.so.6:fork
+libc.so.6:fputs
 libc.so.6:fread
 libc.so.6:free
 libc.so.6:fseek
@@ -61,6 +67,7 @@ libc.so.6:inotify_rm_watch
 libc.so.6:kill
 libc.so.6:lstat64
 libc.so.6:malloc
+libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memset
 libc.so.6:open64
@@ -88,11 +95,13 @@ libc.so.6:pthread_rwlock_init
 libc.so.6:pthread_rwlock_rdlock
 libc.so.6:pthread_rwlock_unlock
 libc.so.6:pthread_rwlock_wrlock
+libc.so.6:putc
 libc.so.6:read
 libc.so.6:readdir64
 libc.so.6:readlink
 libc.so.6:readlinkat
 libc.so.6:realpath
+libc.so.6:sched_setaffinity
 libc.so.6:sched_setscheduler
 libc.so.6:secure_getenv
 libc.so.6:select
@@ -100,8 +109,10 @@ libc.so.6:setpriority
 libc.so.6:setsid
 libc.so.6:signal
 libc.so.6:sleep
+libc.so.6:snprintf
 libc.so.6:stderr
 libc.so.6:stdout
+libc.so.6:strcasecmp
 libc.so.6:strchr
 libc.so.6:strcmp
 libc.so.6:strdup

--- a/packages/g/gamemode/abi_used_symbols32
+++ b/packages/g/gamemode/abi_used_symbols32
@@ -25,6 +25,7 @@ libc.so.6:fdopen
 libc.so.6:fgets
 libc.so.6:fopen64
 libc.so.6:fork
+libc.so.6:fputs
 libc.so.6:fread
 libc.so.6:free
 libc.so.6:fseek
@@ -45,9 +46,11 @@ libc.so.6:openat64
 libc.so.6:openlog
 libc.so.6:pidfd_open
 libc.so.6:pipe
+libc.so.6:putc
 libc.so.6:read
 libc.so.6:select
 libc.so.6:stderr
+libc.so.6:strcmp
 libc.so.6:strerror
 libc.so.6:strncmp
 libc.so.6:strncpy

--- a/packages/g/gamemode/package.yml
+++ b/packages/g/gamemode/package.yml
@@ -1,8 +1,8 @@
 name       : gamemode
-version    : '1.7'
-release    : 12
+version    : '1.8.1'
+release    : 13
 source     :
-    - https://github.com/FeralInteractive/gamemode/releases/download/1.7/gamemode-1.7.tar.xz : c1860f76f1d4c0d6e3965e52de21c824f24791049946da728da50f0c63748389
+    - https://github.com/FeralInteractive/gamemode/releases/download/1.8.1/gamemode-1.8.1.tar.xz : cdb117d05d65dbd03c0bd2104df874a1f878db8f23cc4d55bfa44e832482269e
 license    : BSD-3-Clause
 component  : games
 libsplit   : no
@@ -21,16 +21,14 @@ builddeps  :
 environment: |
     export CFLAGS="$CFLAGS -Wno-error=implicit-function-declaration"
 setup      : |
-    %meson_configure -Dwith-pam-group=users
+    %meson_configure -Dwith-examples=false \
+    -Dwith-pam-limits-dir=/usr/share/defaults/etc/security/limits.d \
+    -Dwith-privileged-group=users
 build      : |
     %ninja_build
 install    : |
     %ninja_install
     install -Dm00644 example/gamemode.ini $installdir/usr/share/doc/gamemode/gamemode.ini
-
-    # Stateless
-    install -Ddm00755 $installdir/usr/share/defaults/etc/security/limits.d
-    mv $installdir/etc/security/limits.d/10-gamemode.conf $installdir/usr/share/defaults/etc/security/limits.d/10-gamemode.conf
 
     # Cleanup
     find $installdir -type d -empty -delete

--- a/packages/g/gamemode/pspec_x86_64.xml
+++ b/packages/g/gamemode/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gamemode</Name>
         <Homepage>https://github.com/FeralInteractive/gamemode</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Kostadin Shishmanov</Name>
+            <Email>kocelfc@tutanota.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>games</PartOf>
@@ -20,14 +20,15 @@
 </Description>
         <PartOf>games</PartOf>
         <Files>
-            <Path fileType="executable">/usr/bin/gamemode-simulate-game</Path>
             <Path fileType="executable">/usr/bin/gamemoded</Path>
             <Path fileType="executable">/usr/bin/gamemodelist</Path>
             <Path fileType="executable">/usr/bin/gamemoderun</Path>
             <Path fileType="library">/usr/lib/systemd/user/gamemoded.service</Path>
             <Path fileType="library">/usr/lib/sysusers.d/gamemode.conf</Path>
+            <Path fileType="library">/usr/lib64/gamemode/cpucorectl</Path>
             <Path fileType="library">/usr/lib64/gamemode/cpugovctl</Path>
             <Path fileType="library">/usr/lib64/gamemode/gpuclockctl</Path>
+            <Path fileType="library">/usr/lib64/gamemode/procsysctl</Path>
             <Path fileType="library">/usr/lib64/libgamemode.so</Path>
             <Path fileType="library">/usr/lib64/libgamemode.so.0</Path>
             <Path fileType="library">/usr/lib64/libgamemode.so.0.0.0</Path>
@@ -37,13 +38,12 @@
             <Path fileType="data">/usr/share/dbus-1/services/com.feralinteractive.GameMode.service</Path>
             <Path fileType="data">/usr/share/defaults/etc/security/limits.d/10-gamemode.conf</Path>
             <Path fileType="doc">/usr/share/doc/gamemode/gamemode.ini</Path>
-            <Path fileType="data">/usr/share/gamemode/gamemode.ini</Path>
-            <Path fileType="man">/usr/share/man/man1/gamemode-simulate-game.1</Path>
             <Path fileType="man">/usr/share/man/man1/gamemodelist.1</Path>
             <Path fileType="man">/usr/share/man/man1/gamemoderun.1</Path>
             <Path fileType="man">/usr/share/man/man8/gamemoded.8</Path>
             <Path fileType="data">/usr/share/metainfo/io.github.feralinteractive.gamemode.metainfo.xml</Path>
             <Path fileType="data">/usr/share/polkit-1/actions/com.feralinteractive.GameMode.policy</Path>
+            <Path fileType="data">/usr/share/polkit-1/rules.d/gamemode.rules</Path>
         </Files>
     </Package>
     <Package>
@@ -53,11 +53,13 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="12">gamemode</Dependency>
+            <Dependency release="13">gamemode</Dependency>
         </RuntimeDependencies>
         <Files>
+            <Path fileType="library">/usr/lib32/gamemode/cpucorectl</Path>
             <Path fileType="library">/usr/lib32/gamemode/cpugovctl</Path>
             <Path fileType="library">/usr/lib32/gamemode/gpuclockctl</Path>
+            <Path fileType="library">/usr/lib32/gamemode/procsysctl</Path>
             <Path fileType="library">/usr/lib32/libgamemode.so</Path>
             <Path fileType="library">/usr/lib32/libgamemode.so.0</Path>
             <Path fileType="library">/usr/lib32/libgamemode.so.0.0.0</Path>
@@ -73,11 +75,10 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="12">gamemode-devel</Dependency>
-            <Dependency release="12">gamemode-32bit</Dependency>
+            <Dependency release="13">gamemode-devel</Dependency>
+            <Dependency release="13">gamemode-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
-            <Path fileType="library">/usr/lib32/libgamemodeauto.a</Path>
             <Path fileType="data">/usr/lib32/pkgconfig/gamemode.pc</Path>
             <Path fileType="data">/usr/lib32/pkgconfig/libgamemodeauto.pc</Path>
         </Files>
@@ -89,22 +90,21 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="12">gamemode</Dependency>
+            <Dependency release="13">gamemode</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gamemode_client.h</Path>
-            <Path fileType="library">/usr/lib64/libgamemodeauto.a</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/gamemode.pc</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/libgamemodeauto.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2023-11-13</Date>
-            <Version>1.7</Version>
+        <Update release="13">
+            <Date>2023-12-27</Date>
+            <Version>1.8.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Kostadin Shishmanov</Name>
+            <Email>kocelfc@tutanota.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Changes:**
Add CPU core pinning and parking capability
Allow disabling the Linux kernel split lock mitigation 
Fix building when pidfd_open is available (Fixes build with glibc 2.36) 
Unify privileged group configuration between pam, systemd, & polkit 
Various other bugfixes and improved default configuration

<!-- Short description of how the package was tested -->
Ran `gamemoded -t` and the tests passed successfully

**Checklist**

- [x] Package was built and tested against unstable
