### PR TITLE
kitty: Update to 0.32.0

### DIFF
--- a/packages/k/kitty/abi_symbols
+++ b/packages/k/kitty/abi_symbols
@@ -144,6 +144,7 @@ glfw-wayland.so:glfwUpdateTimer
 glfw-wayland.so:glfwVulkanSupported
 glfw-wayland.so:glfwWaylandActivateWindow
 glfw-wayland.so:glfwWaylandCheckForServerSideDecorations
+glfw-wayland.so:glfwWaylandRedrawCSDWindowTitle
 glfw-wayland.so:glfwWaylandRunWithActivationToken
 glfw-wayland.so:glfwWaylandSetTitlebarColor
 glfw-wayland.so:glfwWindowBell

--- a/packages/k/kitty/abi_used_symbols
+++ b/packages/k/kitty/abi_used_symbols
@@ -88,6 +88,7 @@ UNKNOWN:socket
 UNKNOWN:sqrt
 UNKNOWN:stat
 UNKNOWN:strdup
+UNKNOWN:strndup
 UNKNOWN:strnlen
 UNKNOWN:strtok_r
 UNKNOWN:strtol
@@ -223,7 +224,6 @@ libc.so.6:exit
 libc.so.6:fclose
 libc.so.6:fcntl
 libc.so.6:fileno
-libc.so.6:fmemopen
 libc.so.6:fopen
 libc.so.6:fprintf
 libc.so.6:fputc
@@ -470,6 +470,7 @@ libpython3.10.so.1.0:PyConfig_SetBytesString
 libpython3.10.so.1.0:PyDict_GetItemString
 libpython3.10.so.1.0:PyDict_New
 libpython3.10.so.1.0:PyDict_Next
+libpython3.10.so.1.0:PyDict_SetItem
 libpython3.10.so.1.0:PyDict_SetItemString
 libpython3.10.so.1.0:PyDict_Size
 libpython3.10.so.1.0:PyDict_Type
@@ -542,6 +543,7 @@ libpython3.10.so.1.0:PyObject_HasAttrString
 libpython3.10.so.1.0:PyObject_IsTrue
 libpython3.10.so.1.0:PyObject_Print
 libpython3.10.so.1.0:PyObject_Repr
+libpython3.10.so.1.0:PyObject_RichCompareBool
 libpython3.10.so.1.0:PyObject_SetAttrString
 libpython3.10.so.1.0:PyPreConfig_InitPythonConfig
 libpython3.10.so.1.0:PyStatus_Exception

--- a/packages/k/kitty/package.yml
+++ b/packages/k/kitty/package.yml
@@ -1,8 +1,8 @@
 name       : kitty
-version    : 0.31.0
-release    : 58
+version    : 0.32.0
+release    : 59
 source     :
-    - https://github.com/kovidgoyal/kitty/releases/download/v0.31.0/kitty-0.31.0.tar.xz : d122497134abab8e25dfcb6b127af40cfe641980e007f696732f70ed298198f5
+    - https://github.com/kovidgoyal/kitty/releases/download/v0.32.0/kitty-0.32.0.tar.xz : 7881a95c1a43d03b230b6ff817e4b5cfec267bac3dbd6dcbbf6c095d476d776d
 license    : GPL-3.0-only
 component  : system.utils
 homepage   : https://sw.kovidgoyal.net/kitty/

--- a/packages/k/kitty/pspec_x86_64.xml
+++ b/packages/k/kitty/pspec_x86_64.xml
@@ -563,6 +563,9 @@ Kitty is designed from the ground up to support all modern terminal features, su
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/select_window.cpython-310.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/select_window.cpython-310.opt-2.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/select_window.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/send_key.cpython-310.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/send_key.cpython-310.opt-2.pyc</Path>
+            <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/send_key.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/send_text.cpython-310.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/send_text.cpython-310.opt-2.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/send_text.cpython-310.pyc</Path>
@@ -625,6 +628,7 @@ Kitty is designed from the ground up to support all modern terminal features, su
             <Path fileType="library">/usr/lib/kitty/kitty/rc/resize_window.py</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/scroll_window.py</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/select_window.py</Path>
+            <Path fileType="library">/usr/lib/kitty/kitty/rc/send_key.py</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/send_text.py</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/set_background_image.py</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/set_background_opacity.py</Path>
@@ -683,15 +687,72 @@ Kitty is designed from the ground up to support all modern terminal features, su
             <Path fileType="data">/usr/share/bash-completion/completions/kitty</Path>
             <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/kitty.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/kitty.svg</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-close-tab.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-close-window.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-create-marker.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-detach-tab.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-detach-window.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-disable-ligatures.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-env.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-focus-tab.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-focus-window.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-get-colors.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-get-text.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-goto-layout.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-kitten.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-last-used-layout.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-launch.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-ls.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-new-window.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-remove-marker.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-resize-os-window.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-resize-window.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-scroll-window.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-select-window.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-send-key.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-send-text.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-set-background-image.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-set-background-opacity.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-set-colors.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-set-enabled-layouts.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-set-font-size.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-set-spacing.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-set-tab-color.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-set-tab-title.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-set-user-vars.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-set-window-logo.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-set-window-title.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-signal-child.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-ask.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-broadcast.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-clipboard.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-diff.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-edit-in-kitty.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-hints.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-hyperlinked-grep.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-icat.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-mouse-demo.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-panel.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-query-terminal.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-remote-file.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-run-shell.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-show-key.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-ssh.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-themes.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-transfer.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-unicode-input.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-update-self.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten.1</Path>
             <Path fileType="man">/usr/share/man/man1/kitty.1</Path>
             <Path fileType="man">/usr/share/man/man5/kitty.conf.5</Path>
             <Path fileType="data">/usr/share/terminfo/x/xterm-kitty</Path>
         </Files>
     </Package>
     <History>
-        <Update release="58">
-            <Date>2023-11-11</Date>
-            <Version>0.31.0</Version>
+        <Update release="59">
+            <Date>2024-01-20</Date>
+            <Version>0.32.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Conditional mappings depending on the state of the focused window
- Support for Modal mappings such as in modal editors like vim
- A new option notify_on_cmd_finish to show a desktop notification when a long running command finishes
- A new action send_key to simplify mapping key presses to other keys without needing send_text
- Allow focusing previously active OS windows via nth_os_window
- Wayland: Fix copying to clipboard under wl-roots based compositors in some circumstances
- Font fallback: Fix the font used to render a character sometimes dependent on their order on screen
- panel kitten: Fix rendering with non-zero margin/padding in kitty.conf
- kitty keyboard protocol: Specify the behavior of the modifier bits during modifier key events
- Wayland: support new cursor-shape protocol so that the mouse cursor is rendered at the correct size
- GNOME Wayland: Fix remembered window size smaller than actual size
- Mouse reporting: Fix incorrect position reported for windows with padding
- Fix focus_visible_window not switching to other window in stack layout when only two windows are present
- [changelog](https://sw.kovidgoyal.net/kitty/changelog/#id1)

**Test Plan**
- kitty; open last cli output with pager (C-S-g)

**Checklist**
- [X] Package was built and tested against unstable
