### PR TITLE
transmission: Update to 4.0.5

### DIFF
--- a/packages/t/transmission/abi_used_symbols
+++ b/packages/t/transmission/abi_used_symbols
@@ -55,6 +55,9 @@ libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoll
+libc.so.6:__isoc23_strtoul
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_single_threaded
 libc.so.6:__libc_start_main
@@ -211,7 +214,6 @@ libc.so.6:strstr
 libc.so.6:strtod
 libc.so.6:strtof
 libc.so.6:strtol
-libc.so.6:strtoll
 libc.so.6:strtoul
 libc.so.6:strtoull
 libc.so.6:textdomain
@@ -442,6 +444,7 @@ libgiomm-2.4.so.1:_ZNK3Gio11ActionGroup27get_action_state_hint_vfuncERKN4Glib7us
 libgiomm-2.4.so.1:_ZNK3Gio11ActionGroup27get_action_state_type_vfuncERKN4Glib7ustringE
 libgiomm-2.4.so.1:_ZNK3Gio11ActionGroup31get_action_parameter_type_vfuncERKN4Glib7ustringE
 libgiomm-2.4.so.1:_ZNK3Gio4DBus13InterfaceInfo11unreferenceEv
+libgiomm-2.4.so.1:_ZNK3Gio4File10get_parentEv
 libgiomm-2.4.so.1:_ZNK3Gio4File10query_infoERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENS_18FileQueryInfoFlagsE
 libgiomm-2.4.so.1:_ZNK3Gio4File14get_parse_nameEv
 libgiomm-2.4.so.1:_ZNK3Gio4File5equalERKN4Glib6RefPtrIKS0_EE
@@ -1252,7 +1255,6 @@ libstdc++.so.6:_ZNKSt6localeeqERKS_
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE16find_last_not_ofEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE17find_first_not_ofEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEPKcmm
-libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7compareEPKc
 libstdc++.so.6:_ZNKSt8__detail20_Prime_rehash_policy14_M_need_rehashEmmm
 libstdc++.so.6:_ZNKSt9exception4whatEv
 libstdc++.so.6:_ZNSdD2Ev
@@ -1339,16 +1341,16 @@ libstdc++.so.6:_ZNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE7_M_syncE
 libstdc++.so.6:_ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEED1Ev
+libstdc++.so.6:_ZNSt7__cxx118numpunctIcE2idE
 libstdc++.so.6:_ZNSt7codecvtIDic11__mbstate_tE2idE
 libstdc++.so.6:_ZNSt8__detail15_List_node_base11_M_transferEPS0_S1_
 libstdc++.so.6:_ZNSt8__detail15_List_node_base4swapERS0_S1_
 libstdc++.so.6:_ZNSt8__detail15_List_node_base7_M_hookEPS0_
 libstdc++.so.6:_ZNSt8__detail15_List_node_base9_M_unhookEv
 libstdc++.so.6:_ZNSt8bad_castD1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitC1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitD1Ev
 libstdc++.so.6:_ZNSt8ios_baseC2Ev
 libstdc++.so.6:_ZNSt8ios_baseD2Ev
+libstdc++.so.6:_ZNSt8time_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE2idE
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE4initEPSt15basic_streambufIcS1_E
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE5clearESt12_Ios_Iostate
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE5imbueERKSt6locale
@@ -1371,6 +1373,7 @@ libstdc++.so.6:_ZSt20__throw_future_errori
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt20__throw_out_of_rangePKc
 libstdc++.so.6:_ZSt20__throw_system_errori
+libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZSt24__throw_invalid_argumentPKc
 libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
 libstdc++.so.6:_ZSt25__throw_bad_function_callv
@@ -1381,12 +1384,9 @@ libstdc++.so.6:_ZSt4cerr
 libstdc++.so.6:_ZSt4cout
 libstdc++.so.6:_ZSt7getlineIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EES4_
 libstdc++.so.6:_ZSt9terminatev
