### PR TITLE
ripgrep: Update to 14.1.0

### DIFF
--- a/packages/r/ripgrep/abi_used_symbols
+++ b/packages/r/ripgrep/abi_used_symbols
@@ -97,11 +97,14 @@ libc.so.6:stat64
 libc.so.6:strlen
 libc.so.6:syscall
 libc.so.6:sysconf
+libc.so.6:waitid
 libc.so.6:waitpid
 libc.so.6:write
 libc.so.6:writev
 libgcc_s.so.1:_Unwind_Backtrace
 libgcc_s.so.1:_Unwind_DeleteException
+libgcc_s.so.1:_Unwind_FindEnclosingFunction
+libgcc_s.so.1:_Unwind_GetCFA
 libgcc_s.so.1:_Unwind_GetDataRelBase
 libgcc_s.so.1:_Unwind_GetIP
 libgcc_s.so.1:_Unwind_GetIPInfo

--- a/packages/r/ripgrep/package.yml
+++ b/packages/r/ripgrep/package.yml
@@ -1,8 +1,8 @@
 name       : ripgrep
-version    : 14.0.3
-release    : 14
+version    : 14.1.0
+release    : 15
 source     :
-    - https://github.com/BurntSushi/ripgrep/archive/refs/tags/14.0.3.tar.gz : f5794364ddfda1e0411ab6cad6dd63abe3a6b421d658d9fee017540ea4c31a0e
+    - https://github.com/BurntSushi/ripgrep/archive/refs/tags/14.1.0.tar.gz : 33c6169596a6bbfdc81415910008f26e0809422fda2d849562637996553b2ab6
 homepage   : https://github.com/BurntSushi/ripgrep
 license    : MIT
 component  : programming.tools

--- a/packages/r/ripgrep/pspec_x86_64.xml
+++ b/packages/r/ripgrep/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ripgrep</Name>
         <Homepage>https://github.com/BurntSushi/ripgrep</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Justin Zobel</Name>
+            <Email>justin@1707.io</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.tools</PartOf>
@@ -28,12 +28,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2023-12-30</Date>
-            <Version>14.0.3</Version>
+        <Update release="15">
+            <Date>2024-02-21</Date>
+            <Version>14.1.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Justin Zobel</Name>
+            <Email>justin@1707.io</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
Bugfix release, changelog [here](https://github.com/BurntSushi/ripgrep/releases/tag/14.1.0)

**Test Plan**

Tested against text files in the repo

**Checklist**

- [x] Package was built and tested against unstable
