### PR TITLE
opentyrian: Add appstream metainfo

### DIFF
--- a/packages/o/opentyrian/MAINTAINERS.md
+++ b/packages/o/opentyrian/MAINTAINERS.md
@@ -1,4 +1,0 @@
-This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
-
-- Beatrice T. Meyers
-  - Email: beatrice@getsol.us

--- a/packages/o/opentyrian/abi_libs
+++ b/packages/o/opentyrian/abi_libs
@@ -1,0 +1,1 @@
+opentyrian

--- a/packages/o/opentyrian/abi_symbols
+++ b/packages/o/opentyrian/abi_symbols
@@ -1,0 +1,1 @@
+opentyrian:main

--- a/packages/o/opentyrian/files/opentyrian.appdata.xml
+++ b/packages/o/opentyrian/files/opentyrian.appdata.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>opentyrian.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0</project_license>
+  <name>OpenTyrian</name>
+  <developer_name>OpenTyrian team</developer_name>
+  <summary>An open-source port of the DOS shoot-em-up Tyrian.</summary>
+  <description>
+    <p>OpenTyrian is an open-source port of the DOS game Tyrian.</p>
+    <p>Tyrian is an arcade-style vertical scrolling shooter.  The story is set in 20,031 where you play as Trent Hawkins, a skilled fighter-pilot employed to fight MicroSol and save the galaxy.</p>
+    <p>Tyrian features a story mode, one- and two-player arcade modes, and networked multiplayer.</p>
+  </description>
+  <url type="homepage">https://github.com/opentyrian/opentyrian</url>
+  <url type="bugtracker">https://github.com/opentyrian/opentyrian/issues</url>
+  <url type="faq">https://github.com/opentyrian/opentyrian/wiki/FAQ</url>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">mild</content_attribute>
+    <content_attribute id="violence-bloodshed">moderate</content_attribute>
+    <content_attribute id="drugs-alcohol">mild</content_attribute>
+  </content_rating>
+  <releases>
+    <release date="2022-11-23" version="v2.1.20221123">
+      <url>https://github.com/opentyrian/opentyrian/releases/tag/v2.1.20221123</url>
+    </release>
+    <release date="2022-05-07" version="v2.1.20220318">
+      <url>https://github.com/opentyrian/opentyrian/releases/tag/v2.1.20220318</url>
+    </release>
+  </releases>
+  <screenshots>
+    <screenshot>
+      <image>https://media.moddb.com/images/games/1/16/15907/OpenTyrian_013.png</image>
+      <caption>Episode selection</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://media.moddb.com/images/games/1/16/15907/OpenTyrian_016.png</image>
+      <caption>Menue</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://media.moddb.com/images/games/1/16/15907/OpenTyrian_008.png</image>
+      <caption>Ingame</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://media.moddb.com/images/games/1/16/15907/OpenTyrian_010.png</image>
+      <caption>Ingame</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://media.moddb.com/images/games/1/16/15907/OpenTyrian_014.png</image>
+      <caption>Ingame</caption>
+    </screenshot>
+    <screenshot type="default">
+      <image>https://media.moddb.com/images/games/1/16/15907/OpenTyrian_011.png</image>
+      <caption>Menue</caption>
+    </screenshot>
+  </screenshots>
+</component>

--- a/packages/o/opentyrian/package.yml
+++ b/packages/o/opentyrian/package.yml
@@ -1,6 +1,6 @@
 name       : opentyrian
 version    : 2.1.20221123
-release    : 7
+release    : 8
 source     :
     - https://github.com/opentyrian/opentyrian/archive/refs/tags/v2.1.20221123.tar.gz : e0e8a8b0d61de10a3a65789ace9ea8e8c5d8dc67f3e423d2c852d64da38aeeb9
     - http://camanis.net/tyrian/tyrian21.zip : 7790d09a2a3addcd33c66ef063d5900eb81cc9c342f4807eb8356364dd1d9277
@@ -30,3 +30,4 @@ install    : |
         install -Dm00644 linux/icons/tyrian-${px}.png \
         $installdir/usr/share/icons/hicolor/${px}x${px}/apps/opentyrian.png
     done
+    install -Dm00644 $pkgfiles/opentyrian.appdata.xml -t $installdir/usr/share/metainfo/

--- a/packages/o/opentyrian/pspec_x86_64.xml
+++ b/packages/o/opentyrian/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>opentyrian</Name>
         <Homepage>https://github.com/opentyrian/opentyrian</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>games.arcade</PartOf>
         <Summary xml:lang="en">OpenTyrian is an open-source port of the DOS game Tyrian</Summary>
         <Description xml:lang="en">OpenTyrian is an open-source port of the DOS game Tyrian. Tyrian is an arcade-style vertical scrolling shooter. The story is set in 20,031 where you play as Trent Hawkins, a skilled fighter-pilot employed to fight MicroSol and save the galaxy. Tyrian features a story mode, one- and two-player arcade modes, and networked multiplayer.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>opentyrian</Name>
@@ -28,6 +28,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/opentyrian.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/opentyrian.png</Path>
             <Path fileType="man">/usr/share/man/man6/opentyrian.6</Path>
+            <Path fileType="data">/usr/share/metainfo/opentyrian.appdata.xml</Path>
             <Path fileType="data">/usr/share/opentyrian/cubetxt1.dat</Path>
             <Path fileType="data">/usr/share/opentyrian/cubetxt2.dat</Path>
             <Path fileType="data">/usr/share/opentyrian/cubetxt3.dat</Path>
@@ -125,12 +126,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2022-11-24</Date>
+        <Update release="8">
+            <Date>2024-02-22</Date>
             <Version>2.1.20221123</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add appstream metadata (Part of https://github.com/getsolus/packages/issues/1389)

**Test Plan**

Verify metadata with `appstream-builder --packages-dir=. --include-failed -v`

**Checklist**

- [x] Package was built and tested against unstable