### PR TITLE
gajim: Add missing rundep

### DIFF
--- a/packages/g/gajim/package.yml
+++ b/packages/g/gajim/package.yml
@@ -1,6 +1,6 @@
 name       : gajim
 version    : 1.8.4
-release    : 23
+release    : 24
 source     :
     - https://gajim.org/downloads/1.8/gajim-1.8.4.tar.gz : 58fced87b1ce01b3d5269bcdf33499246533b01b4008d9701eb1e10cf94e49c5
 homepage   : https://gajim.org
@@ -19,6 +19,7 @@ rundeps    :
     - gstreamer-1.0-libav        # Audio/Video.
     - gstreamer-1.0-plugins-ugly # Audio/Video.
     - libgtk-3
+    - libgtksourceview4
     - python-css-parser
     - python-gssapi
     - python-keyring

--- a/packages/g/gajim/pspec_x86_64.xml
+++ b/packages/g/gajim/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gajim</Name>
         <Homepage>https://gajim.org</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Nazar Stasiv</Name>
+            <Email>nazar@autistici.org</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.im</PartOf>
@@ -1138,12 +1138,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2023-12-12</Date>
+        <Update release="24">
+            <Date>2024-01-31</Date>
             <Version>1.8.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Nazar Stasiv</Name>
+            <Email>nazar@autistici.org</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- With fresh install gajim won't start
- Install libgtksourceview4 as a manual workaround

**Test Plan**
- gajim starts on fresh and updated system

**Checklist**
- [X] Package was built and tested against unstable

