### PR TITLE
musescore: Fix icon generation on appstream metainfo

### DIFF
--- a/packages/m/musescore/files/musescore-appdata.diff
+++ b/packages/m/musescore/files/musescore-appdata.diff
@@ -1,0 +1,45 @@
+diff --git a/build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in b/build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in
+index 2ff55728b0..bdb3c4ace8 100644
+--- a/build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in
++++ b/build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in
+@@ -7,13 +7,12 @@
+ 
+         After editing, run either of these commands to check for errors in this file:
+             $  appstreamcli validate [filename]
+-            $  appstream-util validate-relax [filename]
++            $  appstream-util validate [filename]
+     -->
+     <id>org.musescore.MuseScore@MUSESCORE_INSTALL_SUFFIX@</id>
+     <metadata_license>CC0-1.0</metadata_license><!-- License of this file. See <project_license> for MuseScore license. -->
+     <name>MuseScore</name>
+     <summary>Create, play and print beautiful sheet music</summary>
+-    <icon type="stock">mscore@MUSESCORE_INSTALL_SUFFIX@</icon>
+     <description>
+         <p>MuseScore is cross-platform, multi-lingual, open source music notation software. It features an easy to use WYSIWYG editor with audio score playback for results that look and sound beautiful. It supports unlimited staves with up to four voices each, dynamics, articulations, lyrics, chords, lead sheet notation, import/export of MIDI and MusicXML, export to PDF and WAV, plus online score sharing.</p>
+         <p>MuseScore can upload scores directly to the score sharing site musescore.com. Program support is provided on musescore.org.</p>
+@@ -115,6 +114,15 @@
+     </kudos>
+     <!-- Only <releases> below this point please! -->
+     <releases>
++        <release date="2024-01-24" version="4.2.1" />
++        <release date="2023-12-18" version="4.2.0" />
++        <release date="2023-07-26" version="4.1.1">
++            <url>https://github.com/musescore/MuseScore/releases/tag/v4.1.1</url>
++        </release>
++        <release date="2023-07-12" version="4.1.0">
++            <url>https://github.com/musescore/MuseScore/releases/tag/v4.1.0</url>
++        </release>
++        <release date="2023-03-13" version="4.0.2" />
+         <release date="2023-01-13" version="4.0.1">
+             <url>https://musescore.org/en/4.0.1</url>
+         </release>
+@@ -136,9 +137,6 @@
+         <release date="2020-10-09" version="3.5.1">
+             <url>https://musescore.org/en/3.5.1</url>
+         </release>
+-        <release date="2020-10-09" version="3.5.1">
+-            <url>https://musescore.org/en/3.5.1</url>
+-        </release>
+         <release date="2020-08-07" version="3.5">
+             <url>https://musescore.org/en/3.5</url>
+         </release>

--- a/packages/m/musescore/package.yml
+++ b/packages/m/musescore/package.yml
@@ -1,6 +1,6 @@
 name       : musescore
 version    : 4.2.1
-release    : 34
+release    : 35
 source     :
     - https://github.com/musescore/MuseScore/archive/refs/tags/v4.2.1.tar.gz : 9636b303afdb44228dc6d64dbc14773b60840dec7225602d79b126d97f555680
 homepage   : https://musescore.org/
@@ -36,6 +36,8 @@ rundeps    :
     - qt5-quickcontrols
     - qt5-quickcontrols2
 setup      : |
+    # Fix icon on appstream generation taken from Flathub manifest
+    %patch -p1 -i $pkgfiles/musescore-appdata.diff
     %cmake -DCMAKE_BUILD_TYPE=Release \
            -DMUSESCORE_BUILD_MODE=release \
            -DMUE_BUILD_CRASHPAD_CLIENT=OFF \

--- a/packages/m/musescore/pspec_x86_64.xml
+++ b/packages/m/musescore/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>musescore</Name>
         <Homepage>https://musescore.org/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <PartOf>multimedia.audio</PartOf>
@@ -935,12 +935,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="34">
-            <Date>2024-03-03</Date>
+        <Update release="35">
+            <Date>2024-03-10</Date>
             <Version>4.2.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Fix icon generation on appstream metainfo with patch taken from [Flathub manifest](https://github.com/flathub/org.musescore.MuseScore/blob/master/patches/musescore-appdata.diff)