### PR TITLE
gnome-clocks: Bump release number to match old repo

### DIFF
--- a/packages/g/gnome-clocks/package.yml
+++ b/packages/g/gnome-clocks/package.yml
@@ -1,6 +1,6 @@
 name       : gnome-clocks
 version    : '45.0'
-release    : 1
+release    : 19
 source     :
     - https://download.gnome.org/sources/gnome-clocks/45/gnome-clocks-45.0.tar.xz : fc8eb4fd9530f1e641dc00ee2086ee7d354a7a00b0a0d1722e305d5c9aab91b5
 homepage   : https://apps.gnome.org/Clocks/

--- a/packages/g/gnome-clocks/pspec_x86_64.xml
+++ b/packages/g/gnome-clocks/pspec_x86_64.xml
@@ -382,8 +382,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-02-27</Date>
+        <Update release="19">
+            <Date>2024-02-28</Date>
             <Version>45.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>


### PR DESCRIPTION
It was 18 on https://phab.getsol.us/source/gnome-clocks/browse/master/package.yml

Undperecation PR : https://github.com/getsolus/solus-sc/pull/307 
