### PR TITLE
libhtp: update to 0.5.47

### DIFF
--- a/packages/l/libhtp/abi_symbols
+++ b/packages/l/libhtp/abi_symbols
@@ -131,6 +131,7 @@ libhtp.so.2:htp_config_register_response_trailer
 libhtp.so.2:htp_config_register_response_trailer_data
 libhtp.so.2:htp_config_register_transaction_complete
 libhtp.so.2:htp_config_register_urlencoded_parser
+libhtp.so.2:htp_config_set_allow_space_uri
 libhtp.so.2:htp_config_set_backslash_convert_slashes
 libhtp.so.2:htp_config_set_bestfit_map
 libhtp.so.2:htp_config_set_bestfit_replacement_byte
@@ -143,6 +144,7 @@ libhtp.so.2:htp_config_set_field_limits
 libhtp.so.2:htp_config_set_log_level
 libhtp.so.2:htp_config_set_lzma_layers
 libhtp.so.2:htp_config_set_lzma_memlimit
+libhtp.so.2:htp_config_set_max_tx
 libhtp.so.2:htp_config_set_nul_encoded_terminates
 libhtp.so.2:htp_config_set_nul_encoded_unwanted
 libhtp.so.2:htp_config_set_nul_raw_terminates
@@ -226,12 +228,16 @@ libhtp.so.2:htp_connp_res_data_consumed
 libhtp.so.2:htp_connp_res_receiver_finalize_clear
 libhtp.so.2:htp_connp_set_user_data
 libhtp.so.2:htp_connp_tx_create
+libhtp.so.2:htp_connp_tx_freed
 libhtp.so.2:htp_connp_tx_remove
 libhtp.so.2:htp_convert_method_to_number
 libhtp.so.2:htp_decode_path_inplace
 libhtp.so.2:htp_extract_quoted_string_as_bstr
 libhtp.so.2:htp_get_version
 libhtp.so.2:htp_gzip_decompressor_create
+libhtp.so.2:htp_gzip_decompressor_decompress
+libhtp.so.2:htp_gzip_decompressor_destroy
+libhtp.so.2:htp_header_has_token
 libhtp.so.2:htp_hook_copy
 libhtp.so.2:htp_hook_create
 libhtp.so.2:htp_hook_destroy
@@ -277,6 +283,7 @@ libhtp.so.2:htp_normalize_parsed_uri
 libhtp.so.2:htp_normalize_uri_path_inplace
 libhtp.so.2:htp_parse_authorization
 libhtp.so.2:htp_parse_authorization_basic
+libhtp.so.2:htp_parse_authorization_bearer
 libhtp.so.2:htp_parse_authorization_digest
 libhtp.so.2:htp_parse_chunked_length
 libhtp.so.2:htp_parse_content_length
@@ -377,11 +384,8 @@ libhtp.so.2:htp_urlenp_destroy
 libhtp.so.2:htp_urlenp_finalize
 libhtp.so.2:htp_urlenp_parse_complete
 libhtp.so.2:htp_urlenp_parse_partial
-libhtp.so.2:htp_utf8_decode
 libhtp.so.2:htp_utf8_decode_allow_overlong
 libhtp.so.2:htp_utf8_decode_path_inplace
 libhtp.so.2:htp_utf8_validate_path
 libhtp.so.2:htp_validate_hostname
 libhtp.so.2:lzma_Alloc
-libhtp.so.2:strlcat
-libhtp.so.2:strlcpy

--- a/packages/l/libhtp/abi_used_symbols
+++ b/packages/l/libhtp/abi_used_symbols
@@ -3,7 +3,6 @@ libc.so.6:__ctype_tolower_loc
 libc.so.6:__ctype_toupper_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__memcpy_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__strncat_chk
@@ -26,6 +25,7 @@ libc.so.6:memset
 libc.so.6:mkstemp
 libc.so.6:realloc
 libc.so.6:strdup
+libc.so.6:strlcat
 libc.so.6:strlen
 libc.so.6:strncpy
 libc.so.6:umask

--- a/packages/l/libhtp/package.yml
+++ b/packages/l/libhtp/package.yml
@@ -1,8 +1,9 @@
 name       : libhtp
-version    : 0.5.39
-release    : 7
+version    : 0.5.47
+release    : 8
 source     :
-    - https://github.com/OISF/libhtp/archive/refs/tags/0.5.39.tar.gz : d5956b49314fc6a058864130fbcf040a12584ee1e38f3b6ea52aedfa99d4c14a
+    - https://github.com/OISF/libhtp/archive/refs/tags/0.5.47.tar.gz : 9792ee19e06352f25204af06cd47b53818b572ef351665eb128259363d1a12fb
+homepage   : https://github.com/OISF/libhtp
 license    : BSD-3-Clause
 component  : security.crypto
 summary    : LibHTP is a security-aware parser for the HTTP protocol and the related bits and pieces

--- a/packages/l/libhtp/pspec_x86_64.xml
+++ b/packages/l/libhtp/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>libhtp</Name>
+        <Homepage>https://github.com/OISF/libhtp</Homepage>
         <Packager>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>security.crypto</PartOf>
         <Summary xml:lang="en">LibHTP is a security-aware parser for the HTTP protocol and the related bits and pieces</Summary>
         <Description xml:lang="en">LibHTP is a security-aware parser for the HTTP protocol and the related bits and pieces.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>libhtp</Name>
@@ -30,7 +31,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="7">libhtp</Dependency>
+            <Dependency release="8">libhtp</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/htp/bstr.h</Path>
@@ -56,12 +57,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2021-11-21</Date>
-            <Version>0.5.39</Version>
+        <Update release="8">
+            <Date>2024-03-24</Date>
+            <Version>0.5.47</Version>
             <Comment>Packaging update</Comment>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/OISF/libhtp/blob/0.5.47/ChangeLog).
- Add homepage to package.yml

**Test plan**
- Built suricata against this.

**Checklist**
- [X] Package was built and tested against unstable.