### PR TITLE
tailscale: Update to 1.58.0

### DIFF
--- a/packages/t/tailscale/abi_used_symbols
+++ b/packages/t/tailscale/abi_used_symbols
@@ -10,7 +10,6 @@ libc.so.6:getaddrinfo
 libc.so.6:getgrgid_r
 libc.so.6:getgrnam_r
 libc.so.6:getgrouplist
-libc.so.6:getnameinfo
 libc.so.6:getpwnam_r
 libc.so.6:getpwuid_r
 libc.so.6:malloc
@@ -32,7 +31,6 @@ libc.so.6:pthread_mutex_unlock
 libc.so.6:pthread_self
 libc.so.6:pthread_setspecific
 libc.so.6:pthread_sigmask
-libc.so.6:res_search
 libc.so.6:setegid
 libc.so.6:setenv
 libc.so.6:seteuid

--- a/packages/t/tailscale/package.yml
+++ b/packages/t/tailscale/package.yml
@@ -1,8 +1,8 @@
 name       : tailscale
-version    : 1.56.1
-release    : 7
+version    : 1.58.0
+release    : 8
 source     :
-    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.56.1.tar.gz : 56b7d25c704e3c22e9e20dcb55695cd9c816878d2c172a73c64aac42e460fd41
+    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.58.0.tar.gz : 01d801dbb2df03a4e0c1563786300e8b26bb570b3aba15063943f78f2c26c316
 homepage   : https://tailscale.com
 license    : BSD-3-Clause
 component  : network.clients

--- a/packages/t/tailscale/pspec_x86_64.xml
+++ b/packages/t/tailscale/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2023-12-22</Date>
-            <Version>1.56.1</Version>
+        <Update release="8">
+            <Date>2024-01-20</Date>
+            <Version>1.58.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- portmap: check the epoch from NAT-PMP & PCP, establish new portmapping if it changes
- portmap: better handle multiple interfaces
- portmap: handle multiple UPnP discovery responses
- increase the number of 4via6 site IDs from 256 to 65,536
- taildrop: allow category Z unicode characters
- increased binary size with 1.56 is resolved in 1.58
- Reduce home DERP flapping when there's still an active connection
- device web ui: fixed issue when accessing shared devices
- device web ui: fixed login issue when accessed over https
- add shell shebang in postinstall script

**Test Plan**
- systemctl restart tailscaled
- tailscale status; tailscale netcheck
- tailscale web and visit http://localhost:8088

**Checklist**
- [X] Package was built and tested against unstable