### PR TITLE
gajim: Add missing runtime dependency on python-pillow

### DIFF
--- a/packages/g/gajim/package.yml
+++ b/packages/g/gajim/package.yml
@@ -1,6 +1,6 @@
 name       : gajim
 version    : 1.8.4
-release    : 25
+release    : 26
 source     :
     - https://gajim.org/downloads/1.8/gajim-1.8.4.tar.gz : 58fced87b1ce01b3d5269bcdf33499246533b01b4008d9701eb1e10cf94e49c5
 homepage   : https://gajim.org
@@ -26,6 +26,7 @@ rundeps    :
     - python-nbxmpp
     - python-omemo-dr
     - python-openssl
+    - python-pillow
     - python-qrcode
 setup      : |
     ./pep517build/build_metadata.py -o .dist/metadata

--- a/packages/g/gajim/pspec_x86_64.xml
+++ b/packages/g/gajim/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gajim</Name>
         <Homepage>https://gajim.org</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.im</PartOf>
@@ -1138,12 +1138,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="25">
-            <Date>2024-02-15</Date>
+        <Update release="26">
+            <Date>2024-03-04</Date>
             <Version>1.8.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add missing runtime dependency to `gajim`.

**Test Plan**

Install the package and see that it launches successfully.

**Checklist**

- [x] Package was built and tested against unstable
