### PR TITLE
sof-firmware: update to 2.8

### DIFF
--- a/packages/s/sof-firmware/package.yml
+++ b/packages/s/sof-firmware/package.yml
@@ -1,9 +1,9 @@
 name       : sof-firmware
 homepage   : https://github.com/thesofproject/sof-bin
-version    : 2.7.2
-release    : 14
+version    : '2.8'
+release    : 15
 source     :
-    - https://github.com/thesofproject/sof-bin/releases/download/v2023.09.2/sof-bin-2023.09.2.tar.gz : 23063a3e447497bbb2683d0c5f3a0fbb248dabfb24544138be0e73e9e15e0f63
+    - https://github.com/thesofproject/sof-bin/releases/download/v2023.12/sof-bin-2023.12.tar.gz : 55e47eb63e6248dbdab7da232bb1e31ca2e7155b37dc116f6dc5b173cba3503b
 license    :
     - BSD-3-Clause
     - ISC

--- a/packages/s/sof-firmware/pspec_x86_64.xml
+++ b/packages/s/sof-firmware/pspec_x86_64.xml
@@ -25,6 +25,7 @@
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-hda-generic-4ch.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-hda-generic-idisp.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-hda-generic.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-cs42l43-l0-cs35l56-l12.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-max98357a-rt5682-ssp2-ssp0-2ch-pdm1.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-max98357a-rt5682-ssp2-ssp0.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-max98357a-rt5682.tplg</Path>
@@ -35,6 +36,7 @@
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-rt712-l0-rt1712-l3.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-rt713-l0-rt1316-l12-rt1713-l3.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-rt713-l0-rt1316-l12.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-rt722-l0.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-sdw-cs42l42-l0-max98363-l2.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ipc4/mtl/community/sof-mtl.ri</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ipc4/mtl/intel-signed/sof-mtl.ri</Path>
@@ -397,9 +399,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2023-11-17</Date>
-            <Version>2.7.2</Version>
+        <Update release="15">
+            <Date>2024-01-06</Date>
+            <Version>2.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Tracey Clark</Name>
             <Email>traceyc.dev@tlcnet.info</Email>


### PR DESCRIPTION
**Summary**

For v2.8 series, the following new topology files have been added since v2.7:

```
v2.8.x/sof-ace-tplg-v2.8
├── sof-mtl-cs42l43-l0-cs35l56-l12.tplg
├── sof-mtl-rt722-l0.tplg
```

Full release notes [here](https://github.com/thesofproject/sof-bin/releases/tag/v2023.12)

**Test Plan**

Verified firmware files were installed to correct paths. Restarted pipewire.
    systemctl --user restart pipewire.service
Listened to music and triggered system sounds to verify that sound still works.

**Checklist**

- [x] Package was built and tested against unstable
