### PR TITLE
cmocka: Update to 1.1.7

### DIFF
--- a/packages/c/cmocka/abi_symbols
+++ b/packages/c/cmocka/abi_symbols
@@ -1,3 +1,5 @@
+libcmocka.so.0:_assert_double_equal
+libcmocka.so.0:_assert_double_not_equal
 libcmocka.so.0:_assert_float_equal
 libcmocka.so.0:_assert_float_not_equal
 libcmocka.so.0:_assert_in_range

--- a/packages/c/cmocka/abi_used_libs
+++ b/packages/c/cmocka/abi_used_libs
@@ -1,3 +1,2 @@
 ld-linux-x86-64.so.2
 libc.so.6
-librt.so.1

--- a/packages/c/cmocka/abi_used_symbols
+++ b/packages/c/cmocka/abi_used_symbols
@@ -8,6 +8,7 @@ libc.so.6:__stack_chk_fail
 libc.so.6:__vsnprintf_chk
 libc.so.6:abort
 libc.so.6:calloc
+libc.so.6:clock_gettime
 libc.so.6:exit
 libc.so.6:fclose
 libc.so.6:fflush
@@ -33,4 +34,3 @@ libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strsignal
 libc.so.6:strstr
-librt.so.1:clock_gettime

--- a/packages/c/cmocka/package.yml
+++ b/packages/c/cmocka/package.yml
@@ -1,8 +1,9 @@
 name       : cmocka
-version    : 1.1.5
-release    : 2
+version    : 1.1.7
+release    : 3
 source     :
-    - https://cmocka.org/files/1.1/cmocka-1.1.5.tar.xz : f0ccd8242d55e2fd74b16ba518359151f6f8383ff8aef4976e48393f77bba8b6
+    - https://cmocka.org/files/1.1/cmocka-1.1.7.tar.xz : 810570eb0b8d64804331f82b29ff47c790ce9cd6b163e98d47a4807047ecad82
+homepage   : https://cmocka.org/
 license    : Apache-2.0
 component  : programming.library
 summary    : An elegant unit testing framework for C with support for mock objects.

--- a/packages/c/cmocka/pspec_x86_64.xml
+++ b/packages/c/cmocka/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>cmocka</Name>
+        <Homepage>https://cmocka.org/</Homepage>
         <Packager>
-            <Name>Rune Morling</Name>
-            <Email>ermo.solus-project.com@spammesenseless.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.library</PartOf>
         <Summary xml:lang="en">An elegant unit testing framework for C with support for mock objects.</Summary>
         <Description xml:lang="en">An elegant unit testing framework for C with support for mock objects.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>cmocka</Name>
@@ -20,7 +21,7 @@
         <PartOf>programming.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libcmocka.so.0</Path>
-            <Path fileType="library">/usr/lib64/libcmocka.so.0.7.0</Path>
+            <Path fileType="library">/usr/lib64/libcmocka.so.0.8.0</Path>
         </Files>
     </Package>
     <Package>
@@ -30,11 +31,12 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">cmocka</Dependency>
+            <Dependency release="3">cmocka</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/cmocka.h</Path>
             <Path fileType="header">/usr/include/cmocka_pbc.h</Path>
+            <Path fileType="library">/usr/lib64/cmake/cmocka/cmocka-config-relwithdebinfo.cmake</Path>
             <Path fileType="library">/usr/lib64/cmake/cmocka/cmocka-config-version.cmake</Path>
             <Path fileType="library">/usr/lib64/cmake/cmocka/cmocka-config.cmake</Path>
             <Path fileType="library">/usr/lib64/libcmocka.so</Path>
@@ -42,12 +44,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2019-05-19</Date>
-            <Version>1.1.5</Version>
+        <Update release="3">
+            <Date>2024-01-06</Date>
+            <Version>1.1.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Rune Morling</Name>
-            <Email>ermo.solus-project.com@spammesenseless.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Changelog can be found [here](https://git.cryptomilk.org/projects/cmocka.git/plain/ChangeLog?h=cmocka-1.1.7)
- Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable