### PR TITLE
appstream-data: Add compat symlinks for Solus SC

### DIFF
--- a/packages/a/appstream-data/package.yml
+++ b/packages/a/appstream-data/package.yml
@@ -1,6 +1,6 @@
 name       : appstream-data
 version    : '29'
-release    : 31
+release    : 32
 source     :
     - https://github.com/getsolus/solus-appstream-data/archive/refs/tags/v29.tar.gz : b98e2330bf2d44bc3fb4b487bacc10fcbbfa92fa714186013aa1e970be65210a
 homepage   : https://www.freedesktop.org/wiki/Distributions/AppStream/
@@ -16,11 +16,20 @@ description: |
 builddeps  :
     - appstream-glib
 install    : |
-    # FIXME: Use current appstream paths. See:
-    # https://www.freedesktop.org/software/appstream/docs/chap-CatalogData.html#sect-AppStream-XML
-    # https://www.freedesktop.org/software/appstream/docs/sect-AppStream-IconCache.html
-
     DESTDIR="$installdir" appstream-util install solus-1.xml.gz solus-1-icons.tar.gz
     chmod 00755 $installdir/usr/share/app-info/xmls
     chmod 00644 $installdir/usr/share/app-info/xmls/solus-1.xml.gz
     ln -sv solus-1 "$installdir/usr/share/app-info/icons/solus"
+
+    # Solus SC <-> KDE Discover/GNOME Software compat symlinks:
+    #
+    # /usr/share/app-info/xmls/solus-1.xml.gz -> /usr/share/swcatalog/xml/solus-1.xml.gz
+    # /usr/share/app-info/icons/ -> /usr/share/swcatalog/icons/
+    #
+    # Use relative links to make the above happen.
+    #
+    ln -srv $installdir/usr/share/app-info $installdir/usr/share/swcatalog
+    ln -srv $installdir/usr/share/app-info/xmls $installdir/usr/share/app-info/xml
+    echo "Verifying that compat symlinks point to the correct targets:"
+    realpath $installdir/usr/share/swcatalog/xml/solus-1.xml.gz
+    realpath $installdir/usr/share/swcatalog/icons

--- a/packages/a/appstream-data/pspec_x86_64.xml
+++ b/packages/a/appstream-data/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>appstream-data</Name>
         <Homepage>https://www.freedesktop.org/wiki/Distributions/AppStream/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
         </Packager>
         <License>CC-BY-SA-3.0</License>
         <License>CC-BY-SA-4.0</License>
@@ -1067,16 +1067,18 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/xpra.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/xyz.z3ntu.razergenie.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/yelp.png</Path>
+            <Path fileType="data">/usr/share/app-info/xml</Path>
             <Path fileType="data">/usr/share/app-info/xmls/solus-1.xml.gz</Path>
+            <Path fileType="data">/usr/share/swcatalog</Path>
         </Files>
     </Package>
     <History>
-        <Update release="31">
+        <Update release="32">
             <Date>2024-01-20</Date>
             <Version>29</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
KDE Discover and Gnome Software expect different paths to appstream data than legacy Solus SC does.

Use the modern paths and set up + verify compat symlinks for Solus SC.

**Test Plan**

Test that the paths added work with both GNOME Software, KDE Discover and Solus SC.

**Checklist**

- [x] Package was built and tested against unstable
