### PR TITLE
dotnet: debootstrap

### DIFF
--- a/packages/d/dotnet/package.yml
+++ b/packages/d/dotnet/package.yml
@@ -1,8 +1,9 @@
 name       : dotnet
 version    : 8.0.1
-release    : 1
+release    : 2
 source     :
-    - git|https://github.com/dotnet/dotnet.git : b27976e5a6850466ee5b4ce24f91ee93bef645f7
+    - https://github.com/dotnet/dotnet/archive/refs/tags/v8.0.1.tar.gz : df2d95fc3f00fea808bb238edf0d29d27b786307d63bdbf3787466b7f08d7963
+    - https://github.com/dotnet/dotnet/releases/download/v8.0.1/release.json : b1743b0f9b13be66f1d73b296672b19cea7057721448c3326d8716dda9c343c1
 homepage   : https://dot.net
 license    : MIT
 component  : programming.dotnet
@@ -26,13 +27,13 @@ builddeps  :
     - pkgconfig(libxml-2.0)
     - pkgconfig(lttng-ust)
     - pkgconfig(zlib)
-    # - dotnet-sdk
-    # - dotnet-source-built-artifacts
+    - dotnet-sdk
+    - dotnet-source-built-artifacts
     - git
     - lldb-devel
 rundeps    :
     - libicu
-    - sdk:
+    - sdk :
         - dotnet
 setup      : |
     %patch -p1 -i $pkgfiles/1005-default-opt-out-of-telemetry.patch
@@ -41,17 +42,13 @@ build      : |
     export EXTRA_CFLAGS="$CFLAGS"
     export EXTRA_CXXFLAGS="$CXXFLAGS"
     export EXTRA_LDFLAGS="$LDFLAGS"
-    if [ -d /usr/lib/dotnet ]; then
-        cp -r /usr/lib/dotnet .dotnet
-    fi
-    if [ -d /usr/share/dotnet/source-built-artifacts ]; then
-        ln -sf /usr/share/dotnet/source-built-artifacts/Private.SourceBuilt.Artifacts.*.tar.gz prereqs/packages/archive/
-        ln -sf /usr/share/dotnet/source-built-artifacts/Private.SourceBuilt.Prebuilts.*.tar.gz prereqs/packages/archive/
-    fi
+    cp -r /usr/lib/dotnet .dotnet
+    ln -sf /usr/share/dotnet/source-built-artifacts/Private.SourceBuilt.*.tar.gz prereqs/packages/archive/
+
     # setting `version` (any case) clobbers the msbuild version target
     unset CFLAGS CXXFLAGS LDFLAGS version
     ./prep.sh
-    ./build.sh --clean-while-building --online
+    ./build.sh --clean-while-building --online --release-manifest $sources/release.json --with-sdk $PWD/.dotnet
 install    : |
     # required bootstrap artifacts
     install -Dm00644 artifacts/x64/Release/Private.SourceBuilt.Artifacts.*.tar.gz -t $installdir/usr/share/dotnet/source-built-artifacts/
@@ -63,7 +60,7 @@ install    : |
     mv $installdir/usr/lib/dotnet/{LICENSE.txt,ThirdPartyNotices.txt} $installdir/usr/share/licenses/dotnet/
     ln -s /usr/lib/dotnet/dotnet $installdir/usr/bin/dotnet
     ln -s /usr/lib/dotnet/host/fxr/$version/libhostfxr.so $installdir/usr/lib/libhostfxr.so
-    
+
     # prevents dotnet from having to search for the install location
     install -Dm00644 /dev/null $installdir/etc/dotnet/install_location
     echo "/usr/lib/dotnet/" > $installdir/etc/dotnet/install_location
@@ -73,11 +70,11 @@ install    : |
     install -Dm00644 src/sdk/scripts/register-completions.zsh $installdir/usr/share/zsh/site-functions/_dotnet
     # install -Dm00644 src/sdk/scripts/register-completions.ps1 $installdir/usr/local/share/powershell/Modules
 patterns   :
-    - sdk:
+    - sdk :
         - /usr/lib/dotnet/metadata
         - /usr/lib/dotnet/packs
         - /usr/lib/dotnet/sdk
         - /usr/lib/dotnet/sdk-manifests
         - /usr/lib/dotnet/templates
-    - source-built-artifacts:
+    - source-built-artifacts :
         - /usr/share/dotnet/source-built-artifacts

--- a/packages/d/dotnet/pspec_x86_64.xml
+++ b/packages/d/dotnet/pspec_x86_64.xml
@@ -364,7 +364,7 @@
         <Summary xml:lang="en">.NET Development Kit</Summary>
         <Description xml:lang="en">.NET is a free, cross-platform, open-source developer platform for building many kinds of applications. It can run programs written in multiple languages, with C# being the most popular.</Description>
         <RuntimeDependencies>
-            <Dependency releaseFrom="1">dotnet</Dependency>
+            <Dependency releaseFrom="2">dotnet</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib/dotnet/metadata/workloads/8.0.100/userlocal</Path>
@@ -4059,8 +4059,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-02-09</Date>
+        <Update release="2">
+            <Date>2024-02-11</Date>
             <Version>8.0.1</Version>
             <Comment>Packaging update</Comment>
             <Name>nelson truran</Name>


### PR DESCRIPTION
**Summary**

De-bootstrapping .net

**Test Plan**

1. With the sdk installed, create the following default templates
   - native AOT web api
   - web api
   - hello world console app
2. Run the web api with `dotnet run` and make a get request
3. run the hello world console app with `dotnet run`
5. build each test as a DLL, also publish each app as self-contained single file apps
4. uninstall the .net SDK, and run the apps again with only the runtime installed
5. uninstall the runtime and run the native apps

**Checklist**

- [x] Package was built and tested against unstable
