### PR TITLE
wxmaxima: Update to 23.12.0

### DIFF
--- a/packages/w/wxmaxima/MAINTAINERS.md
+++ b/packages/w/wxmaxima/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Muhammad Alfi Syahrin
+  - Matrix: @alfisya:matrix.org
+  - Email: malfisya.dev@hotmail.com

--- a/packages/w/wxmaxima/abi_used_symbols
+++ b/packages/w/wxmaxima/abi_used_symbols
@@ -6,7 +6,6 @@ libc.so.6:__libc_single_threaded
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__stack_chk_fail
-libc.so.6:abort
 libc.so.6:calloc
 libc.so.6:exit
 libc.so.6:fclose
@@ -48,6 +47,7 @@ libm.so.6:fmodf
 libm.so.6:lround
 libm.so.6:pow
 libm.so.6:round
+libm.so.6:roundf
 libm.so.6:sincosf
 libm.so.6:sqrtf
 libm.so.6:tanf
@@ -77,6 +77,7 @@ libstdc++.so.6:_ZNSt6thread20hardware_concurrencyEv
 libstdc++.so.6:_ZNSt6thread4joinEv
 libstdc++.so.6:_ZNSt6thread6_StateD2Ev
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_disposeEv
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE10_M_disposeEv
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE10_M_replaceEmmPKwm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE13_S_copy_charsEPwPKwS7_
@@ -155,9 +156,9 @@ libwx_baseu-3.2.so.0:_Z19wxGet_wxConvLibcPtrv
 libwx_baseu-3.2.so.0:_Z19wxGet_wxConvUTF8Ptrv
 libwx_baseu-3.2.so.0:_Z20wxGet_wxConvLocalPtrv
 libwx_baseu-3.2.so.0:_Z21wxSetWorkingDirectoryRK8wxString
-libwx_baseu-3.2.so.0:_Z23wxHandleFatalExceptionsb
 libwx_baseu-3.2.so.0:_Z28wxGet_wxConvWhateverWorksPtrv
 libwx_baseu-3.2.so.0:_Z6wxExitv
+libwx_baseu-3.2.so.0:_Z6wxKilll8wxSignalP11wxKillErrori
 libwx_baseu-3.2.so.0:_Z7wxMkdirRK8wxStringi
 libwx_baseu-3.2.so.0:_Z7wxSleepi
 libwx_baseu-3.2.so.0:_Z8wxGetCwdv
@@ -223,10 +224,8 @@ libwx_baseu-3.2.so.0:_ZN12wxTextBuffer6ms_eofE
 libwx_baseu-3.2.so.0:_ZN12wxTextBufferD2Ev
 libwx_baseu-3.2.so.0:_ZN13wxArrayString3AddERK8wxStringm
 libwx_baseu-3.2.so.0:_ZN13wxArrayString4InitEb
-libwx_baseu-3.2.so.0:_ZN13wxArrayString4SortEb
 libwx_baseu-3.2.so.0:_ZN13wxArrayString5ClearEv
 libwx_baseu-3.2.so.0:_ZN13wxArrayString7reserveEm
-libwx_baseu-3.2.so.0:_ZN13wxArrayString8RemoveAtEmm
 libwx_baseu-3.2.so.0:_ZN13wxArrayStringC1ERKS_
 libwx_baseu-3.2.so.0:_ZN13wxArrayStringD1Ev
 libwx_baseu-3.2.so.0:_ZN13wxArrayStringD2Ev
@@ -421,7 +420,6 @@ libwx_baseu-3.2.so.0:_ZNK12wxEvtHandler17DoGetClientObjectEv
 libwx_baseu-3.2.so.0:_ZNK12wxEvtHandler17GetEventHashTableEv
 libwx_baseu-3.2.so.0:_ZNK12wxStreamBase7GetSizeEv
 libwx_baseu-3.2.so.0:_ZNK12wxTextBuffer6ExistsEv
