### PR TITLE
fritzing-parts: Update to 1.0.2

### DIFF
--- a/packages/f/fritzing-parts/package.yml
+++ b/packages/f/fritzing-parts/package.yml
@@ -1,10 +1,11 @@
 name       : fritzing-parts
-version    : 10052022 # Date of the latest commit formatted as ddmmyyyy
-release    : 5
+version    : 1.0.2
+release    : 6
 source     :
     # This must be a git clone according to: https://github.com/fritzing/fritzing-app/wiki/2.1-Part-file-format
-    # Make sure to use a commit in the master branch. The default branch is develop.
-    - git|https://github.com/fritzing/fritzing-parts.git : 4713511c894cb2894eae505b9307c6555afcc32c
+    # Use latest commit from branch "1.0.2"
+    - git|https://github.com/fritzing/fritzing-parts.git : 015626e6cafb1fc7831c2e536d97ca2275a83d32
+homepage   : https://fritzing.org/
 license    : CC-BY-SA-3.0
 component  : programming
 summary    : Fritzing parts

--- a/packages/f/fritzing-parts/pspec_x86_64.xml
+++ b/packages/f/fritzing-parts/pspec_x86_64.xml
@@ -1,6 +1,7 @@
 <PISI>
     <Source>
         <Name>fritzing-parts</Name>
+        <Homepage>https://fritzing.org/</Homepage>
         <Packager>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>
@@ -10,7 +11,7 @@
         <Summary xml:lang="en">Fritzing parts</Summary>
         <Description xml:lang="en">Fritzing data file of supplemental parts.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>fritzing-parts</Name>
