### PR TITLE
font-clear-sans-ttf: Move appstream metadata out of legacy path

### DIFF
--- a/packages/f/font-clear-sans-ttf/package.yml
+++ b/packages/f/font-clear-sans-ttf/package.yml
@@ -1,6 +1,6 @@
 name       : font-clear-sans-ttf
 version    : '1.00'
-release    : 5
+release    : 6
 source     :
     - git|https://github.com/intel/clear-sans.git : 1993725b24a36af21e7ebaa8977103983b608572
 homepage   : https://github.com/intel/clear-sans
@@ -12,4 +12,4 @@ description: |
 install    : |
     install -dm00644 $installdir/usr/share/fonts/truetype/clear-sans/
     install -Dm00644 TTF/*.ttf $installdir/usr/share/fonts/truetype/clear-sans/
-    install -Dm00644 $pkgfiles/metainfo.xml $installdir/usr/share/appdata/font-clear-sans-ttf.metainfo.xml
+    install -Dm00644 $pkgfiles/metainfo.xml $installdir/usr/share/metainfo/font-clear-sans-ttf.metainfo.xml

--- a/packages/f/font-clear-sans-ttf/pspec_x86_64.xml
+++ b/packages/f/font-clear-sans-ttf/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>font-clear-sans-ttf</Name>
         <Homepage>https://github.com/intel/clear-sans</Homepage>
         <Packager>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>desktop.font</PartOf>
@@ -20,7 +20,6 @@
 </Description>
         <PartOf>desktop.font</PartOf>
         <Files>
-            <Path fileType="data">/usr/share/appdata/font-clear-sans-ttf.metainfo.xml</Path>
             <Path fileType="data">/usr/share/fonts/truetype/clear-sans/ClearSans-Bold.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/clear-sans/ClearSans-BoldItalic.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/clear-sans/ClearSans-Italic.ttf</Path>
@@ -29,15 +28,16 @@
             <Path fileType="data">/usr/share/fonts/truetype/clear-sans/ClearSans-MediumItalic.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/clear-sans/ClearSans-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/clear-sans/ClearSans-Thin.ttf</Path>
+            <Path fileType="data">/usr/share/metainfo/font-clear-sans-ttf.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2023-10-14</Date>
+        <Update release="6">
+            <Date>2024-01-22</Date>
             <Version>1.00</Version>
             <Comment>Packaging update</Comment>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Move appstream metadata out of legacy path