### PR TITLE
fb2converter: Update to 1.74.4

### DIFF
--- a/packages/f/fb2converter/package.yml
+++ b/packages/f/fb2converter/package.yml
@@ -1,23 +1,27 @@
 name       : fb2converter
-version    : 1.74.1
-release    : 19
+version    : 1.74.4
+release    : 20
 source     :
-    - https://github.com/rupor-github/fb2converter/archive/refs/tags/v1.74.1.tar.gz : 370389df59b48d695b1865e3908b8613c47dc57d5a087c7f12bcb4c2aa49c0af
+    - git|https://github.com/rupor-github/fb2converter.git : v1.74.4
 homepage   : https://github.com/rupor-github/fb2converter
 license    : GPL-3.0-only
 component  : office.viewers
 summary    : Unified converter of FB2 files into epub2, kepub, mobi and azw3 formats.
 description: |
     CLI ebook format converter, a complete rewrite of fb2mobi. Aims to be faster than python implementation and much easier to maintain. Simpler configuration, zero dependencies, better diagnostics and no installation required.
+networking : yes
 builddeps  :
     - git
+    - go-task
     - golang
+    - wget
 setup      : |
     export CMAKE_CROSSCOMPILING=false
     export MSYSTEM_NAME=linux_amd64
     %apply_patches
-    %cmake 
 build      : |
-    %make
+    go-task
 install    : |
-    install -Dm00755 fb2c $installdir/usr/bin/fb2c
+    install -Dm00755 build/fb2c $installdir/usr/bin/fb2c
+    install -Dm00755 build/kindlegen $installdir/usr/bin/kindlegen
+    install -Dm00755 build/stringer $installdir/usr/bin/stringer

--- a/packages/f/fb2converter/pspec_x86_64.xml
+++ b/packages/f/fb2converter/pspec_x86_64.xml
@@ -21,12 +21,14 @@
         <PartOf>office.viewers</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/fb2c</Path>
+            <Path fileType="executable">/usr/bin/kindlegen</Path>
+            <Path fileType="executable">/usr/bin/stringer</Path>
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2024-01-20</Date>
-            <Version>1.74.1</Version>
+        <Update release="20">
+            <Date>2024-02-11</Date>
+            <Version>1.74.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Switch from cmake to taskfile
- Updated dependencies

**Test Plan**
- fb2c convert file

**Checklist**
- [X] Package was built and tested against unstable
