### PR TITLE
wxmaxima: Update to 24.02.0

### DIFF
--- a/packages/w/wxmaxima/abi_used_symbols
+++ b/packages/w/wxmaxima/abi_used_symbols
@@ -27,7 +27,6 @@ libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset
 libc.so.6:pthread_mutex_lock
-libc.so.6:pthread_mutex_trylock
 libc.so.6:pthread_mutex_unlock
 libc.so.6:qsort
 libc.so.6:realloc
@@ -199,6 +198,7 @@ libwx_baseu-3.2.so.0:_ZN12wxEvtHandler12ProcessEventER7wxEvent
 libwx_baseu-3.2.so.0:_ZN12wxEvtHandler15DoSetClientDataEPv
 libwx_baseu-3.2.so.0:_ZN12wxEvtHandler16SearchEventTableER12wxEventTableR7wxEvent
 libwx_baseu-3.2.so.0:_ZN12wxEvtHandler17DoSetClientObjectEP12wxClientData
+libwx_baseu-3.2.so.0:_ZN12wxEvtHandler19DeletePendingEventsEv
 libwx_baseu-3.2.so.0:_ZN12wxEvtHandler19ProcessEventLocallyER7wxEvent
 libwx_baseu-3.2.so.0:_ZN12wxEvtHandler21WXReservedEvtHandler1EPv
 libwx_baseu-3.2.so.0:_ZN12wxEvtHandler21WXReservedEvtHandler2EPv
@@ -253,6 +253,8 @@ libwx_baseu-3.2.so.0:_ZN15wxCmdLineParser4InitEv
 libwx_baseu-3.2.so.0:_ZN15wxCmdLineParser5ParseEb
 libwx_baseu-3.2.so.0:_ZN15wxCmdLineParser7SetDescEPK18wxCmdLineEntryDesc
 libwx_baseu-3.2.so.0:_ZN15wxCmdLineParserD1Ev
+libwx_baseu-3.2.so.0:_ZN15wxMessageOutput13DoPrintfWcharEPKwz
+libwx_baseu-3.2.so.0:_ZN15wxMessageOutput3GetEv
 libwx_baseu-3.2.so.0:_ZN15wxSystemOptions9SetOptionERK8wxStringS2_
 libwx_baseu-3.2.so.0:_ZN16wxAppConsoleBase10OnLaunchedEv
 libwx_baseu-3.2.so.0:_ZN16wxAppConsoleBase10SetCLocaleEv
@@ -427,7 +429,6 @@ libwx_baseu-3.2.so.0:_ZNK13wxInputStream7CanReadEv
 libwx_baseu-3.2.so.0:_ZNK14wxFormatString15GetArgumentTypeEj
 libwx_baseu-3.2.so.0:_ZNK14wxTranslations19GetTranslatedStringERK8wxStringS2_S2_
 libwx_baseu-3.2.so.0:_ZNK15wxCmdLineParser13GetParamCountEv
-libwx_baseu-3.2.so.0:_ZNK15wxCmdLineParser14GetUsageStringEv
 libwx_baseu-3.2.so.0:_ZNK15wxCmdLineParser5FoundERK8wxString
 libwx_baseu-3.2.so.0:_ZNK15wxCmdLineParser5FoundERK8wxStringPS0_
 libwx_baseu-3.2.so.0:_ZNK15wxCmdLineParser8GetParamEm
@@ -490,8 +491,8 @@ libwx_baseu-3.2.so.0:_ZTV10wxTextFile
 libwx_baseu-3.2.so.0:_ZTV11wxLogBuffer
 libwx_baseu-3.2.so.0:_ZTV11wxLogStderr
 libwx_baseu-3.2.so.0:_ZTV12wxMBConvUTF8
+libwx_baseu-3.2.so.0:_ZTV13wxThreadEvent
 libwx_baseu-3.2.so.0:_ZTV14wxLogFormatter
