### PR TITLE
pygal: update to 3.0.4

### DIFF
--- a/packages/py/pygal/package.yml
+++ b/packages/py/pygal/package.yml
@@ -1,8 +1,8 @@
 name       : pygal
-version    : 3.0.0
-release    : 6
+version    : 3.0.4
+release    : 7
 source     :
-    - https://github.com/Kozea/pygal/archive/refs/tags/3.0.0.tar.gz : 3bcce2c8353d4b2b2a883490cc1bc50c971e5baca95fcee8ca8133b9c3f9fad6
+    - https://github.com/Kozea/pygal/archive/refs/tags/3.0.4.tar.gz : b36633ad1ec3566b56b953ef43b0452412cf54c2366efb3586f2b01912d7cdb0
 homepage   : https://www.pygal.org/
 license    : LGPL-3.0-or-later
 component  : programming.python

--- a/packages/py/pygal/pspec_x86_64.xml
+++ b/packages/py/pygal/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pygal</Name>
         <Homepage>https://www.pygal.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>LGPL-3.0-or-later</License>
         <PartOf>programming.python</PartOf>
@@ -21,11 +21,11 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/pygal_gen.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pygal-3.0.0-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pygal-3.0.0-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pygal-3.0.0-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pygal-3.0.0-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pygal-3.0.0-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygal-3.0.4-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygal-3.0.4-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygal-3.0.4-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygal-3.0.4-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygal-3.0.4-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygal/__about__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygal/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygal/__pycache__/__about__.cpython-311.pyc</Path>
@@ -170,12 +170,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2024-02-16</Date>
-            <Version>3.0.0</Version>
+        <Update release="7">
+            <Date>2024-03-11</Date>
+            <Version>3.0.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Bump 3.0.4
- No release notes.

**Test plan**
- Verified that it installed correctly.

**Checklist**
- [X] Package was built and tested against unstable.