### PR TITLE
visidata: Update to 3.0.2

### DIFF
--- a/packages/v/visidata/package.yml
+++ b/packages/v/visidata/package.yml
@@ -1,8 +1,8 @@
 name       : visidata
-version    : 3.0.1
-release    : 10
+version    : 3.0.2
+release    : 11
 source     :
-    - https://github.com/saulpw/visidata/archive/refs/tags/v3.0.1.tar.gz : 8b5736c3dbd3812942c7bab6136916ba2e48ddaf27359726a4221df0ebad8806
+    - https://github.com/saulpw/visidata/archive/refs/tags/v3.0.2.tar.gz : cc1506b96192de49419a77a3f9606999779ff77d37a7be0806506c32e16d57f7
 homepage   : https://www.visidata.org/
 license    : GPL-3.0-only
 component  : office.viewers

--- a/packages/v/visidata/pspec_x86_64.xml
+++ b/packages/v/visidata/pspec_x86_64.xml
@@ -23,12 +23,12 @@
             <Path fileType="executable">/usr/bin/vd</Path>
             <Path fileType="executable">/usr/bin/vd2to3.vdx</Path>
             <Path fileType="executable">/usr/bin/visidata</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0.1-py3.10.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0.1-py3.10.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0.1-py3.10.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0.1-py3.10.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0.1-py3.10.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0.1-py3.10.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0.2-py3.10.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0.2-py3.10.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0.2-py3.10.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0.2-py3.10.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0.2-py3.10.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/visidata-3.0.2-py3.10.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/visidata/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/visidata/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/visidata/__pycache__/__init__.cpython-310.pyc</Path>
@@ -518,9 +518,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2024-01-13</Date>
-            <Version>3.0.1</Version>
+        <Update release="11">
+            <Date>2024-01-20</Date>
+            <Version>3.0.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- [cli] add --guides to open the guide index
- [cmdpalette] only first 10 suggestions should have shortcut keys
- [draw] use default bg on col hdr sep
- [input] draw help sidebar on top of sheet/updater
- [graph] sort by x and y columns when diving
- [guides] improve formatting of command and options in sidebar + guides
- [replay] stop stderr batch progress when entering interactive mode
- [shell] clean up DirSheet sidebar
- [sidebar] grab user's keystroke of sidebar-toggle for helpstring
- [sort] a better fix for maintaining sort ordering on sheet copies
- [tests] add "test" extras for installing PyPI packages needed to run tests

**Test Plan**
- open, filter and sort tsv

**Checklist**
- [X] Package was built and tested against unstable
