### PR TITLE
Update efl to 1.27.0

### DIFF
--- a/packages/e/efl/abi_libs
+++ b/packages/e/efl/abi_libs
@@ -5,7 +5,6 @@ elementary_quicklaunch
 elementary_run
 elementary_test
 elm_prefs_cc
-evas_image_loader.ps
 libecore.so.1
 libecore_audio.so.1
 libecore_avahi.so.1

--- a/packages/e/efl/abi_symbols
+++ b/packages/e/efl/abi_symbols
@@ -45,9 +45,6 @@ elm_prefs_cc:__data_start
 elm_prefs_cc:_edata
 elm_prefs_cc:_end
 elm_prefs_cc:_start
-evas_image_loader.ps:__bss_start
-evas_image_loader.ps:_edata
-evas_image_loader.ps:_end
 libecore.so.1:ECORE_EXE_EVENT_ADD
 libecore.so.1:ECORE_EXE_EVENT_DATA
 libecore.so.1:ECORE_EXE_EVENT_DEL
@@ -1206,6 +1203,7 @@ libecore_evas.so.1:ecore_evas_dnd_pos_get
 libecore_evas.so.1:ecore_evas_dnd_position_set
 libecore_evas.so.1:ecore_evas_done
 libecore_evas.so.1:ecore_evas_drag_cancel
+libecore_evas.so.1:ecore_evas_drag_offset_set
 libecore_evas.so.1:ecore_evas_drag_start
 libecore_evas.so.1:ecore_evas_draw_frame_get
 libecore_evas.so.1:ecore_evas_draw_frame_set
@@ -3817,6 +3815,7 @@ libeet.so.1:eet_read_cipher
 libeet.so.1:eet_read_direct
 libeet.so.1:eet_shutdown
 libeet.so.1:eet_sync
+libeet.so.1:eet_sync_sync
 libeet.so.1:eet_version
 libeet.so.1:eet_write
 libeet.so.1:eet_write_cipher
@@ -4997,6 +4996,7 @@ libeina.so.1:eina_file_mkdtemp
 libeina.so.1:eina_file_mkstemp
 libeina.so.1:eina_file_mtime_get
 libeina.so.1:eina_file_open
+libeina.so.1:eina_file_path_relative
 libeina.so.1:eina_file_path_sanitize
 libeina.so.1:eina_file_refresh
 libeina.so.1:eina_file_size_get
@@ -5406,6 +5406,7 @@ libeina.so.1:eina_safepointer_register
 libeina.so.1:eina_safepointer_unregister
 libeina.so.1:eina_sched_prio_drop
 libeina.so.1:eina_seed
+libeina.so.1:eina_sha1
 libeina.so.1:eina_shutdown
 libeina.so.1:eina_simple_xml_attribute_free
 libeina.so.1:eina_simple_xml_attribute_new
@@ -6569,6 +6570,7 @@ libelementary.so.1:efl_ui_datepicker_date_min_set
 libelementary.so.1:efl_ui_datepicker_date_set
 libelementary.so.1:efl_ui_default_item_class_get
 libelementary.so.1:efl_ui_dnd_drag_cancel
+libelementary.so.1:efl_ui_dnd_drag_offset_set
 libelementary.so.1:efl_ui_dnd_drag_start
 libelementary.so.1:efl_ui_dnd_drop_data_get
 libelementary.so.1:efl_ui_dnd_mixin_get
@@ -12310,6 +12312,8 @@ libevas.so.1:evas_common_draw_context_apply_clear_cutouts
 libevas.so.1:evas_common_draw_context_apply_cutouts
 libevas.so.1:evas_common_draw_context_clear_cutouts
 libevas.so.1:evas_common_draw_context_clip_clip
+libevas.so.1:evas_common_draw_context_cutout_max_set
+libevas.so.1:evas_common_draw_context_cutout_size_min_set
 libevas.so.1:evas_common_draw_context_cutouts_del
 libevas.so.1:evas_common_draw_context_cutouts_free
 libevas.so.1:evas_common_draw_context_cutouts_new

--- a/packages/e/efl/abi_used_symbols
+++ b/packages/e/efl/abi_used_symbols
@@ -517,8 +517,12 @@ libc.so.6:__environ
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_fscanf
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_fscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoll
+libc.so.6:__isoc23_strtoul
+libc.so.6:__isoc23_strtoull
 libc.so.6:__libc_current_sigrtmin
 libc.so.6:__libc_start_main
 libc.so.6:__longjmp_chk
