### PR TITLE
audacious: Install appstream metainfo

### DIFF
--- a/packages/a/audacious/package.yml
+++ b/packages/a/audacious/package.yml
@@ -1,6 +1,6 @@
 name       : audacious
 version    : 4.3.1
-release    : 38
+release    : 39
 source     :
     - https://distfiles.audacious-media-player.org/audacious-4.3.1.tar.bz2 : 85e9e26841505b51e342ee72a2d05f19bef894f567a029ebb3f3e0c1adb42042
 homepage   : https://audacious-media-player.org/
@@ -40,3 +40,5 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    # Install appstream metainfo
+    install -Dm00644 contrib/audacious.appdata.xml -t $installdir/usr/share/metainfo/

--- a/packages/a/audacious/pspec_x86_64.xml
+++ b/packages/a/audacious/pspec_x86_64.xml
@@ -4,7 +4,7 @@
         <Homepage>https://audacious-media-player.org/</Homepage>
         <Packager>
             <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>multimedia.audio</PartOf>
@@ -20,7 +20,7 @@
 </Description>
         <PartOf>multimedia.audio</PartOf>
         <RuntimeDependencies>
-            <Dependency release="38">audacious-libs</Dependency>
+            <Dependency release="39">audacious-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/audacious</Path>
@@ -80,6 +80,7 @@
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/audacious.mo</Path>
             <Path fileType="man">/usr/share/man/man1/audacious.1</Path>
             <Path fileType="man">/usr/share/man/man1/audtool.1</Path>
+            <Path fileType="data">/usr/share/metainfo/audacious.appdata.xml</Path>
         </Files>
     </Package>
     <Package>
@@ -106,7 +107,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="38">audacious-libs</Dependency>
+            <Dependency releaseFrom="39">audacious-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/audacious/audtag.h</Path>
@@ -163,12 +164,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="38">
-            <Date>2023-11-26</Date>
+        <Update release="39">
+            <Date>2024-03-05</Date>
             <Version>4.3.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Install appstream metainfo (Part of getsolus/packages#1389)

**Test Plan**

Verify metainfo with `appstream-builder --packages-dir=. --include-failed -v`

**Checklist**

- [x] Package was built and tested against unstable