### PR TITLE
font-iosevka-ttf: Update to 29.0.2

### DIFF
--- a/packages/f/font-iosevka-ttf/package.yml
+++ b/packages/f/font-iosevka-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : font-iosevka-ttf
-version    : 29.0.0
-release    : 55
+version    : 29.0.2
+release    : 56
 source     :
-    - https://github.com/be5invis/Iosevka/releases/download/v29.0.0/PkgTTF-Iosevka-29.0.0.zip : 9f27b64c70e445246e518ce434a226e8a39eeb8e91967862c5772f28fb0fc4dc
+    - https://github.com/be5invis/Iosevka/releases/download/v29.0.2/PkgTTF-Iosevka-29.0.2.zip : ed03aabace0ffbb3869f0129f34d74875305cd0ab57495d4ceb8980fb2f2a3b1
 homepage   : https://typeof.net/Iosevka
 license    : OFL-1.1
 component  : desktop.font

--- a/packages/f/font-iosevka-ttf/pspec_x86_64.xml
+++ b/packages/f/font-iosevka-ttf/pspec_x86_64.xml
@@ -78,9 +78,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="55">
-            <Date>2024-03-09</Date>
-            <Version>29.0.0</Version>
+        <Update release="56">
+            <Date>2024-03-16</Date>
+            <Version>29.0.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Added new characters
- Fix broken s/t variants for U+01BE
- Fix precomposed iota with double marks
- Fix leaning mark placement on letters around i/l
- Fix sans-serif linking for U+2781..U+2784 and U+278B..U+278E

**Test Plan**
- render text with the font

**Checklist**
- [X] Package was built and tested against unstable