@@ -582,6 +586,7 @@ libc.so.6:fchmod
 libc.so.6:fchown
 libc.so.6:fclose
 libc.so.6:fcntl64
+libc.so.6:fdatasync
 libc.so.6:fdopen
 libc.so.6:feof
 libc.so.6:ferror
@@ -825,10 +830,6 @@ libc.so.6:strstr
 libc.so.6:strtod
 libc.so.6:strtof
 libc.so.6:strtok
-libc.so.6:strtol
-libc.so.6:strtoll
-libc.so.6:strtoul
-libc.so.6:strtoull
 libc.so.6:symlink
 libc.so.6:syscall
 libc.so.6:sysconf
@@ -874,7 +875,6 @@ libcrypto.so.3:BIO_s_mem
 libcrypto.so.3:BIO_set_data
 libcrypto.so.3:BIO_set_flags
 libcrypto.so.3:BIO_set_init
-libcrypto.so.3:CRYPTO_free
 libcrypto.so.3:DH_check
 libcrypto.so.3:DH_free
 libcrypto.so.3:DH_generate_key
@@ -912,6 +912,7 @@ libcrypto.so.3:EVP_VerifyFinal
 libcrypto.so.3:EVP_aes_256_cbc
 libcrypto.so.3:EVP_sha1
 libcrypto.so.3:HMAC
+libcrypto.so.3:OPENSSL_init_crypto
 libcrypto.so.3:OPENSSL_sk_num
 libcrypto.so.3:OPENSSL_sk_value
 libcrypto.so.3:PEM_read_bio_PrivateKey
@@ -1577,6 +1578,7 @@ libspectre.so.1:spectre_render_context_free
 libspectre.so.1:spectre_render_context_new
 libspectre.so.1:spectre_render_context_set_page_size
 libspectre.so.1:spectre_status_to_string
+libssl.so.3:OPENSSL_init_ssl
 libssl.so.3:SSL_CIPHER_get_name
 libssl.so.3:SSL_CIPHER_get_version
 libssl.so.3:SSL_CTX_check_private_key
@@ -1622,7 +1624,6 @@ libssl.so.3:TLS_client_method
 libssl.so.3:TLS_server_method
 libstdc++.so.6:_ZNKSt5ctypeIcE13_M_widen_initEv
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE5rfindEPKcmm
-libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7compareEPKc
 libstdc++.so.6:_ZNKSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE3strEv
 libstdc++.so.6:_ZNSo3putEc
 libstdc++.so.6:_ZNSo5flushEv
@@ -1650,8 +1651,6 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9push_backEc
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1EOS4_
 libstdc++.so.6:_ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEEC1Ev
 libstdc++.so.6:_ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEED1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitC1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitD1Ev
 libstdc++.so.6:_ZNSt8ios_baseC2Ev
 libstdc++.so.6:_ZNSt8ios_baseD2Ev
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE4initEPSt15basic_streambufIcS1_E
@@ -1663,6 +1662,7 @@ libstdc++.so.6:_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_incrementPKSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
+libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZSt25__throw_bad_function_callv
 libstdc++.so.6:_ZSt28_Rb_tree_rebalance_for_erasePSt18_Rb_tree_node_baseRS_
 libstdc++.so.6:_ZSt28__throw_bad_array_new_lengthv
@@ -1746,7 +1746,6 @@ libwayland-client.so.0:wl_display_dispatch_pending
 libwayland-client.so.0:wl_display_flush
 libwayland-client.so.0:wl_display_get_error
 libwayland-client.so.0:wl_display_get_fd
-libwayland-client.so.0:wl_list_init
 libwayland-client.so.0:wl_proxy_add_listener
 libwayland-client.so.0:wl_proxy_destroy
 libwayland-client.so.0:wl_proxy_get_user_data
@@ -1767,6 +1766,7 @@ libwayland-server.so.0:wl_display_terminate
 libwayland-server.so.0:wl_event_loop_add_signal
 libwayland-server.so.0:wl_event_source_remove
 libwayland-server.so.0:wl_global_create
+libwayland-server.so.0:wl_list_init
 libwayland-server.so.0:wl_registry_interface
 libwayland-server.so.0:wl_resource_create
 libwayland-server.so.0:wl_resource_destroy

