### PR TITLE
transmission: Fix tray icon and add monitoring.yml

### DIFF
--- a/packages/t/transmission/abi_used_libs
+++ b/packages/t/transmission/abi_used_libs
@@ -1,6 +1,7 @@
 UNKNOWN
 ld-linux-x86-64.so.2
 libatkmm-1.6.so.1
+libayatana-appindicator3.so.1
 libc.so.6
 libcairomm-1.0.so.1
 libcrypto.so.3

--- a/packages/t/transmission/abi_used_symbols
+++ b/packages/t/transmission/abi_used_symbols
@@ -49,6 +49,10 @@ UNKNOWN:_ZTIN4Glib6ObjectE
 UNKNOWN:_ZTIN4Glib9InterfaceE
 ld-linux-x86-64.so.2:__tls_get_addr
 libatkmm-1.6.so.1:_ZN3Atk11Implementor21ref_accessibile_vfuncEv
+libayatana-appindicator3.so.1:app_indicator_new
+libayatana-appindicator3.so.1:app_indicator_set_menu
+libayatana-appindicator3.so.1:app_indicator_set_status
+libayatana-appindicator3.so.1:app_indicator_set_title
 libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_tolower_loc
 libc.so.6:__cxa_atexit
@@ -680,6 +684,7 @@ libglibmm-2.4.so.1:_ZNK4Glib7ustring7compareERKS0_
 libglibmm-2.4.so.1:_ZNK4Glib7ustring8casefoldEv
 libglibmm-2.4.so.1:_ZNK4Glib7ustring9lowercaseEv
 libglibmm-2.4.so.1:_ZNK4Glib8DateTime6formatERKNS_7ustringE
+libgobject-2.0.so.0:g_object_unref
 libgobject-2.0.so.0:g_signal_emit_by_name
 libgobject-2.0.so.0:g_type_ensure
 libgobject-2.0.so.0:g_type_from_name
@@ -704,10 +709,6 @@ libgtkmm-3.0.so.1:_ZN3Gtk10SpinButton13get_base_typeEv
 libgtkmm-3.0.so.1:_ZN3Gtk10SpinButton14set_adjustmentERKN4Glib6RefPtrINS_10AdjustmentEEE
 libgtkmm-3.0.so.1:_ZN3Gtk10SpinButton20signal_value_changedEv
 libgtkmm-3.0.so.1:_ZN3Gtk10SpinButton9set_valueEd
-libgtkmm-3.0.so.1:_ZN3Gtk10StatusIcon15signal_activateEv
-libgtkmm-3.0.so.1:_ZN3Gtk10StatusIcon16set_tooltip_textERKN4Glib7ustringE
-libgtkmm-3.0.so.1:_ZN3Gtk10StatusIcon17signal_popup_menuEv
-libgtkmm-3.0.so.1:_ZN3Gtk10StatusIcon6createERKN4Glib7ustringE
 libgtkmm-3.0.so.1:_ZN3Gtk10TextBuffer6createEv
 libgtkmm-3.0.so.1:_ZN3Gtk10TextBuffer8set_textERKN4Glib7ustringE
 libgtkmm-3.0.so.1:_ZN3Gtk11AboutDialog11set_licenseERKN4Glib7ustringE

--- a/packages/t/transmission/monitoring.yml
+++ b/packages/t/transmission/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 5002
+  rss: https://github.com/transmission/transmission/releases.atom
+security:
+  cpe:
+    - vendor: transmissionbt
+      product: transmission

--- a/packages/t/transmission/package.yml
+++ b/packages/t/transmission/package.yml
@@ -1,6 +1,6 @@
 name       : transmission
 version    : 4.0.5
-release    : 25
+release    : 26
 source     :
     - https://github.com/transmission/transmission/releases/download/4.0.5/transmission-4.0.5.tar.xz : fd68ff114a479200043c30c7e69dba4c1932f7af36ca4c5b5d2edcb5866e6357
 homepage   : https://transmissionbt.com/
@@ -11,6 +11,7 @@ description: |
     Transmission provides a simple and easy to use cross-platform lightweight BitTorrent client
 networking : yes # check
 builddeps  :
+    - pkgconfig(ayatana-appindicator3-0.1)
     - pkgconfig(gtkmm-3.0)
     - pkgconfig(libcurl)
     - pkgconfig(libevent)

--- a/packages/t/transmission/pspec_x86_64.xml
+++ b/packages/t/transmission/pspec_x86_64.xml
@@ -139,8 +139,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="25">
-            <Date>2024-02-03</Date>
+        <Update release="26">
+            <Date>2024-03-25</Date>
             <Version>4.0.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>


### PR DESCRIPTION
**Summary**

This adds a dependency on ayatana-appindicator to add support for StatusNotifier trays (like Budgie)

Resolves #1961

**Test Plan**

Confirmed the tray icon now shows up on Budgie

**Checklist**

- [x] Package was built and tested against unstable
