### PR TITLE
fb2converter: Update to 1.74.1

### DIFF
--- a/packages/f/fb2converter/package.yml
+++ b/packages/f/fb2converter/package.yml
@@ -1,8 +1,8 @@
 name       : fb2converter
-version    : 1.73.1
-release    : 18
+version    : 1.74.1
+release    : 19
 source     :
-    - https://github.com/rupor-github/fb2converter/archive/refs/tags/v1.73.1.tar.gz : 99c0ce59f331d769c6239133a0e70395aaef05ebcaeadca13338ee1f738bc982
+    - https://github.com/rupor-github/fb2converter/archive/refs/tags/v1.74.1.tar.gz : 370389df59b48d695b1865e3908b8613c47dc57d5a087c7f12bcb4c2aa49c0af
 homepage   : https://github.com/rupor-github/fb2converter
 license    : GPL-3.0-only
 component  : office.viewers

--- a/packages/f/fb2converter/pspec_x86_64.xml
+++ b/packages/f/fb2converter/pspec_x86_64.xml
@@ -24,9 +24,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2024-01-02</Date>
-            <Version>1.73.1</Version>
+        <Update release="19">
+            <Date>2024-01-20</Date>
+            <Version>1.74.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Fixed notes body processing in float-new-XXXX modes
- Now notes bodies could have images and cross-links
- epub:type attributes now will only be set on "anchor" tags
- Added new notes type: "float-new-more"

**Test Plan**
- fb2c convert in.fb2; then skim through epub

**Checklist**
- [X] Package was built and tested against unstable
