### PR TITLE
cantata: Add appstream metainfo

### DIFF
--- a/packages/c/cantata/files/io.github.cdrummond.cantata.metainfo.xml
+++ b/packages/c/cantata/files/io.github.cdrummond.cantata.metainfo.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.cdrummond.cantata</id>
+
+  <name>Cantata</name>
+  <summary>Qt5 Graphical MPD Client</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+
+  <description>
+    <p>
+      Cantata is a graphical client for MPD. Cantata started off as a fork of QtMPC, however, the code (and user interface) is now very different to that of QtMPC.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">cantata.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://github.com/CDrummond/cantata/raw/master/screenshots/mainwindow.png</image>
+    </screenshot>
+  </screenshots>
+</component>

--- a/packages/c/cantata/package.yml
+++ b/packages/c/cantata/package.yml
@@ -1,6 +1,6 @@
 name       : cantata
 version    : 2.5.0
-release    : 21
+release    : 22
 source     :
     - https://github.com/CDrummond/cantata/releases/download/v2.5.0/cantata-2.5.0.tar.bz2 : eb7e00ab3f567afaa02ea2c86e2fe811a475afab93182b95922c6eb126821724
 homepage   : https://github.com/CDrummond/cantata
@@ -31,3 +31,5 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    # Install appstream metainfo
+    install -Dm00644 $pkgfiles/io.github.cdrummond.cantata.metainfo.xml -t $installdir/usr/share/metainfo/

--- a/packages/c/cantata/pspec_x86_64.xml
+++ b/packages/c/cantata/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>cantata</Name>
         <Homepage>https://github.com/CDrummond/cantata</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>multimedia.audio</PartOf>
@@ -56,15 +56,16 @@
             <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/cantata.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/cantata.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/symbolic/apps/cantata-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/metainfo/io.github.cdrummond.cantata.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2024-01-20</Date>
+        <Update release="22">
+            <Date>2024-03-05</Date>
             <Version>2.5.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add appstream metainfo (Part of getsolus/packages#1389)

**Test Plan**

Verify metainfo with `appstream-builder --packages-dir=. --include-failed -v`

**Checklist**

- [x] Package was built and tested against unstable