### PR TITLE
packagekit: Adjust policy rules for package installation/remove

### DIFF
--- a/packages/p/packagekit/files/0001-policy-Change-group-to-sudo-and-allow-package-remove.patch
+++ b/packages/p/packagekit/files/0001-policy-Change-group-to-sudo-and-allow-package-remove.patch
@@ -1,0 +1,30 @@
+From 10821825e5d80dd9112ac43cd444ea77b4b09df8 Mon Sep 17 00:00:00 2001
+From: Joey Riches <josephriches@gmail.com>
+Date: Fri, 15 Mar 2024 22:58:08 +0000
+Subject: [PATCH 1/1] policy: Change group to sudo and allow package-remove
+
+---
+ policy/org.freedesktop.packagekit.rules | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/policy/org.freedesktop.packagekit.rules b/policy/org.freedesktop.packagekit.rules
+index 6a1c8a701..73fdbd51c 100644
+--- a/policy/org.freedesktop.packagekit.rules
++++ b/policy/org.freedesktop.packagekit.rules
+@@ -1,7 +1,12 @@
+ polkit.addRule(function(action, subject) {
+     if (action.id == "org.freedesktop.packagekit.package-install" &&
+         subject.active == true && subject.local == true &&
+-        subject.isInGroup("wheel")) {
++        subject.isInGroup("sudo")) {
++            return polkit.Result.YES;
++    }
++    if (action.id == "org.freedesktop.packagekit.package-remove" &&
++        subject.active == true && subject.local == true &&
++        subject.isInGroup("sudo")) {
+             return polkit.Result.YES;
+     }
+ });
+-- 
+2.44.0
+

--- a/packages/p/packagekit/package.yml
+++ b/packages/p/packagekit/package.yml
@@ -1,6 +1,6 @@
 name       : packagekit
 version    : 1.2.8
-release    : 22
+release    : 23
 source     :
     - git|https://github.com/getsolus/PackageKit.git : 065102d894a7dec5c646a61b151fabc3f2d9c73b
 license    : GPL-2.0-or-later
@@ -25,6 +25,7 @@ builddeps  :
     - vala
 setup      : |
     %patch -p1 -i $pkgfiles/0001-dynamic-backend.patch
+    %patch -p1 -i $pkgfiles/0001-policy-Change-group-to-sudo-and-allow-package-remove.patch
     %meson_configure \
         -Dpackaging_backend=eopkg \
         -Dpythonpackagedir=/usr/lib/python%python3_version%/site-packages/ \

--- a/packages/p/packagekit/pspec_x86_64.xml
+++ b/packages/p/packagekit/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>packagekit</Name>
         <Homepage>https://www.freedesktop.org/software/PackageKit/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>reilly@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>programming.library</PartOf>
@@ -151,7 +151,7 @@ PackageKit is a DBUS abstraction layer that allows the session user to manage pa
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="22">packagekit</Dependency>
+            <Dependency release="23">packagekit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/PackageKit/packagekit-glib2/packagekit.h</Path>
@@ -198,12 +198,12 @@ PackageKit is a DBUS abstraction layer that allows the session user to manage pa
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2024-02-25</Date>
+        <Update release="23">
+            <Date>2024-03-15</Date>
             <Version>1.2.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>reilly@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Allow users in sudo group to remove/install pkgs without prompt

**Test Plan**

`pkcon install pkg; pkcon remove pkg` <- no password prompt if i'm part of sudo group

**Checklist**

- [x] Package was built and tested against unstable
