### PR TITLE
deadbeef: Add appstream metainfo 

### DIFF
--- a/packages/d/deadbeef/files/io.sourceforge.deadbeef.deadbeef.metainfo.xml
+++ b/packages/d/deadbeef/files/io.sourceforge.deadbeef.deadbeef.metainfo.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.sourceforge.deadbeef.deadbeef</id>
+
+  <name>DeaDBeeF</name>
+  <summary> DeaDBeeF is a modular cross-platform audio player</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-only and LGPL-2.1-only</project_license>
+
+  <description>
+    <p>
+      DeaDBeeF (as in 0xDEADBEEF) is a modular cross-platform audio player which runs on GNU/Linux distributions, macOS, Windows, *BSD, OpenSolaris, and other UNIX-like systems.
+    </p>
+    <p>
+      DeaDBeeF plays a variety of audio formats, converts between them, lets you customize the UI in almost any way you want, and use many additional plugins which can extend it even more.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">deadbeef.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://deadbeef.sourceforge.io/title_screenshot.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://deadbeef.sourceforge.io/deadbeef-linux-tageditor.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://deadbeef.sourceforge.io/deadbeef-linux-rgscan.png</image>
+    </screenshot>
+  </screenshots>
+</component>

--- a/packages/d/deadbeef/package.yml
+++ b/packages/d/deadbeef/package.yml
@@ -1,6 +1,6 @@
 name       : deadbeef
 version    : 1.9.6
-release    : 50
+release    : 51
 source     :
     - git|https://github.com/DeaDBeeF-Player/deadbeef.git : 1.9.6
 license    :
@@ -42,3 +42,5 @@ build      : |
 install    : |
     %make_install
     rm -r $installdir/usr/share/doc/deadbeef/README
+    # Install appstream metainfo
+    install -Dm00644 $pkgfiles/io.sourceforge.deadbeef.deadbeef.metainfo.xml -t $installdir/usr/share/metainfo/

--- a/packages/d/deadbeef/pspec_x86_64.xml
+++ b/packages/d/deadbeef/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>deadbeef</Name>
         <Homepage>https://deadbeef.sourceforge.io/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <License>LGPL-2.1-only</License>
@@ -253,6 +253,7 @@
             <Path fileType="localedata">/usr/share/locale/vi/LC_MESSAGES/deadbeef.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/deadbeef.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/deadbeef.mo</Path>
+            <Path fileType="data">/usr/share/metainfo/io.sourceforge.deadbeef.deadbeef.metainfo.xml</Path>
         </Files>
     </Package>
     <Package>
@@ -262,7 +263,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="50">deadbeef</Dependency>
+            <Dependency release="51">deadbeef</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/deadbeef/artwork.h</Path>
@@ -272,12 +273,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="50">
-            <Date>2024-01-20</Date>
+        <Update release="51">
+            <Date>2024-03-05</Date>
             <Version>1.9.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add appstream metainfo (Part of getsolus/packages#1389)

**Test Plan**

Verify metainfo with `appstream-builder --packages-dir=. --include-failed -v`

**Checklist**

- [x] Package was built and tested against unstable