### PR TITLE
cracklib: Update to 2.9.11

### DIFF
--- a/packages/c/cracklib/abi_used_symbols
+++ b/packages/c/cracklib/abi_used_symbols
@@ -10,6 +10,7 @@ libc.so.6:__stack_chk_fail
 libc.so.6:__stpcpy_chk
 libc.so.6:__strcat_chk
 libc.so.6:__strcpy_chk
+libc.so.6:bindtextdomain
 libc.so.6:dcgettext
 libc.so.6:fclose
 libc.so.6:fgets

--- a/packages/c/cracklib/package.yml
+++ b/packages/c/cracklib/package.yml
@@ -1,9 +1,10 @@
 name       : cracklib
-version    : 2.9.7
-release    : 8
+version    : 2.9.11
+release    : 9
 source     :
-    - https://github.com/cracklib/cracklib/releases/download/v2.9.7/cracklib-2.9.7.tar.bz2 : fe82098509e4d60377b998662facf058dc405864a8947956718857dbb4bc35e6
-    - https://github.com/cracklib/cracklib/releases/download/v2.9.7/cracklib-words-2.9.7.bz2 : ec25ac4a474588c58d901715512d8902b276542b27b8dd197e9c2ad373739ec4
+    - https://github.com/cracklib/cracklib/releases/download/v2.9.11/cracklib-2.9.11.tar.bz2 : ca8b049a3c2d3b2225a1e8d15d613798ebc748e3950388eda2694de507ba6020
+    - https://github.com/cracklib/cracklib/releases/download/v2.9.11/cracklib-words-2.9.11.bz2 : ec25ac4a474588c58d901715512d8902b276542b27b8dd197e9c2ad373739ec4
+homepage   : https://github.com/cracklib/cracklib
 license    :
     - GPL-2.0-or-later
     - LGPL-2.1-or-later

--- a/packages/c/cracklib/pspec_x86_64.xml
+++ b/packages/c/cracklib/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>cracklib</Name>
+        <Homepage>https://github.com/cracklib/cracklib</Homepage>
         <Packager>
-            <Name>Martin Reboredo</Name>
-            <Email>yakoyoku@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -11,7 +12,7 @@
         <Summary xml:lang="en">A ProActive Password Sanity Library</Summary>
         <Description xml:lang="en">The CrackLib package contains a library used to enforce strong passwords by comparing user selected passwords to words in chosen word lists.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>cracklib</Name>
@@ -26,6 +27,7 @@
             <Path fileType="executable">/usr/sbin/cracklib-format</Path>
             <Path fileType="executable">/usr/sbin/cracklib-packer</Path>
             <Path fileType="executable">/usr/sbin/cracklib-unpacker</Path>
+            <Path fileType="executable">/usr/sbin/cracklib-update</Path>
             <Path fileType="executable">/usr/sbin/create-cracklib-dict</Path>
             <Path fileType="data">/usr/share/cracklib/cracklib-small</Path>
             <Path fileType="data">/usr/share/cracklib/cracklib-words</Path>
@@ -79,6 +81,9 @@
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/cracklib.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/cracklib.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/cracklib.mo</Path>
+            <Path fileType="man">/usr/share/man/man8/cracklib-check.8</Path>
+            <Path fileType="man">/usr/share/man/man8/cracklib-format.8</Path>
+            <Path fileType="man">/usr/share/man/man8/cracklib-update.8</Path>
         </Files>
     </Package>
     <Package>
@@ -88,21 +93,22 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="8">cracklib</Dependency>
+            <Dependency release="9">cracklib</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/crack.h</Path>
             <Path fileType="header">/usr/include/packer.h</Path>
             <Path fileType="library">/usr/lib64/libcrack.so</Path>
+            <Path fileType="man">/usr/share/man/man3/FascistCheck.3</Path>
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2021-04-03</Date>
-            <Version>2.9.7</Version>
+        <Update release="9">
+            <Date>2024-01-10</Date>
+            <Version>2.9.11</Version>
             <Comment>Packaging update</Comment>
-            <Name>Martin Reboredo</Name>
-            <Email>yakoyoku@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Full changelog can be found [here](https://raw.githubusercontent.com/cracklib/cracklib/v2.9.11/src/NEWS)
- Added `homepage` key to `package.yml` (Part of getsolus/packages/issues/411)

**Test Plan**

- Rebuild libpwquality and mariadb against this package
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable