### PR TITLE
espeak-ng: inclusion of homepage

### DIFF
--- a/packages/e/espeak-ng/package.yml
+++ b/packages/e/espeak-ng/package.yml
@@ -1,11 +1,13 @@
 name       : espeak-ng
 version    : '1.51'
-release    : 6
+release    : 7
 source     :
     - https://github.com/espeak-ng/espeak-ng/archive/refs/tags/1.51.tar.gz : f0e028f695a8241c4fa90df7a8c8c5d68dcadbdbc91e758a97e594bbb0a3bdbf
+homepage   : https://github.com/espeak-ng/espeak-ng
 license    :
-    - GPL-3.0
+    - Apache-2.0
     - BSD-2-Clause
+    - GPL-3.0-or-later
 component  : programming.library
 summary    : Text-to-speech engine
 description: |

--- a/packages/e/espeak-ng/pspec_x86_64.xml
+++ b/packages/e/espeak-ng/pspec_x86_64.xml
@@ -1,17 +1,19 @@
 <PISI>
     <Source>
         <Name>espeak-ng</Name>
+        <Homepage>https://github.com/espeak-ng/espeak-ng</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
-        <License>GPL-3.0</License>
+        <License>Apache-2.0</License>
         <License>BSD-2-Clause</License>
+        <License>GPL-3.0-or-later</License>
         <PartOf>programming.library</PartOf>
         <Summary xml:lang="en">Text-to-speech engine</Summary>
         <Description xml:lang="en">Next generation text-to-speech engine, a fork of espeak.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>espeak-ng</Name>
@@ -527,7 +529,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="6">espeak-ng</Dependency>
+            <Dependency release="7">espeak-ng</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/espeak-ng/encoding.h</Path>
@@ -539,12 +541,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2022-06-13</Date>
+        <Update release="7">
+            <Date>2024-02-23</Date>
             <Version>1.51</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Inclusion of "homepage" to package.yml
- Part of [#411](https://github.com/getsolus/packages/issues/411)
- Added Apache 2.0 license to package.yml

**Test plan**
- Installed and played some text

**Checklist**
- [X] Package was built and tested against unstable