### PR TITLE
repo-wide: Switch back to pkgconfig builddep for freerdp2

### DIFF
--- a/packages/g/gnome-remote-desktop/package.yml
+++ b/packages/g/gnome-remote-desktop/package.yml
@@ -12,7 +12,7 @@ description: |
 builddeps  :
     - pkgconfig(fdk-aac)
     - pkgconfig(ffnvcodec)
-    - freerdp2-devel # FIXME: change back to pkgconfig
+    - pkgconfig(freerdp2)
     - pkgconfig(fuse3)
     - pkgconfig(gbm)
     - pkgconfig(gtk+-3.0)

--- a/packages/k/krdc/package.yml
+++ b/packages/k/krdc/package.yml
@@ -13,7 +13,7 @@ summary    : KDE's remote desktop client
 description: |
     KRDC is a client application that allows you to view or even control the desktop session on another machine that is running a compatible server. VNC and RDP are supported.
 builddeps  :
-    - freerdp2-devel # FIXME: change back to pkgconfig
+    - pkgconfig(freerdp2)
     - pkgconfig(libKActivities)
     - pkgconfig(libssh)
     - pkgconfig(libvncserver)

--- a/packages/v/vinagre/package.yml
+++ b/packages/v/vinagre/package.yml
@@ -11,7 +11,7 @@ description: |
     Vinagre is a remote desktop viewer for GNOME.
 builddeps  :
     - pkgconfig(appstream-glib)
-    - freerdp2-devel # FIXME: change back to pkgconfig
+    - pkgconfig(freerdp2)
     - pkgconfig(gtk+-3.0)
     - pkgconfig(gtk-vnc-2.0)
     - pkgconfig(libsecret-1)

--- a/packages/w/weston/package.yml
+++ b/packages/w/weston/package.yml
@@ -11,7 +11,7 @@ description: |
     Weston is the reference implementation of a Wayland compositor, as well as a useful environment in and of itself. Out of the box, Weston provides a very basic desktop, or a full-featured environment for non-desktop uses such as automotive, embedded, in-flight, industrial, kiosks, set-top boxes and TVs. It also provides a library allowing other projects to build their own full-featured environments on top of Weston's core.
 builddeps  :
     - pkgconfig(colord)
-    - freerdp2-devel # FIXME: change back to pkgconfig
+    - pkgconfig(freerdp2)
     - pkgconfig(gbm)
     - pkgconfig(glu)
     - pkgconfig(gstreamer-plugins-base-1.0)


### PR DESCRIPTION
**Summary**

- Now freerdp(3) and freerdp2 are indexed into the repo it's safe
      to switch back to the pkgconfig after the conflict.
- Depends on #1953 

**Test Plan**

N/A

**Checklist**

- [ ] Package was built and tested against unstable N/A
