### PR TITLE
fwupd: Update to v1..9.14

### DIFF
--- a/packages/f/fwupd/abi_symbols
+++ b/packages/f/fwupd/abi_symbols
@@ -358,6 +358,7 @@ fwupd:_edata
 fwupd:_end
 fwupd:_start
 fwupd:fu_daemon_get_type
+fwupd:fu_daemon_machine_kind_from_string
 fwupd:fu_daemon_new
 fwupd:fu_daemon_set_machine_kind
 fwupd:fu_daemon_setup
@@ -365,6 +366,7 @@ fwupd:fu_daemon_start
 fwupd:fu_daemon_stop
 fwupd:fu_engine_install_phase_to_string
 fwupd:fu_engine_request_flag_to_string
+fwupd:fu_idle_inhibit_to_string
 fwupd:fu_p2p_policy_from_string
 fwupd:fu_release_priority_from_string
 fwupd:main
@@ -378,6 +380,7 @@ fwupdtool:_end
 fwupdtool:_start
 fwupdtool:fu_engine_install_phase_to_string
 fwupdtool:fu_engine_request_flag_to_string
+fwupdtool:fu_idle_inhibit_to_string
 fwupdtool:fu_p2p_policy_from_string
 fwupdtool:fu_release_priority_from_string
 fwupdtool:main
@@ -1311,6 +1314,20 @@ libfwupdengine.so:fu_ch347_device_chip_select
 libfwupdengine.so:fu_ch347_device_get_type
 libfwupdengine.so:fu_ch347_device_send_command
 libfwupdengine.so:fu_ch347_plugin_get_type
+libfwupdengine.so:fu_client_get_feature_flags
+libfwupdengine.so:fu_client_get_sender
+libfwupdengine.so:fu_client_get_type
+libfwupdengine.so:fu_client_has_flag
+libfwupdengine.so:fu_client_insert_hint
+libfwupdengine.so:fu_client_list_get_all
+libfwupdengine.so:fu_client_list_get_by_sender
+libfwupdengine.so:fu_client_list_get_type
+libfwupdengine.so:fu_client_list_new
+libfwupdengine.so:fu_client_list_register
+libfwupdengine.so:fu_client_lookup_hint
+libfwupdengine.so:fu_client_new
+libfwupdengine.so:fu_client_remove_flag
+libfwupdengine.so:fu_client_set_feature_flags
 libfwupdengine.so:fu_colorhug_device_get_type
 libfwupdengine.so:fu_colorhug_plugin_get_type
 libfwupdengine.so:fu_corsair_bp_activate_firmware
@@ -1499,6 +1516,7 @@ libfwupdengine.so:fu_engine_config_get_p2p_policy
 libfwupdengine.so:fu_engine_config_get_release_dedupe
 libfwupdengine.so:fu_engine_config_get_release_priority
 libfwupdengine.so:fu_engine_config_get_show_device_private
+libfwupdengine.so:fu_engine_config_get_test_devices
 libfwupdengine.so:fu_engine_config_get_trusted_reports
 libfwupdengine.so:fu_engine_config_get_trusted_uids
 libfwupdengine.so:fu_engine_config_get_type
@@ -1543,7 +1561,9 @@ libfwupdengine.so:fu_engine_get_results
 libfwupdengine.so:fu_engine_get_silo_from_blob
 libfwupdengine.so:fu_engine_get_type
 libfwupdengine.so:fu_engine_get_upgrades
+libfwupdengine.so:fu_engine_idle_inhibit
 libfwupdengine.so:fu_engine_idle_reset
+libfwupdengine.so:fu_engine_idle_uninhibit
 libfwupdengine.so:fu_engine_install_blob
 libfwupdengine.so:fu_engine_install_phase_to_string
 libfwupdengine.so:fu_engine_install_release
@@ -1679,15 +1699,16 @@ libfwupdengine.so:fu_history_modify_device_release
 libfwupdengine.so:fu_history_new
 libfwupdengine.so:fu_history_remove_all
 libfwupdengine.so:fu_history_remove_device
-libfwupdengine.so:fu_idle_get_status
 libfwupdengine.so:fu_idle_get_type
 libfwupdengine.so:fu_idle_has_inhibit
 libfwupdengine.so:fu_idle_inhibit
