### PR TITLE
papirus-icon-theme: Update to 20240201

### DIFF
--- a/packages/p/papirus-icon-theme/package.yml
+++ b/packages/p/papirus-icon-theme/package.yml
@@ -1,8 +1,8 @@
 name       : papirus-icon-theme
-version    : '20231201'
-release    : 85
+version    : '20240201'
+release    : 86
 source     :
-    - https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/archive/refs/tags/20231201.tar.gz : 9dde683d6444ed2d3b3dacf8579b04d527ce278cef575d606f690c7b31c7aebd
+    - https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/archive/refs/tags/20240201.tar.gz : 8ff3caded7862e5e6f531dbae54b213ff1cd3666d26f23357c6183173856f380
 license    : GPL-3.0-or-later
 homepage   : https://git.io/papirus-icon-theme
 component  :
@@ -43,7 +43,6 @@ install    : |
         "pycharm"
         "rider"
         "rubymine"
-        "skype"
         "slack"
         "spotify"
         "sublime-text"
@@ -70,10 +69,7 @@ install    : |
             install -Dm00644 $installdir/$appsLoc/${icon}.svg $scDir/${i}x${i}/apps/${icon}.svg
         done
     done
-    for i in 16 22 24; do # im-google-talk is special. It's in actions and only a small range of sizes
-        actionsDir=/usr/share/icons/Papirus/${i}x${i}/actions
-        install -Dm00644 $installdir/$actionsDir/im-google-talk.svg $scDir/${i}x${i}/actions/im-google-talk.svg
-    done
+
     install -Dm00644 $pkgfiles/index.theme $scDir/index.theme
     install -Dm00644 $pkgfiles/Papirus-Adapta@index.theme $installdir/usr/share/icons/Papirus-Adapta/index.theme
     install -Dm00644 $pkgfiles/Papirus-Adapta-Nokto@index.theme $installdir/usr/share/icons/Papirus-Adapta-Nokto/index.theme


### PR DESCRIPTION
**Summary**

Release notes available [here](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/releases/tag/20240201)

Note: Also removes some outdated Third Party Repo icons from `solus-sc-icons`

**Test Plan**

Looked at icons in my menu and `solus-sc` and confirmed everything was alright

**Checklist**

- [x] Package was built and tested against unstable
