### PR TITLE
Taskfile: Fix several tasks that failed when in a worktree

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -224,16 +224,16 @@ tasks:
   init:
     desc: Initialize the packages repo
     cmds:
-      - ln -sf ../../common/Hooks/pre-commit.py .git/hooks/pre-commit
-      - ln -sf ../../common/Hooks/prepare-commit-msg.py .git/hooks/prepare-commit-msg
-      - ln -sf ../../common/Hooks/post-merge.sh .git/hooks/post-merge
-      - ln -sf ../../common/Hooks/post-rewrite.sh .git/hooks/post-rewrite
+      - ln -sf ../../common/Hooks/pre-commit.py $(git rev-parse --git-path hooks)/pre-commit
+      - ln -sf ../../common/Hooks/prepare-commit-msg.py $(git rev-parse --git-path hooks)/prepare-commit-msg
+      - ln -sf ../../common/Hooks/post-merge.sh $(git rev-parse --git-path hooks)/post-merge
+      - ln -sf ../../common/Hooks/post-rewrite.sh $(git rev-parse --git-path hooks)/post-rewrite
 
   pull:
     desc: Pull/rebase latest changes
     dir: '{{ .USER_WORKING_DIR }}'
     preconditions:
-      - test -d .git
+      - git rev-parse --is-inside-work-tree
     cmds:
       - git pull --rebase
 


### PR DESCRIPTION
**Summary**
- Use `git rev-parse --git-path hooks` to find the hooks directory
- Use `git rev-parse --is-inside-work-tree` to find out if we're in an active git repo or not (despite the name this works for the "normal" repo as well as worktrees).