### PR TITLE
adw-gtk3-theme: Update to 5.3

### DIFF
--- a/packages/a/adw-gtk3-theme/package.yml
+++ b/packages/a/adw-gtk3-theme/package.yml
@@ -1,8 +1,8 @@
 name       : adw-gtk3-theme
-version    : '5.2'
-release    : 12
+version    : '5.3'
+release    : 13
 source     :
-    - https://github.com/lassekongo83/adw-gtk3/archive/refs/tags/v5.2.tar.gz : 1265b9dbc933bf602da1c419e515752bc8d7b9e6f8a09eafd740315d321501d7
+    - https://github.com/lassekongo83/adw-gtk3/archive/refs/tags/v5.3.tar.gz : 73382b28c7bc1b44ebda4ed7f8f743d8ccd9deb5d429cbd04119753aefe1d392
 license    : LGPL-2.1-only
 homepage   : https://github.com/lassekongo83/adw-gtk3
 component  : desktop.theme

--- a/packages/a/adw-gtk3-theme/pspec_x86_64.xml
+++ b/packages/a/adw-gtk3-theme/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>adw-gtk3-theme</Name>
         <Homepage>https://github.com/lassekongo83/adw-gtk3</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-only</License>
         <PartOf>desktop.theme</PartOf>
@@ -145,12 +145,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2023-12-18</Date>
-            <Version>5.2</Version>
+        <Update release="13">
+            <Date>2024-03-21</Date>
+            <Version>5.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Full changelog available [here](https://github.com/lassekongo83/adw-gtk3/compare/v5.2...v5.3).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Swap to this theme in Budgie and see that the theme changed.

**Checklist**

- [x] Package was built and tested against unstable
