### PR TITLE
libavif: Update to 1.0.4 and add monitoring.yml

### DIFF
--- a/packages/l/libavif/files/Fix-SVT-encoding.patch
+++ b/packages/l/libavif/files/Fix-SVT-encoding.patch
@@ -1,0 +1,88 @@
+From 350aedd68c161580c60fc93f74a42f73e83fd572 Mon Sep 17 00:00:00 2001
+From: Yannis Guyon <yguyon@google.com>
+Date: Fri, 9 Feb 2024 16:54:37 +0100
+Subject: [PATCH] Encode alpha as 4:2:0 with SVT
+
+---
+ src/codec_svt.c | 32 ++++++++++++++++++++++++++++++--
+ 1 file changed, 30 insertions(+), 2 deletions(-)
+
+diff --git a/src/codec_svt.c b/src/codec_svt.c
+index 58a92cdce..ea9efc2b5 100644
+--- a/src/codec_svt.c
++++ b/src/codec_svt.c
+@@ -7,6 +7,7 @@
+ 
+ #include "svt-av1/EbSvtAv1Enc.h"
+ 
++#include <stdint.h>
+ #include <string.h>
+ 
+ // The SVT_AV1_VERSION_MAJOR, SVT_AV1_VERSION_MINOR, SVT_AV1_VERSION_PATCHLEVEL, and
+@@ -76,6 +77,7 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
+ 
+     avifResult result = AVIF_RESULT_UNKNOWN_ERROR;
+     EbColorFormat color_format = EB_YUV420;
++    uint8_t * uvPlanes = NULL; // 4:2:0 U and V placeholder for alpha because SVT-AV1 does not support 4:0:0.
+     EbBufferHeaderType * input_buffer = NULL;
+     EbErrorType res = EB_ErrorNone;
+ 
+@@ -98,6 +100,7 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
+                 y_shift = 1;
+                 break;
+             case AVIF_PIXEL_FORMAT_YUV400:
++                // Setting color_format = EB_YUV400; results in "Svt[error]: Instance 1: Only support 420 now".
+             case AVIF_PIXEL_FORMAT_NONE:
+             case AVIF_PIXEL_FORMAT_COUNT:
+             default:
+@@ -198,16 +201,38 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
+     }
+     EbSvtIOFormat * input_picture_buffer = (EbSvtIOFormat *)input_buffer->p_buffer;
+ 
+-    int bytesPerPixel = image->depth > 8 ? 2 : 1;
++    const uint32_t bytesPerPixel = image->depth > 8 ? 2 : 1;
++    const uint32_t uvHeight = (image->height + y_shift) >> y_shift;
+     if (alpha) {
+         input_picture_buffer->y_stride = image->alphaRowBytes / bytesPerPixel;
+         input_picture_buffer->luma = image->alphaPlane;
+         input_buffer->n_filled_len = image->alphaRowBytes * image->height;
++
++#if SVT_AV1_CHECK_VERSION(1, 8, 0)
++        // Simulate 4:2:0 UV planes. SVT-AV1 does not support 4:0:0 samples.
++        const uint32_t uvWidth = (image->width + y_shift) >> y_shift;
++        const uint32_t uvRowBytes = uvWidth * bytesPerPixel;
++        const uint32_t uvSize = uvRowBytes * uvHeight;
++        uvPlanes = avifAlloc(uvSize);
++        if (uvPlanes == NULL) {
++            goto cleanup;
++        }
++        memset(uvPlanes, 0, uvSize);
++        input_picture_buffer->cb = uvPlanes;
++        input_buffer->n_filled_len += uvSize;
++        input_picture_buffer->cr = uvPlanes;
++        input_buffer->n_filled_len += uvSize;
++        input_picture_buffer->cb_stride = uvWidth;
++        input_picture_buffer->cr_stride = uvWidth;
++#else
++        // This workaround was not needed before SVT-AV1 1.8.0.
++        // See https://github.com/AOMediaCodec/libavif/issues/1992.
++        (void)uvPlanes;
++#endif
+     } else {
+         input_picture_buffer->y_stride = image->yuvRowBytes[0] / bytesPerPixel;
+         input_picture_buffer->luma = image->yuvPlanes[0];
+         input_buffer->n_filled_len = image->yuvRowBytes[0] * image->height;
+-        uint32_t uvHeight = (image->height + y_shift) >> y_shift;
+         input_picture_buffer->cb = image->yuvPlanes[1];
+         input_buffer->n_filled_len += image->yuvRowBytes[1] * uvHeight;
+         input_picture_buffer->cr = image->yuvPlanes[2];
+@@ -232,6 +257,9 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
+ 
+     result = dequeue_frame(codec, output, AVIF_FALSE);
+ cleanup:
++    if (uvPlanes) {
++        avifFree(uvPlanes);
++    }
+     if (input_buffer) {
+         if (input_buffer->p_buffer) {
+             avifFree(input_buffer->p_buffer);

--- a/packages/l/libavif/monitoring.yml
+++ b/packages/l/libavif/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 178015
+  rss: https://github.com/AOMediaCodec/libavif/releases.atom
+security:
+  cpe:
+    - vendor: aomedia
+      product: libavif

--- a/packages/l/libavif/package.yml
+++ b/packages/l/libavif/package.yml
@@ -1,8 +1,8 @@
 name       : libavif
-version    : 1.0.3
-release    : 16
+version    : 1.0.4
+release    : 17
 source     :
-    - https://github.com/AOMediaCodec/libavif/archive/refs/tags/v1.0.3.tar.gz : 35e3cb3cd7158209dcc31d3bf222036de5b9597e368a90e18449ecc89bb86a19
+    - https://github.com/AOMediaCodec/libavif/archive/refs/tags/v1.0.4.tar.gz : dc56708c83a4b934a8af2b78f67f866ba2fb568605c7cf94312acf51ee57d146
 license    : BSD-2-Clause
 component  : multimedia.library
 homepage   : https://github.com/AOMediaCodec/libavif
@@ -20,6 +20,8 @@ builddeps  :
     - pkgconfig(libsharpyuv)
     - pkgconfig(rav1e)
 setup      : |
+    # Fix a segfault during tests
+    %patch -p1 -i $pkgfiles/Fix-SVT-encoding.patch
     %cmake_ninja \
                  -DAVIF_BUILD_APPS=ON \
                  -DAVIF_BUILD_TESTS=ON \
@@ -33,4 +35,4 @@ build      : |
 install    : |
     %ninja_install
 check      : |
-    %ninja_check || :
+    %ninja_check

--- a/packages/l/libavif/pspec_x86_64.xml
+++ b/packages/l/libavif/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libavif</Name>
         <Homepage>https://github.com/AOMediaCodec/libavif</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>multimedia.library</PartOf>
@@ -24,7 +24,7 @@
             <Path fileType="executable">/usr/bin/avifenc</Path>
             <Path fileType="library">/usr/lib64/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-avif.so</Path>
             <Path fileType="library">/usr/lib64/libavif.so.16</Path>
-            <Path fileType="library">/usr/lib64/libavif.so.16.0.3</Path>
+            <Path fileType="library">/usr/lib64/libavif.so.16.0.4</Path>
             <Path fileType="data">/usr/share/thumbnailers/avif.thumbnailer</Path>
         </Files>
     </Package>
@@ -35,7 +35,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="16">libavif</Dependency>
+            <Dependency release="17">libavif</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/avif/avif.h</Path>
@@ -47,12 +47,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2024-01-15</Date>
-            <Version>1.0.3</Version>
+        <Update release="17">
+            <Date>2024-02-09</Date>
+            <Version>1.0.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- `AVIF_ENABLE_WERROR` is set to `OFF` by default
- Fix wrong alpha plane deallocation when decoded tile pixel format does not match reconstructed output image pixel format
- Fix identical chunk skipping optimization when writing animation data
- Fix ID selection for artificial grid alpha item when decoding a grid of tiles which each have an associated auxiliary alpha image item

**Summary**

<!-- Info on what this pull request updates/changes/etc -->

**Test Plan**

<!-- Short description of how the package was tested -->

**Checklist**

- [ ] Package was built and tested against unstable