-libwx_baseu-3.2.so.0:_ZTV14wxProcessEvent
 libwx_baseu-3.2.so.0:_ZTV18wxZlibOutputStream
 libwx_baseu-3.2.so.0:_ZTV19wxStringInputStream
 libwx_baseu-3.2.so.0:_ZTV20wxStringOutputStream
@@ -510,6 +511,7 @@ libwx_baseu-3.2.so.0:_ZplRK8wxString9wxUniChar
 libwx_baseu-3.2.so.0:_ZplRK8wxStringPKc
 libwx_baseu-3.2.so.0:_ZplRK8wxStringPKw
 libwx_baseu-3.2.so.0:_ZplRK8wxStringS1_
+libwx_baseu-3.2.so.0:wxAnyNullValueType
 libwx_baseu-3.2.so.0:wxConvLibcPtr
 libwx_baseu-3.2.so.0:wxConvLocalPtr
 libwx_baseu-3.2.so.0:wxConvUTF8Ptr
@@ -535,7 +537,6 @@ libwx_baseu_net-3.2.so.0:_ZN12wxSocketBase5WriteEPKvj
 libwx_baseu_net-3.2.so.0:_ZN12wxSocketBase6NotifyEb
 libwx_baseu_net-3.2.so.0:_ZN12wxSocketBase7DestroyEv
 libwx_baseu_net-3.2.so.0:_ZN12wxSocketBase8SetFlagsEi
-libwx_baseu_net-3.2.so.0:_ZN12wxSocketBase8ShutdownEv
 libwx_baseu_net-3.2.so.0:_ZN12wxSocketBase9SetNotifyEi
 libwx_baseu_net-3.2.so.0:_ZN13wxSockAddressC2Ev
 libwx_baseu_net-3.2.so.0:_ZN13wxSockAddressD2Ev
@@ -556,6 +557,7 @@ libwx_baseu_xml-3.2.so.0:_ZN13wxXmlDocument14AppendToPrologEP9wxXmlNode
 libwx_baseu_xml-3.2.so.0:_ZN13wxXmlDocument4LoadER13wxInputStreamRK8wxStringi
 libwx_baseu_xml-3.2.so.0:_ZN13wxXmlDocument4LoadERK8wxStringS2_i
 libwx_baseu_xml-3.2.so.0:_ZN13wxXmlDocumentC1ERK8wxStringS2_
+libwx_baseu_xml-3.2.so.0:_ZN13wxXmlDocumentC1ERKS_
 libwx_baseu_xml-3.2.so.0:_ZN13wxXmlDocumentC1Ev
 libwx_baseu_xml-3.2.so.0:_ZN9wxXmlNodeC1EPS_13wxXmlNodeTypeRK8wxStringS4_P14wxXmlAttributeS0_i
 libwx_baseu_xml-3.2.so.0:_ZNK13wxXmlDocument4SaveER14wxOutputStreami
@@ -613,8 +615,6 @@ libwx_gtk3u_core-3.2.so.0:_Z19wxGetColourFromUserP8wxWindowRK8wxColourRK8wxStrin
 libwx_gtk3u_core-3.2.so.0:_Z22wxLaunchDefaultBrowserRK8wxStringi
 libwx_gtk3u_core-3.2.so.0:_ZN10wxBoxSizer8DoInsertEmP11wxSizerItem
 libwx_gtk3u_core-3.2.so.0:_ZN10wxBoxSizer9AddSpacerEi
-libwx_gtk3u_core-3.2.so.0:_ZN10wxBusyInfo4InitERK15wxBusyInfoFlags
-libwx_gtk3u_core-3.2.so.0:_ZN10wxBusyInfoD1Ev
 libwx_gtk3u_core-3.2.so.0:_ZN10wxCheckBox6CreateEP8wxWindowiRK8wxStringRK7wxPointRK6wxSizelRK11wxValidatorS4_
 libwx_gtk3u_core-3.2.so.0:_ZN10wxClientDCC1EP8wxWindow
 libwx_gtk3u_core-3.2.so.0:_ZN10wxComboBox4InitEv
