### PR TITLE
Xorg Updates for January

### DIFF
--- a/packages/i/imake/package.yml
+++ b/packages/i/imake/package.yml
@@ -1,8 +1,8 @@
 name       : imake
-version    : 1.0.9
-release    : 13
+version    : 1.0.10
+release    : 14
 source     :
-    - https://www.x.org/releases/individual/util/imake-1.0.9.tar.gz : ca53ad18c683091490596d72fee8dbee4c6ddb7693709e25f26da140d29687c1
+    - https://www.x.org/releases/individual/util/imake-1.0.10.tar.gz : 9bbe76b6bb39caf34a437f50010f58a13d7dd6d512e00e765a2b7883e6ae613c
 license    : MIT
 component  : programming
 homepage   : https://www.x.org/

--- a/packages/i/imake/pspec_x86_64.xml
+++ b/packages/i/imake/pspec_x86_64.xml
@@ -41,9 +41,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2023-10-20</Date>
-            <Version>1.0.9</Version>
+        <Update release="14">
+            <Date>2024-01-16</Date>
+            <Version>1.0.10</Version>
             <Comment>Packaging update</Comment>
             <Name>Reilly Brogan</Name>
             <Email>solus@reillybrogan.com</Email>

--- a/packages/p/pixman/abi_symbols
+++ b/packages/p/pixman/abi_symbols
@@ -78,6 +78,7 @@ libpixman-1.so.0:pixman_region32_clear
 libpixman-1.so.0:pixman_region32_contains_point
 libpixman-1.so.0:pixman_region32_contains_rectangle
 libpixman-1.so.0:pixman_region32_copy
+libpixman-1.so.0:pixman_region32_empty
 libpixman-1.so.0:pixman_region32_equal
 libpixman-1.so.0:pixman_region32_extents
 libpixman-1.so.0:pixman_region32_fini
@@ -102,6 +103,7 @@ libpixman-1.so.0:pixman_region_clear
 libpixman-1.so.0:pixman_region_contains_point
 libpixman-1.so.0:pixman_region_contains_rectangle
 libpixman-1.so.0:pixman_region_copy
+libpixman-1.so.0:pixman_region_empty
 libpixman-1.so.0:pixman_region_equal
 libpixman-1.so.0:pixman_region_extents
 libpixman-1.so.0:pixman_region_fini

--- a/packages/p/pixman/abi_symbols32
+++ b/packages/p/pixman/abi_symbols32
@@ -78,6 +78,7 @@ libpixman-1.so.0:pixman_region32_clear
 libpixman-1.so.0:pixman_region32_contains_point
 libpixman-1.so.0:pixman_region32_contains_rectangle
 libpixman-1.so.0:pixman_region32_copy
+libpixman-1.so.0:pixman_region32_empty
 libpixman-1.so.0:pixman_region32_equal
 libpixman-1.so.0:pixman_region32_extents
 libpixman-1.so.0:pixman_region32_fini
@@ -102,6 +103,7 @@ libpixman-1.so.0:pixman_region_clear
 libpixman-1.so.0:pixman_region_contains_point
 libpixman-1.so.0:pixman_region_contains_rectangle
 libpixman-1.so.0:pixman_region_copy
+libpixman-1.so.0:pixman_region_empty
 libpixman-1.so.0:pixman_region_equal
 libpixman-1.so.0:pixman_region_extents
 libpixman-1.so.0:pixman_region_fini

--- a/packages/p/pixman/abi_used_symbols
+++ b/packages/p/pixman/abi_used_symbols
@@ -20,5 +20,4 @@ libc.so.6:strncmp
 libm.so.6:atan2
 libm.so.6:exp
 libm.so.6:sin
-libm.so.6:sqrt
 libm.so.6:sqrtf

--- a/packages/p/pixman/abi_used_symbols32
+++ b/packages/p/pixman/abi_used_symbols32
@@ -22,5 +22,4 @@ libm.so.6:ceil
 libm.so.6:exp
 libm.so.6:floor
 libm.so.6:sin
-libm.so.6:sqrt
 libm.so.6:sqrtf

--- a/packages/p/pixman/package.yml
+++ b/packages/p/pixman/package.yml
@@ -1,8 +1,8 @@
 name       : pixman
-version    : 0.42.2
-release    : 16
+version    : 0.43.0
+release    : 17
 source     :
