### PR TITLE
fd: Update to 9.0.0

### DIFF
--- a/packages/f/fd/abi_used_libs
+++ b/packages/f/fd/abi_used_libs
@@ -1,3 +1,2 @@
 libc.so.6
 libgcc_s.so.1
-libm.so.6

--- a/packages/f/fd/abi_used_symbols
+++ b/packages/f/fd/abi_used_symbols
@@ -29,6 +29,7 @@ libc.so.6:fstatat64
 libc.so.6:getcwd
 libc.so.6:getenv
 libc.so.6:getgrnam_r
+libc.so.6:getpid
 libc.so.6:getpwnam_r
 libc.so.6:getpwuid_r
 libc.so.6:gettimeofday
@@ -95,12 +96,15 @@ libc.so.6:read
 libc.so.6:readdir64
 libc.so.6:readlink
 libc.so.6:realpath
+libc.so.6:recv
+libc.so.6:recvmsg
 libc.so.6:sbrk
 libc.so.6:sched_getaffinity
 libc.so.6:sched_getcpu
 libc.so.6:sched_setaffinity
 libc.so.6:sched_yield
 libc.so.6:secure_getenv
+libc.so.6:sendmsg
 libc.so.6:setgid
 libc.so.6:setgroups
 libc.so.6:setpgid
@@ -111,6 +115,7 @@ libc.so.6:sigaltstack
 libc.so.6:sigemptyset
 libc.so.6:sigfillset
 libc.so.6:signal
+libc.so.6:socketpair
 libc.so.6:stat64
 libc.so.6:strchr
 libc.so.6:strcmp
@@ -135,4 +140,3 @@ libgcc_s.so.1:_Unwind_RaiseException
 libgcc_s.so.1:_Unwind_Resume
 libgcc_s.so.1:_Unwind_SetGR
 libgcc_s.so.1:_Unwind_SetIP
-libm.so.6:ceil

--- a/packages/f/fd/package.yml
+++ b/packages/f/fd/package.yml
@@ -1,8 +1,8 @@
 name       : fd
-version    : 8.7.0
-release    : 18
+version    : 9.0.0
+release    : 19
 source     :
-    - https://github.com/sharkdp/fd/archive/refs/tags/v8.7.0.tar.gz : 13da15f3197d58a54768aaad0099c80ad2e9756dd1b0c7df68c413ad2d5238c9
+    - https://github.com/sharkdp/fd/archive/refs/tags/v9.0.0.tar.gz : 306d7662994e06e23d25587246fa3fb1f528579e42a84f5128e75feec635a370
 homepage   : https://github.com/sharkdp/fd
 license    :
     - Apache-2.0

--- a/packages/f/fd/pspec_x86_64.xml
+++ b/packages/f/fd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>fd</Name>
         <Homepage>https://github.com/sharkdp/fd</Homepage>
         <Packager>
-            <Name>Longwu Ou</Name>
-            <Email>xulongwu4@gmail.com</Email>
+            <Name>Matthias Homann</Name>
+            <Email>palto@mailbox.org</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>MIT</License>
@@ -12,7 +12,7 @@
         <Summary xml:lang="en">A simple, fast and user-friendly alternative to find</Summary>
         <Description xml:lang="en">fd is a program to find entries in your filesystem. It is a simple, fast and user-friendly alternative to find. While it does not aim to support all of find&apos;s powerful functionality, it provides sensible (opinionated) defaults for a majority of use cases.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>fd</Name>
@@ -29,12 +29,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2023-05-03</Date>
-            <Version>8.7.0</Version>
+        <Update release="19">
+            <Date>2023-12-30</Date>
+            <Version>9.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Longwu Ou</Name>
-            <Email>xulongwu4@gmail.com</Email>
+            <Name>Matthias Homann</Name>
+            <Email>palto@mailbox.org</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Bugfixes:

- 9.0.0
  - Fix `NO_COLOR` support
- 8.7.1
  - `-1` properly conflicts with the exec family of options.
  - `--max-results` overrides `-1`
  - `--quiet` properly conflicts with the exec family of options. This used to be the case, but broke during the switch to clap-derive
  - `--changed-within` now accepts a space as well as a "T" as the separator between date and time (due to update of chrono dependency)

Enhancements:

- Performance has been significantly improved
- Support character and block device file types
- Breaking: `.git/` is now ignored by default when using `--hidden` / `-H`, use `--no-ignore` / `-I` or `--no-ignore-vcs` to override

Full release notes:

- [Changelog](https://github.com/sharkdp/fd/blob/master/CHANGELOG.md)

**Test Plan**

Installed and executes some searches with different options.

**Checklist**

- [X] Package was built and tested against unstable
