### PR TITLE
libgtk-4: Update to 4.12.5

### DIFF
--- a/packages/l/libgtk-4/monitoring.yml
+++ b/packages/l/libgtk-4/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 13942
+  rss: https://gitlab.gnome.org/GNOME/gtk/-/tags?&format=atom
+security:
+  cpe:
+    - vendor: gnome
+      product: gtk

--- a/packages/l/libgtk-4/package.yml
+++ b/packages/l/libgtk-4/package.yml
@@ -1,9 +1,9 @@
 name       : libgtk-4
-version    : 4.12.4
-release    : 35
+version    : 4.12.5
+release    : 36
 source     :
-    - https://download.gnome.org/sources/gtk/4.12/gtk-4.12.4.tar.xz : ba67c6498e5599f928edafb9e08a320adfaa50ab2f0da6fc6ab2252fc2d57520
-homepage   : https://gnome.org
+    - https://download.gnome.org/sources/gtk/4.12/gtk-4.12.5.tar.xz : 28b356d590ee68ef626e2ef9820b2dd21441484a9a042a5a3f0c40e9dfc4f4f8
+homepage   : https://www.gtk.org/
 license    : LGPL-2.0-or-later
 component  :
     - desktop.gtk
@@ -45,10 +45,10 @@ builddeps  :
     - pkgconfig(atk)
     - pkgconfig(cloudproviders)
     - pkgconfig(colord)
-    - pkgconfig(graphene-1.0)
     - pkgconfig(epoxy)
-    - pkgconfig(json-glib-1.0)
+    - pkgconfig(graphene-1.0)
     - pkgconfig(gstreamer-player-1.0)
+    - pkgconfig(json-glib-1.0)
     - pkgconfig(libavformat)
     - pkgconfig(libcrypt)
     - pkgconfig(librsvg-2.0)
@@ -56,6 +56,8 @@ builddeps  :
     - pkgconfig(pango)
     - pkgconfig(rest-0.7)
     - pkgconfig(shaderc)
+    - pkgconfig(vulkan)
+    - pkgconfig(wayland-protocols)
     - pkgconfig(xcomposite)
     - pkgconfig(xcursor)
     - pkgconfig(xdamage)
@@ -63,8 +65,6 @@ builddeps  :
     - pkgconfig(xinerama)
     - pkgconfig(xkbcommon)
     - pkgconfig(xrandr)
-    - pkgconfig(vulkan)
-    - pkgconfig(wayland-protocols)
     - cups-devel
     - python-gobject
     - sassc

--- a/packages/l/libgtk-4/pspec_x86_64.xml
+++ b/packages/l/libgtk-4/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>libgtk-4</Name>
-        <Homepage>https://gnome.org</Homepage>
+        <Homepage>https://www.gtk.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>LGPL-2.0-or-later</License>
         <PartOf>desktop.gtk</PartOf>
@@ -33,7 +33,7 @@
             <Path fileType="library">/usr/lib64/gtk-4.0/4.0.0/printbackends/libprintbackend-cups.so</Path>
             <Path fileType="library">/usr/lib64/gtk-4.0/4.0.0/printbackends/libprintbackend-file.so</Path>
             <Path fileType="library">/usr/lib64/libgtk-4.so.1</Path>
-            <Path fileType="library">/usr/lib64/libgtk-4.so.1.1200.4</Path>
+            <Path fileType="library">/usr/lib64/libgtk-4.so.1.1200.5</Path>
             <Path fileType="data">/usr/share/gettext/its/gtk4builder.its</Path>
             <Path fileType="data">/usr/share/gettext/its/gtk4builder.loc</Path>
             <Path fileType="data">/usr/share/gir-1.0/Gdk-4.0.gir</Path>
@@ -45,20 +45,27 @@
             <Path fileType="data">/usr/share/glib-2.0/schemas/org.gtk.gtk4.Settings.Debug.gschema.xml</Path>
             <Path fileType="data">/usr/share/glib-2.0/schemas/org.gtk.gtk4.Settings.EmojiChooser.gschema.xml</Path>
             <Path fileType="data">/usr/share/glib-2.0/schemas/org.gtk.gtk4.Settings.FileChooser.gschema.xml</Path>
