### PR TITLE
neovim update

### DIFF
--- a/packages/l/libuv/abi_used_symbols
+++ b/packages/l/libuv/abi_used_symbols
@@ -1,6 +1,7 @@
 libc.so.6:__environ
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
 libc.so.6:__memcpy_chk
 libc.so.6:__memmove_chk
 libc.so.6:__open64_2
@@ -201,7 +202,6 @@ libc.so.6:strncmp
 libc.so.6:strnlen
 libc.so.6:strrchr
 libc.so.6:strstr
-libc.so.6:strtol
 libc.so.6:symlink
 libc.so.6:syscall
 libc.so.6:sysconf

--- a/packages/l/libuv/package.yml
+++ b/packages/l/libuv/package.yml
@@ -1,8 +1,8 @@
 name       : libuv
-version    : 1.46.0
-release    : 15
+version    : 1.47.0
+release    : 16
 source     :
-    - https://github.com/libuv/libuv/archive/refs/tags/v1.46.0.tar.gz : 7aa66be3413ae10605e1f5c9ae934504ffe317ef68ea16fdaa83e23905c681bd
+    - https://github.com/libuv/libuv/archive/refs/tags/v1.47.0.tar.gz : d50af7e6d72526db137e66fad812421c8a1cae09d146b0ec2bb9a22c5f23ba93
 homepage   : https://libuv.org
 license    : MIT
 component  : programming.library

--- a/packages/l/libuv/pspec_x86_64.xml
+++ b/packages/l/libuv/pspec_x86_64.xml
@@ -11,7 +11,7 @@
         <Summary xml:lang="en">A multi-platform support library with a focus on asynchronous I/O</Summary>
         <Description xml:lang="en">libuv is a multi-platform support library with a focus on asynchronous I/O. It was primarily developed for use by Node.js, but it&apos;s also used by Luvit, Julia, pyuv, and others.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>libuv</Name>
@@ -33,7 +33,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="15">libuv</Dependency>
+            <Dependency release="16">libuv</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/uv.h</Path>
@@ -59,9 +59,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2023-10-05</Date>
-            <Version>1.46.0</Version>
+        <Update release="16">
+            <Date>2024-01-01</Date>
+            <Version>1.47.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>

--- a/packages/l/libvterm/package.yml
+++ b/packages/l/libvterm/package.yml
@@ -1,8 +1,8 @@
 name       : libvterm
-version    : 0.3.2
-release    : 5
+version    : 0.3.3
+release    : 6
 source     :
-    - https://www.leonerd.org.uk/code/libvterm/libvterm-0.3.2.tar.gz : 91eb5088069f4e6edab69e14c4212f6da0192e65695956dc048016a0dab8bcf6
+    - https://www.leonerd.org.uk/code/libvterm/libvterm-0.3.3.tar.gz : 09156f43dd2128bd347cbeebe50d9a571d32c64e0cf18d211197946aff7226e0
 homepage   : https://www.leonerd.org.uk/code/libvterm
 license    : MIT
 component  : programming

--- a/packages/l/libvterm/pspec_x86_64.xml
+++ b/packages/l/libvterm/pspec_x86_64.xml
@@ -11,7 +11,7 @@
         <Summary xml:lang="en">Abstract library implementation of a VT220/xterm/ECMA-48 terminal emulator</Summary>
         <Description xml:lang="en">Abstract library implementation of a VT220/xterm/ECMA-48 terminal emulator
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>libvterm</Name>
@@ -34,7 +34,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="5">libvterm</Dependency>
+            <Dependency release="6">libvterm</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/vterm.h</Path>
@@ -44,9 +44,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2023-10-05</Date>
-            <Version>0.3.2</Version>
+        <Update release="6">
+            <Date>2024-01-01</Date>
+            <Version>0.3.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>

--- a/packages/n/neovim-qt/package.yml
+++ b/packages/n/neovim-qt/package.yml
@@ -1,6 +1,6 @@
 name       : neovim-qt
 version    : 0.2.18
-release    : 12
+release    : 13
 source     :
     - https://github.com/equalsraf/neovim-qt/archive/refs/tags/v0.2.18.tar.gz : b1e1e019946ecb106b3aea8e35fc6e367d2efce44ca1c1599a2ccdfb35a28635
 homepage   : https://github.com/equalsraf/neovim-qt

--- a/packages/n/neovim-qt/pspec_x86_64.xml
+++ b/packages/n/neovim-qt/pspec_x86_64.xml
@@ -31,8 +31,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2023-10-22</Date>
+        <Update release="13">
+            <Date>2024-01-01</Date>
             <Version>0.2.18</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>

