### PR TITLE
Subpackage default gnome shell extensions

### DIFF
--- a/packages/g/gnome-desktop-branding/package.yml
+++ b/packages/g/gnome-desktop-branding/package.yml
@@ -1,6 +1,6 @@
 name       : gnome-desktop-branding
 version    : '19'
-release    : 50
+release    : 51
 source     :
     - git|https://github.com/getsolus/gnome-desktop-branding.git : 40fbfcb8a1cc95bc0753f429252f534466ebc355
 homepage   : https://github.com/getsolus/gnome-desktop-branding
@@ -29,7 +29,13 @@ rundeps    :
     - gnome-browser-connector
     - gnome-shell
     - gnome-shell-extension-appindicator
+    - gnome-shell-extension-apps-menu # default ext.
+    - gnome-shell-extension-auto-move-windows # default ext.
+    - gnome-shell-extension-native-window-placement # default ext.
     - gnome-shell-extension-speedinator
+    - gnome-shell-extension-screenshot-window-sizer # default ext.
+    - gnome-shell-extension-user-theme # default ext.
+    - gnome-shell-extension-window-list # default ext.
     - gnome-shell-extensions
     - noto-sans-ttf
     - noto-serif-ttf

--- a/packages/g/gnome-desktop-branding/pspec_x86_64.xml
+++ b/packages/g/gnome-desktop-branding/pspec_x86_64.xml
@@ -34,15 +34,15 @@
         <Description xml:lang="en">Solus 4.0 LiveCD configuration.</Description>
         <PartOf>desktop.gnome</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="50">gnome-desktop-branding</Dependency>
+            <Dependency releaseFrom="51">gnome-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/glib-2.0/schemas/50_gnome_livecd.gschema.override</Path>
         </Files>
     </Package>
     <History>
-        <Update release="50">
-            <Date>2023-12-18</Date>
+        <Update release="51">
+            <Date>2024-01-08</Date>
             <Version>19</Version>
             <Comment>Packaging update</Comment>
             <Name>Joey Riches</Name>

--- a/packages/g/gnome-shell-extensions/package.yml
+++ b/packages/g/gnome-shell-extensions/package.yml
@@ -1,6 +1,6 @@
 name       : gnome-shell-extensions
 version    : '45.2'
-release    : 45
+release    : 46
 source     :
     - https://download.gnome.org/sources/gnome-shell-extensions/45/gnome-shell-extensions-45.2.tar.xz : ee32f6387a2d18adbff7a956689bc747866b4a8712d73790c002abeae4ccaaaf
 homepage   : https://wiki.gnome.org/Projects/GnomeShell/Extensions
