### PR TITLE
mupen64plus-qt: Add appstream metadata

### DIFF
--- a/packages/m/mupen64plus-qt/files/io.github.dh4.mupen64plus_qt.metainfo.xml
+++ b/packages/m/mupen64plus-qt/files/io.github.dh4.mupen64plus_qt.metainfo.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.dh4.mupen64plus_qt</id>
+
+  <name>Mupen64Plus-Qt </name>
+  <summary>A customizable launcher for Mupen64Plus </summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>BSD-3-Clause</project_license>
+
+  <description>
+    <p>
+      A customizable cross-platform launcher. This was adapted from CEN64-Qt to work with Mupen64Plus
+    </p>
+  </description>
+
+  <launchable type="desktop-id">mupen64plus-qt.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/dh4/mupen64plus-qt/master/resources/demos/main.jpg</image>
+    </screenshot>
+  </screenshots>
+</component>

--- a/packages/m/mupen64plus-qt/package.yml
+++ b/packages/m/mupen64plus-qt/package.yml
@@ -1,11 +1,11 @@
 name       : mupen64plus-qt
 version    : "1.15"
-release    : 2
+release    : 3
 source     :
     - https://github.com/dh4/mupen64plus-qt/archive/1.15.tar.gz : c41448adb7dd6acb6d4f56f7cdd2f25a8fd9a9e9ee23e334c0969b835802f20a
+homepage   : https://github.com/dh4/mupen64plus-qt
 license    : BSD-3-Clause
 component  : games.emulator
-homepage   : https://github.com/dh4/mupen64plus-qt
 summary    : Customizable cross-platform launcher for mupen64plus
 description: |
     A customizable cross-platform launcher. This was adapted from CEN64-Qt to work with Mupen64Plus.
@@ -31,3 +31,4 @@ install    : |
     install -Dm00644 $workdir/resources/mupen64plus-qt.desktop $installdir/usr/share/applications/mupen64plus-qt.desktop
     install -Dm00644 $workdir/resources/images/mupen64plus.png $installdir/usr/share/icons/hicolor/128x128/apps/mupen64plus-qt.png
     install -Dm00644 $workdir/resources/mupen64plus-qt.6 $installdir/usr/share/man/man6/mupen64plus-qt.6
+    install -Dm00644 $pkgfiles/io.github.dh4.mupen64plus_qt.metainfo.xml -t $installdir/usr/share/metainfo/

--- a/packages/m/mupen64plus-qt/pspec_x86_64.xml
+++ b/packages/m/mupen64plus-qt/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mupen64plus-qt</Name>
         <Homepage>https://github.com/dh4/mupen64plus-qt</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>games.emulator</PartOf>
@@ -24,15 +24,16 @@
             <Path fileType="data">/usr/share/applications/mupen64plus-qt.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/mupen64plus-qt.png</Path>
             <Path fileType="man">/usr/share/man/man6/mupen64plus-qt.6</Path>
+            <Path fileType="data">/usr/share/metainfo/io.github.dh4.mupen64plus_qt.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2023-11-22</Date>
+        <Update release="3">
+            <Date>2024-02-05</Date>
             <Version>1.15</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add appstream metadata (Part of getsolus/packages#1389)

**Test Plan**

Verify metadata with `appstream-builder --packages-dir=. --include-failed -v`

**Checklist**

- [x] Package was built and tested against unstable