### PR TITLE
strongswan: Update to 5.9.13

### DIFF
--- a/packages/s/strongswan/abi_symbols
+++ b/packages/s/strongswan/abi_symbols
@@ -138,6 +138,7 @@ libcharon.so.0:notify_payload_create
 libcharon.so.0:notify_payload_create_from_protocol_and_type
 libcharon.so.0:notify_type_names
 libcharon.so.0:notify_type_short_names
+libcharon.so.0:ocsp_policy_names
 libcharon.so.0:parser_create
 libcharon.so.0:payload_create
 libcharon.so.0:payload_get_field
@@ -348,6 +349,7 @@ libstrongswan-mgf1.so:mgf1_xof_create
 libstrongswan-nonce.so:nonce_nonceg_create
 libstrongswan-nonce.so:nonce_plugin_create
 libstrongswan-openssl.so:openssl_aead_create
+libstrongswan-openssl.so:openssl_asn1_int2chunk
 libstrongswan-openssl.so:openssl_asn1_known_oid
 libstrongswan-openssl.so:openssl_asn1_obj2chunk
 libstrongswan-openssl.so:openssl_asn1_str2chunk
@@ -356,6 +358,7 @@ libstrongswan-openssl.so:openssl_bn2chunk
 libstrongswan-openssl.so:openssl_bn_cat
 libstrongswan-openssl.so:openssl_bn_split
 libstrongswan-openssl.so:openssl_check_ec_key_curve
+libstrongswan-openssl.so:openssl_check_explicit_params
 libstrongswan-openssl.so:openssl_compute_shared_key
 libstrongswan-openssl.so:openssl_crl_load
 libstrongswan-openssl.so:openssl_crypter_create
@@ -504,6 +507,8 @@ libstrongswan-x509.so:x509_crl_gen
 libstrongswan-x509.so:x509_crl_load
 libstrongswan-x509.so:x509_generate_eku_extension
 libstrongswan-x509.so:x509_ocsp_request_gen
+libstrongswan-x509.so:x509_ocsp_request_load
+libstrongswan-x509.so:x509_ocsp_response_gen
 libstrongswan-x509.so:x509_ocsp_response_load
 libstrongswan-x509.so:x509_parse_authorityKeyIdentifier
 libstrongswan-x509.so:x509_parse_crlDistributionPoints
@@ -523,6 +528,7 @@ libstrongswan.so.0:ASN1_INTEGER_1
 libstrongswan.so.0:ASN1_INTEGER_2
 libstrongswan.so.0:aead_create
 libstrongswan.so.0:allocate_unique_if_ids
+libstrongswan.so.0:allocate_unique_marks
 libstrongswan.so.0:array_bsearch
 libstrongswan.so.0:array_compress
 libstrongswan.so.0:array_count
@@ -601,6 +607,7 @@ libstrongswan.so.0:chunk_from_fd
 libstrongswan.so.0:chunk_from_hex
 libstrongswan.so.0:chunk_hash
 libstrongswan.so.0:chunk_hash_inc
+libstrongswan.so.0:chunk_hash_ptr
 libstrongswan.so.0:chunk_hash_seed
 libstrongswan.so.0:chunk_hash_static
 libstrongswan.so.0:chunk_hash_static_inc
@@ -615,6 +622,7 @@ libstrongswan.so.0:chunk_printf_hook
 libstrongswan.so.0:chunk_split
 libstrongswan.so.0:chunk_to_base32
 libstrongswan.so.0:chunk_to_base64
+libstrongswan.so.0:chunk_to_dec
 libstrongswan.so.0:chunk_to_hex
 libstrongswan.so.0:chunk_unmap
 libstrongswan.so.0:chunk_unmap_clear
@@ -771,7 +779,9 @@ libstrongswan.so.0:metadata_set_put
 libstrongswan.so.0:mkdir_p
 libstrongswan.so.0:mutex_create
 libstrongswan.so.0:nop
+libstrongswan.so.0:ocsp_responders_create
 libstrongswan.so.0:ocsp_response_wrapper_create
+libstrongswan.so.0:ocsp_single_response_create
 libstrongswan.so.0:ocsp_status_names
 libstrongswan.so.0:oid_names
 libstrongswan.so.0:options_create

