### PR TITLE
clj-kondo: Update to 2024.03.05

### DIFF
--- a/packages/c/clj-kondo/package.yml
+++ b/packages/c/clj-kondo/package.yml
@@ -1,8 +1,8 @@
 name       : clj-kondo
-version    : 2023.12.15
-release    : 8
+version    : 2024.03.05
+release    : 9
 source     :
-    - https://github.com/clj-kondo/clj-kondo/archive/refs/tags/v2023.12.15.tar.gz : 850f057ac134c15cc308cc65e765dda424ef5e9795766a027fc545e2ce08a40a
+    - https://github.com/clj-kondo/clj-kondo/archive/refs/tags/v2024.03.05.tar.gz : 5180ab998f9dfce0dba7629c73fa811656367a90ee4e02ea4c440d45eec1e49c
 homepage   : https://github.com/clj-kondo/clj-kondo/
 license    : EPL-1.0
 component  : programming.tools

--- a/packages/c/clj-kondo/pspec_x86_64.xml
+++ b/packages/c/clj-kondo/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>clj-kondo</Name>
         <Homepage>https://github.com/clj-kondo/clj-kondo/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Oliver Marks</Name>
+            <Email>oly@digitaloctave.com</Email>
         </Packager>
         <License>EPL-1.0</License>
         <PartOf>programming.tools</PartOf>
@@ -24,12 +24,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2024-01-04</Date>
-            <Version>2023.12.15</Version>
+        <Update release="9">
+            <Date>2024-03-11</Date>
+            <Version>2024.03.05</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Oliver Marks</Name>
+            <Email>oly@digitaloctave.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Changelog can be found [here](https://github.com/clj-kondo/clj-kondo/blob/v2024.03.05/CHANGELOG.md)

**Test Plan**

- Installed locally and ran clj-kondo --version to check updated version returned

**Checklist**

- [ ] Package was built and tested against unstable
