### PR TITLE
papirus-icon-theme: Update to 20231201

### DIFF
--- a/packages/p/papirus-icon-theme/package.yml
+++ b/packages/p/papirus-icon-theme/package.yml
@@ -1,8 +1,8 @@
 name       : papirus-icon-theme
-version    : '20231101'
-release    : 84
+version    : '20231201'
+release    : 86
 source     :
-    - https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/archive/refs/tags/20231101.tar.gz : b42c2cb0beb066e01c6611aa4427dc46fe89ab7ae6cbbcbe4a606afbb2bdaaf0
+    - https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/archive/refs/tags/20231201.tar.gz : 9dde683d6444ed2d3b3dacf8579b04d527ce278cef575d606f690c7b31c7aebd
 license    : GPL-3.0-or-later
 homepage   : https://git.io/papirus-icon-theme
 component  :


### PR DESCRIPTION
**Summary**

Release notes can be found [here](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/releases/tag/20231201)
Solves #1400 

**Test Plan**

* Set icon theme to Papirus, browsed through system folders and menu
* Checked icons in Software Center
* Check handful of icons from flathub mentioned in release note

**Checklist**

- [ x] Package was built and tested against unstable
