### PR TITLE
convmv: Update to 2.05

### DIFF
--- a/packages/c/convmv/package.yml
+++ b/packages/c/convmv/package.yml
@@ -1,9 +1,10 @@
 name       : convmv
-version    : 2.0
-release    : 1
+version    : '2.05'
+release    : 2
 source     :
-    - https://www.j3e.de/linux/convmv/convmv-2.0.tar.gz : 170cf675be1fca77868ff472e9340ca828b1463865a63d4f4b7b3bf4053db93f
-license    : GPL-2.0
+    - https://www.j3e.de/linux/convmv/convmv-2.05.tar.gz : 53b6ac8ae4f9beaee5bc5628f6a5382bfd14f42a5bed3d881b829d7b52d81ca6
+homepage   : https://www.j3e.de/linux/convmv/
+license    : GPL-2.0-or-later
 component  : system.utils
 summary    : converts filenames from one encoding to another
 description: |

--- a/packages/c/convmv/pspec_x86_64.xml
+++ b/packages/c/convmv/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>convmv</Name>
+        <Homepage>https://www.j3e.de/linux/convmv/</Homepage>
         <Packager>
-            <Name>Bryan T. Meyers</Name>
-            <Email>bmeyers@datadrake.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
-        <License>GPL-2.0</License>
+        <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">converts filenames from one encoding to another</Summary>
         <Description xml:lang="en">converts filenames from one encoding to another
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://solus-project.com/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>convmv</Name>
@@ -19,17 +20,17 @@
 </Description>
         <PartOf>system.utils</PartOf>
         <Files>
-            <Path fileType="executable">/usr/bin</Path>
-            <Path fileType="man">/usr/share/man</Path>
+            <Path fileType="executable">/usr/bin/convmv</Path>
+            <Path fileType="man">/usr/share/man/man1/convmv.1.gz</Path>
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2016-12-29</Date>
-            <Version>2.0</Version>
+        <Update release="2">
+            <Date>2024-01-08</Date>
+            <Version>2.05</Version>
             <Comment>Packaging update</Comment>
-            <Name>Bryan T. Meyers</Name>
-            <Email>bmeyers@datadrake.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Changelog :
  - 2.05 : 
     - allow NFC/NFD conversion on APFS volumes, add man page section for that filesystem 
     - use case- and normalization-insensitivity workarounds also for parsable mode
  - 2.04 :
    - check for valid utf-8 also in `upperlower_checkenc()`
    - fix parsable output, missed the path files to run utime() on - add `--run-parsable` option to blindly run what a file generated with `--parsable` tells us to do
  - 2.03 : 
     - fix man page build due to non-ASCII char
  - 2.02 :
     - add option `--caseful-sz` to optionally treat upper-/lowercasing of sz. This also fixes unwanted unidirectional lowercasing of U+1E9E
  - 2.01 :
       -  map : instead of / in SFU mapping tables
- Added `homepage` key to `package.yml` (Part of getsolus/packages/issues/411)

**Test Plan**

- Change encoding of a few filenames
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable