### PR TITLE
bandwhich: Update to 0.22.2

### DIFF
--- a/packages/b/bandwhich/abi_used_symbols
+++ b/packages/b/bandwhich/abi_used_symbols
@@ -35,6 +35,7 @@ libc.so.6:getenv
 libc.so.6:gethostname
 libc.so.6:getifaddrs
 libc.so.6:getpeername
+libc.so.6:getpid
 libc.so.6:getsockname
 libc.so.6:getsockopt
 libc.so.6:getuid
@@ -92,9 +93,11 @@ libc.so.6:realloc
 libc.so.6:realpath
 libc.so.6:recv
 libc.so.6:recvfrom
+libc.so.6:recvmsg
 libc.so.6:sched_getaffinity
 libc.so.6:sched_yield
 libc.so.6:send
+libc.so.6:sendmsg
 libc.so.6:sendto
 libc.so.6:setgid
 libc.so.6:setgroups
@@ -135,3 +138,4 @@ libm.so.6:ceil
 libm.so.6:exp
 libm.so.6:pow
 libm.so.6:round
+libm.so.6:trunc

--- a/packages/b/bandwhich/package.yml
+++ b/packages/b/bandwhich/package.yml
@@ -1,8 +1,8 @@
 name       : bandwhich
-version    : 0.21.1
-release    : 3
+version    : 0.22.2
+release    : 4
 source     :
-    - https://github.com/imsnif/bandwhich/archive/refs/tags/v0.21.1.tar.gz : 8ba9bf6469834ad498b9fd17f86759a16793b00a6ef44edd6e525ec40adcb0b0
+    - https://github.com/imsnif/bandwhich/archive/refs/tags/v0.22.2.tar.gz : 4c41719549e05dbaac1bc84828269e59b2f2032e76ae646da9b9e3b87e5a5fd1
 homepage   : https://github.com/imsnif/bandwhich
 license    : MIT
 component  : system.utils
@@ -10,6 +10,8 @@ summary    : Terminal bandwidth utilization tool
 description: |
     This is a CLI utility for displaying current network utilization by process, connection and remote IP/hostname
 networking : yes
+environment: |
+    export BANDWHICH_GEN_DIR=$workdir
 builddeps  :
     - cargo
 build      : |
@@ -17,4 +19,4 @@ build      : |
     cargo build --release    
 install    : |
     install -Dm00755 target/release/bandwhich $installdir/usr/bin/bandwhich
-    install -Dm00644 docs/bandwhich.1 -t $installdir/usr/share/man/man1/
+    install -Dm00644 bandwhich.1 -t $installdir/usr/share/man/man1/

--- a/packages/b/bandwhich/pspec_x86_64.xml
+++ b/packages/b/bandwhich/pspec_x86_64.xml
@@ -25,9 +25,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2023-10-16</Date>
-            <Version>0.21.1</Version>
+        <Update release="4">
+            <Date>2024-02-03</Date>
+            <Version>0.22.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Generate completion & manpage
- Log unresolved processes in more detail + general refactor
- Display bandwidth in different unit families
- Show interface names
- Table formatting logic overhaul
- Make logging race-free using a global lock & macro
- Use once_cell::sync::Lazy to make regex usage more ergonomic
- Fix vague CLI option documentation

**Test Plan**
- watch IP connections on network interface

**Checklist**
- [X] Package was built and tested against unstable
