### PR TITLE
tailscale: Update to 1.62.0

### DIFF
--- a/packages/t/tailscale/package.yml
+++ b/packages/t/tailscale/package.yml
@@ -1,8 +1,8 @@
 name       : tailscale
-version    : 1.60.1
-release    : 11
+version    : 1.62.0
+release    : 12
 source     :
-    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.60.1.tar.gz : 9766336845cef4d8b906145bc863f20ec8b9af71051471de45d7f964539a9817
+    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.62.0.tar.gz : 19d91f208a7337b8f2caad030936112c641533d7c1d932a2a8732731e2e80ae5
 homepage   : https://tailscale.com
 license    : BSD-3-Clause
 component  : network.clients

--- a/packages/t/tailscale/pspec_x86_64.xml
+++ b/packages/t/tailscale/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2024-03-02</Date>
-            <Version>1.60.1</Version>
+        <Update release="12">
+            <Date>2024-03-16</Date>
+            <Version>1.62.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- New: Web interface now uses ACL grants to manage access on tagged devices
- Changed: Tailscale SSH connections now disable unnecessary hostname canonicalization
- Changed: tailscale bugreport command for generating diagnostic logs now contain ethtool information
- Changed: Mullvad's family-friendly server is added to the list of well known DNS over HTTPS (DoH) servers
- Changed: DNS over HTTP requests now contain a timeout
- Changed: TCP forwarding attempts in userspace mode now have a per-client limit
- Changed: Endpoints with link-local IPv6 addresses is preferred over private addresses
- Changed: WireGuard logs are less verbose
- Fixed: DERP server region no longer changes if connectivity to the new DERP region is degraded
- Changed: Auto-update version detection on Alpine Linux is improved
- Changed: IPv6 support detection in a container environment is improved
- Fixed: DNS configuration on Amazon Linux 2023 no longer causes an infinite loop

**Test Plan**
- systemctl restart tailscaled; tailscale netcheck

**Checklist**
- [X] Package was built and tested against unstable
