### PR TITLE
worklog.py: Add a -s/--sort option that sorts output

### DIFF
--- a/common/Scripts/worklog.py
+++ b/common/Scripts/worklog.py
@@ -180,6 +180,7 @@ if __name__ == '__main__':
     parser.add_argument('after', type=str, help='Show builds after this date')
     parser.add_argument('before', type=str, help='Show builds before this date')
     parser.add_argument('--format', '-f', type=str, choices=['md', 'tty'], default='tty')
+    parser.add_argument('--sort', '-s', action='store_true', help='Sort packages in lexically ascending order')
 
     cli_args = parser.parse_args()
     start = parse_date(cli_args.after)
@@ -196,7 +197,8 @@ if __name__ == '__main__':
         case 'commits':
             items = git.commits(start, end)
 
-    items = sorted(items, key=lambda item: (item.package, item.date))
+    if cli_args.sort:
+        items = sorted(items, key=lambda item: (item.package, item.date))
 
     match cli_args.format:
         case 'tty':


### PR DESCRIPTION
**Summary**

Without specifying the -s/--sort option, worklog.py will output the latest build or commit last.

This enables the ability to trivially keep an eye on large PR (re)builds with something like:

    while true; do
        date
        ./worklog.py --format md builds 2024-02-24 now |tail -n5
        echo "----"
        sleep 30
    done

**Test Plan**

Test the output of worklog.py with and without -s/--sort options.

**Checklist**

- [ ] Package was built and tested against unstable
