### PR TITLE
hplip: update to 3.23.12

### DIFF
--- a/packages/h/hplip/abi_used_symbols
+++ b/packages/h/hplip/abi_used_symbols
@@ -69,6 +69,8 @@ libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
 libc.so.6:__longjmp_chk
@@ -132,6 +134,7 @@ libc.so.6:isupper
 libc.so.6:localtime
 libc.so.6:lseek
 libc.so.6:malloc
+libc.so.6:memccpy
 libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
@@ -331,7 +334,7 @@ libstdc++.so.6:_ZNKSt5ctypeIcE13_M_widen_initEv
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE13find_first_ofEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEPKcm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEPKcmm
-libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7compareEPKc
+libstdc++.so.6:_ZNSdC2Ev
 libstdc++.so.6:_ZNSdD2Ev
 libstdc++.so.6:_ZNSo3putEc
 libstdc++.so.6:_ZNSo5flushEv
@@ -345,7 +348,6 @@ libstdc++.so.6:_ZNSt6localeC1Ev
 libstdc++.so.6:_ZNSt6localeD1Ev
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_disposeEv
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
-libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE14_M_replace_auxEmmmc
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6appendEPKc
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6appendEPKcm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7reserveEm
@@ -356,11 +358,9 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_mutateEm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1EOS4_
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1ERKS4_
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev
+libstdc++.so.6:_ZNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE17_M_stringbuf_initESt13_Ios_Openmode
 libstdc++.so.6:_ZNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE7_M_syncEPcmm
-libstdc++.so.6:_ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEEC1ERKNS_12basic_stringIcS2_S3_EESt13_Ios_Openmode
 libstdc++.so.6:_ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEED1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitC1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitD1Ev
 libstdc++.so.6:_ZNSt8ios_baseC2Ev
 libstdc++.so.6:_ZNSt8ios_baseD2Ev
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE4initEPSt15basic_streambufIcS1_E
@@ -373,6 +373,7 @@ libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt20__throw_out_of_rangePKc
+libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
 libstdc++.so.6:_ZSt28__throw_bad_array_new_lengthv
 libstdc++.so.6:_ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_

