### PR TITLE
firewalld: Update to 2.1.1

### DIFF
--- a/packages/f/firewalld/monitoring.yml
+++ b/packages/f/firewalld/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 9989
+  rss: https://github.com/firewalld/firewalld/tags.atom
+security:
+  cpe:
+    - vendor: firewalld
+      product: firewalld

--- a/packages/f/firewalld/package.yml
+++ b/packages/f/firewalld/package.yml
@@ -1,20 +1,48 @@
 name       : firewalld
-version    : 1.3.2
-release    : 14
+version    : 2.1.1
+release    : 15
 source     :
-    - https://github.com/firewalld/firewalld/archive/refs/tags/v1.3.2.tar.gz : 3be5a3caa36d1026c5b72d3f61dd963dccd953791b04af03d9946b24bef8391e
+    - https://github.com/firewalld/firewalld/releases/download/v2.1.1/firewalld-2.1.1.tar.bz2 : a138a3799b5f6e6539bac308e5ae8950998d5173f588231214e979524e7c9416
+homepage   : https://firewalld.org/
 license    : GPL-2.0-or-later
 component  :
     - security
     - applet : security
     - config : security
-homepage   : https://firewalld.org/
 summary    :
     - Firewall daemon with D-Bus interface
     - applet : The firewall Qt panel applet provides a status information of firewalld and also the firewalld settings
     - config : Application to configure firewalld
 description: |
     firewalld provides a dynamically managed firewall with support for network or firewall zones to define the trust level of network connections or interfaces. It has support for IPv4, IPv6 firewall settings and for ethernet bridges and a separation of runtime and permanent configuration options. It also provides an interface for services or applications to add ip*tables and ebtables rules directly.
+builddeps  :
+    - pkgconfig(libipset)
+    - pkgconfig(libnftnl)
+    - pkgconfig(pygobject-3.0)
+    - docbook-xml
+    - gettext-devel
+    - nftables
+    - podman
+rundeps    :
+    - applet :
+        - firewalld-config
+        - python3-qt5
+    - config :
+        - firewalld
+        - libgtk-3
+    - ipset
+    - nftables
+    - python-capng
+    - python-gobject
+    - python3-dbus
+setup      : |
+    %autogen --disable-schemas-compile \
+             --disable-sysconfig \
+             PYTHON=/usr/bin/python3
+build      : |
+    %make
+install    : |
+    %make_install
 patterns   :
     - applet :
         - /usr/bin/firewall-applet
