### PR TITLE
jags: Update to 4.3.2

### DIFF
--- a/packages/j/jags/abi_used_symbols
+++ b/packages/j/jags/abi_used_symbols
@@ -41,6 +41,7 @@ libc.so.6:__ctype_tolower_loc
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
@@ -81,11 +82,9 @@ libc.so.6:realloc
 libc.so.6:stderr
 libc.so.6:stdin
 libc.so.6:stdout
-libc.so.6:stpcpy
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strtod
-libc.so.6:strtol
 libc.so.6:system
 libc.so.6:time
 libgcc_s.so.1:_Unwind_Resume
@@ -125,6 +124,7 @@ libm.so.6:sinh
 libm.so.6:sqrt
 libm.so.6:tan
 libm.so.6:tanh
+libm.so.6:trunc
 libopenblas.so.0:daxpy_
 libopenblas.so.0:dcopy_
 libopenblas.so.0:ddot_
@@ -144,7 +144,6 @@ libopenblas.so.0:ztrsm_
 libopenblas.so.0:ztrsv_
 libstdc++.so.6:_ZNKSt13runtime_error4whatEv
 libstdc++.so.6:_ZNKSt5ctypeIcE13_M_widen_initEv
-libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7compareEPKc
 libstdc++.so.6:_ZNKSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE3strEv
 libstdc++.so.6:_ZNSo3putEc
 libstdc++.so.6:_ZNSo5flushEv
@@ -193,8 +192,6 @@ libstdc++.so.6:_ZNSt8__detail15_List_node_base11_M_transferEPS0_S1_
 libstdc++.so.6:_ZNSt8__detail15_List_node_base4swapERS0_S1_
 libstdc++.so.6:_ZNSt8__detail15_List_node_base7_M_hookEPS0_
 libstdc++.so.6:_ZNSt8__detail15_List_node_base9_M_unhookEv
-libstdc++.so.6:_ZNSt8ios_base4InitC1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitD1Ev
 libstdc++.so.6:_ZNSt8ios_baseC2Ev
 libstdc++.so.6:_ZNSt8ios_baseD2Ev
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE4initEPSt15basic_streambufIcS1_E
@@ -207,6 +204,7 @@ libstdc++.so.6:_ZSt18_Rb_tree_incrementPKSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
+libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
 libstdc++.so.6:_ZSt28_Rb_tree_rebalance_for_erasePSt18_Rb_tree_node_baseRS_
 libstdc++.so.6:_ZSt28__throw_bad_array_new_lengthv

--- a/packages/j/jags/package.yml
+++ b/packages/j/jags/package.yml
@@ -1,8 +1,9 @@
 name       : jags
-version    : 4.3.0
-release    : 3
+version    : 4.3.2
+release    : 4 
 source     :
-    - https://nchc.dl.sourceforge.net/project/mcmc-jags/JAGS/4.x/Source/JAGS-4.3.0.tar.gz : 8ac5dd57982bfd7d5f0ee384499d62f3e0bb35b5f1660feb368545f1186371fc
+    - https://sourceforge.net/projects/mcmc-jags/files/JAGS/4.x/Source/JAGS-4.3.2.tar.gz/download : 871f556af403a7c2ce6a0f02f15cf85a572763e093d26658ebac55c4ab472fc8
+homepage   : https://mcmc-jags.sourceforge.io
 license    : GPL-2.0
 component  : office.scientific
 summary    : JAGS is Just Another Gibbs Sampler.  It is a program for analysis of Bayesian hierarchical models using Markov Chain Monte Carlo (MCMC) simulation  not wholly unlike BUGS.

--- a/packages/j/jags/pspec_x86_64.xml
+++ b/packages/j/jags/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>jags</Name>
+        <Homepage>https://mcmc-jags.sourceforge.io</Homepage>
         <Packager>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0</License>
         <PartOf>office.scientific</PartOf>
         <Summary xml:lang="en">JAGS is Just Another Gibbs Sampler.  It is a program for analysis of Bayesian hierarchical models using Markov Chain Monte Carlo (MCMC) simulation  not wholly unlike BUGS.</Summary>
         <Description xml:lang="en">JAGS is Just Another Gibbs Sampler.  It is a program for analysis of Bayesian hierarchical models using Markov Chain Monte Carlo (MCMC) simulation  not wholly unlike BUGS.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>jags</Name>
@@ -42,7 +43,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="3">jags</Dependency>
+            <Dependency release="4">jags</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/JAGS/Console.h</Path>
@@ -145,12 +146,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2022-06-23</Date>
-            <Version>4.3.0</Version>
+        <Update release="4">
+            <Date>2024-02-16</Date>
+            <Version>4.3.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Release notes can be found [here](https://martynplummer.wordpress.com/2023/03/04/jags-4-3-2-is-released/).

**Test Plan**
Installed and started application, checked man pages.

**Checklist**

- [X] Package was built and tested against unstable
