### PR TITLE
newsboat: Update to 2.35

### DIFF
--- a/packages/n/newsboat/abi_used_symbols
+++ b/packages/n/newsboat/abi_used_symbols
@@ -88,6 +88,7 @@ libc.so.6:isalnum
 libc.so.6:isalpha
 libc.so.6:isblank
 libc.so.6:isspace
+libc.so.6:isupper
 libc.so.6:iswprint
 libc.so.6:kill
 libc.so.6:lchown
@@ -155,7 +156,6 @@ libc.so.6:pthread_setname_np
 libc.so.6:pthread_setspecific
 libc.so.6:pwrite64
 libc.so.6:pwritev
-libc.so.6:rand
 libc.so.6:read
 libc.so.6:readdir
 libc.so.6:readdir64
@@ -304,6 +304,7 @@ libstdc++.so.6:_ZNKSt13runtime_error4whatEv
 libstdc++.so.6:_ZNKSt5ctypeIcE13_M_widen_initEv
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE13find_first_ofEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE17find_first_not_ofEPKcmm
+libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEPKcm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEcm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE5rfindEPKcmm
@@ -331,6 +332,9 @@ libstdc++.so.6:_ZNSt13basic_filebufIcSt11char_traitsIcEE5closeEv
 libstdc++.so.6:_ZNSt13basic_filebufIcSt11char_traitsIcEEC1Ev
 libstdc++.so.6:_ZNSt13basic_filebufIcSt11char_traitsIcEED1Ev
 libstdc++.so.6:_ZNSt13basic_fstreamIcSt11char_traitsIcEED1Ev
+libstdc++.so.6:_ZNSt13random_device7_M_finiEv
+libstdc++.so.6:_ZNSt13random_device7_M_initERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+libstdc++.so.6:_ZNSt13random_device9_M_getvalEv
 libstdc++.so.6:_ZNSt13runtime_errorC1EPKc
 libstdc++.so.6:_ZNSt13runtime_errorC1ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
 libstdc++.so.6:_ZNSt13runtime_errorC1ERKS_
@@ -439,7 +443,7 @@ libstdc++.so.6:_ZTVSt14basic_ofstreamIcSt11char_traitsIcEE
 libstdc++.so.6:_ZTVSt15basic_streambufIcSt11char_traitsIcEE
 libstdc++.so.6:_ZTVSt9basic_iosIcSt11char_traitsIcEE
 libstdc++.so.6:_ZdaPv
-libstdc++.so.6:_ZdlPv
+libstdc++.so.6:_ZdlPvm
 libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
 libstdc++.so.6:_ZnwmRKSt9nothrow_t

--- a/packages/n/newsboat/monitoring.yml
+++ b/packages/n/newsboat/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 16651
+  rss: https://github.com/newsboat/newsboat/tags.atom
+# No known CPE, checked 2024-03-19
+security:
+  cpe: ~

--- a/packages/n/newsboat/package.yml
+++ b/packages/n/newsboat/package.yml
@@ -1,8 +1,8 @@
 name       : newsboat
-version    : '2.34'
-release    : 1
+version    : '2.35'
+release    : 2
 source     :
-    - https://newsboat.org/releases/2.34/newsboat-2.34.tar.xz : 73d7b539b0c906f6843a1542e1904a02ae430e79d6be4d6f9e2e2034eac2434e
+    - https://newsboat.org/releases/2.35/newsboat-2.35.tar.xz : f4f003f6ca38e44c0fef01fb6bc8c5ba6b53589c7c87db7b0cc2284e018db6c4
 homepage   : https://newsboat.org/
 license    : MIT
 component  : network.news

--- a/packages/n/newsboat/pspec_x86_64.xml
+++ b/packages/n/newsboat/pspec_x86_64.xml
@@ -88,9 +88,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-03-13</Date>
-            <Version>2.34</Version>
+        <Update release="2">
+            <Date>2024-03-26</Date>
+            <Version>2.35</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
             <Email>malfisya.dev@hotmail.com</Email>


### PR DESCRIPTION
**Summary**

Full changelog can be found [here](https://raw.githubusercontent.com/newsboat/newsboat/r2.35/CHANGELOG.md)

**Test Plan**

Open the app and check news feeds

**Checklist**

- [x] Package was built and tested against unstable