### PR TITLE
m64py: Update to latest git source

### DIFF
--- a/packages/m/m64py/package.yml
+++ b/packages/m/m64py/package.yml
@@ -1,14 +1,15 @@
 name       : m64py
 version    : 0.2.5
-release    : 10
+release    : 11
 source     :
-    - git|https://github.com/mupen64plus/mupen64plus-ui-python.git : 2c27f94f4dd25916bdce6ad981721dd751b9d739
+    - git|https://github.com/mupen64plus/mupen64plus-ui-python.git : 90093ce3b353ff0fbe3277eb5d75130debdf0fab
 license    :
     - BSD-3-Clause     #loader.py
     - CC-BY-SA-3.0     #Mupen64plus logo, Python snake logo, Controller image
     - GPL-2.0-or-later #joystick.py
     - GPL-3.0-or-later #m64py
     - Public-Domain    #Icons
+homepage   : https://m64py.sourceforge.net/
 component  : games.emulator
 summary    : Qt5 front-end for Mupen64Plus
 description: |

--- a/packages/m/m64py/pspec_x86_64.xml
+++ b/packages/m/m64py/pspec_x86_64.xml
@@ -1,6 +1,7 @@
 <PISI>
     <Source>
         <Name>m64py</Name>
+        <Homepage>https://m64py.sourceforge.net/</Homepage>
         <Packager>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>
@@ -14,7 +15,7 @@
         <Summary xml:lang="en">Qt5 front-end for Mupen64Plus</Summary>
         <Description xml:lang="en">M64Py is a Qt5 frontend (GUI) for Mupen64Plus, a cross-platform plugin-based Nintendo 64 emulator. The frontend is written in Python and it provides a user-friendly interface over the Mupen64Plus shared library.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>m64py</Name>
@@ -127,8 +128,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2023-01-07</Date>
+        <Update release="11">
+            <Date>2024-02-04</Date>
             <Version>0.2.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>


### PR DESCRIPTION
**Summary**

Changes:
- Fix import error when using setuptools 69 or newer
- Search for `lrelease` in the system's Qt binary directory
- Resize game to keep aspect ratio, rather than resizing window itself
- Size game properly even if user doesn't manually resize window

**Test Plan**

Navigated the menus, changed plugins, and played Banjo-Kazooie

**Checklist**

- [x] Package was built and tested against unstable
