### PR TITLE
gpxsee: Update to 13.16

### DIFF
--- a/packages/g/gpxsee/abi_used_symbols
+++ b/packages/g/gpxsee/abi_used_symbols
@@ -590,8 +590,12 @@ libQt5Gui.so.5:_ZN12QPixmapCache13setCacheLimitEi
 libQt5Gui.so.5:_ZN12QPixmapCache4findERK7QStringP7QPixmap
 libQt5Gui.so.5:_ZN12QPixmapCache5clearEv
 libQt5Gui.so.5:_ZN12QPixmapCache6insertERK7QStringRK7QPixmap
+libQt5Gui.so.5:_ZN14QSurfaceFormat10setProfileENS_20OpenGLContextProfileE
 libQt5Gui.so.5:_ZN14QSurfaceFormat10setSamplesEi
+libQt5Gui.so.5:_ZN14QSurfaceFormat10setVersionEii
 libQt5Gui.so.5:_ZN14QSurfaceFormat16setDefaultFormatERKS_
+libQt5Gui.so.5:_ZN14QSurfaceFormat17setRenderableTypeENS_14RenderableTypeE
+libQt5Gui.so.5:_ZN14QSurfaceFormat18setDepthBufferSizeEi
 libQt5Gui.so.5:_ZN14QSurfaceFormat20setStencilBufferSizeEi
 libQt5Gui.so.5:_ZN14QSurfaceFormatC1Ev
 libQt5Gui.so.5:_ZN14QSurfaceFormatD1Ev
@@ -638,7 +642,6 @@ libQt5Gui.so.5:_ZN6QBrushC1ERKS_
 libQt5Gui.so.5:_ZN6QBrushC1Ev
 libQt5Gui.so.5:_ZN6QBrushD1Ev
 libQt5Gui.so.5:_ZN6QBrushaSERKS_
-libQt5Gui.so.5:_ZN6QColor13setNamedColorE13QLatin1String
 libQt5Gui.so.5:_ZN6QColor13setNamedColorERK7QString
 libQt5Gui.so.5:_ZN6QColor8fromHsvFEdddd
 libQt5Gui.so.5:_ZN6QColor8setAlphaEi
@@ -788,6 +791,7 @@ libQt5Gui.so.5:_ZNK6QImage11sizeInBytesEv
 libQt5Gui.so.5:_ZNK6QImage11transformedERK10QTransformN2Qt18TransformationModeE
 libQt5Gui.so.5:_ZNK6QImage12bytesPerLineEv
 libQt5Gui.so.5:_ZNK6QImage15mirrored_helperEbb
+libQt5Gui.so.5:_ZNK6QImage16devicePixelRatioEv
 libQt5Gui.so.5:_ZNK6QImage22convertToFormat_helperENS_6FormatE6QFlagsIN2Qt19ImageConversionFlagEE
 libQt5Gui.so.5:_ZNK6QImage4bitsEv
 libQt5Gui.so.5:_ZNK6QImage4copyERK5QRect

--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.15'
-release    : 33
+version    : '13.16'
+release    : 34
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.15.tar.gz : cfb7e5ec9bfc4d767766ef9d4da26edd2a991a856d433305e2270f22d9ba6926
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.16.tar.gz : f027ec5bf62c1ac79274e51867157f86c9d93cc61e722f9c1d34989be79addbd
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -136,9 +136,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2024-01-27</Date>
-            <Version>13.15</Version>
+        <Update release="34">
+            <Date>2024-02-16</Date>
+            <Version>13.16</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Improved vector maps rendering.
- Minor fixes.
- [changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

**Test Plan**
- view map

**Checklist**
- [X] Package was built and tested against unstable
