### PR TITLE
helpers*sh: Add a primitive cvefuzzysearch function

### DIFF
--- a/common/Scripts/helpers.sh
+++ b/common/Scripts/helpers.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 
+# Primitive CVE searching
+function cvefuzzysearch() {
+    if [[ -z "$1" ]]; then
+        echo "usage: cvefuzzysearch <package-name>"
+    else
+        curl -s -X POST https://cpe-guesser.cve-search.org/search -d "{\"query\": [\"$1\"]}" | jq .
+        
+        echo "Verify successful hits by visiting https://cve.circl.lu/search/\$VENDOR/\$PRODUCT"
+        echo "- CPE entries for software applications have the form 'cpe:2.3:a:\$VENDOR:\$PRODUCT'"
+    fi
+}
+
 # Goes to the root directory of the solus packages
 # git repository from anywhere on the filesystem.
 # This function will only work if this script is sourced


### PR DESCRIPTION
This can be useful when looking up the correct CPE $PRODUCT:$VENDOR pair for monitoring.yml purpurses and for manually searching for known CVEs.

This commit only adds a PoC bash script helper.

Example output:
```
$ cvefuzzysearch zlib
[
  [
    109789,
    "cpe:2.3:a:zlib:pigz"
  ],
  [
    111701,
    "cpe:2.3:a:gnu:zlib"
  ],
  [
    117793,
    "cpe:2.3:a:zlib:zlib"
  ]
]
Verify successful hits by visiting https://cve.circl.lu/search/$VENDOR/$PRODUCT
- CPE entries for software applications have the form 'cpe:2.3:a:$VENDOR:$PRODUCT'
```