@@ -20,3 +20,23 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+patterns   :
+    # NOTE: remember to subpackage any new extensions
+    - ^gnome-shell-extension-apps-menu :
+        - /usr/share/glib-2.0/schemas/org.gnome.shell.extensions.apps-menu.gschema.xml
+        - /usr/share/gnome-shell/extensions/apps-menu@gnome-shell-extensions.gcampax.github.com/*
+    - ^gnome-shell-extension-auto-move-windows :
+        - /usr/share/glib-2.0/schemas/org.gnome.shell.extensions.auto-move-windows.gschema.xml
+        - /usr/share/gnome-shell/extensions/auto-move-windows@gnome-shell-extensions.gcampax.github.com/*
+    - ^gnome-shell-extension-native-window-placement :
+        - /usr/share/glib-2.0/schemas/org.gnome.shell.extensions.native-window-placement.gschema.xml
+        - /usr/share/gnome-shell/extensions/native-window-placement@gnome-shell-extensions.gcampax.github.com/*
+    - ^gnome-shell-extension-screenshot-window-sizer :
+        - /usr/share/glib-2.0/schemas/org.gnome.shell.extensions.screenshot-window-sizer.gschema.xml
+        - /usr/share/gnome-shell/extensions/screenshot-window-sizer@gnome-shell-extensions.gcampax.github.com/*
+    - ^gnome-shell-extension-user-theme :
+        - /usr/share/glib-2.0/schemas/org.gnome.shell.extensions.user-theme.gschema.xml
+        - /usr/share/gnome-shell/extensions/user-theme@gnome-shell-extensions.gcampax.github.com/*
+    - ^gnome-shell-extension-window-list :
+        - /usr/share/glib-2.0/schemas/org.gnome.shell.extensions.window-list.gschema.xml
+        - /usr/share/gnome-shell/extensions/window-list@gnome-shell-extensions.gcampax.github.com/*

--- a/packages/g/gnome-shell-extensions/pspec_x86_64.xml
+++ b/packages/g/gnome-shell-extensions/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-shell-extensions</Name>
         <Homepage>https://wiki.gnome.org/Projects/GnomeShell/Extensions</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.gnome</PartOf>
@@ -20,18 +20,6 @@
 </Description>
         <PartOf>desktop.gnome</PartOf>
         <Files>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.shell.extensions.apps-menu.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.shell.extensions.auto-move-windows.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.shell.extensions.native-window-placement.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.shell.extensions.screenshot-window-sizer.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.shell.extensions.user-theme.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.shell.extensions.window-list.gschema.xml</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/apps-menu@gnome-shell-extensions.gcampax.github.com/extension.js</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/apps-menu@gnome-shell-extensions.gcampax.github.com/metadata.json</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/apps-menu@gnome-shell-extensions.gcampax.github.com/stylesheet.css</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/auto-move-windows@gnome-shell-extensions.gcampax.github.com/extension.js</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/auto-move-windows@gnome-shell-extensions.gcampax.github.com/metadata.json</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/auto-move-windows@gnome-shell-extensions.gcampax.github.com/prefs.js</Path>
             <Path fileType="data">/usr/share/gnome-shell/extensions/drive-menu@gnome-shell-extensions.gcampax.github.com/extension.js</Path>
             <Path fileType="data">/usr/share/gnome-shell/extensions/drive-menu@gnome-shell-extensions.gcampax.github.com/metadata.json</Path>
             <Path fileType="data">/usr/share/gnome-shell/extensions/drive-menu@gnome-shell-extensions.gcampax.github.com/stylesheet.css</Path>
@@ -39,26 +27,10 @@
             <Path fileType="data">/usr/share/gnome-shell/extensions/launch-new-instance@gnome-shell-extensions.gcampax.github.com/metadata.json</Path>
             <Path fileType="data">/usr/share/gnome-shell/extensions/light-style@gnome-shell-extensions.gcampax.github.com/extension.js</Path>
             <Path fileType="data">/usr/share/gnome-shell/extensions/light-style@gnome-shell-extensions.gcampax.github.com/metadata.json</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/native-window-placement@gnome-shell-extensions.gcampax.github.com/extension.js</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/native-window-placement@gnome-shell-extensions.gcampax.github.com/metadata.json</Path>
             <Path fileType="data">/usr/share/gnome-shell/extensions/places-menu@gnome-shell-extensions.gcampax.github.com/extension.js</Path>
             <Path fileType="data">/usr/share/gnome-shell/extensions/places-menu@gnome-shell-extensions.gcampax.github.com/metadata.json</Path>
             <Path fileType="data">/usr/share/gnome-shell/extensions/places-menu@gnome-shell-extensions.gcampax.github.com/placeDisplay.js</Path>
             <Path fileType="data">/usr/share/gnome-shell/extensions/places-menu@gnome-shell-extensions.gcampax.github.com/stylesheet.css</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/screenshot-window-sizer@gnome-shell-extensions.gcampax.github.com/extension.js</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/screenshot-window-sizer@gnome-shell-extensions.gcampax.github.com/metadata.json</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/screenshot-window-sizer@gnome-shell-extensions.gcampax.github.com/stylesheet.css</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/user-theme@gnome-shell-extensions.gcampax.github.com/extension.js</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/user-theme@gnome-shell-extensions.gcampax.github.com/metadata.json</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/user-theme@gnome-shell-extensions.gcampax.github.com/prefs.js</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/user-theme@gnome-shell-extensions.gcampax.github.com/util.js</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/window-list@gnome-shell-extensions.gcampax.github.com/extension.js</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/window-list@gnome-shell-extensions.gcampax.github.com/metadata.json</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/window-list@gnome-shell-extensions.gcampax.github.com/prefs.js</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/window-list@gnome-shell-extensions.gcampax.github.com/stylesheet-dark.css</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/window-list@gnome-shell-extensions.gcampax.github.com/stylesheet-light.css</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/window-list@gnome-shell-extensions.gcampax.github.com/windowPicker.js</Path>
-            <Path fileType="data">/usr/share/gnome-shell/extensions/window-list@gnome-shell-extensions.gcampax.github.com/workspaceIndicator.js</Path>
             <Path fileType="data">/usr/share/gnome-shell/extensions/windowsNavigator@gnome-shell-extensions.gcampax.github.com/extension.js</Path>
             <Path fileType="data">/usr/share/gnome-shell/extensions/windowsNavigator@gnome-shell-extensions.gcampax.github.com/metadata.json</Path>
             <Path fileType="data">/usr/share/gnome-shell/extensions/windowsNavigator@gnome-shell-extensions.gcampax.github.com/stylesheet.css</Path>
@@ -141,13 +113,89 @@
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/gnome-shell-extensions.mo</Path>
         </Files>
     </Package>
+    <Package>
+        <Name>gnome-shell-extension-apps-menu</Name>
+        <Summary xml:lang="en">Extensions for GNOME Shell</Summary>
+        <Description xml:lang="en">The GNOME Shell extension design is designed to give a high degree of power to the parts of the GNOME interface managed by the shell, such as window management and application launching. It simply loads arbitrary JavaScript and CSS. This gives developers a way to make many kinds of changes and share those changes with others, without having to patch the original source code and recompile it, and somehow distribute the patched code.
+</Description>
+        <Files>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.shell.extensions.apps-menu.gschema.xml</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/apps-menu@gnome-shell-extensions.gcampax.github.com/extension.js</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/apps-menu@gnome-shell-extensions.gcampax.github.com/metadata.json</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/apps-menu@gnome-shell-extensions.gcampax.github.com/stylesheet.css</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>gnome-shell-extension-auto-move-windows</Name>
+        <Summary xml:lang="en">Extensions for GNOME Shell</Summary>
+        <Description xml:lang="en">The GNOME Shell extension design is designed to give a high degree of power to the parts of the GNOME interface managed by the shell, such as window management and application launching. It simply loads arbitrary JavaScript and CSS. This gives developers a way to make many kinds of changes and share those changes with others, without having to patch the original source code and recompile it, and somehow distribute the patched code.
+</Description>
+        <Files>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.shell.extensions.auto-move-windows.gschema.xml</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/auto-move-windows@gnome-shell-extensions.gcampax.github.com/extension.js</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/auto-move-windows@gnome-shell-extensions.gcampax.github.com/metadata.json</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/auto-move-windows@gnome-shell-extensions.gcampax.github.com/prefs.js</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>gnome-shell-extension-native-window-placement</Name>
+        <Summary xml:lang="en">Extensions for GNOME Shell</Summary>
+        <Description xml:lang="en">The GNOME Shell extension design is designed to give a high degree of power to the parts of the GNOME interface managed by the shell, such as window management and application launching. It simply loads arbitrary JavaScript and CSS. This gives developers a way to make many kinds of changes and share those changes with others, without having to patch the original source code and recompile it, and somehow distribute the patched code.
+</Description>
+        <Files>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.shell.extensions.native-window-placement.gschema.xml</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/native-window-placement@gnome-shell-extensions.gcampax.github.com/extension.js</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/native-window-placement@gnome-shell-extensions.gcampax.github.com/metadata.json</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>gnome-shell-extension-screenshot-window-sizer</Name>
+        <Summary xml:lang="en">Extensions for GNOME Shell</Summary>
+        <Description xml:lang="en">The GNOME Shell extension design is designed to give a high degree of power to the parts of the GNOME interface managed by the shell, such as window management and application launching. It simply loads arbitrary JavaScript and CSS. This gives developers a way to make many kinds of changes and share those changes with others, without having to patch the original source code and recompile it, and somehow distribute the patched code.
+</Description>
+        <Files>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.shell.extensions.screenshot-window-sizer.gschema.xml</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/screenshot-window-sizer@gnome-shell-extensions.gcampax.github.com/extension.js</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/screenshot-window-sizer@gnome-shell-extensions.gcampax.github.com/metadata.json</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/screenshot-window-sizer@gnome-shell-extensions.gcampax.github.com/stylesheet.css</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>gnome-shell-extension-user-theme</Name>
+        <Summary xml:lang="en">Extensions for GNOME Shell</Summary>
+        <Description xml:lang="en">The GNOME Shell extension design is designed to give a high degree of power to the parts of the GNOME interface managed by the shell, such as window management and application launching. It simply loads arbitrary JavaScript and CSS. This gives developers a way to make many kinds of changes and share those changes with others, without having to patch the original source code and recompile it, and somehow distribute the patched code.
+</Description>
+        <Files>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.shell.extensions.user-theme.gschema.xml</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/user-theme@gnome-shell-extensions.gcampax.github.com/extension.js</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/user-theme@gnome-shell-extensions.gcampax.github.com/metadata.json</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/user-theme@gnome-shell-extensions.gcampax.github.com/prefs.js</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/user-theme@gnome-shell-extensions.gcampax.github.com/util.js</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>gnome-shell-extension-window-list</Name>
+        <Summary xml:lang="en">Extensions for GNOME Shell</Summary>
+        <Description xml:lang="en">The GNOME Shell extension design is designed to give a high degree of power to the parts of the GNOME interface managed by the shell, such as window management and application launching. It simply loads arbitrary JavaScript and CSS. This gives developers a way to make many kinds of changes and share those changes with others, without having to patch the original source code and recompile it, and somehow distribute the patched code.
+</Description>
+        <Files>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.shell.extensions.window-list.gschema.xml</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/window-list@gnome-shell-extensions.gcampax.github.com/extension.js</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/window-list@gnome-shell-extensions.gcampax.github.com/metadata.json</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/window-list@gnome-shell-extensions.gcampax.github.com/prefs.js</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/window-list@gnome-shell-extensions.gcampax.github.com/stylesheet-dark.css</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/window-list@gnome-shell-extensions.gcampax.github.com/stylesheet-light.css</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/window-list@gnome-shell-extensions.gcampax.github.com/windowPicker.js</Path>
+            <Path fileType="data">/usr/share/gnome-shell/extensions/window-list@gnome-shell-extensions.gcampax.github.com/workspaceIndicator.js</Path>
+        </Files>
+    </Package>
     <History>
-        <Update release="45">
-            <Date>2023-12-21</Date>
+        <Update release="46">
+            <Date>2024-01-08</Date>
             <Version>45.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- To fix fault appstream-builder generation. Resolves #1. Part of #6.

**Test Plan**
- Build and run `appstream-builder --packages-dir=. --include-failed -v`
- Verify each extension gets their appstream data generated properly

**Checklist**

- [x] Package was built and tested against unstable
