### PR TITLE
starship: Update to 1.18.0

### DIFF
--- a/packages/s/starship/package.yml
+++ b/packages/s/starship/package.yml
@@ -1,8 +1,8 @@
 name       : starship
-version    : 1.17.0
-release    : 14
+version    : 1.18.0
+release    : 15
 source     :
-    - https://github.com/starship/starship/archive/refs/tags/v1.17.0.tar.gz : 24b6c17b5d948e04149bf35bfc42889ec60168c2a158ae6f90589cd993099ba5
+    - https://github.com/starship/starship/archive/refs/tags/v1.18.0.tar.gz : e387ead17edeccb603b15dc2bd9b61c6541e795e0f4a9d9015015743228c2368
 homepage   : https://starship.rs/
 license    : ISC
 component  : system.utils

--- a/packages/s/starship/pspec_x86_64.xml
+++ b/packages/s/starship/pspec_x86_64.xml
@@ -34,9 +34,9 @@ Easy: quick to install – start using it in minutes.
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2024-01-01</Date>
-            <Version>1.17.0</Version>
+        <Update release="15">
+            <Date>2024-03-21</Date>
+            <Version>1.18.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**

Features:
  - `$gemset` variable for Ruby module
  - bash: Support right prompt and transience
  - bash: use PS0 for preexec hook
  - quarto: Add Quarto module
  - username: add detect_env_vars as option

Fixes:
  - bash: Handle Unbound Variables Errors in Bash
  - bash: improve integration with bash-preexec
  - character: also handle vi edit mode in pwsh
  - git_branch: fall back to "HEAD" when there is no current branch
  - nu: continuation prompt not being displayed correctly
  - status: fix pipestatus width calculation
  - zsh: improve starship binary path escaping

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new shell running Starship, navigate to directories, navigate to a git directory.

**Checklist**

- [x] Package was built and tested against unstable
