### PR TITLE
handbrake: update to 1.7.3

### DIFF
--- a/packages/h/handbrake/abi_used_symbols
+++ b/packages/h/handbrake/abi_used_symbols
@@ -332,6 +332,7 @@ libc.so.6:unlink
 libc.so.6:unlinkat
 libc.so.6:unsetenv
 libc.so.6:usleep
+libc.so.6:waitid
 libc.so.6:waitpid
 libc.so.6:write
 libc.so.6:writev

--- a/packages/h/handbrake/package.yml
+++ b/packages/h/handbrake/package.yml
@@ -1,8 +1,8 @@
 name       : handbrake
-version    : 1.7.2
-release    : 39
+version    : 1.7.3
+release    : 40
 source     :
-    - https://github.com/HandBrake/HandBrake/releases/download/1.7.2/HandBrake-1.7.2-source.tar.bz2 : 6a0fa23420483a2d74e58f0ad9944931d8f2e65bee63cf17333cbd9cb560ba93
+    - https://github.com/HandBrake/HandBrake/releases/download/1.7.3/HandBrake-1.7.3-source.tar.bz2 : 228681e9f361a69f1e813a112e9029d90fcf89e54172e7ff1863ce1995eae79a
 license    :
     - GPL-2.0-or-later
     - LGPL-2.1-or-later

--- a/packages/h/handbrake/pspec_x86_64.xml
+++ b/packages/h/handbrake/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>handbrake</Name>
         <Homepage>https://handbrake.fr/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -62,12 +62,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="39">
-            <Date>2024-01-17</Date>
-            <Version>1.7.2</Version>
+        <Update release="40">
+            <Date>2024-03-09</Date>
+            <Version>1.7.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/HandBrake/HandBrake/releases/tag/1.7.3).
- Fixes https://github.com/getsolus/packages/issues/1795

**Test plan**
- Encoded a movie.

**Checklist**
- [X] Package was built and tested against unstable.
