### PR TITLE
allegro: Update to 5.2.9.1

### DIFF
--- a/packages/a/allegro/abi_symbols
+++ b/packages/a/allegro/abi_symbols
@@ -114,6 +114,9 @@ liballegro.so.5.2:_al_display_settings_sorter
 liballegro.so.5.2:_al_display_xglx_await_resize
 liballegro.so.5.2:_al_display_xglx_closebutton
 liballegro.so.5.2:_al_display_xglx_driver
+liballegro.so.5.2:_al_display_xglx_handle_drag_and_drop
+liballegro.so.5.2:_al_display_xglx_handle_drag_and_drop_selection
+liballegro.so.5.2:_al_display_xglx_init_dnd_atoms
 liballegro.so.5.2:_al_draw_bitmap_region_memory
 liballegro.so.5.2:_al_draw_pixel_memory
 liballegro.so.5.2:_al_draw_soft_triangle
@@ -2169,6 +2172,7 @@ liballegro.so.5.2:_al_xsys_mheadx_get_xscreen
 liballegro.so.5.2:_al_xsys_mmon_exit
 liballegro.so.5.2:_al_xsys_xrandr_exit
 liballegro.so.5.2:_al_xsys_xrandr_init
+liballegro.so.5.2:_al_xwin_accept_drag_and_drop
 liballegro.so.5.2:_al_xwin_add_clipboard_functions
 liballegro.so.5.2:_al_xwin_add_cursor_functions
 liballegro.so.5.2:_al_xwin_background_thread
@@ -2180,7 +2184,9 @@ liballegro.so.5.2:_al_xwin_display_selection_notify
 liballegro.so.5.2:_al_xwin_display_selection_request
 liballegro.so.5.2:_al_xwin_display_switch_handler
 liballegro.so.5.2:_al_xwin_display_switch_handler_inner
+liballegro.so.5.2:_al_xwin_get_borders
 liballegro.so.5.2:_al_xwin_grab_mouse
+liballegro.so.5.2:_al_xwin_initial_icon
 liballegro.so.5.2:_al_xwin_keyboard_driver
 liballegro.so.5.2:_al_xwin_keyboard_handler
 liballegro.so.5.2:_al_xwin_keyboard_switch_handler
@@ -2216,6 +2222,8 @@ liballegro.so.5.2:al_build_camera_transform
 liballegro.so.5.2:al_build_shader
 liballegro.so.5.2:al_build_transform
 liballegro.so.5.2:al_calloc_with_context
+liballegro.so.5.2:al_can_get_mouse_cursor_position
+liballegro.so.5.2:al_can_set_keyboard_leds
 liballegro.so.5.2:al_change_directory
 liballegro.so.5.2:al_check_inverse
 liballegro.so.5.2:al_clear_depth_buffer
@@ -2355,6 +2363,7 @@ liballegro.so.5.2:al_get_current_directory
 liballegro.so.5.2:al_get_current_display
 liballegro.so.5.2:al_get_current_inverse_transform
 liballegro.so.5.2:al_get_current_projection_transform
+liballegro.so.5.2:al_get_current_shader
 liballegro.so.5.2:al_get_current_transform
 liballegro.so.5.2:al_get_default_shader_source
 liballegro.so.5.2:al_get_display_event_source
@@ -2474,6 +2483,7 @@ liballegro.so.5.2:al_get_timer_started
 liballegro.so.5.2:al_get_touch_input_event_source
 liballegro.so.5.2:al_get_touch_input_mouse_emulation_event_source
 liballegro.so.5.2:al_get_touch_input_state
+liballegro.so.5.2:al_get_window_borders
 liballegro.so.5.2:al_get_window_constraints
 liballegro.so.5.2:al_get_window_position
 liballegro.so.5.2:al_get_x_window_id
@@ -2774,7 +2784,6 @@ liballegro.so.5.2:al_wait_for_event_timed
 liballegro.so.5.2:al_wait_for_event_until
 liballegro.so.5.2:al_wait_for_vsync
 liballegro.so.5.2:al_x_set_initial_icon
