### PR TITLE
yubico-authenticator: update to 6.4.0

### DIFF
--- a/packages/y/yubico-authenticator/abi_used_symbols
+++ b/packages/y/yubico-authenticator/abi_used_symbols
@@ -10,7 +10,7 @@ libatk-1.0.so.0:atk_state_set_new
 libatk-1.0.so.0:atk_text_get_text
 libatk-1.0.so.0:atk_text_get_type
 libayatana-appindicator3.so.1:app_indicator_new
-libayatana-appindicator3.so.1:app_indicator_set_icon
+libayatana-appindicator3.so.1:app_indicator_set_icon_full
 libayatana-appindicator3.so.1:app_indicator_set_label
 libayatana-appindicator3.so.1:app_indicator_set_menu
 libayatana-appindicator3.so.1:app_indicator_set_status

--- a/packages/y/yubico-authenticator/package.yml
+++ b/packages/y/yubico-authenticator/package.yml
@@ -1,8 +1,8 @@
 name       : yubico-authenticator
-version    : 6.3.1
-release    : 6
+version    : 6.4.0
+release    : 7
 source     :
-    - https://github.com/Yubico/yubioath-flutter/archive/refs/tags/6.3.1.tar.gz : bb643e83e48fb0ded71c4043884112abefeeaf90c58a4212e35236ddd731a3a4
+    - https://github.com/Yubico/yubioath-flutter/archive/refs/tags/6.4.0.tar.gz : cd0d4794205e386866872b945efdfb00fe514e1ff027f6f8c1c87d33dbb53c79
     - https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.16.5-stable.tar.xz#flutter.tar.xz : 57e59fa3a31be7e87b3847cdf782f1323578bbf70a0cd35f3615f01ab429ac29
 homepage   : https://www.yubico.com/products/yubico-authenticator/
 license    : BSD-2-Clause

--- a/packages/y/yubico-authenticator/pspec_x86_64.xml
+++ b/packages/y/yubico-authenticator/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>yubico-authenticator</Name>
         <Homepage>https://www.yubico.com/products/yubico-authenticator/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>security</PartOf>
@@ -36,16 +36,12 @@ The Yubico Authenticator securely generates a code used to verify your identity 
             <Path fileType="data">/usr/share/yubioath-desktop/data/flutter_assets/AssetManifest.json</Path>
             <Path fileType="data">/usr/share/yubioath-desktop/data/flutter_assets/FontManifest.json</Path>
             <Path fileType="data">/usr/share/yubioath-desktop/data/flutter_assets/NOTICES.Z</Path>
+            <Path fileType="data">/usr/share/yubioath-desktop/data/flutter_assets/assets/fonts/Roboto-Bold.ttf</Path>
             <Path fileType="data">/usr/share/yubioath-desktop/data/flutter_assets/assets/fonts/Roboto-Light.ttf</Path>
             <Path fileType="data">/usr/share/yubioath-desktop/data/flutter_assets/assets/fonts/Roboto-Regular.ttf</Path>
             <Path fileType="data">/usr/share/yubioath-desktop/data/flutter_assets/assets/fonts/Roboto-Thin.ttf</Path>
             <Path fileType="data">/usr/share/yubioath-desktop/data/flutter_assets/assets/graphics/app-icon.png</Path>
-            <Path fileType="data">/usr/share/yubioath-desktop/data/flutter_assets/assets/graphics/manage-accounts.png</Path>
-            <Path fileType="data">/usr/share/yubioath-desktop/data/flutter_assets/assets/graphics/no-accounts.png</Path>
-            <Path fileType="data">/usr/share/yubioath-desktop/data/flutter_assets/assets/graphics/no-fingerprints.png</Path>
             <Path fileType="data">/usr/share/yubioath-desktop/data/flutter_assets/assets/graphics/no-key.png</Path>
-            <Path fileType="data">/usr/share/yubioath-desktop/data/flutter_assets/assets/graphics/no-key_dark.png</Path>
-            <Path fileType="data">/usr/share/yubioath-desktop/data/flutter_assets/assets/graphics/no-permission.png</Path>
             <Path fileType="data">/usr/share/yubioath-desktop/data/flutter_assets/assets/graphics/yubico-green.png</Path>
             <Path fileType="data">/usr/share/yubioath-desktop/data/flutter_assets/assets/graphics/yubico-white.png</Path>
             <Path fileType="data">/usr/share/yubioath-desktop/data/flutter_assets/assets/licenses/.gitignore</Path>
@@ -132,12 +128,12 @@ The Yubico Authenticator securely generates a code used to verify your identity 
         </Replaces>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2024-02-17</Date>
-            <Version>6.3.1</Version>
+        <Update release="7">
+            <Date>2024-03-04</Date>
+            <Version>6.4.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Changelog:**

- UI: Major UI overhaul, with improvements including:
    - Add new UI layouts for wider windows to better utilize screen space.
    - Add YubiKey personalization through custom naming and theme color.
    - Split FIDO/WebAuthn into multiple sections.
    - Move factory reset functionality into a single dialog, from the individual sections.
- Add support for Yubico OTP provisioning.
- PIV: Display more information about keys and certificates.
- PIV: Add output format for public key when generating keys.
- Desktop: Window hidden/shown state no longer saved when closing the app, use --hidden to start the app in a hidden to systray state.
- Desktop: Fix FIDO reset over NFC.
- Windows: Add option to launch Windows Settings for FIDO management.
- Android: Increase read timeout for NFC, improving compatibility with older YubiKeys.

Full release notes available [here](https://github.com/Yubico/yubico-flutter/releases)

**Test Plan**
- YubiKey Authenticator launches from the app menu
- YubiKey recognized
- Logged into an account with 2 factor auth successfully