### PR TITLE
nushell: Update to 0.91.0

### DIFF
--- a/packages/n/nushell/abi_used_symbols
+++ b/packages/n/nushell/abi_used_symbols
@@ -8,6 +8,7 @@ libc.so.6:__environ
 libc.so.6:__errno_location
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
+libc.so.6:__memmove_chk
 libc.so.6:__memset_chk
 libc.so.6:__pread_chk
 libc.so.6:__register_atfork
@@ -36,7 +37,6 @@ libc.so.6:dlclose
 libc.so.6:dlerror
 libc.so.6:dlopen
 libc.so.6:dlsym
-libc.so.6:dup
 libc.so.6:dup2
 libc.so.6:environ
 libc.so.6:epoll_create
@@ -44,6 +44,7 @@ libc.so.6:epoll_create1
 libc.so.6:epoll_ctl
 libc.so.6:epoll_wait
 libc.so.6:eventfd
+libc.so.6:execv
 libc.so.6:execvp
 libc.so.6:exit
 libc.so.6:fchmod
@@ -73,6 +74,7 @@ libc.so.6:getgid
 libc.so.6:getgrgid
 libc.so.6:getgrgid_r
 libc.so.6:getgrouplist
+libc.so.6:getgroups
 libc.so.6:gethostname
 libc.so.6:getifaddrs
 libc.so.6:getmntent
@@ -99,15 +101,12 @@ libc.so.6:ioctl
 libc.so.6:isatty
 libc.so.6:killpg
 libc.so.6:lchown
-libc.so.6:lgetxattr
 libc.so.6:link
 libc.so.6:linkat
 libc.so.6:listen
-libc.so.6:llistxattr
 libc.so.6:localtime_r
 libc.so.6:lseek
 libc.so.6:lseek64
-libc.so.6:lsetxattr
 libc.so.6:lstat
 libc.so.6:lstat64
 libc.so.6:lutimes
@@ -144,6 +143,7 @@ libc.so.6:posix_spawnattr_setpgroup
 libc.so.6:posix_spawnattr_setsigdefault
 libc.so.6:posix_spawnp
 libc.so.6:pread
+libc.so.6:pread64
 libc.so.6:pthread_attr_destroy
 libc.so.6:pthread_attr_getguardsize
 libc.so.6:pthread_attr_getstack
@@ -173,6 +173,7 @@ libc.so.6:pthread_self
 libc.so.6:pthread_setname_np
 libc.so.6:pthread_setspecific
 libc.so.6:pwrite
+libc.so.6:pwrite64
 libc.so.6:qsort
 libc.so.6:raise
 libc.so.6:read
@@ -203,7 +204,6 @@ libc.so.6:sigaddset
 libc.so.6:sigaltstack
 libc.so.6:sigemptyset
 libc.so.6:signal
-libc.so.6:sigprocmask
 libc.so.6:socket
 libc.so.6:socketpair
 libc.so.6:splice
@@ -225,6 +225,7 @@ libc.so.6:strncpy
 libc.so.6:strnlen
 libc.so.6:strrchr
 libc.so.6:strsignal
+libc.so.6:strspn
 libc.so.6:strstr
 libc.so.6:strtol
 libc.so.6:symlink
@@ -239,8 +240,10 @@ libc.so.6:umask
 libc.so.6:uname
 libc.so.6:unlink
 libc.so.6:unlinkat
+libc.so.6:unsetenv
 libc.so.6:utimensat
 libc.so.6:utimes
+libc.so.6:waitid
 libc.so.6:waitpid
 libc.so.6:write
 libc.so.6:writev
@@ -284,6 +287,8 @@ libcrypto.so.3:X509_up_ref
 libcrypto.so.3:X509_verify_cert_error_string
 libgcc_s.so.1:_Unwind_Backtrace
 libgcc_s.so.1:_Unwind_DeleteException
+libgcc_s.so.1:_Unwind_FindEnclosingFunction
+libgcc_s.so.1:_Unwind_GetCFA
 libgcc_s.so.1:_Unwind_GetDataRelBase
 libgcc_s.so.1:_Unwind_GetIP
 libgcc_s.so.1:_Unwind_GetIPInfo

--- a/packages/n/nushell/package.yml
+++ b/packages/n/nushell/package.yml
@@ -1,10 +1,10 @@
 name       : nushell
-version    : 0.88.1
-release    : 2
+version    : 0.91.0
+release    : 3
 homepage   : https://www.nushell.sh/
 networking : yes
 source     :
-    - https://github.com/nushell/nushell/archive/refs/tags/0.88.1.tar.gz: 19f5a46799142117f61989a76f85fdd24361fe9e5068565d7fff36b91a7a7a39
+    - https://github.com/nushell/nushell/archive/refs/tags/0.91.0.tar.gz : 8957808c3d87b17c6e874b8382e8be45100e83c540556b2c43864c428c2b80b5
 license    : MIT
 component  : system.utils
 summary    : A new type of shell.

--- a/packages/n/nushell/pspec_x86_64.xml
+++ b/packages/n/nushell/pspec_x86_64.xml
@@ -27,12 +27,13 @@
             <Path fileType="executable">/usr/bin/nu_plugin_gstat</Path>
             <Path fileType="executable">/usr/bin/nu_plugin_inc</Path>
             <Path fileType="executable">/usr/bin/nu_plugin_query</Path>
+            <Path fileType="executable">/usr/bin/nu_plugin_stream_example</Path>
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-01-07</Date>
-            <Version>0.88.1</Version>
+        <Update release="3">
+            <Date>2024-03-11</Date>
+            <Version>0.91.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Oliver Marks</Name>
             <Email>oly@digitaloctave.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://www.nushell.sh/blog/2024-03-05-nushell_0_91_0.html#full-changelog-toc).

**Test plan**
- Built installed locally ran nu --version to check version then launched the shell and ran a few commands.

**Checklist**

- [ ] Package was built and tested against unstable