-    - https://www.cairographics.org/releases/pixman-0.42.2.tar.gz : ea1480efada2fd948bc75366f7c349e1c96d3297d09a3fe62626e38e234a625e
+    - https://www.x.org/releases/individual/lib/pixman-0.43.0.tar.gz : a65c28209858fb16bee50d809c80f90a8e415c0e4fd8321078a1822785a5560a
 license    : MIT
 homepage   : https://www.cairographics.org/
 component  : desktop.library
@@ -11,13 +11,14 @@ description: |
     pixman is a low-level software library for pixel manipulation, providing features such as image compositing.
 builddeps  :
     - pkgconfig32(libpng16)
+    - libgomp-32bit
 optimize   : speed
 emul32     : yes
 setup      : |
-    %configure --disable-static
+    %meson_configure
 build      : |
-    %make
+    %ninja_build
 install    : |
-    %make_install
+    %ninja_install
 check      : |
-    %make check
+    %ninja_check

--- a/packages/p/pixman/pspec_x86_64.xml
+++ b/packages/p/pixman/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pixman</Name>
         <Homepage>https://www.cairographics.org/</Homepage>
         <Packager>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Reilly Brogan</Name>
+            <Email>solus@reillybrogan.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>desktop.library</PartOf>
@@ -21,7 +21,7 @@
         <PartOf>desktop.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libpixman-1.so.0</Path>
-            <Path fileType="library">/usr/lib64/libpixman-1.so.0.42.2</Path>
+            <Path fileType="library">/usr/lib64/libpixman-1.so.0.43.0</Path>
         </Files>
     </Package>
     <Package>
@@ -31,11 +31,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="16">pixman</Dependency>
+            <Dependency release="17">pixman</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpixman-1.so.0</Path>
-            <Path fileType="library">/usr/lib32/libpixman-1.so.0.42.2</Path>
+            <Path fileType="library">/usr/lib32/libpixman-1.so.0.43.0</Path>
         </Files>
     </Package>
     <Package>
@@ -45,8 +45,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="16">pixman-devel</Dependency>
-            <Dependency release="16">pixman-32bit</Dependency>
+            <Dependency release="17">pixman-devel</Dependency>
+            <Dependency release="17">pixman-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpixman-1.so</Path>
@@ -60,7 +60,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="16">pixman</Dependency>
+            <Dependency release="17">pixman</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/pixman-1/pixman-version.h</Path>
@@ -70,12 +70,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2023-10-08</Date>
-            <Version>0.42.2</Version>
+        <Update release="17">
+            <Date>2024-01-16</Date>
+            <Version>0.43.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Reilly Brogan</Name>
+            <Email>solus@reillybrogan.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/t/tigervnc/package.yml
+++ b/packages/t/tigervnc/package.yml
@@ -1,9 +1,9 @@
 name       : tigervnc
 version    : 1.13.1
-release    : 19
+release    : 20
 source     :
     - https://github.com/TigerVNC/tigervnc/archive/refs/tags/v1.13.1.tar.gz : b7c5b8ed9e4e2c2f48c7b2c9f21927db345e542243b4be88e066b2daa3d1ae25
-    - https://www.x.org/releases/individual/xserver/xorg-server-21.1.10.tar.xz : ceb0b3a2efc57ac3ccf388d3dc88b97615068639fb284d469689ae3d105611d0
+    - https://www.x.org/releases/individual/xserver/xorg-server-21.1.11.tar.xz : 1d3dadbd57fb86b16a018e9f5f957aeeadf744f56c0553f55737628d06d326ef
 homepage   : https://tigervnc.org/
 license    :
     - GPL-2.0-or-later

--- a/packages/t/tigervnc/pspec_x86_64.xml
+++ b/packages/t/tigervnc/pspec_x86_64.xml
@@ -80,8 +80,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2023-12-13</Date>
+        <Update release="20">
+            <Date>2024-01-16</Date>
             <Version>1.13.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Reilly Brogan</Name>

--- a/packages/x/xorg-server/package.yml
+++ b/packages/x/xorg-server/package.yml
@@ -1,8 +1,9 @@
+# Updating this package? Make sure to update the bundled xorg-server in tigervnc too
 name       : xorg-server
-version    : 21.1.10
-release    : 95
+version    : 21.1.11
+release    : 96
 source     :
