### PR TITLE
tailscale: Update to 1.60.0

### DIFF
--- a/packages/t/tailscale/package.yml
+++ b/packages/t/tailscale/package.yml
@@ -1,8 +1,8 @@
 name       : tailscale
-version    : 1.58.2
-release    : 9
+version    : 1.60.0
+release    : 10
 source     :
-    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.58.2.tar.gz : 452f355408e4e2179872387a863387e06346fc8a6f9887821f9b8a072c6a5b0a
+    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.60.0.tar.gz : b857ba9944e37332c245bc9ebc158150b2e785909f27d32b6f7e01557150e88a
 homepage   : https://tailscale.com
 license    : BSD-3-Clause
 component  : network.clients

--- a/packages/t/tailscale/pspec_x86_64.xml
+++ b/packages/t/tailscale/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2024-01-27</Date>
-            <Version>1.58.2</Version>
+        <Update release="10">
+            <Date>2024-02-16</Date>
+            <Version>1.60.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- authentication: present users with a valid login page when attempting to login even after leaving device unattended for several days
- networking: mute noisy peer mtu discovery errors
- networking: expose gVisor metrics in debug mode
- port mapper: support legacy "urn:dslforum-org" port mapping services
- port mapper: fix crash when no support mapping services found
- ssh: log warning when unable to find SSH host keys
- serve: improve error message when running as non-root
- cloud servers: Detect when Tailscale is running on Digital Ocean and automatically use Digital Ocean's DNS resolvers
- app connectors: enable app connectors to install routes for domains that resolve to CNAME records
- app connectors: support pre-configured routes from control server
- web client: add new read-only mode
- tailscale status command: fix output formatting Tailnet includes location-based exit nodes

**Test Plan**
- tailscale status

**Checklist**
- [X] Package was built and tested against unstable
