### PR TITLE
usysconf: Backport patch to trigger CBM on shim changes

### DIFF
--- a/packages/u/usysconf/files/handlers-kernel-trigger-cbm-on-shim-changes.patch
+++ b/packages/u/usysconf/files/handlers-kernel-trigger-cbm-on-shim-changes.patch
@@ -1,0 +1,21 @@
+From 2641207c9d9b21d7724f5f4601f710d64ae46359 Mon Sep 17 00:00:00 2001
+From: Joey Riches <josephriches@gmail.com>
+Date: Fri, 22 Mar 2024 20:36:01 +0000
+Subject: [PATCH] handlers/kernel: Trigger clr-boot-manager on shim changes
+
+---
+ src/handlers/kernel/clr-boot-manager.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/handlers/kernel/clr-boot-manager.c b/src/handlers/kernel/clr-boot-manager.c
+index 19ee09c..b9a539e 100644
+--- a/src/handlers/kernel/clr-boot-manager.c
++++ b/src/handlers/kernel/clr-boot-manager.c
+@@ -23,6 +23,7 @@ static const char *boot_paths[] = {
+         KERNEL_DIR,
+         "/usr/lib/goofiboot",
+         "/usr/lib/systemd/boot/efi",
++        "/usr/lib/shim/",
+ };
+ 
+ /**

--- a/packages/u/usysconf/package.yml
+++ b/packages/u/usysconf/package.yml
@@ -1,6 +1,6 @@
 name       : usysconf
 version    : 0.5.6
-release    : 38
+release    : 39
 source     :
     - https://github.com/getsolus/usysconf/releases/download/v0.5.6/usysconf-v0.5.6.tar.xz : 303626bbd180014845fd5f5d266af904a22c795a5ae706374fdf01f42e4ccc53
 homepage   : https://github.com/getsolus/usysconf/
@@ -22,6 +22,8 @@ optimize   :
     - size
     - lto
 setup      : |
+    %patch -p1 -i $pkgfiles/handlers-kernel-trigger-cbm-on-shim-changes.patch
+
     export CC=musl-gcc
     %meson_configure -Dwith-static-binary=true \
                      -Dwith-systemd-reexec=true \

--- a/packages/u/usysconf/pspec_x86_64.xml
+++ b/packages/u/usysconf/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>usysconf</Name>
         <Homepage>https://github.com/getsolus/usysconf/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>system.base</PartOf>
@@ -39,12 +39,12 @@ usysconf is a Solus project.
         </Files>
     </Package>
     <History>
-        <Update release="38">
-            <Date>2024-03-01</Date>
+        <Update release="39">
+            <Date>2024-03-22</Date>
             <Version>0.5.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- So the updated shim files actually get copied to the ESP.

**Test Plan**

- Install, reinstall shim-signed, verify CBM gets triggered

**Checklist**

- [x] Package was built and tested against unstable
