### PR TITLE
discover: Use livingsilver94's patch to enable driver installation

### DIFF
--- a/packages/d/discover/abi_used_symbols
+++ b/packages/d/discover/abi_used_symbols
@@ -1,6 +1,9 @@
 libAppStreamQt5.so.3:_ZN9AppStream10LaunchableD1Ev
 libAppStreamQt5.so.3:_ZN9AppStream10ScreenshotD1Ev
 libAppStreamQt5.so.3:_ZN9AppStream10SystemInfo24currentDistroComponentIdEv
+libAppStreamQt5.so.3:_ZN9AppStream10SystemInfo25hasDeviceMatchingModaliasERK7QString
+libAppStreamQt5.so.3:_ZN9AppStream10SystemInfoC1Ev
+libAppStreamQt5.so.3:_ZN9AppStream10SystemInfoD1Ev
 libAppStreamQt5.so.3:_ZN9AppStream11ReleaseListD1Ev
 libAppStreamQt5.so.3:_ZN9AppStream12ComponentBoxD1Ev
 libAppStreamQt5.so.3:_ZN9AppStream12ComponentBoxaSERKS0_

--- a/packages/d/discover/files/0001-PackageKitBackend-Add-the-Drivers-menu-filtered-by-t.patch
+++ b/packages/d/discover/files/0001-PackageKitBackend-Add-the-Drivers-menu-filtered-by-t.patch
@@ -1,0 +1,160 @@
+From cc71ca40c556151cd3aa24a0182913789effc319 Mon Sep 17 00:00:00 2001
+From: Fabio Forni <development@redaril.me>
+Date: Tue, 13 Feb 2024 11:32:28 +0100
+Subject: [PATCH] PackageKitBackend: Add the "Drivers" menu, filtered by the
+ "Drivers" Category
+
+---
+ .../AppPackageKitResource.cpp                 | 41 +++++++++++++++++--
+ .../PackageKitBackend/AppPackageKitResource.h |  2 +
+ .../PackageKitBackend/PackageKitBackend.cpp   | 15 ++++++-
+ .../packagekit-backend-categories.xml         | 20 +++++++++
+ 4 files changed, 73 insertions(+), 5 deletions(-)
+
+diff --git a/libdiscover/backends/PackageKitBackend/AppPackageKitResource.cpp b/libdiscover/backends/PackageKitBackend/AppPackageKitResource.cpp
+index 2ea8362..4200802 100644
+--- a/libdiscover/backends/PackageKitBackend/AppPackageKitResource.cpp
++++ b/libdiscover/backends/PackageKitBackend/AppPackageKitResource.cpp
+@@ -13,12 +13,14 @@
+ #include <AppStreamQt5/image.h>
+ #include <AppStreamQt5/release.h>
+ #include <AppStreamQt5/screenshot.h>
++#include <AppStreamQt5/systeminfo.h>
+ #include <AppStreamQt5/version.h>
+ #else
+ #include <AppStreamQt/icon.h>
+ #include <AppStreamQt/image.h>
+ #include <AppStreamQt/release.h>
+ #include <AppStreamQt/screenshot.h>
++#include <AppStreamQt/systeminfo.h>
+ #include <AppStreamQt/version.h>
+ #endif
+ 
+@@ -113,14 +115,40 @@ QStringList AppPackageKitResource::mimetypes() const
+ 
+ static constexpr auto s_addonKinds = {AppStream::Component::KindAddon, AppStream::Component::KindCodec};
+ 
++static bool hasDeviceModaliases(const AppStream::Component &comp)
++{
++    const auto mods = comp.provided(AppStream::Provided::KindModalias);
++    auto sys = AppStream::SystemInfo();
++    for (const auto &mod : mods.items()) {
++        if (sys.hasDeviceMatchingModalias(mod)) {
++            return true;
++        }
++    }
++    return false;
++}
++
+ QStringList AppPackageKitResource::categories()
+ {
+-    auto cats = m_appdata.categories();
+-    if (!kContainsValue(s_addonKinds, m_appdata.kind()))
+-        cats.append(QStringLiteral("Application"));
+-    return cats;
++    switch (m_appdata.kind()) {
++    case AppStream::Component::KindDriver: {
++        auto cats = QStringList();
++        cats.reserve(2);
++        cats.append(QStringLiteral("Drivers"));
++        if (hasDeviceModaliases(m_appdata)) {
++          cats.append(QStringLiteral("ThisDeviceDrivers"));
++        }
++        return cats;
++    }
++    default: {
++        auto cats = m_appdata.categories();
++        if (!kContainsValue(s_addonKinds, m_appdata.kind()))
++            cats.append(QStringLiteral("Application"));
++        return cats;
++    }
++    }
+ }
+ 
++
+ QString AppPackageKitResource::comment()
+ {
+     const auto summary = m_appdata.summary();
+@@ -305,3 +333,8 @@ uint AppPackageKitResource::contentRatingMinimumAge() const
+ {
+     return AppStreamUtils::contentRatingMinimumAge(m_appdata);
+ }
++
++AppStream::Component AppPackageKitResource::component() const
++{
++    return m_appdata;
++}
+\ No newline at end of file
+diff --git a/libdiscover/backends/PackageKitBackend/AppPackageKitResource.h b/libdiscover/backends/PackageKitBackend/AppPackageKitResource.h
+index d5bb808..986fde1 100644
+--- a/libdiscover/backends/PackageKitBackend/AppPackageKitResource.h
++++ b/libdiscover/backends/PackageKitBackend/AppPackageKitResource.h
+@@ -50,6 +50,8 @@ public:
+     ContentIntensity contentRatingIntensity() const override;
+     uint contentRatingMinimumAge() const override;
+ 
++    AppStream::Component component() const;
++
+ private:
+     const AppStream::Component m_appdata;
+     mutable QString m_name;
+diff --git a/libdiscover/backends/PackageKitBackend/PackageKitBackend.cpp b/libdiscover/backends/PackageKitBackend/PackageKitBackend.cpp
+index 186cb30..0548d3e 100644
+--- a/libdiscover/backends/PackageKitBackend/PackageKitBackend.cpp
++++ b/libdiscover/backends/PackageKitBackend/PackageKitBackend.cpp
+@@ -735,7 +735,20 @@ ResultsStream *PackageKitBackend::search(const AbstractResourcesBackend::Filters
+ #endif
+ #if ASQ_CHECK_VERSION(0, 15, 6)
+             } else if (filter.category) {
+-                components = AppStreamUtils::componentsByCategories(m_appdata.get(), filter.category, AppStream::Bundle::KindUnknown);
++                if (filter.category->involvedCategories()[0] == QStringLiteral("Drivers")
++                    || filter.category->involvedCategories()[0] == QStringLiteral("ThisDeviceDrivers")) {
++                    for (auto &resource : m_packages.packages) {
++                        auto resourceCast = qobject_cast<AppPackageKitResource *>(resource);
++                        if (resourceCast == nullptr) {
++                            continue;
++                        }
++                        if (resourceCast->categories().contains(filter.category->involvedCategories()[0])) {
++                            components.append(resourceCast->component());
++                        }
++                    }
++                } else {
++                    components = AppStreamUtils::componentsByCategories(m_appdata.get(), filter.category, AppStream::Bundle::KindUnknown);
++                }
+ #endif
+             } else {
+ #if ASQ_CHECK_VERSION(1, 0, 0)
+diff --git a/libdiscover/backends/PackageKitBackend/packagekit-backend-categories.xml b/libdiscover/backends/PackageKitBackend/packagekit-backend-categories.xml
+index ff1a922..7a20277 100644
+--- a/libdiscover/backends/PackageKitBackend/packagekit-backend-categories.xml
++++ b/libdiscover/backends/PackageKitBackend/packagekit-backend-categories.xml
+@@ -548,6 +548,26 @@
+       </Or>
+     </Include>
+   </Menu>
++
++  <Menu>
++    <Name>Hardware Drivers</Name>
++    <Icon>cpu</Icon>
++    <Include>
++      <And>
++        <Category>Drivers</Category>
++      </And>
++    </Include>
++    <Menu>
++      <Name>Drivers For This Device</Name>
++      <Icon>cpu</Icon>
++      <Include>
++        <And>
++          <Category>ThisDeviceDrivers</Category>
++        </And>
++      </Include>
++    </Menu>
++  </Menu>
++
+   <Menu>
+     <Name>Plasma Addons</Name>
+     <Icon>plasma</Icon>
+-- 
+2.43.0
+

--- a/packages/d/discover/package.yml
+++ b/packages/d/discover/package.yml
@@ -1,6 +1,6 @@
 name       : discover
 version    : 5.27.10.1
-release    : 6
+release    : 7
 source     :
     - https://cdn.download.kde.org/stable/plasma/5.27.10/discover-5.27.10.1.tar.xz : d856aeb1288b966955e04d5669cfc2b3fb659fdd3f07b869a41dc705a7f6d1ac
 homepage   : https://apps.kde.org/discover/
@@ -42,6 +42,7 @@ rundeps    :
     - kirigami2
     - qt5-quickcontrols2
 setup      : |
+    %patch -p1 -i $pkgfiles/0001-PackageKitBackend-Add-the-Drivers-menu-filtered-by-t.patch
     %cmake_ninja
 build      : |
     %ninja_build

--- a/packages/d/discover/pspec_x86_64.xml
+++ b/packages/d/discover/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>discover</Name>
         <Homepage>https://apps.kde.org/discover/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Hans Kelson</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.kde</PartOf>
@@ -274,12 +274,12 @@ See getsolus/packages#715 and getsolus/packages#716
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2024-02-13</Date>
+        <Update release="7">
+            <Date>2024-03-01</Date>
             <Version>5.27.10.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Hans Kelson</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Add livingsilver94's patch to Discover enabling GUI driver installation. There is a category showing all hardware drivers, and also one showing only drivers applicable to the device.

**Test Plan**

1. Build Discover from this PR, then install it.
2. Follow the test plan [here](https://github.com/getsolus/discover/issues/1), starting from step 3.

**Checklist**

- [x] Package was built and tested against unstable