--- a/packages/s/strongswan/abi_used_symbols
+++ b/packages/s/strongswan/abi_used_symbols
@@ -5,6 +5,10 @@ libc.so.6:__errno_location
 libc.so.6:__explicit_bzero_chk
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoul
+libc.so.6:__isoc23_strtoull
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
@@ -383,6 +387,7 @@ libcrypto.so.3:EVP_PKEY_get_base_id
 libcrypto.so.3:EVP_PKEY_get_bits
 libcrypto.so.3:EVP_PKEY_get_bn_param
 libcrypto.so.3:EVP_PKEY_get_group_name
+libcrypto.so.3:EVP_PKEY_get_int_param
 libcrypto.so.3:EVP_PKEY_get_raw_public_key
 libcrypto.so.3:EVP_PKEY_get_size
 libcrypto.so.3:EVP_PKEY_keygen
@@ -412,6 +417,7 @@ libcrypto.so.3:EVP_shake128
 libcrypto.so.3:EVP_shake256
 libcrypto.so.3:GENERAL_NAME_free
 libcrypto.so.3:IPAddressFamily_free
+libcrypto.so.3:NAME_CONSTRAINTS_free
 libcrypto.so.3:OBJ_get0_data
 libcrypto.so.3:OBJ_length
 libcrypto.so.3:OBJ_nid2obj
@@ -570,6 +576,7 @@ libm.so.6:log
 libm.so.6:pow
 libnm.so.0:nm_connection_get_setting
 libnm.so.0:nm_setting_connection_get_id
+libnm.so.0:nm_setting_connection_get_interface_name
 libnm.so.0:nm_setting_connection_get_type
 libnm.so.0:nm_setting_to_string
 libnm.so.0:nm_setting_vpn_get_data_item

--- a/packages/s/strongswan/monitoring.yml
+++ b/packages/s/strongswan/monitoring.yml
@@ -1,0 +1,13 @@
+releases:
+  id: 4899
+  ignore:
+    # We're not android
+    - "android*"
+    # No betas
+    - "*rc*"
+    - "*dr*"
+  rss: https://github.com/strongswan/strongswan/tags.atom
+security:
+  cpe:
+    - vendor: strongswan
+      product: strongswan

--- a/packages/s/strongswan/package.yml
+++ b/packages/s/strongswan/package.yml
@@ -1,8 +1,9 @@
 name       : strongswan
-version    : 5.9.11
-release    : 9
+version    : 5.9.14
+release    : 10
 source     :
-    - https://download.strongswan.org/strongswan-5.9.11.tar.gz : c0a8160c4d2743d7b998af27a4f268d3ba14b7509c2fd29af96c73685feec0c7
+    - https://download.strongswan.org/strongswan-5.9.14.tar.gz : 7bef87faf92ad5ffa5342a90c326223ccf64864df8b4ee3a506f325d7f833c9e
+homepage   : https://strongswan.org/
 license    : GPL-2.0-or-later
 component  : network.clients
 summary    : An Open Source IPsec-based VPN solution for Linux

--- a/packages/s/strongswan/pspec_x86_64.xml
+++ b/packages/s/strongswan/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>strongswan</Name>
+        <Homepage>https://strongswan.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>network.clients</PartOf>
         <Summary xml:lang="en">An Open Source IPsec-based VPN solution for Linux</Summary>
         <Description xml:lang="en">strongSwan is an Open Source IPsec-based VPN solution for Linux
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>strongswan</Name>
@@ -179,6 +180,7 @@
             <Path fileType="man">/usr/share/man/man1/pki---gen.1</Path>
             <Path fileType="man">/usr/share/man/man1/pki---issue.1</Path>
             <Path fileType="man">/usr/share/man/man1/pki---keyid.1</Path>
+            <Path fileType="man">/usr/share/man/man1/pki---ocsp.1</Path>
             <Path fileType="man">/usr/share/man/man1/pki---pkcs7.1</Path>
             <Path fileType="man">/usr/share/man/man1/pki---print.1</Path>
             <Path fileType="man">/usr/share/man/man1/pki---pub.1</Path>
@@ -255,12 +257,12 @@
         </Conflicts>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2023-08-21</Date>
-            <Version>5.9.11</Version>
+        <Update release="10">
+            <Date>2024-04-19</Date>
+            <Version>5.9.14</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- [5.9.14](https://github.com/strongswan/strongswan/releases/tag/5.9.14)
- [5.9.13](https://github.com/strongswan/strongswan/releases/tag/5.9.13)
- [5.9.12](https://github.com/strongswan/strongswan/releases/tag/5.9.12)

**Security**
- CVE-2023-41913

**Test Plan**

- *TBD*

**Checklist**

- [x] Package was built and tested against unstable
