### PR TITLE
calamares: Remove network-manager-livecd in post-install

### DIFF
--- a/packages/c/calamares/files/install/modules/shellprocess_removeliveos.conf
+++ b/packages/c/calamares/files/install/modules/shellprocess_removeliveos.conf
@@ -7,7 +7,7 @@
 dontChroot: false
 
 script:
-    - command: "eopkg rmf -y budgie-desktop-branding-livecd gnome-desktop-branding-livecd mate-desktop-branding-livecd plasma-desktop-branding-livecd xfce4-desktop-branding-livecd"
+    - command: "eopkg rmf -y budgie-desktop-branding-livecd gnome-desktop-branding-livecd mate-desktop-branding-livecd plasma-desktop-branding-livecd xfce4-desktop-branding-livecd network-manager-livecd"
       timeout: 300
     - command: "eopkg rmf -y calamares"
       timeout: 300

--- a/packages/c/calamares/package.yml
+++ b/packages/c/calamares/package.yml
@@ -1,6 +1,6 @@
 name       : calamares
 version    : 3.3.5
-release    : 17
+release    : 18
 source     :
     - https://github.com/calamares/calamares/releases/download/v3.3.5/calamares-3.3.5.tar.gz : 65b11d6bb2ba76fc74fed08faa4b6fe43d1a5bf4a2522b30fc43b44151686c47
 homepage   : https://calamares.io

--- a/packages/c/calamares/pspec_x86_64.xml
+++ b/packages/c/calamares/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>calamares</Name>
         <Homepage>https://calamares.io</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <License>CC-BY-4.0</License>
@@ -289,7 +289,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="17">calamares</Dependency>
+            <Dependency release="18">calamares</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libcalamares/Branding.h</Path>
@@ -409,12 +409,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2024-03-15</Date>
+        <Update release="18">
+            <Date>2024-03-26</Date>
             <Version>3.3.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- accidentally missed during calamares bring up

**Test Plan**

Not tested

**Checklist**

- [x] Package was built and tested against unstable