+libfwupdengine.so:fu_idle_inhibit_to_string
 libfwupdengine.so:fu_idle_locker_free
 libfwupdengine.so:fu_idle_locker_new
 libfwupdengine.so:fu_idle_new
 libfwupdengine.so:fu_idle_reset
 libfwupdengine.so:fu_idle_set_timeout
+libfwupdengine.so:fu_idle_uninhibit
 libfwupdengine.so:fu_igsc_aux_device_get_type
 libfwupdengine.so:fu_igsc_aux_device_new
 libfwupdengine.so:fu_igsc_aux_firmware_get_major_vcn
@@ -3951,6 +3972,7 @@ libfwupdplugin.so:fu_config_get_value_strv
 libfwupdplugin.so:fu_config_get_value_u64
 libfwupdplugin.so:fu_config_load
 libfwupdplugin.so:fu_config_new
+libfwupdplugin.so:fu_config_set_default
 libfwupdplugin.so:fu_config_set_value
 libfwupdplugin.so:fu_context_add_compile_version
 libfwupdplugin.so:fu_context_add_esp_volume
@@ -4087,7 +4109,6 @@ libfwupdplugin.so:fu_device_get_equivalent_id
 libfwupdplugin.so:fu_device_get_firmware_gtype
 libfwupdplugin.so:fu_device_get_firmware_size_max
 libfwupdplugin.so:fu_device_get_firmware_size_min
-libfwupdplugin.so:fu_device_get_guids_as_str
 libfwupdplugin.so:fu_device_get_instance_str
 libfwupdplugin.so:fu_device_get_internal_flags
 libfwupdplugin.so:fu_device_get_logical_id
@@ -4588,6 +4609,7 @@ libfwupdplugin.so:fu_plugin_get_config_value
 libfwupdplugin.so:fu_plugin_get_config_value_boolean
 libfwupdplugin.so:fu_plugin_get_context
 libfwupdplugin.so:fu_plugin_get_data
+libfwupdplugin.so:fu_plugin_get_device_gtype_default
 libfwupdplugin.so:fu_plugin_get_devices
 libfwupdplugin.so:fu_plugin_get_name
 libfwupdplugin.so:fu_plugin_get_order
@@ -4631,8 +4653,10 @@ libfwupdplugin.so:fu_plugin_runner_unlock
 libfwupdplugin.so:fu_plugin_runner_verify
 libfwupdplugin.so:fu_plugin_runner_write_firmware
 libfwupdplugin.so:fu_plugin_security_attr_new
+libfwupdplugin.so:fu_plugin_set_config_default
 libfwupdplugin.so:fu_plugin_set_config_value
 libfwupdplugin.so:fu_plugin_set_context
+libfwupdplugin.so:fu_plugin_set_device_gtype_default
 libfwupdplugin.so:fu_plugin_set_name
 libfwupdplugin.so:fu_plugin_set_order
 libfwupdplugin.so:fu_plugin_set_priority

--- a/packages/f/fwupd/abi_used_symbols
+++ b/packages/f/fwupd/abi_used_symbols
@@ -112,7 +112,6 @@ libc.so.6:stdin
 libc.so.6:stdout
 libc.so.6:strcmp
 libc.so.6:strdup
-libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strncpy
@@ -173,6 +172,7 @@ libgio-2.0.so.0:g_cancellable_set_error_if_cancelled
 libgio-2.0.so.0:g_converter_input_stream_new
 libgio-2.0.so.0:g_dbus_connection_call_sync
 libgio-2.0.so.0:g_dbus_connection_emit_signal
+libgio-2.0.so.0:g_dbus_connection_get_type
 libgio-2.0.so.0:g_dbus_connection_new_for_address
 libgio-2.0.so.0:g_dbus_connection_new_for_address_finish
 libgio-2.0.so.0:g_dbus_connection_register_object
@@ -260,8 +260,6 @@ libgio-2.0.so.0:g_input_stream_get_type
 libgio-2.0.so.0:g_input_stream_read
 libgio-2.0.so.0:g_input_stream_read_all
 libgio-2.0.so.0:g_input_stream_read_bytes
-libgio-2.0.so.0:g_input_stream_read_bytes_async
-libgio-2.0.so.0:g_input_stream_read_bytes_finish
 libgio-2.0.so.0:g_io_error_from_errno
 libgio-2.0.so.0:g_io_error_quark
 libgio-2.0.so.0:g_memory_input_stream_new_from_bytes
