### PR TITLE
eza: Update to 0.18.8

### DIFF
--- a/packages/e/eza/package.yml
+++ b/packages/e/eza/package.yml
@@ -1,8 +1,8 @@
 name       : eza
-version    : 0.18.3
-release    : 19
+version    : 0.18.8
+release    : 20
 source     :
-    - https://github.com/eza-community/eza/archive/refs/tags/v0.18.3.tar.gz : 0fccd2751568715d708106a23b570201298c2347a360afc522d7029b432f5206
+    - https://github.com/eza-community/eza/archive/refs/tags/v0.18.8.tar.gz : 4169f57c522cd17e195a7bc36a9ea671e5b1d905f9ab57c66a49f6edf343179c
 homepage   : https://github.com/eza-community/eza
 license    : MIT
 component  : system.utils

--- a/packages/e/eza/pspec_x86_64.xml
+++ b/packages/e/eza/pspec_x86_64.xml
@@ -32,9 +32,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2024-02-18</Date>
-            <Version>0.18.3</Version>
+        <Update release="20">
+            <Date>2024-03-21</Date>
+            <Version>0.18.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Add fennel lang icon and associations
- Bugfix to resolve absolute paths that are not symlinks
- Add filetype and icon for .hh extension
- Fix total-size option
- Add fortran to source filetypes
- Fix `absolute_path()` for broken symlinks
- Add filetype and icon for age
- Adding icons for graphql extensions
- Add nim icons
- Use fsharp icon for fsproj files
- Add new icons, diverse selection
- Add `--absolute` flag
- Classification width should be taken into account with `-F=auto`

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run eza to view files in a directory.

**Checklist**

- [x] Package was built and tested against unstable