-    - https://www.x.org/releases/individual/xserver/xorg-server-21.1.10.tar.xz : ceb0b3a2efc57ac3ccf388d3dc88b97615068639fb284d469689ae3d105611d0
+    - https://www.x.org/releases/individual/xserver/xorg-server-21.1.11.tar.xz : 1d3dadbd57fb86b16a018e9f5f957aeeadf744f56c0553f55737628d06d326ef
 homepage   : https://xorg.freedesktop.org/wiki/
 license    : MIT
 component  :
@@ -11,25 +12,6 @@ component  :
 summary    : The Xorg Server is the core of the X Window system
 description: |
     The Xorg Server is the core of the X Window system.
-optimize   :
-    - no-bind-now
-    - no-symbolic
-patterns   :
-    - xvfb :
-        - /usr/bin/Xvfb
-        - /usr/bin/xvfb-run
-        - /usr/share/man/man1/Xvfb.1
-rundeps    :
-    - dbus-launch
-    - linux-driver-management
-    - xorg-xwayland
-    - xvfb :
-        - xauth
-        - xkbcomp
-        - xkeyboard-config
-replaces   :
-    - glamor-egl
-    - xorg-driver-video-modesetting
 builddeps  :
     - pkgconfig(dri)
     - pkgconfig(epoxy)
@@ -51,15 +33,26 @@ builddeps  :
     - pkgconfig(xcb-image)
     - pkgconfig(xcb-keysyms)
     - pkgconfig(xcb-renderutil)
-    - pkgconfig(xkbcomp)
     - pkgconfig(xfont2)
     - pkgconfig(xi)
+    - pkgconfig(xkbcomp)
     - pkgconfig(xkbfile)
     - pkgconfig(xorg-macros)
     - pkgconfig(xproto)
     - pkgconfig(xrender)
     - pkgconfig(xshmfence)
     - pkgconfig(xtrans)
+rundeps    :
+    - dbus-launch
+    - linux-driver-management
+    - xorg-xwayland
+    - xvfb :
+        - xauth
+        - xkbcomp
+        - xkeyboard-config
+optimize   :
+    - no-bind-now
+    - no-symbolic
 setup      : |
     %apply_patches
     %meson_configure \
@@ -90,3 +83,11 @@ install    : |
     # tmpfiles
     rm -rf $installdir/var
     install -Dm00644 $pkgfiles/xorg-server.tmpfiles $installdir/%libdir%/tmpfiles.d/xorg-server.conf
+patterns   :
+    - xvfb :
+        - /usr/bin/Xvfb
+        - /usr/bin/xvfb-run
+        - /usr/share/man/man1/Xvfb.1
+replaces   :
+    - glamor-egl
+    - xorg-driver-video-modesetting

--- a/packages/x/xorg-server/pspec_x86_64.xml
+++ b/packages/x/xorg-server/pspec_x86_64.xml
@@ -67,7 +67,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="95">xorg-server</Dependency>
+            <Dependency release="96">xorg-server</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/xorg/XIstubs.h</Path>
@@ -244,9 +244,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="95">
-            <Date>2023-12-13</Date>
-            <Version>21.1.10</Version>
+        <Update release="96">
+            <Date>2024-01-16</Date>
+            <Version>21.1.11</Version>
             <Comment>Packaging update</Comment>
             <Name>Reilly Brogan</Name>
             <Email>solus@reillybrogan.com</Email>

--- a/packages/x/xorg-xwayland/abi_used_symbols
+++ b/packages/x/xorg-xwayland/abi_used_symbols
@@ -634,6 +634,7 @@ libepoxy.so.0:epoxy_glCheckFramebufferStatus
 libepoxy.so.0:epoxy_glClear
 libepoxy.so.0:epoxy_glClearColor
 libepoxy.so.0:epoxy_glClearTexImage
+libepoxy.so.0:epoxy_glColorMask
 libepoxy.so.0:epoxy_glCompileShader
 libepoxy.so.0:epoxy_glCreateProgram
 libepoxy.so.0:epoxy_glCreateShader

--- a/packages/x/xorg-xwayland/package.yml
+++ b/packages/x/xorg-xwayland/package.yml
@@ -1,26 +1,25 @@
 name       : xorg-xwayland
-version    : 23.2.3
-release    : 21
+version    : 23.2.4
+release    : 22
 source     :