@@ -32,31 +60,3 @@ patterns   :
         - /usr/share/metainfo/firewall-config.appdata.xml
         - /usr/share/icons/hicolor/*/apps/firewall-config*.*
         - /usr/man/man1/firewall-config*.1*
-builddeps  :
-    - pkgconfig(libipset)
-    - pkgconfig(libnftnl)
-    - pkgconfig(pygobject-3.0)
-    - gettext-devel
-    - docbook-xml
-    - nftables
-    - podman
-rundeps    :
-    - ipset
-    - nftables
-    - python3-dbus
-    - python-capng
-    - python-gobject
-    - applet :
-        - firewalld-config
-        - python3-qt5
-    - config :
-        - firewalld
-        - libgtk-3
-setup      : |
-    %autogen --disable-schemas-compile \
-             --disable-sysconfig \
-             PYTHON=/usr/bin/python3
-build      : |
-    %make
-install    : |
-    %make_install

--- a/packages/f/firewalld/pspec_x86_64.xml
+++ b/packages/f/firewalld/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>firewalld</Name>
         <Homepage>https://firewalld.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>security</PartOf>
@@ -61,6 +61,10 @@
             <Path fileType="library">/usr/lib/firewalld/icmptypes/host-unknown.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/icmptypes/host-unreachable.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/icmptypes/ip-header-bad.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/icmptypes/mld-listener-done.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/icmptypes/mld-listener-query.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/icmptypes/mld-listener-report.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/icmptypes/mld2-listener-report.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/icmptypes/neighbour-advertisement.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/icmptypes/neighbour-solicitation.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/icmptypes/network-prohibited.xml</Path>
@@ -93,13 +97,17 @@
             <Path fileType="library">/usr/lib/firewalld/icmptypes/unknown-option.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/ipsets/README.md</Path>
             <Path fileType="library">/usr/lib/firewalld/policies/allow-host-ipv6.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/0-AD.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/RH-Satellite-6-capsule.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/RH-Satellite-6.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/afp.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/alvr.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/amanda-client.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/amanda-k5-client.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/amqp.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/amqps.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/anno-1602.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/anno-1800.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/apcupsd.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/audit.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/ausweisapp2.xml</Path>
@@ -120,6 +128,8 @@
             <Path fileType="library">/usr/lib/firewalld/services/ceph.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/cfengine.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/checkmk-agent.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/civilization-iv.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/civilization-v.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/cockpit.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/collectd.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/condor-collector.xml</Path>
@@ -132,6 +142,7 @@
             <Path fileType="library">/usr/lib/firewalld/services/dhcpv6-client.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/dhcpv6.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/distcc.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/dns-over-quic.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/dns-over-tls.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/dns.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/docker-registry.xml</Path>
@@ -140,6 +151,7 @@
             <Path fileType="library">/usr/lib/firewalld/services/elasticsearch.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/etcd-client.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/etcd-server.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/factorio.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/finger.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/foreman-proxy.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/foreman.xml</Path>
@@ -206,6 +218,7 @@
             <Path fileType="library">/usr/lib/firewalld/services/matrix.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/mdns.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/memcache.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/minecraft.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/minidlna.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/mongodb.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/mosh.xml</Path>
@@ -218,6 +231,7 @@
             <Path fileType="library">/usr/lib/firewalld/services/mysql.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/nbd.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/nebula.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/need-for-speed-most-wanted.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/netbios-ns.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/netdata-dashboard.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/nfs.xml</Path>
@@ -226,6 +240,7 @@
             <Path fileType="library">/usr/lib/firewalld/services/nrpe.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/ntp.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/nut.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/opentelemetry.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/openvpn.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/ovirt-imageio.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/ovirt-storageconsole.xml</Path>
@@ -262,6 +277,7 @@
             <Path fileType="library">/usr/lib/firewalld/services/samba-dc.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/samba.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/sane.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/settlers-history-collection.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/sip.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/sips.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/slp.xml</Path>
@@ -277,17 +293,24 @@
             <Path fileType="library">/usr/lib/firewalld/services/squid.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/ssdp.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/ssh.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/statsrv.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/steam-streaming.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/stellaris.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/stronghold-crusader.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/submission.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/supertuxkart.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/svdrp.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/svn.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/syncthing-gui.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/syncthing-relay.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/syncthing.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/synergy.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/syscomlan.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/syslog-tls.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/syslog.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/telnet.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/tentacle.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/terraria.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/tftp.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/tile38.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/tinc.xml</Path>
@@ -296,6 +319,7 @@
             <Path fileType="library">/usr/lib/firewalld/services/upnp-client.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/vdsm.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/vnc-server.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/vrrp.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/warpinator.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/wbem-http.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/wbem-https.xml</Path>
@@ -312,8 +336,17 @@
             <Path fileType="library">/usr/lib/firewalld/services/xmpp-local.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/xmpp-server.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/zabbix-agent.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/zabbix-java-gateway.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/zabbix-server.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/zabbix-trapper.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/zabbix-web-service.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/services/zero-k.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/services/zerotier.xml</Path>
+            <Path fileType="library">/usr/lib/firewalld/xmlschema/check.sh</Path>
+            <Path fileType="library">/usr/lib/firewalld/xmlschema/icmptype.xsd</Path>
+            <Path fileType="library">/usr/lib/firewalld/xmlschema/ipset.xsd</Path>
+            <Path fileType="library">/usr/lib/firewalld/xmlschema/service.xsd</Path>
+            <Path fileType="library">/usr/lib/firewalld/xmlschema/zone.xsd</Path>
             <Path fileType="library">/usr/lib/firewalld/zones/block.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/zones/dmz.xml</Path>
             <Path fileType="library">/usr/lib/firewalld/zones/drop.xml</Path>
@@ -391,8 +424,8 @@
             <Path fileType="data">/usr/share/firewalld/testsuite/integration/testsuite</Path>
             <Path fileType="data">/usr/share/firewalld/testsuite/python/firewalld_config.py</Path>
             <Path fileType="data">/usr/share/firewalld/testsuite/python/firewalld_direct.py</Path>
+            <Path fileType="data">/usr/share/firewalld/testsuite/python/firewalld_misc.py</Path>
             <Path fileType="data">/usr/share/firewalld/testsuite/python/firewalld_rich.py</Path>
-            <Path fileType="data">/usr/share/firewalld/testsuite/python/firewalld_test.py</Path>
             <Path fileType="data">/usr/share/firewalld/testsuite/testsuite</Path>
             <Path fileType="data">/usr/share/glib-2.0/schemas/org.fedoraproject.FirewallConfig.gschema.xml</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/firewalld.mo</Path>
@@ -434,9 +467,11 @@
             <Path fileType="localedata">/usr/share/locale/pl/LC_MESSAGES/firewalld.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt/LC_MESSAGES/firewalld.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/firewalld.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ro/LC_MESSAGES/firewalld.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ru/LC_MESSAGES/firewalld.mo</Path>
             <Path fileType="localedata">/usr/share/locale/si/LC_MESSAGES/firewalld.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sk/LC_MESSAGES/firewalld.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sl/LC_MESSAGES/firewalld.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sq/LC_MESSAGES/firewalld.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sr/LC_MESSAGES/firewalld.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sr@latin/LC_MESSAGES/firewalld.mo</Path>
@@ -477,7 +512,7 @@
 </Description>
         <PartOf>security</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="14">firewalld-config</Dependency>
+            <Dependency releaseFrom="15">firewalld-config</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="config">/etc/firewall/applet.conf</Path>
@@ -511,7 +546,7 @@
 </Description>
         <PartOf>security</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="14">firewalld</Dependency>
+            <Dependency releaseFrom="15">firewalld</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/firewall-config</Path>
@@ -529,12 +564,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2024-02-15</Date>
-            <Version>1.3.2</Version>
+        <Update release="15">
+            <Date>2024-02-26</Date>
+            <Version>2.1.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/firewalld/firewalld/releases/tag/v2.1.1).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Restart the computer and verify that the applet appears in the tray and that the firewall appears to be active.

**Checklist**

- [x] Package was built and tested against unstable