-libwx_baseu-3.2.so.0:_ZNK13wxArrayString5IndexERK8wxStringbb
 libwx_baseu-3.2.so.0:_ZNK13wxArrayStringeqERKS_
 libwx_baseu-3.2.so.0:_ZNK13wxInputStream3EofEv
 libwx_baseu-3.2.so.0:_ZNK13wxInputStream5TellIEv
@@ -831,6 +829,7 @@ libwx_gtk3u_core-3.2.so.0:_ZN13wxMenuBarBase11UpdateMenusEv
 libwx_gtk3u_core-3.2.so.0:_ZN13wxMenuBarBase5CheckEib
 libwx_gtk3u_core-3.2.so.0:_ZN13wxMenuBarBase6EnableEib
 libwx_gtk3u_core-3.2.so.0:_ZN13wxRadioButton6CreateEP8wxWindowiRK8wxStringRK7wxPointRK6wxSizelRK11wxValidatorS4_
+libwx_gtk3u_core-3.2.so.0:_ZN14wxBitmapBundle7FromSVGEPKcRK6wxSize
 libwx_gtk3u_core-3.2.so.0:_ZN14wxBitmapBundleC1ERK7wxImage
 libwx_gtk3u_core-3.2.so.0:_ZN14wxBitmapBundleC1ERK8wxBitmap
 libwx_gtk3u_core-3.2.so.0:_ZN14wxBitmapBundleC1ERKS_
@@ -1331,6 +1330,8 @@ libwx_gtk3u_core-3.2.so.0:_ZNK12wxWindowBase9IsEnabledEv
 libwx_gtk3u_core-3.2.so.0:_ZNK13wxControlBase16GetDefaultBorderEv
 libwx_gtk3u_core-3.2.so.0:_ZNK13wxControlBase21DoGetSizeFromTextSizeEii
 libwx_gtk3u_core-3.2.so.0:_ZNK13wxMenuBarBase9IsEnabledEi
+libwx_gtk3u_core-3.2.so.0:_ZNK14wxBitmapBundle25GetPreferredBitmapSizeForEPK8wxWindow
+libwx_gtk3u_core-3.2.so.0:_ZNK14wxBitmapBundle9GetBitmapERK6wxSize
 libwx_gtk3u_core-3.2.so.0:_ZNK14wxCommandEvent9GetStringEv
 libwx_gtk3u_core-3.2.so.0:_ZNK14wxListCtrlBase12GetImageListEi
 libwx_gtk3u_core-3.2.so.0:_ZNK14wxListCtrlBase13OnGetItemAttrEl
@@ -1679,9 +1680,13 @@ libwx_gtk3u_core-3.2.so.0:wxEVT_PAINT
 libwx_gtk3u_core-3.2.so.0:wxEVT_QUERY_END_SESSION
 libwx_gtk3u_core-3.2.so.0:wxEVT_RADIOBUTTON
 libwx_gtk3u_core-3.2.so.0:wxEVT_RIGHT_DOWN
-libwx_gtk3u_core-3.2.so.0:wxEVT_SCROLLWIN_LINEUP
-libwx_gtk3u_core-3.2.so.0:wxEVT_SCROLLWIN_THUMBTRACK
 libwx_gtk3u_core-3.2.so.0:wxEVT_SCROLL_CHANGED
+libwx_gtk3u_core-3.2.so.0:wxEVT_SCROLL_LINEDOWN
+libwx_gtk3u_core-3.2.so.0:wxEVT_SCROLL_LINEUP
+libwx_gtk3u_core-3.2.so.0:wxEVT_SCROLL_PAGEDOWN
+libwx_gtk3u_core-3.2.so.0:wxEVT_SCROLL_PAGEUP
+libwx_gtk3u_core-3.2.so.0:wxEVT_SCROLL_THUMBRELEASE
+libwx_gtk3u_core-3.2.so.0:wxEVT_SCROLL_THUMBTRACK
 libwx_gtk3u_core-3.2.so.0:wxEVT_SET_FOCUS
 libwx_gtk3u_core-3.2.so.0:wxEVT_SIZE
 libwx_gtk3u_core-3.2.so.0:wxEVT_TEXT

