### PR TITLE
protonmail-bridge: update to 3.8.2

### DIFF
--- a/packages/p/protonmail-bridge/package.yml
+++ b/packages/p/protonmail-bridge/package.yml
@@ -1,8 +1,8 @@
 name       : protonmail-bridge
-version    : 3.8.1
-release    : 19
+version    : 3.8.2
+release    : 20
 source     :
-    - https://github.com/ProtonMail/proton-bridge/archive/refs/tags/v3.8.1.tar.gz : ff49b43fb796a7fe129bdd1c5334165d63af3220d7c2448d0d381e62dd6658db
+    - https://github.com/ProtonMail/proton-bridge/archive/refs/tags/v3.8.2.tar.gz : 3d844fa74c06767283a73305737e82b9ec7c59cc35d08fcb8a5bd68a128735e2
 homepage   : https://proton.me/mail/bridge
 license    : GPL-3.0-or-later
 component  : network.mail

--- a/packages/p/protonmail-bridge/pspec_x86_64.xml
+++ b/packages/p/protonmail-bridge/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>protonmail-bridge</Name>
         <Homepage>https://proton.me/mail/bridge</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jasper Behrensdorf</Name>
+            <Email>solus.citizen140@passmail.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.mail</PartOf>
@@ -28,12 +28,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2024-02-03</Date>
-            <Version>3.8.1</Version>
+        <Update release="20">
+            <Date>2024-02-05</Date>
+            <Version>3.8.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jasper Behrensdorf</Name>
+            <Email>solus.citizen140@passmail.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

**Changelog**:

- Resolved an issue that prevented Windows and Linux users to auto update to newer versions of Bridge, and in some cases reverted to a previous version of Bridge. NOTE: All Bridge versions that are between v3.2.0 and v3.8.1 (inclusive) need to be update to the latest Bridge version manually.

Link to release notes: https://proton.me/download/bridge/stable_releases.html

**Test Plan**

Synced mail through thunderbird.

**Checklist**

- [x] Package was built and tested against unstable
