### PR TITLE
font-iosevka-ttf: Update to 28.0.4

### DIFF
--- a/packages/f/font-iosevka-ttf/package.yml
+++ b/packages/f/font-iosevka-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : font-iosevka-ttf
-version    : 28.0.1
-release    : 49
+version    : 28.0.4
+release    : 50
 source     :
-    - https://github.com/be5invis/Iosevka/releases/download/v28.0.1/PkgTTF-Iosevka-28.0.1.zip : da173efbffad54c2e25cee966eade17799595c4655639b0515f4c66547c8b579
+    - https://github.com/be5invis/Iosevka/releases/download/v28.0.4/PkgTTF-Iosevka-28.0.4.zip : 4178d006ced1c53790599ef3c2c84cf5a161ca856da603fa5878c59f18a5129c
 homepage   : https://typeof.net/Iosevka
 license    : OFL-1.1
 component  : desktop.font

--- a/packages/f/font-iosevka-ttf/pspec_x86_64.xml
+++ b/packages/f/font-iosevka-ttf/pspec_x86_64.xml
@@ -78,9 +78,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="49">
-            <Date>2023-12-22</Date>
-            <Version>28.0.1</Version>
+        <Update release="50">
+            <Date>2024-01-07</Date>
+            <Version>28.0.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Fix leaning marks of turned capital F/L
- Fix overlay bar placement of Z with Hook and Z with Swash Tail
- Fix attachment of descender parts of Cyrillic Lower Ha/X under x = cursive
- Make the Eng part in LATIN SMALL LETTER FENG DIGRAPH always connected to the f part
- Fix top bar shape in CYRILLIC CAPITAL LETTER DJE
- Fix leaning marks placement for reversed k/F/P
- Added characters
- Remove tailless variants for Latin Iota (U+0196, U+0269) and Cyrillic Iota (U+A646, U+A647).
- Fix slash ligations when frac feature is enabled
- Fix leaning marks of turned r
- Refine shape of Tshe and Cyrillic Capital Letter Te with Middle Hook (U+A68A)
- Remove bottom serif of Cyrillic Small Letter Ghe with Middle Hook (U+0495) under italics.
- Make serif variants of Cyrillic Small Letter Tall Te (U+1C84) respond to italics.
- Make terminal serif behavior of palatalized Komi consonants (U+0502...U+0505, U+0508...U+050F) more consistent with each other.
- Refine serifs of Turned M (U+019C, U+026F, U+0270, U+1D1F, U+1D5A, U+1DAD), Cyrillic Sha (U+0448, U+2DF2, U+1E046, U+1E064), and Cyrillic Shcha (U+0449, U+2DF3) under monospace.

**Test Plan**
- render text with the font

**Checklist**
- [X] Package was built and tested against unstable
