### PR TITLE
libgtk-3: Update to 3.24.41

### DIFF
--- a/packages/l/libgtk-3/monitoring.yml
+++ b/packages/l/libgtk-3/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 311549
+  rss: https://gitlab.gnome.org/GNOME/gtk/-/tags?&format=atom
+security:
+  cpe:
+    - vendor: gnome
+      product: gtk

--- a/packages/l/libgtk-3/package.yml
+++ b/packages/l/libgtk-3/package.yml
@@ -1,9 +1,9 @@
 name       : libgtk-3
-version    : 3.24.39
-release    : 115
+version    : 3.24.41
+release    : 116
 source     :
-    - https://download.gnome.org/sources/gtk+/3.24/gtk+-3.24.39.tar.xz : 1cac3e566b9b2f3653a458c08c2dcdfdca9f908037ac03c9d8564b4295778d79
-homepage   : http://www.gnome.org
+    - https://download.gnome.org/sources/gtk+/3.24/gtk+-3.24.41.tar.xz : 47da61487af3087a94bc49296fd025ca0bc02f96ef06c556e7c8988bd651b6fa
+homepage   : https://www.gtk.org/
 license    : LGPL-2.0-or-later
 summary    :
     - The GTK+ 3 package contains the libraries used for creating graphical user interfaces for applications
@@ -35,10 +35,7 @@ patterns   :
         - /usr/bin/gtk3-icon-browser
         - /usr/share/applications/gtk3-icon-browser.desktop
 builddeps  :
-    - pkgconfig(gtk-doc)
-    - pkgconfig(wayland-protocols)
-    - at-spi2-32bit-devel
-    - at-spi2-32bit-devel
+    - pkgconfig32(atspi-2)
     - pkgconfig32(colord)
     - pkgconfig32(epoxy)
     - pkgconfig32(gdk-pixbuf-2.0)
@@ -54,12 +51,14 @@ builddeps  :
     - pkgconfig32(xcomposite)
     - pkgconfig32(xcursor)
     - pkgconfig32(xdamage)
-    - pkgconfig32(xinerama)
     - pkgconfig32(xi)
+    - pkgconfig32(xinerama)
     - pkgconfig32(xkbcommon)
     - pkgconfig32(xrandr)
     - pkgconfig32(xshmfence)
     - pkgconfig32(zlib)
+    - pkgconfig(gtk-doc)
+    - pkgconfig(wayland-protocols)
     - cups-32bit-devel
 rundeps    :
     - gsettings-desktop-schemas

--- a/packages/l/libgtk-3/pspec_x86_64.xml
+++ b/packages/l/libgtk-3/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>libgtk-3</Name>
-        <Homepage>http://www.gnome.org</Homepage>
+        <Homepage>https://www.gtk.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>LGPL-2.0-or-later</License>
         <PartOf>desktop.gtk</PartOf>
@@ -46,9 +46,9 @@
             <Path fileType="library">/usr/lib64/libgailutil-3.so.0</Path>
             <Path fileType="library">/usr/lib64/libgailutil-3.so.0.0.0</Path>
             <Path fileType="library">/usr/lib64/libgdk-3.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgdk-3.so.0.2407.32</Path>
+            <Path fileType="library">/usr/lib64/libgdk-3.so.0.2409.32</Path>
             <Path fileType="library">/usr/lib64/libgtk-3.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgtk-3.so.0.2407.32</Path>
+            <Path fileType="library">/usr/lib64/libgtk-3.so.0.2409.32</Path>
             <Path fileType="data">/usr/share/gettext/its/gtkbuilder.its</Path>
             <Path fileType="data">/usr/share/gettext/its/gtkbuilder.loc</Path>
             <Path fileType="data">/usr/share/gir-1.0/Gdk-3.0.gir</Path>
@@ -59,9 +59,28 @@
             <Path fileType="data">/usr/share/glib-2.0/schemas/org.gtk.Settings.EmojiChooser.gschema.xml</Path>
             <Path fileType="data">/usr/share/glib-2.0/schemas/org.gtk.Settings.FileChooser.gschema.xml</Path>
             <Path fileType="data">/usr/share/glib-2.0/schemas/org.gtk.exampleapp.gschema.xml</Path>
