### PR TITLE
citra: Update to 2090

### DIFF
--- a/packages/c/citra/abi_used_symbols
+++ b/packages/c/citra/abi_used_symbols
@@ -241,6 +241,7 @@ libQt6Core.so.6:_ZN6QTimer7timeoutENS_14QPrivateSignalE
 libQt6Core.so.6:_ZN6QTimerC1EP7QObject
 libQt6Core.so.6:_ZN6QTimerD1Ev
 libQt6Core.so.6:_ZN7QLocale16languageToStringENS_8LanguageE
+libQt6Core.so.6:_ZN7QLocale17territoryToStringENS_7CountryE
 libQt6Core.so.6:_ZN7QLocaleC1E11QStringView
 libQt6Core.so.6:_ZN7QLocaleC1Ev
 libQt6Core.so.6:_ZN7QLocaleD1Ev
@@ -286,6 +287,7 @@ libQt6Core.so.6:_ZN7QString6insertExPK5QCharx
 libQt6Core.so.6:_ZN7QString6numberEdci
 libQt6Core.so.6:_ZN7QString6numberEii
 libQt6Core.so.6:_ZN7QString6numberEji
+libQt6Core.so.6:_ZN7QString6numberEli
 libQt6Core.so.6:_ZN7QString6numberEmi
 libQt6Core.so.6:_ZN7QString6numberExi
 libQt6Core.so.6:_ZN7QString6removeExx
@@ -368,7 +370,6 @@ libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperI11QModelIndexE8metaType
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperI5QListI7QStringEE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperI6QPointE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperI7QStringE8metaTypeE
-libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperIPvE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperIbE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperIfE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperIiE8metaTypeE
@@ -483,6 +484,7 @@ libQt6Core.so.6:_ZNK5QTime8addMSecsEi
 libQt6Core.so.6:_ZNK5QTime8toStringE11QStringView
 libQt6Core.so.6:_ZNK7QLocale8languageEv
 libQt6Core.so.6:_ZNK7QLocale8toStringE5QTimeNS_10FormatTypeE
+libQt6Core.so.6:_ZNK7QLocale9territoryEv
 libQt6Core.so.6:_ZNK7QObject10metaObjectEv
 libQt6Core.so.6:_ZNK7QObject10objectNameEv
 libQt6Core.so.6:_ZNK7QObject6senderEv
@@ -586,6 +588,7 @@ libQt6Gui.so.6:_ZN13QIntValidatorD1Ev
 libQt6Gui.so.6:_ZN13QStandardItem11setEditableEb
 libQt6Gui.so.6:_ZN13QStandardItem4readER11QDataStream
 libQt6Gui.so.6:_ZN13QStandardItem7setDataERK8QVarianti
+libQt6Gui.so.6:_ZN13QStandardItem8setFlagsE6QFlagsIN2Qt8ItemFlagEE
 libQt6Gui.so.6:_ZN13QStandardItem9insertRowEiRK5QListIPS_E
 libQt6Gui.so.6:_ZN13QStandardItem9removeRowEi
 libQt6Gui.so.6:_ZN13QStandardItemC1ERK7QString
@@ -604,6 +607,7 @@ libQt6Gui.so.6:_ZN14QOpenGLContext22supportsThreadedOpenGLEv
 libQt6Gui.so.6:_ZN14QOpenGLContext6createEv
 libQt6Gui.so.6:_ZN14QOpenGLContext9setFormatERK14QSurfaceFormat
 libQt6Gui.so.6:_ZN14QOpenGLContextC1EP7QObject
+libQt6Gui.so.6:_ZN14QOpenGLContextD1Ev
 libQt6Gui.so.6:_ZN14QSurfaceFormat10setProfileENS_20OpenGLContextProfileE
 libQt6Gui.so.6:_ZN14QSurfaceFormat10setVersionEii
 libQt6Gui.so.6:_ZN14QSurfaceFormat15setSwapBehaviorENS_12SwapBehaviorE
@@ -627,6 +631,7 @@ libQt6Gui.so.6:_ZN16QDoubleValidatorC1EP7QObject
 libQt6Gui.so.6:_ZN17QOffscreenSurface6createEv
 libQt6Gui.so.6:_ZN17QOffscreenSurface9setFormatERK14QSurfaceFormat
 libQt6Gui.so.6:_ZN17QOffscreenSurfaceC1EP7QScreenP7QObject
+libQt6Gui.so.6:_ZN17QOffscreenSurfaceD1Ev
 libQt6Gui.so.6:_ZN18QStandardItemModel11itemChangedEP13QStandardItem
 libQt6Gui.so.6:_ZN18QStandardItemModel11setSortRoleEi
 libQt6Gui.so.6:_ZN18QStandardItemModel13insertColumnsEiiRK11QModelIndex
@@ -750,6 +755,7 @@ libQt6Gui.so.6:_ZNK13QStandardItem4dataEi
 libQt6Gui.so.6:_ZNK13QStandardItem4typeEv
 libQt6Gui.so.6:_ZNK13QStandardItem5childEii
 libQt6Gui.so.6:_ZNK13QStandardItem5cloneEv