-libstdc++.so.6:_ZSt9use_facetINSt7__cxx118numpunctIcEEERKT_RKSt6locale
-libstdc++.so.6:_ZSt9use_facetISt8time_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEEERKT_RKSt6locale
 libstdc++.so.6:_ZStrsIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EE
 libstdc++.so.6:_ZTIN10__cxxabiv115__forced_unwindE
 libstdc++.so.6:_ZTINSt13__future_base12_Result_baseE
-libstdc++.so.6:_ZTINSt6locale5facetE
 libstdc++.so.6:_ZTINSt6thread6_StateE
 libstdc++.so.6:_ZTINSt8ios_base7failureB5cxx11E
 libstdc++.so.6:_ZTISt12bad_weak_ptr
@@ -1394,7 +1394,6 @@ libstdc++.so.6:_ZTISt12future_error
 libstdc++.so.6:_ZTISt12system_error
 libstdc++.so.6:_ZTISt13runtime_error
 libstdc++.so.6:_ZTISt15basic_streambufIcSt11char_traitsIcEE
-libstdc++.so.6:_ZTISt7codecvtIDic11__mbstate_tE
 libstdc++.so.6:_ZTISt8bad_cast
 libstdc++.so.6:_ZTISt9exception
 libstdc++.so.6:_ZTTNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEEE
@@ -1427,7 +1426,6 @@ libstdc++.so.6:_ZdlPvm
 libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
 libstdc++.so.6:__cxa_allocate_exception
-libstdc++.so.6:__cxa_bad_cast
 libstdc++.so.6:__cxa_begin_catch
 libstdc++.so.6:__cxa_end_catch
 libstdc++.so.6:__cxa_guard_abort

--- a/packages/t/transmission/package.yml
+++ b/packages/t/transmission/package.yml
@@ -1,8 +1,8 @@
 name       : transmission
-version    : 4.0.4
-release    : 24
+version    : 4.0.5
+release    : 25
 source     :
-    - https://github.com/transmission/transmission/releases/download/4.0.4/transmission-4.0.4.tar.xz : 15f7b4318fdfbffb19aa8d9a6b0fd89348e6ef1e86baa21a0806ffd1893bd5a6
+    - https://github.com/transmission/transmission/releases/download/4.0.5/transmission-4.0.5.tar.xz : fd68ff114a479200043c30c7e69dba4c1932f7af36ca4c5b5d2edcb5866e6357
 homepage   : https://transmissionbt.com/
 license    : GPL-2.0-or-later
 component  : network.download

--- a/packages/t/transmission/pspec_x86_64.xml
+++ b/packages/t/transmission/pspec_x86_64.xml
@@ -11,7 +11,7 @@
         <Summary xml:lang="en">Lightweight BitTorrent client</Summary>
         <Description xml:lang="en">Transmission provides a simple and easy to use cross-platform lightweight BitTorrent client
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>transmission</Name>
@@ -133,14 +133,15 @@
             <Path fileType="data">/usr/share/transmission/public_html/images/favicon.png</Path>
             <Path fileType="data">/usr/share/transmission/public_html/images/webclip-icon.png</Path>
             <Path fileType="data">/usr/share/transmission/public_html/index.html</Path>
+            <Path fileType="data">/usr/share/transmission/public_html/transmission-app.css</Path>
             <Path fileType="data">/usr/share/transmission/public_html/transmission-app.js</Path>
-            <Path fileType="data">/usr/share/transmission/public_html/transmission-app.js.LICENSE.txt</Path>
+            <Path fileType="data">/usr/share/transmission/public_html/transmission-app.js.LEGAL.txt</Path>
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2023-09-17</Date>
-            <Version>4.0.4</Version>
+        <Update release="25">
+            <Date>2024-02-03</Date>
+            <Version>4.0.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Highlighted changes:
- Fixed `4.0.0` bug where the IP address field in UDP announces were not encoded in network byte order
- Fixed a bug that incorrectly escaped JSON strings in some locales.
- Fixed `4.0.4` decreased download speeds for people who set a low upload bandwidth limit.

Full release notes available [here](https://github.com/transmission/transmission/releases/tag/4.0.5)

**Test Plan**

- Added, downloaded, and seeded a torrent

**Checklist**

- [x] Package was built and tested against unstable
