### PR TITLE
eopkg4-bin: Sync with git

### DIFF
--- a/packages/e/eopkg4-bin/package.yml
+++ b/packages/e/eopkg4-bin/package.yml
@@ -1,9 +1,9 @@
 name       : eopkg4-bin
 version    : 4.0.0
-release    : 3
+release    : 4
 source     :
-    - git|https://github.com/getsolus/eopkg : 0bcb2e75ea1f5deaf40a3a3bb4f1665461931f32
-    - git|https://github.com/getsolus/PackageKit.git : f53ab2959e13b55ba3f973988063bbac33e90b99
+    - git|https://github.com/getsolus/eopkg : 42e803fe632063331e3924a1389f295eee478780
+    - git|https://github.com/getsolus/PackageKit.git : 201b4c0999950e412f9366ae17856eb295c3af21
 homepage   : https://github.com/getsolus/eopkg
 license    : GPL-2.0-or-later
 component  : system.utils
@@ -32,7 +32,6 @@ builddeps  :
     - python-wheel
     - python-zstandard
 setup      : |
-    %patch -p1 -i $pkgfiles/0001-Use-different-database.patch
     %python3_setup
 build      : |
     # We're not actually using self-execution. In this case, eopkg is using the -c flag as shorthand for --component, rather than for passing the program as a string (as is default python behavior).

--- a/packages/e/eopkg4-bin/pspec_x86_64.xml
+++ b/packages/e/eopkg4-bin/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>eopkg4-bin</Name>
         <Homepage>https://github.com/getsolus/eopkg</Homepage>
         <Packager>
-            <Name>Rune Morling</Name>
-            <Email>ermo@serpentos.com</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -39,12 +39,12 @@ See getsolus/packages#1316
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-02-02</Date>
+        <Update release="4">
+            <Date>2024-02-16</Date>
             <Version>4.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Rune Morling</Name>
-            <Email>ermo@serpentos.com</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Update eopkg4-bin to the latest git version.
Also rebuild to fix errors introduced by glibc update.

**Test Plan**

- Install eopkg4-bin as built from this PR
- Make sure `eopkg` operations still work
- Make sure PackageKit still works (test an operation or two in Discover, Gnome Software, or with `pkcon` on the command line

**Checklist**

- [x] Package was built and tested against unstable
