### PR TITLE
Update snapd to 2.61.1

### DIFF
--- a/packages/s/snapd/abi_used_symbols
+++ b/packages/s/snapd/abi_used_symbols
@@ -6,6 +6,7 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
 libc.so.6:__getdelim
+libc.so.6:__isoc23_strtol
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
@@ -167,7 +168,6 @@ libc.so.6:strrchr
 libc.so.6:strsep
 libc.so.6:strstr
 libc.so.6:strtok_r
-libc.so.6:strtol
 libc.so.6:strtoul
 libc.so.6:symlink
 libc.so.6:syscall

--- a/packages/s/snapd/package.yml
+++ b/packages/s/snapd/package.yml
@@ -1,9 +1,9 @@
 name       : snapd
-version    : 2.60.3
+version    : 2.61.1
 homepage   : https://snapcraft.io/
-release    : 77
+release    : 78
 source     :
-    - https://github.com/snapcore/snapd/releases/download/2.60.3/snapd_2.60.3.vendor.tar.xz : c65d6a23288195864ac11997475234b8c15a5e14849f3ab309ccba4832675bc4
+    - https://github.com/snapcore/snapd/releases/download/2.61.1/snapd_2.61.1.vendor.tar.xz : 775b7a250f5241b3bfcebcb3df5055b9c9304c4520502b7abf12438a1cdd771d
 license    : GPL-3.0-only
 component  : desktop
 summary    : The snapd and snap tools enable systems to work with .snap files
@@ -13,9 +13,10 @@ networking : yes
 builddeps  :
     - pkgconfig(glib-2.0)
     - pkgconfig(libapparmor)
+    - pkgconfig(libcap)
     - pkgconfig(libseccomp)
     - pkgconfig(libudev)
-    - pkgconfig(libcap)
+    - autoconf-archive
     - golang
     - python-docutils
     - xfsprogs-devel

--- a/packages/s/snapd/pspec_x86_64.xml
+++ b/packages/s/snapd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>snapd</Name>
         <Homepage>https://snapcraft.io/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Zygmunt Krynicki</Name>
+            <Email>me@zygoon.pl</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <PartOf>desktop</PartOf>
@@ -79,12 +79,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="77">
-            <Date>2023-10-04</Date>
-            <Version>2.60.3</Version>
+        <Update release="78">
+            <Date>2024-02-01</Date>
+            <Version>2.61.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Zygmunt Krynicki</Name>
+            <Email>me@zygoon.pl</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Update snapd to 2.61.1

- Stop requiring default provider snaps on image building and first  boot if alternative providers are included and available
- Fix auth.json access for login as non-root group ID
- Fix incorrect remodelling conflict when changing track to older snapd version
- Improved check-rerefresh message
- Fix UC16/18 kernel/gadget update failure due volume mismatch with installed disk
- Stop auto-import of assertions during install modes
- Desktop interface exposes GetIdletime
- Polkit interface support for new polkit versions
- Fix not applying snapd snap changes in tracked channel when remodelling

**Test Plan**

I've tested this on a virtual machine running unstable.
I've installed and played with the snaps "ohmygiraffe" and "okular".

**Checklist**

- [x] Package was built and tested against unstable