--- a/packages/w/wxmaxima/package.yml
+++ b/packages/w/wxmaxima/package.yml
@@ -1,8 +1,8 @@
 name       : wxmaxima
-version    : 23.10.0
-release    : 23
+version    : 23.12.0
+release    : 24
 source     :
-    - https://github.com/wxMaxima-developers/wxmaxima/archive/refs/tags/Version-23.10.0.tar.gz : 1c41352be0d88dc3b2413bab06f0a2e791579d61ac1e3a406c3349f5ea0fffe7
+    - https://github.com/wxMaxima-developers/wxmaxima/archive/refs/tags/Version-23.12.0.tar.gz : abec636e96474adf6451e81728b16afaa83ed1a70b86a695fa083ecec65aaae1
 homepage   : https://wxmaxima-developers.github.io/wxmaxima/
 license    : GPL-2.0-or-later
 component  : office.maths

--- a/packages/w/wxmaxima/pspec_x86_64.xml
+++ b/packages/w/wxmaxima/pspec_x86_64.xml
@@ -4,7 +4,7 @@
         <Homepage>https://wxmaxima-developers.github.io/wxmaxima/</Homepage>
         <Packager>
             <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>office.maths</PartOf>
@@ -38,6 +38,9 @@
             <Path fileType="doc">/usr/share/doc/wxmaxima/cell-example.png</Path>
             <Path fileType="doc">/usr/share/doc/wxmaxima/ezUnits.png</Path>
             <Path fileType="doc">/usr/share/doc/wxmaxima/header.html</Path>
+            <Path fileType="doc">/usr/share/doc/wxmaxima/horizontal-cursor-between-cells.png</Path>
+            <Path fileType="doc">/usr/share/doc/wxmaxima/horizontal-cursor-only.png</Path>
+            <Path fileType="doc">/usr/share/doc/wxmaxima/locale-warning.png</Path>
             <Path fileType="doc">/usr/share/doc/wxmaxima/maxima_screenshot.png</Path>
             <Path fileType="doc">/usr/share/doc/wxmaxima/sbclMemory.png</Path>
             <Path fileType="doc">/usr/share/doc/wxmaxima/wxMaximaLogo.png</Path>
@@ -52,6 +55,7 @@
             <Path fileType="doc">/usr/share/doc/wxmaxima/wxmaxima.tr.html</Path>
             <Path fileType="doc">/usr/share/doc/wxmaxima/wxmaxima.uk.html</Path>
             <Path fileType="doc">/usr/share/doc/wxmaxima/wxmaxima.zh_CN.html</Path>
+            <Path fileType="doc">/usr/share/doc/wxmaxima/wxsubscripts.png</Path>
             <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/wxMaxima.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/wxMaxima.mo</Path>
             <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/wxMaxima.mo</Path>
@@ -90,12 +94,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2023-11-03</Date>
-            <Version>23.10.0</Version>
+        <Update release="24">
+            <Date>2024-01-21</Date>
+            <Version>23.12.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Input text selection was cleared when right-clicking on it
- Pressing both mouse buttons simultaneously caused an assert
- Corrected the cursor position after unsuccessful autocompletes
- Corrected the handling of question prompts from `maxima`
- Bug corrections in the search functionality
- RegEx search works again
- Clicking on the notification now is more likely to focus the worksheet
- Corrected the cell folding logic
- Folded cells are no more evaluated
- Now we try to generate a backtrace on crashes
- Corrected the position of integral limits
- Nicer product, sum and integral signs
- Hidden cells weren't restored from wxm files
- `diff()` no longer causes spurious multiplication dots

**Test Plan**

- Open example files and make sure everything looks right

**Checklist**

- [x] Package was built and tested against unstable