### PR TITLE
font-iosevka-ttf: Update to 28.0.6

### DIFF
--- a/packages/f/font-iosevka-ttf/package.yml
+++ b/packages/f/font-iosevka-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : font-iosevka-ttf
-version    : 28.0.5
-release    : 51
+version    : 28.0.6
+release    : 52
 source     :
-    - https://github.com/be5invis/Iosevka/releases/download/v28.0.5/PkgTTF-Iosevka-28.0.5.zip : 8e988d116c6c188bb1ccba295e8e8d456ac95eb60f4e02affd9aaacb9424f542
+    - https://github.com/be5invis/Iosevka/releases/download/v28.0.6/PkgTTF-Iosevka-28.0.6.zip : 7c2da5876ba3b4abba89f0121506f641b99b42c312943bc3b140f67f61bea21a
 homepage   : https://typeof.net/Iosevka
 license    : OFL-1.1
 component  : desktop.font

--- a/packages/f/font-iosevka-ttf/pspec_x86_64.xml
+++ b/packages/f/font-iosevka-ttf/pspec_x86_64.xml
@@ -78,9 +78,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="51">
-            <Date>2024-01-20</Date>
-            <Version>28.0.5</Version>
+        <Update release="52">
+            <Date>2024-01-27</Date>
+            <Version>28.0.6</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Fix application of APLF for several Uiua operators.
- Adjust serif shapes for lowercase italic Yeri glyphs with corner body shape
- Make a (cv26) use single-storey-tailed under slab italic by default
- Make b (cv27) use toothed-motion-serifed under slab italic by default
- Make g (cv32) use single-storey-serifless under slab italic by default
- Make q (cv41) use straight-bottom-serifed under slab italic by default

**Test Plan**
- render text with the font

**Checklist**
- [X] Package was built and tested against unstable
