### PR TITLE
baselayout: Enable IPv6 mDNS lookups

### DIFF
--- a/packages/a/avahi/files/0001-Reduce-resolution-timeout-to-1s.patch
+++ b/packages/a/avahi/files/0001-Reduce-resolution-timeout-to-1s.patch
@@ -1,0 +1,53 @@
+From 8271c290296d23bf7ec43f63e5d8ef04c2074f23 Mon Sep 17 00:00:00 2001
+From: Silke Hofstra <silke@slxh.eu>
+Date: Wed, 28 Feb 2024 12:28:09 +0100
+Subject: [PATCH] Reduce resolution timeout to 1s
+
+---
+ avahi-core/resolve-address.c   | 2 +-
+ avahi-core/resolve-host-name.c | 2 +-
+ avahi-core/resolve-service.c   | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/avahi-core/resolve-address.c b/avahi-core/resolve-address.c
+index ac0b29b..37a8193 100644
+--- a/avahi-core/resolve-address.c
++++ b/avahi-core/resolve-address.c
+@@ -30,7 +30,7 @@
+ 
+ #include "browse.h"
+ 
+-#define TIMEOUT_MSEC 5000
++#define TIMEOUT_MSEC 1000
+ 
+ struct AvahiSAddressResolver {
+     AvahiServer *server;
+diff --git a/avahi-core/resolve-host-name.c b/avahi-core/resolve-host-name.c
+index 808b0e7..c17d6ea 100644
+--- a/avahi-core/resolve-host-name.c
++++ b/avahi-core/resolve-host-name.c
+@@ -31,7 +31,7 @@
+ #include "browse.h"
+ #include "log.h"
+ 
+-#define TIMEOUT_MSEC 5000
++#define TIMEOUT_MSEC 1000
+ 
+ struct AvahiSHostNameResolver {
+     AvahiServer *server;
+diff --git a/avahi-core/resolve-service.c b/avahi-core/resolve-service.c
+index 66bf3ca..0c1b3a8 100644
+--- a/avahi-core/resolve-service.c
++++ b/avahi-core/resolve-service.c
+@@ -33,7 +33,7 @@
+ #include "browse.h"
+ #include "log.h"
+ 
+-#define TIMEOUT_MSEC 5000
++#define TIMEOUT_MSEC 1000
+ 
+ struct AvahiSServiceResolver {
+     AvahiServer *server;
+-- 
+2.44.0
+

--- a/packages/a/avahi/files/series
+++ b/packages/a/avahi/files/series
@@ -1,3 +1,4 @@
 0001-Fall-back-to-stateless-directory.patch
 0001-daemon-Ensure-system-is-online-before-starting-Avahi.patch
 0001-Disable-chroot.patch
+0001-Reduce-resolution-timeout-to-1s.patch

--- a/packages/a/avahi/package.yml
+++ b/packages/a/avahi/package.yml
@@ -1,6 +1,6 @@
 name       : avahi
 version    : '0.8'
-release    : 24
+release    : 25
 source     :
     # - https://github.com/avahi/avahi/archive/refs/tags/v0.8.tar.gz : c15e750ef7c6df595fb5f2ce10cac0fee2353649600e6919ad08ae8871e4945f
     # Use git source until v0.9 releases:

--- a/packages/a/avahi/pspec_x86_64.xml
+++ b/packages/a/avahi/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>avahi</Name>
         <Homepage>https://www.avahi.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>desktop.core</PartOf>
@@ -157,7 +157,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="24">avahi</Dependency>
+            <Dependency release="25">avahi</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/girepository-1.0/Avahi-0.6.typelib</Path>
@@ -189,8 +189,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="24">avahi-devel</Dependency>
-            <Dependency release="24">avahi-32bit</Dependency>
+            <Dependency release="25">avahi-devel</Dependency>
+            <Dependency release="25">avahi-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/lib32/pkgconfig/avahi-client.pc</Path>
@@ -207,7 +207,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="24">avahi</Dependency>
+            <Dependency release="25">avahi</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/avahi-client/client.h</Path>
@@ -252,12 +252,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2024-01-30</Date>
+        <Update release="25">
+            <Date>2024-03-23</Date>
             <Version>0.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/b/baselayout/files/nsswitch.conf
+++ b/packages/b/baselayout/files/nsswitch.conf
@@ -9,4 +9,4 @@
 # sudo cp /usr/share/defaults/etc/nsswitch.conf /etc/nsswitch.conf
 #
 ## Then you can make your changes to the /etc/nsswitch.conf as needed.
-hosts: mymachines mdns4_minimal [NOTFOUND=return] resolve [!UNAVAIL=return] files myhostname dns
+hosts: mymachines mdns_minimal [NOTFOUND=return] resolve [!UNAVAIL=return] files myhostname dns

--- a/packages/b/baselayout/pspec.xml
+++ b/packages/b/baselayout/pspec.xml
@@ -57,6 +57,14 @@
     </Package>
 
     <History>
+        <Update release="75">
+            <Date>02-03-2024</Date>
+            <Version>1.9.0</Version>
+            <Comment>Package bump</Comment>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
+        </Update>
+
         <Update release="74">
             <Date>12-08-2023</Date>
             <Version>1.9.0</Version>


### PR DESCRIPTION
**Summary**

Enable mDNS lookups for IPv6 to ensure that mDNS hosts and addresses can be resolved for both IPv4 and IPv6.

**Test Plan**

| Test            | Before | After | 
|-----------------|:------:|:-----:|
| IPv4-only host  | IPv4   | IPv4  |
| IPv6-only host  | :x:    | IPv6  |
| Dual-stack host | IPv4   | IPv6  |

**Checklist**

- [x] Package was built and tested against unstable
