### PR TITLE
libgsf: Update to 1.4.52 and fix license

### DIFF
--- a/packages/l/libgsf/abi_symbols
+++ b/packages/l/libgsf/abi_symbols
@@ -264,6 +264,7 @@ libgsf-1.so.114:gsf_timestamp_new
 libgsf-1.so.114:gsf_timestamp_parse
 libgsf-1.so.114:gsf_timestamp_set_time
 libgsf-1.so.114:gsf_timestamp_to_value
+libgsf-1.so.114:gsf_value_get_docprop_array
 libgsf-1.so.114:gsf_value_get_docprop_varray
 libgsf-1.so.114:gsf_value_get_docprop_vector
 libgsf-1.so.114:gsf_value_set_timestamp

--- a/packages/l/libgsf/monitoring.yml
+++ b/packages/l/libgsf/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 1980
+  rss: https://gitlab.gnome.org/GNOME/libgsf/-/tags?&format=atom
+security:
+  cpe:
+    - vendor: gnome
+      product: libgsf

--- a/packages/l/libgsf/package.yml
+++ b/packages/l/libgsf/package.yml
@@ -1,9 +1,10 @@
 name       : libgsf
-version    : 1.14.51
-release    : 11
+version    : 1.14.52
+release    : 12
 source     :
-    - https://download.gnome.org/sources/libgsf/1.14/libgsf-1.14.51.tar.xz : f0b83251f98b0fd5592b11895910cc0e19f798110b389aba7da1cb7c474017f5
-license    : LGPL-2.1-or-later
+    - https://download.gnome.org/sources/libgsf/1.14/libgsf-1.14.52.tar.xz : 9181c914b9fac0e05d6bcaa34c7b552fe5fc0961d3c9f8c01ccc381fb084bcf0
+homepage   : https://gitlab.gnome.org/GNOME/libgsf
+license    : LGPL-2.1-only
 component  : desktop.library
 summary    : Library providing I/O for structured file formats
 description: |

--- a/packages/l/libgsf/pspec_x86_64.xml
+++ b/packages/l/libgsf/pspec_x86_64.xml
@@ -1,11 +1,12 @@
 <PISI>
     <Source>
         <Name>libgsf</Name>
+        <Homepage>https://gitlab.gnome.org/GNOME/libgsf</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
-        <License>LGPL-2.1-or-later</License>
+        <License>LGPL-2.1-only</License>
         <PartOf>desktop.library</PartOf>
         <Summary xml:lang="en">Library providing I/O for structured file formats</Summary>
         <Description xml:lang="en">libgsf contains the library used for providing an extensible input/output abstraction layer for structured file formats within GNOME.
@@ -23,7 +24,7 @@
             <Path fileType="executable">/usr/bin/gsf-office-thumbnailer</Path>
             <Path fileType="executable">/usr/bin/gsf-vba-dump</Path>
             <Path fileType="library">/usr/lib64/libgsf-1.so.114</Path>
-            <Path fileType="library">/usr/lib64/libgsf-1.so.114.0.51</Path>
+            <Path fileType="library">/usr/lib64/libgsf-1.so.114.0.52</Path>
             <Path fileType="localedata">/usr/share/locale/as/LC_MESSAGES/libgsf.mo</Path>
             <Path fileType="localedata">/usr/share/locale/bs/LC_MESSAGES/libgsf.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/libgsf.mo</Path>
@@ -86,7 +87,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="11">libgsf</Dependency>
+            <Dependency release="12">libgsf</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libgsf-1/gsf/gsf-blob.h</Path>
@@ -191,12 +192,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2023-12-21</Date>
-            <Version>1.14.51</Version>
+        <Update release="12">
+            <Date>2024-02-11</Date>
+            <Version>1.14.52</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Export gsf_value_get_docprop_array
- xml: Fix build with libxml2 2.12

Packaging note: Upstream project has clarified their license to be LGPL-2.1-only, see discussion [here](https://gitlab.gnome.org/GNOME/libgsf/-/issues/28)

**Test Plan**

- Used `gnumeric`, `abiword`
- Did a test rebuild of `libgoffice`

**Checklist**

- [x] Package was built and tested against unstable
