### PR TITLE
ppsspp: Update to 1.17.1

### DIFF
--- a/packages/p/ppsspp/abi_used_symbols
+++ b/packages/p/ppsspp/abi_used_symbols
@@ -710,6 +710,10 @@ libzstd.so.1:ZSTD_compress
 libzstd.so.1:ZSTD_compress2
 libzstd.so.1:ZSTD_compressBound
 libzstd.so.1:ZSTD_createCCtx
+libzstd.so.1:ZSTD_createDStream
 libzstd.so.1:ZSTD_decompress
+libzstd.so.1:ZSTD_decompressStream
 libzstd.so.1:ZSTD_freeCCtx
+libzstd.so.1:ZSTD_freeDStream
+libzstd.so.1:ZSTD_initDStream
 libzstd.so.1:ZSTD_isError

--- a/packages/p/ppsspp/files/org.ppsspp.PPSSPP.metainfo.xml
+++ b/packages/p/ppsspp/files/org.ppsspp.PPSSPP.metainfo.xml
@@ -1,0 +1,387 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>org.ppsspp.PPSSPP</id>
+  <name>PPSSPP</name>
+  <summary>A PlayStation Portable emulator</summary>
+  <summary xml:lang="de">Ein PlayStation Portable-Emulator</summary>
+  <summary xml:lang="pl">Emulator PlayStation Portable</summary>
+  <developer_name>Henrik Rydgård</developer_name>
+  <launchable type="desktop-id">PPSSPPSDL.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-or-later</project_license>
+  <update_contact>b@bpiotrowski.pl</update_contact>
+  <description>
+    <p>PPSSPP is a PSP emulator that can run games in full HD resolution. It can
+      even upscale textures that would otherwise be too blurry as they were made
+      for the small screen of the original PSP.</p>
+    <p xml:lang="de">PPSSPP ist ein PSP-Emulator, der Spiele in voller HD-Auflösung
+      abspielen kann. Er kann sogar Texturen höher skalieren, welche ansonsten 
+      zu verwaschen wären, da sie für den kleinen Bildschirm der ursprünglichen
+      PSP erstellt wurden.</p>
+    <p xml:lang="pl">PPSSPP, to emulator PSP, który potrafi odtwarzać gry w pełnej rozdzielczości
+      HD. Jest nawet w stanie przeskalować tekstury na większe, które w innym
+      przypadku byłyby za bardzo rozmazane, ponieważ zostały stworzone na mały
+      ekran pierwotnej PSP.</p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Recent Games</caption>
+      <image type="source">https://raw.githubusercontent.com/flathub/org.ppsspp.PPSSPP/master/screenshots/1.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Credits screen</caption>
+      <image type="source">https://raw.githubusercontent.com/flathub/org.ppsspp.PPSSPP/master/screenshots/2.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Settings</caption>
+      <image type="source">https://raw.githubusercontent.com/flathub/org.ppsspp.PPSSPP/master/screenshots/3.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>In-game</caption>
+      <image type="source">https://raw.githubusercontent.com/flathub/org.ppsspp.PPSSPP/master/screenshots/4.png</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="1.17.1" date="2024-02-04"/>
+    <release version="1.17" date="2024-01-27"/>
+    <release version="1.16.6" date="2023-10-12"/>
+    <release version="1.16.5" date="2023-09-28"/>
+    <release version="1.16.3" date="2023-09-22"/>
+    <release version="1.16.2" date="2023-09-19"/>
+    <release version="1.16.1" date="2023-09-15"/>
+    <release version="1.15.4" date="2023-05-23"/>
+    <release version="1.15.3" date="2023-05-08"/>
+    <release version="1.15.2" date="2023-05-05"/>
+    <release version="1.15" date="2023-05-01"/>
+    <release version="1.14.4" date="2023-01-03"/>
+    <release version="1.14.3" date="2023-01-02"/>
+    <release version="1.14.2" date="2022-12-30"/>
+    <release version="1.14.1" date="2022-12-20"/>
+    <release version="1.14" date="2022-12-15"/>
+    <release version="1.13.2" date="2022-09-10">
+      <description>
+        <p>What's new in 1.13.2</p>
+        <ul>
+          <li>Crashfix on Android 12 when playing certain background music ([#15990])</li>
+          <li>Fix Star Ocean battles in D3D backends (#[15889])</li>
+          <li>Minor fixes that might fix some other crashes</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.13.1b" date="2022-09-10"/>
+    <release version="1.13.1" date="2022-07-28">
+      <description>
+        <p>What's new in 1.13.1</p>
+        <ul>
+          <li>Confirmation dialog added before change of MAC address (#15738)</li>
+          <li>IR interpreter regression fixed (#15739)</li>
+          <li>Fix clearing of replacement texture cache (#15740)</li>
+          <li>Improved Portuguese-pt translation (#15734)</li>
+          <li>Fix graphical regression in Split/Second (#15733)</li>
+          <li>Couple of minor crash fixes</li>
+        </ul>
+      </description>
+      <issues>
+        <issue url="https://github.com/hrydgard/ppsspp/issues/15733">#15733</issue>
+        <issue url="https://github.com/hrydgard/ppsspp/issues/15734">#15734</issue>
+        <issue url="https://github.com/hrydgard/ppsspp/issues/15738">#15738</issue>
+        <issue url="https://github.com/hrydgard/ppsspp/issues/15739">#15739</issue>
+        <issue url="https://github.com/hrydgard/ppsspp/issues/15889">#15740</issue>
+      </issues>
+    </release>
+    <release version="1.13" date="2022-07-26">
+      <description>
+        <p>What's new in 1.13</p>
+        <p>General</p>
+        <ul>
+          <li>Fix assorted Android "scoped storage"-related bugs and performance issues (#15237, #15487), etc.</li>
+          <li>Analog mapping for fast-forward (#15645)</li>
+          <li>Major softgpu accuracy fixes and speedups, including a JIT (#15163, #15345, #15389, #15529, #15440, #15410, #15405, #15400) and many, many more</li>
+          <li>Fixed some NEON code paths (#15481)</li>
+          <li>Fix performance of texture uploads with Vulkan (#15474)</li>
+          <li>Don't include the large font atlas when we don't need it</li>
+          <li>Improved upscaling shaders (#15566)</li>
+          <li>Vulkan texture upscaling performance improvements (#15238), etc.</li>
+          <li>Vulkan correctness fixes (#15217, #15211), use the VMA allocator (#15162), etc.</li>
+          <li>Fixes to depth culling (#15106), many more</li>
+          <li>Background loading of texture replacement (#15025)</li>
+          <li>Threading manager improvements and fixes (#15470), etc.</li>
+          <li>Added search in settings (#14414)</li>
+          <li>Added fast button repeats on custom touch buttons (#15613)</li>
+          <li>Two new bicubic upscaling shader: Catmull-Rom and Mitchell-Netravali (#15569)</li>
+          <li>Allow to change screen rotation per game and to bind a key to change it (#15494, #15510)</li>
+          <li>Re-enabled software rendering option on Android (#12958)</li>
+        </ul>
+        <p>Game fixes</p>
+        <ul>
+          <li>Add more workarounds for Mali driver bugs (#15016)</li>
+          <li>Vortex in God of War: Ghost of Sparta can now be passed (#15640)</li>
+          <li>Various proAdhoc fixes (#15213, #15215), and many more</li>
+          <li>Correct flickering text in Sol Trigger and Last Ranker. (#15549)</li>
+          <li>Fix and improve line drawing in Echochrome (#15583), after line refactoring (#15073, #15075)</li>
+          <li>Fix HUD graphics in Split/Second (#15500, #15501)</li>
+          <li>Fix bad screen overlay issues in Clone Wars and Force Unleashed (#15691, #15696, #12949, #9572)</li>
+          <li>Zettai Zetsumei Toshi 3 no longer hangs on character select screen (#15687)</li>
+          <li>Juiced 2: Bloom effect no longer covering the screen (#7295, #15717)</li>
+          <li>Fix keyboard shift issue in a few games (#15698)</li>
+        </ul>
+        <p>UI</p>
+        <ul>
+          <li>Windows/Xbox UWP directory navigation improvements (#15652)</li>
+          <li>Color change and basic theme support (#15396, #15394)</li>
+          <li>Fix input focus bug (#15560)</li>
+          <li>New GE debugger features and other UI fixes (#15393, #15324, #15377, #15424, #15402, #15378, #15338), etc.</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.12.3" date="2021-10-18">
+      <description>
+        <p>What's new in 1.12.3</p>
+        <ul>
+          <li>Fix background music speed. A couple translation fixes.</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.12.2" date="2021-10-10">
+      <description>
+        <p>What's new in 1.12.2</p>
+        <ul>
+          <li>Fix joystick detection bug on Android.</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.12.1" date="2021-10-09">
+      <description>
+        <p>What's new in 1.12.1</p>
+        <ul>
+          <li>Bug fixes (control mapping fix, popup menus in the Windows debugger, a few crashfixes)</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.12" date="2021-10-07">
+      <description>
+        <p>What's new in 1.12</p>
+        <p>Platform support:</p>
+        <ul>
+          <li>Add support for Android 12 Scoped Storage restrictions ([#11997])</li>
+          <li>iOS: Fix multitouch tracking ([#5099])</li>
+          <li>Android: Fix screenshot orientation on Vulkan ([#14053])</li>
+          <li>Linux: Improve support for system FFmpeg 3.1+ ([#14176], [#14188], [#14199])</li>
+          <li>libretro: Always enable function hooks ([#14145])</li>
+          <li>AMD: Enable Vulkan rendering on a thread ([#13864])</li>
+          <li>Add iOS version detection, turn off JIT on bootup if &gt;= 14.3. ([#14201])</li>
+          <li>iOS: Try a different JIT detection method, thanks Halo-Michael ([#14241])</li>
+          <li>Windows: Restore window size correctly ([#14317])</li>
+        </ul>
+        <p>Game fixes:</p>
+        <ul>
+          <li>Fix NBA Live 08 loading ([#8288])</li>
+          <li>Display Open Season title screen correctly ([#13252])</li>
+          <li>Fix Metal Gear Solid Peace Walker Chinese Patched blue screen ([#14127])</li>
+          <li>Load Ape Academy 2 correctly ([#14271])</li>
+          <li>Many more...</li>
+        </ul>
+        <p>Graphics and Sound:</p>
+        <ul>
+          <li>Add new texture filtering mode "Auto Max Quality" ([#14789])</li>
+          <li>Fix Princess Maker 5 Portable half screen in Vulkan ([#13741])</li>
+          <li>Fix Pro Yakyu Spirits 2010 (NPJH50234): Rendering errors with hardware transform off  ([#14167])</li>
+          <li>Support texture replacement filtering overrides ([#14230])</li>
+          <li>Fix Yarudora Portable: Double Cast's FMVs artifacting  ([#13759])</li>
+          <li>Fix Sims 2 Castaway/Pets EA Logo glitched out ([#13146])</li>
+          <li>Fix bad size &amp; position on Japanese &amp; Numbers &amp; Alphabets ([#14209])</li>
+          <li>Implement basic depth texturing for OpenGL ([#14042])</li>
+          <li>Google Cardboard fixes ([#14966], [#14768])</li>
+          <li>Correct mini-map update in Z.H.P. ([#14069])</li>
+          <li>Fix crash in vertex jit on ARM32 ([#14879])</li>
+          <li>Add a setting for reverb volume ([#14711])</li>
+          <li>Option to switch to new devices or not, on Windows.</li>
+        </ul>
+        <p>UI:</p>
+        <ul>
+          <li>Add a setting for choosing background animation in PPSSPP's menus ([#14313], [#14818], [#14810], [#14347])</li>
+          <li>Add CRC calculation on game info screen and feedback screen ([#14000], [#14041])</li>
+          <li>Add a Storage tab to System Information with some path info ([#14224], [#14238])</li>
+          <li>Track and show memory allocation / usage information in debugger ([#14056])</li>
+          <li>Allow searching within the savedata manager ([#14237])</li>
+          <li>Enable postshaders to access previous frame ([#14528])</li>
+          <li>Add missing japanese keyboard symbol ([#14548])</li>
+          <li>Add Reset button on crash screen, allow load state and related ([#14708])</li>
+          <li>Implement savestate load and save undo ([#14676], [#14679], [#14697])</li>
+          <li>A lot of minor debugger improvements</li>
+        </ul>
+        <p>Controls:</p>
+        <ul>
+          <li>New analog stick calibration menu ([#14596])</li>
+          <li>Improved combo button and moved settings to Customize Touch Control -&gt; Customize -&gt; Custom button ([#13869])</li>
+          <li>Improved tilt control, allow to change axis ([#12530])</li>
+          <li>Add a visual means of control mapping ([#14769])</li>
+          <li>Add basic motion gesture support ([#13107])</li>
+          <li>Fix touch control DPAD not getting input when dragged over, and make touch analog drag not activate other buttons ([#14843])</li>
+          <li>Allow adjusting touch control analog stick head size ([#14480])</li>
+        </ul>
+        <p>Adhoc/Network:</p>
+        <ul>
+          <li>Fix multiplayer issue on MGS:PW due to detecting an incorrect source port on incoming data ([#14140])</li>
+          <li>Always enable TCPNoDelay to improve response time ([#14235])</li>
+          <li>Fix Teenage Mutant Ninja Turtles multiplayer ([#14284])</li>
+          <li>Fix FlatOut Head On multiplayer ([#14290])</li>
+          <li>Prevent flooding Adhoc Server with connection attempts ([#14335])</li>
+          <li>Fix crashing issue when leaving a multiplayer game room (ie. GTA Vice City Stories) ([#14342])</li>
+          <li>Fix stuck issue when scanning AP to Recruit on MGS:PW ([#14345])</li>
+          <li>Fix possible crash issue on blocking socket implementation (ie. Kao Challengers) ([#14466])</li>
+          <li>Create GameMode's socket after Master and all Replicas have been created (ie. Fading Shadows) ([#14492])</li>
+          <li>Reduce HLE delays due to multiplayer performance regressions (ie. Ys vs. Sora no Kiseki) ([#14513])</li>
+          <li>Fix socket error 10014 on Windows when hosting a game of Vulcanus Seek and Destroy ([#14849])</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.11.3" date="2021-06-10">
+      <description>
+        <p>What's new in 1.11.3:</p>
+        <ul>
+          <li>Fix for graphics glitches in the on-screen keyboard</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.11.2" date="2021-02-14">
+      <description>
+        <p>What's new in 1.11.2:</p>
+        <ul>
+          <li>An additional few crash fixes(#14129, #14134, #14132)</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.11.1" date="2021-02-11">
+      <description>
+        <p>What's new in 1.11.1:</p>
+        <ul>
+          <li>A few crash fixes (#14085, #14089, #14091, #14092), a few adhoc fixes</li>
+          <li>Glitchy menu audio on some devices (#14101), in-game UI font memory leak (#14078)</li>
+          <li>Couple of adhoc fixes (#14106, #14117)</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.11.0" date="2021-02-07">
+      <description>
+        <p>What's new in 1.11.0:</p>
+        <ul>
+          <li>Lots of minor bug fixes, crash fixes, and performance fixes and improvements.</li>
+          <li>New Browse... button to allow opening SD cards on Android 11</li>
+          <li>Countless AdHoc networking fixes by ANR2ME, for example Dragon Ball Shin Budokai, PowerStone, Bleach Heat The Soul 7, Kingdom Hearts, GTA: VCS and many more.</li>
+          <li>Graphics issue with car reflections fixed in Outrun, Dirt 2 (#13636, #13640, #13760)</li>
+          <li>Cut-off cards in Yu Gi Oh fixed (#7124).</li>
+          <li>Numerous fixes to the builtin fonts by nassau-tk</li>
+          <li>Added exception handler so PPSSPP stays alive if a game crashes (#11795/#13092)</li>
+          <li>Desktop: Support for multiple instance multiplayer (#13172, ...)</li>
+          <li>Workaround for rendering bugs with flat shading in iOS 14</li>
+          <li>Multiple fixes to the IR interpreter (#13897, ...)</li>
+          <li>UI: New fullscreen button on desktop platforms, optional navigation sounds (#13239)</li>
+          <li>Audio and multiple hangs fixes in UWP version (#13792, ...)</li>
+          <li>Partial microphone support (#12336, ...)</li>
+          <li>Workaround for wacky action mirroring bug in Hitman Reborn Battle Arena 2 (#13706, #13526)</li>
+          <li>Hardware texture upscaling for Vulkan, mipmap generation (#13235, #13514)</li>
+          <li>Added MMPX Vulkan texture upscaling shader (#13986)</li>
+          <li>Depth texturing support in Vulkan and D3D11 (#13262, #13556, ...)</li>
+          <li>Performance fix for Test Drive Unlimited (#13355, ...)</li>
+          <li>Allow rewind on mobile (#13866)</li>
+          <li>Added option to disable on-screen messages (#13695)</li>
+          <li>Added "Lower resolution for effects" on libretro (#13654)</li>
+          <li>Allow chaining multiple post-processing shaders (#12924)</li>
+          <li>Support for loading game-specific plugins (#13335)</li>
+          <li>Fixed Assassin's Creed: Bloodlines Save issue on Android (#12761)</li>
+          <li>Hanayaka Nari Wa ga Ichizoku: mono voices fixed (#5213)</li>
+          <li>Additional fixed games:</li>
+          <li>Namco Museum - Battle Collection, Vol 2 ([#9523], [#13297], [#13298])</li>
+          <li>Dream Club Portable (graphics bugs, GL and Vulkan) ([#6025])</li>
+          <li>Xyanide Resurrection (freezing) ([#8526])</li>
+          <li>Dissidia Final Fantasy Chinese (patched game, invalid address) ([#13204])</li>
+          <li>Crazy Taxi ([#13368])</li>
+          <li>Spiderman: Friend or Foe ([#13969])</li>
+          <li>Downstream Panic (US) (New Game crash) ([#13633])</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.10.0" date="2020-06-27"/>
+    <release version="1.9.4" date="2019-10-16"/>
+    <release version="1.8.0" date="2019-03-14"/>
+    <release version="1.7.5" date="2018-12-05"/>
+    <release version="1.7.2" date="2018-11-03"/>
+    <release version="1.7.1" date="2018-11-01"/>
+    <release version="1.6.3" date="2018-06-05"/>
+    <release version="1.6.1" date="2018-05-30">
+      <description>
+        <p>Fix various crashes.</p>
+      </description>
+    </release>
+    <release version="1.6" date="2018-05-26">
+      <description>
+        <p>What's new in 1.6</p>
+        <ul>
+          <li>OpenGL backend now properly multithreaded, giving a good speed boost.</li>
+          <li>Various Vulkan performance improvements and memory allocation fixes.</li>
+          <li>GPU command interpreter performance improvements</li>
+          <li>Bugfixes and some performance improvements in the ARM64 JIT compiler and IR interpreter</li>
+          <li>Shader cache enabled for Vulkan</li>
+          <li>Texture replacement ID bugfix (note: some textures from 1.5.4 may become incompatible)</li>
+          <li>Adhoc multiplayer fixes</li>
+          <li>Vulkan support on Linux/SDL</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.5.4" date="2017-12-05"/>
+    <release version="1.5.1" date="2017-11-29">
+      <description>
+        <p>1.5 has support for Vulkan, the new faster way to draw graphics. Supported on many modern Android devices, and if enabled (change Backend in Graphics settings) you will see a massive speed boost. PPSSPP 1.5 also has the usual assortment of fixes:</p>
+        <ul>
+          <li>Full Vulkan support, also for Android now. Very fast on supported devices. (#10033, #10049)</li>
+          <li>Smarter graphics state management, reduced CPU consumption on all backends (#9899)</li>
+          <li>Android: Support for Arabic and other scripts we couldn't support before</li>
+          <li>Fixes to video dumping</li>
+          <li>Fix Android widgets, screen scaling (#10145)</li>
+          <li>Geometry problems fixed in Medal of Honor</li>
+          <li>Implement immediate draws, fixing Thrillville (#7459)</li>
+          <li>Software rendering improvements, speed and accuracy</li>
+          <li>Partial sceUsbGps and sceUsbCam support (Android)</li>
+          <li>Hardware tesselation of PSP Beziers and Splines (used by a few games)</li>
+          <li>Android "Sustained performance mode" to avoid thermal throttling (#9901)</li>
+          <li>Linux controller mapping fixes (#9997)</li>
+          <li>Assorted bugfixes and compatibility improvements</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
+  <url type="homepage">https://www.ppsspp.org/</url>
+  <url type="bugtracker">https://github.com/hrydgard/ppsspp/issues</url>
+  <url type="faq">https://www.ppsspp.org/faq.html</url>
+  <url type="help">https://www.ppsspp.org/guides.html</url>
+  <url type="translate">https://github.com/hrydgard/ppsspp/tree/master/assets/lang</url>
+  <url type="contact">https://www.ppsspp.org/contact</url>
+  <url type="vcs-browser">https://github.com/hrydgard/ppsspp</url>
+  <url type="contribute">https://www.ppsspp.org/development.html</url>
+  <categories>
+    <category>Game</category>
+    <category>Emulator</category>
+  </categories>
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>gamepad</control>
+  </supports>
+  <content_rating type="oars-1.1"/>
+  <keywords>
+    <keyword translate="no">Sony</keyword>
+    <keyword translate="no">PlayStation</keyword>
+    <keyword translate="no">Portable</keyword>
+    <keyword translate="no">PSP</keyword>
+    <keyword>emulator</keyword>
+    <keyword xml:lang="de">Emulator</keyword>
+    <keyword xml:lang="pl">emulator</keyword>
+    <keyword>handheld</keyword>
+    <keyword xml:lang="de">handlich</keyword>
+    <keyword xml:lang="pl">ręczna</keyword>
+    <keyword>console</keyword>
+    <keyword xml:lang="de">Konsole</keyword>
+    <keyword xml:lang="pl">konsola</keyword>
+  </keywords>
+</component>

--- a/packages/p/ppsspp/package.yml
+++ b/packages/p/ppsspp/package.yml
@@ -1,13 +1,13 @@
 name       : ppsspp
-version    : "1.17"
-release    : 38
+version    : "1.17.1"
+release    : 39
 source     :
-    - git|https://github.com/hrydgard/ppsspp.git : v1.17
+    - git|https://github.com/hrydgard/ppsspp.git : v1.17.1
 license    :
     - BSD-3-Clause
     - GPL-2.0-or-later
-component  : games.emulator
 homepage   : https://www.ppsspp.org
+component  : games.emulator
 summary    : PSP emulator
 description: |
     A fast and portable PSP emulator
@@ -35,3 +35,5 @@ build      : |
 install    : |
     %ninja_install
     ln -s /usr/bin/PPSSPPSDL $installdir/usr/bin/ppsspp
+    # Install appstream metainfo
+    install -Dm00644 $pkgfiles/org.ppsspp.PPSSPP.metainfo.xml -t $installdir/usr/share/metainfo/

--- a/packages/p/ppsspp/pspec_x86_64.xml
+++ b/packages/p/ppsspp/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ppsspp</Name>
         <Homepage>https://www.ppsspp.org</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>GPL-2.0-or-later</License>
@@ -34,6 +34,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/ppsspp.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/96x96/apps/ppsspp.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/ppsspp.svg</Path>
+            <Path fileType="data">/usr/share/metainfo/org.ppsspp.PPSSPP.metainfo.xml</Path>
             <Path fileType="data">/usr/share/mime/packages/ppsspp.xml</Path>
             <Path fileType="data">/usr/share/ppsspp/assets/7z.png</Path>
             <Path fileType="data">/usr/share/ppsspp/assets/Roboto-Condensed.ttf</Path>
@@ -187,12 +188,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="38">
-            <Date>2024-01-30</Date>
-            <Version>1.17</Version>
+        <Update release="39">
+            <Date>2024-02-06</Date>
+            <Version>1.17.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Changelog: 
   - Fixed green rendering errors on some PowerVR GPUs 
   - Release all held keys on pause to avoid "stuck keys" after unpausing or in run-behind-pause 
   - UI fixes - Update `libchdr` with `zstd` support, warn the user about bad CHDs 
   - Add workaround for AdHoc mode in Resistance 
   - Fix graphics in Tokimeki Memorial 4 
   - Fix crash in UFC 2010 on Mali GPUs 
   - Temporarily disable MSAA on Adreno GPUs due to crashing 
   - Fixed some crashes and optimized the game metadata cache 
   - Additional crashfixes and similar 
   - Fixed playback of frame dumps with Vulkan 
   - Volume slider added for RetroAchievements sounds
- Added appstream metadata (Part of getsolus/packages#1389)

**Test Plan**

- Play "Crash Tag Team Racing"
- Verify metadata with `appstream-builder --packages-dir=. --include-failed -v`

**Checklist**

- [x] Package was built and tested against unstable