@@ -351,7 +349,6 @@ libglib-2.0.so.0:g_byte_array_remove_index
 libglib-2.0.so.0:g_byte_array_remove_range
 libglib-2.0.so.0:g_byte_array_set_size
 libglib-2.0.so.0:g_byte_array_sized_new
-libglib-2.0.so.0:g_byte_array_steal
 libglib-2.0.so.0:g_byte_array_unref
 libglib-2.0.so.0:g_bytes_compare
 libglib-2.0.so.0:g_bytes_get_data
@@ -446,6 +443,8 @@ libglib-2.0.so.0:g_key_file_has_key
 libglib-2.0.so.0:g_key_file_load_from_data
 libglib-2.0.so.0:g_key_file_load_from_file
 libglib-2.0.so.0:g_key_file_new
+libglib-2.0.so.0:g_key_file_remove_comment
+libglib-2.0.so.0:g_key_file_remove_group
 libglib-2.0.so.0:g_key_file_remove_key
 libglib-2.0.so.0:g_key_file_save_to_file
 libglib-2.0.so.0:g_key_file_set_boolean

--- a/packages/f/fwupd/package.yml
+++ b/packages/f/fwupd/package.yml
@@ -1,8 +1,8 @@
 name       : fwupd
-version    : 1.9.12
-release    : 13
+version    : 1.9.14
+release    : 14
 source     :
-    - https://github.com/fwupd/fwupd/releases/download/1.9.12/fwupd-1.9.12.tar.xz : d2596ca8ff2320ca76e69d4617b72cf322f654979270553e4f0267ae2ccec839
+    - https://github.com/fwupd/fwupd/releases/download/1.9.14/fwupd-1.9.14.tar.xz : b16cbb9480c9a957735d15cfc1e876198b3c607b08e92958f9fc098e31613279
 license    : LGPL-2.1-or-later
 homepage   : https://fwupd.org/
 component  : system.utils

--- a/packages/f/fwupd/pspec_x86_64.xml
+++ b/packages/f/fwupd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>fwupd</Name>
         <Homepage>https://fwupd.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Ravi Jain</Name>
+            <Email>ravijain87@gmail.com</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -24,11 +24,9 @@ Additional information is available at the website: https://fwupd.org/
         <Files>
             <Path fileType="config">/etc/fwupd/bios-settings.d/README.md</Path>
             <Path fileType="config">/etc/fwupd/fwupd.conf</Path>
-            <Path fileType="config">/etc/fwupd/remotes.d/fwupd-tests.conf</Path>
             <Path fileType="config">/etc/fwupd/remotes.d/lvfs-testing.conf</Path>
             <Path fileType="config">/etc/fwupd/remotes.d/lvfs.conf</Path>
             <Path fileType="config">/etc/fwupd/remotes.d/vendor-directory.conf</Path>
-            <Path fileType="config">/etc/fwupd/remotes.d/vendor.conf</Path>
             <Path fileType="config">/etc/grub.d/35_fwupd</Path>
             <Path fileType="config">/etc/pki/fwupd-metadata/GPG-KEY-Linux-Foundation-Metadata</Path>
             <Path fileType="config">/etc/pki/fwupd-metadata/GPG-KEY-Linux-Vendor-Firmware-Service</Path>
@@ -48,11 +46,11 @@ Additional information is available at the website: https://fwupd.org/
             <Path fileType="library">/usr/lib/systemd/system/system-update.target.wants/fwupd-offline-update.service</Path>
             <Path fileType="library">/usr/lib/sysusers.d/fwupd.conf</Path>
             <Path fileType="library">/usr/lib/udev/rules.d/90-fwupd-devices.rules</Path>
