### PR TITLE
geonkick: Update to 3.3.2

### DIFF
--- a/packages/g/geonkick/abi_symbols
+++ b/packages/g/geonkick/abi_symbols
@@ -56,6 +56,7 @@ geonkick_lv2.so:geonkick_get_sample_rate
 geonkick_lv2.so:geonkick_group_enabled
 geonkick_lv2.so:geonkick_group_get_amplitude
 geonkick_lv2.so:geonkick_group_set_amplitude
+geonkick_lv2.so:geonkick_instruments_number
 geonkick_lv2.so:geonkick_is_audio_output_tuned
 geonkick_lv2.so:geonkick_is_module_enabed
 geonkick_lv2.so:geonkick_is_oscillator_enabled
@@ -92,7 +93,6 @@ geonkick_lv2.so:geonkick_percussion_get_limiter
 geonkick_lv2.so:geonkick_percussion_is_muted
 geonkick_lv2.so:geonkick_percussion_is_solo
 geonkick_lv2.so:geonkick_percussion_mute
-geonkick_lv2.so:geonkick_percussion_number
 geonkick_lv2.so:geonkick_percussion_set_limiter
 geonkick_lv2.so:geonkick_percussion_solo
 geonkick_lv2.so:geonkick_play
@@ -627,6 +627,7 @@ geonkick_single_lv2.so:geonkick_get_sample_rate
 geonkick_single_lv2.so:geonkick_group_enabled
 geonkick_single_lv2.so:geonkick_group_get_amplitude
 geonkick_single_lv2.so:geonkick_group_set_amplitude
+geonkick_single_lv2.so:geonkick_instruments_number
 geonkick_single_lv2.so:geonkick_is_audio_output_tuned
 geonkick_single_lv2.so:geonkick_is_module_enabed
 geonkick_single_lv2.so:geonkick_is_oscillator_enabled
@@ -663,7 +664,6 @@ geonkick_single_lv2.so:geonkick_percussion_get_limiter
 geonkick_single_lv2.so:geonkick_percussion_is_muted
 geonkick_single_lv2.so:geonkick_percussion_is_solo
 geonkick_single_lv2.so:geonkick_percussion_mute
-geonkick_single_lv2.so:geonkick_percussion_number
 geonkick_single_lv2.so:geonkick_percussion_set_limiter
 geonkick_single_lv2.so:geonkick_percussion_solo
 geonkick_single_lv2.so:geonkick_play

--- a/packages/g/geonkick/files/org.geonkick.geonkick.metainfo.xml
+++ b/packages/g/geonkick/files/org.geonkick.geonkick.metainfo.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.geonkick.geonkick</id>
+
+  <name>Geonkick</name>
+  <summary>A free software percussive synthesizer</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+
+  <description>
+    <p>
+      Geonkick is a free software synthesizer capable of generating a wide range of percussive sounds, including kicks, snares, claps, hi-hats, shakers, and also unique effect sounds.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">geonkick.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://geonkick.org/screenshot.png</image>
+    </screenshot>
+  </screenshots>
+</component>

--- a/packages/g/geonkick/package.yml
+++ b/packages/g/geonkick/package.yml
@@ -1,8 +1,8 @@
 name       : geonkick
-version    : 3.3.0
-release    : 16
+version    : 3.3.2
+release    : 17
 source     :
-    - https://github.com/Geonkick-Synthesizer/geonkick/archive/refs/tags/v3.3.0.tar.gz : 9e0ca9d5dc816dbfd9757d8ff19fceb6a2255de0ee0ab066693ec98f28e6b4ad
+    - https://github.com/Geonkick-Synthesizer/geonkick/archive/refs/tags/v3.3.2.tar.gz : 5eead121337c20bce56fd14d7ede177e6533eac9d5987fe9a08bf388315a6ab1
 homepage   : https://geonkick.org/
 license    : GPL-3.0-or-later
 component  : multimedia.audio
@@ -23,6 +23,7 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
-
+    # Install appstream metadata
+    install -Dm00644 $pkgfiles/org.geonkick.geonkick.metainfo.xml -t $installdir/usr/share/metainfo
     # Install config file to allow access to memory lock
     install -Dm00644 $pkgfiles/10-geonkick.conf -t $installdir/usr/share/defaults/etc/security/limits.d/

--- a/packages/g/geonkick/pspec_x86_64.xml
+++ b/packages/g/geonkick/pspec_x86_64.xml
@@ -106,13 +106,14 @@
             <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/geonkick.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/geonkick.svg</Path>
             <Path fileType="man">/usr/share/man/man1/geonkick.1</Path>
+            <Path fileType="data">/usr/share/metainfo/org.geonkick.geonkick.metainfo.xml</Path>
             <Path fileType="data">/usr/share/mime/packages/geonkick.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2024-01-19</Date>
-            <Version>3.3.0</Version>
+        <Update release="17">
+            <Date>2024-02-02</Date>
+            <Version>3.3.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
             <Email>malfisya.dev@hotmail.com</Email>


### PR DESCRIPTION
**Summary**

- Changelog:
   - 3.3.2 : 
       - Fix high CPU usage by DSP 
       - Fix limiter for the audition channel, use a separate audition channel for samples preview 
       - Fix instrument leveler value 
   - 3.3.1 : 
       - Fix out of bound index in KitModel 
       - Fix warning related to clang 
       - Fix not running Geonkick standalone if can't lock memory 

**Test Plan**

Run application and make noise

**Checklist**

- [x] Package was built and tested against unstable