+libQt6Gui.so.6:_ZNK13QStandardItem5flagsEv
 libQt6Gui.so.6:_ZNK13QStandardItem5indexEv
 libQt6Gui.so.6:_ZNK13QStandardItem5writeER11QDataStream
 libQt6Gui.so.6:_ZNK13QStandardItem6columnEv
@@ -759,6 +765,7 @@ libQt6Gui.so.6:_ZNK13QStandardItemltERKS_
 libQt6Gui.so.6:_ZNK13QTextDocument11toPlainTextEv
 libQt6Gui.so.6:_ZNK14QOpenGLContext14getProcAddressEPKc
 libQt6Gui.so.6:_ZNK14QOpenGLContext6formatEv
+libQt6Gui.so.6:_ZNK14QOpenGLContext9functionsEv
 libQt6Gui.so.6:_ZNK14QSurfaceFormat14renderableTypeEv
 libQt6Gui.so.6:_ZNK18QStandardItemModel17invisibleRootItemEv
 libQt6Gui.so.6:_ZNK18QStandardItemModel4itemEii
@@ -1147,6 +1154,7 @@ libQt6Widgets.so.6:_ZN7QLayout17setSizeConstraintENS_14SizeConstraintE
 libQt6Widgets.so.6:_ZN7QLayout18setContentsMarginsEiiii
 libQt6Widgets.so.6:_ZN7QLayout9addWidgetEP7QWidget
 libQt6Widgets.so.6:_ZN7QSlider15setTickPositionENS_12TickPositionE
+libQt6Widgets.so.6:_ZN7QSliderC1EN2Qt11OrientationEP7QWidget
 libQt6Widgets.so.6:_ZN7QSliderC1EP7QWidget
 libQt6Widgets.so.6:_ZN7QWidget10adjustSizeEv
 libQt6Widgets.so.6:_ZN7QWidget10closeEventEP11QCloseEvent
@@ -1431,6 +1439,7 @@ libQt6Widgets.so.6:_ZNK9QComboBox11currentDataEi
 libQt6Widgets.so.6:_ZNK9QComboBox11currentTextEv
 libQt6Widgets.so.6:_ZNK9QComboBox12currentIndexEv
 libQt6Widgets.so.6:_ZNK9QComboBox5countEv
+libQt6Widgets.so.6:_ZNK9QComboBox5modelEv
 libQt6Widgets.so.6:_ZNK9QComboBox8findDataERK8QVarianti6QFlagsIN2Qt9MatchFlagEE
 libQt6Widgets.so.6:_ZNK9QComboBox8itemDataEii
 libQt6Widgets.so.6:_ZNK9QComboBox8itemTextEi
@@ -1661,6 +1670,7 @@ libc.so.6:fwrite
 libc.so.6:getaddrinfo
 libc.so.6:getcwd
 libc.so.6:getenv
+libc.so.6:gethostbyaddr
 libc.so.6:gethostbyname
 libc.so.6:getifaddrs
 libc.so.6:getnameinfo
@@ -1787,6 +1797,7 @@ libc.so.6:signal
 libc.so.6:sigprocmask
 libc.so.6:sleep
 libc.so.6:snprintf
+libc.so.6:sockatmark
 libc.so.6:socket
 libc.so.6:stat
 libc.so.6:stat64
@@ -1808,6 +1819,7 @@ libc.so.6:strncasecmp
 libc.so.6:strncmp
 libc.so.6:strncpy
 libc.so.6:strndup
+libc.so.6:strnlen
 libc.so.6:strrchr
 libc.so.6:strsep
 libc.so.6:strspn

--- a/packages/c/citra/package.yml
+++ b/packages/c/citra/package.yml
@@ -1,8 +1,8 @@
 name       : citra
-version    : 2044
-release    : 11
+version    : '2090'
+release    : 12
 source     :
-    - git|https://github.com/citra-emu/citra-nightly : nightly-2044
+    - git|https://github.com/citra-emu/citra-nightly : nightly-2090
 homepage   : https://citra-emu.org/
 license    : GPL-2.0-or-later
 component  : games.emulator

--- a/packages/c/citra/pspec_x86_64.xml
+++ b/packages/c/citra/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>citra</Name>
         <Homepage>https://citra-emu.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>games.emulator</PartOf>
@@ -32,12 +32,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2023-11-29</Date>
-            <Version>2044</Version>
+        <Update release="12">
+            <Date>2024-02-06</Date>
+            <Version>2090</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Update citra to release 2090

Major changes: 
- Add several new hotkeys for configuring emulation settings
- Many small tweaks to improve emulator accuracy

Full changelog [here](https://github.com/citra-emu/citra-nightly/compare/nightly-2044...nightly-2090)

**Test Plan**

Launch citra and configure a controller. Launch a game. Make sure things work as expected.

**Checklist**

- [x] Package was built and tested against unstable
