### PR TITLE
kitty: Update to 0.32.1

### DIFF
--- a/packages/k/kitty/package.yml
+++ b/packages/k/kitty/package.yml
@@ -1,8 +1,8 @@
 name       : kitty
-version    : 0.32.0
-release    : 59
+version    : 0.32.1
+release    : 60
 source     :
-    - https://github.com/kovidgoyal/kitty/releases/download/v0.32.0/kitty-0.32.0.tar.xz : 7881a95c1a43d03b230b6ff817e4b5cfec267bac3dbd6dcbbf6c095d476d776d
+    - https://github.com/kovidgoyal/kitty/releases/download/v0.32.1/kitty-0.32.1.tar.xz : f0c6cd610a3ac62c35a2f2696768232f10af62270042fa36074763d7007e5c6b
 license    : GPL-3.0-only
 component  : system.utils
 homepage   : https://sw.kovidgoyal.net/kitty/

--- a/packages/k/kitty/pspec_x86_64.xml
+++ b/packages/k/kitty/pspec_x86_64.xml
@@ -93,6 +93,14 @@ Kitty is designed from the ground up to support all modern terminal features, su
             <Path fileType="library">/usr/lib/kitty/kittens/icat/__pycache__/main.cpython-310.opt-2.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kittens/icat/__pycache__/main.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kittens/icat/main.py</Path>
+            <Path fileType="library">/usr/lib/kitty/kittens/pager/__init__.py</Path>
+            <Path fileType="library">/usr/lib/kitty/kittens/pager/__pycache__/__init__.cpython-310.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/kitty/kittens/pager/__pycache__/__init__.cpython-310.opt-2.pyc</Path>
+            <Path fileType="library">/usr/lib/kitty/kittens/pager/__pycache__/__init__.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/kitty/kittens/pager/__pycache__/main.cpython-310.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/kitty/kittens/pager/__pycache__/main.cpython-310.opt-2.pyc</Path>
+            <Path fileType="library">/usr/lib/kitty/kittens/pager/__pycache__/main.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/kitty/kittens/pager/main.py</Path>
             <Path fileType="library">/usr/lib/kitty/kittens/panel/__init__.py</Path>
             <Path fileType="library">/usr/lib/kitty/kittens/panel/__pycache__/__init__.cpython-310.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kittens/panel/__pycache__/__init__.cpython-310.opt-2.pyc</Path>
@@ -750,9 +758,9 @@ Kitty is designed from the ground up to support all modern terminal features, su
         </Files>
     </Package>
     <History>
-        <Update release="59">
-            <Date>2024-01-20</Date>
-            <Version>0.32.0</Version>
+        <Update release="60">
+            <Date>2024-01-27</Date>
+            <Version>0.32.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Fix a regression that caused multi-key sequences to not abort when pressing an unknown key
- Fix a regression that caused kitten @ launch --cwd=current to fail over SSH
- Fix a regression that caused kitten @ send-text with a match tab parameter to send text twice to the active window
- Fix a regression that caused overriding of existing multi-key mappings to fail
- Wayland+NVIDIA: Do not request an sRGB output buffer as a bug in Wayland causes kitty to not start
- [changelog](https://sw.kovidgoyal.net/kitty/changelog/#id1)

**Test Plan**
- run cli command; redirect output to pager

**Checklist**
- [X] Package was built and tested against unstable
