### PR TITLE
mpc-qt: Add appstream metainfo

### DIFF
--- a/packages/m/mpc-qt/files/io.github.mpc_qt.mpc_qt.metainfo.xml
+++ b/packages/m/mpc-qt/files/io.github.mpc_qt.mpc_qt.metainfo.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.mpc_qt.mpc_qt</id>
+
+  <name>Media Player Classic Qute Theater</name>
+  <summary>Cross-platform multimedia player</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-or-later</project_license>
+
+  <description>
+    <p>
+      Media Player Classic Qute Theater (&quot;Mpc-Qt&quot;) is a cross-platform multimedia player with a focus on reproducing the interface of Media Player Classic Home Cinema (&quot;Mpc-Hc&quot;).
+    </p>
+  </description>
+
+  <launchable type="desktop-id">mpc-qt.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://mpc-qt.github.io/images/Screenshot_20220226_155532.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://mpc-qt.github.io/images/Screenshot_20220304_221625.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://mpc-qt.github.io/images/Screenshot_20220304_223057.png</image>
+    </screenshot>
+  </screenshots>
+</component>

--- a/packages/m/mpc-qt/package.yml
+++ b/packages/m/mpc-qt/package.yml
@@ -1,6 +1,6 @@
 name       : mpc-qt
 version    : '23.12'
-release    : 10
+release    : 11
 source     :
     - https://github.com/mpc-qt/mpc-qt/archive/refs/tags/v23.12.tar.gz : 6a639bc7911a8972cb7d7e207d3cb24606d2439af2665c373745ae8a6ced65be
 homepage   : https://mpc-qt.github.io
@@ -18,3 +18,5 @@ build      : |
     %make
 install    : |
     %make_install INSTALL_ROOT=$installdir
+    # Install appstream metainfo
+    install -Dm00644 $pkgfiles/io.github.mpc_qt.mpc_qt.metainfo.xml -t $installdir/usr/share/metainfo/

--- a/packages/m/mpc-qt/pspec_x86_64.xml
+++ b/packages/m/mpc-qt/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mpc-qt</Name>
         <Homepage>https://mpc-qt.github.io</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>multimedia.video</PartOf>
@@ -24,15 +24,16 @@
             <Path fileType="data">/usr/share/applications/mpc-qt.desktop</Path>
             <Path fileType="doc">/usr/share/doc/mpc-qt/ipc.md</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/mpc-qt.svg</Path>
+            <Path fileType="data">/usr/share/metainfo/io.github.mpc_qt.mpc_qt.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2024-02-15</Date>
+        <Update release="11">
+            <Date>2024-03-09</Date>
             <Version>23.12</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add appstream metainfo (Part of #1389)

**Test Plan**

Verify metainfo with `appstream-builder --packages-dir=. --include-failed -v`

**Checklist**

- [x] Package was built and tested against unstable