### PR TITLE
cmus: Update to 2.10.0

### DIFF
--- a/packages/c/cmus/abi_symbols
+++ b/packages/c/cmus/abi_symbols
@@ -70,6 +70,8 @@ cmus:cdda_device
 cmus:channel_map_init_waveex
 cmus:charset
 cmus:client_head
+cmus:clipped_text_format
+cmus:clipped_text_internal
 cmus:cmdline
 cmus:cmdline_backspace
 cmus:cmdline_backspace_to_bol
@@ -104,12 +106,15 @@ cmus:cmus_lib_dir
 cmus:cmus_mutex_lock
 cmus:cmus_mutex_unlock
 cmus:cmus_next
+cmus:cmus_next_album
 cmus:cmus_next_track_request_fd
 cmus:cmus_play_file
 cmus:cmus_playlist_dir
 cmus:cmus_playlist_for_each
 cmus:cmus_prev
+cmus:cmus_prev_album
 cmus:cmus_provide_next_track
+cmus:cmus_queue_active
 cmus:cmus_raise_vte
 cmus:cmus_running
 cmus:cmus_rwlock_rdlock
@@ -327,6 +332,7 @@ cmus:keyvals_new
 cmus:keyvals_terminate
 cmus:lib_add_filter
 cmus:lib_add_track
+cmus:lib_album_shuffle_root
 cmus:lib_artist_root
 cmus:lib_clear_store
 cmus:lib_cur_track
@@ -339,7 +345,9 @@ cmus:lib_for_each
 cmus:lib_for_each_filtered
 cmus:lib_get_cur_stored_track
 cmus:lib_goto_next
+cmus:lib_goto_next_album
 cmus:lib_goto_prev
+cmus:lib_goto_prev_album
 cmus:lib_init
 cmus:lib_live_filter
 cmus:lib_remove
@@ -349,6 +357,7 @@ cmus:lib_set_filter
 cmus:lib_set_live_filter
 cmus:lib_set_track
 cmus:lib_shuffle_root
+cmus:lib_sort_artists
 cmus:lib_store_cur_track
 cmus:lib_track_win
 cmus:lib_tree_win
@@ -361,6 +370,7 @@ cmus:lookup_cache_entry
 cmus:main
 cmus:main_thread
 cmus:malloc_fail
+cmus:mark_clipped_text
 cmus:misc_init
 cmus:mixer_close
 cmus:mixer_get_fds
@@ -418,6 +428,7 @@ cmus:path_absolute
 cmus:path_absolute_cwd
 cmus:path_basename
 cmus:path_strip
+cmus:pause_on_output_change
 cmus:pcm_conv
 cmus:pcm_conv_in_place
 cmus:pl_add_file_to_marked_pl
@@ -568,6 +579,7 @@ cmus:shuffle_list_add
 cmus:shuffle_list_get_next
 cmus:shuffle_list_get_prev
 cmus:shuffle_list_reshuffle
+cmus:shuffle_names
 cmus:simple_list_for_each
 cmus:simple_list_for_each_marked
 cmus:simple_list_get_next

--- a/packages/c/cmus/abi_used_symbols
+++ b/packages/c/cmus/abi_used_symbols
@@ -91,6 +91,7 @@ libavutil.so.56:av_log_set_level
 libavutil.so.56:av_opt_set_int
 libavutil.so.56:av_opt_set_sample_fmt
 libavutil.so.56:av_rescale_q
+libavutil.so.56:av_strerror
 libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_tolower_loc
 libc.so.6:__errno_location

--- a/packages/c/cmus/package.yml
+++ b/packages/c/cmus/package.yml
@@ -1,8 +1,9 @@
 name       : cmus
-version    : 2.9.1
-release    : 18
+version    : 2.10.0
+release    : 19
 source     :
-    - https://github.com/cmus/cmus/archive/v2.9.1.tar.gz : 6fb799cae60db9324f03922bbb2e322107fd386ab429c0271996985294e2ef44
+    - https://github.com/cmus/cmus/archive/refs/tags/v2.10.0.tar.gz : ff40068574810a7de3990f4f69c9c47ef49e37bd31d298d372e8bcdafb973fff
+homepage   : https://cmus.github.io/
 license    : GPL-2.0-or-later
 component  : multimedia.audio
 summary    : Small, fast and powerful console music player for Unix-like operating systems

--- a/packages/c/cmus/pspec_x86_64.xml
+++ b/packages/c/cmus/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>cmus</Name>
+        <Homepage>https://cmus.github.io/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>multimedia.audio</PartOf>
         <Summary xml:lang="en">Small, fast and powerful console music player for Unix-like operating systems</Summary>
         <Description xml:lang="en">Small, fast and powerful console music player for Unix-like operating systems
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>cmus</Name>
@@ -50,6 +51,7 @@
             <Path fileType="data">/usr/share/cmus/rc</Path>
             <Path fileType="data">/usr/share/cmus/solarized-dark.theme</Path>
             <Path fileType="data">/usr/share/cmus/solarized-light.theme</Path>
+            <Path fileType="data">/usr/share/cmus/spotify.theme</Path>
             <Path fileType="data">/usr/share/cmus/xterm-white.theme</Path>
             <Path fileType="data">/usr/share/cmus/zenburn.theme</Path>
             <Path fileType="doc">/usr/share/doc/cmus/examples/cmus-status-display</Path>
@@ -59,12 +61,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2023-01-11</Date>
-            <Version>2.9.1</Version>
+        <Update release="19">
+            <Date>2024-01-06</Date>
+            <Version>2.10.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Changelog:
   - Implement smart ReplayGain setting
   - Start from end on player-prev with no current track
   - Add reshuffle when current track has disappeared
   - Make tracks hold shuffle info
   - Use a direct album reference in AAA filter
   - Add an album shuffle mode
   - Add "player-next-album" and "player-prev-album" commands
   - Rename "shuffle" command to "reshuffle"
   - Reset position in shuffle list after a manual reshuffle
   - Fixes channel map for multichannel flac files
   - Replaces improper `fcntl` with `ioctl` in `op/oss`
   - Removes unmaintained notice
   - Initialize active to zero in `print_editable`
   - Allow output plugins to have multiple mixer FD lists
   - Preserve compatibility with `ABI v1` output plugins
   - Implement `pause_on_output_change` option
   - Implement `MIXER_FDS_OUTPUT` for pulse
   - Handle colors in active windows correctly
   - Initialize window size in init_curses
   - Fix send/receive API usage
   - Indicate elided text with "…" & related formatting tweaks
   - Limit max draw width to 1023 columns
   - Add `spotify.theme`
   - Fixes a few typo/style to the manpages
- Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

- Load music library and play "Some Minds" by Flume ft Andrew Wyatt
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable