### PR TITLE
sshfs-fuse: Fix PubkeyAcceptedKeyTypes

### DIFF
--- a/packages/s/sshfs-fuse/abi_used_symbols
+++ b/packages/s/sshfs-fuse/abi_used_symbols
@@ -1,9 +1,9 @@
 libc.so.6:__assert_fail
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtoul
 libc.so.6:__libc_start_main
-libc.so.6:__memcpy_chk
 libc.so.6:__printf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:_exit
@@ -84,7 +84,6 @@ libc.so.6:strncmp
 libc.so.6:strncpy
 libc.so.6:strrchr
 libc.so.6:strsep
-libc.so.6:strtoul
 libc.so.6:time
 libc.so.6:unlockpt
 libc.so.6:unsetenv

--- a/packages/s/sshfs-fuse/package.yml
+++ b/packages/s/sshfs-fuse/package.yml
@@ -1,8 +1,9 @@
 name       : sshfs-fuse
-version    : 3.7.1
-release    : 9
+version    : 3.7.3
+release    : 10
 source     :
-    - https://github.com/libfuse/sshfs/archive/refs/tags/sshfs-3.7.1.tar.gz : 0f0f8f239555effd675d03a3cabfb35ef691a3054c98b62bc28e85620ad9e30d
+    - https://github.com/libfuse/sshfs/archive/refs/tags/sshfs-3.7.3.tar.gz : 52a1a1e017859dfe72a550e6fef8ad4f8703ce312ae165f74b579fd7344e3a26
+homepage   : https://github.com/libfuse/sshfs
 license    : GPL-2.0-only
 component  : network.util
 summary    : A network filesystem client to connect to SSH servers

--- a/packages/s/sshfs-fuse/pspec_x86_64.xml
+++ b/packages/s/sshfs-fuse/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>sshfs-fuse</Name>
+        <Homepage>https://github.com/libfuse/sshfs</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>network.util</PartOf>
         <Summary xml:lang="en">A network filesystem client to connect to SSH servers</Summary>
         <Description xml:lang="en">SSHFS allows you to mount a remote filesystem using SFTP. Most SSH servers support and enable this SFTP access by default, so SSHFS is very simple to use - there&apos;s nothing to do on the server-side.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>sshfs-fuse</Name>
@@ -25,12 +26,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2022-03-29</Date>
-            <Version>3.7.1</Version>
+        <Update release="10">
+            <Date>2023-12-30</Date>
+            <Version>3.7.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

This fixes an issue reported where browsing files via kdeconnect was no longer possible.

**Test Plan**

Browse files on phone from kdeconnect.

**Checklist**

- [X] Package was built and tested against unstable
