### PR TITLE
Update run time dep to package.yml

### DIFF
--- a/packages/t/torbrowser-launcher/package.yml
+++ b/packages/t/torbrowser-launcher/package.yml
@@ -14,6 +14,7 @@ rundeps    :
     - gnupg
     - python3-qt5
     - python-gpg
+    - python-packaging
     - python-pysocks
     - python-requests
     - tor


### PR DESCRIPTION
Adding python-packaging as a run time dep for the Tor Browser installer

**Summary**

Installer currently does nothing on a fresh Solus install.  On investigation the system is missing python-packaging throwing the following error in terminal:

  File "/usr/lib/python3.10/site-packages/torbrowser_launcher/launcher.py", line 40, in <module>
    from packaging import version
ModuleNotFoundError: No module named 'packaging'

**Test Plan**

Installed python-packaging and the installer completes

**Checklist**

- Installer now completes and starts TOR browser as designed
