### PR TITLE
eopkg4-bin: Fix compatibility with older x86_64 systems

### DIFF
--- a/packages/e/eopkg4-bin/package.yml
+++ b/packages/e/eopkg4-bin/package.yml
@@ -1,8 +1,8 @@
 name       : eopkg4-bin
 version    : 4.0.0
-release    : 4
+release    : 5
 source     :
-    - git|https://github.com/getsolus/eopkg : 42e803fe632063331e3924a1389f295eee478780
+    - git|https://github.com/getsolus/eopkg : 2bb04794d761dd815f7611d1ff7bebe357703f6e
     - git|https://github.com/getsolus/PackageKit.git : 201b4c0999950e412f9366ae17856eb295c3af21
 homepage   : https://github.com/getsolus/eopkg
 license    : GPL-2.0-or-later
@@ -34,8 +34,9 @@ builddeps  :
 setup      : |
     %python3_setup
 build      : |
+    export GLIBC_TUNABLES=glibc.cpu.hwcaps=-AVX
     # We're not actually using self-execution. In this case, eopkg is using the -c flag as shorthand for --component, rather than for passing the program as a string (as is default python behavior).
-    nuitka3 --onefile --include-module=dbm.gnu --no-deployment-flag=self-execution $workdir/eopkg-cli
+    nuitka3 --onefile --include-module=dbm.gnu --show-scons --no-deployment-flag=self-execution $workdir/eopkg-cli
     nuitka3 --onefile --include-module=dbm.gnu $sources/PackageKit.git/backends/eopkg/eopkgBackend.py
 install    : |
     install -Dm0755 $workdir/eopkg-cli.bin $installdir/usr/bin/eopkg4-bin

--- a/packages/e/eopkg4-bin/pspec_x86_64.xml
+++ b/packages/e/eopkg4-bin/pspec_x86_64.xml
@@ -3,7 +3,7 @@
         <Name>eopkg4-bin</Name>
         <Homepage>https://github.com/getsolus/eopkg</Homepage>
         <Packager>
-            <Name>Hans K</Name>
+            <Name>Hans Kelson</Name>
             <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
@@ -39,11 +39,11 @@ See getsolus/packages#1316
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-02-16</Date>
+        <Update release="5">
+            <Date>2024-03-05</Date>
             <Version>4.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Hans K</Name>
+            <Name>Hans Kelson</Name>
             <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>


### PR DESCRIPTION
**Summary**
Set GLIBC_TUNABLES to prevent Nuitka from picking up glibc-hwcaps libraries which won't work on older systems. Credit to Reilly Brogan for finding the fix.

**Test Plan**

1. Build from this PR
2. Install package on a Core 2 Duo (just about the oldest platform we support)
3. Check that eopkg4-bin works
4. Check that the packagekit backend works

**Checklist**

- [X] Package was built and tested against unstable
