### PR TITLE
kdeconnect: Add rundep on kirigami2

### DIFF
--- a/packages/k/kdeconnect/abi_used_symbols
+++ b/packages/k/kdeconnect/abi_used_symbols
@@ -136,7 +136,6 @@ libKF5GuiAddons.so.5:_ZN16KSystemClipboard16staticMetaObjectE
 libKF5GuiAddons.so.5:_ZN16KSystemClipboard4textEN10QClipboard4ModeE
 libKF5GuiAddons.so.5:_ZN16KSystemClipboard7changedEN10QClipboard4ModeE
 libKF5GuiAddons.so.5:_ZN16KSystemClipboard8instanceEv
-libKF5GuiAddons.so.5:wl_pointer_interface
 libKF5I18n.so.5:_Z5ki18nPKc
 libKF5I18n.so.5:_Z6ki18ncPKcS0_
 libKF5I18n.so.5:_Z6ki18ndPKcS0_
@@ -1418,7 +1417,7 @@ libQt5WaylandClient.so.5:_ZN23QWaylandClientExtensionD2Ev
 libQt5WaylandClient.so.5:_ZNK23QWaylandClientExtension10metaObjectEv
 libQt5WaylandClient.so.5:_ZNK23QWaylandClientExtension7versionEv
 libQt5WaylandClient.so.5:_ZTI23QWaylandClientExtension
-libQt5WaylandClient.so.5:wl_surface_interface
+libQt5WaylandClient.so.5:wl_pointer_interface
 libQt5Widgets.so.5:_ZN10QBoxLayout10setSpacingEi
 libQt5Widgets.so.5:_ZN10QBoxLayout9addLayoutEP7QLayouti
 libQt5Widgets.so.5:_ZN10QBoxLayout9addWidgetEP7QWidgeti6QFlagsIN2Qt13AlignmentFlagEE
@@ -1799,4 +1798,5 @@ libwayland-client.so.0:wl_proxy_get_version
 libwayland-client.so.0:wl_proxy_marshal_constructor_versioned
 libwayland-client.so.0:wl_proxy_marshal_flags
 libwayland-client.so.0:wl_region_interface
+libwayland-client.so.0:wl_surface_interface
 libxkbcommon.so.0:xkb_utf32_to_keysym

--- a/packages/k/kdeconnect/package.yml
+++ b/packages/k/kdeconnect/package.yml
@@ -1,6 +1,6 @@
 name       : kdeconnect
 version    : 23.08.4
-release    : 64
+release    : 65
 source     :
     - https://cdn.download.kde.org/stable/release-service/23.08.4/src/kdeconnect-kde-23.08.4.tar.xz : 0bd5a45a31da21d0e5939930059fad23b608efa727db6ff020166912db78f871
 homepage   : https://kdeconnect.kde.org/
@@ -39,6 +39,7 @@ builddeps  :
     - pulseaudio-qt-devel
     - qqc2-desktop-style-devel
 rundeps    :
+    - kirigami2
     - kpeoplevcard
     - sshfs-fuse
 setup      : |

--- a/packages/k/kdeconnect/pspec_x86_64.xml
+++ b/packages/k/kdeconnect/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>kdeconnect</Name>
         <Homepage>https://kdeconnect.kde.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.kde</PartOf>
@@ -859,12 +859,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="64">
-            <Date>2024-01-05</Date>
+        <Update release="65">
+            <Date>2024-01-23</Date>
             <Version>23.08.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fix starting on systems that don't have `kirigami2` installed

Fixes https://github.com/getsolus/packages/issues/1387

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install KDE Connect on Budgie and see that it works.

**Checklist**

- [x] Package was built and tested against unstable
