### PR TITLE
qutebrowser: update to 3.1.0

### DIFF
--- a/packages/q/qutebrowser/package.yml
+++ b/packages/q/qutebrowser/package.yml
@@ -1,20 +1,20 @@
 name       : qutebrowser
-version    : 2.5.0
-release    : 42
+version    : 3.1.0
+release    : 43
 source     :
-    - https://github.com/qutebrowser/qutebrowser/releases/download/v2.5.0/qutebrowser-2.5.0.tar.gz : e18442a230570f25918a2e89ad4d073ace46c4f59b5fdda2e80ab3c4764451fd
+    - https://github.com/qutebrowser/qutebrowser/archive/refs/tags/v3.1.0.tar.gz : 9307d55f1d9157b7906ac08566e3951bffd6f5b753432deaa9a13681995ba3ca
+homepage   : https://qutebrowser.org
 license    : GPL-3.0-or-later
 component  : network.web.browser
-summary    : A keyboard-driven, vim-like browser based on PyQt5
+summary    : A keyboard-driven, vim-like browser based on PyQt6.
 description: |
-    A keyboard-driven, vim-like browser based on PyQt5.
+    A keyboard-driven, vim-like browser based on PyQt6.
 builddeps  :
     - pkgconfig(python3)
     - asciidoc
 rundeps    :
-    - python3-qt5
     - python-jinja
-    - python-qtwebengine
+    - python-pyqt6-webengine
     - pyyaml
 build      : |
     %make -f misc/Makefile

--- a/packages/q/qutebrowser/pspec_x86_64.xml
+++ b/packages/q/qutebrowser/pspec_x86_64.xml
@@ -1,32 +1,33 @@
 <PISI>
     <Source>
         <Name>qutebrowser</Name>
+        <Homepage>https://qutebrowser.org</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.web.browser</PartOf>
-        <Summary xml:lang="en">A keyboard-driven, vim-like browser based on PyQt5</Summary>
-        <Description xml:lang="en">A keyboard-driven, vim-like browser based on PyQt5.
+        <Summary xml:lang="en">A keyboard-driven, vim-like browser based on PyQt6.</Summary>
+        <Description xml:lang="en">A keyboard-driven, vim-like browser based on PyQt6.
 </Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>qutebrowser</Name>
-        <Summary xml:lang="en">A keyboard-driven, vim-like browser based on PyQt5</Summary>
-        <Description xml:lang="en">A keyboard-driven, vim-like browser based on PyQt5.
+        <Summary xml:lang="en">A keyboard-driven, vim-like browser based on PyQt6.</Summary>
+        <Description xml:lang="en">A keyboard-driven, vim-like browser based on PyQt6.
 </Description>
         <PartOf>network.web.browser</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/qutebrowser</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-2.5.0-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-2.5.0-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-2.5.0-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-2.5.0-py3.11.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-2.5.0-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-2.5.0-py3.11.egg-info/top_level.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-2.5.0-py3.11.egg-info/zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.1.0-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.1.0-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.1.0-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.1.0-py3.11.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.1.0-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.1.0-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.1.0-py3.11.egg-info/zip-safe</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
