### PR TITLE
syncthing: update to 1.27.4

### DIFF
--- a/packages/s/syncthing/package.yml
+++ b/packages/s/syncthing/package.yml
@@ -1,9 +1,9 @@
 name       : syncthing
-version    : 1.27.3
-release    : 93
+version    : 1.27.4
+release    : 94
 homepage   : https://syncthing.net
 source     :
-    - https://github.com/syncthing/syncthing/releases/download/v1.27.3/syncthing-source-v1.27.3.tar.gz : 3fe25b863bb3a0f74bc95a7afa71bdaa2a79971542962236be5d85f469aa897d
+    - https://github.com/syncthing/syncthing/archive/refs/tags/v1.27.4.tar.gz : 65542335212f10703a8ace949b811744f96c1adaea6deed6d3d7399b9f398ecd
 license    : MPL-2.0
 component  : network.util
 networking : yes

--- a/packages/s/syncthing/pspec_x86_64.xml
+++ b/packages/s/syncthing/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>syncthing</Name>
         <Homepage>https://syncthing.net</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>MPL-2.0</License>
         <PartOf>network.util</PartOf>
@@ -50,12 +50,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="93">
-            <Date>2024-02-07</Date>
-            <Version>1.27.3</Version>
+        <Update release="94">
+            <Date>2024-03-04</Date>
+            <Version>1.27.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Bugfixes:

- Panic in ignore matching on invalid UTF-8 from filesystem watcher
- syncthing should be cgroup aware

Enhancements:

- File system watcher should skip ignored directories in more cases
- Set `GOMAXPROCS` quota aware in Linux containers

Other issues:

- typo in folder_sendrecv.go refrences nonexistent type `dbUpdateShourtcutFile`
- typo: `Complection` → `Completion` ?

**Test Plan**
- Restart Syncthing-GTK and verify it can connect to the syncthing backend, all folders sync
- View syncthing gui in web browser, ensure everything looks good

**Checklist**

- [x] Package was built and tested against unstable