-            <Path fileType="library">/usr/lib64/fwupd-1.9.12/libfu_plugin_flashrom.so</Path>
-            <Path fileType="library">/usr/lib64/fwupd-1.9.12/libfu_plugin_modem_manager.so</Path>
-            <Path fileType="library">/usr/lib64/fwupd-1.9.12/libfwupdengine.so</Path>
-            <Path fileType="library">/usr/lib64/fwupd-1.9.12/libfwupdplugin.so</Path>
-            <Path fileType="library">/usr/lib64/fwupd-1.9.12/libfwupdutil.so</Path>
+            <Path fileType="library">/usr/lib64/fwupd-1.9.14/libfu_plugin_flashrom.so</Path>
+            <Path fileType="library">/usr/lib64/fwupd-1.9.14/libfu_plugin_modem_manager.so</Path>
+            <Path fileType="library">/usr/lib64/fwupd-1.9.14/libfwupdengine.so</Path>
+            <Path fileType="library">/usr/lib64/fwupd-1.9.14/libfwupdplugin.so</Path>
+            <Path fileType="library">/usr/lib64/fwupd-1.9.14/libfwupdutil.so</Path>
             <Path fileType="library">/usr/lib64/fwupd/fwupd/fwupd</Path>
             <Path fileType="library">/usr/lib64/fwupd/fwupd/fwupd-detect-cet</Path>
             <Path fileType="library">/usr/lib64/fwupd/fwupd/fwupdoffline</Path>
@@ -66,7 +64,6 @@ Additional information is available at the website: https://fwupd.org/
             <Path fileType="library">/usr/lib64/fwupd/installed-tests/fwupd/ccgx-self-test</Path>
             <Path fileType="library">/usr/lib64/fwupd/installed-tests/fwupd/elantp-self-test</Path>
             <Path fileType="library">/usr/lib64/fwupd/installed-tests/fwupd/fu-dfu-self-test</Path>
-            <Path fileType="library">/usr/lib64/fwupd/installed-tests/fwupd/fwupd.sh</Path>
             <Path fileType="library">/usr/lib64/fwupd/installed-tests/fwupd/linux-swap-self-test</Path>
             <Path fileType="library">/usr/lib64/fwupd/installed-tests/fwupd/mtd-self-test</Path>
             <Path fileType="library">/usr/lib64/fwupd/installed-tests/fwupd/nitrokey-self-test</Path>
@@ -235,6 +232,7 @@ Additional information is available at the website: https://fwupd.org/
             <Path fileType="doc">/usr/share/doc/libfwupd/const.PLUGIN_FLAG_READY.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupd/const.PLUGIN_FLAG_REQUIRE_HWID.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupd/const.PLUGIN_FLAG_SECURE_CONFIG.html</Path>
+            <Path fileType="doc">/usr/share/doc/libfwupd/const.PLUGIN_FLAG_TEST_ONLY.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupd/const.PLUGIN_FLAG_UNLOCK_REQUIRED.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupd/const.PLUGIN_FLAG_USER_WARNING.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupd/const.RELEASE_FLAG_BLOCKED_APPROVAL.html</Path>
@@ -248,6 +246,7 @@ Additional information is available at the website: https://fwupd.org/
             <Path fileType="doc">/usr/share/doc/libfwupd/const.RELEASE_FLAG_TRUSTED_PAYLOAD.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupd/const.RELEASE_FLAG_TRUSTED_REPORT.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupd/const.REPORT_FLAG_FROM_OEM.html</Path>
+            <Path fileType="doc">/usr/share/doc/libfwupd/const.REPORT_FLAG_IS_UPGRADE.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupd/const.REPORT_FLAG_NONE.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupd/const.REQUEST_FLAG_ALLOW_GENERIC_IMAGE.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupd/const.REQUEST_FLAG_ALLOW_GENERIC_MESSAGE.html</Path>
@@ -1277,6 +1276,7 @@ Additional information is available at the website: https://fwupd.org/
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/const.DEVICE_INTERNAL_FLAG_DISPLAY_REQUIRED.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/const.DEVICE_INTERNAL_FLAG_ENFORCE_REQUIRES.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/const.DEVICE_INTERNAL_FLAG_ENSURE_SEMVER.html</Path>
+            <Path fileType="doc">/usr/share/doc/libfwupdplugin/const.DEVICE_INTERNAL_FLAG_EXPLICIT_ORDER.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/const.DEVICE_INTERNAL_FLAG_HOST_CPU.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/const.DEVICE_INTERNAL_FLAG_HOST_CPU_CHILD.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/const.DEVICE_INTERNAL_FLAG_HOST_FIRMWARE.html</Path>
@@ -3169,6 +3169,7 @@ Additional information is available at the website: https://fwupd.org/
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Config.get_value_strv.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Config.get_value_u64.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Config.load.html</Path>
+            <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Config.set_default.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Config.set_value.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Context.add_compile_version.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Context.add_esp_volume.html</Path>
@@ -3278,7 +3279,6 @@ Additional information is available at the website: https://fwupd.org/
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Device.get_firmware_gtype.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Device.get_firmware_size_max.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Device.get_firmware_size_min.html</Path>
-            <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Device.get_guids_as_str.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Device.get_instance_str.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Device.get_internal_flags.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Device.get_logical_id.html</Path>
@@ -3572,6 +3572,7 @@ Additional information is available at the website: https://fwupd.org/
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Plugin.get_config_value_boolean.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Plugin.get_context.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Plugin.get_data.html</Path>
+            <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Plugin.get_device_gtype_default.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Plugin.get_devices.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Plugin.get_name.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Plugin.get_order.html</Path>
@@ -3611,8 +3612,10 @@ Additional information is available at the website: https://fwupd.org/
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Plugin.runner_verify.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Plugin.runner_write_firmware.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Plugin.security_attr_new.html</Path>
+            <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Plugin.set_config_default.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Plugin.set_config_value.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Plugin.set_context.html</Path>
+            <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Plugin.set_device_gtype_default.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Plugin.set_name.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Plugin.set_order.html</Path>
             <Path fileType="doc">/usr/share/doc/libfwupdplugin/method.Plugin.set_priority.html</Path>
