### PR TITLE
compiz-bcop: homepage inclusion

### DIFF
--- a/packages/c/compiz-bcop/package.yml
+++ b/packages/c/compiz-bcop/package.yml
@@ -1,8 +1,9 @@
 name       : compiz-bcop
 version    : 0.8.18
-release    : 2
+release    : 3
 source     :
     - https://gitlab.com/compiz/compiz-bcop/-/archive/v0.8.18/compiz-bcop-v0.8.18.tar.bz2 : 1bc027d683ba3694aae0664d341379cb29fd721d4761fe45c1c185ee0d46d255
+homepage   : https://gitlab.com/compiz/compiz-bcop/
 license    : GPL-2.0-or-later
 component  : desktop.mate
 summary    : compiz bcop

--- a/packages/c/compiz-bcop/pspec_x86_64.xml
+++ b/packages/c/compiz-bcop/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>compiz-bcop</Name>
+        <Homepage>https://gitlab.com/compiz/compiz-bcop/</Homepage>
         <Packager>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.mate</PartOf>
         <Summary xml:lang="en">compiz bcop</Summary>
         <Description xml:lang="en">compiz bcop
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>compiz-bcop</Name>
@@ -30,19 +31,19 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">compiz-bcop</Dependency>
+            <Dependency release="3">compiz-bcop</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/pkgconfig/bcop.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2020-04-11</Date>
+        <Update release="3">
+            <Date>2024-01-06</Date>
             <Version>0.8.18</Version>
             <Comment>Packaging update</Comment>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Added `homepage` key to `package.yml` (Part of #411)

**Test Plan**

Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable