### PR TITLE
fceux: Add appstream metadata

### DIFF
--- a/packages/f/fceux/files/org.TasEmulators.fceux.metainfo.xml
+++ b/packages/f/fceux/files/org.TasEmulators.fceux.metainfo.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.TasEmulators.fceux</id>
+
+  <name>FCEUX</name>
+  <summary>The all in one NES/Famicom/Dendy Emulator </summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-or-later</project_license>
+
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>gamepad</control>
+  </supports>
+
+  <description>
+    <p>
+      FCEUX is a Nintendo Entertainment System (NES), Famicom, Famicom Disk System (FDS), and Dendy emulator. It supports NTSC (USA/JPN), PAL (European), and NTSC-PAL Hybrid modes. It supports both Windows and SDL versions for cross compatibility.
+    </p>
+    <p>
+      The FCEUX concept is that of an &quot;all in one&quot; emulator that offers accurate emulation and the best options for both casual play and a variety of more advanced emulator functions. For pro users, FCEUX offers tools for debugging, rom-hacking, map making, Tool-assisted movies, and Lua scripting
+    </p>
+    <p>
+      FCEUX is an evolution of the original FCE Ultra emulator. Over time FCE Ultra had separated into many distinct branches.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">org.TasEmulators.fceux.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://fceux.com/web/assets/FCEUX-main.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://fceux.com/web/assets/QtSDL-DebugTools-HiRes.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://fceux.com/web/assets/debugging_environment_1900px.png</image>
+    </screenshot>
+  </screenshots>
+</component>

--- a/packages/f/fceux/package.yml
+++ b/packages/f/fceux/package.yml
@@ -1,6 +1,6 @@
 name       : fceux
 version    : 2.6.6
-release    : 15
+release    : 16
 source     :
     - https://github.com/TASEmulators/fceux/archive/refs/tags/v2.6.6.tar.gz : 0320241d45c6d609f7aeb6f85fdd9019552047206b0864a7f9fddff15b004daa
 license    : GPL-2.0-or-later
@@ -35,3 +35,5 @@ install    : |
     mv $installdir/usr/share/pixmaps/fceux1.png $installdir/usr/share/pixmaps/fceux.png
     install -Dm00644 $pkgfiles/org.TasEmulators.fceux.desktop $installdir/usr/share/applications/org.TasEmulators.fceux.desktop
     rm -v $installdir/usr/share/applications/fceux.desktop
+    # Install appstream metadata
+    install -Dm00644 $pkgfiles/org.TasEmulators.fceux.metainfo.xml -t $installdir/usr/share/metainfo

--- a/packages/f/fceux/pspec_x86_64.xml
+++ b/packages/f/fceux/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>fceux</Name>
         <Homepage>https://fceux.com</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>games.emulator</PartOf>
@@ -117,16 +117,17 @@
             <Path fileType="data">/usr/share/fceux/tools/taseditor_patterns.txt</Path>
             <Path fileType="man">/usr/share/man/man6/fceux-net-server.6</Path>
             <Path fileType="man">/usr/share/man/man6/fceux.6</Path>
+            <Path fileType="data">/usr/share/metainfo/org.TasEmulators.fceux.metainfo.xml</Path>
             <Path fileType="data">/usr/share/pixmaps/fceux.png</Path>
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2024-01-20</Date>
+        <Update release="16">
+            <Date>2024-01-25</Date>
             <Version>2.6.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Added appstream metadata (Part of getsolus/packages#1389)

**Test Plan**

Verify metadata with `appstream-builder --packages-dir=. --include-failed -v`

**Checklist**

- [x] Package was built and tested against unstable