### PR TITLE
budgie-desktop: Fix regressions from 10.9

### DIFF
--- a/packages/b/budgie-desktop/files/fix-run-dialog-in-tasklist.patch
+++ b/packages/b/budgie-desktop/files/fix-run-dialog-in-tasklist.patch
@@ -1,0 +1,23 @@
+From 3bcd2fff2e2e78349c1629ef9a4fd28d8296b834 Mon Sep 17 00:00:00 2001
+From: Joshua Strobl <me@joshuastrobl.com>
+Date: Tue, 6 Feb 2024 22:34:06 +0200
+Subject: [PATCH] fix: set budgie run dialog to skip pager and taskbar
+
+fixes #529
+---
+ src/dialogs/run/RunDialog.vala | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/dialogs/run/RunDialog.vala b/src/dialogs/run/RunDialog.vala
+index 5138e50a5..faa3be5c0 100644
+--- a/src/dialogs/run/RunDialog.vala
++++ b/src/dialogs/run/RunDialog.vala
+@@ -44,6 +44,8 @@ namespace Budgie {
+ 		construct {
+ 			set_keep_above(true);
+ 			set_position(Gtk.WindowPosition.CENTER);
++			set_skip_pager_hint(true);
++			set_skip_taskbar_hint(true);
+ 			Gdk.Visual? visual = screen.get_rgba_visual();
+ 			if (visual != null) {
+ 				this.set_visual(visual);

--- a/packages/b/budgie-desktop/files/workspace-switcher-fix.patch
+++ b/packages/b/budgie-desktop/files/workspace-switcher-fix.patch
@@ -1,0 +1,33 @@
+From 8b4430b6877d2c86acba7d60222875879e3d36a4 Mon Sep 17 00:00:00 2001
+From: Joshua Strobl <me@joshuastrobl.com>
+Date: Sat, 3 Feb 2024 21:04:14 +0200
+Subject: [PATCH] fix: workspace applet window icon click not performing
+ workspace switch
+
+---
+ src/panel/applets/workspaces/WindowIcon.vala | 12 ++++--------
+ 1 file changed, 4 insertions(+), 8 deletions(-)
+
+diff --git a/src/panel/applets/workspaces/WindowIcon.vala b/src/panel/applets/workspaces/WindowIcon.vala
+index 8995be1ba..a9efc0232 100644
+--- a/src/panel/applets/workspaces/WindowIcon.vala
++++ b/src/panel/applets/workspaces/WindowIcon.vala
+@@ -55,14 +55,10 @@ namespace Workspaces {
+ 		public override bool button_release_event(Gdk.EventButton event) {
+ 			if (event.button != 1) return Gdk.EVENT_STOP;
+ 
+-			var workspace = WorkspacesApplet.workspace_group.get_active_workspace();
+-			if (workspace != null && workspace == window.get_workspace()) {
+-				try {
+-					window.activate(event.time);
+-				} catch (Error e) {
+-					warning("Failed to activate window: %s", e.message);
+-				}
+-				return Gdk.EVENT_STOP;
++			try {
++				window.activate(event.time);
++			} catch (Error e) {
++				warning("Failed to activate window: %s", e.message);
+ 			}
+ 			return Gdk.EVENT_STOP;
+ 		}

--- a/packages/b/budgie-desktop/package.yml
+++ b/packages/b/budgie-desktop/package.yml
@@ -1,6 +1,6 @@
 name       : budgie-desktop
 version    : 10.9.1
-release    : 269
+release    : 270
 source     :
     - https://github.com/BuddiesOfBudgie/budgie-desktop/releases/download/v10.9.1/budgie-desktop-v10.9.1.tar.xz : 6971be6e64612e63f460cbd4d37cde8cfa201ebb3b21a4230ffaea1a7abf075a
 homepage   : https://blog.buddiesofbudgie.org
@@ -43,6 +43,9 @@ rundeps    :
     - xdg-desktop-portal-gtk
     - xdotool
 setup      : |
+    %patch -p1 -i $pkgfiles/fix-run-dialog-in-tasklist.patch
+    %patch -p1 -i $pkgfiles/workspace-switcher-fix.patch
+
     %meson_configure -Dwith-stateless=true -Duse-old-zenity=true
 build      : |
     %ninja_build

--- a/packages/b/budgie-desktop/pspec_x86_64.xml
+++ b/packages/b/budgie-desktop/pspec_x86_64.xml
@@ -250,7 +250,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="269">budgie-desktop</Dependency>
+            <Dependency release="270">budgie-desktop</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/budgie-desktop/applet-info.h</Path>
@@ -309,8 +309,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="269">
-            <Date>2024-02-02</Date>
+        <Update release="270">
+            <Date>2024-03-13</Date>
             <Version>10.9.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
- Fix Budgie Run Dialog appearing in the tasklist
- Fix window icons not switching workspace when clicked in the workspace switcher

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

I've been running Budgie Desktop with these patches for a few weeks now.

**Checklist**

- [x] Package was built and tested against unstable
