### PR TITLE
github-cli: Update to 2.46.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.45.0
-release    : 42
+version    : 2.46.0
+release    : 43
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.45.0.tar.gz : 61363c109487a17fad44dff3a55f0c7dd36c8d6e4d7b630755705bd3aa34a323
+    - https://github.com/cli/cli/archive/refs/tags/v2.46.0.tar.gz : 663871687310c671ecc183a258fa573622e1e972c681982ac79a25c967fd40b2
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -213,9 +213,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="42">
-            <Date>2024-03-04</Date>
-            <Version>2.45.0</Version>
+        <Update release="43">
+            <Date>2024-03-21</Date>
+            <Version>2.46.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Draft issue IDs are included in project `item-list` output
- New `--dry-run` option for `pr create`
- Bump go-keyring to fix race condition
- PR numbers are prefixed with owner/repo for context
- Extra word removed in `codespaces` code comments
- Clarified description of the `-u`, `--user` option for `gh auth token`
- Fixed formatting for the description of `release upload`
- Clarified the usage of `auth status` to list all authenticated accounts
- Document auth switch behavior for two or more accounts
- Document run watch and view not supporting fine grained PATs

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, `gh pr view 1944` (while in the packages git repo), create this pull request.

**Checklist**

- [x] Package was built and tested against unstable
