### PR TITLE
mate-desktop: Update to 1.28.2

### DIFF
--- a/packages/m/mate-desktop/package.yml
+++ b/packages/m/mate-desktop/package.yml
@@ -1,8 +1,8 @@
 name       : mate-desktop
-version    : 1.28.1
-release    : 33
+version    : 1.28.2
+release    : 34
 source     :
-    - https://github.com/mate-desktop/mate-desktop/releases/download/v1.28.1/mate-desktop-1.28.1.tar.xz : 71ed1bcf775e2cbba4d80a73c33c795d3864e6ce429a37eed875885ac86b206e
+    - https://github.com/mate-desktop/mate-desktop/releases/download/v1.28.2/mate-desktop-1.28.2.tar.xz : 32bb4b792014b391c1e1b8ae9c18a82b4d447650984b4cba7d28e95564964aa2
 license    :
     - GPL-2.0-or-later
     - LGPL-2.0-or-later

--- a/packages/m/mate-desktop/pspec_x86_64.xml
+++ b/packages/m/mate-desktop/pspec_x86_64.xml
@@ -188,7 +188,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="33">mate-desktop</Dependency>
+            <Dependency release="34">mate-desktop</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/mate-desktop-2.0/libmate-desktop/mate-bg-crossfade.h</Path>
@@ -251,9 +251,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2024-03-07</Date>
-            <Version>1.28.1</Version>
+        <Update release="34">
+            <Date>2024-03-25</Date>
+            <Version>1.28.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Make MateImageMenuItem subclassable
- MateImageMenuItem: Remove unnecessary label field

Resolves #1972

**Test Plan**

Launched a MATE session in a VM and on my laptop, used it for a while

**Checklist**

- [x] Package was built and tested against unstable
