### PR TITLE
kitty: Update to 0.33.1

### DIFF
--- a/packages/k/kitty/package.yml
+++ b/packages/k/kitty/package.yml
@@ -1,8 +1,8 @@
 name       : kitty
-version    : 0.33.0
-release    : 63
+version    : 0.33.1
+release    : 64
 source     :
-    - https://github.com/kovidgoyal/kitty/releases/download/v0.33.0/kitty-0.33.0.tar.xz : 5b11b4edddba41269824df9049d60e22ffc35551446161018dfaf5cd22f77297
+    - https://github.com/kovidgoyal/kitty/releases/download/v0.33.1/kitty-0.33.1.tar.xz : b7c9af1bdac066099142d3cdf212bf36b83d5610a22c648b66f27b95d5537c7c
     - git|https://github.com/simd-everywhere/simde.git : v0.7.6
 license    : GPL-3.0-only
 component  : system.utils

--- a/packages/k/kitty/pspec_x86_64.xml
+++ b/packages/k/kitty/pspec_x86_64.xml
@@ -768,9 +768,9 @@ Kitty is designed from the ground up to support all modern terminal features, su
         </Files>
     </Package>
     <History>
-        <Update release="63">
-            <Date>2024-03-16</Date>
-            <Version>0.33.0</Version>
+        <Update release="64">
+            <Date>2024-03-23</Date>
+            <Version>0.33.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Fix requesting data via OSC 52 to instead return data from the primary selection
- Allow resizing until one of the halves in a split is minimally sized
- [changelog](https://sw.kovidgoyal.net/kitty/changelog/#id1)

**Test Plan**
- run cli command; view output in pager;

**Checklist**
- [X] Package was built and tested against unstable
