### PR TITLE
snapd: Update to 2.61.2

### DIFF
--- a/packages/s/snapd/package.yml
+++ b/packages/s/snapd/package.yml
@@ -1,9 +1,9 @@
 name       : snapd
-version    : 2.61.1
+version    : 2.61.2
 homepage   : https://snapcraft.io/
-release    : 78
+release    : 79
 source     :
-    - https://github.com/snapcore/snapd/releases/download/2.61.1/snapd_2.61.1.vendor.tar.xz : 775b7a250f5241b3bfcebcb3df5055b9c9304c4520502b7abf12438a1cdd771d
+    - https://github.com/snapcore/snapd/releases/download/2.61.2/snapd_2.61.2.vendor.tar.xz : d000725250a4d9c8a931b74df9733479a2851d03fe1e663a81fcb61b21509702
 license    : GPL-3.0-only
 component  : desktop
 summary    : The snapd and snap tools enable systems to work with .snap files

--- a/packages/s/snapd/pspec_x86_64.xml
+++ b/packages/s/snapd/pspec_x86_64.xml
@@ -26,7 +26,6 @@
             <Path fileType="library">/usr/lib/environment.d/990-snapd.conf</Path>
             <Path fileType="library">/usr/lib/systemd/system-environment-generators/snapd-env-generator</Path>
             <Path fileType="library">/usr/lib/systemd/system-generators/snapd-generator</Path>
-            <Path fileType="library">/usr/lib/systemd/user/snapd.aa-prompt-ui.service</Path>
             <Path fileType="library">/usr/lib/systemd/user/snapd.session-agent.service</Path>
             <Path fileType="library">/usr/lib/systemd/user/snapd.session-agent.socket</Path>
             <Path fileType="library">/usr/lib64/snapd/complete.sh</Path>
@@ -46,7 +45,6 @@
             <Path fileType="library">/usr/lib64/snapd/snapd</Path>
             <Path fileType="library">/usr/lib64/snapd/snapd-apparmor</Path>
             <Path fileType="library">/usr/lib64/snapd/snapd.run-from-snap</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/snapd.aa-prompt-listener.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/snapd.apparmor.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/snapd.failure.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/snapd.mounts-pre.target</Path>
@@ -61,7 +59,6 @@
             <Path fileType="data">/usr/share/applications/snap-handle-link.desktop</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/snap</Path>
             <Path fileType="data">/usr/share/dbus-1/services/io.snapcraft.Launcher.service</Path>
-            <Path fileType="data">/usr/share/dbus-1/services/io.snapcraft.Prompt.service</Path>
             <Path fileType="data">/usr/share/dbus-1/services/io.snapcraft.SessionAgent.service</Path>
             <Path fileType="data">/usr/share/dbus-1/services/io.snapcraft.Settings.service</Path>
             <Path fileType="data">/usr/share/dbus-1/session.d/snapd.session-services.conf</Path>
@@ -79,9 +76,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="78">
-            <Date>2024-02-01</Date>
-            <Version>2.61.1</Version>
+        <Update release="79">
+            <Date>2024-02-20</Date>
+            <Version>2.61.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Zygmunt Krynicki</Name>
             <Email>me@zygoon.pl</Email>


### PR DESCRIPTION
**Summary**
New upstream release.

    - Fix to enable plug/slot sanitization for prepare-image
    - Fix panic when device-service.access=offline
    - Support offline remodeling
    - Allow offline update only remodels without serial
    - Fail early when remodeling to old model revision
    - Fix to enable plug/slot sanitization for validate-seed
    - Allow removal of core snap on classic systems
    - Fix network-control interface denial for file lock on /run/netns
    - Add well-known core24 snap-id
    - Fix remodel snap installation order
    - Prevent remodeling from UC18+ to UC16
    - Fix cups auto-connect on classic with cups snap installed
    - u2f-devices interface support for GoTrust Idem Key with USB-C
    - Fix to restore services after unlink failure
    - Add libcudnn.so to Nvidia libraries
    - Fix skipping base snap download due to false snapd downgrade conflict

**Summary**

<!-- Info on what this pull request updates/changes/etc -->

**Test Plan**

I've tested by updating my system and testing with a few snaps.

**Checklist**

- [x] Package was built and tested against unstable