+            <Path fileType="data">/usr/share/gtk-4.0/emoji/bn.gresource</Path>
             <Path fileType="data">/usr/share/gtk-4.0/emoji/da.gresource</Path>
             <Path fileType="data">/usr/share/gtk-4.0/emoji/de.gresource</Path>
             <Path fileType="data">/usr/share/gtk-4.0/emoji/es.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-4.0/emoji/et.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-4.0/emoji/fi.gresource</Path>
             <Path fileType="data">/usr/share/gtk-4.0/emoji/fr.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-4.0/emoji/hi.gresource</Path>
             <Path fileType="data">/usr/share/gtk-4.0/emoji/hu.gresource</Path>
             <Path fileType="data">/usr/share/gtk-4.0/emoji/it.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-4.0/emoji/ja.gresource</Path>
             <Path fileType="data">/usr/share/gtk-4.0/emoji/ko.gresource</Path>
             <Path fileType="data">/usr/share/gtk-4.0/emoji/lt.gresource</Path>
             <Path fileType="data">/usr/share/gtk-4.0/emoji/ms.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-4.0/emoji/nb.gresource</Path>
             <Path fileType="data">/usr/share/gtk-4.0/emoji/nl.gresource</Path>
             <Path fileType="data">/usr/share/gtk-4.0/emoji/pl.gresource</Path>
             <Path fileType="data">/usr/share/gtk-4.0/emoji/pt.gresource</Path>
             <Path fileType="data">/usr/share/gtk-4.0/emoji/ru.gresource</Path>
             <Path fileType="data">/usr/share/gtk-4.0/emoji/sv.gresource</Path>
+            <Path fileType="data">/usr/share/gtk-4.0/emoji/th.gresource</Path>
             <Path fileType="data">/usr/share/gtk-4.0/emoji/uk.gresource</Path>
             <Path fileType="data">/usr/share/gtk-4.0/emoji/zh.gresource</Path>
             <Path fileType="data">/usr/share/gtk-4.0/gtk4builder.rng</Path>
@@ -189,7 +196,7 @@
         <Description xml:lang="en">Demonstrations of major GTK4 features.</Description>
         <PartOf>desktop.gtk</PartOf>
         <RuntimeDependencies>
-            <Dependency release="35">libgtk-4</Dependency>
+            <Dependency release="36">libgtk-4</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/gtk4-demo</Path>
@@ -224,7 +231,7 @@
         <Description xml:lang="en">libgtk-4 contains the libraries used for creating graphical user interfaces and applications.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="35">libgtk-4</Dependency>
+            <Dependency release="36">libgtk-4</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gtk-4.0/gdk/deprecated/gdkpixbuf.h</Path>
@@ -615,7 +622,7 @@
         <Description xml:lang="en">Sample application to graphically search well known GTK4 icon names.</Description>
         <PartOf>desktop.gtk</PartOf>
         <RuntimeDependencies>
-            <Dependency release="35">libgtk-4</Dependency>
+            <Dependency release="36">libgtk-4</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/gtk4-icon-browser</Path>
@@ -626,12 +633,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="35">
-            <Date>2023-12-21</Date>
-            <Version>4.12.4</Version>
+        <Update release="36">
+            <Date>2024-02-12</Date>
+            <Version>4.12.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- GtkColumnView: Fix a crash on dispose
- GtkEmojiChooser: Update to CLDR v44
- GtkEmojiChooser: Add more translations
- GtkFileDialog: Return an error if no file is selected
- GtkFileDialog: Make closing the portal file chooser work
- GtkDropDown: Fix display of the initial checkmark
- GtkShortcutsWindow: Reduce the minimum width
- GDK: Make the png loader safer against overflow
- Wayland: Fix cursor handling with graphics tablets
- Translation updates

**Test Plan**
- Opened and used a bunch of gtk4 apps
- Built a couple of gtk4 apps to test -devel
- Used emoji picker in gtk4 app

**Checklist**

- [x] Package was built and tested against unstable
