### PR TITLE
protontricks: Update to 1.11.0

### DIFF
--- a/packages/p/protontricks/monitoring.yml
+++ b/packages/p/protontricks/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 39111
+  rss: https://github.com/Matoking/protontricks/tags.atom
+# No known CPE, checked 20240210
+security:
+  cpe: ~

--- a/packages/p/protontricks/package.yml
+++ b/packages/p/protontricks/package.yml
@@ -1,8 +1,8 @@
 name       : protontricks
-version    : 1.10.3
-release    : 22
+version    : 1.11.0
+release    : 23
 source     :
-    - git|https://github.com/Matoking/protontricks.git : 1.10.3
+    - git|https://github.com/Matoking/protontricks.git : 1.11.0
 homepage   : https://github.com/Matoking/protontricks
 license    : GPL-3.0-or-later
 component  : virt
@@ -10,9 +10,13 @@ summary    : A simple wrapper that does winetricks things for Proton enabled gam
 description: |
     A simple wrapper that does winetricks things for Proton enabled games
 builddeps  :
+    - python-pillow
     - python-setuptools-scm
     - python-vdf
+checkdeps  :
+    - python-pytest
 rundeps    :
+    - python-pillow
     - python-vdf
     - winetricks
     - yad
@@ -21,4 +25,4 @@ build      : |
 install    : |
     %python3_install
 check      : |
-    %python3_test
+    %python3_test pytest

--- a/packages/p/protontricks/pspec_x86_64.xml
+++ b/packages/p/protontricks/pspec_x86_64.xml
@@ -11,7 +11,7 @@
         <Summary xml:lang="en">A simple wrapper that does winetricks things for Proton enabled games</Summary>
         <Description xml:lang="en">A simple wrapper that does winetricks things for Proton enabled games
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>protontricks</Name>
@@ -23,12 +23,12 @@
             <Path fileType="executable">/usr/bin/protontricks</Path>
             <Path fileType="executable">/usr/bin/protontricks-desktop-install</Path>
             <Path fileType="executable">/usr/bin/protontricks-launch</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/protontricks-1.10.3-py3.10.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/protontricks-1.10.3-py3.10.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/protontricks-1.10.3-py3.10.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/protontricks-1.10.3-py3.10.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/protontricks-1.10.3-py3.10.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/protontricks-1.10.3-py3.10.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/protontricks-1.11.0-py3.10.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/protontricks-1.11.0-py3.10.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/protontricks-1.11.0-py3.10.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/protontricks-1.11.0-py3.10.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/protontricks-1.11.0-py3.10.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/protontricks-1.11.0-py3.10.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/protontricks/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/protontricks/__pycache__/__init__.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/protontricks/__pycache__/_version.cpython-310.pyc</Path>
@@ -67,9 +67,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2023-05-10</Date>
-            <Version>1.10.3</Version>
+        <Update release="23">
+            <Date>2024-02-10</Date>
+            <Version>1.11.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fix crash caused by the Steam shortcut configuration file containing extra data after the VDF section
- Fix differently sized custom app icons breaking the layout in the app selector
- Fix crash caused by custom app icons with non-RGB mode
- Show app icons for custom shortcuts in the app selector
- Verbose flag can be enabled with `-vv` for additional debug logging
- Fix Protontricks not recognizing supported Steam Runtime installation due to changed name
- Fix Protontricks not recognizing default Proton installation for games with different Proton preselected by Valve testing
- Fix Protontricks crash when app has an unidentifiable app icon

**Test Plan**

Used `protontricks` to install a missing runtime into a game prefix

**Checklist**

- [x] Package was built and tested against unstable