--- a/packages/e/efl/monitoring.yml
+++ b/packages/e/efl/monitoring.yml
@@ -1,0 +1,5 @@
+releases:
+  id: 6128
+# No known CPE, checked 20240211
+security:
+  cpe: ~

--- a/packages/e/efl/package.yml
+++ b/packages/e/efl/package.yml
@@ -1,8 +1,8 @@
 name       : efl
-version    : 1.26.3
-release    : 33
+version    : 1.27.0
+release    : 34
 source     :
-    - https://download.enlightenment.org/rel/libs/efl/efl-1.26.3.tar.xz : d9f83aa0fd9334f44deeb4e4952dc0e5144683afac786feebce6030951617d15
+    - https://download.enlightenment.org/rel/libs/efl/efl-1.27.0.tar.xz : 3dfb99fbcc268c0bc797e2f83e8c503ef9de66284f40b381bb597a08185c00f4
 homepage   : https://www.enlightenment.org/about-efl
 license    :
     - BSD-2-Clause

--- a/packages/e/efl/pspec_x86_64.xml
+++ b/packages/e/efl/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>efl</Name>
         <Homepage>https://www.enlightenment.org/about-efl</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <License>GPL-2.0-or-later</License>
@@ -14,7 +14,7 @@
         <Summary xml:lang="en">Enlightenment Foundation Libraries</Summary>
         <Description xml:lang="en">EFL is a collection of libraries for handling many common tasks a developer may have such as data structures, communication, rendering, widgets and more.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>efl</Name>
@@ -41,52 +41,54 @@
             <Path fileType="executable">/usr/bin/exactness_play</Path>
             <Path fileType="executable">/usr/bin/exactness_record</Path>
             <Path fileType="library">/usr/lib/systemd/user/ethumb.service</Path>
-            <Path fileType="library">/usr/lib64/ecore/system/systemd/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/ecore/system/upower/v-1.26/module.so</Path>
+            <Path fileType="library">/usr/lib64/ecore/system/systemd/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/ecore/system/upower/v-1.27/module.so</Path>
             <Path fileType="library">/usr/lib64/ecore_buffer/bin/bqmgr</Path>
-            <Path fileType="library">/usr/lib64/ecore_buffer/modules/shm/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/ecore_con/utils/v-1.26/efl_net_proxy_helper</Path>
-            <Path fileType="library">/usr/lib64/ecore_evas/engines/extn/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/ecore_evas/engines/sdl/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/ecore_evas/engines/x/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/ecore_imf/modules/ibus/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/ecore_imf/modules/xim/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/edje/modules/elm/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/edje/modules/emotion/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/edje/utils/v-1.26/epp</Path>
-            <Path fileType="library">/usr/lib64/eeze/modules/sensor/fake/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/eeze/modules/sensor/udev/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/efreet/v-1.26/efreet_desktop_cache_create</Path>
-            <Path fileType="library">/usr/lib64/efreet/v-1.26/efreet_icon_cache_create</Path>
-            <Path fileType="library">/usr/lib64/efreet/v-1.26/efreet_mime_cache_create</Path>
-            <Path fileType="library">/usr/lib64/elementary/modules/access_output/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/elementary/modules/prefs/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/elementary/modules/test_entry/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/elementary/modules/test_map/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/elementary/modules/web/none/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/emotion/modules/gstreamer1/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/ethumb/modules/emotion/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/ethumb_client/utils/v-1.26/ethumbd_slave</Path>
-            <Path fileType="library">/usr/lib64/evas/modules/engines/buffer/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/evas/modules/engines/gl_generic/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/evas/modules/engines/gl_x11/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/evas/modules/engines/software_x11/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/bmp/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/generic/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/gif/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/ico/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/jp2k/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/pmaps/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/psd/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/tga/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/tgv/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/tiff/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/wbmp/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/webp/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/xpm/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/evas/modules/image_savers/tgv/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/evas/modules/image_savers/tiff/v-1.26/module.so</Path>
-            <Path fileType="library">/usr/lib64/evas/modules/image_savers/webp/v-1.26/module.so</Path>
+            <Path fileType="library">/usr/lib64/ecore_buffer/modules/shm/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/ecore_con/utils/v-1.27/efl_net_proxy_helper</Path>
+            <Path fileType="library">/usr/lib64/ecore_evas/engines/extn/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/ecore_evas/engines/sdl/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/ecore_evas/engines/x/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/ecore_imf/modules/ibus/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/ecore_imf/modules/xim/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/edje/modules/elm/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/edje/modules/emotion/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/edje/utils/v-1.27/epp</Path>
+            <Path fileType="library">/usr/lib64/eeze/modules/sensor/fake/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/eeze/modules/sensor/udev/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/efreet/v-1.27/efreet_desktop_cache_create</Path>
+            <Path fileType="library">/usr/lib64/efreet/v-1.27/efreet_icon_cache_create</Path>
+            <Path fileType="library">/usr/lib64/efreet/v-1.27/efreet_mime_cache_create</Path>
+            <Path fileType="library">/usr/lib64/elementary/modules/access_output/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/elementary/modules/prefs/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/elementary/modules/test_entry/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/elementary/modules/test_map/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/elementary/modules/web/none/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/emotion/modules/gstreamer1/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/ethumb/modules/emotion/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/ethumb_client/utils/v-1.27/ethumbd_slave</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/engines/buffer/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/engines/gl_generic/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/engines/gl_x11/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/engines/software_x11/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/bmp/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/generic/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/gif/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/ico/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/jp2k/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/pmaps/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/psd/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/qoi/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/tga/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/tgv/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/tiff/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/wbmp/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/webp/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/image_loaders/xpm/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/image_savers/qoi/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/image_savers/tgv/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/image_savers/tiff/v-1.27/module.so</Path>
+            <Path fileType="library">/usr/lib64/evas/modules/image_savers/webp/v-1.27/module.so</Path>
             <Path fileType="library">/usr/lib64/evas/utils/evas_generic_pdf_loader.doc</Path>
             <Path fileType="library">/usr/lib64/evas/utils/evas_generic_pdf_loader.docx</Path>
             <Path fileType="library">/usr/lib64/evas/utils/evas_generic_pdf_loader.libreoffice</Path>
