### PR TITLE
perl-sdl: Work with newer perl versions

### DIFF
--- a/packages/p/perl-sdl/abi_used_symbols
+++ b/packages/p/perl-sdl/abi_used_symbols
@@ -57,7 +57,6 @@ UNKNOWN:Perl_warn_nocontext
 UNKNOWN:Perl_xs_boot_epilog
 UNKNOWN:Perl_xs_handshake
 UNKNOWN:perl_clone
-UNKNOWN:sv_nv
 ld-linux-x86-64.so.2:__tls_get_addr
 libSDL-1.2.so.0:SDL_AddTimer
 libSDL-1.2.so.0:SDL_AllocRW
@@ -459,7 +458,7 @@ libSDL_ttf-2.0.so.0:TTF_SizeUNICODE
 libSDL_ttf-2.0.so.0:TTF_SizeUTF8
 libSDL_ttf-2.0.so.0:TTF_WasInit
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:exit

--- a/packages/p/perl-sdl/files/Adapt-to-perl-5.37.1.patch
+++ b/packages/p/perl-sdl/files/Adapt-to-perl-5.37.1.patch
@@ -1,0 +1,71 @@
+From d734d03862d7dcc776bd2fa3ba662cdd5879b32e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Petr=20P=C3=ADsa=C5=99?= <ppisar@redhat.com>
+Date: Wed, 12 Jul 2023 17:55:27 +0200
+Subject: [PATCH] Adapt to perl 5.37.1
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Perl 5.37.1 removed a deprecated sv_nv() macro and SDL fails to build
+with Perl 5.38.0:
+
+lib/SDLx/Controller/Interface.xs:60:26: error: implicit declaration of function 'sv_nv'
+   60 |         out->dv_x      = sv_nv(temp);
+      |                          ^~~~~
+
+Users are advised to use SvNVx() macro instead. SvNVx() seems to have been
+available all the time (it predates a commit from 1993-10-07).
+
+This patch does that.
+
+https://github.com/PerlGameDev/SDL/issues/303
+Signed-off-by: Petr Písař <ppisar@redhat.com>
+---
+ src/SDLx/Controller/Interface.xs | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/SDLx/Controller/Interface.xs b/src/SDLx/Controller/Interface.xs
+index 3dc202b7..d326c885 100644
+--- a/src/SDLx/Controller/Interface.xs
++++ b/src/SDLx/Controller/Interface.xs
+@@ -57,15 +57,15 @@ void evaluate(SDLx_Interface *obj, SDLx_Derivative *out, SDLx_State *initial, fl
+ 
+ 	SV *temp;
+ 	temp           = av_pop(accel);
+-	out->dv_x      = sv_nv(temp);
++	out->dv_x      = SvNVx(temp);
+ 	SvREFCNT_dec(temp);
+ 
+ 	temp           = av_pop(accel);
+-	out->dv_y      = sv_nv(temp);
++	out->dv_y      = SvNVx(temp);
+ 	SvREFCNT_dec(temp);
+ 
+ 	temp           = av_pop(accel);
+-	out->dang_v    = sv_nv(temp);
++	out->dang_v    = SvNVx(temp);
+ 	SvREFCNT_dec(temp);
+ 
+ 	SvREFCNT_dec((SV *)accel);
+@@ -90,15 +90,15 @@ void evaluate_dt(SDLx_Interface *obj, SDLx_Derivative *out, SDLx_State *initial,
+ 
+ 	SV *temp;
+ 	temp           = av_pop(accel);
+-	out->dv_x      = sv_nv(temp);
++	out->dv_x      = SvNVx(temp);
+ 	SvREFCNT_dec(temp);
+ 
+ 	temp           = av_pop(accel);
+-	out->dv_y      = sv_nv(temp);
++	out->dv_y      = SvNVx(temp);
+ 	SvREFCNT_dec(temp);
+ 
+ 	temp           = av_pop(accel);
+-	out->dang_v    = sv_nv(temp);
++	out->dang_v    = SvNVx(temp);
+ 	SvREFCNT_dec(temp);
+ 
+ 	SvREFCNT_dec((SV *)accel);
+-- 
+2.41.0
+

--- a/packages/p/perl-sdl/package.yml
+++ b/packages/p/perl-sdl/package.yml
@@ -1,8 +1,9 @@
 name       : perl-sdl
-version    : 2.548
-release    : 8
+version    : '2.548'
+release    : 9
 source     :
     - https://cpan.metacpan.org/authors/id/F/FR/FROGGS/SDL-2.548.tar.gz : 252a192bfa9c2070a4883707d139c3a45d9c4518ccd66a1e699b5b7959bd4fb5
+homepage   : https://metacpan.org/dist/SDL
 license    : LGPL-2.1-or-later
 component  : programming.perl
 summary    : Simple DirectMedia Layer for Perl
@@ -19,6 +20,8 @@ builddeps  :
     - perl-test-most
     - perl-tie-simple
 setup      : |
+    %patch -p1 -i $pkgfiles/Adapt-to-perl-5.37.1.patch
+
     %perl_setup
 build      : |
     %perl_build

--- a/packages/p/perl-sdl/pspec_x86_64.xml
+++ b/packages/p/perl-sdl/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>perl-sdl</Name>
+        <Homepage>https://metacpan.org/dist/SDL</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>programming.perl</PartOf>
         <Summary xml:lang="en">Simple DirectMedia Layer for Perl</Summary>
         <Description xml:lang="en">Package of modules that provide both functional and object oriented interfaces to the Simple DirectMedia Layer for Perl. This package takes some liberties with the SDL API, and attempts to adhere to the spirit of both the SDL and Perl.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>perl-sdl</Name>
@@ -275,6 +276,18 @@
             <Path fileType="library">/usr/lib64/perl5/vendor_perl/5.38/x86_64-linux-thread-multi/pods/SDLx/Sprite/Animated.pod</Path>
             <Path fileType="library">/usr/lib64/perl5/vendor_perl/5.38/x86_64-linux-thread-multi/pods/SDLx/Surface.pod</Path>
             <Path fileType="library">/usr/lib64/perl5/vendor_perl/5.38/x86_64-linux-thread-multi/pods/SDLx/Text.pod</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>perl-sdl-devel</Name>
+        <Summary xml:lang="en">Development files for perl-sdl</Summary>
+        <Description xml:lang="en">Package of modules that provide both functional and object oriented interfaces to the Simple DirectMedia Layer for Perl. This package takes some liberties with the SDL API, and attempts to adhere to the spirit of both the SDL and Perl.
+</Description>
+        <PartOf>programming.devel</PartOf>
+        <RuntimeDependencies>
+            <Dependency release="9">perl-sdl</Dependency>
+        </RuntimeDependencies>
+        <Files>
             <Path fileType="man">/usr/share/man/man3/Module::Build::SDL.3</Path>
             <Path fileType="man">/usr/share/man/man3/SDL::ConfigData.3</Path>
             <Path fileType="man">/usr/share/man/man3/SDLx::FPS.3</Path>
@@ -349,12 +362,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2023-07-29</Date>
+        <Update release="9">
+            <Date>2024-01-23</Date>
             <Version>2.548</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Packager notes:
 - sv_nv() is deprecated use SvNVx() instead.

Resolves getsolus/packages#1410

**Test Plan**

Play frozen-bubble

**Checklist**

- [x] Package was built and tested against unstable
