### PR TITLE
font-iosevka-ttf: Update to 29.0.0

### DIFF
--- a/packages/f/font-iosevka-ttf/package.yml
+++ b/packages/f/font-iosevka-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : font-iosevka-ttf
-version    : 28.1.0
-release    : 54
+version    : 29.0.0
+release    : 55
 source     :
-    - https://github.com/be5invis/Iosevka/releases/download/v28.1.0/PkgTTF-Iosevka-28.1.0.zip : 3ba0a89dfb29231a2669b78e2684351fffde30d1d96b3f2e93a39704d0b4b7bc
+    - https://github.com/be5invis/Iosevka/releases/download/v29.0.0/PkgTTF-Iosevka-29.0.0.zip : 9f27b64c70e445246e518ce434a226e8a39eeb8e91967862c5772f28fb0fc4dc
 homepage   : https://typeof.net/Iosevka
 license    : OFL-1.1
 component  : desktop.font

--- a/packages/f/font-iosevka-ttf/pspec_x86_64.xml
+++ b/packages/f/font-iosevka-ttf/pspec_x86_64.xml
@@ -78,9 +78,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="54">
-            <Date>2024-02-16</Date>
-            <Version>28.1.0</Version>
+        <Update release="55">
+            <Date>2024-03-09</Date>
+            <Version>29.0.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Added separate serifed variants for digits 2 through 5, current variants are renamed and reordered
- Reorder of glyph variants: I, U, Z, i, l, u, z, Greek Lower Mu (μ), Micro Sign (µ).
- Quasi-proportional will now use a six-unit system instead of four. Metrics of various letters (f, t, r, m, w, etc.) are adjusted
- Add new characters
- Fix a disjoint stroke of Outlined Curly Z under some weights
- Unify diagonal box drawings' angles
- Fix Large Type Piece U+1CE3B
- Added a MOSC feature that turns certain geometric shapes into mosaics
- Fix frac feature for better recognizing fraction patterns
- Fix broken shape of U+1FB95, U+1FB96 and U+1FB97
- Increase weight for U+276E/U+276F
- Fixed ligation for [|]
- [changelog](https://raw.githubusercontent.com/be5invis/Iosevka/main/changes/29.0.0.md)

**Test Plan**
- render text with the font

**Checklist**
- [X] Package was built and tested against unstable