-liballegro.so.5.2:x11_xpm
 liballegro_acodec.so.5.2:_al_acodec_start_feed_thread
 liballegro_acodec.so.5.2:_al_acodec_stop_feed_thread
 liballegro_acodec.so.5.2:_al_identify_flac
@@ -2914,6 +2923,7 @@ liballegro_audio.so.5.2:al_load_audio_stream_f
 liballegro_audio.so.5.2:al_load_sample
 liballegro_audio.so.5.2:al_load_sample_f
 liballegro_audio.so.5.2:al_lock_sample_id
+liballegro_audio.so.5.2:al_mixer_has_attachments
 liballegro_audio.so.5.2:al_play_audio_stream
 liballegro_audio.so.5.2:al_play_audio_stream_f
 liballegro_audio.so.5.2:al_play_sample
@@ -2964,6 +2974,7 @@ liballegro_audio.so.5.2:al_stop_sample_instance
 liballegro_audio.so.5.2:al_stop_samples
 liballegro_audio.so.5.2:al_uninstall_audio
 liballegro_audio.so.5.2:al_unlock_sample_id
+liballegro_audio.so.5.2:al_voice_has_attachments
 liballegro_color.so.5.2:al_color_cmyk
 liballegro_color.so.5.2:al_color_cmyk_to_rgb
 liballegro_color.so.5.2:al_color_distance_ciede2000

--- a/packages/a/allegro/abi_used_libs
+++ b/packages/a/allegro/abi_used_libs
@@ -6,7 +6,6 @@ libX11.so.6
 libXcursor.so.1
 libXi.so.6
 libXinerama.so.1
-libXpm.so.4
 libXrandr.so.2
 libc.so.6
 libfreetype.so.6

--- a/packages/a/allegro/abi_used_symbols
+++ b/packages/a/allegro/abi_used_symbols
@@ -90,6 +90,7 @@ libX11.so.6:XCreatePixmap
 libX11.so.6:XCreatePixmapCursor
 libX11.so.6:XCreateWindow
 libX11.so.6:XDefineCursor
+libX11.so.6:XDeleteProperty
 libX11.so.6:XDestroyIC
 libX11.so.6:XDestroyWindow
 libX11.so.6:XDisplayKeycodes
@@ -102,6 +103,7 @@ libX11.so.6:XFreeCursor
 libX11.so.6:XFreeGC
 libX11.so.6:XFreeModifiermap
 libX11.so.6:XFreePixmap
+libX11.so.6:XGetAtomName
 libX11.so.6:XGetEventData
 libX11.so.6:XGetIMValues
 libX11.so.6:XGetInputFocus
@@ -136,7 +138,6 @@ libX11.so.6:XSetICValues
 libX11.so.6:XSetLocaleModifiers
 libX11.so.6:XSetSelectionOwner
 libX11.so.6:XSetTextProperty
-libX11.so.6:XSetWMHints
 libX11.so.6:XSetWMNormalHints
 libX11.so.6:XSetWMProperties
 libX11.so.6:XSetWMProtocols
@@ -161,7 +162,6 @@ libXinerama.so.1:XineramaIsActive
 libXinerama.so.1:XineramaQueryExtension
 libXinerama.so.1:XineramaQueryScreens
 libXinerama.so.1:XineramaQueryVersion
-libXpm.so.4:XpmCreatePixmapFromData
 libXrandr.so.2:XRRFreeCrtcInfo
 libXrandr.so.2:XRRFreeOutputInfo
 libXrandr.so.2:XRRFreeScreenResources
@@ -290,6 +290,8 @@ libfreetype.so.6:FT_Load_Glyph
 libfreetype.so.6:FT_Open_Face
 libfreetype.so.6:FT_Request_Size
 libfreetype.so.6:FT_Set_Pixel_Sizes
+libgdk-3.so.0:gdk_display_get_default_seat
+libgdk-3.so.0:gdk_seat_get_pointer
 libgdk-3.so.0:gdk_set_allowed_backends
 libgdk-3.so.0:gdk_threads_add_timeout
 libgdk-3.so.0:gdk_window_get_display
@@ -301,6 +303,8 @@ libglib-2.0.so.0:g_async_queue_pop
 libglib-2.0.so.0:g_async_queue_push
 libglib-2.0.so.0:g_async_queue_unref
 libglib-2.0.so.0:g_free
