### PR TITLE
font-iosevka-ttf: Update to 28.0.7

### DIFF
--- a/packages/f/font-iosevka-ttf/package.yml
+++ b/packages/f/font-iosevka-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : font-iosevka-ttf
-version    : 28.0.6
-release    : 52
+version    : 28.0.7
+release    : 53
 source     :
-    - https://github.com/be5invis/Iosevka/releases/download/v28.0.6/PkgTTF-Iosevka-28.0.6.zip : 7c2da5876ba3b4abba89f0121506f641b99b42c312943bc3b140f67f61bea21a
+    - https://github.com/be5invis/Iosevka/releases/download/v28.0.7/PkgTTF-Iosevka-28.0.7.zip : 2bd1753c9d019a4a47182dd36dae19b8e8c5b326c2adad4c7fb18959d14114e1
 homepage   : https://typeof.net/Iosevka
 license    : OFL-1.1
 component  : desktop.font

--- a/packages/f/font-iosevka-ttf/pspec_x86_64.xml
+++ b/packages/f/font-iosevka-ttf/pspec_x86_64.xml
@@ -78,9 +78,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="52">
-            <Date>2024-01-27</Date>
-            <Version>28.0.6</Version>
+        <Update release="53">
+            <Date>2024-02-02</Date>
+            <Version>28.0.7</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Make superscript/subscript/overscript Cyrillic characters obey localization forms of base letters
- Add IPA localization forms for Greek Lower Beta (β) and Chi (χ)
- Add APLF variants for U+25F0, U+25F3, and U+25F4.
- Make Ezh follow variants of Z/z
- Fix serif form for Cyrillic Lower Tall / Iotified Yat
- Make top serifs of Cyrillic Lower Straight U (ү, ұ) and Latin Lower Gamma (ɣ) respond to italics.
- Fix leaning marks of Capital Turned/Half H (U+2C75, U+2C76, U+A78D, U+A7F5, U+A7F6).
- Fix leaning marks of Wynn (U+01BF, U+01F7)
- Fix leaning marks of Insular R (U+A782, U+A783)
- Fix leaning marks of Greek/Latin Beta (U+03B2, U+A7B4, U+A7B5)
- Fix leaning marks of Greek Lower San (U+03FB)

**Test Plan**
- render text with the font

**Checklist**
- [X] Package was built and tested against unstable