@@ -189,116 +191,116 @@
             <Path fileType="library">/usr/lib64/evas/utils/evas_image_loader.xlsx</Path>
             <Path fileType="library">/usr/lib64/libecore.so</Path>
             <Path fileType="library">/usr/lib64/libecore.so.1</Path>
-            <Path fileType="library">/usr/lib64/libecore.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libecore.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libecore_audio.so</Path>
             <Path fileType="library">/usr/lib64/libecore_audio.so.1</Path>
-            <Path fileType="library">/usr/lib64/libecore_audio.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libecore_audio.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libecore_avahi.so</Path>
             <Path fileType="library">/usr/lib64/libecore_avahi.so.1</Path>
-            <Path fileType="library">/usr/lib64/libecore_avahi.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libecore_avahi.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libecore_buffer.so</Path>
             <Path fileType="library">/usr/lib64/libecore_buffer.so.1</Path>
-            <Path fileType="library">/usr/lib64/libecore_buffer.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libecore_buffer.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libecore_con.so</Path>
             <Path fileType="library">/usr/lib64/libecore_con.so.1</Path>
-            <Path fileType="library">/usr/lib64/libecore_con.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libecore_con.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libecore_evas.so</Path>
             <Path fileType="library">/usr/lib64/libecore_evas.so.1</Path>
-            <Path fileType="library">/usr/lib64/libecore_evas.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libecore_evas.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libecore_file.so</Path>
             <Path fileType="library">/usr/lib64/libecore_file.so.1</Path>
-            <Path fileType="library">/usr/lib64/libecore_file.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libecore_file.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libecore_imf.so</Path>
             <Path fileType="library">/usr/lib64/libecore_imf.so.1</Path>
-            <Path fileType="library">/usr/lib64/libecore_imf.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libecore_imf.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libecore_imf_evas.so</Path>
             <Path fileType="library">/usr/lib64/libecore_imf_evas.so.1</Path>
-            <Path fileType="library">/usr/lib64/libecore_imf_evas.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libecore_imf_evas.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libecore_input.so</Path>
             <Path fileType="library">/usr/lib64/libecore_input.so.1</Path>
-            <Path fileType="library">/usr/lib64/libecore_input.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libecore_input.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libecore_input_evas.so</Path>
             <Path fileType="library">/usr/lib64/libecore_input_evas.so.1</Path>
-            <Path fileType="library">/usr/lib64/libecore_input_evas.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libecore_input_evas.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libecore_ipc.so</Path>
             <Path fileType="library">/usr/lib64/libecore_ipc.so.1</Path>
