### PR TITLE
steam: Fix source 1 games when using native runtime

### DIFF
--- a/packages/l/linux-steam-integration/package.yml
+++ b/packages/l/linux-steam-integration/package.yml
@@ -1,9 +1,9 @@
 name       : linux-steam-integration
 version    : 0.7.3
 homepage   : https://github.com/getsolus/linux-steam-integration
-release    : 45
+release    : 46
 source     :
-    - git|https://github.com/getsolus/linux-steam-integration.git : 93d6b89129d970b6203a7d6f6396a26bc6ce3fdb
+    - git|https://github.com/getsolus/linux-steam-integration.git : dffff457d11ecbbb3852a5f6bae813dcfadb3165
 license    : LGPL-2.1-or-later
 component  : games
 summary    : Helper for enabling better Steam integration on Linux

--- a/packages/l/linux-steam-integration/pspec_x86_64.xml
+++ b/packages/l/linux-steam-integration/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>linux-steam-integration</Name>
         <Homepage>https://github.com/getsolus/linux-steam-integration</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>games</PartOf>
         <Summary xml:lang="en">Helper for enabling better Steam integration on Linux</Summary>
         <Description xml:lang="en">A helper shim to enable better Steam* integration on Linux systems. This is part of an effort by Solus to enhance Steam for everyone.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>linux-steam-integration</Name>
@@ -69,12 +69,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="45">
-            <Date>2023-09-22</Date>
+        <Update release="46">
+            <Date>2024-03-12</Date>
             <Version>0.7.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/s/steam/package.yml
+++ b/packages/s/steam/package.yml
@@ -1,6 +1,6 @@
 name       : steam
 version    : 1.0.0.79
-release    : 92
+release    : 93
 source     :
     - https://repo.steampowered.com/steam/pool/steam/s/steam/steam_1.0.0.79.tar.gz : 3a0012daf5889311c2e1dcf33a587b409019b66d893a52192df6947e18f1ec46
 homepage   : https://store.steampowered.com
@@ -14,6 +14,7 @@ rundeps    :
     - alsa-plugins-32bit
     - attr-32bit
     - bzip2-32bit
+    - curl-32bit
     - curl-gnutls-32bit
     - dconf-32bit
     - diffutils

--- a/packages/s/steam/pspec_x86_64.xml
+++ b/packages/s/steam/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>steam</Name>
         <Homepage>https://store.steampowered.com</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>Distributable</License>
         <PartOf>games</PartOf>
@@ -45,12 +45,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="92">
-            <Date>2024-02-09</Date>
+        <Update release="93">
+            <Date>2024-03-12</Date>
             <Version>1.0.0.79</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Blacklist libtcmalloc_minimal.so, in LSI intercept. It's bork
- Add missing rundep on curl-32bit

**Test Plan**

- TF2 now launches, should also fix HL2 DM and others.

**Checklist**

- [x] Package was built and tested against unstable