@@ -627,6 +627,7 @@ libwx_gtk3u_core-3.2.so.0:_ZN10wxMemoryDCC1ER8wxBitmap
 libwx_gtk3u_core-3.2.so.0:_ZN10wxMemoryDCC1Ev
 libwx_gtk3u_core-3.2.so.0:_ZN10wxMenuBase4InitEl
 libwx_gtk3u_core-3.2.so.0:_ZN10wxMenuBase5CheckEib
+libwx_gtk3u_core-3.2.so.0:_ZN10wxMenuBase6DeleteEP10wxMenuItem
 libwx_gtk3u_core-3.2.so.0:_ZN10wxMenuBase6EnableEib
 libwx_gtk3u_core-3.2.so.0:_ZN10wxMenuBase8SetLabelEiRK8wxString
 libwx_gtk3u_core-3.2.so.0:_ZN10wxMenuBaseD2Ev
@@ -724,7 +725,6 @@ libwx_gtk3u_core-3.2.so.0:_ZN11wxTextEntryD2Ev
 libwx_gtk3u_core-3.2.so.0:_ZN11wxWrapSizer18RepositionChildrenERK6wxSize
 libwx_gtk3u_core-3.2.so.0:_ZN11wxWrapSizer20InformFirstDirectionEiii
 libwx_gtk3u_core-3.2.so.0:_ZN11wxWrapSizer7CalcMinEv
-libwx_gtk3u_core-3.2.so.0:_ZN11wxWrapSizerC1Eii
 libwx_gtk3u_core-3.2.so.0:_ZN11wxWrapSizerC2Eii
 libwx_gtk3u_core-3.2.so.0:_ZN11wxWrapSizerD2Ev
 libwx_gtk3u_core-3.2.so.0:_ZN12wxBitmapBase8UseAlphaEb
@@ -811,6 +811,7 @@ libwx_gtk3u_core-3.2.so.0:_ZN12wxWindowBase8DoCentreEi
 libwx_gtk3u_core-3.2.so.0:_ZN12wxWindowBase8SetSizerEP7wxSizerb
 libwx_gtk3u_core-3.2.so.0:_ZN12wxWindowBase8TryAfterER7wxEvent
 libwx_gtk3u_core-3.2.so.0:_ZN12wxWindowBase8ValidateEv
+libwx_gtk3u_core-3.2.so.0:_ZN12wxWindowBase9FindFocusEv
 libwx_gtk3u_core-3.2.so.0:_ZN12wxWindowBase9FitInsideEv
 libwx_gtk3u_core-3.2.so.0:_ZN12wxWindowBase9PopupMenuEP6wxMenuii
 libwx_gtk3u_core-3.2.so.0:_ZN12wxWindowBase9TryBeforeER7wxEvent
@@ -1250,6 +1251,7 @@ libwx_gtk3u_core-3.2.so.0:_ZN9wxToolTip6EnableEb
 libwx_gtk3u_core-3.2.so.0:_ZNK10wxFontBase21GetNativeFontInfoDescEv
 libwx_gtk3u_core-3.2.so.0:_ZNK10wxFontBase9GetFamilyEv
 libwx_gtk3u_core-3.2.so.0:_ZNK10wxListView12GetClassInfoEv
+libwx_gtk3u_core-3.2.so.0:_ZNK10wxMenuBase18FindItemByPositionEm
 libwx_gtk3u_core-3.2.so.0:_ZNK10wxMenuBase8FindItemEiPP6wxMenu
 libwx_gtk3u_core-3.2.so.0:_ZNK10wxMenuBase9IsCheckedEi
 libwx_gtk3u_core-3.2.so.0:_ZNK10wxPrintout12GetClassInfoEv
