### PR TITLE
blender: revert to ROCm 5.5 and add more supported GPU arches

### DIFF
--- a/packages/b/blender/abi_used_symbols
+++ b/packages/b/blender/abi_used_symbols
@@ -1501,6 +1501,7 @@ libjemalloc.so.2:_ZdlPvSt11align_val_t
 libjemalloc.so.2:_Znam
 libjemalloc.so.2:_Znwm
 libjemalloc.so.2:calloc
+libjemalloc.so.2:free
 libjemalloc.so.2:malloc_usable_size
 libjemalloc.so.2:memalign
 libjpeg.so.8:jpeg_CreateCompress
@@ -1815,9 +1816,9 @@ libosdGPU.so.3.6.0:_ZN10OpenSubdiv6v3_6_03Osd14GLVertexBuffer7BindVBOEPv
 libosdGPU.so.3.6.0:_ZN10OpenSubdiv6v3_6_03Osd14GLVertexBufferD1Ev
 libosdGPU.so.3.6.0:_ZN10OpenSubdiv6v3_6_03Osd21GLSLPatchShaderSource25GetPatchBasisShaderSourceB5cxx11Ev
 libosdGPU.so.3.6.0:_ZNK10OpenSubdiv6v3_6_03Osd14GLVertexBuffer14GetNumVerticesEv
+liboslcomp.so.1.12:_ZN9OSL_v1_1211OSLCompilerD1Ev
 liboslexec.so.1.12:_ZN9OSL_v1_1211OSLCompiler7compileEN16OpenImageIO_v2_417basic_string_viewIcSt11char_traitsIcEEERKSt6vectorINSt7__cxx1112basic_stringIcS4_SaIcEEESaISA_EES5_
 liboslexec.so.1.12:_ZN9OSL_v1_1211OSLCompilerC1EPN16OpenImageIO_v2_412ErrorHandlerE
-liboslexec.so.1.12:_ZN9OSL_v1_1211OSLCompilerD1Ev
 liboslexec.so.1.12:_ZN9OSL_v1_1213ShadingSystem11get_contextEPNS_13PerThreadInfoEPN16OpenImageIO_v2_413TextureSystem9PerthreadE
 liboslexec.so.1.12:_ZN9OSL_v1_1213ShadingSystem14ConnectShadersEN16OpenImageIO_v2_417basic_string_viewIcSt11char_traitsIcEEES5_S5_S5_
 liboslexec.so.1.12:_ZN9OSL_v1_1213ShadingSystem14ShaderGroupEndEv

--- a/packages/b/blender/package.yml
+++ b/packages/b/blender/package.yml
@@ -1,8 +1,9 @@
 name       : blender
 version    : 4.0.0
-release    : 77
+release    : 79
 source     :
     - https://download.blender.org/source/blender-4.0.0.tar.xz : e5a523c14082dae93706fb002b16e731f2ab4b202f5e82337d62272ca4884569
+    - https://download.blender.org/demo/test/BMW27.blend.zip : 08170de260488c14855a13db81c8d5ad844bc6162c3db13e1d9ba8094f55fe2b
 license    : GPL-2.0-or-later
 homepage   : https://blender.org/
 component  : multimedia.graphics
@@ -89,7 +90,8 @@ setup      : |
         -DWITH_SYSTEM_GLEW=ON \
         -DWITH_SYSTEM_LZO=ON \
         -DWITH_USD=ON \
-        -DWITH_X11_XINPUT=ON
+        -DWITH_X11_XINPUT=ON \
+        -DCYCLES_HIP_BINARIES_ARCH="%AMDGPUTARGETS%;gfx90c;gfx902;gfx1011;gfx1012;gfx1031;gfx1032;gfx1033;gfx1034;gfx1035;gfx1036;gfx1103"
 build      : |
     %ninja_build
 install    : |
@@ -97,3 +99,11 @@ install    : |
     %python3_compile $installdir/usr/share/blender
     install -Dm00644 $pkgfiles/blender.thumbnailer -t $installdir/usr/share/thumbnailers
     rm -r $installdir/usr/share/doc/blender/license/
+# TODO(GZGavinZhao): enable headless blender testing; currently it can't
+# find Python scripts needed at runtime
+# check      : |
+#     unzip $sources/BMW27.blend.zip
+# 
+#     if [ -e /dev/kfd ]; then
+#         # ./solusBuildDir/bin/blender -b BMW27.blend -f 0 -- --cycles-device HIP
+#     fi

--- a/packages/b/blender/pspec_x86_64.xml
+++ b/packages/b/blender/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>blender</Name>
         <Homepage>https://blender.org/</Homepage>
         <Packager>
-            <Name>Alexander Vorobyev</Name>
-            <Email>avorobyev@protonmail.com</Email>
+            <Name>Gavin Zhao</Name>
+            <Email>me@gzgz.dev</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>multimedia.graphics</PartOf>
@@ -730,14 +730,21 @@
             <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/lib/kernel_gfx1030.fatbin</Path>
             <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/lib/kernel_gfx1031.fatbin</Path>
             <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/lib/kernel_gfx1032.fatbin</Path>
+            <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/lib/kernel_gfx1033.fatbin</Path>
             <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/lib/kernel_gfx1034.fatbin</Path>
             <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/lib/kernel_gfx1035.fatbin</Path>
             <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/lib/kernel_gfx1036.fatbin</Path>
             <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/lib/kernel_gfx1100.fatbin</Path>
             <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/lib/kernel_gfx1101.fatbin</Path>
             <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/lib/kernel_gfx1102.fatbin</Path>
+            <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/lib/kernel_gfx1103.fatbin</Path>
+            <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/lib/kernel_gfx803.fatbin</Path>
             <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/lib/kernel_gfx900.fatbin</Path>
             <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/lib/kernel_gfx902.fatbin</Path>
+            <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/lib/kernel_gfx906:xnack-.fatbin</Path>
+            <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/lib/kernel_gfx908:xnack-.fatbin</Path>
+            <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/lib/kernel_gfx90a:xnack+.fatbin</Path>
+            <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/lib/kernel_gfx90a:xnack-.fatbin</Path>
             <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/lib/kernel_gfx90c.fatbin</Path>
             <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/license/Apache2-license.txt</Path>
             <Path fileType="data">/usr/share/blender/4.0/scripts/addons/cycles/license/BSD-3-Clause-license.txt</Path>
@@ -3744,12 +3751,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="77">
-            <Date>2023-12-10</Date>
+        <Update release="79">
+            <Date>2024-01-07</Date>
             <Version>4.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Alexander Vorobyev</Name>
-            <Email>avorobyev@protonmail.com</Email>
+            <Name>Gavin Zhao</Name>
+            <Email>me@gzgz.dev</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Reverted Blender to v4.0.0 and ROCm 5.5 and compiled for more GPU arches.

**Test Plan**

Rendered the BMW27 example with HIP Cycles: `blender -b BMW27.blend -f 0 -- --cycles-device HIP`

**Checklist**

- [x] Package was built and tested against unstable