-            <Path fileType="library">/usr/lib64/libecore_ipc.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libecore_ipc.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libecore_sdl.so</Path>
             <Path fileType="library">/usr/lib64/libecore_x.so</Path>
             <Path fileType="library">/usr/lib64/libecore_x.so.1</Path>
-            <Path fileType="library">/usr/lib64/libecore_x.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libecore_x.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libector.so</Path>
             <Path fileType="library">/usr/lib64/libector.so.1</Path>
-            <Path fileType="library">/usr/lib64/libector.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libector.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libedje.so</Path>
             <Path fileType="library">/usr/lib64/libedje.so.1</Path>
-            <Path fileType="library">/usr/lib64/libedje.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libedje.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libeet.so</Path>
             <Path fileType="library">/usr/lib64/libeet.so.1</Path>
-            <Path fileType="library">/usr/lib64/libeet.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libeet.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libeeze.so</Path>
             <Path fileType="library">/usr/lib64/libeeze.so.1</Path>
-            <Path fileType="library">/usr/lib64/libeeze.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libeeze.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libefl.so</Path>
             <Path fileType="library">/usr/lib64/libefl.so.1</Path>
-            <Path fileType="library">/usr/lib64/libefl.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libefl.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libefreet.so</Path>
             <Path fileType="library">/usr/lib64/libefreet.so.1</Path>
-            <Path fileType="library">/usr/lib64/libefreet.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libefreet.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libefreet_mime.so</Path>
             <Path fileType="library">/usr/lib64/libefreet_mime.so.1</Path>
-            <Path fileType="library">/usr/lib64/libefreet_mime.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libefreet_mime.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libefreet_trash.so</Path>
             <Path fileType="library">/usr/lib64/libefreet_trash.so.1</Path>
-            <Path fileType="library">/usr/lib64/libefreet_trash.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libefreet_trash.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libeina.so</Path>
             <Path fileType="library">/usr/lib64/libeina.so.1</Path>
-            <Path fileType="library">/usr/lib64/libeina.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libeina.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libeio.so</Path>
             <Path fileType="library">/usr/lib64/libeio.so.1</Path>
-            <Path fileType="library">/usr/lib64/libeio.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libeio.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libeldbus.so</Path>
             <Path fileType="library">/usr/lib64/libeldbus.so.1</Path>
-            <Path fileType="library">/usr/lib64/libeldbus.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libeldbus.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libelementary.so</Path>
             <Path fileType="library">/usr/lib64/libelementary.so.1</Path>
-            <Path fileType="library">/usr/lib64/libelementary.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libelementary.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libelput.so</Path>
             <Path fileType="library">/usr/lib64/libelput.so.1</Path>
-            <Path fileType="library">/usr/lib64/libelput.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libelput.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libembryo.so</Path>
             <Path fileType="library">/usr/lib64/libembryo.so.1</Path>
-            <Path fileType="library">/usr/lib64/libembryo.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libembryo.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libemile.so</Path>
             <Path fileType="library">/usr/lib64/libemile.so.1</Path>
-            <Path fileType="library">/usr/lib64/libemile.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libemile.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libemotion.so</Path>
             <Path fileType="library">/usr/lib64/libemotion.so.1</Path>
-            <Path fileType="library">/usr/lib64/libemotion.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libemotion.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libeo.so</Path>
             <Path fileType="library">/usr/lib64/libeo.so.1</Path>
-            <Path fileType="library">/usr/lib64/libeo.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libeo.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libeo_dbg.so</Path>
             <Path fileType="library">/usr/lib64/libeo_dbg.so.1</Path>
-            <Path fileType="library">/usr/lib64/libeo_dbg.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libeo_dbg.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libeolian.so</Path>
             <Path fileType="library">/usr/lib64/libeolian.so.1</Path>
-            <Path fileType="library">/usr/lib64/libeolian.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libeolian.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libethumb.so</Path>
             <Path fileType="library">/usr/lib64/libethumb.so.1</Path>
-            <Path fileType="library">/usr/lib64/libethumb.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libethumb.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libethumb_client.so</Path>
             <Path fileType="library">/usr/lib64/libethumb_client.so.1</Path>
-            <Path fileType="library">/usr/lib64/libethumb_client.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libethumb_client.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libevas.so</Path>
             <Path fileType="library">/usr/lib64/libevas.so.1</Path>
