### PR TITLE
gpxsee: Update to 13.18

### DIFF
--- a/packages/g/gpxsee/abi_used_symbols
+++ b/packages/g/gpxsee/abi_used_symbols
@@ -89,6 +89,7 @@ libQt5Core.so.5:_ZN12QMapDataBase18recalcMostLeftNodeEv
 libQt5Core.so.5:_ZN12QMapDataBase20freeNodeAndRebalanceEP12QMapNodeBase
 libQt5Core.so.5:_ZN12QMapDataBase8freeDataEPS_
 libQt5Core.so.5:_ZN12QMapDataBase8freeTreeEP12QMapNodeBasei
+libQt5Core.so.5:_ZN13QJsonDocument11fromVariantERK8QVariant
 libQt5Core.so.5:_ZN13QJsonDocument8fromJsonERK10QByteArrayP15QJsonParseError
 libQt5Core.so.5:_ZN13QJsonDocumentD1Ev
 libQt5Core.so.5:_ZN13QTemporaryDirC1Ev
@@ -238,6 +239,7 @@ libQt5Core.so.5:_ZN8QSysInfo20buildCpuArchitectureEv
 libQt5Core.so.5:_ZN8QVariantC1EPKc
 libQt5Core.so.5:_ZN8QVariantC1ERK10QByteArray
 libQt5Core.so.5:_ZN8QVariantC1ERK4QMapI7QStringS_E
+libQt5Core.so.5:_ZN8QVariantC1ERK5QListIS_E
 libQt5Core.so.5:_ZN8QVariantC1ERK7QPointF
 libQt5Core.so.5:_ZN8QVariantC1ERK7QString
 libQt5Core.so.5:_ZN8QVariantC1ERKS_
@@ -345,8 +347,10 @@ libQt5Core.so.5:_ZNK10QByteArray7toFloatEPb
 libQt5Core.so.5:_ZNK10QByteArray8endsWithEPKc
 libQt5Core.so.5:_ZNK10QByteArray8toBase64Ev
 libQt5Core.so.5:_ZNK10QByteArray8toDoubleEPb
+libQt5Core.so.5:_ZNK10QJsonArray13toVariantListEv
 libQt5Core.so.5:_ZNK10QJsonArray2atEi
 libQt5Core.so.5:_ZNK10QJsonArray4sizeEv
+libQt5Core.so.5:_ZNK10QJsonArray7isEmptyEv
 libQt5Core.so.5:_ZNK10QJsonValue4typeEv
 libQt5Core.so.5:_ZNK10QJsonValue7toArrayEv
 libQt5Core.so.5:_ZNK10QJsonValue8toDoubleEd
@@ -372,8 +376,10 @@ libQt5Core.so.5:_ZNK12QMapNodeBase12previousNodeEv
 libQt5Core.so.5:_ZNK12QMapNodeBase8nextNodeEv
 libQt5Core.so.5:_ZNK13QJsonDocument6isNullEv
 libQt5Core.so.5:_ZNK13QJsonDocument6objectEv
+libQt5Core.so.5:_ZNK13QJsonDocument6toJsonENS_10JsonFormatE
 libQt5Core.so.5:_ZNK13QJsonValueRef7toArrayEv
 libQt5Core.so.5:_ZNK13QJsonValueRef7toValueEv
+libQt5Core.so.5:_ZNK13QJsonValueRef8toObjectEv
 libQt5Core.so.5:_ZNK13QTemporaryDir4pathEv
 libQt5Core.so.5:_ZNK13QTemporaryDir7isValidEv
 libQt5Core.so.5:_ZNK14QMessageLogger7warningEPKcz

--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.17'
-release    : 35
+version    : '13.18'
+release    : 36
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.17.tar.gz : 047e2d7a22b383b8dc95211ab613e1f5bfae15c6ab915ab9ad3690ab0b924d59
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.18.tar.gz : d80d77a271c5ac1857f87c7f5be2c7c1264b7c35a8f4e8f21e225c2b14e3b7da
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -136,9 +136,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="35">
-            <Date>2024-03-08</Date>
-            <Version>13.17</Version>
+        <Update release="36">
+            <Date>2024-03-24</Date>
+            <Version>13.18</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Added support for arbitrary CRSs in GeoJSON files.
- Added support for GeoJSON Coordinate Properties extension.
- CRS database consolidation.
- [changelog](https://build.opensuse.org/projects/home:tumic:GPXSee/packages/gpxsee/files/gpxsee.changes)

**Test Plan**
- open map file, zoom in and out

**Checklist**
- [X] Package was built and tested against unstable
