### PR TITLE
mupen64plus: Update core and plugins to latest git sources

### DIFF
--- a/packages/m/mupen64plus/abi_symbols
+++ b/packages/m/mupen64plus/abi_symbols
@@ -69,6 +69,7 @@ libmupen64plus.so.2:VidExt_GL_GetProcAddress
 libmupen64plus.so.2:VidExt_GL_SetAttribute
 libmupen64plus.so.2:VidExt_GL_SwapBuffers
 libmupen64plus.so.2:VidExt_Init
+libmupen64plus.so.2:VidExt_InitWithRenderMode
 libmupen64plus.so.2:VidExt_ListFullscreenModes
 libmupen64plus.so.2:VidExt_ListFullscreenRates
 libmupen64plus.so.2:VidExt_Quit
@@ -77,6 +78,8 @@ libmupen64plus.so.2:VidExt_SetCaption
 libmupen64plus.so.2:VidExt_SetVideoMode
 libmupen64plus.so.2:VidExt_SetVideoModeWithRate
 libmupen64plus.so.2:VidExt_ToggleFullScreen
+libmupen64plus.so.2:VidExt_VK_GetInstanceExtensions
+libmupen64plus.so.2:VidExt_VK_GetSurface
 mupen64plus:main
 mupen64plus-audio-sdl.so:AiDacrateChanged
 mupen64plus-audio-sdl.so:AiLenChanged

--- a/packages/m/mupen64plus/abi_used_symbols
+++ b/packages/m/mupen64plus/abi_used_symbols
@@ -175,12 +175,6 @@ libSDL2-2.0.so.0:SDL_GetTicks
 libSDL2-2.0.so.0:SDL_GetWindowFlags
 libSDL2-2.0.so.0:SDL_GetWindowPosition
 libSDL2-2.0.so.0:SDL_GetWindowSize
-libSDL2-2.0.so.0:SDL_HapticClose
-libSDL2-2.0.so.0:SDL_HapticOpenFromJoystick
-libSDL2-2.0.so.0:SDL_HapticRumbleInit
-libSDL2-2.0.so.0:SDL_HapticRumblePlay
-libSDL2-2.0.so.0:SDL_HapticRumbleStop
-libSDL2-2.0.so.0:SDL_HapticRumbleSupported
 libSDL2-2.0.so.0:SDL_Init
 libSDL2-2.0.so.0:SDL_InitSubSystem
 libSDL2-2.0.so.0:SDL_JoystickClose
@@ -188,9 +182,11 @@ libSDL2-2.0.so.0:SDL_JoystickGetAttached
 libSDL2-2.0.so.0:SDL_JoystickGetAxis
 libSDL2-2.0.so.0:SDL_JoystickGetButton
 libSDL2-2.0.so.0:SDL_JoystickGetHat
+libSDL2-2.0.so.0:SDL_JoystickHasRumble
 libSDL2-2.0.so.0:SDL_JoystickInstanceID
 libSDL2-2.0.so.0:SDL_JoystickName
 libSDL2-2.0.so.0:SDL_JoystickOpen
+libSDL2-2.0.so.0:SDL_JoystickRumble
 libSDL2-2.0.so.0:SDL_JoystickUpdate
 libSDL2-2.0.so.0:SDL_LockAudioDevice
 libSDL2-2.0.so.0:SDL_LockMutex
@@ -218,6 +214,10 @@ libSDL2-2.0.so.0:SDL_SetWindowTitle
 libSDL2-2.0.so.0:SDL_ShowCursor
 libSDL2-2.0.so.0:SDL_UnlockAudioDevice
 libSDL2-2.0.so.0:SDL_UnlockMutex
+libSDL2-2.0.so.0:SDL_Vulkan_CreateSurface
+libSDL2-2.0.so.0:SDL_Vulkan_GetInstanceExtensions
+libSDL2-2.0.so.0:SDL_Vulkan_LoadLibrary
+libSDL2-2.0.so.0:SDL_Vulkan_UnloadLibrary
 libSDL2-2.0.so.0:SDL_WaitThread
 libSDL2-2.0.so.0:SDL_WarpMouseInWindow
 libSDL2-2.0.so.0:SDL_WasInit
@@ -317,6 +317,7 @@ libc.so.6:readlink
 libc.so.6:realloc
 libc.so.6:rewind
 libc.so.6:signal
+libc.so.6:snprintf
 libc.so.6:sprintf
 libc.so.6:srand
 libc.so.6:stat

--- a/packages/m/mupen64plus/package.yml
+++ b/packages/m/mupen64plus/package.yml
@@ -1,18 +1,18 @@
 name       : mupen64plus
 version    : 2.5.9
