### PR TITLE
kitty: Update to 0.33.0

### DIFF
--- a/packages/k/kitty/abi_symbols
+++ b/packages/k/kitty/abi_symbols
@@ -1,4 +1,11 @@
 fast_data_types.so:PyInit_fast_data_types
+fast_data_types.so:base64_decode
+fast_data_types.so:base64_encode
+fast_data_types.so:base64_stream_decode
+fast_data_types.so:base64_stream_decode_init
+fast_data_types.so:base64_stream_encode
+fast_data_types.so:base64_stream_encode_final
+fast_data_types.so:base64_stream_encode_init
 glfw-wayland.so:glfwAddTimer
 glfw-wayland.so:glfwAreSwapsAllowed
 glfw-wayland.so:glfwCreateCursor

--- a/packages/k/kitty/abi_used_symbols
+++ b/packages/k/kitty/abi_used_symbols
@@ -65,6 +65,7 @@ UNKNOWN:png_set_read_fn
 UNKNOWN:png_set_strip_16
 UNKNOWN:png_set_tRNS_to_alpha
 UNKNOWN:poll
+UNKNOWN:posix_memalign
 UNKNOWN:pread64
 UNKNOWN:pthread_self
 UNKNOWN:pwrite64
@@ -458,6 +459,7 @@ libm.so.6:fminf
 libm.so.6:powf
 libm.so.6:round
 libpython3.11.so.1.0:PyBuffer_Release
+libpython3.11.so.1.0:PyByteArray_Type
 libpython3.11.so.1.0:PyBytes_FromStringAndSize
 libpython3.11.so.1.0:PyCallable_Check
 libpython3.11.so.1.0:PyCapsule_GetPointer
@@ -491,13 +493,13 @@ libpython3.11.so.1.0:PyExc_KeyError
 libpython3.11.so.1.0:PyExc_KeyboardInterrupt
 libpython3.11.so.1.0:PyExc_OSError
 libpython3.11.so.1.0:PyExc_RuntimeError
+libpython3.11.so.1.0:PyExc_SystemError
 libpython3.11.so.1.0:PyExc_TimeoutError
 libpython3.11.so.1.0:PyExc_TypeError
 libpython3.11.so.1.0:PyExc_ValueError
 libpython3.11.so.1.0:PyFloat_AsDouble
 libpython3.11.so.1.0:PyFloat_FromDouble
 libpython3.11.so.1.0:PyFloat_FromString
-libpython3.11.so.1.0:PyFloat_Type
 libpython3.11.so.1.0:PyImport_ImportModule
 libpython3.11.so.1.0:PyIter_Next
 libpython3.11.so.1.0:PyList_Append
@@ -565,10 +567,10 @@ libpython3.11.so.1.0:PyUnicode_AsUTF8
 libpython3.11.so.1.0:PyUnicode_AsUTF8AndSize
 libpython3.11.so.1.0:PyUnicode_CompareWithASCIIString
 libpython3.11.so.1.0:PyUnicode_Concat
+libpython3.11.so.1.0:PyUnicode_CopyCharacters
 libpython3.11.so.1.0:PyUnicode_Decode
 libpython3.11.so.1.0:PyUnicode_DecodeFSDefaultAndSize
 libpython3.11.so.1.0:PyUnicode_DecodeUTF8
-libpython3.11.so.1.0:PyUnicode_FindChar
 libpython3.11.so.1.0:PyUnicode_FromFormat
 libpython3.11.so.1.0:PyUnicode_FromFormatV
 libpython3.11.so.1.0:PyUnicode_FromKindAndData
@@ -586,6 +588,7 @@ libpython3.11.so.1.0:Py_PreInitialize
 libpython3.11.so.1.0:Py_RunMain
 libpython3.11.so.1.0:_PyArg_ParseTupleAndKeywords_SizeT
 libpython3.11.so.1.0:_PyArg_ParseTuple_SizeT
+libpython3.11.so.1.0:_PyByteArray_empty_string
 libpython3.11.so.1.0:_PyBytes_Resize
 libpython3.11.so.1.0:_PyObject_CallFunction_SizeT
 libpython3.11.so.1.0:_PyObject_CallMethod_SizeT

--- a/packages/k/kitty/package.yml
+++ b/packages/k/kitty/package.yml
@@ -1,8 +1,9 @@
 name       : kitty
-version    : 0.32.2
-release    : 62
+version    : 0.33.0
+release    : 63
 source     :
-    - https://github.com/kovidgoyal/kitty/releases/download/v0.32.2/kitty-0.32.2.tar.xz : d4bb54f7bfc16e274d60326323555b63733915c3e32d2ef711fd9860404bd6f2
+    - https://github.com/kovidgoyal/kitty/releases/download/v0.33.0/kitty-0.33.0.tar.xz : 5b11b4edddba41269824df9049d60e22ffc35551446161018dfaf5cd22f77297
+    - git|https://github.com/simd-everywhere/simde.git : v0.7.6
 license    : GPL-3.0-only
 component  : system.utils
 homepage   : https://sw.kovidgoyal.net/kitty/
@@ -30,6 +31,11 @@ rundeps    :
     - libcanberra
     - libpng
     - pygments
+environment: |
+    export CFLAGS="$CFLAGS -I$workdir/include"
+setup      : |
+    mkdir -p $workdir/include
+    cp -R $sources/simde.git/simde $workdir/include/simde
 build      : |
     %make
 install    : |

--- a/packages/k/kitty/pspec_x86_64.xml
+++ b/packages/k/kitty/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>kitty</Name>
         <Homepage>https://sw.kovidgoyal.net/kitty/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Nazar Stasiv</Name>
+            <Email>nazar@autistici.org</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <PartOf>system.utils</PartOf>
@@ -768,12 +768,12 @@ Kitty is designed from the ground up to support all modern terminal features, su
         </Files>
     </Package>
     <History>
-        <Update release="62">
-            <Date>2024-02-19</Date>
-            <Version>0.32.2</Version>
+        <Update release="63">
+            <Date>2024-03-16</Date>
+            <Version>0.33.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Nazar Stasiv</Name>
+            <Email>nazar@autistici.org</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Cheetah speed with a redesigned render loop and a 2x faster escape code parser that uses SIMD CPU vector instruction to parse data in parallel
- A new benchmark kitten (kitten __benchmark__) to measure terminal throughput performance
- Graphics protocol: Add a new delete mode for deleting images whose ids fall within a range. Useful for bulk deletion
- Keyboard protocol: Fix the Enter, Tab and Backspace keys generating spurious release events even when report all keys as escape codes is not set
- Allow specifying where the new tab is created for detach_window
- hints kitten: The option to set the text color for hints now allows arbitrary colors
- icat kitten: Add a command line argument to override terminal window size detection
- A new action toggle_tab to easily switch to and back from a tab with a single shortcut
- When clearing terminal add a new type to_cursor_scroll which can be used to clear to prompt while moving cleared lines into the scrollback
- Fix a performance bottleneck when dealing with thousands of small images
- kitten @ ls: Return the timestamp at which the window was created
- hints kitten: Use default editor rather than hardcoding vim to open file at specific line
- Remote control: Fix --match argument not working for @ls, @send-key, @set-background-image
- Keyboard protocol: Do not deliver a fake key release events on OS window focus out for engaged modifiers
- Ignore startup_session when kitty is invoked with command line options specifying a command to run
- Box drawing: Specialize rendering for the Fira Code progress bar/spinner glyphs

**Test Plan**
- kitty -v

**Checklist**
- [X] Package was built and tested against unstable
