### PR TITLE
python-polib: Reintroduce for git-cola

### DIFF
--- a/packages/g/git-cola/package.yml
+++ b/packages/g/git-cola/package.yml
@@ -1,6 +1,6 @@
 name       : git-cola
 version    : 4.6.1
-release    : 32
+release    : 33
 source     :
     - https://github.com/git-cola/git-cola/archive/refs/tags/v4.6.1.tar.gz : 665019bc23f794d4f9f796bb7ee8e666ed13c9c3a1848fe37fb3541a0a143a64
 homepage   : https://git-cola.github.io
@@ -18,6 +18,7 @@ builddeps  :
 rundeps    :
     - git
     - meld
+    - python-polib
     - python-qtpy
     - python3-qt5
 build      : |

--- a/packages/g/git-cola/pspec_x86_64.xml
+++ b/packages/g/git-cola/pspec_x86_64.xml
@@ -369,8 +369,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2024-03-05</Date>
+        <Update release="33">
+            <Date>2024-03-10</Date>
             <Version>4.6.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Algent Albrahimi</Name>

--- a/packages/py/python-polib/package.yml
+++ b/packages/py/python-polib/package.yml
@@ -1,0 +1,15 @@
+name       : python-polib
+version    : 1.2.0
+release    : 5
+source     :
+    - https://pypi.python.org/packages/source/p/polib/polib-1.2.0.tar.gz : f3ef94aefed6e183e342a8a269ae1fc4742ba193186ad76f175938621dbfc26b
+homepage   : https://github.com/izimobil/polib/
+license    : MIT
+component  : programming.python
+summary    : Python library to manipulate gettext files
+description: |
+    polib is a library to manipulate, create, modify gettext files (pot, po and mo files). You can load existing files, iterate through it’s entries, add, modify entries, comments or metadata, etc… or create new po files from scratch.
+build      : |
+    %python3_setup
+install    : |
+    %python3_install

--- a/packages/py/python-polib/pspec_x86_64.xml
+++ b/packages/py/python-polib/pspec_x86_64.xml
@@ -1,0 +1,40 @@
+<PISI>
+    <Source>
+        <Name>python-polib</Name>
+        <Homepage>https://github.com/izimobil/polib/</Homepage>
+        <Packager>
+            <Name>Algent Albrahimi</Name>
+            <Email>algent@protonmail.com</Email>
+        </Packager>
+        <License>MIT</License>
+        <PartOf>programming.python</PartOf>
+        <Summary xml:lang="en">Python library to manipulate gettext files</Summary>
+        <Description xml:lang="en">polib is a library to manipulate, create, modify gettext files (pot, po and mo files). You can load existing files, iterate through it’s entries, add, modify entries, comments or metadata, etc… or create new po files from scratch.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>python-polib</Name>
+        <Summary xml:lang="en">Python library to manipulate gettext files</Summary>
+        <Description xml:lang="en">polib is a library to manipulate, create, modify gettext files (pot, po and mo files). You can load existing files, iterate through it’s entries, add, modify entries, comments or metadata, etc… or create new po files from scratch.
+</Description>
+        <PartOf>programming.python</PartOf>
+        <Files>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/__pycache__/polib.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/polib-1.2.0-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/polib-1.2.0-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/polib-1.2.0-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/polib-1.2.0-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/polib.py</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="5">
+            <Date>2024-03-10</Date>
+            <Version>1.2.0</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Algent Albrahimi</Name>
+            <Email>algent@protonmail.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**

- Reintroduce `python-polib`. This is a dependency for `git-cola` 

**Test Plan**

- Run `git-cola` to view changes.
- Run `pip3 check` to check broken requirements.

**Checklist**

- [x] Package was built and tested against unstable
