### PR TITLE
svtplay-dl: Update to 4.69

### DIFF
--- a/packages/s/svtplay-dl/MAINTAINERS.md
+++ b/packages/s/svtplay-dl/MAINTAINERS.md
@@ -1,4 +1,4 @@
 This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
 
-- Stig Svensson 
-  - Email: stig@knugen.nu
+- Jakob Gezelius 
+  - Email: jakob@knugen.nu

--- a/packages/s/svtplay-dl/package.yml
+++ b/packages/s/svtplay-dl/package.yml
@@ -1,8 +1,8 @@
 name       : svtplay-dl
-version    : '3.7'
-release    : 16
+version    : '4.69'
+release    : 17
 source     :
-    - https://github.com/spaam/svtplay-dl/archive/refs/tags/3.7.tar.gz : 34c99bd9061c0b1563974656f95e5ac1969f0675998221bc836bec0ff7b25e0c
+    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.69.tar.gz : eb48a2f47d1d779cff042013da00b5f499e19ad200c3bfb482b5355dc16ce78a
 homepage   : https://svtplay-dl.se/
 license    : MIT
 component  : network.download

--- a/packages/s/svtplay-dl/pspec_x86_64.xml
+++ b/packages/s/svtplay-dl/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>svtplay-dl</Name>
         <Homepage>https://svtplay-dl.se/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>network.download</PartOf>
         <Summary xml:lang="en">Small command-line program to download videos from some streaming sites</Summary>
         <Description xml:lang="en">svtplay-dl is an open source command-line program written in python. You can quickly download published videos from various sites to your local computer.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>svtplay-dl</Name>
@@ -21,11 +21,11 @@
         <PartOf>network.download</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/svtplay-dl</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl-3.7-py3.10.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl-3.7-py3.10.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl-3.7-py3.10.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl-3.7-py3.10.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl-3.7-py3.10.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl-4.69-py3.10.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl-4.69-py3.10.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl-4.69-py3.10.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl-4.69-py3.10.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl-4.69-py3.10.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/__pycache__/__init__.cpython-310.pyc</Path>
@@ -38,19 +38,20 @@
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/fetcher/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/fetcher/__pycache__/__init__.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/fetcher/__pycache__/dash.cpython-310.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/fetcher/__pycache__/hds.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/fetcher/__pycache__/hls.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/fetcher/__pycache__/http.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/fetcher/__pycache__/m3u8.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/fetcher/dash.py</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/fetcher/hds.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/fetcher/hls.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/fetcher/http.py</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/fetcher/m3u8.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/log.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/postprocess/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/postprocess/__pycache__/__init__.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/__pycache__/__init__.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/__pycache__/aftonbladet.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/__pycache__/angelstudios.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/__pycache__/atg.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/__pycache__/barnkanalen.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/__pycache__/bigbrother.cpython-310.pyc</Path>
@@ -73,6 +74,7 @@
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/__pycache__/nrk.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/__pycache__/oppetarkiv.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/__pycache__/picsearch.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/__pycache__/plutotv.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/__pycache__/pokemon.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/__pycache__/radioplay.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/__pycache__/raw.cpython-310.pyc</Path>
@@ -93,6 +95,7 @@
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/__pycache__/vimeo.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/__pycache__/youplay.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/aftonbladet.py</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/angelstudios.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/atg.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/barnkanalen.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/bigbrother.py</Path>
@@ -115,6 +118,7 @@
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/nrk.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/oppetarkiv.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/picsearch.py</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/plutotv.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/pokemon.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/radioplay.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/service/raw.py</Path>
@@ -138,6 +142,7 @@
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/subtitle/__pycache__/__init__.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/utils/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/utils/__pycache__/__init__.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/utils/__pycache__/fetcher.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/utils/__pycache__/getmedia.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/utils/__pycache__/http.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/utils/__pycache__/nfo.cpython-310.pyc</Path>
@@ -147,6 +152,7 @@
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/utils/__pycache__/stream.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/utils/__pycache__/terminal.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/utils/__pycache__/text.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/utils/fetcher.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/utils/getmedia.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/utils/http.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/svtplay_dl/utils/nfo.py</Path>
@@ -159,12 +165,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2022-04-12</Date>
-            <Version>3.7</Version>
+        <Update release="17">
+            <Date>2024-02-16</Date>
+            <Version>4.69</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Release notes can be found [here](https://github.com/spaam/svtplay-dl/releases/tag/4.69).

**Test Plan**
Installed new package and downloaded a movie.

**Checklist**

- [X] Package was built and tested against unstable
