### PR TITLE
tailscale: Update to 1.58.2

### DIFF
--- a/packages/t/tailscale/package.yml
+++ b/packages/t/tailscale/package.yml
@@ -1,8 +1,8 @@
 name       : tailscale
-version    : 1.58.0
-release    : 8
+version    : 1.58.2
+release    : 9
 source     :
-    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.58.0.tar.gz : 01d801dbb2df03a4e0c1563786300e8b26bb570b3aba15063943f78f2c26c316
+    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.58.2.tar.gz : 452f355408e4e2179872387a863387e06346fc8a6f9887821f9b8a072c6a5b0a
 homepage   : https://tailscale.com
 license    : BSD-3-Clause
 component  : network.clients

--- a/packages/t/tailscale/pspec_x86_64.xml
+++ b/packages/t/tailscale/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2024-01-20</Date>
-            <Version>1.58.0</Version>
+        <Update release="9">
+            <Date>2024-01-27</Date>
+            <Version>1.58.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- App connectors have improved scheduling and merging of route changes under some conditions
- Fixed crash when performing UPnP portmapping on older routers with no supported portmapping services

**Test Plan**
- tailscale netcheck

**Checklist**
- [X] Package was built and tested against unstable
