### PR TITLE
libxfce4ui: Update to 4.18.6

### DIFF
--- a/packages/l/libxfce4ui/monitoring.yml
+++ b/packages/l/libxfce4ui/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 232000
+  rss: https://gitlab.xfce.org/xfce/libxfce4ui/-/tags?format=atom
+# No known CPE. Checked 2024-03-11
+security:
+  cpe: ~

--- a/packages/l/libxfce4ui/package.yml
+++ b/packages/l/libxfce4ui/package.yml
@@ -1,8 +1,8 @@
 name       : libxfce4ui
-version    : 4.18.5
-release    : 7
+version    : 4.18.6
+release    : 8
 source     :
-    - https://archive.xfce.org/src/xfce/libxfce4ui/4.18/libxfce4ui-4.18.5.tar.bz2 : 0dbbf7fc6da07fe743cca020280e1f6cc437cba61698bb0694619fbebf4ee7e7
+    - https://archive.xfce.org/src/xfce/libxfce4ui/4.18/libxfce4ui-4.18.6.tar.bz2 : 77dd99206cc8c6c7f69c269c83c7ee6a037bca9d4a89b1a6d9765e5a09ce30cd
 homepage   : https://docs.xfce.org/xfce/libxfce4ui/start
 license    : GPL-2.0-only
 component  : desktop.xfce

--- a/packages/l/libxfce4ui/pspec_x86_64.xml
+++ b/packages/l/libxfce4ui/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libxfce4ui</Name>
         <Homepage>https://docs.xfce.org/xfce/libxfce4ui/start</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>desktop.xfce</PartOf>
@@ -112,7 +112,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="7">libxfce4ui</Dependency>
+            <Dependency release="8">libxfce4ui</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/xfce4/libxfce4kbd-private-3/libxfce4kbd-private/xfce-shortcut-dialog.h</Path>
@@ -181,12 +181,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2024-02-13</Date>
-            <Version>4.18.5</Version>
+        <Update release="8">
+            <Date>2024-03-11</Date>
+            <Version>4.18.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- shortcuts-grabber: Remove filtering by level

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Updated in a VM and observe that the desktop does not crash upon logging in.

**Checklist**

- [x] Package was built and tested against unstable