+libglib-2.0.so.0:g_list_free
+libglib-2.0.so.0:g_list_length
 libglib-2.0.so.0:g_mutex_lock
 libglib-2.0.so.0:g_mutex_unlock
 libglib-2.0.so.0:g_slist_free
@@ -317,6 +321,7 @@ libgtk-3.so.0:gtk_check_menu_item_get_active
 libgtk-3.so.0:gtk_check_menu_item_new_with_mnemonic
 libgtk-3.so.0:gtk_check_menu_item_set_active
 libgtk-3.so.0:gtk_container_add
+libgtk-3.so.0:gtk_container_get_children
 libgtk-3.so.0:gtk_css_provider_load_from_data
 libgtk-3.so.0:gtk_css_provider_new
 libgtk-3.so.0:gtk_dialog_add_button
@@ -340,7 +345,7 @@ libgtk-3.so.0:gtk_menu_bar_new
 libgtk-3.so.0:gtk_menu_item_new_with_mnemonic
 libgtk-3.so.0:gtk_menu_item_set_submenu
 libgtk-3.so.0:gtk_menu_new
-libgtk-3.so.0:gtk_menu_popup_at_widget
+libgtk-3.so.0:gtk_menu_popup_at_rect
 libgtk-3.so.0:gtk_menu_shell_append
 libgtk-3.so.0:gtk_menu_shell_insert
 libgtk-3.so.0:gtk_message_dialog_format_secondary_text
@@ -360,6 +365,7 @@ libgtk-3.so.0:gtk_text_view_new
 libgtk-3.so.0:gtk_text_view_scroll_mark_onscreen
 libgtk-3.so.0:gtk_text_view_set_editable
 libgtk-3.so.0:gtk_widget_destroy
+libgtk-3.so.0:gtk_widget_get_allocation
 libgtk-3.so.0:gtk_widget_get_parent
 libgtk-3.so.0:gtk_widget_get_realized
 libgtk-3.so.0:gtk_widget_get_style_context
@@ -371,14 +377,18 @@ libgtk-3.so.0:gtk_widget_show
 libgtk-3.so.0:gtk_widget_show_all
 libgtk-3.so.0:gtk_window_fullscreen
 libgtk-3.so.0:gtk_window_get_position
+libgtk-3.so.0:gtk_window_is_maximized
+libgtk-3.so.0:gtk_window_maximize
 libgtk-3.so.0:gtk_window_move
 libgtk-3.so.0:gtk_window_new
 libgtk-3.so.0:gtk_window_resize
+libgtk-3.so.0:gtk_window_set_decorated
 libgtk-3.so.0:gtk_window_set_default_size
 libgtk-3.so.0:gtk_window_set_deletable
 libgtk-3.so.0:gtk_window_set_resizable
 libgtk-3.so.0:gtk_window_set_title
 libgtk-3.so.0:gtk_window_unfullscreen
+libgtk-3.so.0:gtk_window_unmaximize
 libjpeg.so.8:jpeg_CreateCompress
 libjpeg.so.8:jpeg_CreateDecompress
 libjpeg.so.8:jpeg_destroy_compress

--- a/packages/a/allegro/package.yml
+++ b/packages/a/allegro/package.yml
@@ -1,8 +1,8 @@
 name       : allegro
-version    : 5.2.8.0
-release    : 14
+version    : 5.2.9.1
+release    : 15
 source     :
-    - https://github.com/liballeg/allegro5/releases/download/5.2.8.0/allegro-5.2.8.0.tar.gz : 089fcbfab0543caa282cd61bd364793d0929876e3d2bf629380ae77b014e4aa4
+    - https://github.com/liballeg/allegro5/releases/download/5.2.9.1/allegro-5.2.9.1.tar.gz : 0ee3fc22ae74601ad36c70afd793ff062f0f7187eeb6e78f8a24e5bf69170d30
 homepage   : https://liballeg.org/
 license    : Zlib
 component  : programming

