### PR TITLE
scrcpy: update to 2.3.1

### DIFF
--- a/packages/s/scrcpy/abi_used_symbols
+++ b/packages/s/scrcpy/abi_used_symbols
@@ -77,6 +77,7 @@ libavcodec.so.60:av_packet_alloc
 libavcodec.so.60:av_packet_free
 libavcodec.so.60:av_packet_ref
 libavcodec.so.60:av_packet_rescale_ts
+libavcodec.so.60:av_packet_side_data_new
 libavcodec.so.60:av_packet_unref
 libavcodec.so.60:avcodec_alloc_context3
 libavcodec.so.60:avcodec_close
@@ -110,6 +111,7 @@ libavformat.so.60:avformat_write_header
 libavformat.so.60:avio_close
 libavformat.so.60:avio_open
 libavutil.so.58:av_dict_set
+libavutil.so.58:av_display_rotation_set
 libavutil.so.58:av_frame_alloc
 libavutil.so.58:av_frame_free
 libavutil.so.58:av_frame_move_ref
@@ -136,7 +138,6 @@ libc.so.6:__memcpy_chk
 libc.so.6:__memmove_chk
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
-libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:_exit
 libc.so.6:abort
@@ -151,6 +152,7 @@ libc.so.6:execvp
 libc.so.6:fcntl64
 libc.so.6:fork
 libc.so.6:free
+libc.so.6:getc
 libc.so.6:getenv
 libc.so.6:getopt_long
 libc.so.6:inet_pton
@@ -180,6 +182,7 @@ libc.so.6:sigprocmask
 libc.so.6:socket
 libc.so.6:stat64
 libc.so.6:stderr
+libc.so.6:stdin
 libc.so.6:stdout
 libc.so.6:strchr
 libc.so.6:strcmp

--- a/packages/s/scrcpy/package.yml
+++ b/packages/s/scrcpy/package.yml
@@ -1,9 +1,9 @@
 name       : scrcpy
-version    : 2.1.1
-release    : 24
+version    : 2.3.1
+release    : 25
 source     :
-    - https://github.com/Genymobile/scrcpy/archive/v2.1.1.tar.gz : 6f3d055159cb125eabe940a901bef8a69e14e2c25f0e47554f846e7f26a36c4d
-    - https://github.com/Genymobile/scrcpy/releases/download/v2.1.1/scrcpy-server-v2.1.1 : 9558db6c56743a1dc03b38f59801fb40e91cc891f8fc0c89e5b0b067761f148e
+    - https://github.com/Genymobile/scrcpy/archive/v2.3.1.tar.gz : 76f38779f00d91d0b46a399ebca32c82ff1facdbd843871b7e46c2e7cad38a42
+    - https://github.com/Genymobile/scrcpy/releases/download/v2.3.1/scrcpy-server-v2.3.1 : f6814822fc308a7a532f253485c9038183c6296a6c5df470a9e383b4f8e7605b
 homepage   : https://github.com/Genymobile/scrcpy
 license    : Apache-2.0
 component  : network.util

--- a/packages/s/scrcpy/pspec_x86_64.xml
+++ b/packages/s/scrcpy/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>scrcpy</Name>
         <Homepage>https://github.com/Genymobile/scrcpy</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>network.util</PartOf>
@@ -31,12 +31,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2024-01-20</Date>
-            <Version>2.1.1</Version>
+        <Update release="25">
+            <Date>2024-01-30</Date>
+            <Version>2.3.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Highlighted changes:
- Camera capture option
- Android 14 support
- Orientation option

Full release notes:
- [2.2](https://github.com/Genymobile/scrcpy/releases/tag/v2.2)
- [2.3](https://github.com/Genymobile/scrcpy/releases/tag/v2.3)
- [2.3.1](https://github.com/Genymobile/scrcpy/releases/tag/v2.3.1)

**Test Plan**

Mirrored my phone screen to my PC; used it with mouse and keyboard

**Checklist**

- [x] Package was built and tested against unstable
