### PR TITLE
visidata: Update to 3.0.1

### DIFF
--- a/packages/v/visidata/package.yml
+++ b/packages/v/visidata/package.yml
@@ -1,8 +1,8 @@
 name       : visidata
-version    : '3.0'
-release    : 9
+version    : 3.0.1
+release    : 10
 source     :
-    - https://github.com/saulpw/visidata/archive/refs/tags/v3.0.tar.gz : 7b994761374dd2e3c87780dfc472fae2d0ebb1e79f3366e9e6f3ce4fc066c2b3
+    - https://github.com/saulpw/visidata/archive/refs/tags/v3.0.1.tar.gz : 8b5736c3dbd3812942c7bab6136916ba2e48ddaf27359726a4221df0ebad8806
 homepage   : https://www.visidata.org/
 license    : GPL-3.0-only
 component  : office.viewers

--- a/packages/v/visidata/pspec_x86_64.xml
+++ b/packages/v/visidata/pspec_x86_64.xml
@@ -23,12 +23,12 @@
             <Path fileType="executable">/usr/bin/vd</Path>
             <Path fileType="executable">/usr/bin/vd2to3.vdx</Path>
             <Path fileType="executable">/usr/bin/visidata</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0-py3.10.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0-py3.10.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0-py3.10.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0-py3.10.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0-py3.10.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0-py3.10.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0.1-py3.10.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0.1-py3.10.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0.1-py3.10.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0.1-py3.10.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0.1-py3.10.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0.1-py3.10.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/visidata/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/visidata/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/visidata/__pycache__/__init__.cpython-310.pyc</Path>
@@ -479,6 +479,7 @@
             <Path fileType="library">/usr/lib/python3.10/site-packages/visidata/tests/__pycache__/test_features.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/visidata/tests/__pycache__/test_menu.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/visidata/tests/__pycache__/test_path.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata/tests/benchmark.csv</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/visidata/tests/conftest.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/visidata/tests/sample.tsv</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/visidata/tests/test_cliptext.py</Path>
@@ -517,9 +518,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2024-01-02</Date>
-            <Version>3.0</Version>
+        <Update release="10">
+            <Date>2024-01-13</Date>
+            <Version>3.0.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- add color_longname to use instead of color_keystrokes
- add displayer attribute to saved column state
- Enter executes first row, if partially typed out
- add sidebar for longname and aggregator palette
- add show-command-info to display command info for a keystroke
- add BtnUp pretty keys for BUTTON#_RELEASED
- dup-selected should unselect all rows in copied sheet
- fix KeyError crash with invalid inputs in expr for Python 3.12
- fix columns sheet sidebar
- ignore parsing exceptions on invalid urls
- limit end separators to rightmost visible column of sheet
- fix fmtstr on DirSheet sidebar for case where source is BaseSheet
- maintain ordering on sheet copies
- do not try to cancel already finished thread
- [changelog](https://raw.githubusercontent.com/saulpw/visidata/v3.0.1/CHANGELOG.md)

**Test Plan**
- select, filter and sort tsv rows

**Checklist**
- [X] Package was built and tested against unstable
