### PR TITLE
sof-firmware: update to 2.8.1

### DIFF
--- a/packages/s/sof-firmware/MAINTAINERS.md
+++ b/packages/s/sof-firmware/MAINTAINERS.md
@@ -2,3 +2,4 @@ This file is used to indicate primary maintainership for this package. A package
 
 - Tracey Clark
   - Email: traceyc.dev@tlcnet.info
+  - Matrix: @traceyc:matrix.org

--- a/packages/s/sof-firmware/package.yml
+++ b/packages/s/sof-firmware/package.yml
@@ -1,9 +1,9 @@
 name       : sof-firmware
 homepage   : https://github.com/thesofproject/sof-bin
-version    : '2.8'
-release    : 15
+version    : 2.8.1
+release    : 16
 source     :
-    - https://github.com/thesofproject/sof-bin/releases/download/v2023.12/sof-bin-2023.12.tar.gz : 55e47eb63e6248dbdab7da232bb1e31ca2e7155b37dc116f6dc5b173cba3503b
+    - https://github.com/thesofproject/sof-bin/releases/download/v2023.12.1/sof-bin-2023.12.1.tar.gz : ea279ddfc99c5b11d634f1f5d2337f6d5c0dc381ce3314790f7b550e4088e674
 license    :
     - BSD-3-Clause
     - ISC

--- a/packages/s/sof-firmware/pspec_x86_64.xml
+++ b/packages/s/sof-firmware/pspec_x86_64.xml
@@ -23,9 +23,15 @@
         <Files>
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-hda-generic-2ch.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-hda-generic-4ch.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-hda-generic-ace1-2ch.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-hda-generic-ace1-4ch.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-hda-generic-cavs25-2ch.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-hda-generic-cavs25-4ch.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-hda-generic-idisp.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-hda-generic.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-cs42l43-l0-cs35l56-l12.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-es83x6-ssp1-hdmi-ssp02.tplg</Path>
+            <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-hdmi-ssp02.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-max98357a-rt5682-ssp2-ssp0-2ch-pdm1.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-max98357a-rt5682-ssp2-ssp0.tplg</Path>
             <Path fileType="data">/lib/firmware/intel/sof-ace-tplg/sof-mtl-max98357a-rt5682.tplg</Path>
@@ -399,9 +405,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2024-01-06</Date>
-            <Version>2.8</Version>
+        <Update release="16">
+            <Date>2024-03-04</Date>
+            <Version>2.8.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Tracey Clark</Name>
             <Email>traceyc.dev@tlcnet.info</Email>


### PR DESCRIPTION
**Summary**

For v2.8 series, the following new topology files have been added since v2.8:

v2.8.x/sof-ace-tplg-v2.8
├── sof-ace-tplg
│   ├── sof-hda-generic-ace1-2ch.tplg
│   ├── sof-hda-generic-ace1-4ch.tplg
│   ├── sof-hda-generic-cavs25-2ch.tplg
│   ├── sof-hda-generic-cavs25-4ch.tplg
│   ├── sof-mtl-es83x6-ssp1-hdmi-ssp02.tplg
│   ├── sof-mtl-hdmi-ssp02.tplg

Full release notes [here](https://github.com/thesofproject/sof-bin/releases)

**Test Plan**

Verified firmware files were installed to correct paths. Restarted pipewire.
    systemctl --user restart pipewire.service
Listened to music and triggered system sounds to verify that sound still works.

**Checklist**

- [x] Package was built and tested against unstable
