### PR TITLE
devedeng: Update to 4.18.0

### DIFF
--- a/packages/d/devedeng/package.yml
+++ b/packages/d/devedeng/package.yml
@@ -1,9 +1,10 @@
 name       : devedeng
-version    : 4.16.0
-release    : 13
+version    : 4.18.0
+release    : 14
 source     :
-    - https://gitlab.com/rastersoft/devedeng/-/archive/4.16.0/devedeng-4.16.0.tar.bz2 : fe2715aa8f73133fc2d809d840fd662dcf9776fcedfb68169984af2e762b5164
-license    : GPL-3.0-only
+    - https://gitlab.com/rastersoft/devedeng/-/archive/4.18.0/devedeng-4.18.0.tar.bz2 : 21b183dcd18592d95a986d564fed54fcfa17d8a565e8e057c7002077a06436dd
+homepage   : https://www.rastersoft.com/programas/devede.html
+license    : GPL-3.0-or-later
 component  : multimedia.video
 summary    : A program to create VideoDVDs and CDs
 description: |
@@ -12,9 +13,8 @@ rundeps    :
     - cdrtools
     - dvdauthor
     - libgtk-3
-    - python-urllib3
-    - python3-cairo
     - python-gobject
+    - python-urllib3
     - vcdimager
 build      : |
     %python3_setup

--- a/packages/d/devedeng/pspec_x86_64.xml
+++ b/packages/d/devedeng/pspec_x86_64.xml
@@ -1,11 +1,12 @@
 <PISI>
     <Source>
         <Name>devedeng</Name>
+        <Homepage>https://www.rastersoft.com/programas/devede.html</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
-        <License>GPL-3.0-only</License>
+        <License>GPL-3.0-or-later</License>
         <PartOf>multimedia.video</PartOf>
         <Summary xml:lang="en">A program to create VideoDVDs and CDs</Summary>
         <Description xml:lang="en">Devede NG is a rewrite of the Devede DVD disc authoring program. This new code has been writen from scratch, and uses Python3 and Gtk3. It is also cleaner, which will allow to add new features in the future.
@@ -21,10 +22,10 @@
         <Files>
             <Path fileType="executable">/usr/bin/copy_files_verbose.py</Path>
             <Path fileType="executable">/usr/bin/devede_ng.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/devedeng-4.16.0-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/devedeng-4.16.0-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/devedeng-4.16.0-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/devedeng-4.16.0-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/devedeng-4.18.0-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/devedeng-4.18.0-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/devedeng-4.18.0-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/devedeng-4.18.0-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/devedeng/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/devedeng/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/devedeng/__pycache__/about.cpython-311.pyc</Path>
@@ -199,6 +200,7 @@
             <Path fileType="localedata">/usr/share/locale/gl/LC_MESSAGES/devedeng.mo</Path>
             <Path fileType="localedata">/usr/share/locale/hu/LC_MESSAGES/devedeng.mo</Path>
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/devedeng.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/devedeng.mo</Path>
             <Path fileType="localedata">/usr/share/locale/nb/LC_MESSAGES/devedeng.mo</Path>
             <Path fileType="localedata">/usr/share/locale/nl/LC_MESSAGES/devedeng.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pl/LC_MESSAGES/devedeng.mo</Path>
@@ -211,16 +213,17 @@
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/devedeng.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/devedeng.mo</Path>
             <Path fileType="man">/usr/share/man/man1/devede.1.gz</Path>
+            <Path fileType="data">/usr/share/metainfo/devedeng.appdata.xml</Path>
             <Path fileType="data">/usr/share/pixmaps/devedeng.svg</Path>
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2024-02-15</Date>
-            <Version>4.16.0</Version>
+        <Update release="14">
+            <Date>2024-03-28</Date>
+            <Version>4.18.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Changelog can be found [here](https://gitlab.com/rastersoft/devedeng/-/raw/4.18.0/HISTORY.md?ref_type=tags)
- Add `homepage` key to `package.yml` (Part of getsolus/packages#411)

**Test Plan**

Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable