### PR TITLE
gedit-plugins: Split plugins into subpackages

### DIFF
--- a/packages/g/gedit-plugins/package.yml
+++ b/packages/g/gedit-plugins/package.yml
@@ -1,14 +1,45 @@
 name       : gedit-plugins
 version    : '46.0'
-release    : 37
+release    : 38
 source     :
     - https://download.gnome.org/sources/gedit-plugins/46/gedit-plugins-46.0.tar.xz : db6b4aa72dac0190a8ae497f770f5a4ba66ae3cf1e03ea8b744e6101df09b251
 homepage   : https://wiki.gnome.org/Apps/Gedit/ShippedPlugins
 license    : GPL-2.0-or-later
 component  : desktop.gnome
-summary    : Gedit Plugins
-description: |
-    Gedit Plugins
+summary    :
+    - Plugins for gedit
+    - common : Common data required for plugins
+    - ^gedit-plugin-bookmarks : gedit bookmarks plugin
+    - ^gedit-plugin-bracketcompletion : gedit bracketcompletion plugin
+    - ^gedit-plugin-charmap : gedit charmap plugin
+    - ^gedit-plugin-codecomment : gedit codecomment plugin
+    - ^gedit-plugin-colorpicker : gedit colorpicker plugin
+    - ^gedit-plugin-drawspaces : gedit drawspaces plugin
+    - ^gedit-plugin-git : gedit git plugin
+    - ^gedit-plugin-joinlines : gedit joinlines plugin
+    - ^gedit-plugin-multiedit : gedit multiedit plugin
+    - ^gedit-plugin-sessionsaver : gedit sessionsaver plugin
+    - ^gedit-plugin-smartspaces : gedit smartspaces plugin
+    - ^gedit-plugin-terminal : gedit terminal plugin
+    - ^gedit-plugin-textsize : gedit textsize plugin
+    - ^gedit-plugin-wordcompletion : gedit wordcompletion plugin
+description:
+    - A collection of plugins for gedit
+    - common : Common files required by all plugins.
+    - ^gedit-plugin-bookmarks : The gedit bookmarks plugin.
+    - ^gedit-plugin-bracketcompletion : The gedit bracketcompletion plugin.
+    - ^gedit-plugin-charmap : The gedit charmap plugin.
+    - ^gedit-plugin-codecomment : The gedit codecomment plugin.
+    - ^gedit-plugin-colorpicker : The gedit colorpicker plugin.
+    - ^gedit-plugin-drawspaces : The gedit drawspaces plugin.
+    - ^gedit-plugin-git : The gedit git plugin.
+    - ^gedit-plugin-joinlines : The gedit joinlines plugin.
+    - ^gedit-plugin-multiedit : The gedit multiedit plugin.
+    - ^gedit-plugin-sessionsaver : The gedit sessionsaver plugin.
+    - ^gedit-plugin-smartspaces : The gedit smartspaces plugin.
+    - ^gedit-plugin-terminal : The gedit terminal plugin.
+    - ^gedit-plugin-textsize : The gedit textsize plugin.
+    - ^gedit-plugin-wordcompletion : The gedit wordcompletion plugin.
 builddeps  :
     - pkgconfig(gedit)
     - pkgconfig(gucharmap-2.90)
@@ -19,12 +50,140 @@ builddeps  :
     - itstool
     - vala
 rundeps    :
-    - gucharmap
-    - libgit2-glib
-    - python-gobject
+    - gedit-plugin-bookmarks
+    - gedit-plugin-bracketcompletion
+    - gedit-plugin-charmap
+    - gedit-plugin-codecomment
+    - gedit-plugin-colorpicker
+    - gedit-plugin-drawspaces
+    - gedit-plugin-git
+    - gedit-plugin-joinlines
+    - gedit-plugin-multiedit
+    - gedit-plugin-sessionsaver
+    - gedit-plugin-smartspaces
+    - gedit-plugin-terminal
+    - gedit-plugin-textsize
+    - gedit-plugin-wordcompletion
+    - common :
+        - python-gobject
+    - ^gedit-plugin-bookmarks :
+        - gedit-plugins-common
+    - ^gedit-plugin-bracketcompletion :
+        - gedit-plugins-common
+    - ^gedit-plugin-charmap :
+        - gedit-plugins-common
+        - gucharmap
+    - ^gedit-plugin-codecomment :
+        - gedit-plugins-common
+    - ^gedit-plugin-colorpicker :
+        - gedit-plugins-common
+    - ^gedit-plugin-drawspaces :
+        - gedit-plugins-common
+    - ^gedit-plugin-git:
+        - gedit-plugins-common
+        - libgit2-glib
+    - ^gedit-plugin-joinlines :
+        - gedit-plugins-common
+    - ^gedit-plugin-multiedit :
+        - gedit-plugins-common
+    - ^gedit-plugin-sessionsaver :
+        - gedit-plugins-common
+    - ^gedit-plugin-smartspaces :
+        - gedit-plugins-common
+    - ^gedit-plugin-terminal :
+        - gedit-plugins-common
+        - libvte
+    - ^gedit-plugin-textsize :
+        - gedit-plugins-common
+    - ^gedit-plugin-wordcompletion :
+        - gedit-plugins-common
 setup      : |
     %meson_configure
 build      : |
     %ninja_build
 install    : |
     %ninja_install
+
+    # Packages don't get created if they have no files in them
+    echo "File created for gedit-plugins" > $workdir/shared
+    install -Dm00644 $workdir/shared $installdir/usr/lib64/gedit/plugins/shared
+patterns   :
+    - common :
+        - /usr/lib64/gedit/plugins/gpdefs.*
+        - /usr/share/help/*/gedit/legal-plugins.xml
+        - /usr/share/locale/*/LC_MESSAGES/gedit-plugins.mo
+    - ^gedit-plugin-bookmarks :
+        - /usr/lib64/gedit/plugins/bookmarks.plugin
+        - /usr/lib64/gedit/plugins/libbookmarks.so
+        - /usr/share/help/*/gedit/bookmarks.page
+        - /usr/share/metainfo/gedit-bookmarks.metainfo.xml
+    - ^gedit-plugin-bracketcompletion : 
+        - /usr/lib64/gedit/plugins/bracketcompletion.plugin
+        - /usr/lib64/gedit/plugins/bracketcompletion.py
+        - /usr/share/help/*/gedit/bracketcompletion.page
+        - /usr/share/help/*/gedit/bracket-comp.page
+        - /usr/share/metainfo/gedit-bracketcompletion.metainfo.xml
+    - ^gedit-plugin-charmap :
+        - /usr/lib64/gedit/plugins/charmap.plugin
+        - /usr/lib64/gedit/plugins/charmap/__init__.py
+        - /usr/lib64/gedit/plugins/charmap/panel.py
+        - /usr/share/help/*/gedit/character-map.page
+        - /usr/share/metainfo/gedit-charmap.metainfo.xml
+    - ^gedit-plugin-codecomment :
+        - /usr/lib64/gedit/plugins/codecomment.plugin
+        - /usr/lib64/gedit/plugins/codecomment.py
+        - /usr/share/help/*/gedit/code-comment.page
+        - /usr/share/metainfo/gedit-codecomment.metainfo.xml
+    - ^gedit-plugin-colorpicker :
+        - /usr/lib64/gedit/plugins/colorpicker.plugin
+        - /usr/lib64/gedit/plugins/colorpicker.py
+        - /usr/share/help/*/gedit/color-picker.page
+        - /usr/share/metainfo/gedit-colorpicker.metainfo.xml
+    - ^gedit-plugin-drawspaces :
+        - /usr/lib64/gedit/plugins/drawspaces.plugin
+        - /usr/lib64/gedit/plugins/libdrawspaces.so
+        - /usr/share/glib-2.0/schemas/org.gnome.gedit.plugins.drawspaces.gschema.xml
+        - /usr/share/help/*/gedit/draw-spaces.page
+        - /usr/share/metainfo/gedit-drawspaces.metainfo.xml
+    - ^gedit-plugin-git :
+        - /usr/lib64/gedit/plugins/git.plugin
+        - /usr/lib64/gedit/plugins/git/*
+        - /usr/share/help/*/gedit/git.page
+        - /usr/share/metainfo/gedit-git.metainfo.xml
+    - ^gedit-plugin-joinlines :
+        - /usr/lib64/gedit/plugins/joinlines.plugin
+        - /usr/lib64/gedit/plugins/joinlines.py
+        - /usr/share/help/*/gedit/join-split-lines.page
+        - /usr/share/metainfo/gedit-joinlines.metainfo.xml
+    - ^gedit-plugin-multiedit :
+        - /usr/lib64/gedit/plugins/multiedit.plugin
+        - /usr/lib64/gedit/plugins/multiedit/*
+        - /usr/share/help/*/gedit/multi-edit.page
+        - /usr/share/metainfo/gedit-multiedit.metainfo.xml
+    - ^gedit-plugin-sessionsaver :
+        - /usr/lib64/gedit/plugins/sessionsaver.plugin
+        - /usr/lib64/gedit/plugins/sessionsaver/*
+        - /usr/share/gedit/plugins/sessionsaver/ui/sessionsaver.ui
+        - /usr/share/help/*/gedit/session-saver.page
+    - ^gedit-plugin-smartspaces :
+        - /usr/lib64/gedit/plugins/libsmartspaces.so
+        - /usr/lib64/gedit/plugins/smartspaces.plugin
+        - /usr/share/help/*/gedit/smartspaces.page
+        - /usr/share/metainfo/gedit-smartspaces.metainfo.xml
+    - ^gedit-plugin-terminal :
+        - /usr/lib64/gedit/plugins/terminal.plugin
+        - /usr/lib64/gedit/plugins/terminal.py
+        - /usr/share/glib-2.0/schemas/org.gnome.gedit.plugins.terminal.gschema.xml
+        - /usr/share/help/*/gedit/terminal.page
+        - /usr/share/metainfo/gedit-terminal.metainfo.xml
+    - ^gedit-plugin-textsize :
+        - /usr/lib64/gedit/plugins/textsize.plugin
+        - /usr/lib64/gedit/plugins/textsize/*
+        - /usr/share/help/*/gedit/text-size.page
+        - /usr/share/metainfo/gedit-textsize.metainfo.xml
+    - ^gedit-plugin-wordcompletion :
+        - /usr/lib64/gedit/plugins/libwordcompletion.so
+        - /usr/lib64/gedit/plugins/wordcompletion.plugin
+        - /usr/share/glib-2.0/schemas/org.gnome.gedit.plugins.wordcompletion.gschema.xml
+        - /usr/share/help/*/gedit/word-completion.page
+        - /usr/share/metainfo/gedit-wordcompletion.metainfo.xml

--- a/packages/g/gedit-plugins/pspec_x86_64.xml
+++ b/packages/g/gedit-plugins/pspec_x86_64.xml
@@ -3,34 +3,308 @@
         <Name>gedit-plugins</Name>
         <Homepage>https://wiki.gnome.org/Apps/Gedit/ShippedPlugins</Homepage>
         <Packager>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.gnome</PartOf>
-        <Summary xml:lang="en">Gedit Plugins</Summary>
-        <Description xml:lang="en">Gedit Plugins
-</Description>
+        <Summary xml:lang="en">Plugins for gedit</Summary>
+        <Description xml:lang="en">A collection of plugins for gedit</Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>gedit-plugins</Name>
-        <Summary xml:lang="en">Gedit Plugins</Summary>
-        <Description xml:lang="en">Gedit Plugins
-</Description>
+        <Summary xml:lang="en">Plugins for gedit</Summary>
+        <Description xml:lang="en">A collection of plugins for gedit</Description>
         <PartOf>desktop.gnome</PartOf>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="38">gedit-plugin-bookmarks</Dependency>
+            <Dependency releaseFrom="38">gedit-plugin-bracketcompletion</Dependency>
+            <Dependency releaseFrom="38">gedit-plugin-charmap</Dependency>
+            <Dependency releaseFrom="38">gedit-plugin-codecomment</Dependency>
+            <Dependency releaseFrom="38">gedit-plugin-colorpicker</Dependency>
+            <Dependency releaseFrom="38">gedit-plugin-drawspaces</Dependency>
+            <Dependency releaseFrom="38">gedit-plugin-git</Dependency>
+            <Dependency releaseFrom="38">gedit-plugin-joinlines</Dependency>
+            <Dependency releaseFrom="38">gedit-plugin-multiedit</Dependency>
+            <Dependency releaseFrom="38">gedit-plugin-sessionsaver</Dependency>
+            <Dependency releaseFrom="38">gedit-plugin-smartspaces</Dependency>
+            <Dependency releaseFrom="38">gedit-plugin-terminal</Dependency>
+            <Dependency releaseFrom="38">gedit-plugin-textsize</Dependency>
+            <Dependency releaseFrom="38">gedit-plugin-wordcompletion</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="library">/usr/lib64/gedit/plugins/shared</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>gedit-plugin-bookmarks</Name>
+        <Summary xml:lang="en">gedit bookmarks plugin</Summary>
+        <Description xml:lang="en">The gedit bookmarks plugin.</Description>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="38">gedit-plugins-common</Dependency>
+        </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/gedit/plugins/bookmarks.plugin</Path>
+            <Path fileType="library">/usr/lib64/gedit/plugins/libbookmarks.so</Path>
+            <Path fileType="doc">/usr/share/help/C/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/ar/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/bg/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/ca/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/cs/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/da/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/de/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/el/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/es/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/eu/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/fi/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/fr/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/gl/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/hu/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/it/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/ja/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/ko/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/lv/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/oc/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/pl/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/pt_BR/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/ru/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/sl/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/sv/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/te/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/th/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/uk/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_CN/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_HK/gedit/bookmarks.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_TW/gedit/bookmarks.page</Path>
+            <Path fileType="data">/usr/share/metainfo/gedit-bookmarks.metainfo.xml</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>gedit-plugin-bracketcompletion</Name>
+        <Summary xml:lang="en">gedit bracketcompletion plugin</Summary>
+        <Description xml:lang="en">The gedit bracketcompletion plugin.</Description>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="38">gedit-plugins-common</Dependency>
+        </RuntimeDependencies>
+        <Files>
             <Path fileType="library">/usr/lib64/gedit/plugins/bracketcompletion.plugin</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/bracketcompletion.py</Path>
+            <Path fileType="doc">/usr/share/help/C/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/ar/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/bg/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/ca/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/cs/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/da/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/de/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/el/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/es/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/eu/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/fi/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/fr/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/gl/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/hu/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/it/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/ja/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/ko/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/lv/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/oc/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/pl/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/pt_BR/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/ru/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/sl/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/sv/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/te/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/th/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/uk/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_CN/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_HK/gedit/bracket-comp.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_TW/gedit/bracket-comp.page</Path>
+            <Path fileType="data">/usr/share/metainfo/gedit-bracketcompletion.metainfo.xml</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>gedit-plugin-charmap</Name>
+        <Summary xml:lang="en">gedit charmap plugin</Summary>
+        <Description xml:lang="en">The gedit charmap plugin.</Description>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="38">gedit-plugins-common</Dependency>
+        </RuntimeDependencies>
+        <Files>
             <Path fileType="library">/usr/lib64/gedit/plugins/charmap.plugin</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/charmap/__init__.py</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/charmap/panel.py</Path>
+            <Path fileType="doc">/usr/share/help/C/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/ar/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/bg/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/ca/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/cs/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/da/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/de/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/el/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/es/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/eu/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/fi/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/fr/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/gl/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/hu/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/it/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/ja/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/ko/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/lv/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/oc/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/pl/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/pt_BR/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/ru/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/sl/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/sv/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/te/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/th/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/uk/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_CN/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_HK/gedit/character-map.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_TW/gedit/character-map.page</Path>
+            <Path fileType="data">/usr/share/metainfo/gedit-charmap.metainfo.xml</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>gedit-plugin-codecomment</Name>
+        <Summary xml:lang="en">gedit codecomment plugin</Summary>
+        <Description xml:lang="en">The gedit codecomment plugin.</Description>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="38">gedit-plugins-common</Dependency>
+        </RuntimeDependencies>
+        <Files>
             <Path fileType="library">/usr/lib64/gedit/plugins/codecomment.plugin</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/codecomment.py</Path>
+            <Path fileType="doc">/usr/share/help/C/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/ar/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/bg/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/ca/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/cs/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/da/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/de/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/el/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/es/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/eu/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/fi/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/fr/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/gl/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/hu/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/it/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/ja/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/ko/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/lv/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/oc/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/pl/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/pt_BR/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/ru/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/sl/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/sv/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/te/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/th/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/uk/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_CN/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_HK/gedit/code-comment.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_TW/gedit/code-comment.page</Path>
+            <Path fileType="data">/usr/share/metainfo/gedit-codecomment.metainfo.xml</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>gedit-plugin-colorpicker</Name>
+        <Summary xml:lang="en">gedit colorpicker plugin</Summary>
+        <Description xml:lang="en">The gedit colorpicker plugin.</Description>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="38">gedit-plugins-common</Dependency>
+        </RuntimeDependencies>
+        <Files>
             <Path fileType="library">/usr/lib64/gedit/plugins/colorpicker.plugin</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/colorpicker.py</Path>
+            <Path fileType="doc">/usr/share/help/C/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/ar/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/bg/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/ca/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/cs/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/da/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/de/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/el/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/es/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/eu/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/fi/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/fr/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/gl/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/hu/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/it/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/ja/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/ko/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/lv/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/oc/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/pl/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/pt_BR/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/ru/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/sl/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/sv/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/te/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/th/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/uk/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_CN/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_HK/gedit/color-picker.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_TW/gedit/color-picker.page</Path>
+            <Path fileType="data">/usr/share/metainfo/gedit-colorpicker.metainfo.xml</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>gedit-plugin-drawspaces</Name>
+        <Summary xml:lang="en">gedit drawspaces plugin</Summary>
+        <Description xml:lang="en">The gedit drawspaces plugin.</Description>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="38">gedit-plugins-common</Dependency>
+        </RuntimeDependencies>
+        <Files>
             <Path fileType="library">/usr/lib64/gedit/plugins/drawspaces.plugin</Path>
+            <Path fileType="library">/usr/lib64/gedit/plugins/libdrawspaces.so</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.gedit.plugins.drawspaces.gschema.xml</Path>
+            <Path fileType="doc">/usr/share/help/C/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/ar/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/bg/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/ca/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/cs/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/da/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/de/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/el/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/es/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/eu/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/fi/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/fr/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/gl/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/hu/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/it/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/ja/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/ko/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/lv/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/oc/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/pl/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/pt_BR/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/ru/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/sl/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/sv/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/te/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/th/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/uk/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_CN/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_HK/gedit/draw-spaces.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_TW/gedit/draw-spaces.page</Path>
+            <Path fileType="data">/usr/share/metainfo/gedit-drawspaces.metainfo.xml</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>gedit-plugin-git</Name>
+        <Summary xml:lang="en">gedit git plugin</Summary>
+        <Description xml:lang="en">The gedit git plugin.</Description>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="38">gedit-plugins-common</Dependency>
+        </RuntimeDependencies>
+        <Files>
             <Path fileType="library">/usr/lib64/gedit/plugins/git.plugin</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/git/__init__.py</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/git/appactivatable.py</Path>
@@ -39,19 +313,137 @@
             <Path fileType="library">/usr/lib64/gedit/plugins/git/viewactivatable.py</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/git/windowactivatable.py</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/git/workerthread.py</Path>
-            <Path fileType="library">/usr/lib64/gedit/plugins/gpdefs.py</Path>
+            <Path fileType="doc">/usr/share/help/C/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/ar/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/bg/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/ca/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/cs/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/da/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/de/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/el/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/es/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/eu/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/fi/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/fr/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/gl/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/hu/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/it/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/ja/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/ko/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/lv/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/oc/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/pl/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/pt_BR/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/ru/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/sl/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/sv/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/te/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/th/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/uk/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_CN/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_HK/gedit/git.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_TW/gedit/git.page</Path>
+            <Path fileType="data">/usr/share/metainfo/gedit-git.metainfo.xml</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>gedit-plugin-joinlines</Name>
+        <Summary xml:lang="en">gedit joinlines plugin</Summary>
+        <Description xml:lang="en">The gedit joinlines plugin.</Description>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="38">gedit-plugins-common</Dependency>
+        </RuntimeDependencies>
+        <Files>
             <Path fileType="library">/usr/lib64/gedit/plugins/joinlines.plugin</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/joinlines.py</Path>
-            <Path fileType="library">/usr/lib64/gedit/plugins/libbookmarks.so</Path>
-            <Path fileType="library">/usr/lib64/gedit/plugins/libdrawspaces.so</Path>
-            <Path fileType="library">/usr/lib64/gedit/plugins/libsmartspaces.so</Path>
-            <Path fileType="library">/usr/lib64/gedit/plugins/libwordcompletion.so</Path>
+            <Path fileType="doc">/usr/share/help/C/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/ar/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/bg/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/ca/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/cs/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/da/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/de/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/el/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/es/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/eu/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/fi/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/fr/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/gl/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/hu/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/it/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/ja/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/ko/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/lv/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/oc/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/pl/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/pt_BR/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/ru/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/sl/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/sv/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/te/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/th/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/uk/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_CN/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_HK/gedit/join-split-lines.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_TW/gedit/join-split-lines.page</Path>
+            <Path fileType="data">/usr/share/metainfo/gedit-joinlines.metainfo.xml</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>gedit-plugin-multiedit</Name>
+        <Summary xml:lang="en">gedit multiedit plugin</Summary>
+        <Description xml:lang="en">The gedit multiedit plugin.</Description>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="38">gedit-plugins-common</Dependency>
+        </RuntimeDependencies>
+        <Files>
             <Path fileType="library">/usr/lib64/gedit/plugins/multiedit.plugin</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/multiedit/__init__.py</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/multiedit/appactivatable.py</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/multiedit/signals.py</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/multiedit/viewactivatable.py</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/multiedit/windowactivatable.py</Path>
+            <Path fileType="doc">/usr/share/help/C/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/ar/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/bg/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/ca/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/cs/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/da/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/de/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/el/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/es/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/eu/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/fi/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/fr/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/gl/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/hu/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/it/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/ja/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/ko/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/lv/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/oc/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/pl/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/pt_BR/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/ru/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/sl/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/sv/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/te/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/th/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/uk/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_CN/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_HK/gedit/multi-edit.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_TW/gedit/multi-edit.page</Path>
+            <Path fileType="data">/usr/share/metainfo/gedit-multiedit.metainfo.xml</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>gedit-plugin-sessionsaver</Name>
+        <Summary xml:lang="en">gedit sessionsaver plugin</Summary>
+        <Description xml:lang="en">The gedit sessionsaver plugin.</Description>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="38">gedit-plugins-common</Dependency>
+        </RuntimeDependencies>
+        <Files>
             <Path fileType="library">/usr/lib64/gedit/plugins/sessionsaver.plugin</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/sessionsaver/__init__.py</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/sessionsaver/appactivatable.py</Path>
@@ -60,438 +452,221 @@
             <Path fileType="library">/usr/lib64/gedit/plugins/sessionsaver/store/sessionstore.py</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/sessionsaver/store/xmlsessionstore.py</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/sessionsaver/windowactivable.py</Path>
+            <Path fileType="data">/usr/share/gedit/plugins/sessionsaver/ui/sessionsaver.ui</Path>
+            <Path fileType="doc">/usr/share/help/C/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/ar/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/bg/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/ca/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/cs/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/da/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/de/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/el/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/es/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/eu/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/fi/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/fr/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/gl/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/hu/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/it/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/ja/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/ko/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/lv/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/oc/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/pl/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/pt_BR/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/ru/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/sl/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/sv/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/te/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/th/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/uk/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_CN/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_HK/gedit/session-saver.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_TW/gedit/session-saver.page</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>gedit-plugin-smartspaces</Name>
+        <Summary xml:lang="en">gedit smartspaces plugin</Summary>
+        <Description xml:lang="en">The gedit smartspaces plugin.</Description>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="38">gedit-plugins-common</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="library">/usr/lib64/gedit/plugins/libsmartspaces.so</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/smartspaces.plugin</Path>
+            <Path fileType="data">/usr/share/metainfo/gedit-smartspaces.metainfo.xml</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>gedit-plugin-terminal</Name>
+        <Summary xml:lang="en">gedit terminal plugin</Summary>
+        <Description xml:lang="en">The gedit terminal plugin.</Description>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="38">gedit-plugins-common</Dependency>
+        </RuntimeDependencies>
+        <Files>
             <Path fileType="library">/usr/lib64/gedit/plugins/terminal.plugin</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/terminal.py</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.gedit.plugins.terminal.gschema.xml</Path>
+            <Path fileType="doc">/usr/share/help/C/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/ar/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/bg/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/ca/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/cs/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/da/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/de/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/el/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/es/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/eu/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/fi/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/fr/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/gl/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/hu/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/it/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/ja/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/ko/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/lv/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/oc/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/pl/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/pt_BR/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/ru/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/sl/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/sv/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/te/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/th/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/uk/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_CN/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_HK/gedit/terminal.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_TW/gedit/terminal.page</Path>
+            <Path fileType="data">/usr/share/metainfo/gedit-terminal.metainfo.xml</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>gedit-plugin-textsize</Name>
+        <Summary xml:lang="en">gedit textsize plugin</Summary>
+        <Description xml:lang="en">The gedit textsize plugin.</Description>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="38">gedit-plugins-common</Dependency>
+        </RuntimeDependencies>
+        <Files>
             <Path fileType="library">/usr/lib64/gedit/plugins/textsize.plugin</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/textsize/__init__.py</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/textsize/signals.py</Path>
             <Path fileType="library">/usr/lib64/gedit/plugins/textsize/viewactivatable.py</Path>
-            <Path fileType="library">/usr/lib64/gedit/plugins/wordcompletion.plugin</Path>
-            <Path fileType="data">/usr/share/gedit/plugins/sessionsaver/ui/sessionsaver.ui</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.gedit.plugins.drawspaces.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.gedit.plugins.terminal.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.gedit.plugins.wordcompletion.gschema.xml</Path>
-            <Path fileType="doc">/usr/share/help/C/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/C/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/C/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/C/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/C/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/C/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/C/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/C/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/C/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/C/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/C/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/C/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/C/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/C/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/ar/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/ar/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/ar/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/ar/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/ar/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/ar/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/ar/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/ar/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/ar/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/ar/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/ar/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/ar/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/ar/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/ar/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/bg/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/bg/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/bg/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/bg/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/bg/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/bg/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/bg/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/bg/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/bg/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/bg/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/bg/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/bg/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/bg/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/bg/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/ca/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/ca/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/ca/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/ca/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/ca/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/ca/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/ca/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/ca/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/ca/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/ca/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/ca/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/ca/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/ca/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/ca/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/cs/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/cs/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/cs/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/cs/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/cs/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/cs/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/cs/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/cs/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/cs/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/cs/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/cs/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/cs/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/cs/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/cs/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/da/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/da/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/da/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/da/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/da/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/da/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/da/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/da/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/da/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/da/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/da/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/da/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/da/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/da/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/de/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/de/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/de/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/de/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/de/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/de/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/de/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/de/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/de/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/de/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/de/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/de/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/de/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/de/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/el/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/el/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/el/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/el/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/el/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/el/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/el/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/el/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/el/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/el/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/el/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/el/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/el/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/el/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/es/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/es/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/es/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/es/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/es/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/es/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/es/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/es/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/es/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/es/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/es/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/es/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/es/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/es/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/eu/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/eu/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/eu/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/eu/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/eu/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/eu/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/eu/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/eu/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/eu/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/eu/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/eu/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/eu/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/eu/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/eu/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/fi/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/fi/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/fi/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/fi/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/fi/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/fi/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/fi/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/fi/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/fi/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/fi/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/fi/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/fi/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/fi/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/fi/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/fr/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/fr/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/fr/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/fr/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/fr/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/fr/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/fr/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/fr/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/fr/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/fr/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/fr/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/fr/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/fr/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/fr/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/gl/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/gl/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/gl/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/gl/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/gl/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/gl/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/gl/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/gl/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/gl/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/gl/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/gl/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/gl/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/gl/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/gl/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/hu/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/hu/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/hu/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/hu/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/hu/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/hu/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/hu/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/hu/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/hu/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/hu/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/hu/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/hu/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/hu/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/hu/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/it/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/it/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/it/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/it/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/it/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/it/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/it/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/it/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/it/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/it/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/it/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/it/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/it/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/it/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/ja/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/ja/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/ja/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/ja/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/ja/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/ja/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/ja/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/ja/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/ja/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/ja/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/ja/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/ja/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/ja/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/ja/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/ko/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/ko/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/ko/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/ko/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/ko/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/ko/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/ko/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/ko/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/ko/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/ko/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/ko/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/ko/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/ko/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/ko/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/lv/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/lv/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/lv/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/lv/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/lv/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/lv/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/lv/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/lv/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/lv/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/lv/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/lv/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/lv/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/lv/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/lv/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/oc/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/oc/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/oc/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/oc/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/oc/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/oc/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/oc/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/oc/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/oc/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/oc/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/oc/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/oc/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/oc/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/oc/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/pl/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/pl/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/pl/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/pl/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/pl/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/pl/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/pl/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/pl/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/pl/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/pl/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/pl/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/pl/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/pl/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/pl/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/pt_BR/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/pt_BR/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/pt_BR/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/pt_BR/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/pt_BR/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/pt_BR/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/pt_BR/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/pt_BR/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/pt_BR/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/pt_BR/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/pt_BR/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/pt_BR/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/pt_BR/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/pt_BR/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/ru/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/ru/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/ru/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/ru/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/ru/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/ru/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/ru/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/ru/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/ru/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/ru/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/ru/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/ru/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/ru/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/ru/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/sl/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/sl/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/sl/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/sl/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/sl/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/sl/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/sl/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/sl/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/sl/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/sl/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/sl/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/sl/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/sl/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/sl/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/sv/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/sv/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/sv/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/sv/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/sv/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/sv/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/sv/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/sv/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/sv/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/sv/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/sv/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/sv/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/sv/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/sv/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/te/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/te/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/te/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/te/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/te/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/te/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/te/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/te/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/te/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/te/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/te/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/te/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/te/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/te/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/th/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/th/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/th/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/th/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/th/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/th/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/th/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/th/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/th/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/th/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/th/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/th/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/th/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/th/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/uk/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/uk/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/uk/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/uk/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/uk/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/uk/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/uk/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/uk/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/uk/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/uk/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/uk/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/uk/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/uk/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/uk/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_CN/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_CN/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_CN/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_CN/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_CN/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_CN/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_CN/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_CN/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_CN/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/zh_CN/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_CN/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_CN/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/zh_CN/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_CN/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_HK/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_HK/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_HK/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_HK/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_HK/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_HK/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_HK/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_HK/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_HK/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/zh_HK/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_HK/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_HK/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/zh_HK/gedit/text-size.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_HK/gedit/word-completion.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_TW/gedit/bookmarks.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_TW/gedit/bracket-comp.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_TW/gedit/character-map.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_TW/gedit/code-comment.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_TW/gedit/color-picker.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_TW/gedit/draw-spaces.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_TW/gedit/git.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_TW/gedit/join-split-lines.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_TW/gedit/legal-plugins.xml</Path>
-            <Path fileType="doc">/usr/share/help/zh_TW/gedit/multi-edit.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_TW/gedit/session-saver.page</Path>
-            <Path fileType="doc">/usr/share/help/zh_TW/gedit/terminal.page</Path>
             <Path fileType="doc">/usr/share/help/zh_TW/gedit/text-size.page</Path>
+            <Path fileType="data">/usr/share/metainfo/gedit-textsize.metainfo.xml</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>gedit-plugin-wordcompletion</Name>
+        <Summary xml:lang="en">gedit wordcompletion plugin</Summary>
+        <Description xml:lang="en">The gedit wordcompletion plugin.</Description>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="38">gedit-plugins-common</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="library">/usr/lib64/gedit/plugins/libwordcompletion.so</Path>
+            <Path fileType="library">/usr/lib64/gedit/plugins/wordcompletion.plugin</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.gedit.plugins.wordcompletion.gschema.xml</Path>
+            <Path fileType="doc">/usr/share/help/C/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/ar/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/bg/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/ca/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/cs/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/da/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/de/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/el/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/es/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/eu/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/fi/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/fr/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/gl/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/hu/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/it/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/ja/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/ko/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/lv/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/oc/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/pl/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/pt_BR/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/ru/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/sl/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/sv/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/te/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/th/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/uk/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_CN/gedit/word-completion.page</Path>
+            <Path fileType="doc">/usr/share/help/zh_HK/gedit/word-completion.page</Path>
             <Path fileType="doc">/usr/share/help/zh_TW/gedit/word-completion.page</Path>
+            <Path fileType="data">/usr/share/metainfo/gedit-wordcompletion.metainfo.xml</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>gedit-plugins-common</Name>
+        <Summary xml:lang="en">Common data required for plugins</Summary>
+        <Description xml:lang="en">Common files required by all plugins.</Description>
+        <Files>
+            <Path fileType="library">/usr/lib64/gedit/plugins/gpdefs.py</Path>
+            <Path fileType="doc">/usr/share/help/C/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/ar/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/bg/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/ca/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/cs/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/da/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/de/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/el/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/es/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/eu/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/fi/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/fr/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/gl/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/hu/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/it/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/ja/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/ko/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/lv/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/oc/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/pl/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/pt_BR/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/ru/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/sl/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/sv/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/te/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/th/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/uk/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/zh_CN/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/zh_HK/gedit/legal-plugins.xml</Path>
+            <Path fileType="doc">/usr/share/help/zh_TW/gedit/legal-plugins.xml</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/gedit-plugins.mo</Path>
             <Path fileType="localedata">/usr/share/locale/am/LC_MESSAGES/gedit-plugins.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/gedit-plugins.mo</Path>
@@ -587,28 +762,15 @@
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/gedit-plugins.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_HK/LC_MESSAGES/gedit-plugins.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/gedit-plugins.mo</Path>
-            <Path fileType="data">/usr/share/metainfo/gedit-bookmarks.metainfo.xml</Path>
-            <Path fileType="data">/usr/share/metainfo/gedit-bracketcompletion.metainfo.xml</Path>
-            <Path fileType="data">/usr/share/metainfo/gedit-charmap.metainfo.xml</Path>
-            <Path fileType="data">/usr/share/metainfo/gedit-codecomment.metainfo.xml</Path>
-            <Path fileType="data">/usr/share/metainfo/gedit-colorpicker.metainfo.xml</Path>
-            <Path fileType="data">/usr/share/metainfo/gedit-drawspaces.metainfo.xml</Path>
-            <Path fileType="data">/usr/share/metainfo/gedit-git.metainfo.xml</Path>
-            <Path fileType="data">/usr/share/metainfo/gedit-joinlines.metainfo.xml</Path>
-            <Path fileType="data">/usr/share/metainfo/gedit-multiedit.metainfo.xml</Path>
-            <Path fileType="data">/usr/share/metainfo/gedit-smartspaces.metainfo.xml</Path>
-            <Path fileType="data">/usr/share/metainfo/gedit-terminal.metainfo.xml</Path>
-            <Path fileType="data">/usr/share/metainfo/gedit-textsize.metainfo.xml</Path>
-            <Path fileType="data">/usr/share/metainfo/gedit-wordcompletion.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="37">
-            <Date>2023-10-17</Date>
+        <Update release="38">
+            <Date>2024-01-23</Date>
             <Version>46.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Split plugins into subpackages

Ref https://github.com/getsolus/packages/issues/1389
Fixes https://github.com/getsolus/packages/issues/4

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install the updated gedit-plugins package, see that the split packages were all installed, verify that the plugins appeared in the Plugins page of the gedit settings.

**Checklist**

- [x] Package was built and tested against unstable
