### PR TITLE
protonmail-bridge: update to 3.10.0

### DIFF
--- a/packages/p/protonmail-bridge/package.yml
+++ b/packages/p/protonmail-bridge/package.yml
@@ -1,8 +1,8 @@
 name       : protonmail-bridge
-version    : 3.8.2
-release    : 20
+version    : 3.10.0
+release    : 21
 source     :
-    - https://github.com/ProtonMail/proton-bridge/archive/refs/tags/v3.8.2.tar.gz : 3d844fa74c06767283a73305737e82b9ec7c59cc35d08fcb8a5bd68a128735e2
+    - https://github.com/ProtonMail/proton-bridge/archive/refs/tags/v3.10.0.tar.gz : fe2b048eb3a442a571e469ed376697a7c038189a29f824ffefc00d6fc36ba766
 homepage   : https://proton.me/mail/bridge
 license    : GPL-3.0-or-later
 component  : network.mail

--- a/packages/p/protonmail-bridge/pspec_x86_64.xml
+++ b/packages/p/protonmail-bridge/pspec_x86_64.xml
@@ -28,9 +28,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2024-02-05</Date>
-            <Version>3.8.2</Version>
+        <Update release="21">
+            <Date>2024-03-22</Date>
+            <Version>3.10.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jasper Behrensdorf</Name>
             <Email>solus.citizen140@passmail.net</Email>


### PR DESCRIPTION


**Summary**


**Summarized Changelog**:
- 3.10.0
  - Preserve attachment encoding.
  - Encrypt only with primary key.
- 3.9.1
  - Updated Go version to 1.21.6 and couple of golang libraries.
  - Updated keychain access library.
  - Improved log format and content.
  - Prevented various startup and sync issues.

Link to release notes: https://proton.me/download/bridge/stable_releases.html (not updated for 3.10.0 yet)

**Test Plan**

Synced and sent mail through Thunderbird.

**Checklist**

- [x] Package was built and tested against unstable
