### PR TITLE
tailscale: Update to 1.60.1

### DIFF
--- a/packages/t/tailscale/package.yml
+++ b/packages/t/tailscale/package.yml
@@ -1,8 +1,8 @@
 name       : tailscale
-version    : 1.60.0
-release    : 10
+version    : 1.60.1
+release    : 11
 source     :
-    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.60.0.tar.gz : b857ba9944e37332c245bc9ebc158150b2e785909f27d32b6f7e01557150e88a
+    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.60.1.tar.gz : 9766336845cef4d8b906145bc863f20ec8b9af71051471de45d7f964539a9817
 homepage   : https://tailscale.com
 license    : BSD-3-Clause
 component  : network.clients

--- a/packages/t/tailscale/pspec_x86_64.xml
+++ b/packages/t/tailscale/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2024-02-16</Date>
-            <Version>1.60.0</Version>
+        <Update release="11">
+            <Date>2024-03-02</Date>
+            <Version>1.60.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Exposing port 8080 to other devices on your tailnet works as expected

**Test Plan**
- tailscale netcheck

**Checklist**
- [X] Package was built and tested against unstable
