### PR TITLE
Taskfile: Call safety catches as a task instead of precondition

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -167,11 +167,10 @@ tasks:
     preconditions:
       - sh: test $(git symbolic-ref HEAD 2>/dev/null) = "refs/heads/main"
         msg: Not on main branch
-      - sh: "{{ .TASKFILE_DIR }}/common/Scripts/package-publish-safety-catches.sh"
-        msg: Failed to pass safety catches
     deps:
       - package-file
     cmds:
+      - task: run-safety-catches
       - git push
       - task: push
 
@@ -181,10 +180,15 @@ tasks:
     preconditions:
       - sh: test $(git symbolic-ref HEAD 2>/dev/null) = "refs/heads/main"
         msg: Not on main branch
-      - sh: "{{ .TASKFILE_DIR }}/common/Scripts/package-publish-safety-catches.sh"
-        msg: Failed to pass safety catches
     cmds:
+      - task: run-safety-catches
       - task: push
+
+  run-safety-catches:
+    desc: Run safety catches script
+    dir: '{{ .USER_WORKING_DIR }}'
+    cmds:
+      - "{{ .TASKFILE_DIR }}/common/Scripts/package-publish-safety-catches.sh"
 
   push:
     desc: Push package to the build server


### PR DESCRIPTION
**Summary**

Part of #1496 

This changes the `Taskfile.yml` so the `publish` and `republish` tasks run the safety catches script as a task, instead of having it as a precondition. As far as I could learn there is no way to get full output from a precondition in `go-task`, so this is a workaround to get full command output plus the ability to force-through, like in the standalone script.

Old behaviour:

```
λ go-task publish
task: Failed to pass safety catches
task: precondition not met
```

New behaviour:

```
λ go-task publish
task: [run-safety-catches] "/home/thomas/Projects/go-task-test/common/Scripts/package-publish-safety-catches.sh"

Warning: Cannot determine that the release has been bumped
Press y to force-through. If unsure press any other key to abort.n
task: Failed to run task "publish": exit status 1
```

This could also be made into an internal task, but I guess there is some use for it as a standalone one. If it stays as a standalone task it might make sense to also add some preconditions like the existence of a `package-file` and/or a check for .git in the current directory.
