### PR TITLE
xsel: update to 1.2.1

### DIFF
--- a/packages/x/xsel/abi_used_symbols
+++ b/packages/x/xsel/abi_used_symbols
@@ -1,3 +1,4 @@
+libX11.so.6:XAllocClassHint
 libX11.so.6:XChangeProperty
 libX11.so.6:XConvertSelection
 libX11.so.6:XCreateSimpleWindow
@@ -14,19 +15,19 @@ libX11.so.6:XNextEvent
 libX11.so.6:XOpenDisplay
 libX11.so.6:XSelectInput
 libX11.so.6:XSendEvent
+libX11.so.6:XSetClassHint
 libX11.so.6:XSetErrorHandler
 libX11.so.6:XSetSelectionOwner
+libX11.so.6:XStoreName
 libX11.so.6:XSync
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
-libc.so.6:__fxstat
 libc.so.6:__libc_start_main
 libc.so.6:__longjmp_chk
 libc.so.6:__printf_chk
 libc.so.6:__sigsetjmp
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
-libc.so.6:__strdup
 libc.so.6:__vsnprintf_chk
 libc.so.6:_exit
 libc.so.6:chdir
@@ -37,7 +38,7 @@ libc.so.6:fork
 libc.so.6:fputc
 libc.so.6:fputs
 libc.so.6:free
-libc.so.6:fwrite
+libc.so.6:fstat
 libc.so.6:getenv
 libc.so.6:isatty
 libc.so.6:malloc
@@ -58,8 +59,8 @@ libc.so.6:signal
 libc.so.6:sigprocmask
 libc.so.6:stderr
 libc.so.6:stdout
-libc.so.6:stpcpy
 libc.so.6:strcmp
+libc.so.6:strdup
 libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncpy

--- a/packages/x/xsel/package.yml
+++ b/packages/x/xsel/package.yml
@@ -1,8 +1,9 @@
 name       : xsel
-version    : 1.2.0
-release    : 1
+version    : 1.2.1
+release    : 2
 source     :
-    - git|https://github.com/kfish/xsel.git : 3254b787c5ea505585f182c32b7aeaf70767309f
+    - https://github.com/kfish/xsel/archive/refs/tags/1.2.1.tar.gz : 18487761f5ca626a036d65ef2db8ad9923bf61685e06e7533676c56d7d60eb14
+homepage   : http://www.kfish.org/software/xsel/ 
 license    : MIT
 component  : xorg.apps
 summary    : Manipulate the X selection

--- a/packages/x/xsel/pspec_x86_64.xml
+++ b/packages/x/xsel/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>xsel</Name>
+        <Homepage>http://www.kfish.org/software/xsel/</Homepage>
         <Packager>
-            <Name>Ikey Doherty</Name>
-            <Email>ikey@solus-project.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>xorg.apps</PartOf>
         <Summary xml:lang="en">Manipulate the X selection</Summary>
         <Description xml:lang="en">Manipulate the X selection (X11 keyboard, etc.)
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://solus-project.com/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>xsel</Name>
@@ -19,17 +20,17 @@
 </Description>
         <PartOf>xorg.apps</PartOf>
         <Files>
-            <Path fileType="executable">/usr/bin</Path>
-            <Path fileType="man">/usr/share/man</Path>
+            <Path fileType="executable">/usr/bin/xsel</Path>
+            <Path fileType="man">/usr/share/man/man1/xsel.1x</Path>
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2017-08-31</Date>
-            <Version>1.2.0</Version>
+        <Update release="2">
+            <Date>2024-03-13</Date>
+            <Version>1.2.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Ikey Doherty</Name>
-            <Email>ikey@solus-project.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/kfish/xsel/releases/tag/1.2.1j)

**Test plan**
- Installed and verified that the commands worked.

**Checklist**
- [X] Package was built and tested against unstable.