### PR TITLE
fb2converter: Update to 1.75.0

### DIFF
--- a/packages/f/fb2converter/package.yml
+++ b/packages/f/fb2converter/package.yml
@@ -1,8 +1,8 @@
 name       : fb2converter
-version    : 1.74.4
-release    : 20
+version    : 1.75.0
+release    : 21
 source     :
-    - git|https://github.com/rupor-github/fb2converter.git : v1.74.4
+    - git|https://github.com/rupor-github/fb2converter.git : v1.75.0
 homepage   : https://github.com/rupor-github/fb2converter
 license    : GPL-3.0-only
 component  : office.viewers

--- a/packages/f/fb2converter/pspec_x86_64.xml
+++ b/packages/f/fb2converter/pspec_x86_64.xml
@@ -26,9 +26,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2024-02-11</Date>
-            <Version>1.74.4</Version>
+        <Update release="21">
+            <Date>2024-02-16</Date>
+            <Version>1.75.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Added "#series_first_word" to "title_format" and "file_name_format" configuration options.
- There is also "series_first_word_length" (default is set to 4) to set cut off length.

**Test Plan**
- fb2c convert infile

**Checklist**
- [X] Package was built and tested against unstable
