### PR TITLE
hplip: Housekeeping

### DIFF
--- a/packages/h/hplip/files/0001-Fix-desktop-files.patch
+++ b/packages/h/hplip/files/0001-Fix-desktop-files.patch
@@ -1,0 +1,53 @@
+From 18ae4e4a8d2c33f2b1e6b4187c2d1aa6bcc51d0f Mon Sep 17 00:00:00 2001
+From: Muhammad Alfi Syahrin <malfisya.dev@hotmail.com>
+Date: Wed, 21 Feb 2024 14:17:15 +0700
+Subject: [PATCH] Fix desktop files
+
+Stop using absolute path for exec and icon in desktop files
+---
+ hp-uiscan.desktop.in     | 4 ++--
+ hplip-systray.desktop.in | 2 +-
+ hplip.desktop.in         | 2 +-
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/hp-uiscan.desktop.in b/hp-uiscan.desktop.in
+index 4a551e5..42c2388 100644
+--- a/hp-uiscan.desktop.in
++++ b/hp-uiscan.desktop.in
+@@ -4,5 +4,5 @@ Version=1.0
+ Type=Application
+ Terminal=false
+ Name=hp-uiscan
+-Exec=/usr/bin/hp-uiscan
+-Icon=/usr/share/icons/Humanity/devices/48/printer.svg
++Exec=hp-uiscan
++Icon=hp-logo
+diff --git a/hplip-systray.desktop.in b/hplip-systray.desktop.in
+index 870dec6..85364e2 100644
+--- a/hplip-systray.desktop.in
++++ b/hplip-systray.desktop.in
+@@ -5,7 +5,7 @@ Name=HP System Tray Service
+ GenericName=Printer Status Applet
+ Comment=HP System Tray Service
+ Exec=hp-systray -x
+-Icon=@abs_datadir@/hplip/data/images/128x128/hp_logo.png
++Icon=hp-logo
+ Terminal=false
+ Categories=Application;Utility;
+ X-KDE-StartupNotify=false
+diff --git a/hplip.desktop.in b/hplip.desktop.in
+index 5a57f5b..809a391 100644
+--- a/hplip.desktop.in
++++ b/hplip.desktop.in
+@@ -5,7 +5,7 @@ Name=HP Device Manager
+ GenericName=Printer Management Application
+ Comment=View device status, ink levels and perform maintenance.
+ Exec=hp-toolbox
+-Icon=@abs_datadir@/hplip/data/images/128x128/hp_logo.png
++Icon=hp-logo
+ Terminal=false
+ Categories=Application;Utility;
+ X-KDE-StartupNotify=false
+-- 
+2.43.1
+

--- a/packages/h/hplip/files/fix-hp-uiscan-icon-path.patch
+++ b/packages/h/hplip/files/fix-hp-uiscan-icon-path.patch
@@ -1,8 +1,0 @@
---- hplip-3.20.9.orig/hp-uiscan.desktop.in	2020-09-23 07:24:21.000000000 +0200
-+++ hplip-3.20.9/hp-uiscan.desktop.in	2021-06-14 04:18:27.187659273 +0200
-@@ -5,4 +5,4 @@
- Terminal=false
- Name=hp-uiscan
- Exec=/usr/bin/hp-uiscan
--Icon=/usr/share/icons/Humanity/devices/48/printer.svg
-+Icon=@abs_datadir@/hplip/data/images/128x128/hp_logo.png

--- a/packages/h/hplip/files/series
+++ b/packages/h/hplip/files/series
@@ -6,6 +6,7 @@
 0025-Remove-all-ImageProcessor-functionality-which-is-clo.patch
 0027-Fixed-incomplete-removal-of-hp-toolbox-features-whic.patch
 0081-Don-t-start-hp-systray-in-GNOME.patch
+0001-Fix-desktop-files.patch
 hplip-add-ppd-crash.patch
 hplip-avahi-parsing.patch
 hplip-check-cups.patch
@@ -27,5 +28,4 @@ hplip-systray-blockerror.patch
 hplip-systray-qt5.patch
 hplip-udev-rules.patch
 hplip-unicodeerror.patch
-fix-hp-uiscan-icon-path.patch
 disable-upgrade.patch

--- a/packages/h/hplip/package.yml
+++ b/packages/h/hplip/package.yml
@@ -1,9 +1,9 @@
 name       : hplip
 version    : 3.23.12
-release    : 57
-homepage   : https://developers.hp.com/hp-linux-imaging-and-printing/gethplip
+release    : 58
 source     :
     - https://downloads.sourceforge.net/project/hplip/hplip/3.23.12/hplip-3.23.12.tar.gz : a76c2ac8deb31ddb5f0da31398d25ac57440928a0692dcb060a48daa718e69ed
+homepage   : https://developers.hp.com/hp-linux-imaging-and-printing/gethplip
 license    :
     - GPL-2.0-or-later
     - MIT
@@ -91,3 +91,13 @@ install    : |
 
     # remove rc script
     rm -vrf $installdir/etc/init.d
+
+    # Make symlink icons to hicolor
+    install -Dm00644 $installdir/usr/share/hplip/data/images/256x256/hp_logo.png $installdir/usr/share/pixmaps/hp-logo.png
+    for i in 16 32 64 128 256; do
+        install -dm00755 $installdir/usr/share/icons/hicolor/${i}x${i}/apps
+        ln -s /usr/share/hplip/data/images/${i}x${i}/hp_logo.png $installdir/usr/share/icons/hicolor/${i}x${i}/apps/hp-logo.png
+    done
+
+    # Install appstream metainfo
+    install -Dm00644 $pkgfiles/hplip.metainfo.xml -t $installdir/usr/share/metainfo/

--- a/packages/h/hplip/pspec_x86_64.xml
+++ b/packages/h/hplip/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>hplip</Name>
         <Homepage>https://developers.hp.com/hp-linux-imaging-and-printing/gethplip</Homepage>
         <Packager>
-            <Name>Tracey Clark</Name>
-            <Email>traceyc.dev@tlcnet.info</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>MIT</License>
@@ -22,7 +22,7 @@
 </Description>
         <PartOf>desktop.core</PartOf>
         <RuntimeDependencies>
-            <Dependency release="57">hplip-drivers</Dependency>
+            <Dependency release="58">hplip-drivers</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="config">/etc/hp/hplip.conf</Path>
@@ -642,6 +642,13 @@
             <Path fileType="data">/usr/share/hplip/unload.py</Path>
             <Path fileType="data">/usr/share/hplip/upgrade.py</Path>
             <Path fileType="data">/usr/share/hplip/wificonfig.py</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/hp-logo.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16/apps/hp-logo.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/hp-logo.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/hp-logo.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/hp-logo.png</Path>
+            <Path fileType="data">/usr/share/metainfo/hplip.metainfo.xml</Path>
+            <Path fileType="data">/usr/share/pixmaps/hp-logo.png</Path>
         </Files>
     </Package>
     <Package>
@@ -2035,12 +2042,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="57">
-            <Date>2024-02-14</Date>
+        <Update release="58">
+            <Date>2024-02-21</Date>
             <Version>3.23.12</Version>
             <Comment>Packaging update</Comment>
-            <Name>Tracey Clark</Name>
-            <Email>traceyc.dev@tlcnet.info</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Install appstream metadata (Part of getsolus/packages#1389)
- Consolidate all patches to fix desktop files into one
- Make symlink of icons to hicolor

**Test Plan**

- Verify metadata with `appstream-builder --packages-dir=. --include-failed -v`
- Launch "HP Device Manager" and "hp-uiscan" from desktop

**Checklist**

- [x] Package was built and tested against unstable