+            <Path fileType="data">/usr/share/gtk-3.0/emoji/bn.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-3.0/emoji/da.gresource</Path>
             <Path fileType="data">/usr/share/gtk-3.0/emoji/de.gresource</Path>
             <Path fileType="data">/usr/share/gtk-3.0/emoji/es.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-3.0/emoji/et.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-3.0/emoji/fi.gresource</Path>
             <Path fileType="data">/usr/share/gtk-3.0/emoji/fr.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-3.0/emoji/hi.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-3.0/emoji/hu.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-3.0/emoji/it.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-3.0/emoji/ja.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-3.0/emoji/ko.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-3.0/emoji/lt.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-3.0/emoji/ms.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-3.0/emoji/nb.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-3.0/emoji/nl.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-3.0/emoji/pl.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-3.0/emoji/pt.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-3.0/emoji/ru.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-3.0/emoji/sv.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-3.0/emoji/th.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-3.0/emoji/uk.gresource</Path>
             <Path fileType="data">/usr/share/gtk-3.0/emoji/zh.gresource</Path>
             <Path fileType="data">/usr/share/gtk-3.0/gtkbuilder.rng</Path>
             <Path fileType="data">/usr/share/gtk-3.0/im-multipress.conf</Path>
@@ -322,7 +341,7 @@
         <Description xml:lang="en">The GTK+ 3 package contains the libraries used for creating graphical user interfaces for applications</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="115">libgtk-3</Dependency>
+            <Dependency release="116">libgtk-3</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/gtk-3.0/3.0.0/immodules/im-am-et.so</Path>
@@ -343,9 +362,9 @@
             <Path fileType="library">/usr/lib32/libgailutil-3.so.0</Path>
             <Path fileType="library">/usr/lib32/libgailutil-3.so.0.0.0</Path>
             <Path fileType="library">/usr/lib32/libgdk-3.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgdk-3.so.0.2407.32</Path>
+            <Path fileType="library">/usr/lib32/libgdk-3.so.0.2409.32</Path>
             <Path fileType="library">/usr/lib32/libgtk-3.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgtk-3.so.0.2407.32</Path>
+            <Path fileType="library">/usr/lib32/libgtk-3.so.0.2409.32</Path>
         </Files>
     </Package>
     <Package>
@@ -354,8 +373,8 @@
         <Description xml:lang="en">The GTK+ 3 package contains the libraries used for creating graphical user interfaces for applications</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="115">libgtk-3-devel</Dependency>
-            <Dependency release="115">libgtk-3-32bit</Dependency>
+            <Dependency release="116">libgtk-3-devel</Dependency>
+            <Dependency release="116">libgtk-3-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libgailutil-3.so</Path>
@@ -377,7 +396,7 @@
         <Description xml:lang="en">Demonstration of major GTK3 features</Description>
         <PartOf>desktop.gtk</PartOf>
         <RuntimeDependencies>
-            <Dependency release="115">libgtk-3</Dependency>
+            <Dependency release="116">libgtk-3</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/gtk3-demo</Path>
@@ -404,7 +423,7 @@
         <Description xml:lang="en">Sample application to graphically search well known iconnames</Description>
         <PartOf>desktop.gtk</PartOf>
         <RuntimeDependencies>
-            <Dependency release="115">libgtk-3</Dependency>
+            <Dependency release="116">libgtk-3</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/gtk3-icon-browser</Path>
@@ -417,7 +436,7 @@
         <Description xml:lang="en">GTK3 Application demonstrating the toolkit theming capabilities</Description>
         <PartOf>desktop.gtk</PartOf>
         <RuntimeDependencies>
-            <Dependency release="115">libgtk-3</Dependency>
+            <Dependency release="116">libgtk-3</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/gtk3-widget-factory</Path>
@@ -442,7 +461,7 @@
         <Description xml:lang="en">The GTK+ 3 package contains the libraries used for creating graphical user interfaces for applications</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="115">libgtk-3</Dependency>
+            <Dependency release="116">libgtk-3</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gail-3.0/libgail-util/gail-util.h</Path>
@@ -1537,12 +1556,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="115">
-            <Date>2023-12-21</Date>
-            <Version>3.24.39</Version>
+        <Update release="116">
+            <Date>2024-02-12</Date>
+            <Version>3.24.41</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- GtkEmojiChooser: Update to CLDR v44
- GtkGestures: Preserve accuracy when translating events
- X11: Support 'virtual' XRANDR monitors
- Build fixes
- Wayland: Fix interpretation of gtk-shell protocol
- Translation updates

**Test Plan**
- Launched and used a couple of gtk3 apps
- Built a few gtk3 apps to test `-devel`
- Used the emoji picker

**Checklist**

- [x] Package was built and tested against unstable
