### PR TITLE
xfdesktop: Add xfce4-screensaver as a runtime dependency

### DIFF
--- a/packages/x/xfdesktop/abi_used_symbols
+++ b/packages/x/xfdesktop/abi_used_symbols
@@ -13,6 +13,7 @@ libX11.so.6:XSetSelectionOwner
 libX11.so.6:XUngrabPointer
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__stack_chk_fail
 libc.so.6:__vfprintf_chk
@@ -34,7 +35,6 @@ libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strrchr
 libc.so.6:strstr
-libc.so.6:strtol
 libc.so.6:symlink
 libc.so.6:time
 libc.so.6:unlink

--- a/packages/x/xfdesktop/package.yml
+++ b/packages/x/xfdesktop/package.yml
@@ -1,8 +1,9 @@
 name       : xfdesktop
 version    : 4.18.1
-release    : 1
+release    : 2
 source     :
     - https://archive.xfce.org/src/xfce/xfdesktop/4.18/xfdesktop-4.18.1.tar.bz2 : ef9268190c25877e22a9ff5aa31cc8ede120239cb0dfca080c174e7eed4ff756
+homepage   : https://docs.xfce.org/xfce/xfdesktop/start
 license    : GPL-2.0-or-later
 component  : desktop.xfce
 summary    : Xfce's desktop manager.
@@ -11,10 +12,12 @@ description: |
 builddeps  :
     - pkgconfig(exo-2)
     - pkgconfig(garcon-gtk3-1)
+    - pkgconfig(libwnck-3.0)
     - pkgconfig(libxfce4ui-2)
     - pkgconfig(libxfconf-0)
-    - pkgconfig(libwnck-3.0)
     - pkgconfig(thunarx-3)
+rundeps    :
+    - xfce4-screensaver
 setup      : |
     %configure --enable-thunarx --enable-notifications --disable-debug
 build      : |

--- a/packages/x/xfdesktop/pspec_x86_64.xml
+++ b/packages/x/xfdesktop/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>xfdesktop</Name>
+        <Homepage>https://docs.xfce.org/xfce/xfdesktop/start</Homepage>
         <Packager>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.xfce</PartOf>
         <Summary xml:lang="en">Xfce&apos;s desktop manager.</Summary>
         <Description xml:lang="en">Xfce&apos;s desktop manager.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>xfdesktop</Name>
@@ -114,12 +115,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2023-07-07</Date>
+        <Update release="2">
+            <Date>2024-01-09</Date>
             <Version>4.18.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Add xfce4-screensaver as a runtime dependency

This ensures that the screensaver is installed on updating.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install this updated and see that the screensaver package is also installed.

**Checklist**

- [x] Package was built and tested against unstable
