### PR TITLE
steam: Update to 1.0.0.79

### DIFF
--- a/packages/s/steam/package.yml
+++ b/packages/s/steam/package.yml
@@ -1,8 +1,8 @@
 name       : steam
-version    : 1.0.0.78
-release    : 91
+version    : 1.0.0.79
+release    : 92
 source     :
-    - https://repo.steampowered.com/steam/pool/steam/s/steam/steam_1.0.0.78.tar.gz : 104259755d7211b5f101db247ff70ebfed6ae6ca3e14da61195d1fbf91c7200d
+    - https://repo.steampowered.com/steam/pool/steam/s/steam/steam_1.0.0.79.tar.gz : 3a0012daf5889311c2e1dcf33a587b409019b66d893a52192df6947e18f1ec46
 homepage   : https://store.steampowered.com
 license    : Distributable
 component  : games
@@ -19,8 +19,8 @@ rundeps    :
     - diffutils
     - freeglut-32bit
     - gconf-32bit
-    - glew110-32bit
     - glew-32bit
+    - glew110-32bit
     - gnome-themes-extra-32bit
     - gperftools-32bit
     - gst-plugins-base-32bit
@@ -52,8 +52,8 @@ rundeps    :
     - libva-32bit
     - libva1-32bit
     - libvdpau-32bit
-    - libvpx1-32bit
     - libvpx-32bit
+    - libvpx1-32bit
     - libxcrypt-compat-32bit
     - libxmu-32bit
     - libxscrnsaver-32bit
@@ -72,6 +72,8 @@ rundeps    :
     - pciutils-32bit
     - pipewire-32bit
     - readline6-32bit
+    - sdl-gfx-32bit
+    - sdl-ttf-32bit
     - sdl1-image-32bit
     - sdl1-mixer-32bit
     - sdl1-net-32bit
@@ -80,14 +82,12 @@ rundeps    :
     - sdl2-mixer-32bit
     - sdl2-net-32bit
     - sdl2-ttf-32bit
-    - sdl-gfx-32bit
-    - sdl-ttf-32bit
     - tcp_wrappers-32bit
     - vulkan-32bit
     - zenity
 install    : |
     %patch -p1 -i $pkgfiles/fix-udev-rules.patch
-    %make_install install-bin install-docs install-icons install-bootstrap install-desktop
+    %make_install
     install -Ddm00755 $installdir/%libdir%/udev/rules.d
     install -m00644 subprojects/steam-devices/* $installdir/%libdir%/udev/rules.d/.
 

--- a/packages/s/steam/pspec_x86_64.xml
+++ b/packages/s/steam/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>steam</Name>
         <Homepage>https://store.steampowered.com</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>Distributable</License>
         <PartOf>games</PartOf>
@@ -45,12 +45,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="91">
-            <Date>2023-12-27</Date>
-            <Version>1.0.0.78</Version>
+        <Update release="92">
+            <Date>2024-02-09</Date>
+            <Version>1.0.0.79</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- `bin_steam.sh`: When running in a Gamescope session, only write messages to the log. Don't pop up a zenity or xterm window, which would not be shown by the Gamescope session
- `bin_steam.sh`: If `~/.steam/steam` is a dangling symlink, don't prompt users to browse for the correct location or reinstall. Instead, just reinstall non-interactively.
- Updated client timestamp 1705108172 (2023-01-13)
- Updated Steam Runtime (scout) version 0.20231127.68515

**Test Plan**

Launched Steam, played a game and sent a message to a friend

**Checklist**

- [x] Package was built and tested against unstable
