### PR TITLE
quodlibet: update to 2.6.0

### DIFF
--- a/packages/q/quodlibet/package.yml
+++ b/packages/q/quodlibet/package.yml
@@ -1,8 +1,9 @@
 name       : quodlibet
-version    : 4.5.0
-release    : 25
+version    : 4.6.0
+release    : 26
 source     :
-    - https://github.com/quodlibet/quodlibet/releases/download/release-4.5.0/quodlibet-4.5.0.tar.gz : 301615829f652cbafedb35539237162a58bc1ee71a567d249f7789d9268245bc
+    - https://github.com/quodlibet/quodlibet/archive/refs/tags/release-4.6.0.tar.gz : 9134f35fea623b5a6a4cb11d6b7f57e10bfc9844f8e3c7ee6bd92112c6e0ce9e
+homepage   : https://quodlibet.readthedocs.io/
 license    : GPL-2.0-or-later
 component  : multimedia.audio
 summary    : A music library, tagger and player

--- a/packages/q/quodlibet/pspec_x86_64.xml
+++ b/packages/q/quodlibet/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>quodlibet</Name>
+        <Homepage>https://quodlibet.readthedocs.io/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>multimedia.audio</PartOf>
@@ -22,10 +23,10 @@
             <Path fileType="executable">/usr/bin/exfalso</Path>
             <Path fileType="executable">/usr/bin/operon</Path>
             <Path fileType="executable">/usr/bin/quodlibet</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet-4.5.0-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet-4.5.0-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet-4.5.0-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet-4.5.0-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet-4.6.0-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet-4.6.0-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet-4.6.0-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet-4.6.0-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/__pycache__/_import.cpython-311.pyc</Path>
@@ -46,9 +47,9 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/__pycache__/_base.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/__pycache__/audiofeeds.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/__pycache__/filesystem.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/__pycache__/iradio.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/__pycache__/podcasts.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/__pycache__/tracks.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/_base.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/albums/__init__.py</Path>
@@ -59,7 +60,6 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/albums/main.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/albums/models.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/albums/prefs.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/audiofeeds.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/collection/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/collection/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/collection/__pycache__/main.cpython-311.pyc</Path>
@@ -71,9 +71,13 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/covergrid/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/covergrid/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/covergrid/__pycache__/main.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/covergrid/__pycache__/models.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/covergrid/__pycache__/prefs.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/covergrid/__pycache__/widgets.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/covergrid/main.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/covergrid/models.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/covergrid/prefs.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/covergrid/widgets.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/filesystem.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/iradio.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/paned/__init__.py</Path>
@@ -98,6 +102,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/playlists/menu.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/playlists/prefs.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/playlists/util.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/podcasts.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/soundcloud/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/soundcloud/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/browsers/soundcloud/__pycache__/api.cpython-311.pyc</Path>
@@ -165,12 +170,12 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/__pycache__/advanced_preferences.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/__pycache__/appinfo.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/__pycache__/auto_library_update.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/__pycache__/auto_update_tags_in_files.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/__pycache__/automask.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/__pycache__/autorating.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/__pycache__/bansheeimport.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/__pycache__/clock.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/__pycache__/discord_status.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/__pycache__/equalizer.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/__pycache__/gajim_status.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/__pycache__/headphonemon.cpython-311.pyc</Path>
@@ -182,6 +187,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/__pycache__/mqtt.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/__pycache__/musicbrainzsync.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/__pycache__/notify.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/__pycache__/notify_bookmarks.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/__pycache__/qlscrobbler.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/__pycache__/radioadmute.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/__pycache__/randomalbum.cpython-311.pyc</Path>
@@ -214,12 +220,12 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/animosd/osdwindow.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/animosd/prefs.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/appinfo.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/auto_library_update.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/auto_update_tags_in_files.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/automask.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/autorating.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/bansheeimport.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/clock.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/discord_status.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/equalizer.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/gajim_status.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/headphonemon.py</Path>
@@ -227,6 +233,10 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/iradiolog.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/jep118.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/language.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/listenbrainz/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/listenbrainz/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/listenbrainz/__pycache__/listenbrainz.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/listenbrainz/listenbrainz.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/mediaserver.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/mpdserver/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/mpdserver/__pycache__/__init__.cpython-311.pyc</Path>
@@ -245,6 +255,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/mqtt.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/musicbrainzsync.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/notify.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/notify_bookmarks.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/qlscrobbler.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/radioadmute.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/events/randomalbum.py</Path>
@@ -325,10 +336,12 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/query/__pycache__/missing.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/query/__pycache__/pythonexpression.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/query/__pycache__/savedsearch.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/query/__pycache__/unique.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/query/conditional.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/query/missing.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/query/pythonexpression.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/query/savedsearch.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/query/unique.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/songsmenu/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/songsmenu/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/ext/songsmenu/__pycache__/albumart.cpython-311.pyc</Path>
@@ -613,6 +626,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/packages/raven/utils/wsgi.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/packages/raven/versioning.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/packages/senf/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/packages/senf/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/packages/senf/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/packages/senf/__pycache__/_argv.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/packages/senf/__pycache__/_compat.cpython-311.pyc</Path>
@@ -675,10 +689,6 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/plugins/events.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/plugins/gstelement.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/plugins/gui.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/plugins/listenbrainz/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/plugins/listenbrainz/__pycache__/__init__.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/plugins/listenbrainz/__pycache__/listenbrainz.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/plugins/listenbrainz/listenbrainz.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/plugins/playlist.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/plugins/playorder.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/quodlibet/plugins/query.py</Path>
@@ -989,12 +999,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="25">
-            <Date>2024-02-16</Date>
-            <Version>4.5.0</Version>
+        <Update release="26">
+            <Date>2024-03-13</Date>
+            <Version>4.6.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
-  Release notes can be found [here](https://quodlibet.readthedocs.io/en/latest/changelog.html#release-4-6-0).

**Test plan**
- Installed and added some music.

**Checklist**

- [X] Package was built and tested against unstable.