### PR TITLE
perl-locale-codes:  update to 3.78

### DIFF
--- a/packages/p/perl-locale-codes/monitoring.yml
+++ b/packages/p/perl-locale-codes/monitoring.yml
@@ -1,0 +1,5 @@
+releases:
+  id: 3033
+  # No known CPE, checked 20240309
+security:
+  cpe: ~

--- a/packages/p/perl-locale-codes/package.yml
+++ b/packages/p/perl-locale-codes/package.yml
@@ -1,8 +1,8 @@
 name       : perl-locale-codes
-version    : '3.77'
-release    : 4
+version    : '3.78'
+release    : 5
 source     :
-    - https://cpan.metacpan.org/authors/id/S/SB/SBECK/Locale-Codes-3.77.tar.gz : cf20b1b5000aac1352069f0c9912eb22343dedf83b3ab86e2ca37aec9e4d20c0
+    - https://cpan.metacpan.org/authors/id/S/SB/SBECK/Locale-Codes-3.78.tar.gz : 5529c6d06556a04da1f2e0f13d1335695d04b19370858f6f051e2421687d8b0e
 homepage   : https://metacpan.org/pod/Locale::Codes
 license    : Artistic-1.0-Perl
 component  : programming.perl

--- a/packages/p/perl-locale-codes/pspec_x86_64.xml
+++ b/packages/p/perl-locale-codes/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>perl-locale-codes</Name>
         <Homepage>https://metacpan.org/pod/Locale::Codes</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>Artistic-1.0-Perl</License>
         <PartOf>programming.perl</PartOf>
@@ -79,12 +79,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-01-12</Date>
-            <Version>3.77</Version>
+        <Update release="5">
+            <Date>2024-03-09</Date>
+            <Version>3.78</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Changelog:**

New code(s)

Full changelog available [here](https://metacpan.org/dist/Locale-Codes/view/lib/Locale/Codes/Changes.pod)

Solus:

Add monitoring.yml

**Test Plan**

Installed the module. Verified perl can load it.

```
perl -MLocale::Codes -e 'print $Locale::Codes::VERSION ."\n";'
```

- [x] Package was built and tested against unstable