-            <Path fileType="library">/usr/lib64/libevas.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libevas.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libexactness_play.so</Path>
             <Path fileType="library">/usr/lib64/libexactness_play.so.1</Path>
-            <Path fileType="library">/usr/lib64/libexactness_play.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libexactness_play.so.1.27.0</Path>
             <Path fileType="library">/usr/lib64/libexactness_record.so</Path>
             <Path fileType="library">/usr/lib64/libexactness_record.so.1</Path>
-            <Path fileType="library">/usr/lib64/libexactness_record.so.1.26.3</Path>
+            <Path fileType="library">/usr/lib64/libexactness_record.so.1.27.0</Path>
             <Path fileType="data">/usr/share/applications/elementary_config.desktop</Path>
             <Path fileType="data">/usr/share/dbus-1/services/org.enlightenment.Ethumb.service</Path>
             <Path fileType="data">/usr/share/edje/include/edje.inc</Path>
@@ -307,6 +309,7 @@
             <Path fileType="data">/usr/share/elementary/colors/candy-mint.pal</Path>
             <Path fileType="data">/usr/share/elementary/colors/default.pal</Path>
             <Path fileType="data">/usr/share/elementary/colors/ebony-brass.pal</Path>
+            <Path fileType="data">/usr/share/elementary/colors/empty.pal</Path>
             <Path fileType="data">/usr/share/elementary/colors/light.pal</Path>
             <Path fileType="data">/usr/share/elementary/colors/mauve-sunset.pal</Path>
             <Path fileType="data">/usr/share/elementary/colors/white-pill.pal</Path>
@@ -879,6 +882,7 @@
             <Path fileType="localedata">/usr/share/locale/hu/LC_MESSAGES/efl.mo</Path>
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/efl.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/efl.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/efl.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ko/LC_MESSAGES/efl.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ko_KR/LC_MESSAGES/efl.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lt/LC_MESSAGES/efl.mo</Path>
@@ -905,7 +909,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="33">efl</Dependency>
+            <Dependency release="34">efl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/diffeet</Path>
@@ -1550,6 +1554,7 @@
             <Path fileType="header">/usr/include/eina-1/eina/eina_refcount.h</Path>
             <Path fileType="header">/usr/include/eina-1/eina/eina_safepointer.h</Path>
             <Path fileType="header">/usr/include/eina-1/eina/eina_safety_checks.h</Path>
+            <Path fileType="header">/usr/include/eina-1/eina/eina_sha.h</Path>
             <Path fileType="header">/usr/include/eina-1/eina/eina_simple_xml_parser.h</Path>
             <Path fileType="header">/usr/include/eina-1/eina/eina_slice.h</Path>
             <Path fileType="header">/usr/include/eina-1/eina/eina_slstr.h</Path>
@@ -2253,6 +2258,7 @@
             <Path fileType="header">/usr/include/elementary-1/elm_widget_icon.h</Path>
             <Path fileType="header">/usr/include/elementary-1/elm_widget_index.h</Path>
             <Path fileType="header">/usr/include/elementary-1/elm_widget_inwin.h</Path>
+            <Path fileType="header">/usr/include/elementary-1/elm_widget_item_container_eo.h</Path>
             <Path fileType="header">/usr/include/elementary-1/elm_widget_item_container_eo.legacy.h</Path>
             <Path fileType="header">/usr/include/elementary-1/elm_widget_item_eo.legacy.h</Path>
             <Path fileType="header">/usr/include/elementary-1/elm_widget_item_static_focus_eo.legacy.h</Path>
@@ -3430,16 +3436,16 @@
             <Path fileType="data">/usr/share/eolian/include/evas-1/efl_input_types.eot</Path>
             <Path fileType="data">/usr/share/eolian/include/evas-1/efl_text_cursor_object.eo</Path>
             <Path fileType="data">/usr/share/eolian/include/evas-1/efl_text_formatter.eo</Path>
-            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib/libeo.so.1.26.3-gdb.py</Path>
+            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib/libeo.so.1.27.0-gdb.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2023-08-20</Date>
-            <Version>1.26.3</Version>
+        <Update release="34">
+            <Date>2024-02-11</Date>
+            <Version>1.27.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/r/rage/monitoring.yml
+++ b/packages/r/rage/monitoring.yml
@@ -1,0 +1,5 @@
+releases:
+  id: 227383
+# No known CPE, checked 20240211
+security:
+  cpe: ~

