### PR TITLE
python-orjson: Update to 3.9.13

### DIFF
--- a/packages/py/python-orjson/abi_used_symbols
+++ b/packages/py/python-orjson/abi_used_symbols
@@ -7,7 +7,6 @@ UNKNOWN:PyCMethod_New
 UNKNOWN:PyCallable_Check
 UNKNOWN:PyCapsule_Import
 UNKNOWN:PyDict_New
-UNKNOWN:PyDict_Next
 UNKNOWN:PyErr_Clear
 UNKNOWN:PyErr_Fetch
 UNKNOWN:PyErr_NewException
@@ -45,6 +44,7 @@ UNKNOWN:PyUnicode_New
 UNKNOWN:_PyBytes_Resize
 UNKNOWN:_PyDict_Contains_KnownHash
 UNKNOWN:_PyDict_NewPresized
+UNKNOWN:_PyDict_Next
 UNKNOWN:_PyDict_SetItem_KnownHash
 UNKNOWN:_PyLong_AsByteArray
 UNKNOWN:_PyObject_MakeTpCall

--- a/packages/py/python-orjson/package.yml
+++ b/packages/py/python-orjson/package.yml
@@ -1,8 +1,8 @@
 name       : python-orjson
-version    : 3.9.9
-release    : 32
+version    : 3.9.13
+release    : 33
 source     :
-    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.9.9.tar.gz : 02e693843c2959befdd82d1ebae8b05ed12d1cb821605d5f9fe9f98ca5c9fd2b
+    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.9.13.tar.gz : fc6bc65b0cf524ee042e0bc2912b9206ef242edfba7426cf95763e4af01f527a
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-orjson/pspec_x86_64.xml
+++ b/packages/py/python-orjson/pspec_x86_64.xml
@@ -21,11 +21,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.9.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.9.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.9.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.9.dist-info/license_files/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.9.dist-info/license_files/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.13.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.13.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.13.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.13.dist-info/license_files/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/orjson-3.9.13.dist-info/license_files/LICENSE-MIT</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/orjson/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/orjson/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/orjson/__pycache__/__init__.cpython-310.opt-1.pyc</Path>
@@ -35,9 +35,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2023-10-13</Date>
-            <Version>3.9.9</Version>
+        <Update release="33">
+            <Date>2024-02-09</Date>
+            <Version>3.9.13</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fixed debug assert failure on 3.12 `--profile=dev` build
- Improved performance of serializing
- Fixed: Serialization `str` escape uses only 128-bit SIMD
- Fixed compatibility with CPython 3.13 alpha 3
- Serialization uses small integer optimization in CPython 3.12 or later

**Test Plan**

Ran through the examples in the README

**Checklist**

- [x] Package was built and tested against unstable
