### PR TITLE
python-toolz: Update to 0.12.1

### DIFF
--- a/packages/py/python-toolz/package.yml
+++ b/packages/py/python-toolz/package.yml
@@ -1,8 +1,8 @@
 name       : python-toolz
-version    : 0.12.0
-release    : 1
+version    : 0.12.1
+release    : 2
 source     :
-    - https://files.pythonhosted.org/packages/source/t/toolz/toolz-0.12.0.tar.gz : 88c570861c440ee3f2f6037c4654613228ff40c93a6c25e0eba70d17282c6194
+    - https://files.pythonhosted.org/packages/source/t/toolz/toolz-0.12.1.tar.gz : ecca342664893f177a13dac0e6b41cbd8ac25a358e5f215316d43e2100224f4d
 license    : BSD-3-Clause
 homepage   : https://github.com/pytoolz/toolz/
 component  : programming.python

--- a/packages/py/python-toolz/pspec_x86_64.xml
+++ b/packages/py/python-toolz/pspec_x86_64.xml
@@ -11,7 +11,7 @@
         <Summary xml:lang="en">A functional standard library for Python</Summary>
         <Description xml:lang="en">A set of utility functions for iterators, functions, and dictionaries for Python
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>python-toolz</Name>
@@ -24,11 +24,11 @@
             <Path fileType="library">/usr/lib/python3.10/site-packages/tlz/__pycache__/__init__.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/tlz/__pycache__/_build_tlz.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/tlz/_build_tlz.py</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/toolz-0.12.0-py3.10.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/toolz-0.12.0-py3.10.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/toolz-0.12.0-py3.10.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/toolz-0.12.0-py3.10.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/toolz-0.12.0-py3.10.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/toolz-0.12.1-py3.10.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/toolz-0.12.1-py3.10.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/toolz-0.12.1-py3.10.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/toolz-0.12.1-py3.10.egg-info/not-zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/toolz-0.12.1-py3.10.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/toolz/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/toolz/__pycache__/__init__.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/toolz/__pycache__/_signatures.cpython-310.pyc</Path>
@@ -86,9 +86,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2023-05-16</Date>
-            <Version>0.12.0</Version>
+        <Update release="2">
+            <Date>2024-02-04</Date>
+            <Version>0.12.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Add support for Python 3.12 and PyPy 3.10
- Drop support for Python 3.5 and 3.6
- Fix typos
- Use codecov for coverage instead of coveralls

**Test Plan**

Tested a couple of examples from the documentation

**Checklist**

- [x] Package was built and tested against unstable