-release    : 22
+release    : 23
 source     :
-    - git|https://github.com/mupen64plus/mupen64plus-core.git : f82b37bf63066190e2b41d74deb17846af017a90
+    - git|https://github.com/mupen64plus/mupen64plus-core.git : 860fac3fbae94194a392c1d9857e185eda6d083e
     - git|https://github.com/mupen64plus/mupen64plus-audio-sdl.git : df0770215f743f70244b09978c123a0a8b2a7d9d
-    - git|https://github.com/mupen64plus/mupen64plus-input-sdl.git : 2129e942fdc2ee74d4d5f9c815dd204c45d9f4c1
+    - git|https://github.com/mupen64plus/mupen64plus-input-sdl.git : fd7ffe63606b6cc4de7dab4e684c5aee68210681
     - git|https://github.com/mupen64plus/mupen64plus-rsp-cxd4.git : 8d2bd0372fd70d38f983662e6d259737029919c8
-    - git|https://github.com/mupen64plus/mupen64plus-rsp-hle.git : aa0ea78030d3c2b80184a35bbb36909fd7a28e70
+    - git|https://github.com/mupen64plus/mupen64plus-rsp-hle.git : f01be76948d9105bc56635f8e83a89d167328819
     - git|https://github.com/mupen64plus/mupen64plus-rsp-z64.git : a7bf40f67fc0afe340d0a396edc21c117b69ab3f
     - git|https://github.com/mupen64plus/mupen64plus-video-arachnoid.git : 82ab630d29c31541b93d4f8293a47b8cf6ef0d35
     - git|https://github.com/mupen64plus/mupen64plus-video-glide64mk2.git : a07050d143dddff921180b081164d46aaef2eb29
     - git|https://github.com/mupen64plus/mupen64plus-video-rice.git : 51582f9e62082f2937a17ac3acfaab08cb7f46ef
     - git|https://github.com/mupen64plus/mupen64plus-video-z64.git : 5dba5bd533911b0306dfad7349f0ed96bf47ec76
-    - git|https://github.com/mupen64plus/mupen64plus-ui-console.git : 42546ab00b23a8052b9c974882628912609990c2
+    - git|https://github.com/mupen64plus/mupen64plus-ui-console.git : 335e826aead146bd6a47d557d78b746e77f337c8
 license    :
     - GPL-2.0-only
     - CC0-1.0 #mupen64plus-rsp-cxd4
@@ -29,8 +29,10 @@ builddeps  :
     - pkgconfig(samplerate)
     - pkgconfig(sdl2)
     - pkgconfig(speex)
+    - pkgconfig(vulkan)
     - pkgconfig(x11)
     - libboost-devel
+    - vulkan-headers
 environment: |
     export PLUGINS="audio-sdl input-sdl rsp-cxd4 rsp-hle rsp-z64 video-arachnoid video-glide64mk2 video-rice video-z64 ui-console"
 setup      : |

--- a/packages/m/mupen64plus/pspec_x86_64.xml
+++ b/packages/m/mupen64plus/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mupen64plus</Name>
         <Homepage>http://mupen64plus.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <License>CC0-1.0</License>
@@ -52,7 +52,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="22">mupen64plus</Dependency>
+            <Dependency release="23">mupen64plus</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/mupen64plus/m64p_common.h</Path>
@@ -65,12 +65,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2023-11-29</Date>
+        <Update release="23">
+            <Date>2024-02-04</Date>
             <Version>2.5.9</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

This updates the mupen64plus core app plus all plugins with relevant changes to the latest git source

Commit logs:
- [Core](https://github.com/mupen64plus/mupen64plus-core/compare/f82b37bf63066190e2b41d74deb17846af017a90...860fac3fbae94194a392c1d9857e185eda6d083e)
- [Input-SDL](https://github.com/mupen64plus/mupen64plus-input-sdl/compare/2129e942fdc2ee74d4d5f9c815dd204c45d9f4c1...fd7ffe63606b6cc4de7dab4e684c5aee68210681)
- [RSP-HLE](https://github.com/mupen64plus/mupen64plus-rsp-hle/compare/aa0ea78030d3c2b80184a35bbb36909fd7a28e70...f01be76948d9105bc56635f8e83a89d167328819)
- [UI-console](https://github.com/mupen64plus/mupen64plus-ui-console/compare/42546ab00b23a8052b9c974882628912609990c2...335e826aead146bd6a47d557d78b746e77f337c8)

**Test Plan**

Changed some emulator settings and played Super Mario 64

**Checklist**

- [x] Package was built and tested against unstable
