### PR TITLE
shim-signed: Update to 15.8

### DIFF
--- a/packages/s/shim-signed/package.yml
+++ b/packages/s/shim-signed/package.yml
@@ -1,8 +1,9 @@
 name       : shim-signed
-version    : 15.6
-release    : 5
+version    : '15.8'
+release    : 6
 source     :
-    - https://kojipkgs.fedoraproject.org/packages/shim/15.6/2/x86_64/shim-x64-15.6-2.x86_64.rpm : d6e5d187c979d450d6fe3401dee545617f409b8a31cc90d1e42052f178617be0
+    - https://kojipkgs.fedoraproject.org/packages/shim/15.8/2/x86_64/shim-x64-15.8-2.x86_64.rpm : 955deea3a9b79d1c3e3853e0696215ece966b2adf507ac932ba6a9559cf4775d
+homepage   : https://github.com/rhboot/shim
 license    : BSD-2-Clause
 component  : system.base
 summary    : Initial UEFI bootloader that handles chaining to a trusted full bootloader under secure boot environments. This package contains the version signed by the UEFI signing service.

--- a/packages/s/shim-signed/pspec_x86_64.xml
+++ b/packages/s/shim-signed/pspec_x86_64.xml
@@ -1,6 +1,7 @@
 <PISI>
     <Source>
         <Name>shim-signed</Name>
+        <Homepage>https://github.com/rhboot/shim</Homepage>
         <Packager>
             <Name>Joey Riches</Name>
             <Email>josephriches@gmail.com</Email>
@@ -10,7 +11,7 @@
         <Summary xml:lang="en">Initial UEFI bootloader that handles chaining to a trusted full bootloader under secure boot environments. This package contains the version signed by the UEFI signing service.</Summary>
         <Description xml:lang="en">Initial UEFI bootloader that handles chaining to a trusted full bootloader under secure boot environments. This package contains the version signed by the UEFI signing service.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>shim-signed</Name>
@@ -26,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2023-05-29</Date>
-            <Version>15.6</Version>
+        <Update release="6">
+            <Date>2024-03-14</Date>
+            <Version>15.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Joey Riches</Name>
             <Email>josephriches@gmail.com</Email>


### PR DESCRIPTION
**Summary**
[15.8](https://github.com/rhboot/shim/releases/tag/15.8) [15.7](https://github.com/rhboot/shim/releases/tag/15.7)

**Security**
- CVE-2023-40546
- CVE-2023-40547
- CVE-2023-40548
- CVE-2023-40549
- CVE-2023-40550
- CVE-2023-40551

**Test Plan**

- Install, verify `clr-boot-manager update` is ran as part of usysconf
- Verify sha256sums match
    - /usr/lib64/shim/fbx64.efi /boot/EFI/BOOT/fbx64.efi 2a437f086400b98534aa1d5c8d6d51c78cd20128667481abdbfd83b80e85e151
    - /usr/lib64/shim/mmx64.efi /boot/EFI/com.solus-project/mmx64.efi b22a6c72a83553f5e9a2d40f384a61c1fd122f6363dcfd633234ad8c8fcb94b0
    - /usr/lib64/shim/shimx64.efi /boot/EFI/com.solus-project/bootloaderx64.efi 4773d74d87c2371a25883b59a3b6d98d157de46933676706d215015b1130f2d1
- Reboot successfully, verify secureboot is enabled

**Checklist**

- [x] Package was built and tested against unstable