--- a/packages/n/neovim/abi_used_symbols
+++ b/packages/n/neovim/abi_used_symbols
@@ -27,8 +27,10 @@ libc.so.6:__environ
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
 libc.so.6:__fread_chk
-libc.so.6:__isoc99_fscanf
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_fscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtoimax
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__memmove_chk
@@ -303,9 +305,7 @@ libc.so.6:strptime
 libc.so.6:strrchr
 libc.so.6:strstr
 libc.so.6:strtod
-libc.so.6:strtoimax
 libc.so.6:strtok_r
-libc.so.6:strtol
 libc.so.6:symlink
 libc.so.6:syscall
 libc.so.6:sysconf

--- a/packages/n/neovim/package.yml
+++ b/packages/n/neovim/package.yml
@@ -1,8 +1,8 @@
 name       : neovim
-version    : 0.9.4
-release    : 36
+version    : 0.9.5
+release    : 37
 source     :
-    - https://github.com/neovim/neovim/archive/refs/tags/v0.9.4.tar.gz : 148356027ee8d586adebb6513a94d76accc79da9597109ace5c445b09d383093
+    - https://github.com/neovim/neovim/archive/refs/tags/v0.9.5.tar.gz : fe74369fc30a32ec7a086b1013acd0eacd674e7570eb1acc520a66180c9e9719
 homepage   : https://neovim.io
 license    : Apache-2.0
 component  : editor

--- a/packages/n/neovim/pspec_x86_64.xml
+++ b/packages/n/neovim/pspec_x86_64.xml
@@ -1756,9 +1756,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2023-10-09</Date>
-            <Version>0.9.4</Version>
+        <Update release="37">
+            <Date>2024-01-01</Date>
+            <Version>0.9.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>

--- a/packages/py/python-neovim/package.yml
+++ b/packages/py/python-neovim/package.yml
@@ -1,8 +1,8 @@
 name       : python-neovim
-version    : 0.4.3
-release    : 19
+version    : 5.0.0
+release    : 20
 source     :
-    - https://github.com/neovim/pynvim/archive/refs/tags/0.4.3.tar.gz : e7c9de44b0201ad874a608270b7a9b10fd48bda65f49bada05815d973ca79391
+    - https://github.com/neovim/pynvim/archive/refs/tags/0.5.0.tar.gz : 448414e8d005b6d99868c8badeec7a20b10a7a37fb6b85fb12846b80c044c279
 homepage   : https://github.com/neovim/pynvim
 license    : Apache-2.0
 component  : programming.python

--- a/packages/py/python-neovim/pspec_x86_64.xml
+++ b/packages/py/python-neovim/pspec_x86_64.xml
@@ -11,7 +11,7 @@
         <Summary xml:lang="en">Python client for Neovim</Summary>
         <Description xml:lang="en">Python client for Neovim
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>python-neovim</Name>
@@ -24,16 +24,17 @@
             <Path fileType="library">/usr/lib/python3.10/site-packages/neovim/__pycache__/__init__.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/neovim/api/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/neovim/api/__pycache__/__init__.cpython-310.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/pynvim-0.4.3-py3.10.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/pynvim-0.4.3-py3.10.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/pynvim-0.4.3-py3.10.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/pynvim-0.4.3-py3.10.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/pynvim-0.4.3-py3.10.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/pynvim-0.4.3-py3.10.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/pynvim-0.5.0-py3.10.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/pynvim-0.5.0-py3.10.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/pynvim-0.5.0-py3.10.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/pynvim-0.5.0-py3.10.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/pynvim-0.5.0-py3.10.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/pynvim/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/pynvim/__pycache__/__init__.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/pynvim/__pycache__/_version.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/pynvim/__pycache__/compat.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/pynvim/__pycache__/util.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/pynvim/_version.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/pynvim/api/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/pynvim/api/__pycache__/__init__.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/pynvim/api/__pycache__/buffer.cpython-310.pyc</Path>
@@ -75,9 +76,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2023-10-05</Date>
-            <Version>0.4.3</Version>
+        <Update release="20">
+            <Date>2024-01-01</Date>
+            <Version>5.0.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**

- libuv: Update to 1.47.0
- libvterm: Update to 0.3.3
- neovim: Update to 0.9.5
- neovim-qt: Safety rebuild for neovim
- python-neovim: Update to 5.0.0

**Note**

`libuv` is included in ISO images, so land this after Solus 4.5.

**Test Plan**

Install all packages, edit files with neovim, including changing text, saving, and re-opening.

**Checklist**

- [x] Package was built and tested against unstable
