### PR TITLE
kitty: Update to 0.32.2

### DIFF
--- a/packages/k/kitty/package.yml
+++ b/packages/k/kitty/package.yml
@@ -1,8 +1,8 @@
 name       : kitty
-version    : 0.32.1
-release    : 60
+version    : 0.32.2
+release    : 61
 source     :
-    - https://github.com/kovidgoyal/kitty/releases/download/v0.32.1/kitty-0.32.1.tar.xz : f0c6cd610a3ac62c35a2f2696768232f10af62270042fa36074763d7007e5c6b
+    - https://github.com/kovidgoyal/kitty/releases/download/v0.32.2/kitty-0.32.2.tar.xz : d4bb54f7bfc16e274d60326323555b63733915c3e32d2ef711fd9860404bd6f2
 license    : GPL-3.0-only
 component  : system.utils
 homepage   : https://sw.kovidgoyal.net/kitty/

--- a/packages/k/kitty/pspec_x86_64.xml
+++ b/packages/k/kitty/pspec_x86_64.xml
@@ -502,6 +502,9 @@ Kitty is designed from the ground up to support all modern terminal features, su
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/__init__.cpython-310.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/__init__.cpython-310.opt-2.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/__init__.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/action.cpython-310.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/action.cpython-310.opt-2.pyc</Path>
+            <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/action.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/base.cpython-310.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/base.cpython-310.opt-2.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/base.cpython-310.pyc</Path>
@@ -550,6 +553,9 @@ Kitty is designed from the ground up to support all modern terminal features, su
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/launch.cpython-310.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/launch.cpython-310.opt-2.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/launch.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/load_config.cpython-310.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/load_config.cpython-310.opt-2.pyc</Path>
+            <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/load_config.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/ls.cpython-310.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/ls.cpython-310.opt-2.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/ls.cpython-310.pyc</Path>
@@ -613,6 +619,7 @@ Kitty is designed from the ground up to support all modern terminal features, su
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/signal_child.cpython-310.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/signal_child.cpython-310.opt-2.pyc</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/__pycache__/signal_child.cpython-310.pyc</Path>
+            <Path fileType="library">/usr/lib/kitty/kitty/rc/action.py</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/base.py</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/close_tab.py</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/close_window.py</Path>
@@ -629,6 +636,7 @@ Kitty is designed from the ground up to support all modern terminal features, su
             <Path fileType="library">/usr/lib/kitty/kitty/rc/kitten.py</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/last_used_layout.py</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/launch.py</Path>
+            <Path fileType="library">/usr/lib/kitty/kitty/rc/load_config.py</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/ls.py</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/new_window.py</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/rc/remove_marker.py</Path>
@@ -695,6 +703,7 @@ Kitty is designed from the ground up to support all modern terminal features, su
             <Path fileType="data">/usr/share/bash-completion/completions/kitty</Path>
             <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/kitty.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/kitty.svg</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-action.1</Path>
             <Path fileType="man">/usr/share/man/man1/kitten-@-close-tab.1</Path>
             <Path fileType="man">/usr/share/man/man1/kitten-@-close-window.1</Path>
             <Path fileType="man">/usr/share/man/man1/kitten-@-create-marker.1</Path>
@@ -710,6 +719,7 @@ Kitty is designed from the ground up to support all modern terminal features, su
             <Path fileType="man">/usr/share/man/man1/kitten-@-kitten.1</Path>
             <Path fileType="man">/usr/share/man/man1/kitten-@-last-used-layout.1</Path>
             <Path fileType="man">/usr/share/man/man1/kitten-@-launch.1</Path>
+            <Path fileType="man">/usr/share/man/man1/kitten-@-load-config.1</Path>
             <Path fileType="man">/usr/share/man/man1/kitten-@-ls.1</Path>
             <Path fileType="man">/usr/share/man/man1/kitten-@-new-window.1</Path>
             <Path fileType="man">/usr/share/man/man1/kitten-@-remove-marker.1</Path>
@@ -758,9 +768,9 @@ Kitty is designed from the ground up to support all modern terminal features, su
         </Files>
     </Package>
     <History>
-        <Update release="60">
-            <Date>2024-01-27</Date>
-            <Version>0.32.1</Version>
+        <Update release="61">
+            <Date>2024-02-16</Date>
+            <Version>0.32.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- kitten @ load-config: Allow (re)loading kitty.conf via remote control
- Remote control: Allow running mappable actions via remote control (kitten @ action)
- kitten @ send-text: Add a new option to automatically wrap the sent text in bracketed paste escape codes if the program in the destination window has turned on bracketed paste.
- Fix a single key mapping not overriding a previously defined multi-key mapping
- Graphics protocol: Improve display of images using Unicode placeholders or row/column boxes by resizing them using linear instead of nearest neighbor interpolation on the GPU
- When matching URLs use the definition of legal characters in URLs from the WHATWG spec rather than older standards
- hints kitten: Respect the kitty url_excluded_characters option
- Special case rendering of some more box drawing characters using shades from the block of symbols for legacy computing
- A new close_other_os_windows to close non active OS windows
- [changelog](https://sw.kovidgoyal.net/kitty/changelog/#id1)

**Test Plan**
- kitty -v

**Checklist**
- [X] Package was built and tested against unstable
