### PR TITLE
wxmaxima: Update to 24.02.1

### DIFF
--- a/packages/w/wxmaxima/abi_used_symbols
+++ b/packages/w/wxmaxima/abi_used_symbols
@@ -71,6 +71,8 @@ libstdc++.so.6:_ZNSt15basic_streambufIcSt11char_traitsIcEE7seekposESt4fposI11__m
 libstdc++.so.6:_ZNSt15basic_streambufIcSt11char_traitsIcEE9pbackfailEi
 libstdc++.so.6:_ZNSt15basic_streambufIcSt11char_traitsIcEE9showmanycEv
 libstdc++.so.6:_ZNSt15basic_streambufIcSt11char_traitsIcEE9underflowEv
+libstdc++.so.6:_ZNSt6localeC1Ev
+libstdc++.so.6:_ZNSt6localeD1Ev
 libstdc++.so.6:_ZNSt6thread15_M_start_threadESt10unique_ptrINS_6_StateESt14default_deleteIS1_EEPFvvE
 libstdc++.so.6:_ZNSt6thread20hardware_concurrencyEv
 libstdc++.so.6:_ZNSt6thread4joinEv
@@ -94,6 +96,9 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEEC1ERKS4_
 libstdc++.so.6:_ZNSt8__detail15_List_node_base11_M_transferEPS0_S1_
 libstdc++.so.6:_ZNSt8__detail15_List_node_base7_M_hookEPS0_
 libstdc++.so.6:_ZNSt8__detail15_List_node_base9_M_unhookEv
+libstdc++.so.6:_ZNSt8ios_baseC2Ev
+libstdc++.so.6:_ZNSt8ios_baseD2Ev
+libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE4initEPSt15basic_streambufIcS1_E
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE5clearESt12_Ios_Iostate
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE5rdbufEPSt15basic_streambufIcS1_E
 libstdc++.so.6:_ZSt11_Hash_bytesPKvmm
@@ -110,9 +115,14 @@ libstdc++.so.6:_ZSt4cerr
 libstdc++.so.6:_ZSt4cout
 libstdc++.so.6:_ZSt9terminatev
 libstdc++.so.6:_ZTINSt6thread6_StateE
+libstdc++.so.6:_ZTISo
+libstdc++.so.6:_ZTISt15basic_streambufIcSt11char_traitsIcEE
 libstdc++.so.6:_ZTVN10__cxxabiv117__class_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv120__si_class_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv121__vmi_class_type_infoE
+libstdc++.so.6:_ZTVSt15basic_streambufIcSt11char_traitsIcEE
+libstdc++.so.6:_ZTVSt9basic_iosIcSt11char_traitsIcEE
+libstdc++.so.6:_ZdaPv
 libstdc++.so.6:_ZdlPv
 libstdc++.so.6:_ZdlPvm
 libstdc++.so.6:_Znam
@@ -189,6 +199,7 @@ libwx_baseu-3.2.so.0:_ZN10wxTextFileC1ERK8wxString
 libwx_baseu-3.2.so.0:_ZN10wxUILocale10UseDefaultEv
 libwx_baseu-3.2.so.0:_ZN11wxLogBuffer16DoLogTextAtLevelEmRK8wxString
 libwx_baseu-3.2.so.0:_ZN11wxLogStderrC1EP8_IO_FILERK8wxMBConv
+libwx_baseu-3.2.so.0:_ZN11wxLogStreamC1EPSoRK8wxMBConv
 libwx_baseu-3.2.so.0:_ZN11wxStopWatch5StartEl
 libwx_baseu-3.2.so.0:_ZN12wxConfigBase10ms_pConfigE
 libwx_baseu-3.2.so.0:_ZN12wxConfigBase3SetEPS_
@@ -355,6 +366,7 @@ libwx_baseu-3.2.so.0:_ZN5wxURIC1ERK8wxString
 libwx_baseu-3.2.so.0:_ZN6wxFile4OpenERK8wxStringNS_8OpenModeEi
 libwx_baseu-3.2.so.0:_ZN6wxFile5CloseEv
 libwx_baseu-3.2.so.0:_ZN6wxFile5WriteEPKvm
+libwx_baseu-3.2.so.0:_ZN6wxFile6ExistsERK8wxString
 libwx_baseu-3.2.so.0:_ZN6wxFileC1ERK8wxStringNS_8OpenModeE
 libwx_baseu-3.2.so.0:_ZN7wxEventC2ERKS_
 libwx_baseu-3.2.so.0:_ZN7wxEventC2Eii

--- a/packages/w/wxmaxima/package.yml
+++ b/packages/w/wxmaxima/package.yml
@@ -1,8 +1,8 @@
 name       : wxmaxima
-version    : 24.02.0
-release    : 26
+version    : 24.02.1
+release    : 27
 source     :
-    - https://github.com/wxMaxima-developers/wxmaxima/archive/refs/tags/Version-24.02.0.tar.gz : 1bb5f9df2f23c1471e5a3f23a82c6caa0f1463c68ccd8ce3e6006fcca3a692db
+    - https://github.com/wxMaxima-developers/wxmaxima/archive/refs/tags/Version-24.02.1.tar.gz : 5c6cf246197e93ac4d6b5ffc07b4b9f1708da79ed923c6f2aab1270ba13bab8b
 homepage   : https://wxmaxima-developers.github.io/wxmaxima/
 license    : GPL-2.0-or-later
 component  : office.maths

--- a/packages/w/wxmaxima/pspec_x86_64.xml
+++ b/packages/w/wxmaxima/pspec_x86_64.xml
@@ -56,6 +56,26 @@
             <Path fileType="doc">/usr/share/doc/wxmaxima/wxmaxima.uk.html</Path>
             <Path fileType="doc">/usr/share/doc/wxmaxima/wxmaxima.zh_CN.html</Path>
             <Path fileType="doc">/usr/share/doc/wxmaxima/wxsubscripts.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/1024x1024/apps/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/150x150/apps/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16/apps/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192/apps/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22/apps/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24/apps/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/310x310/apps/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36/apps/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/42x42/apps/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/44x44/apps/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512/apps/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72/apps/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/8x8/apps/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96/apps/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/io.github.wxmaxima_developers.wxMaxima.svg</Path>
             <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/wxMaxima.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/wxMaxima.mo</Path>
             <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/wxMaxima.mo</Path>
@@ -94,9 +114,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2024-02-04</Date>
-            <Version>24.02.0</Version>
+        <Update release="27">
+            <Date>2024-02-11</Date>
+            <Version>24.02.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
             <Email>malfisya.dev@hotmail.com</Email>


### PR DESCRIPTION
**Summary**

- wxMaxima now correctly installs its icons
- A race condition on closing Maxima
- Update the autocompletion only in idle state
- Fixed a race condition on dropping the log target
- Alt+Up at startup no more crashes
- Resolved a compilation error on old wxWidgets versions
- Resolved GCC errors about too long functions
- Resolved an assert if no history file exists

**Test Plan**

Open test file and do calculations

**Checklist**

- [x] Package was built and tested against unstable