### PR TITLE
Add section to issue templates for searching existing issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,7 +7,7 @@ body:
   - type: checkboxes
     id: search
     attributes:
-      label: Confirm
+      label: Please confirm there isn't an existing open bug report
       description: Before opening a new issue, please search [the open bugs](https://github.com/getsolus/packages/issues?q=is%3Aissue+is%3Aopen+label%3ABug) to ensure there is not already an open issue for the problem.
       options:
         - label: I have searched open bugs for this issue

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -4,6 +4,14 @@ description: Report problems, defects and bugs with Solus, the installer, or sof
 labels:
   - Bug
 body:
+  - type: checkboxes
+    id: search
+    attributes:
+      label: Confirm
+      description: Before opening a new issue, please search [the open bugs](https://github.com/getsolus/packages/issues?q=is%3Aissue+is%3Aopen+label%3ABug) to ensure there is not already an open issue for the problem.
+      options:
+        - label: I have searched open bugs for this issue
+          required: true
   - type: textarea
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/request-new-package.yml
+++ b/.github/ISSUE_TEMPLATE/request-new-package.yml
@@ -3,6 +3,14 @@ description: Request a package that isn't in the Solus repository yet.
 labels: ["Package Request", "Priority: Wishlist"]
 title: "What's the package name?"
 body:
+    - type: checkboxes
+      id: search
+      attributes:
+        label: Please confirm there isn't an existing package request
+        description: Before opening a new package request, please search [existing package requests](https://github.com/getsolus/packages/labels/Package%20Request) to ensure there is not an existing one.
+        options:
+          - label: I have searched through package requests
+            required: true
     - type: input
       id: homepage
       attributes:

--- a/.github/ISSUE_TEMPLATE/request-package-update.yml
+++ b/.github/ISSUE_TEMPLATE/request-package-update.yml
@@ -4,6 +4,14 @@ description: Request an update to a package available in the repository.
 labels:
   - Package Update Request
 body:
+  - type: checkboxes
+    id: search
+    attributes:
+      label: Please confirm there isn't already an existing package update request
+      description: Before opening a new package update request, please search [existing package update requests](https://github.com/getsolus/packages/labels/Package%20Update%20Request) to ensure there is not an existing one.
+      options:
+        - label: I have searched through package update requests
+          required: true
   - type: input
     id: name
     attributes:


### PR DESCRIPTION
**Summary**

Add text asking the user to search existing issues before filing a new one, for each template. Also add a link to the appropriate search.

**Test Plan**

Visually verified that the text looks good, and that links open the appropriate search.

**Checklist**

- [ ] Package was built and tested against unstable - N/A
