### PR TITLE
torbrowser-launcher: Update to 0.3.7 and add dependency

### DIFF
--- a/packages/t/torbrowser-launcher/package.yml
+++ b/packages/t/torbrowser-launcher/package.yml
@@ -1,8 +1,9 @@
 name       : torbrowser-launcher
-version    : 0.3.6
-release    : 15
+version    : 0.3.7
+release    : 16
 source     :
-    - https://github.com/micahflee/torbrowser-launcher/archive/refs/tags/v0.3.6.tar.gz : 39db8bd936502bc6d9adf3a628fba13a728c7b1aa2b5bac148454c8718863654
+    - https://gitlab.torproject.org/tpo/applications/torbrowser-launcher/-/archive/v0.3.7/torbrowser-launcher-v0.3.7.tar.gz : bd348fd5d923f078c75870a9139678a467b2ab5ba21117fd42ccf0cfa3e4be21
+homepage   : https://gitlab.torproject.org/tpo/applications/torbrowser-launcher
 license    : BSD-1-Clause
 component  : network.web.browser
 summary    : Securely and easily install Tor Browser
@@ -12,10 +13,11 @@ builddeps  :
     - python-distro
 rundeps    :
     - gnupg
-    - python3-qt5
     - python-gpg
+    - python-packaging
     - python-pysocks
     - python-requests
+    - python3-qt5
     - tor
 setup      : |
     %python3_setup

--- a/packages/t/torbrowser-launcher/pspec_x86_64.xml
+++ b/packages/t/torbrowser-launcher/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>torbrowser-launcher</Name>
+        <Homepage>https://gitlab.torproject.org/tpo/applications/torbrowser-launcher</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>BSD-1-Clause</License>
         <PartOf>network.web.browser</PartOf>
         <Summary xml:lang="en">Securely and easily install Tor Browser</Summary>
         <Description xml:lang="en">Tor Browser Launcher is intended to make Tor Browser easier to install and use for GNU/Linux users.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>torbrowser-launcher</Name>
@@ -25,11 +26,11 @@
             <Path fileType="config">/etc/apparmor.d/torbrowser.Tor.tor</Path>
             <Path fileType="config">/etc/apparmor.d/tunables/torbrowser</Path>
             <Path fileType="executable">/usr/bin/torbrowser-launcher</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/torbrowser_launcher-0.3.6-py3.10.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/torbrowser_launcher-0.3.6-py3.10.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/torbrowser_launcher-0.3.6-py3.10.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/torbrowser_launcher-0.3.6-py3.10.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/torbrowser_launcher-0.3.6-py3.10.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/torbrowser_launcher-0.3.7-py3.10.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/torbrowser_launcher-0.3.7-py3.10.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/torbrowser_launcher-0.3.7-py3.10.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/torbrowser_launcher-0.3.7-py3.10.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/torbrowser_launcher-0.3.7-py3.10.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/torbrowser_launcher/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/torbrowser_launcher/__pycache__/__init__.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/torbrowser_launcher/__pycache__/common.cpython-310.pyc</Path>
@@ -55,19 +56,19 @@
             <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/torbrowser-launcher.mo</Path>
             <Path fileType="localedata">/usr/share/locale/tr/LC_MESSAGES/torbrowser-launcher.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/torbrowser-launcher.mo</Path>
-            <Path fileType="data">/usr/share/metainfo/torbrowser.appdata.xml</Path>
+            <Path fileType="data">/usr/share/metainfo/org.torproject.torbrowser-launcher.metainfo.xml</Path>
             <Path fileType="data">/usr/share/torbrowser-launcher/mirrors.txt</Path>
             <Path fileType="data">/usr/share/torbrowser-launcher/tor-browser-developers.asc</Path>
             <Path fileType="data">/usr/share/torbrowser-launcher/version</Path>
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2023-09-29</Date>
-            <Version>0.3.6</Version>
+        <Update release="16">
+            <Date>2024-02-05</Date>
+            <Version>0.3.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

This updates torbrowser-launcher to version 0.3.7 and adds the missing `python-packaging` dependency (thanks to @clivej for the hint in https://github.com/getsolus/packages/pull/1148)

Changes:
- Use Tor Browser 13.0 new filenames
- Adapt AppArmor profile for Tor Browser 13.0
- Set the `TORBROWSER_LAUNCHER` environment variable to make it easier for Tor Browser to see that it is being run by `torbrowser-launcher`
- Use a proper rDNS ID in AppStream metainfo
- Update to latest version of the Tor Browser OpenPGP signing key
- Remove some unused code to fix a warning

Note: this also changes to the new upstream repository on gitlab, managed by the Tor Project

**Test Plan**

Let `torbrowser-launcher` download and launch Tor Browser

**Checklist**

- [x] Package was built and tested against unstable
