### PR TITLE
python-maturin: Update to 1.4.0

### DIFF
--- a/packages/py/python-maturin/package.yml
+++ b/packages/py/python-maturin/package.yml
@@ -1,8 +1,8 @@
 name       : python-maturin
-version    : 1.3.1
-release    : 38
+version    : 1.4.0
+release    : 39
 source     :
-    - https://github.com/PyO3/maturin/archive/refs/tags/v1.3.1.tar.gz : 9e4f6cf2b5127103042d7319e9cbeee3df5b429c3c29b930fd360cbf8da84828
+    - https://github.com/PyO3/maturin/archive/refs/tags/v1.4.0.tar.gz : cd2cd3d465619bb997b41594398310e8b257d0c17854a58ca0598efa11e6d698
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-maturin/pspec_x86_64.xml
+++ b/packages/py/python-maturin/pspec_x86_64.xml
@@ -22,12 +22,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/maturin</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.1-py3.10.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.1-py3.10.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.1-py3.10.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.1-py3.10.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.1-py3.10.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.3.1-py3.10.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.4.0-py3.10.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.4.0-py3.10.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.4.0-py3.10.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.4.0-py3.10.egg-info/not-zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.4.0-py3.10.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/maturin-1.4.0-py3.10.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/maturin/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/maturin/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/maturin/__pycache__/__init__.cpython-310.pyc</Path>
@@ -37,9 +37,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="38">
-            <Date>2023-10-24</Date>
-            <Version>1.3.1</Version>
+        <Update release="39">
+            <Date>2024-02-09</Date>
+            <Version>1.4.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Un-deprecate `MATURIN_PEP517_ARGS` env var
- Add support for uniffi library mode
- Fix missing member in Cargo.toml for sdist of nested workspace layout
- Metadata: escape display name in email addresses
- Fix glob workspace members matching in sdist
- Add support for cross compiling with `cross`
- Updated dependencies
 
**Test Plan**

Built `python-orjson`

**Checklist**

- [x] Package was built and tested against unstable