@@ -3931,6 +3934,7 @@ Additional information is available at the website: https://fwupd.org/
             <Path fileType="data">/usr/share/fwupd/metainfo/org.freedesktop.fwupd.remotes.lvfs-testing.metainfo.xml</Path>
             <Path fileType="data">/usr/share/fwupd/metainfo/org.freedesktop.fwupd.remotes.lvfs.metainfo.xml</Path>
             <Path fileType="data">/usr/share/fwupd/quirks.d/builtin.quirk.gz</Path>
+            <Path fileType="data">/usr/share/fwupd/remotes.d/fwupd-tests.conf</Path>
             <Path fileType="data">/usr/share/fwupd/remotes.d/vendor/firmware/README.md</Path>
             <Path fileType="data">/usr/share/fwupd/simple_client.py</Path>
             <Path fileType="data">/usr/share/fwupd/uefi-capsule-ux.tar.xz</Path>
@@ -3952,6 +3956,7 @@ Additional information is available at the website: https://fwupd.org/
             <Path fileType="data">/usr/share/installed-tests/fwupd/fakedevice124.metainfo.xml</Path>
             <Path fileType="data">/usr/share/installed-tests/fwupd/firmware.zip</Path>
             <Path fileType="data">/usr/share/installed-tests/fwupd/fwupd-tests.xml</Path>
+            <Path fileType="data">/usr/share/installed-tests/fwupd/fwupd.sh</Path>
             <Path fileType="data">/usr/share/installed-tests/fwupd/fwupd.test</Path>
             <Path fileType="data">/usr/share/installed-tests/fwupd/fwupdmgr-p2p.sh</Path>
             <Path fileType="data">/usr/share/installed-tests/fwupd/fwupdmgr-p2p.test</Path>
@@ -4039,7 +4044,7 @@ Additional information is available at the website: https://fwupd.org/
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="13">fwupd</Dependency>
+            <Dependency release="14">fwupd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/fwupd-1/fwupd.h</Path>
@@ -4065,12 +4070,12 @@ Additional information is available at the website: https://fwupd.org/
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2024-02-15</Date>
-            <Version>1.9.12</Version>
+        <Update release="14">
+            <Date>2024-02-27</Date>
+            <Version>1.9.14</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Ravi Jain</Name>
+            <Email>ravijain87@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

This release adds the following features:

    Allow plugins to opt-into a default device GType

This release fixes the following bugs:

    Correctly detect ARM32 and RISC-V UEFI binaries
    Correctly migrate the database schema from very old fwupd versions
    Fix critical warnings when using FWUPD_DBUS_SOCKET= on macOS
    Fix DS-20 descriptors by opening the GUsbDevice earlier
    Fix updating the fingerprint reader on the Framework 13 and 16 laptop
    Fix warning when probing devices using the metadata allowlist
    Only recover the version format for specific devices

Release notes can be found [here](https://github.com/fwupd/fwupd/releases/tag/1.9.14).

**Test Plan**

Installed on Framework 13 using unstable branch and ran various commands.
Used this test version to update FW13 fingerprint sensor from lvfs-testing and it worked successfully

**Checklist**

- [x ] Package was built and tested against unstable
- [x ] Successfully updated the firmware of a device on my laptop