### PR TITLE
solus-mate-transition-tool: Initial inclusion at v0.4

### DIFF
--- a/packages/s/solus-mate-transition-tool/package.yml
+++ b/packages/s/solus-mate-transition-tool/package.yml
@@ -1,0 +1,19 @@
+name       : solus-mate-transition-tool
+version    : '0.4'
+release    : 1
+source     :
+    - https://github.com/getsolus/solus-mate-transition-tool/archive/refs/tags/v0.4.tar.gz : 95b5142b741354baf9762d39ee2b76d235df3dc8d732849ed59a5434a9c39819
+homepage   : https://github.com/getsolus/solus-mate-transition-tool
+license    : GPL-2.0-or-later
+component  : desktop
+summary    : This is a tool is to help MATE users transition to a Budgie or XFCE environment without completely reinstalling
+description: |
+    As of Solus 4.5 the MATE Edition is deprecated and the MATE desktop enviornment will not be maintained. This is a tool is to help MATE users transition to a Budgie or XFCE environment without completely reinstalling.
+rundeps    :
+    - packagekit
+setup      : |
+    %meson_configure --libexecdir="libexec"
+build      : |
+    %ninja_build
+install    : |
+    %ninja_install

--- a/packages/s/solus-mate-transition-tool/pspec_x86_64.xml
+++ b/packages/s/solus-mate-transition-tool/pspec_x86_64.xml
@@ -1,0 +1,63 @@
+<PISI>
+    <Source>
+        <Name>solus-mate-transition-tool</Name>
+        <Homepage>https://github.com/getsolus/solus-mate-transition-tool</Homepage>
+        <Packager>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
+        </Packager>
+        <License>GPL-2.0-or-later</License>
+        <PartOf>desktop</PartOf>
+        <Summary xml:lang="en">This is a tool is to help MATE users transition to a Budgie or XFCE environment without completely reinstalling</Summary>
+        <Description xml:lang="en">As of Solus 4.5 the MATE Edition is deprecated and the MATE desktop enviornment will not be maintained. This is a tool is to help MATE users transition to a Budgie or XFCE environment without completely reinstalling.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>solus-mate-transition-tool</Name>
+        <Summary xml:lang="en">This is a tool is to help MATE users transition to a Budgie or XFCE environment without completely reinstalling</Summary>
+        <Description xml:lang="en">As of Solus 4.5 the MATE Edition is deprecated and the MATE desktop enviornment will not be maintained. This is a tool is to help MATE users transition to a Budgie or XFCE environment without completely reinstalling.
+</Description>
+        <PartOf>desktop</PartOf>
+        <Files>
+            <Path fileType="executable">/usr/bin/solus-mate-transition-notification</Path>
+            <Path fileType="executable">/usr/bin/solus-mate-transition-tool</Path>
+            <Path fileType="executable">/usr/libexec/solus-matetransition-authorizer</Path>
+            <Path fileType="data">/usr/share/applications/us.getsol.matetransition.desktop</Path>
+            <Path fileType="data">/usr/share/dbus-1/system-services/us.getsol.matetransition.Authorizer.service</Path>
+            <Path fileType="data">/usr/share/dbus-1/system.d/us.getsol.matetransition.conf</Path>
+            <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/solus-mate-transition-tool.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/cs_CZ/LC_MESSAGES/solus-mate-transition-tool.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/solus-mate-transition-tool.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/de_AT/LC_MESSAGES/solus-mate-transition-tool.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/solus-mate-transition-tool.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/es_ES/LC_MESSAGES/solus-mate-transition-tool.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/fi/LC_MESSAGES/solus-mate-transition-tool.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/fr_FR/LC_MESSAGES/solus-mate-transition-tool.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/he_IL/LC_MESSAGES/solus-mate-transition-tool.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/solus-mate-transition-tool.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/it_IT/LC_MESSAGES/solus-mate-transition-tool.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/nl_NL/LC_MESSAGES/solus-mate-transition-tool.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/pl_PL/LC_MESSAGES/solus-mate-transition-tool.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ru_RU/LC_MESSAGES/solus-mate-transition-tool.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sv_SE/LC_MESSAGES/solus-mate-transition-tool.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/tr/LC_MESSAGES/solus-mate-transition-tool.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/zh-Hans/LC_MESSAGES/solus-mate-transition-tool.mo</Path>
+            <Path fileType="data">/usr/share/polkit-1/actions/us.getsol.matetransition.policy</Path>
+            <Path fileType="data">/usr/share/solus-mate-transition-tool/budgie-pkgs.txt</Path>
+            <Path fileType="data">/usr/share/solus-mate-transition-tool/mate-pkgs.txt</Path>
+            <Path fileType="data">/usr/share/solus-mate-transition-tool/solus-mate-transition.ui</Path>
+            <Path fileType="data">/usr/share/solus-mate-transition-tool/xfce-pkgs.txt</Path>
+            <Path fileType="data">/usr/share/xdg/autostart/us.getsol.MateTransitionNotification.desktop</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2024-04-29</Date>
+            <Version>0.4</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**

- Provides an upgrade path for existing MATE installs
- Resolves #1134.

**Test Plan**

- Run tool on MATE vm and install XFCE in non US locale
- Run tool on MATE vm and install Budgie in non US locale

**Checklist**

- [x] Package was built and tested against unstable
