### PR TITLE
gpxsee: Update to 13.17

### DIFF
--- a/packages/g/gpxsee/abi_used_symbols
+++ b/packages/g/gpxsee/abi_used_symbols
@@ -675,6 +675,7 @@ libQt5Gui.so.5:_ZN7QCursorC1EN2Qt11CursorShapeE
 libQt5Gui.so.5:_ZN7QCursorC1Ev
 libQt5Gui.so.5:_ZN7QCursorD1Ev
 libQt5Gui.so.5:_ZN7QPixmap12loadFromDataEPKhjPKc6QFlagsIN2Qt19ImageConversionFlagEE
+libQt5Gui.so.5:_ZN7QPixmap16convertFromImageERK6QImage6QFlagsIN2Qt19ImageConversionFlagEE
 libQt5Gui.so.5:_ZN7QPixmap16fromImageInPlaceER6QImage6QFlagsIN2Qt19ImageConversionFlagEE
 libQt5Gui.so.5:_ZN7QPixmap19setDevicePixelRatioEd
 libQt5Gui.so.5:_ZN7QPixmap4fillERK6QColor
@@ -683,7 +684,6 @@ libQt5Gui.so.5:_ZN7QPixmap9fromImageERK6QImage6QFlagsIN2Qt19ImageConversionFlagE
 libQt5Gui.so.5:_ZN7QPixmapC1ERK5QSize
 libQt5Gui.so.5:_ZN7QPixmapC1ERK7QStringPKc6QFlagsIN2Qt19ImageConversionFlagEE
 libQt5Gui.so.5:_ZN7QPixmapC1ERKS_
-libQt5Gui.so.5:_ZN7QPixmapC1Eii
 libQt5Gui.so.5:_ZN7QPixmapC1Ev
 libQt5Gui.so.5:_ZN7QPixmapD1Ev
 libQt5Gui.so.5:_ZN7QPixmapaSERKS_
@@ -1453,7 +1453,6 @@ libQt5Widgets.so.5:_ZNK6QLabel14heightForWidthEi
 libQt5Widgets.so.5:_ZNK6QLabel15minimumSizeHintEv
 libQt5Widgets.so.5:_ZNK6QLabel8sizeHintEv
 libQt5Widgets.so.5:_ZNK7QAction4dataEv
-libQt5Widgets.so.5:_ZNK7QAction4textEv
 libQt5Widgets.so.5:_ZNK7QAction9isCheckedEv
 libQt5Widgets.so.5:_ZNK7QAction9isEnabledEv
 libQt5Widgets.so.5:_ZNK7QDialog15minimumSizeHintEv

--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.16'
-release    : 34
+version    : '13.17'
+release    : 35
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.16.tar.gz : f027ec5bf62c1ac79274e51867157f86c9d93cc61e722f9c1d34989be79addbd
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.17.tar.gz : 047e2d7a22b383b8dc95211ab613e1f5bfae15c6ab915ab9ad3690ab0b924d59
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -136,9 +136,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="34">
-            <Date>2024-02-16</Date>
-            <Version>13.16</Version>
+        <Update release="35">
+            <Date>2024-03-08</Date>
+            <Version>13.17</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Added support for hillshading (IMG & Mapsforge maps).
- Fixed broken "recent files" under KDE/Plasma 6 style.
- Minor fixes (Mapsforge, IMG and ENC maps).

**Test Plan**
- open map file, zoom in and out

**Checklist**
- [X] Package was built and tested against unstable
