### PR TITLE
epson-inkjet-printer-escpr: Update to 1.8.3

### DIFF
--- a/packages/e/epson-inkjet-printer-escpr/package.yml
+++ b/packages/e/epson-inkjet-printer-escpr/package.yml
@@ -1,8 +1,8 @@
 name       : epson-inkjet-printer-escpr
-version    : 1.7.26
-release    : 13
+version    : 1.8.3
+release    : 14
 source     :
-    - https://download3.ebz.epson.net/dsc/f/03/00/14/48/15/c864d000b06bebeec8832ce6f68bb079c36d838a/epson-inkjet-printer-escpr-1.7.26-1lsb3.2.tar.gz : 690e8c9c5b993489830de5ddb16ba2ba4c21b474978bda082ed7d1d1c48482e9
+    - https://download3.ebz.epson.net/dsc/f/03/00/15/47/99/379a81c231d0b6b3dfb3db2032ff6e23f7ccaa34/epson-inkjet-printer-escpr-1.8.3-1.src.rpm : e2abd94153044ae154cd8a149d30cc0240d858c1b3ebc2fc65589f1fd045ec88
 homepage   : http://download.ebz.epson.net/dsc/search/01/search/?OSC=LX
 license    : GPL-2.0-or-later
 component  : desktop.core
@@ -15,6 +15,8 @@ builddeps  :
 rundeps    :
     - cups
 setup      : |
+    tar -xvf epson-inkjet-printer-escpr-%version%-1.tar.gz
+    cd epson-inkjet-printer-escpr-%version%
     %reconfigure --prefix=/usr --disable-static
 build      : |
     %make

--- a/packages/e/epson-inkjet-printer-escpr/pspec_x86_64.xml
+++ b/packages/e/epson-inkjet-printer-escpr/pspec_x86_64.xml
@@ -11,7 +11,7 @@
         <Summary xml:lang="en">Printer drivers for Epson printers</Summary>
         <Description xml:lang="en">Common Linux printer driver for Epson Multifunction Inkjet Printers.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>epson-inkjet-printer-escpr</Name>
@@ -76,6 +76,7 @@
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-713A_Series-epson-escpr-en.ppd</Path>
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-714A_Series-epson-escpr-en.ppd</Path>
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-715A_Series-epson-escpr-en.ppd</Path>
+            <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-716A_Series-epson-escpr-en.ppd</Path>
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-774A-epson-escpr-en.ppd</Path>
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-775A_Series-epson-escpr-en.ppd</Path>
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-776A_Series-epson-escpr-en.ppd</Path>
@@ -94,6 +95,7 @@
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-813A_Series-epson-escpr-en.ppd</Path>
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-814A_Series-epson-escpr-en.ppd</Path>
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-815A_Series-epson-escpr-en.ppd</Path>
+            <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-816A_Series-epson-escpr-en.ppd</Path>
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-901A-epson-escpr-en.ppd</Path>
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-901F-epson-escpr-en.ppd</Path>
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-902A-epson-escpr-en.ppd</Path>
@@ -109,6 +111,7 @@
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-977A3_Series-epson-escpr-en.ppd</Path>
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-978A3_Series-epson-escpr-en.ppd</Path>
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-979A3_Series-epson-escpr-en.ppd</Path>
+            <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-M476T_Series-epson-escpr-en.ppd</Path>
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-M552T_Series-epson-escpr-en.ppd</Path>
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-M553T_Series-epson-escpr-en.ppd</Path>
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-EP-M570T_Series-epson-escpr-en.ppd</Path>
@@ -130,6 +133,8 @@
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-ET-2810_Series-epson-escpr-en.ppd</Path>
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-ET-2820_Series-epson-escpr-en.ppd</Path>
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-ET-2850_Series-epson-escpr-en.ppd</Path>
+            <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-ET-2860_Series-epson-escpr-en.ppd</Path>
+            <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-ET-2870_Series-epson-escpr-en.ppd</Path>
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-ET-4500_Series-epson-escpr-en.ppd</Path>
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-ET-4550_Series-epson-escpr-en.ppd</Path>
             <Path fileType="data">/usr/share/cups/model/epson-inkjet-printer-escpr/Epson-ET-4700_Series-epson-escpr-en.ppd</Path>
@@ -631,9 +636,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2023-05-29</Date>
-            <Version>1.7.26</Version>
+        <Update release="14">
+            <Date>2023-12-28</Date>
+            <Version>1.8.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Algent Albrahimi</Name>
             <Email>algent@protonmail.com</Email>


### PR DESCRIPTION
**Summary**

- Support new epson printers

**Test Plan**

- N/A. I don't have a printer. 

**Packager notes:**
 Just figured out a way to update this package to latest version. Upstream there are no more direct `.tar.gz` links.

**Checklist**

- [x] Package was built and tested against unstable