@@ -1520,7 +1522,6 @@ libwx_gtk3u_core-3.2.so.0:_ZTI8wxWindow
 libwx_gtk3u_core-3.2.so.0:_ZTI9wxMenuBar
 libwx_gtk3u_core-3.2.so.0:_ZTI9wxPaintDC
 libwx_gtk3u_core-3.2.so.0:_ZTV10wxBoxSizer
-libwx_gtk3u_core-3.2.so.0:_ZTV10wxBusyInfo
 libwx_gtk3u_core-3.2.so.0:_ZTV10wxCheckBox
 libwx_gtk3u_core-3.2.so.0:_ZTV10wxComboBox
 libwx_gtk3u_core-3.2.so.0:_ZTV10wxListCtrl
@@ -1538,7 +1539,6 @@ libwx_gtk3u_core-3.2.so.0:_ZTV11wxSizerItem
 libwx_gtk3u_core-3.2.so.0:_ZTV11wxStaticBox
 libwx_gtk3u_core-3.2.so.0:_ZTV11wxStatusBar
 libwx_gtk3u_core-3.2.so.0:_ZTV12wxButtonBase
-libwx_gtk3u_core-3.2.so.0:_ZTV12wxCloseEvent
 libwx_gtk3u_core-3.2.so.0:_ZTV12wxGIFHandler
 libwx_gtk3u_core-3.2.so.0:_ZTV12wxMouseEvent
 libwx_gtk3u_core-3.2.so.0:_ZTV12wxPNGHandler
@@ -1716,6 +1716,7 @@ libwx_gtk3u_core-3.2.so.0:wxStatusBarNameStr
 libwx_gtk3u_core-3.2.so.0:wxTextCtrlNameStr
 libwx_gtk3u_core-3.2.so.0:wxTheBrushList
 libwx_gtk3u_core-3.2.so.0:wxThePenList
+libwx_gtk3u_core-3.2.so.0:wxTopLevelWindows
 libwx_gtk3u_richtext-3.2.so.0:_ZN14wxRichTextAttr4CopyERKS_
 libwx_gtk3u_richtext-3.2.so.0:_ZN14wxRichTextCtrl10AppendTextERK8wxString
 libwx_gtk3u_richtext-3.2.so.0:_ZN14wxRichTextCtrl10ApplyStyleEP25wxRichTextStyleDefinition
@@ -1825,6 +1826,7 @@ libwx_gtk3u_richtext-3.2.so.0:_ZN14wxRichTextCtrl9MoveCaretElbP28wxRichTextParag
 libwx_gtk3u_richtext-3.2.so.0:_ZN14wxRichTextCtrl9MoveRightEii
 libwx_gtk3u_richtext-3.2.so.0:_ZN14wxRichTextCtrl9WordRightEii
 libwx_gtk3u_richtext-3.2.so.0:_ZN14wxRichTextCtrl9WriteTextERK8wxString
+libwx_gtk3u_richtext-3.2.so.0:_ZN14wxRichTextCtrlC1EP8wxWindowiRK8wxStringRK7wxPointRK6wxSizelRK11wxValidatorS4_
 libwx_gtk3u_richtext-3.2.so.0:_ZN14wxRichTextCtrlC2EP8wxWindowiRK8wxStringRK7wxPointRK6wxSizelRK11wxValidatorS4_
 libwx_gtk3u_richtext-3.2.so.0:_ZN14wxRichTextCtrlD2Ev
 libwx_gtk3u_richtext-3.2.so.0:_ZN16wxRichTextBuffer10BeginStyleERK14wxRichTextAttr