--- a/packages/h/hplip/files/hplip-fix-Wreturn-type-warning.patch
+++ b/packages/h/hplip/files/hplip-fix-Wreturn-type-warning.patch
@@ -1,111 +1,96 @@
---- hplip-3.20.3/prnt/hpps/hppsfilter.c.orig	2020-03-25 01:09:51.585129957 +0000
-+++ hplip-3.20.3/prnt/hpps/hppsfilter.c	2020-03-25 01:10:15.610058293 +0000
-@@ -104,7 +104,7 @@ static void open_tempbookletfile(char *m
-     if(ptempbooklet_file == NULL)
+From 771c5915c74a6957bd5a9f9f0a38bf03e4fd94d6 Mon Sep 17 00:00:00 2001
+From: Tracey Clark <tclark77@tlcnet.info>
+Date: Tue, 16 Jan 2024 16:55:21 -0600
+Subject: [PATCH] hplip-fix-Wreturn-type-warning.patch
+
+---
+ prnt/hpps/hppsfilter.c |  2 +-
+ scan/sane/hpaio.c      | 41 +++++++++++++++++++++++++++--------------
+ 2 files changed, 28 insertions(+), 15 deletions(-)
+
+diff --git a/prnt/hpps/hppsfilter.c b/prnt/hpps/hppsfilter.c
+index a81d693..bfd66ae 100644
+--- a/prnt/hpps/hppsfilter.c
++++ b/prnt/hpps/hppsfilter.c
+@@ -116,7 +116,7 @@ static int open_tempbookletfile(char *mode)
      {
-             fprintf(stderr, "ERROR: Unable to open temp file %s\n", temp_filename);
--            return 1;
-+            return;
+         close(fd);
+         fprintf(stderr, "ERROR: Unable to open temp file %s\n", temp_filename);
+-        return 1;
++        return;
      }  
-     chmod(temp_filename, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
- 
---- hplip-3.20.3/scan/sane/hpaio.c.orig	2020-03-25 01:24:15.558732638 +0000
-+++ hplip-3.20.3/scan/sane/hpaio.c	2020-03-25 02:48:36.097054366 +0000
-@@ -406,20 +406,34 @@ extern SANE_Status sane_hpaio_open(SANE_
- 
+     //chmod(temp_filename, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+     return 0;
+diff --git a/scan/sane/hpaio.c b/scan/sane/hpaio.c
+index 62d14eb..b2eddba 100644
+--- a/scan/sane/hpaio.c
++++ b/scan/sane/hpaio.c
+@@ -415,19 +415,26 @@ extern SANE_Status sane_hpaio_open(SANE_String_Const devicename, SANE_Handle * p
  extern void sane_hpaio_close(SANE_Handle handle)
  {
--    if (strcmp(*((char **)handle), "MARVELL") == 0)
+     if (strcmp(*((char **)handle), "MARVELL") == 0)
 -       return marvell_close(handle);
--    if (strcmp(*((char **)handle), "SOAP") == 0)
--       return soap_close(handle);
--    if (strcmp(*((char **)handle), "SOAPHT") == 0)
--       return soapht_close(handle);
--    if (strcmp(*((char **)handle), "LEDM") == 0)
--       return ledm_close(handle);
--    if (strcmp(*((char **)handle), "SCL-PML") == 0)
--       return sclpml_close(handle);
--    if (strcmp(*((char **)handle), "ESCL") == 0)
--       return escl_close(handle);
--    if (strcmp(*((char **)handle), "ORBLITE") == 0)
--       return orblite_close(handle);
-+    if (strcmp(*((char **)handle), "MARVELL") == 0) {
 +       marvell_close(handle);
 +       return;
-+    }
-+    if (strcmp(*((char **)handle), "SOAP") == 0) {
+     if (strcmp(*((char **)handle), "SOAP") == 0)
+-       return soap_close(handle);
 +       soap_close(handle);
 +       return;
-+    }
-+    if (strcmp(*((char **)handle), "SOAPHT") == 0) {
+     if (strcmp(*((char **)handle), "SOAPHT") == 0)
+-       return soapht_close(handle);
 +       soapht_close(handle);
 +       return;
-+    }
-+    if (strcmp(*((char **)handle), "LEDM") == 0) {
+     if (strcmp(*((char **)handle), "LEDM") == 0)
+-       return ledm_close(handle);
 +       ledm_close(handle);
 +       return;
-+    }
-+    if (strcmp(*((char **)handle), "SCL-PML") == 0) {
+     if (strcmp(*((char **)handle), "SCL-PML") == 0)
+-       return sclpml_close(handle);
 +       sclpml_close(handle);
 +       return;
-+    }
-+    if (strcmp(*((char **)handle), "ESCL") == 0) {
+     if (strcmp(*((char **)handle), "ESCL") == 0)
+-       return escl_close(handle);
 +       escl_close(handle);
 +       return;
-+    }
-+    if (strcmp(*((char **)handle), "ORBLITE") == 0) {
+     if (strcmp(*((char **)handle), "ORBLITE") == 0)
+-       return orblite_close(handle);
 +       orblite_close(handle);
 +       return;
-+    }
  }  /* sane_hpaio_close() */
  
  extern const SANE_Option_Descriptor * sane_hpaio_get_option_descriptor(SANE_Handle handle, SANE_Int option)
-@@ -539,20 +553,34 @@ extern SANE_Status sane_hpaio_read(SANE_
- /* Note, sane_cancel is called normally not just during IO abort situations. */
+@@ -548,19 +555,25 @@ extern SANE_Status sane_hpaio_read(SANE_Handle handle, SANE_Byte *data, SANE_Int
  extern void sane_hpaio_cancel( SANE_Handle handle )
  {
--    if (strcmp(*((char **)handle), "MARVELL") == 0)
+     if (strcmp(*((char **)handle), "MARVELL") == 0)
 -       return marvell_cancel(handle);
--    if (strcmp(*((char **)handle), "SOAP") == 0)
--       return soap_cancel(handle);
--    if (strcmp(*((char **)handle), "SOAPHT") == 0)
--       return soapht_cancel(handle);
--    if (strcmp(*((char **)handle), "LEDM") == 0)
--       return ledm_cancel(handle);
--    if (strcmp(*((char **)handle), "SCL-PML") == 0)
--       return sclpml_cancel(handle);
--    if (strcmp(*((char **)handle), "ESCL") == 0)
--       return escl_cancel(handle);
--    if (strcmp(*((char **)handle), "ORBLITE") == 0)
--       return orblite_cancel(handle);
-+    if (strcmp(*((char **)handle), "MARVELL") == 0) {
 +       marvell_cancel(handle);
 +       return;
-+    }
-+    if (strcmp(*((char **)handle), "SOAP") == 0) {
+     if (strcmp(*((char **)handle), "SOAP") == 0)
+-       return soap_cancel(handle);
 +       soap_cancel(handle);
 +       return;
-+    }
-+    if (strcmp(*((char **)handle), "SOAPHT") == 0) {
+     if (strcmp(*((char **)handle), "SOAPHT") == 0)
+-       return soapht_cancel(handle);
 +       soapht_cancel(handle);
-+       return;
-+    }
-+    if (strcmp(*((char **)handle), "LEDM") == 0) {
+     if (strcmp(*((char **)handle), "LEDM") == 0)
+-       return ledm_cancel(handle);
 +       ledm_cancel(handle);
 +       return;
-+    }
-+    if (strcmp(*((char **)handle), "SCL-PML") == 0) {
+     if (strcmp(*((char **)handle), "SCL-PML") == 0)
+-       return sclpml_cancel(handle);
 +       sclpml_cancel(handle);
 +       return;
-+    }
-+    if (strcmp(*((char **)handle), "ESCL") == 0) {
+     if (strcmp(*((char **)handle), "ESCL") == 0)
+-       return escl_cancel(handle);
 +       escl_cancel(handle);
 +       return;
-+    }
-+    if (strcmp(*((char **)handle), "ORBLITE") == 0) {
+     if (strcmp(*((char **)handle), "ORBLITE") == 0)
+-       return orblite_cancel(handle);
 +       orblite_cancel(handle);
 +       return;
-+    }
  }  /* sane_hpaio_cancel() */
  
  extern SANE_Status sane_hpaio_set_io_mode(SANE_Handle handle, SANE_Bool nonBlocking)
+-- 
+2.43.0

--- a/packages/h/hplip/files/hplip.metainfo.xml
+++ b/packages/h/hplip/files/hplip.metainfo.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id type="desktop">hplip.desktop</id>
+  <name>hplip</name>
+  <project_license>GPL-2.0-or-later and MIT and BSD-3-Clause</project_license>
+  <developer_name>New Vector Ltd</developer_name>
+  <summary>HP Linux Imaging and Printing - Print, scan, fax drivers and service tools</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <url type="homepage">https://developers.hp.com/hp-linux-imaging-and-printing</url>
+  <url type="help">https://developers.hp.com/hp-linux-imaging-and-printing/support</url>
+  <description>
+    <p>The Hewlett-Packard Linux Imaging and Printing Project provides drivers for HP printers and multi-function peripherals.</p>
+  </description>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="violence-desecration">none</content_attribute>
+    <content_attribute id="violence-slavery">none</content_attribute>
+    <content_attribute id="violence-worship">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="sex-homosexuality">none</content_attribute>
+    <content_attribute id="sex-prostitution">none</content_attribute>
+    <content_attribute id="sex-adultery">none</content_attribute>
+    <content_attribute id="sex-appearance">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">intense</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">intense</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">intense</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+  <update_contact>releng@getsol.us</update_contact>
+</component>

--- a/packages/h/hplip/package.yml
+++ b/packages/h/hplip/package.yml
@@ -1,8 +1,9 @@
 name       : hplip
-version    : 3.23.5
-release    : 56
+version    : 3.23.12
+release    : 57
+homepage   : https://developers.hp.com/hp-linux-imaging-and-printing/gethplip
 source     :
-    - https://downloads.sourceforge.net/project/hplip/hplip/3.23.5/hplip-3.23.5.tar.gz : f68e5ed749b122fc3654a69c4206e840a53b68d981e55e023fb4d3fb8995cbc8
+    - https://downloads.sourceforge.net/project/hplip/hplip/3.23.12/hplip-3.23.12.tar.gz : a76c2ac8deb31ddb5f0da31398d25ac57440928a0692dcb060a48daa718e69ed
 license    :
     - GPL-2.0-or-later
     - MIT
@@ -27,20 +28,20 @@ builddeps  :
     - cups-devel
     - libjpeg-turbo-devel
     - net-snmp-devel
-    - python3-dbus
     - python-distro
     - python-pillow
-    - python3-qt5
     - python-reportlab
+    - python3-dbus
+    - python3-qt5
 rundeps    :
     - hplip-drivers
     - lsb-release
-    - python3-dbus
-    - python3-qt5
     - python-distro
     - python-gobject
     - python-pillow
     - python-reportlab
+    - python3-dbus
+    - python3-qt5
 patterns   :
     - drivers :
         - /usr/share/ppd

--- a/packages/h/hplip/pspec_x86_64.xml
+++ b/packages/h/hplip/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>hplip</Name>
+        <Homepage>https://developers.hp.com/hp-linux-imaging-and-printing/gethplip</Homepage>
         <Packager>
             <Name>Tracey Clark</Name>
-            <Email>tracey_dev@tlcnet.info</Email>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>MIT</License>
@@ -12,7 +13,7 @@
         <Summary xml:lang="en">HP Linux Imaging &amp; Printing - Print, scan, fax drivers and service tools</Summary>
         <Description xml:lang="en">The Hewlett-Packard Linux Imaging and Printing Project provides drivers for HP printers and multi-function peripherals.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>hplip</Name>
@@ -21,7 +22,7 @@
 </Description>
         <PartOf>desktop.core</PartOf>
         <RuntimeDependencies>
-            <Dependency release="56">hplip-drivers</Dependency>
+            <Dependency release="57">hplip-drivers</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="config">/etc/hp/hplip.conf</Path>
@@ -70,40 +71,40 @@
             <Path fileType="library">/usr/lib/systemd/system/hplip-printer@.service</Path>
             <Path fileType="data">/usr/share/applications/hp-uiscan.desktop</Path>
             <Path fileType="data">/usr/share/applications/hplip.desktop</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/COPYING</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/README_LIBJPG</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/commandline.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/copying.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/copyright</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/devicemanager.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/faxtrouble.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/gettinghelp.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/hpscan.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/images/favicon.ico</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/images/print.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/images/toolbox_actions.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/images/toolbox_fax.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/images/toolbox_print_control.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/images/toolbox_print_settings.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/images/toolbox_status.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/images/toolbox_supplies.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/images/xsane.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/index.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/mainttask.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/plugins.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/print.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/printing.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/printoptions.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/printtroubleshooting.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/scanning.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/scantrouble.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/sendfax.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/setup.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/styles/css.css</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/systray.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/troubleshooting.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/uninstalling.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.5/upgrading.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/COPYING</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/README_LIBJPG</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/commandline.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/copying.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/copyright</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/devicemanager.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/faxtrouble.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/gettinghelp.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/hpscan.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/images/favicon.ico</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/images/print.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/images/toolbox_actions.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/images/toolbox_fax.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/images/toolbox_print_control.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/images/toolbox_print_settings.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/images/toolbox_status.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/images/toolbox_supplies.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/images/xsane.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/index.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/mainttask.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/plugins.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/print.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/printing.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/printoptions.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/printtroubleshooting.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/scanning.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/scantrouble.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/sendfax.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/setup.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/styles/css.css</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/systray.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/troubleshooting.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/uninstalling.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/upgrading.html</Path>
             <Path fileType="data">/usr/share/hplip/__init__.py</Path>
             <Path fileType="data">/usr/share/hplip/align.py</Path>
             <Path fileType="data">/usr/share/hplip/base/CdmWifi.py</Path>
@@ -698,6 +699,9 @@
             <Path fileType="data">/usr/share/ppd/HP/hp-2500c.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-910.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-915.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-Deskjet_2800_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-Deskjet_4200_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-Deskjet_4900_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-amp.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-business_inkjet_1000.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-business_inkjet_1100.ppd.gz</Path>
@@ -856,6 +860,7 @@
             <Path fileType="data">/usr/share/ppd/HP/hp-color_laserjet_flow_6800-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-color_laserjet_flow_X579-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-color_laserjet_flow_X57945-ps.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-color_laserjet_flow_X580-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-color_laserjet_flow_e57540-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-color_laserjet_flow_e78625-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-color_laserjet_flow_e78630-ps.ppd.gz</Path>
@@ -1604,6 +1609,7 @@
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_pro_mfp_m27cnw.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_pro_mfp_m329-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_pro_mfp_m435-ps.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_pro_p1100_plus_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_professional_m1132_mfp.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_professional_m1136_mfp.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_professional_m1137_mfp.ppd.gz</Path>
@@ -1773,6 +1779,9 @@
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_8740-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9010_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9020_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9110b_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9120b_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9130b_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_k5300.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_k5400.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_k550.ppd.gz</Path>
@@ -2026,12 +2035,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="56">
-            <Date>2023-07-22</Date>
-            <Version>3.23.5</Version>
+        <Update release="57">
+            <Date>2024-02-14</Date>
+            <Version>3.23.12</Version>
             <Comment>Packaging update</Comment>
             <Name>Tracey Clark</Name>
-            <Email>tracey_dev@tlcnet.info</Email>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
After installing or updating this package, run `hp-plugin` on command line before attempting to add a printer, print or scan.

**Summary**

Added support for new devices.

Solus:
- Updated release notes URL, added homepage.
- Updated patch after upstream code update.
- Added metainfo file.

**Test Plan**
Verified
- plugin was installed successfully by `hp-plugin`
- previously installed HP Printer is still configurable in Print Settings
- hp-toolbox launches HP Device Manager successfully
- ability to remove and re-add printer / fax in hp-toolbox (Note: must first run hp-plugin)
- can start Simple Scan
- scanning works
- printing works

**Known Issue**
The HP Device Manager UI may display an error on the status tab of the printer 'Device is busy, powered down or unplugged (5002)'

Workaround: Manage the printer via System Settings rather than HP Device Manager. Printing is still successful.