@@ -39,6 +40,9 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/bins/more/frc-mono.png</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/bins/more/frc.fzb</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/bins/more/frc.png</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/bins/more/infineon-mono.png</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/bins/more/infineon.fzb</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/bins/more/infineon.png</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/bins/more/intel-mono.png</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/bins/more/intel.fzb</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/bins/more/intel.png</Path>
@@ -217,6 +221,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Arduino-Pro-Mini_3.3v-v14.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Arduino-Pro-Mini_5v-v14.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Arduino-Sensor-Shield-v5_1.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Arduino-nano-rp2040-tht_1.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/ArduinoBluetoothMatev13.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Arduino_ADK_MEGA_2560-Rev3(fix).fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Arduino_ADK_MEGA_2560-Rev3(icsp).fzp</Path>
@@ -240,7 +245,6 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/BASIC_Stamp_2sx.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/BMP085 Breakout-v13.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Barometric Pressure Sensor.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Basic Force Sensing Resistor (FSR).fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Battery block 9V.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Bean_revE.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Breadboard Power Supply - SMD v13.fzp</Path>
@@ -284,9 +288,8 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Dagu DGServo 9g header (male).fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Dagu DGServo 9g header connector (female).fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/DeadOn RTC - DS3234 Breakout-v11.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Dial Potentiometer with switch.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Digital_Panel_Meter__Voltage__DMS_20PC.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Dual_VNH2SP30_Motor_Driver.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Dual_VNH2SP30_Motor_Driver_23a2baa_2.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/EDGY_Analog_In.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/EDGY_motor_control.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/ESP8266-Thing-Dev.fzp</Path>
@@ -328,6 +331,8 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/ISD1932 Breakout-v11.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/ITG-3200-v11.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/IchigoJamT.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Infineon_H-BRIDGE_KIT2GO.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Infineon_MY_IOT_ADAPTER.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/InvenSense_MPU6050.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/JST-03JQ-BT.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/JST-B3P-VH.fzp</Path>
@@ -338,7 +343,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/L293D.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/L3G4200D-Breakout-v10.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/LDH-45-350B.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/LDR_photocell_300mil.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/LDR_photocell_300mil_v5.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/LED Tactile Button Breakout v10.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/LED-generic-3mm.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/LED-generic-5mm.fzp</Path>
@@ -610,10 +615,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Teensy 2.0.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Teensy 3.0+pads.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Teensy 3.0.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Textile Analog Pressure Sensor.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Textile Potentiometer.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Textile Pushbutton.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Textile Stretch Sensor.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Tilt switch.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Touch_Shield-v11.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Trackballer-v12.fzp</Path>
@@ -647,7 +649,6 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/acpower.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/ad5330 breakout-v11.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/aisler_cloud.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/alps-starter-pot9mm.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/amplified-mic-electret_15e7e05_002.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/aoz3013pi_0671c5779d4831e9bb583672ac1d7afe_1.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/aoz3018pi_4b4d7335497bbf379c232d88829b4eaf_1.fzp</Path>
@@ -657,6 +658,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/arduino-mega-rev3-shield_two_layer.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/arduino-shield.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/arduino-shield_r3_two_layer.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/arduino-shield_r4_two_layer.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/arduinoXbeere.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/arduino_Uno_Rev3(fix).fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/arduino_Yun(rev1)_v1.fzp</Path>
@@ -681,12 +683,11 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/audiojack_breakout-v11.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/avr_spi_prog-pth.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/bareconductive_touchboard.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/basic-relay.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/basic-relay-6p_1c569ac_002.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/basic-toggle-switch.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/basic-toggle-switch_pressed.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/basic_fet_n.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/basic_fet_p.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/basic_fsr.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/basic_power_transistor_npn.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/basic_power_transistor_pnp.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/battery-AA.fzp</Path>
@@ -742,6 +743,8 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/fc-51-IR-Sensor.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/fc-51-IR-Sensor_On.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/femtobuck.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/force_sensor_resistor_025in_6in_5.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/force_sensor_resistor_circular_05in_5.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/fritzing_donuts-white.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/fritzing_donuts.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/gear-motor_2.fzp</Path>
@@ -788,10 +791,10 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/jlpcb-128.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/ky_006_1.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/lcd-GDM1602K.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/led-rgb-4pin-anode.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/led-rgb-4pin-anode_rbg.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/led-rgb-4pin-cathode.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/led-rgb-4pin-cathode_rbg.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/led-rgb-4pin-anode_rbg_v5.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/led-rgb-4pin-anode_v5.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/led-rgb-4pin-cathode_rbg_v5.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/led-rgb-4pin-cathode_v5.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/led-rgb-6pin.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/led_flux_blue_anode.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/led_flux_blue_cathode.fzp</Path>
@@ -854,10 +857,12 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/placeholder.txt</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/polarizedheader4pin_0.156in.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/pololu0002_a988.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/pot-slider.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/pot_big.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/pot_trimmer_12mm.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/pot_trimmer_6mm.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/potentiometer_dial_switch_5.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/potentiometer_rotary_16mm_5.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/potentiometer_rotary_9mm_6.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/potentiometer_slider_5.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/potentiometer_trimmer_12mm_5.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/potentiometer_trimmer_6mm_5.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/powerbutton_adafruit.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/proto_shield_v6MEGA.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/pushbutton_2_horizontal.fzp</Path>
@@ -1811,6 +1816,9 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/tdk_ussm.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/teensy_3.1.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/telegaertner_bnc_socket_50r.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/textile_analog_pressure_sensor_005.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/textile_potentiometer_005.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/textile_stretch_sensor_005.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/thermalprinter.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/thermistor_300mil.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/tilt-switch-sw200d.fzp</Path>
@@ -1875,12 +1883,15 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/Arduino_Micro_Rev03.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/Arduino_UNO_R3.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/Atmega_168_TQFP32.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/Basic Force Sensing Resistor (FSR)_4.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/Battery block 9V.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/Cherry-MX-Keyswitch_44a6316938b1b0a2c83ac0276dac5539_22.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/DB25M.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/DIP_Relay_D31A.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/DS18B20.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/DS18B20__5240d891e23cace35a4de6acc361c049.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/Dial Potentiometer with switch_4.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/Dual_VNH2SP30_Motor_Driver.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/ELECTRON_90f1556e6dcbdc62b58429de7696758a_7.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/ESP8266_7_723ce4de09d714597656302fbbc6971c_17.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/ESP8266_module_7127946da8b954839406bc6bc9d8d0d6_59.fzp</Path>
@@ -1893,6 +1904,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/HC-05-male_50ef644d14e5d1dfea3ec45159c12c96_4.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/HC-SR04 Ultrasonic Distance Sensor.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/LBT2088AH.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/LDR_photocell_300mil_v4.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/LED-blue-5mm (2).fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/LED-blue-5mm (3).fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/LED-blue-5mm.fzp</Path>
@@ -1974,10 +1986,14 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/SparkFun___Breakout_Board_for_microSD_Transflash_v4__0b0c87ce0a9414b7db3b2898baf3a987.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/TE_RELAY_6b97f554b4dba02fd6f20b912a42ebf0_9.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/TI Launchpad MSP430G2__ebb2b2673b63f5dd6fb32b9685c74b9e.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/Textile Analog Pressure Sensor_4.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/Textile Potentiometer_4.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/Textile Stretch Sensor_4.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/WIZ820io.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/WeMos-D1-mini-female-headers-above.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/WeMos-D1-mini-male-headers-above.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/accelerometer-adxl.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/alps-starter-pot9mm_5.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/arduino-mega-r3-shield_two_layer.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/arduino-shield_two_layer.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/arduino.fzp</Path>
@@ -1988,6 +2004,8 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/atmega168.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/avr_isp_10_pin.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/basic-diode.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/basic-relay.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/basic_fsr_4.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/basic_ldr.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/basic_poti.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/basic_pushbutton.fzp</Path>
@@ -2098,6 +2116,10 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/kameleon.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/lcd-screen.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/led-rgb-4pin-anode.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/led-rgb-4pin-anode_rbg_v4.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/led-rgb-4pin-anode_v4.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/led-rgb-4pin-cathode_rbg_v4.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/led-rgb-4pin-cathode_v4.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/led-rgb-6pin.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/mystery_part1.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/mystery_part10.fzp</Path>
@@ -2125,9 +2147,13 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/placeholder.txt</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/pololu0002_7d1d85d9e29084ad573942b0077ce80e_1.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/pot-slider.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/pot-slider_4.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/pot-small.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/pot-small2.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/pot_big_4.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/pot_trimmer_12mm_4.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/pot_trimmer_6mm.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/pot_trimmer_6mm_4.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/prefix0000_20f55f90aa18635d44e794080c8bfbf6_9.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/prefix0000_66b8ccc42f9cca842a85f140a2fd782b_4.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/prefix0000_RICHARDB_279ea5112d8641747da44ac250011e59_6.fzp</Path>
@@ -2258,6 +2284,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/props2csv.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/removegorn.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/replacedby.py</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/requirements.txt</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/schem2csv.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/schemmatch.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/schemobs.py</Path>
@@ -2269,6 +2296,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/thtsmd.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/unusedsvgs.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/unzeroradius.py</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/utf8stats.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/version.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/version4.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/contrib/breadboard/placeholder.txt</Path>
@@ -2368,6 +2396,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Arduino-Pro-Mini-v13_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Arduino-Pro-Mini_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Arduino-Sensor-Shield-v5_1_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Arduino-nano-rp2040-tht_1_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/ArduinoBluetoothMatev13_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Arduino_ADK_MEGA_2560-Rev3_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Arduino_DUE_V02b_breadboard.svg</Path>
@@ -2391,7 +2420,6 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/BASIC_Stamp_2sx.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/BMP085 Breakout-v13_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Barometric_Pressure_Sensor__2eaec138e035.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Basic_Force_Sensing_Resistor_(FSR)__a4ff.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Battery_block_9V85_leg.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Bean_revE_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Blend_Micro_1.0_breadboard.svg</Path>
@@ -2438,6 +2466,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Dagu_DGServo_9g_header_male_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/DeadOn RTC - DS3234 Breakout-v11_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Digital_Panel_Meter__Voltage__DMS_20PC__.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Dual_VNH2SP30_Motor_Driver_23a2baa_2_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Dual_VNH2SP30_Motor_Driver_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/EDGY_Analog_In_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/EDGY_motor_control.svg</Path>
@@ -2485,6 +2514,8 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/ISD1932 Breakout-v11_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/ITG-3200-v11_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/IchigoJamT_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Infineon_H-BRIDGE_KIT2GO_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Infineon_MY_IOT_ADAPTER_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/JST-03JQ-BT_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/JST-B3P-VH_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/JST-VHR-3N_breadboard.svg</Path>
@@ -2682,7 +2713,6 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Sparkfun_Tilt-a-Whirl_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Stepper_Motor_Bipolar_breadboard_leg.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Stepper_Motor_Unipolar_breadboard_leg.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Stretch sensor.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Subminiature_Rotary_Switch_RM-series_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/TB6612FNG Breakout v11.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/TEMT6000_Breakout-v12_breadboard.svg</Path>
@@ -2703,8 +2733,6 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Teensy_2.0_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Teensy_3.0+pads_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Teensy_3.0_breadboard.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Textile_analog_sensor.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Textile_potentiometer.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Textile_push_button.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Touch_Shield-v11_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Trackballer-v12_breadboard.svg</Path>
@@ -2767,7 +2795,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/avr_isp_10_pin_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/badger_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/bareconductive_touchboard_breadboard.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/basic_fsr.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/basic-relay-6p_1c569ac_002.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/basic_pbutton.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/basic_pbutton_2leg_horizon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/basic_pbutton_2leg_horizon_pressed.svg</Path>
@@ -2819,6 +2847,8 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/electron_board_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/fc-51_2.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/femtobuck_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/force_sensor_resistor_025in_6in_5_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/force_sensor_resistor_circular_05in_5_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/fritzing_donuts-white_breaboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/gear-motor_2_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/gogoboard_4.043282.svg</Path>
@@ -2926,10 +2956,12 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/pinoccio_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/polarizedheader4pin_0.156in_bread.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/pololu0002_a988_breadboard.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/pot-slider.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/potentiometer.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/potentiometer_trimmer.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/potentiometer_w_switch.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/potentiometer_dial_with_switch_5_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/potentiometer_rotary_16mm_5_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/potentiometer_rotary_9mm_6_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/potentiometer_slider_5_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/potentiometer_trimmer_12mm_5_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/potentiometer_trimmer_6mm_5_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/power_plug.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/powerpushbutton_adafruit_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/powertransistor_npn.svg</Path>
@@ -2948,7 +2980,6 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/raspberrypi_zero_1_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/raspio_duino_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/reed_switch_leg.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/relay_reloaded.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/resistor_220.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/resistor_5bands.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/resonator-2pin-leg.svg</Path>
@@ -3607,12 +3638,14 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/sparkfun-sensors_vcnl4000_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/sparkfun_storage_microsd_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/st662_d81bd34a8e087fc44299900ed7e2e4a8_1_breadboard.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/starter-poti-small_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/stereo_jack_pg203j_6d7c0c2_002.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/sx1509-breakout_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/tdk_ussm_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/teensy_3.1_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/telegaertner_bnc_socket_50r_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/textile_analog_pressure_sensor_005.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/textile_potentiometer_005.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/textile_strech_sensor_005.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/thermalprinter_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/tilt-switch_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/tilt_switch.svg</Path>
@@ -3801,7 +3834,6 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/BUZZER-CMT1102.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/BUZZER-CMT1603.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Barometric_Pressure_Sensor__2eaec138e035.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Basic_Force_Sensing_Resistor_(FSR)__a4ff.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Battery_block_9V82.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Bean_revE_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Blend_Micro_1.0_icon.svg</Path>
@@ -3861,8 +3893,8 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Dagu_DGServo_9g_header_connector_female_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Dagu_DGServo_9g_header_male_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Dagu_DGServo_9g_pan_and_tilt_icon.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Dial_Potentiometer_with_switch.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Digital_Panel_Meter__Voltage__DMS_20PC__.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Dual_VNH2SP30_Motor_Driver_23a2baa_2_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Dual_VNH2SP30_Motor_Driver_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/EB-85A.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/EDGY.svg</Path>
@@ -3940,6 +3972,8 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/IPOD_MALE_CONNECTOR.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/IRF520_mos_module_5.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/IchigoJamT_icon.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Infineon_H-BRIDGE_KIT2GO_icon.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Infineon_MY_IOT_ADAPTER_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/JOYSTICK-PSP1000.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/JOYSTICK.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/JOYSTICK_MINI.svg</Path>
@@ -4158,7 +4192,6 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Sparkfun_Tilt-a-Whirl_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Stepper_Motor_-_Bipolar__icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Stepper_Motor_-_Unipolar__icon.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Stretch sensor.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/TACTILE-PTH-12MM.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/TACTILE-PTH.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/TACTILE-SWITCH-1101NE.svg</Path>
@@ -4182,8 +4215,6 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Teensy_2.0_++_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Teensy_2.0_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Teensy_3.0_icon.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Textile_analog_sensor.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Textile_potentiometer.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Textile_push_button.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/U.FL.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/ULN2003A_icon.svg</Path>
@@ -4245,12 +4276,12 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/avr_isp_10_pin_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/avr_mini_prog.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/basic-diode.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/basic_fsr.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/basic-relay-6p_1c569ac_002.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/basic_ldr.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/basic_pbutton.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/basic_pbutton_2leg_horizon.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/basic_pbutton_2leg_horizon_pressed.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/basic_photo_transistoricon.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/basic_poti_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/basic_relay.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/basic_resistor.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/basic_servo.svg</Path>
@@ -4258,6 +4289,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/basic_transistor_npnicon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/basic_transistor_pnpicon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/batterypack_2xAA.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/batterypack_4xAAA.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/bmp180_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/breadboardicon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/camera_cmos_con.svg</Path>
@@ -4293,6 +4325,8 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/emb001.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/fc-51_2.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/ffc26.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/force_sensor_resistor_025in_6in_5_icon.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/force_sensor_resistor_circular_05in_5_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/gear-motor_2_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/generic_male_header.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/generic_rounded_female_header.svg</Path>
@@ -4375,8 +4409,12 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/plain_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/polarizedheader4pin.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/pololu0002_a988_icon.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/pot-slider.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/potentiometer.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/potentiometer_dial_with_switch_5_icon.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/potentiometer_rotary_16mm_1_icon.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/potentiometer_rotary_9mm_6_icon.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/potentiometer_slider_5_icon.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/potentiometer_trimmer_12mm_5_icon.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/potentiometer_trimmer_6mm_5_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/power.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/power_plug.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/powerpushbutton_adafruit_icon.svg</Path>
@@ -4390,7 +4428,6 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/raspberry_pi_b+_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/raspberrypi_zero_1_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/reed_switch.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/relay_reloaded.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/resistor_5bands.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/resistor_icon_220.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/resonator-2pin.svg</Path>
@@ -4417,10 +4454,12 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/solenoid.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/sparkfun_storage_microsd_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/st662_d81bd34a8e087fc44299900ed7e2e4a8_1_icon.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/starter-poti-small_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/stereo_jack_pg203j_6d7c0c2_002.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/tdk_ussm_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/teensy_3.1_icon.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/textile_analog_pressure_sensor_005.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/textile_potentiometer_005.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/textile_strech_sensor_005.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/thermalprinter_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/tilt-switch-sw200d_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/tilt_switch.svg</Path>
@@ -4521,6 +4560,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/Arduino-Pro-Mini-v13_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/Arduino-Pro-Mini_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/Arduino-Sensor-Shield-v5_1_pcb.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/Arduino-nano-rp2040-tht_1_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/ArduinoBluetoothMatev13_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/Arduino_ADK_MEGA_2560-Rev3(icsp)_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/Arduino_ADK_MEGA_2560-Rev3_pcb.svg</Path>
@@ -4581,8 +4621,8 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/Dagu_DGServo_9g_header_male_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/Dagu_DGServo_9g_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/DeadOn RTC - DS3234 Breakout-v11_pcb.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/Dial_Potentiometer_with_switch_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/Digital_Panel_Meter__Voltage__DMS_20PC__.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/Dual_VNH2SP30_Motor_Driver_23a2baa_2_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/Dual_VNH2SP30_Motor_Driver_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/EDGY_Analog_In_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/EDGY_motor_control.svg</Path>
@@ -4591,7 +4631,6 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/ESP8266_module_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/EasyDriver_v44_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/EspruinoPico_pcb.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/FRS1B-S-relay-fp.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/FT230XQ_5.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/FTDI Basic-v13_3.3v_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/FTDI Basic-v13_lily_pcb.svg</Path>
@@ -4633,6 +4672,8 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/ISD1932 Breakout-v11_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/ITG-3200-v11_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/IchigoJamT_pcb.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/Infineon_H-BRIDGE_KIT2GO_pcb.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/Infineon_MY_IOT_ADAPTER_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/JST-03JQ-BT_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/JST-B3P-VH_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/JST-VHR-3N_pcb.svg</Path>
@@ -4892,7 +4933,6 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/aisler_cloud_logo_part.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/aisler_cloud_pcb_shape.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/aisler_donut-cloud_logo_pcb.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/alps-starter-pot9mm_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/amplified-mic-electret_15e7e05_002.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/aoz3013pi_2f301098dde4e38490ab7f8d0ae0376b_1_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/aoz3018pi_007a70b9384772c13aaca27b3fa85f5d_1_pcb.svg</Path>
@@ -4927,6 +4967,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/axial_stand1_2_100mil_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/badger_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/bareconductive_touchboard_pcb.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/basic-relay-6p_1c569ac_002.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/battery_pack_mounted_500mil_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/blueIOT_Rc1-final_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/bmp180_pcb.svg</Path>
@@ -4964,6 +5005,8 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/electron_board_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/fc-51_2.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/femtobuck_pcb.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/force_sensor_resistor_025in_6in_5_pcb.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/force_sensor_resistor_circular_05in_5_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/freqctrl_crystal-smd-3.2x2.5_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/gear-motor_2_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/gogoboard_4.043282.svg</Path>
@@ -5067,6 +5110,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/pcb-arduino-mega-Rev3.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/pcb-arduino-mini-usb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/pcb-arduino-pro-mini.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/pcb-arduino-shield-r4wifi.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/pcb-arduino-shield-rev3.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/pcb-arduino-shield.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/pcb-lightblue-bean-shield.svg</Path>
@@ -5075,7 +5119,12 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/pinoccio_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/polarizedheader4pin_0.156in_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/pololu0002_a988_pcb.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/pot-slider.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/potentiometer_dial_with_switch_5_pcb.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/potentiometer_rotary_16mm_5_pcb.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/potentiometer_rotary_9mm_6_pcb.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/potentiometer_slider_5_pcb.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/potentiometer_trimmer_12mm_5_pcb.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/potentiometer_trimmer_6mm_5_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/powerpushbutton_adafruit_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/prefix0000_1.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/prefix0000_SFE-10467-v10_2.svg</Path>
@@ -5861,8 +5910,6 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/trimmer_3_4_p_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/trimmer_smd1_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/trimmer_smd2_pcb.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/trimpot.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/trimpot_meggitt_pih.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/tsop312_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/usb_3.0_female_fix_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/wiring.svg</Path>
@@ -5989,6 +6036,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/Arduino-Pro-Mini-v13_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/Arduino-Pro-Mini_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/Arduino-Sensor-Shield-v5_1_schematic.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/Arduino-nano-rp2040-tht_1_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/ArduinoBluetoothMatev13_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/Arduino_ADK_MEGA_2560-Rev3_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/Arduino_DUE_V02b_schematic.svg</Path>
@@ -6052,8 +6100,8 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/Dagu_DGServo_9g_header_male_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/Dagu_DGServo_9g_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/DeadOn RTC - DS3234 Breakout-v11_schematic.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/Dial_Potentiometer_with_switch_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/Digital_Panel_Meter__Voltage__DMS_20PC__.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/Dual_VNH2SP30_Motor_Driver_23a2baa_2_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/Dual_VNH2SP30_Motor_Driver_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/EDGY_Analog_In_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/EDGY_motor_control.svg</Path>
@@ -6124,6 +6172,8 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/ISD1932 Breakout-v11_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/ITG-3200-v11_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/IchigoJamT_schematic.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/Infineon_H-BRIDGE_KIT2GO_schematic.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/Infineon_MY_IOT_ADAPTER_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/JST-03JQ-BT_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/JST-B3P-VH_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/JST-VHR-3N_schematic.svg</Path>
@@ -6396,8 +6446,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/avr_isp_10_pin_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/badger_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/bareconductive_touchboard_schematic.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/basic_fsr.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/basic_poti.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/basic-relay-6p_1c569ac_002.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/basic_transistor_npn.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/basic_transistor_pnp.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/blueIOT_Rc1-final_schematic.svg</Path>
@@ -6546,6 +6595,8 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/pinoccio_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/polarizedheader4pin_0.156in_schem.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/pololu0002_a988_schematic.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/potentiometer_1_schematic.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/potentiometer_with_switch_1_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/power.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/power_plug.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/powerpushbutton_adafruit_schematic.svg</Path>
@@ -6567,10 +6618,10 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/raspberrypi_zero_1_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/raspio_duino_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/reed_switch.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/relay.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/resistor.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/resonator-3pin.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/rfid_reader_id12.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/rheostat_1_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/roborio_1_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/router_1_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/rtc_ds3231_breakout_schematic.svg</Path>
@@ -7150,6 +7201,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/Arduino_LilyPad7f6.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/Arduino_Mini_Proc8.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/Atmega_168_TQFP32_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/Basic_Force_Sensing_Resistor_(FSR)__a4ff.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/Battery_block_9V85.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/Breakout_Board_for_microSD_Transflash_v1__breadboard__2af30564c1fde27f27144aa631c413a8.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/Cherry-MX-Keyswitch_44a6316938b1b0a2c83ac0276dac5539_22_breadboard.svg</Path>
@@ -7157,6 +7209,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/DIP_Relay_D31A_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/DS18B20__5240d891e23cace35a4de6acc361c04__breadboard__7b535917175078873c2dd8e438e15652.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/DS18B20_old_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/Dual_VNH2SP30_Motor_Driver_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/ELECTRON_739a9addbae108685e6c3dccb3216bb9_4_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/ESP8266_7_3d9a9742b08b59b877d1a9c22c0ed5dc_3_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/ESP8266_module_9c7794a5d6f6bb1b98d1bc9beab814d5_1_breadboard.svg</Path>
@@ -7184,12 +7237,16 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/SPARKCORE_v10_2e5da62ec746862822eab27a1f6c2ec4_1_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/Stepper_Motor_-_Bipolar__breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/Stepper_Motor_-_Unipolar__breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/Stretch sensor.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/TI_Launchpad_MSP430G2__ebb2b2673b63f5dd6__breadboard__98696ce55bfaf674ef9c24f01d976248.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/Textile_analog_sensor.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/Textile_potentiometer.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/WeMos-D1-mini-female-headers-above_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/accelerometer-adxl.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/artreeno.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/atmega168.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/basic_diode.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/basic_fsr.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/basic_ldr.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/basic_relay.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/basic_resistor.svg</Path>
@@ -7290,7 +7347,11 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/mystery_part8.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/mystery_part9.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/pololu0002_7d1d85d9e29084ad573942b0077ce80e_1_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/pot-slider.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/pot-small.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/potentiometer.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/potentiometer_trimmer.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/potentiometer_w_switch.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/prefix0000_66b8ccc42f9cca842a85f140a2fd782b_16_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/prefix0000_80c09cd9cd6fa9bfa6ff5f5f4d652799_1_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/prefix0000_RICHARDB_279ea5112d8641747da44ac250011e59_16_breadboard.svg</Path>
@@ -7300,6 +7361,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/raspberry_pi_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/red_led_matrix8x8.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/reed_switch.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/relay_reloaded.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/resistor_1.5k.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/resistor_10.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/resistor_100.svg</Path>
@@ -7334,6 +7396,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/resonator-2pin.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/resonator-3pin.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/screw_terminal.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/starter-poti-small_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/stereo-jack-3_5mm.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/svg.breadboard.zero_RPi_1_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/usb_3.0_female_breadboard.svg</Path>
@@ -7346,10 +7409,13 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/Arduino_Mini.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/Arduino_Mini_Prod5.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/Atmega_168_TQFP32_icon.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/Basic_Force_Sensing_Resistor_(FSR)__a4ff.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/Cherry-MX-Keyswitch_44a6316938b1b0a2c83ac0276dac5539_22_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/DB25M.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/DIP_Relay_D31A_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/DS18B20__5240d891e23cace35a4de6acc361c04__icon__d53cbcd19f32fb9a9236373b10833a61.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/Dial_Potentiometer_with_switch.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/Dual_VNH2SP30_Motor_Driver_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/ELECTRON_739a9addbae108685e6c3dccb3216bb9_4_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/ESP8266_7_3d9a9742b08b59b877d1a9c22c0ed5dc_3_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/ESP8266_module_9c7794a5d6f6bb1b98d1bc9beab814d5_1_icon.svg</Path>
@@ -7371,10 +7437,15 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/SEN-10621 RPI-1031 Tilt-a-Whirl Breakout-sfe_c4f3fbd3a94f0953d33d8ac83b51e5ac_3_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/SM130_7c3fb81e05f5cd451db8fb4bd067edae_5_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/SPARKCORE_v10_2e5da62ec746862822eab27a1f6c2ec4_1_icon.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/Stretch sensor.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/TI_Launchpad_MSP430G2__ebb2b2673b63f5dd6__icon__d5bd55db9735ae6f290efdcaf7dcbe5f.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/Textile_analog_sensor.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/Textile_potentiometer.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/WeMos-D1-mini-female-headers-above_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/accelerometer-adxl.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/arduino_diecimila.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/basic_fsr.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/basic_poti_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/ceramic_disk_capacitor_ochre_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/controller_arduino_mega.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/electrolytic_capacitor_100uF_icon.svg</Path>
@@ -7388,13 +7459,16 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/lcd-screen.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/mystery_part_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/pololu0002_7d1d85d9e29084ad573942b0077ce80e_1_icon.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/pot-slider.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/pot-small.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/potentiometer.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/prefix0000_66b8ccc42f9cca842a85f140a2fd782b_16_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/prefix0000_80c09cd9cd6fa9bfa6ff5f5f4d652799_1_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/prefix0000_RICHARDB_279ea5112d8641747da44ac250011e59_16_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/prefix0000_SFE-SEN-11084_05654ad87c1390d7ff5c5e6a1ba23294_6_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/prefix0000_rbrun_41e2db2b27ebc0f7c890cf07e8f6b2f0_3_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/red_led_matrix8x8.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/relay_reloaded.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/resistor_icon_1.5k.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/resistor_icon_10.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/resistor_icon_100.svg</Path>
@@ -7426,6 +7500,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/resistor_icon_680.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/resistor_icon_680k.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/resistor_icon_68k.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/starter-poti-small_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/stereo-jack-3_5mm.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/svg.icon.zero_RPi_1_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/usb_3.0_female_icon.svg</Path>
@@ -7892,6 +7967,8 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/DS18B20_old_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/DW 24.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/DW 28.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/Dial_Potentiometer_with_switch_pcb.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/Dual_VNH2SP30_Motor_Driver_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/EIA3216.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/EIA3528.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/EIA6032.svg</Path>
@@ -7901,6 +7978,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/ESP8266_module_9c7794a5d6f6bb1b98d1bc9beab814d5_1_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/Eric_d0eaed56260dd65e5641982bd03333c7_5_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/EspruinoPico_8fb644a5b6642112445ed6d90bc494d8_8_pcb.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/FRS1B-S-relay-fp.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/Fairchild_MBR745_18076f1e430710281eda337815213d88_2_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/Generic_TSOP48_Flash.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/HC-05-male_c9e76767f4a2f48bb94589daadd42c38_2_pcb.svg</Path>
@@ -9159,6 +9237,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/ZIP28.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/ZIP40.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/ZIP9.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/alps-starter-pot9mm_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/artreeno.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/axial_lay_300mil.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/axial_lay_400mil.svg</Path>
@@ -9231,6 +9310,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/pcb_75x100mm.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/peltier_sensor.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/pololu0002_7d1d85d9e29084ad573942b0077ce80e_1_pcb.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/pot-slider.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/pq100.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/pq128.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/pq144.svg</Path>
@@ -9267,6 +9347,8 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/svg.pcb.zero_RPi_1_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/test_filter.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/to92.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/trimpot.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/trimpot_meggitt_pih.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/usb_3.0_female_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/0.3.schem.10x2-Epaper-Breakout-Board-v11_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/0.3.schem.11LC010_schematic.svg</Path>
@@ -9663,6 +9745,8 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/DB25M.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/DIP_Relay_D31A_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/DS18B20__5240d891e23cace35a4de6acc361c04__schematic__7051cf864e168372439496e5f0a88453.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/Dial_Potentiometer_with_switch_schematic.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/Dual_VNH2SP30_Motor_Driver_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/ELECTRON_739a9addbae108685e6c3dccb3216bb9_4_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/ESP8266_7_3d9a9742b08b59b877d1a9c22c0ed5dc_3_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/ESP8266_module_9c7794a5d6f6bb1b98d1bc9beab814d5_1_schematic.svg</Path>
@@ -9688,6 +9772,8 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/accelerometer-adxl.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/artreeno.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/atmega168_schematic.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/basic_fsr.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/basic_poti.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/cell.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/controller_arduino_mega.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/controller_arduino_mini.svg</Path>
@@ -9753,6 +9839,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/prefix0000_rbrun_41e2db2b27ebc0f7c890cf07e8f6b2f0_3_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/raspberry_pi_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/red_led_matrix8x8.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/relay.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/schematic-arduino-diecimila.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/schematic-arduino-diecimila_old.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/schematic-arduino-uno-r3.svg</Path>
@@ -9775,9 +9862,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2022-09-18</Date>
-            <Version>10052022</Version>
+        <Update release="6">
+            <Date>2024-02-04</Date>
+            <Version>1.0.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>


### PR DESCRIPTION
**Summary**

Depends on #1529

Align parts with latest app release.

Changelog:

- [Commit log v1.0.2](https://github.com/fritzing/fritzing-parts/commits/1.0.2)

**Test Plan**

- Installed and tested with Fritzing v1.0.2

**Checklist**

- [X] Package was built and tested against unstable