### PR TITLE
eopkg4-bin: Move out of system.base

### DIFF
--- a/packages/e/eopkg4-bin/package.yml
+++ b/packages/e/eopkg4-bin/package.yml
@@ -1,12 +1,12 @@
 name       : eopkg4-bin
 version    : 4.0.0
-release    : 1
+release    : 2
 source     :
     - git|https://github.com/getsolus/eopkg : 0bcb2e75ea1f5deaf40a3a3bb4f1665461931f32
     - git|https://github.com/getsolus/PackageKit.git : f53ab2959e13b55ba3f973988063bbac33e90b99
 homepage   : https://github.com/getsolus/eopkg
 license    : GPL-2.0-or-later
-component  : system.base
+component  : system.utils
 summary    : "Python3 port of eopkg/pisi. WARNING: For testing only."
 description: |
     Python3 port of eopkg/pisi, compiled with Nuitka. WARNING: this is for testing only and may break your system!

--- a/packages/e/eopkg4-bin/pspec_x86_64.xml
+++ b/packages/e/eopkg4-bin/pspec_x86_64.xml
@@ -7,7 +7,7 @@
             <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
-        <PartOf>system.base</PartOf>
+        <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">Python3 port of eopkg/pisi. WARNING: For testing only.</Summary>
         <Description xml:lang="en">Python3 port of eopkg/pisi, compiled with Nuitka. WARNING: this is for testing only and may break your system!
 </Description>
@@ -18,15 +18,15 @@
         <Summary xml:lang="en">Python3 port of eopkg/pisi. WARNING: For testing only.</Summary>
         <Description xml:lang="en">Python3 port of eopkg/pisi, compiled with Nuitka. WARNING: this is for testing only and may break your system!
 </Description>
-        <PartOf>system.base</PartOf>
+        <PartOf>system.utils</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/eopkg4-bin</Path>
             <Path fileType="data">/usr/share/PackageKit/helpers/eopkg/eopkgBackend.bin</Path>
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-01-28</Date>
+        <Update release="2">
+            <Date>2024-02-01</Date>
             <Version>4.0.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Hans K</Name>


### PR DESCRIPTION
**Summary**
This moves eopkg4-bin out of system.base. It'll belong there once it's ready for primetime.

**Summary**
eopkg4-bin doesn't belong in system.base yet. We don't want it getting installed for everyone until we're ready!
<!-- Info on what this pull request updates/changes/etc -->

**Test Plan**
Built. Still works. No changes to the package other than component and relnum.
<!-- Short description of how the package was tested -->

**Checklist**

- [x] Package was built and tested against unstable
