### PR TITLE
fb2converter: Update to 1.73.1

### DIFF
--- a/packages/f/fb2converter/package.yml
+++ b/packages/f/fb2converter/package.yml
@@ -1,8 +1,8 @@
 name       : fb2converter
-version    : 1.72.3
-release    : 17
+version    : 1.73.1
+release    : 18
 source     :
-    - https://github.com/rupor-github/fb2converter/archive/refs/tags/v1.72.3.tar.gz : 57f2d27c6acdcc6ddab1d742b148713e361d7ce8f77d4ae772aa66cd5c50a07a
+    - https://github.com/rupor-github/fb2converter/archive/refs/tags/v1.73.1.tar.gz : 99c0ce59f331d769c6239133a0e70395aaef05ebcaeadca13338ee1f738bc982
 homepage   : https://github.com/rupor-github/fb2converter
 license    : GPL-3.0-only
 component  : office.viewers

--- a/packages/f/fb2converter/pspec_x86_64.xml
+++ b/packages/f/fb2converter/pspec_x86_64.xml
@@ -24,9 +24,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2023-12-22</Date>
-            <Version>1.72.3</Version>
+        <Update release="18">
+            <Date>2024-01-02</Date>
+            <Version>1.73.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Optimized PNGs will only be used if smaller in size
- Added debug level log
- Added some image size optimization

**Test Plan**
- convert fb2 file; view produced epub

**Checklist**
- [X] Package was built and tested against unstable