--- a/packages/a/allegro/pspec_x86_64.xml
+++ b/packages/a/allegro/pspec_x86_64.xml
@@ -4,7 +4,7 @@
         <Homepage>https://liballeg.org/</Homepage>
         <Packager>
             <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>Zlib</License>
         <PartOf>programming</PartOf>
@@ -21,31 +21,31 @@
         <PartOf>programming</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/liballegro.so.5.2</Path>
-            <Path fileType="library">/usr/lib64/liballegro.so.5.2.8</Path>
+            <Path fileType="library">/usr/lib64/liballegro.so.5.2.9</Path>
             <Path fileType="library">/usr/lib64/liballegro_acodec.so.5.2</Path>
-            <Path fileType="library">/usr/lib64/liballegro_acodec.so.5.2.8</Path>
+            <Path fileType="library">/usr/lib64/liballegro_acodec.so.5.2.9</Path>
             <Path fileType="library">/usr/lib64/liballegro_audio.so.5.2</Path>
-            <Path fileType="library">/usr/lib64/liballegro_audio.so.5.2.8</Path>
+            <Path fileType="library">/usr/lib64/liballegro_audio.so.5.2.9</Path>
             <Path fileType="library">/usr/lib64/liballegro_color.so.5.2</Path>
-            <Path fileType="library">/usr/lib64/liballegro_color.so.5.2.8</Path>
+            <Path fileType="library">/usr/lib64/liballegro_color.so.5.2.9</Path>
             <Path fileType="library">/usr/lib64/liballegro_dialog.so.5.2</Path>
-            <Path fileType="library">/usr/lib64/liballegro_dialog.so.5.2.8</Path>
+            <Path fileType="library">/usr/lib64/liballegro_dialog.so.5.2.9</Path>
             <Path fileType="library">/usr/lib64/liballegro_font.so.5.2</Path>
-            <Path fileType="library">/usr/lib64/liballegro_font.so.5.2.8</Path>
+            <Path fileType="library">/usr/lib64/liballegro_font.so.5.2.9</Path>
             <Path fileType="library">/usr/lib64/liballegro_image.so.5.2</Path>
-            <Path fileType="library">/usr/lib64/liballegro_image.so.5.2.8</Path>
+            <Path fileType="library">/usr/lib64/liballegro_image.so.5.2.9</Path>
             <Path fileType="library">/usr/lib64/liballegro_main.so.5.2</Path>
-            <Path fileType="library">/usr/lib64/liballegro_main.so.5.2.8</Path>
+            <Path fileType="library">/usr/lib64/liballegro_main.so.5.2.9</Path>
             <Path fileType="library">/usr/lib64/liballegro_memfile.so.5.2</Path>
-            <Path fileType="library">/usr/lib64/liballegro_memfile.so.5.2.8</Path>
+            <Path fileType="library">/usr/lib64/liballegro_memfile.so.5.2.9</Path>
             <Path fileType="library">/usr/lib64/liballegro_physfs.so.5.2</Path>
-            <Path fileType="library">/usr/lib64/liballegro_physfs.so.5.2.8</Path>
+            <Path fileType="library">/usr/lib64/liballegro_physfs.so.5.2.9</Path>
             <Path fileType="library">/usr/lib64/liballegro_primitives.so.5.2</Path>
-            <Path fileType="library">/usr/lib64/liballegro_primitives.so.5.2.8</Path>
+            <Path fileType="library">/usr/lib64/liballegro_primitives.so.5.2.9</Path>
             <Path fileType="library">/usr/lib64/liballegro_ttf.so.5.2</Path>
-            <Path fileType="library">/usr/lib64/liballegro_ttf.so.5.2.8</Path>
+            <Path fileType="library">/usr/lib64/liballegro_ttf.so.5.2.9</Path>
             <Path fileType="library">/usr/lib64/liballegro_video.so.5.2</Path>
-            <Path fileType="library">/usr/lib64/liballegro_video.so.5.2.8</Path>
+            <Path fileType="library">/usr/lib64/liballegro_video.so.5.2.9</Path>
         </Files>
     </Package>
     <Package>
