### PR TITLE
eopkg4-bin: Revert progress bar work in packagekit backend

### DIFF
--- a/packages/e/eopkg4-bin/package.yml
+++ b/packages/e/eopkg4-bin/package.yml
@@ -1,9 +1,9 @@
 name       : eopkg4-bin
 version    : 4.0.0
-release    : 9
+release    : 10
 source     :
     - git|https://github.com/getsolus/eopkg : f9226f156db1b6ca71b77134454188dca1ba1bfe
-    - git|https://github.com/getsolus/PackageKit.git : 437b7121846130d3d0ba71b06903dc7c2caa2ae0
+    - git|https://github.com/getsolus/PackageKit.git : 0ae3483c278d909e76b1db9c0b5e3cc710719fac
 homepage   : https://github.com/getsolus/eopkg
 license    : GPL-2.0-or-later
 component  : system.utils

--- a/packages/e/eopkg4-bin/pspec_x86_64.xml
+++ b/packages/e/eopkg4-bin/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>eopkg4-bin</Name>
         <Homepage>https://github.com/getsolus/eopkg</Homepage>
         <Packager>
-            <Name>Rune Morling</Name>
-            <Email>ermo@serpentos.com</Email>
+            <Name>Hans Kelson</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -51,12 +51,12 @@ https://github.com/getsolus/packages/issues/1316
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2024-03-05</Date>
+        <Update release="10">
+            <Date>2024-03-15</Date>
             <Version>4.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Rune Morling</Name>
-            <Email>ermo@serpentos.com</Email>
+            <Name>Hans Kelson</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Revert progress bar work in packagekit backend, as it was breaking package installation


**Test Plan**
- Build the package.
- Install the package. 
- See that PackageKit install operations work using the eopkg4-bin backend.


**Checklist**

- [x] Package was built and tested against unstable