-    - https://www.x.org/releases/individual/xserver/xwayland-23.2.3.tar.xz : eb9d9aa7232c47412c8835ec15a97c575f03563726c787754ff0c019bd07e302
+    - https://www.x.org/releases/individual/xserver/xwayland-23.2.4.tar.xz : a99e159b6d0d33098b3b6ab22a88bfcece23c8b9d0ca72c535c55dcb0681b46b
 license    : MIT
 component  : xorg.server
 homepage   : https://www.x.org/
 summary    : X server intended for Xorg only clients to run under Wayland for backwards compatability.
 description: |
     X server intended for Xorg only clients to run under Wayland for backwards compatability.
-patterns   : /*
 builddeps  :
     - pkgconfig(dri)
     - pkgconfig(epoxy)
     - pkgconfig(fontutil)
     - pkgconfig(gdm)
+    - pkgconfig(inputproto)
     - pkgconfig(libdecor-0)
     - pkgconfig(libdrm)
     - pkgconfig(libei-1.0)
     - pkgconfig(libtirpc)
     - pkgconfig(libxcvt)
-    - pkgconfig(inputproto)
     - pkgconfig(nettle)
     - pkgconfig(pixman-1)
     - pkgconfig(wayland-client)
@@ -41,3 +40,4 @@ install    : |
     # Provided by xorg-server
     rm -fr $installdir/usr/lib64/xorg/
     rm $installdir/usr/share/man/man1/Xserver.1
+patterns   : /*

--- a/packages/x/xorg-xwayland/pspec_x86_64.xml
+++ b/packages/x/xorg-xwayland/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2023-12-13</Date>
-            <Version>23.2.3</Version>
+        <Update release="22">
+            <Date>2024-01-16</Date>
+            <Version>23.2.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Reilly Brogan</Name>
             <Email>solus@reillybrogan.com</Email>

--- a/packages/x/xrdp/abi_used_symbols
+++ b/packages/x/xrdp/abi_used_symbols
@@ -100,8 +100,8 @@ libc.so.6:getc
 libc.so.6:getcwd
 libc.so.6:getenv
 libc.so.6:getgid
-libc.so.6:getgrgid
 libc.so.6:getgrnam
+libc.so.6:getgrouplist
 libc.so.6:gethostname
 libc.so.6:getlogin_r
 libc.so.6:getopt

--- a/packages/x/xrdp/package.yml
+++ b/packages/x/xrdp/package.yml
@@ -1,8 +1,8 @@
 name       : xrdp
-version    : 0.9.23.1
-release    : 22
+version    : 0.9.24
+release    : 23
 source     :
-    - https://github.com/neutrinolabs/xrdp/releases/download/v0.9.23.1/xrdp-0.9.23.1.tar.gz : 8fb71f6b90c2769fa0e02032c17e3c7ac70785c724d59fa1e08a9af5b9e7f5ca
+    - https://github.com/neutrinolabs/xrdp/releases/download/v0.9.24/xrdp-0.9.24.tar.gz : 68b2c58254ed8488900b99e6f84ed666324e7665614ce68d21dcf2f5e8ad1717
 homepage   : http://xrdp.org/
 license    : Apache-2.0
 component  : network.util

--- a/packages/x/xrdp/pspec_x86_64.xml
+++ b/packages/x/xrdp/pspec_x86_64.xml
@@ -108,7 +108,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="22">xrdp</Dependency>
+            <Dependency release="23">xrdp</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/ms-erref.h</Path>
@@ -137,9 +137,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2023-12-04</Date>
-            <Version>0.9.23.1</Version>
+        <Update release="23">
+            <Date>2024-01-16</Date>
+            <Version>0.9.24</Version>
             <Comment>Packaging update</Comment>
             <Name>Reilly Brogan</Name>
             <Email>solus@reillybrogan.com</Email>


### PR DESCRIPTION
Updating to the latest security releases for Xorg-server and Xwayland while also flushing out all of the xorg-related projects in my updates list.

**Summary**
- Updates xorg-server to v21.1.11
  - Including bundled build in tigervnc (adding a note to xorg-server just to make sure this always gets done in the future)
- Updates xorg-xwayland to v23.2.4
- Pixman 0.43.0
- Imake v1.0.10
- xrdp v0.9.24 (which technically isn't an xorg project but it was in my todo list and is tangentially related so in it goes)

Resolves the following CVEs:
- CVE-2023-6816
- CVE-2024-0229
- CVE-2024-21885
- CVE-2024-21886
- CVE-2024-0408
- CVE-2024-0409