### PR TITLE
python-waitress: Update to 3.0.0

### DIFF
--- a/packages/py/python-waitress/package.yml
+++ b/packages/py/python-waitress/package.yml
@@ -1,8 +1,9 @@
 name       : python-waitress
-version    : 2.1.2
-release    : 7
+version    : 3.0.0
+release    : 8
 source     :
-    - https://github.com/Pylons/waitress/archive/v2.1.2.tar.gz : 2de9b24b8097c82535aa6f512d9c93096c51affd22cb640342c21761a5b38873
+    - https://github.com/Pylons/waitress/archive/v3.0.0.tar.gz : 40b5681dffdafb00c145d6ef420547454198ea4c28c609045aeca1e5d7df1d32
+homepage   : https://docs.pylonsproject.org/projects/waitress/en/latest/
 license    : ZPL-2.1
 component  : programming.python
 summary    : A WSGI server for Python

--- a/packages/py/python-waitress/pspec_x86_64.xml
+++ b/packages/py/python-waitress/pspec_x86_64.xml
@@ -1,6 +1,7 @@
 <PISI>
     <Source>
         <Name>python-waitress</Name>
+        <Homepage>https://docs.pylonsproject.org/projects/waitress/en/latest/</Homepage>
         <Packager>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>
@@ -10,7 +11,7 @@
         <Summary xml:lang="en">A WSGI server for Python</Summary>
         <Description xml:lang="en">Waitress is meant to be a production-quality pure-Python WSGI server with very acceptable performance. It supports HTTP/1.0 and HTTP/1.1.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>python-waitress</Name>
@@ -20,12 +21,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/waitress-serve</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/waitress-2.1.2-py3.10.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/waitress-2.1.2-py3.10.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/waitress-2.1.2-py3.10.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/waitress-2.1.2-py3.10.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/waitress-2.1.2-py3.10.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/waitress-2.1.2-py3.10.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/waitress-3.0.0-py3.10.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/waitress-3.0.0-py3.10.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/waitress-3.0.0-py3.10.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/waitress-3.0.0-py3.10.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/waitress-3.0.0-py3.10.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/waitress-3.0.0-py3.10.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/waitress/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/waitress/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/waitress/__pycache__/__init__.cpython-310.pyc</Path>
@@ -61,9 +62,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2022-05-31</Date>
-            <Version>2.1.2</Version>
+        <Update release="8">
+            <Date>2024-02-09</Date>
+            <Version>3.0.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fixed testing of vendored asyncore code to not rely on particular naming for errno's
- HTTP Request methods and versions are now validated to meet the HTTP standards thereby dropping invalid requests on the floor
- No longer close the connection when sending a HEAD request response
- Always attempt to send the `Connection: close` response header when we are going to close the connection to let the remote know in more instances
- Python 3.7 is no longer supported. Add support for Python 3.11, 3.12 and PyPy 3.9, 3.10
- `clear_untrusted_proxy_headers` is set to `True` by default

**Test Plan**
- Ran through some examples from the documentation
- Confirmed `anki` still works correctly

**Checklist**

- [x] Package was built and tested against unstable
