### PR TITLE
libheif: Update to 1.17.6 and add monitoring.yml

### DIFF
--- a/packages/l/libheif/abi_used_symbols
+++ b/packages/l/libheif/abi_used_symbols
@@ -322,3 +322,4 @@ libstdc++.so.6:__dynamic_cast
 libstdc++.so.6:__gxx_personality_v0
 libstdc++.so.6:__once_proxy
 libx265.so.200:x265_api_get_200
+libx265.so.200:x265_cleanup

--- a/packages/l/libheif/monitoring.yml
+++ b/packages/l/libheif/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 64439
+  rss: https://github.com/strukturag/libheif/releases.atom
+security:
+  cpe:
+    - vendor: struktur
+      product: libheif

--- a/packages/l/libheif/package.yml
+++ b/packages/l/libheif/package.yml
@@ -1,8 +1,8 @@
 name       : libheif
-version    : 1.17.1
-release    : 36
+version    : 1.17.6
+release    : 37
 source     :
-    - https://github.com/strukturag/libheif/releases/download/v1.17.1/libheif-1.17.1.tar.gz : 97d74c58a346887c1bbf98dcf0322c13b728286153d0f1be2b350f7107e49dba
+    - https://github.com/strukturag/libheif/releases/download/v1.17.6/libheif-1.17.6.tar.gz : 8390baf4913eda0a183e132cec62b875fb2ef507ced5ddddc98dfd2f17780aee
 license    : LGPL-3.0-or-later
 homepage   : https://github.com/strukturag/libheif
 component  : multimedia.codecs

--- a/packages/l/libheif/pspec_x86_64.xml
+++ b/packages/l/libheif/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libheif</Name>
         <Homepage>https://github.com/strukturag/libheif</Homepage>
         <Packager>
-            <Name>Alexander Vorobyev</Name>
-            <Email>avorobyev@protonmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>LGPL-3.0-or-later</License>
         <PartOf>multimedia.codecs</PartOf>
@@ -29,7 +29,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
             <Path fileType="library">/usr/lib64/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-heif.so</Path>
             <Path fileType="library">/usr/lib64/libheif</Path>
             <Path fileType="library">/usr/lib64/libheif.so.1</Path>
-            <Path fileType="library">/usr/lib64/libheif.so.1.17.1</Path>
+            <Path fileType="library">/usr/lib64/libheif.so.1.17.6</Path>
             <Path fileType="man">/usr/share/man/man1/heif-convert.1</Path>
             <Path fileType="man">/usr/share/man/man1/heif-enc.1</Path>
             <Path fileType="man">/usr/share/man/man1/heif-info.1</Path>
@@ -45,7 +45,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="36">libheif</Dependency>
+            <Dependency release="37">libheif</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libheif/heif.h</Path>
@@ -62,12 +62,12 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2023-12-31</Date>
-            <Version>1.17.1</Version>
+        <Update release="37">
+            <Date>2024-02-09</Date>
+            <Version>1.17.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Alexander Vorobyev</Name>
-            <Email>avorobyev@protonmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Fixed loading of HEIF files with extra zero bytes at the end
- Default nclx values now match sRGB
- Support JPEG2000 images with alpha channel
- Corrected transform box generation for `heif_orientation_flip_vertically` and `heif_orientation_rotate_90_cw_then_flip_vertically`
- Fixed: ispe boxes in AVIF images with clap boxes were written with the wrong size
- Always output MIAF brand for AVIF images
- Fix kvazaar encoding with odd image sizes and encodings with non-4:2:0 chroma

**Security**
Includes fixes for:
- CVE-2023-49462
- CVE-2023-49463

**Test Plan**

Encoded and viewed a couple of heif images

**Checklist**

- [x] Package was built and tested against unstable
