### PR TITLE
eopkg4-bin: Sync PackageKit Backend with git

### DIFF
--- a/packages/e/eopkg4-bin/package.yml
+++ b/packages/e/eopkg4-bin/package.yml
@@ -1,9 +1,9 @@
 name       : eopkg4-bin
 version    : 4.0.0
-release    : 10
+release    : 11
 source     :
     - git|https://github.com/getsolus/eopkg : f9226f156db1b6ca71b77134454188dca1ba1bfe
-    - git|https://github.com/getsolus/PackageKit.git : 0ae3483c278d909e76b1db9c0b5e3cc710719fac
+    - git|https://github.com/getsolus/PackageKit.git : bee531c98e76c92fb7d41ad4e3795a821be54cbe
 homepage   : https://github.com/getsolus/eopkg
 license    : GPL-2.0-or-later
 component  : system.utils

--- a/packages/e/eopkg4-bin/pspec_x86_64.xml
+++ b/packages/e/eopkg4-bin/pspec_x86_64.xml
@@ -51,8 +51,8 @@ https://github.com/getsolus/packages/issues/1316
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2024-03-15</Date>
+        <Update release="11">
+            <Date>2024-03-17</Date>
             <Version>4.0.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Hans Kelson</Name>


### PR DESCRIPTION
**Summary**
Sync eopkg4-bin's PackageKit backend with latest git, which includes a fix for [broken quick successive operations](https://github.com/getsolus/PackageKit/issues/3).

**Test Plan**
1. Install eopkg4-bin (rel 10) from the repo
2. Install PackageKit
3. Install a package for testing (I'm partial to `0ad`, but use anything)
4. Attempt to remove and quickly reinstall a package with PackageKit: `pkcon remove 0ad; pkcon install 0ad`
5. See that no packages are found on attempted reinstall
6. Build and install the PRed `eopkg4-bin` package
7. Attempt to remove and quickly reinstall the package again: `pkcon remove 0ad; pkcon install 0ad`
8. See that it works now
9. Celebrate!

**Checklist**

- [x] Package was built and tested against unstable
