### PR TITLE
helpers.*sh: Add reindex-localrepo convenience function

### DIFF
--- a/common/Scripts/helpers.fish
+++ b/common/Scripts/helpers.fish
@@ -19,6 +19,11 @@ function gotopkg -a package -d "Go to a package directory"
     cd (__solus_toplevel)/packages/*/$package
 end
 
+function reindex-localrepo -d "Re-index the local repo and update eopkg's cache"
+    sudo eopkg index --skip-signing /var/lib/solbuild/local/ --output /var/lib/solbuild/local/eopkg-index.xml && \
+    sudo eopkg update-repo
+end
+
 function whatprovides -a library -d "Show packages that provide a certain library"
     path basename (path dirname (grep $library (__solus_toplevel)/packages/*/*/abi_libs))
 end

--- a/common/Scripts/helpers.sh
+++ b/common/Scripts/helpers.sh
@@ -18,6 +18,12 @@ function gotopkg() {
     cd "$(git rev-parse --show-toplevel)"/packages/*/"$1" || return 1
 }
 
+# Re-index the local repo and update eopkg's cache
+function reindex-localrepo() {
+    sudo eopkg index --skip-signing /var/lib/solbuild/local/ --output /var/lib/solbuild/local/eopkg-index.xml && \
+    sudo eopkg update-repo
+}
+
 # What provides a lib
 function whatprovides() {
     grep "$1" "$(git rev-parse --show-toplevel)"/packages/*/*/abi_libs

--- a/common/Scripts/helpers.zsh
+++ b/common/Scripts/helpers.zsh
@@ -22,6 +22,12 @@ function gotopkg() {
     cd $(git rev-parse --show-toplevel)/packages/*/$1
 }
 
+# Re-index the local repo and update eopkg's cache
+function reindex-localrepo() {
+    sudo eopkg index --skip-signing /var/lib/solbuild/local/ --output /var/lib/solbuild/local/eopkg-index.xml && \
+    sudo eopkg update-repo
+}
+
 # What provides a lib
 function whatprovides() {
     grep $1 $(git rev-parse --show-toplevel)/packages/*/*/abi_libs


### PR DESCRIPTION
**Summary**
We have no convenient way to re-index our local repo.

Since it is quite a long command, why not add a convenience function to do it correctly that is maintained by Solus Staff?

This commit does just that for all helper scripts.

**Test Plan**

Test helper function with bash, fish and zsh.

**Checklist**

- [x] Package was built and tested against unstable
