### PR TITLE
cemu: Update to 2.0-64

### DIFF
--- a/packages/c/cemu/abi_used_symbols
+++ b/packages/c/cemu/abi_used_symbols
@@ -150,6 +150,7 @@ libc.so.6:__strncpy_chk
 libc.so.6:__swprintf_chk
 libc.so.6:__vfprintf_chk
 libc.so.6:__vsnprintf_chk
+libc.so.6:_exit
 libc.so.6:abort
 libc.so.6:accept
 libc.so.6:aligned_alloc
@@ -176,6 +177,7 @@ libc.so.6:fcntl64
 libc.so.6:fflush
 libc.so.6:fopen
 libc.so.6:fopen64
+libc.so.6:fork
 libc.so.6:fread
 libc.so.6:free
 libc.so.6:freeaddrinfo
@@ -194,6 +196,7 @@ libc.so.6:getpeername
 libc.so.6:getpid
 libc.so.6:getsockname
 libc.so.6:getsockopt
+libc.so.6:gettid
 libc.so.6:if_indextoname
 libc.so.6:inet_ntop
 libc.so.6:inet_pton
@@ -221,9 +224,11 @@ libc.so.6:munmap
 libc.so.6:nanosleep
 libc.so.6:open64
 libc.so.6:pause
+libc.so.6:perror
 libc.so.6:pipe
 libc.so.6:poll
 libc.so.6:posix_memalign
+libc.so.6:prctl
 libc.so.6:pthread_cond_broadcast
 libc.so.6:pthread_cond_clockwait
 libc.so.6:pthread_cond_destroy
@@ -253,6 +258,7 @@ libc.so.6:pthread_rwlock_wrlock
 libc.so.6:pthread_self
 libc.so.6:pthread_setname_np
 libc.so.6:pthread_sigmask
+libc.so.6:ptrace
 libc.so.6:putenv
 libc.so.6:puts
 libc.so.6:qsort
@@ -307,6 +313,7 @@ libc.so.6:tolower
 libc.so.6:toupper
 libc.so.6:usleep
 libc.so.6:vsnprintf
+libc.so.6:waitpid
 libc.so.6:wcslen
 libc.so.6:wmemchr
 libc.so.6:wmemcmp

--- a/packages/c/cemu/package.yml
+++ b/packages/c/cemu/package.yml
@@ -1,8 +1,8 @@
 name       : cemu
-version    : 2.0.59
-release    : 4
+version    : 2.0.64
+release    : 5
 source     :
-    - git|https://github.com/cemu-project/Cemu : v2.0-59
+    - git|https://github.com/cemu-project/Cemu : v2.0-64
 homepage   : https://cemu.info/
 license    : MPL-2.0
 component  : games.emulator
@@ -54,5 +54,6 @@ install    : |
     ln -s $cemudir/cemu $installdir/usr/bin/cemu
 
     install -Dm00644 dist/linux/info.cemu.Cemu.png -T $installdir/usr/share/icons/hicolor/128x128/apps/info.cemu.Cemu.png
+    sed -i -e '/^Exec=/cExec=cemu' dist/linux/info.cemu.Cemu.desktop
     install -Dm00644 dist/linux/info.cemu.Cemu.desktop -T $installdir/usr/share/applications/info.cemu.Cemu.desktop
     install -Dm00644 dist/linux/info.cemu.Cemu.metainfo.xml $installdir/usr/share/metainfo/info.cemu.Cemu.metainfo.xml

--- a/packages/c/cemu/pspec_x86_64.xml
+++ b/packages/c/cemu/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>cemu</Name>
         <Homepage>https://cemu.info/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Packager>
         <License>MPL-2.0</License>
         <PartOf>games.emulator</PartOf>
@@ -287,12 +287,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-01-13</Date>
-            <Version>2.0.59</Version>
+        <Update release="5">
+            <Date>2024-01-15</Date>
+            <Version>2.0.64</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Update Cemu to 2.0-64. [Full changelog here](https://github.com/cemu-project/Cemu/compare/v2.0-59...v2.0-64).
- Fix an issue where Cemu did not appear in the Budgie menu because the executable name did not match the desktop file.

**Test Plan**

Verify that the app shows up in Budgie menu. Open Cemu and launch a game. Test that things generally work as expected.

**Checklist**

- [x] Package was built and tested against unstable
