### PR TITLE
m64py: Add appstream metadata

### DIFF
--- a/packages/m/m64py/files/net.sourceforge.m64py.metainfo.xml
+++ b/packages/m/m64py/files/net.sourceforge.m64py.metainfo.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>net.sourceforge.m64py</id>
+
+  <name>M64Py</name>
+  <summary>A frontend for Mupen64Plus</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>gamepad</control>
+  </supports>
+
+  <description>
+    <p>
+      M64Py is a Qt5 front-end (GUI) for Mupen64Plus, a cross-platform plugin-based Nintendo 64 emulator. Front-end is written in Python and it provides a user-friendly interface over Mupen64Plus shared library.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">m64py.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://m64py.sourceforge.net/assets/images/about.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://m64py.sourceforge.net/assets/images/screenshots/ss_01.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://m64py.sourceforge.net/assets/images/screenshots/ss_03.png</image>
+    </screenshot>
+  </screenshots>
+</component>

--- a/packages/m/m64py/package.yml
+++ b/packages/m/m64py/package.yml
@@ -1,6 +1,6 @@
 name       : m64py
 version    : 0.2.5
-release    : 11
+release    : 12
 source     :
     - git|https://github.com/mupen64plus/mupen64plus-ui-python.git : 90093ce3b353ff0fbe3277eb5d75130debdf0fab
 license    :
@@ -27,3 +27,5 @@ build      : |
     %python3_setup
 install    : |
     %python3_install
+    # Install appstream metainfo
+    install -Dm00644 $pkgfiles/net.sourceforge.m64py.metainfo.xml -t $installdir/usr/share/metainfo/

--- a/packages/m/m64py/pspec_x86_64.xml
+++ b/packages/m/m64py/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>m64py</Name>
         <Homepage>https://m64py.sourceforge.net/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>CC-BY-SA-3.0</License>
@@ -124,16 +124,17 @@
             <Path fileType="library">/usr/lib/python3.10/site-packages/m64py/ui/title_rc.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/m64py/utils.py</Path>
             <Path fileType="data">/usr/share/applications/m64py.desktop</Path>
+            <Path fileType="data">/usr/share/metainfo/net.sourceforge.m64py.metainfo.xml</Path>
             <Path fileType="data">/usr/share/pixmaps/m64py.png</Path>
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2024-02-04</Date>
+        <Update release="12">
+            <Date>2024-02-05</Date>
             <Version>0.2.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Added appstream metadata (Part of getsolus/packages#1389)

**Test Plan**

Verify metadata with `appstream-builder --packages-dir=. --include-failed -v`

**Checklist**

- [x] Package was built and tested against unstable