### PR TITLE
cinnamon-translations: homepage inclusion

### DIFF
--- a/packages/c/cinnamon-translations/package.yml
+++ b/packages/c/cinnamon-translations/package.yml
@@ -1,8 +1,9 @@
 name       : cinnamon-translations
 version    : 5.8.2
-release    : 3
+release    : 4
 source     :
     - https://github.com/linuxmint/cinnamon-translations/archive/refs/tags/5.8.2.tar.gz : 3c4454696bd5d57d96dbbde10232c72b575d6e6e5364c657836967aa783ab0c8
+homepage   : https://translations.launchpad.net/linuxmint/
 license    : GPL-2.0-or-later
 component  : desktop.library
 summary    : Translation files for the Cinnamon desktop

--- a/packages/c/cinnamon-translations/pspec_x86_64.xml
+++ b/packages/c/cinnamon-translations/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>cinnamon-translations</Name>
+        <Homepage>https://translations.launchpad.net/linuxmint/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.library</PartOf>
         <Summary xml:lang="en">Translation files for the Cinnamon desktop</Summary>
         <Description xml:lang="en">The package contains the translation files for all the Cinnamon packages.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>cinnamon-translations</Name>
@@ -191,12 +192,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2023-09-26</Date>
+        <Update release="4">
+            <Date>2024-01-03</Date>
             <Version>5.8.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable

**Note**

There is new release version [6.0.1](https://github.com/linuxmint/cinnamon-translations/releases/tag/master.mint21)