@@ -35,12 +36,8 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__pycache__/__main__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__pycache__/app.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__pycache__/app.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__pycache__/qt.cpython-311.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__pycache__/qt.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__pycache__/qutebrowser.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__pycache__/qutebrowser.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__pycache__/resources.cpython-311.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__pycache__/resources.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/api/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/api/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/api/__pycache__/__init__.cpython-311.pyc</Path>
@@ -382,17 +379,6 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/bindings.html</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/bookmarks.html</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/dirbrowser.html</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/changelog.html</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/commands.html</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/configuring.html</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/contributing.html</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/faq.html</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/img/cheatsheet-big.png</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/img/cheatsheet-small.png</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/index.html</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/quickstart.html</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/settings.html</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/userscripts.html</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/error.html</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/history.html</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/license.html</Path>
@@ -401,11 +387,28 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/pre.html</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/process.html</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/settings.html</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/startpage.html</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/styled.html</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/tabs.html</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/version.html</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/warning-qt5.html</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/warning-sessions.html</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/warning-webkit.html</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/icons/qutebrowser-128x128.png</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/icons/qutebrowser-16x16.png</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/icons/qutebrowser-24x24.png</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/icons/qutebrowser-256x256.png</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/icons/qutebrowser-32x32.png</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/icons/qutebrowser-48x48.png</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/icons/qutebrowser-512x512.png</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/icons/qutebrowser-64x64.png</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/icons/qutebrowser-96x96.png</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/icons/qutebrowser-all.svg</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/icons/qutebrowser-favicon.svg</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/icons/qutebrowser.icns</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/icons/qutebrowser.ico</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/icons/qutebrowser.svg</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/icons/qutebrowser.xpm</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/img/broken_qutebrowser_logo.png</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/img/file.svg</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/img/folder.svg</Path>
@@ -415,10 +418,9 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/javascript/history.js</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/javascript/pac_utils.js</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/javascript/position_caret.js</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/javascript/quirks/array_at.user.js</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/javascript/quirks/discord.user.js</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/javascript/quirks/globalthis.user.js</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/javascript/quirks/googledocs.user.js</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/javascript/quirks/object_fromentries.user.js</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/javascript/quirks/string_replaceall.user.js</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/javascript/quirks/whatsapp_web.user.js</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/javascript/scroll.js</Path>
@@ -470,6 +472,8 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/__pycache__/backforward.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/__pycache__/bar.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/__pycache__/bar.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/__pycache__/clock.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/__pycache__/clock.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/__pycache__/command.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/__pycache__/command.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/__pycache__/keystring.cpython-311.opt-1.pyc</Path>
@@ -478,6 +482,8 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/__pycache__/percentage.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/__pycache__/progress.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/__pycache__/progress.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/__pycache__/searchmatch.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/__pycache__/searchmatch.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/__pycache__/tabindex.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/__pycache__/tabindex.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/__pycache__/textbase.cpython-311.opt-1.pyc</Path>
@@ -486,10 +492,12 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/__pycache__/url.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/backforward.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/bar.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/clock.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/command.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/keystring.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/percentage.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/progress.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/searchmatch.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/tabindex.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/textbase.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/mainwindow/statusbar/url.py</Path>
@@ -503,6 +511,8 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/autoupdate.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/backendproblem.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/backendproblem.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/binparsing.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/binparsing.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/checkpyver.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/checkpyver.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/cmdhistory.cpython-311.opt-1.pyc</Path>
@@ -535,8 +545,12 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/miscwidgets.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/msgbox.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/msgbox.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/nativeeventfilter.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/nativeeventfilter.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/objects.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/objects.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/pakjoy.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/pakjoy.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/pastebin.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/pastebin.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/quitter.cpython-311.opt-1.pyc</Path>
@@ -555,6 +569,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/__pycache__/utilcmds.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/autoupdate.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/backendproblem.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/binparsing.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/checkpyver.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/cmdhistory.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/consolewidget.py</Path>
@@ -571,7 +586,9 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/lineparser.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/miscwidgets.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/msgbox.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/nativeeventfilter.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/objects.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/pakjoy.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/pastebin.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/quitter.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/savemanager.py</Path>
@@ -580,9 +597,61 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/sql.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/throttle.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/misc/utilcmds.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/_core_pyqtproperty.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/_core_pyqtproperty.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/core.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/core.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/dbus.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/dbus.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/gui.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/gui.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/machinery.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/machinery.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/network.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/network.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/opengl.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/opengl.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/printsupport.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/printsupport.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/qml.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/qml.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/sip.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/sip.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/sql.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/sql.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/test.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/test.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/webenginecore.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/webenginecore.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/webenginewidgets.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/webenginewidgets.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/webkit.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/webkit.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/webkitwidgets.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/webkitwidgets.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/widgets.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/__pycache__/widgets.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/_core_pyqtproperty.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/core.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/dbus.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/gui.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/machinery.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/network.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/opengl.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/printsupport.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/qml.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/sip.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/sql.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/test.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/webenginecore.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/webenginewidgets.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/webkit.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/webkitwidgets.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qt/widgets.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/qutebrowser.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/resources.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/utils/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/utils/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/utils/__pycache__/__init__.cpython-311.pyc</Path>
@@ -602,6 +671,8 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/utils/__pycache__/message.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/utils/__pycache__/objreg.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/utils/__pycache__/objreg.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/utils/__pycache__/qtlog.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/utils/__pycache__/qtlog.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/utils/__pycache__/qtutils.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/utils/__pycache__/qtutils.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/utils/__pycache__/resources.cpython-311.opt-1.pyc</Path>
@@ -626,6 +697,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/utils/log.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/utils/message.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/utils/objreg.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/utils/qtlog.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/utils/qtutils.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/utils/resources.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/utils/standarddir.py</Path>
@@ -669,6 +741,7 @@
             <Path fileType="data">/usr/share/qutebrowser/userscripts/openfeeds</Path>
             <Path fileType="data">/usr/share/qutebrowser/userscripts/password_fill</Path>
             <Path fileType="data">/usr/share/qutebrowser/userscripts/qr</Path>
+            <Path fileType="data">/usr/share/qutebrowser/userscripts/qute-1pass</Path>
             <Path fileType="data">/usr/share/qutebrowser/userscripts/qute-bitwarden</Path>
             <Path fileType="data">/usr/share/qutebrowser/userscripts/qute-keepass</Path>
             <Path fileType="data">/usr/share/qutebrowser/userscripts/qute-keepassxc</Path>
@@ -685,12 +758,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="42">
-            <Date>2024-02-16</Date>
-            <Version>2.5.0</Version>
+        <Update release="43">
+            <Date>2024-03-12</Date>
+            <Version>3.1.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/qutebrowser/qutebrowser/blob/main/doc/changelog.asciidoc).
- Change from QT5 to QT6.

**Test plan**
- Installed, started and checked that it used QT6.

**Checklist**
- [X] Package was built and tested against unstable.