### PR TITLE
github-cli: Update to 2.45.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.44.1
-release    : 41
+version    : 2.45.0
+release    : 42
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.44.1.tar.gz : 6254bbfbca8964e1f0f6631724e9c5f027637df0b4cd0998c4bdfec4554067e2
+    - https://github.com/cli/cli/archive/refs/tags/v2.45.0.tar.gz : 61363c109487a17fad44dff3a55f0c7dd36c8d6e4d7b630755705bd3aa34a323
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -139,8 +139,10 @@
             <Path fileType="man">/usr/share/man/man1/gh-project-item-delete.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-project-item-edit.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-project-item-list.1</Path>
+            <Path fileType="man">/usr/share/man/man1/gh-project-link.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-project-list.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-project-mark-template.1</Path>
+            <Path fileType="man">/usr/share/man/man1/gh-project-unlink.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-project-view.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-project.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-release-create.1</Path>
@@ -211,9 +213,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="41">
-            <Date>2024-02-18</Date>
-            <Version>2.44.1</Version>
+        <Update release="42">
+            <Date>2024-03-04</Date>
+            <Version>2.45.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Resolve go compiler regression
- Fixed the msg returned for patching a repo variable
- Fix regression around commas in commit titles during `pr create`
- Add `ref` option to `gh cache list`
- Make comments in the default config file more informative
- Link Project to Repository or Team Command
- Clarify helptext for search PRs regarding archived repos
- Support `project view --web` with TTY

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Ran `gh status`, and in a repository ran `gh pr list` and `gh pr view #number`. Also created this PR.

**Checklist**

- [x] Package was built and tested against unstable