@@ -55,7 +55,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="14">allegro</Dependency>
+            <Dependency release="15">allegro</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/allegro5/alcompat.h</Path>
@@ -148,6 +148,10 @@
             <Path fileType="header">/usr/include/allegro5/touch_input.h</Path>
             <Path fileType="header">/usr/include/allegro5/transformations.h</Path>
             <Path fileType="header">/usr/include/allegro5/utf8.h</Path>
+            <Path fileType="library">/usr/lib/cmake/allegro/AllegroConfig.cmake</Path>
+            <Path fileType="library">/usr/lib/cmake/allegro/AllegroConfigVersion.cmake</Path>
+            <Path fileType="library">/usr/lib/cmake/allegro/AllegroTargets-relwithdebinfo.cmake</Path>
+            <Path fileType="library">/usr/lib/cmake/allegro/AllegroTargets.cmake</Path>
             <Path fileType="library">/usr/lib64/liballegro.so</Path>
             <Path fileType="library">/usr/lib64/liballegro_acodec.so</Path>
             <Path fileType="library">/usr/lib64/liballegro_audio.so</Path>
@@ -177,12 +181,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2023-11-16</Date>
-            <Version>5.2.8.0</Version>
+        <Update release="15">
+            <Date>2024-01-21</Date>
+            <Version>5.2.9.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/l/liberation-circuit/package.yml
+++ b/packages/l/liberation-circuit/package.yml
@@ -1,6 +1,6 @@
 name       : liberation-circuit
 version    : '1.3'
-release    : 4
+release    : 5
 source     :
     - https://github.com/linleyh/liberation-circuit/archive/refs/tags/v1.3.tar.gz : 3c18c5815aa139e2bf3048e42bbb4bf7f1b3d05022ea0a3c764bc25f420f2b4f
 homepage   : https://linleyh.itch.io/liberation-circuit
@@ -16,13 +16,17 @@ setup      : |
     %patch -p1 -i $pkgfiles/0001-Set-a-default-savefile-location.patch
 build      : |
     %make CFLAGS='-fcommon'
-install    : |-
+install    : |
+    # Install launch script
     install -Dm00755 $pkgfiles/libcirc $installdir/usr/bin/libcirc
+    # Remove unneeded files
     rm bin/libcirc.do
     rm bin/launcher.sh
+    # Install game data and save location
     install -dm00644 $installdir/usr/share/libcirc/
     install -dm00777 $installdir/usr/share/libcirc/saves
     cp -R bin/* $installdir/usr/share/libcirc/
+    # Install app icon, metainfo, and desktop file
     install -Dm00644 $pkgfiles/icon-16px.png $installdir/usr/share/icons/hicolor/16x16/apps/liberation-circuit.png
     install -Dm00644 $pkgfiles/icon-32px.png $installdir/usr/share/icons/hicolor/32x32/apps/liberation-circuit.png
     install -Dm00644 $pkgfiles/icon-256px.png $installdir/usr/share/icons/hicolor/256x256/apps/liberation-circuit.png

--- a/packages/l/liberation-circuit/pspec_x86_64.xml
+++ b/packages/l/liberation-circuit/pspec_x86_64.xml
@@ -4,7 +4,7 @@
         <Homepage>https://linleyh.itch.io/liberation-circuit</Homepage>
         <Packager>
             <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <PartOf>games.strategy</PartOf>
@@ -231,12 +231,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2023-11-17</Date>
+        <Update release="5">
+            <Date>2024-01-21</Date>
             <Version>1.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- 5.2.9.1 :
   - Fix a regression where toggling fullscreen window when menus are used stopped working
- 5.2.9.0 :
   - Fix fullscreen window creation
   - Fix some X11 + fullscreen window interaction
   - Allow setting higher quality icons
   - Improve `DISPLAY_SWITCH_IN/OUT` events
   - Work on improving Window positioning
   - Fix creating an initially maximized window
   - Enable toggling and setting maximized/frameless modes when menus are used
   - Fix popup menu
   - Make AltGr (right Alt) toggle the `ALLEGRO_KEYMOD_ALTGR` modifier
   - Full changelog can be found [here](https://github.com/liballeg/allegro5/releases/tag/5.2.9.0)

**Test Plan**

Rebuild `liberation-circuit` against this package

**Checklist**

- [x] Package was built and tested against unstable