### PR TITLE
helpers*sh: Update/add cpesearch for bash/fish/zsh

### DIFF
--- a/common/Scripts/helpers.fish
+++ b/common/Scripts/helpers.fish
@@ -7,6 +7,17 @@ function __solus_toplevel
     git rev-parse --show-toplevel
 end
 
+function cpesearch -d "Search for known CPE entries for a program or library"
+    if test "$argv[1]" = "--help"; or test "$argv[1]" = "-h"; or test (count $argv) -ne 1
+        echo "usage: cpesearch <package-name>"
+    else
+        curl -s -X POST https://cpe-guesser.cve-search.org/search -d "{\"query\": [\"$argv[1]\"]}" | jq .
+        
+        echo "Verify successful hits by visiting https://cve.circl.lu/search/\$VENDOR/\$PRODUCT"
+        echo "- CPE entries for software applications have the form 'cpe:2.3:a:\$VENDOR:\$PRODUCT"        
+    end
+end
+
 function gotosoluspkgs -d "Go to the root of the Solus packages repository"
     cd (__solus_package_dir)
 end

--- a/common/Scripts/helpers.sh
+++ b/common/Scripts/helpers.sh
@@ -2,7 +2,7 @@
 
 # Primitive CPE search tool
 function cpesearch() {
-    if [[ -z "$1" ]]; then
+    if [[ -z "$1" || "$1" == "--help" || "$1" == "-h" ]]; then
         echo "usage: cpesearch <package-name>"
     else
         curl -s -X POST https://cpe-guesser.cve-search.org/search -d "{\"query\": [\"$1\"]}" | jq .

--- a/common/Scripts/helpers.zsh
+++ b/common/Scripts/helpers.zsh
@@ -3,6 +3,19 @@
 autoload -U +X compinit && compinit
 autoload -U +X bashcompinit && bashcompinit
 
+# Primitive CPE search tool
+function cpesearch() {
+    if [[ -z $1 || $1 == "--help" || $1 == "-h" ]]; then
+        echo "usage: cpesearch <package-name>"
+    else
+        curl -s -X POST https://cpe-guesser.cve-search.org/search -d "{\"query\": [\"$1\"]}" | jq .
+        
+        echo "Verify successful hits by visiting https://cve.circl.lu/search/\$VENDOR/\$PRODUCT"
+        echo "- CPE entries for software applications have the form 'cpe:2.3:a:\$VENDOR:\$PRODUCT'"
+    fi
+}
+
+
 # Goes to the root directory of the solus packages
 # git repository from anywhere on the filesystem.
 # This function will only work if this script is sourced


### PR DESCRIPTION
Now supports showing usage if '-h' and '--help' are supplied as arguments