### PR TITLE
gpxsee: Update to 13.14

### DIFF
--- a/packages/g/gpxsee/abi_used_symbols
+++ b/packages/g/gpxsee/abi_used_symbols
@@ -51,7 +51,7 @@ libQt5Core.so.5:_ZN10QEventLoopD1Ev
 libQt5Core.so.5:_ZN10QJsonArrayD1Ev
 libQt5Core.so.5:_ZN10QJsonValueC1ENS_4TypeE
 libQt5Core.so.5:_ZN10QJsonValueD1Ev
-libQt5Core.so.5:_ZN10QTextCodec12codecForNameERK10QByteArray
+libQt5Core.so.5:_ZN10QTextCodec11codecForMibEi
 libQt5Core.so.5:_ZN11QBasicTimer4stopEv
 libQt5Core.so.5:_ZN11QBasicTimer5startEiP7QObject
 libQt5Core.so.5:_ZN11QDataStream11readRawDataEPci
@@ -816,6 +816,7 @@ libQt5Network.so.5:_ZN13QNetworkReply16staticMetaObjectE
 libQt5Network.so.5:_ZN13QNetworkReply8finishedEv
 libQt5Network.so.5:_ZN15QNetworkRequest12setAttributeENS_9AttributeERK8QVariant
 libQt5Network.so.5:_ZN15QNetworkRequest12setRawHeaderERK10QByteArrayS2_
+libQt5Network.so.5:_ZN15QNetworkRequest18setTransferTimeoutEi
 libQt5Network.so.5:_ZN15QNetworkRequest26setMaximumRedirectsAllowedEi
 libQt5Network.so.5:_ZN15QNetworkRequestC1ERK4QUrl
 libQt5Network.so.5:_ZN15QNetworkRequestD1Ev

--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.13'
-release    : 31
+version    : '13.14'
+release    : 32
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.13.tar.gz : 83b462d209981cc2449b4479a5e39a8810837c79eb2847f7dc49bc62efd540a0
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.14.tar.gz : 3a3e60d6cfd87c43d77a0a5af4f2d463eea62f0f7becdb1974f1c3deb35c1355
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -26,12 +26,12 @@
             <Path fileType="data">/usr/share/gpxsee/CRS/gcs.csv</Path>
             <Path fileType="data">/usr/share/gpxsee/CRS/pcs.csv</Path>
             <Path fileType="data">/usr/share/gpxsee/CRS/projections.csv</Path>
-            <Path fileType="data">/usr/share/gpxsee/maps/4UMaps.xml</Path>
             <Path fileType="data">/usr/share/gpxsee/maps/Antarctica.xml</Path>
             <Path fileType="data">/usr/share/gpxsee/maps/OpenStreetMap.xml</Path>
             <Path fileType="data">/usr/share/gpxsee/maps/OpenTopoMap.xml</Path>
             <Path fileType="data">/usr/share/gpxsee/maps/USGS-imagery.xml</Path>
             <Path fileType="data">/usr/share/gpxsee/maps/USGS-topo.xml</Path>
+            <Path fileType="data">/usr/share/gpxsee/maps/mtbmap-cz.xml</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/ATV.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Airport.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Amusement Park.png</Path>
@@ -136,9 +136,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2023-12-22</Date>
-            <Version>13.13</Version>
+        <Update release="32">
+            <Date>2024-01-02</Date>
+            <Version>13.14</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Removed 4Umaps map source (map service discontinued)
- Added mtbmap.cz map source.
- Multiple minor map formats fixes/improvements (TrekBuddy, IMG).

**Test Plan**
- open map file; zoom in and out

**Checklist**
- [X] Package was built and tested against unstable