@@ -1834,7 +1836,10 @@ libwx_gtk3u_richtext-3.2.so.0:_ZN16wxRichTextBuffer14BeginBatchUndoERK8wxString
 libwx_gtk3u_richtext-3.2.so.0:_ZN16wxRichTextBuffer15BeginTextColourERK8wxColour
 libwx_gtk3u_richtext-3.2.so.0:_ZN16wxRichTextBuffer15EndSuppressUndoEv
 libwx_gtk3u_richtext-3.2.so.0:_ZN16wxRichTextBuffer17BeginSuppressUndoEv
+libwx_gtk3u_richtext-3.2.so.0:_ZN16wxRichTextBuffer17BeginSymbolBulletERK8wxStringiii
+libwx_gtk3u_richtext-3.2.so.0:_ZN16wxRichTextBuffer8BeginURLERK8wxStringS2_
 libwx_gtk3u_richtext-3.2.so.0:_ZN16wxRichTextBuffer8EndStyleEv
+libwx_gtk3u_richtext-3.2.so.0:_ZN16wxRichTextBuffer9BeginBoldEv
 libwx_gtk3u_richtext-3.2.so.0:_ZNK14wxRichTextCtrl10DoGetValueEv
 libwx_gtk3u_richtext-3.2.so.0:_ZNK14wxRichTextCtrl10IsEditableEv
 libwx_gtk3u_richtext-3.2.so.0:_ZNK14wxRichTextCtrl10IsModifiedEv

--- a/packages/w/wxmaxima/package.yml
+++ b/packages/w/wxmaxima/package.yml
@@ -1,8 +1,8 @@
 name       : wxmaxima
-version    : 23.12.0
-release    : 25
+version    : 24.02.0
+release    : 26
 source     :
-    - https://github.com/wxMaxima-developers/wxmaxima/archive/refs/tags/Version-23.12.0.tar.gz : abec636e96474adf6451e81728b16afaa83ed1a70b86a695fa083ecec65aaae1
+    - https://github.com/wxMaxima-developers/wxmaxima/archive/refs/tags/Version-24.02.0.tar.gz : 1bb5f9df2f23c1471e5a3f23a82c6caa0f1463c68ccd8ce3e6006fcca3a692db
 homepage   : https://wxmaxima-developers.github.io/wxmaxima/
 license    : GPL-2.0-or-later
 component  : office.maths

--- a/packages/w/wxmaxima/pspec_x86_64.xml
+++ b/packages/w/wxmaxima/pspec_x86_64.xml
@@ -94,9 +94,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="25">
-            <Date>2024-02-02</Date>
-            <Version>23.12.0</Version>
+        <Update release="26">
+            <Date>2024-02-04</Date>
+            <Version>24.02.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
             <Email>malfisya.dev@hotmail.com</Email>


### PR DESCRIPTION
**Summary**

- Faster start-up
- Better performance directly after startup
- Faster loading of files
- Better button placement in sidebars
- Clear wxMaxima's input buffer on starting a new maxima process
- A nicer ChangeLog dialogue
- Corrected for swapped row and columns in wizard enter matrix
- Fixed a few bugs in the XML saving code
- Zooming did cause recalculation only for the 1st cell
- Many config changes now have immediately effect on the worksheet
- Added the unicode-enhanced ASCII art from maxima to the menus
- Steamlined the cell size calculation stuff
- Completely overhauled the printing functionality
- Moved more of the help file indexing to the background
- Better event handling in the unicode sidebars
- Reading out the values of maxima variables for the GUI was broken
- Many checkmarks in menus had the wrong value
- Maxima's demos are now available in the menu and context menu
- Default the filter search boxes to text search, not regex
- Rescaling affected size calculations for code only with a delay
- The context menu in the "greek letters" sidebar now works
- Resolved an assert if the internal help browser was disabled, but requested
- wxMaxima now preserves history entries between sessions
- Better LibreOffice compatibility with the MathML output
- Better HTML output
- Fix crash when exporting a worksheet with animations to TeX
- Resolved a crash on closing a window

**Test Plan**

Open example file

**Checklist**

- [x] Package was built and tested against unstable