### PR TITLE
wine: Update to 9.2

### DIFF
--- a/packages/w/wine/abi_symbols
+++ b/packages/w/wine/abi_symbols
@@ -274,9 +274,7 @@ ntdll.so:__wine_dbg_get_channel_flags
 ntdll.so:__wine_dbg_header
 ntdll.so:__wine_dbg_output
 ntdll.so:__wine_dbg_strdup
-ntdll.so:__wine_longjmp
 ntdll.so:__wine_main
-ntdll.so:__wine_setjmpex
 ntdll.so:__wine_syscall_dispatcher
 ntdll.so:__wine_syscall_dispatcher_prolog_end_ptr
 ntdll.so:__wine_syscall_dispatcher_return

--- a/packages/w/wine/abi_symbols32
+++ b/packages/w/wine/abi_symbols32
@@ -268,9 +268,7 @@ ntdll.so:__wine_dbg_get_channel_flags
 ntdll.so:__wine_dbg_header
 ntdll.so:__wine_dbg_output
 ntdll.so:__wine_dbg_strdup
-ntdll.so:__wine_longjmp
 ntdll.so:__wine_main
-ntdll.so:__wine_setjmpex
 ntdll.so:__wine_syscall_dispatcher
 ntdll.so:__wine_syscall_dispatcher_prolog_end
 ntdll.so:__wine_syscall_dispatcher_return

--- a/packages/w/wine/abi_used_symbols
+++ b/packages/w/wine/abi_used_symbols
@@ -345,6 +345,7 @@ libc.so.6:__res_state
 libc.so.6:__stack_chk_fail
 libc.so.6:_dl_find_object
 libc.so.6:_exit
+libc.so.6:_setjmp
 libc.so.6:abort
 libc.so.6:accept
 libc.so.6:access
@@ -451,6 +452,7 @@ libc.so.6:kill
 libc.so.6:link
 libc.so.6:listen
 libc.so.6:localtime
+libc.so.6:longjmp
 libc.so.6:lseek
 libc.so.6:lstat
 libc.so.6:madvise
@@ -747,6 +749,7 @@ libgstreamer-1.0.so.0:gst_memory_unmap
 libgstreamer-1.0.so.0:gst_message_parse_error
 libgstreamer-1.0.so.0:gst_message_parse_warning
 libgstreamer-1.0.so.0:gst_message_type_get_name
+libgstreamer-1.0.so.0:gst_mini_object_copy
 libgstreamer-1.0.so.0:gst_mini_object_is_writable
 libgstreamer-1.0.so.0:gst_mini_object_make_writable
 libgstreamer-1.0.so.0:gst_mini_object_ref
@@ -804,6 +807,7 @@ libgstreamer-1.0.so.0:gst_sample_new
 libgstreamer-1.0.so.0:gst_segment_copy_into
 libgstreamer-1.0.so.0:gst_segment_init
 libgstreamer-1.0.so.0:gst_segment_to_running_time
+libgstreamer-1.0.so.0:gst_segtrap_set_enabled
 libgstreamer-1.0.so.0:gst_structure_free
 libgstreamer-1.0.so.0:gst_structure_get_boolean
 libgstreamer-1.0.so.0:gst_structure_get_fraction

--- a/packages/w/wine/abi_used_symbols32
+++ b/packages/w/wine/abi_used_symbols32
@@ -363,6 +363,7 @@ libc.so.6:__stack_chk_fail
 libc.so.6:__stat64_time64
 libc.so.6:__time64
 libc.so.6:_exit
+libc.so.6:_setjmp
 libc.so.6:abort
 libc.so.6:access
 libc.so.6:asctime
@@ -434,6 +435,7 @@ libc.so.6:inet_addr
 libc.so.6:inotify_add_watch
 libc.so.6:inotify_init1
 libc.so.6:isatty
+libc.so.6:longjmp
 libc.so.6:lseek64
 libc.so.6:madvise
 libc.so.6:malloc
@@ -702,6 +704,7 @@ libgstreamer-1.0.so.0:gst_memory_unmap
 libgstreamer-1.0.so.0:gst_message_parse_error
 libgstreamer-1.0.so.0:gst_message_parse_warning
 libgstreamer-1.0.so.0:gst_message_type_get_name
+libgstreamer-1.0.so.0:gst_mini_object_copy
 libgstreamer-1.0.so.0:gst_mini_object_is_writable
 libgstreamer-1.0.so.0:gst_mini_object_make_writable
 libgstreamer-1.0.so.0:gst_mini_object_ref
@@ -759,6 +762,7 @@ libgstreamer-1.0.so.0:gst_sample_new
 libgstreamer-1.0.so.0:gst_segment_copy_into
 libgstreamer-1.0.so.0:gst_segment_init
 libgstreamer-1.0.so.0:gst_segment_to_running_time
+libgstreamer-1.0.so.0:gst_segtrap_set_enabled
 libgstreamer-1.0.so.0:gst_structure_free
 libgstreamer-1.0.so.0:gst_structure_get_boolean
 libgstreamer-1.0.so.0:gst_structure_get_fraction

--- a/packages/w/wine/monitoring.yml
+++ b/packages/w/wine/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 5134
+  rss: https://gitlab.winehq.org/wine/wine/-/tags?format=atom
+security:
+  cpe:
+    - vendor: winehq
+      product: wine

--- a/packages/w/wine/package.yml
+++ b/packages/w/wine/package.yml
@@ -1,8 +1,8 @@
 name       : wine
-version    : '9.1'
-release    : 168
+version    : '9.2'
+release    : 169
 source     :
-    - https://dl.winehq.org/wine/source/9.x/wine-9.1.tar.xz : 01b3b91b6fc35cabe93b28f190a237ba95c8ac70c436d919586deaa3da258fff
+    - https://dl.winehq.org/wine/source/9.x/wine-9.2.tar.xz : 8281c5a082cc47ac3c2c91ceaade5f17396553b39adcb32e741253865b658162
 license    : LGPL-2.1-or-later
 component  : virt
 homepage   : https://www.winehq.org/

--- a/packages/w/wine/pspec_x86_64.xml
+++ b/packages/w/wine/pspec_x86_64.xml
@@ -978,7 +978,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="168">wine</Dependency>
+            <Dependency release="169">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/wine</Path>
@@ -1806,7 +1806,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="168">wine</Dependency>
+            <Dependency release="169">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wine/debug.h</Path>
@@ -3096,9 +3096,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="168">
-            <Date>2024-02-04</Date>
-            <Version>9.1</Version>
+        <Update release="169">
+            <Date>2024-02-09</Date>
+            <Version>9.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Highlighted changes:
- Mono engine updated to version 9.0.0
- A number of system tray fixes
- Exception handling improvements on ARM platforms
- Various bug fixes

Full release notes available [here](https://gitlab.winehq.org/wine/wine/-/releases/wine-9.2)

**Test Plan**
- Ran wineconsole, winecfg, winefile, winemine
- Played Age of Empires I

**Checklist**

- [x] Package was built and tested against unstable
