### PR TITLE
pencil: Add appstream metainfo

### DIFF
--- a/packages/p/pencil/files/vn.evolus.pencil.pencil.metainfo.xml
+++ b/packages/p/pencil/files/vn.evolus.pencil.pencil.metainfo.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>vn.evolus.pencil.pencil</id>
+  
+  <name>Pencil </name>
+  <summary>An open-source GUI prototyping tool</summary>
+  
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-or-later</project_license>
+  
+  <description>
+    <p>
+      Pencil is built for the purpose of providing a free and open-source GUI prototyping tool that people can easily install and use to create mockups in popular desktop platforms.
+    </p>
+  </description>
+  
+  <launchable type="desktop-id">pencil.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://pencil.evolus.vn/images/Pencil-3.1.1-thumb.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://pencil.evolus.vn/images/android-app.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://pencil.evolus.vn/images/stencils.png</image>
+    </screenshot>
+  </screenshots>
+</component>

--- a/packages/p/pencil/package.yml
+++ b/packages/p/pencil/package.yml
@@ -1,6 +1,6 @@
 name       : pencil
 version    : 3.1.1
-release    : 7
+release    : 8
 source     :
     - https://github.com/evolus/pencil/archive/v3.1.1.tar.gz : 84675567281ccdd0d5e273e628cf99a9b76d15245794ef4d38c5bfb2d64c0468
 homepage   : https://pencil.evolus.vn/
@@ -26,9 +26,10 @@ build      : |
 install    : |
     install -Dm00644 $pkgfiles/pencil.desktop $installdir/usr/share/applications/pencil.desktop
     install -Dm00644 $pkgfiles/mimetypes.xml $installdir/usr/share/mime/application/pencil.xml
+    install -Dm00644 $pkgfiles/vn.evolus.pencil.pencil.metainfo.xml -t $installdir/usr/share/metainfo/
 
     for i in 16 24 32 48 64 96 128 256; do
-        install -Dm00644 app/build/icons/${i}x${i}.png $installdir/usr/share/icons/hicolor/${i}x${i}/apps/$name.png
+        install -Dm00644 app/build/icons/${i}x${i}.png $installdir/usr/share/icons/hicolor/${i}x${i}/apps/pencil.png
     done
 
     install -dm00755 $installdir/usr/share/pencil/

--- a/packages/p/pencil/pspec_x86_64.xml
+++ b/packages/p/pencil/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pencil</Name>
         <Homepage>https://pencil.evolus.vn/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>multimedia.graphics</PartOf>
@@ -22,14 +22,15 @@
         <Files>
             <Path fileType="executable">/usr/bin/pencil</Path>
             <Path fileType="data">/usr/share/applications/pencil.desktop</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/16x16/apps/.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/24x24/apps/.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/96x96/apps/.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/pencil.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16/apps/pencil.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24/apps/pencil.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/pencil.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/pencil.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/pencil.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/pencil.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96/apps/pencil.png</Path>
+            <Path fileType="data">/usr/share/metainfo/vn.evolus.pencil.pencil.metainfo.xml</Path>
             <Path fileType="data">/usr/share/mime/application/pencil.xml</Path>
             <Path fileType="data">/usr/share/pencil/LICENSE.electron.txt</Path>
             <Path fileType="data">/usr/share/pencil/LICENSES.chromium.html</Path>
@@ -107,12 +108,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2023-10-26</Date>
+        <Update release="8">
+            <Date>2024-03-05</Date>
             <Version>3.1.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add appstream metainfo (Part of getsolus/packages#1389)

**Test Plan**

Verify metainfo with `appstream-builder --packages-dir=. --include-failed -v`

**Checklist**

- [x] Package was built and tested against unstable