--- a/packages/r/rage/package.yml
+++ b/packages/r/rage/package.yml
@@ -1,6 +1,6 @@
 name       : rage
 version    : 0.4.0
-release    : 1
+release    : 2
 source     :
     - https://download.enlightenment.org/rel/apps/rage/rage-0.4.0.tar.xz : 7ce58419aa5197aa6c33f2e3f9eb9d78ff379cae863d5fa114fd1428d5a1ca0f
 homepage   : https://www.enlightenment.org/about-rage

--- a/packages/r/rage/pspec_x86_64.xml
+++ b/packages/r/rage/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>rage</Name>
         <Homepage>https://www.enlightenment.org/about-rage</Homepage>
         <Packager>
-            <Name>Jarno Turkki</Name>
-            <Email>stalebrim@posteo.net</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>multimedia.video</PartOf>
         <Summary xml:lang="en">Simple video and audio player written using the Enlightenment Foundation Libraries (EFL)</Summary>
         <Description xml:lang="en">Rage is a simple video and audio player intended to be slick yet simplistic. If you want a simple video player like MPlayer, but with a few more visual niceties, then Rage may be for you. Almost all of the nuts and bolts it relies on for video playback and UI are provided by EFL itself or by something EFL wraps, like GStreamer, Xine, VLC and so on. Since it uses EFL, Rage will work in X11, Wayland, even the raw framebuffer with the Framebuffer console (fbcon) or the Direct Rendering Manager (DMS) subsystem.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>rage</Name>
@@ -28,12 +28,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2023-07-01</Date>
+        <Update release="2">
+            <Date>2024-02-11</Date>
             <Version>0.4.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jarno Turkki</Name>
-            <Email>stalebrim@posteo.net</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/t/terminology/abi_used_symbols
+++ b/packages/t/terminology/abi_used_symbols
@@ -1,6 +1,9 @@
 libc.so.6:__assert_fail
 libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoll
 libc.so.6:__isoc99_scanf
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
@@ -80,8 +83,6 @@ libc.so.6:strncpy
 libc.so.6:strndup
 libc.so.6:strpbrk
 libc.so.6:strrchr
-libc.so.6:strtol
-libc.so.6:strtoll
 libc.so.6:tcgetattr
 libc.so.6:tcsetattr
 libc.so.6:textdomain

--- a/packages/t/terminology/monitoring.yml
+++ b/packages/t/terminology/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 4951
+security:
+  cpe:
+    - vendor: enlightenment
+      product: terminology

--- a/packages/t/terminology/package.yml
+++ b/packages/t/terminology/package.yml
@@ -1,6 +1,6 @@
 name       : terminology
 version    : 1.13.0
-release    : 7
+release    : 8
 source     :
     - https://download.enlightenment.org/rel/apps/terminology/terminology-1.13.0.tar.xz : 16a37fecd7bbd63ec9de3ec6c0af331cee77d6dfda838a1b1573d6f298474da5
 homepage   : https://www.enlightenment.org/about-terminology

--- a/packages/t/terminology/pspec_x86_64.xml
+++ b/packages/t/terminology/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>terminology</Name>
         <Homepage>https://www.enlightenment.org/about-terminology</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">This is an EFL terminal emulator with some extra bells and whistles</Summary>
         <Description xml:lang="en">Terminology is a terminal emulator for Linux/BSD/UNIX systems that uses EFL. It has a whole bunch of bells and whistles. Use it as your regular vt100 terminal emulator with all the usual features, such as 256 color support. Terminology is designed to emulate Xterm as closely as possible in most respects.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>terminology</Name>
@@ -129,12 +129,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2022-12-02</Date>
+        <Update release="8">
+            <Date>2024-02-11</Date>
             <Version>1.13.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Update efl to 1.27.0, rebuild reverse dependencies for safety and add `monitoring.yml`s to all packages

Changes:
- Lots of minor bug fixes
- New eina APIS (releative path and sha1)
- Add URI List to elm cnp
- Add JXL Evas loader/saver
- Add Eet fs sync call to force writes to disk
- Add support for LibreSSL 3.5.x
- Removed GNUTLS support now openssl3 is out
- Elementary icons - policy change to use theme icons for std icons
- Elementary entry - allow past into password entries
- Add QOI Evas image loader/saver

**Test Plan**

Built and used `terminology` and `rage`

**Checklist**

- [x] Package was built and tested against unstable
