### PR TITLE
Add inxi to bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -64,7 +64,7 @@ body:
     id: system
     attributes:
       label: System details
-      description: Provide the output of *About This System* from the *Application Menu*
+      description: Provide the output of *About This System* from the *Application Menu* or from command line using `inxi -b`
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
XFCE does not have a way to copy the information in About ... dialogs. This small change provides a way for users to get us system information from command line.

**Summary**

<!-- Info on what this pull request updates/changes/etc -->

**Test Plan**

<!-- Short description of how the package was tested -->

**Checklist**

- [ ] Package was built and tested against unstable
