### PR TITLE
hugo: Update to 0.123.0

### DIFF
--- a/packages/h/hugo/package.yml
+++ b/packages/h/hugo/package.yml
@@ -1,8 +1,8 @@
 name       : hugo
-version    : 0.122.0
-release    : 150
+version    : 0.123.0
+release    : 151
 source     :
-    - https://github.com/gohugoio/hugo/archive/refs/tags/v0.122.0.tar.gz : 7468280290ce43276e26f964b0cab234d2bf0546f80295890189054b98ffac38
+    - https://github.com/gohugoio/hugo/archive/refs/tags/v0.123.0.tar.gz : 877f4d8246053d6e577fc57d85291c8b1e88635e2711d00ba5708c3782cef89e
 license    : Apache-2.0
 homepage   : https://gohugo.io
 component  : programming

--- a/packages/h/hugo/pspec_x86_64.xml
+++ b/packages/h/hugo/pspec_x86_64.xml
@@ -24,9 +24,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="150">
-            <Date>2024-01-28</Date>
-            <Version>0.122.0</Version>
+        <Update release="151">
+            <Date>2024-02-20</Date>
+            <Version>0.123.0</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Changelog**

- This release is a rewrite of the Hugo core, fixing lots of long-lived bugs and adding some other exciting improvements.
- There are some breaking changes that have been announced for a long time. Most sites will not be affected by this, but we recommend that you test your site with the new Hugo version before you set it up to build to production.

Full changelog [here](https://github.com/gohugoio/hugo/releases/tag/v0.123.0)

**Test Plan**

- Build a local site

**Checklist**

- [x] Package was built and tested against unstable
