### PR TITLE
zstd: Update to v1.5.6

### DIFF
--- a/packages/z/zstd/abi_symbols
+++ b/packages/z/zstd/abi_symbols
@@ -13,6 +13,7 @@ libzstd.so.1:ZDICT_trainFromBuffer_legacy
 libzstd.so.1:ZSTD_CCtxParams_getParameter
 libzstd.so.1:ZSTD_CCtxParams_init
 libzstd.so.1:ZSTD_CCtxParams_init_advanced
+libzstd.so.1:ZSTD_CCtxParams_registerSequenceProducer
 libzstd.so.1:ZSTD_CCtxParams_reset
 libzstd.so.1:ZSTD_CCtxParams_setParameter
 libzstd.so.1:ZSTD_CCtx_getParameter

--- a/packages/z/zstd/abi_symbols32
+++ b/packages/z/zstd/abi_symbols32
@@ -13,6 +13,7 @@ libzstd.so.1:ZDICT_trainFromBuffer_legacy
 libzstd.so.1:ZSTD_CCtxParams_getParameter
 libzstd.so.1:ZSTD_CCtxParams_init
 libzstd.so.1:ZSTD_CCtxParams_init_advanced
+libzstd.so.1:ZSTD_CCtxParams_registerSequenceProducer
 libzstd.so.1:ZSTD_CCtxParams_reset
 libzstd.so.1:ZSTD_CCtxParams_setParameter
 libzstd.so.1:ZSTD_CCtx_getParameter

--- a/packages/z/zstd/abi_used_symbols
+++ b/packages/z/zstd/abi_used_symbols
@@ -4,7 +4,6 @@ libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
 libc.so.6:__libc_single_threaded
 libc.so.6:__libc_start_main
-libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__sysv_signal
 libc.so.6:abort

--- a/packages/z/zstd/monitoring.yml
+++ b/packages/z/zstd/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 12083
+  rss: https://github.com/facebook/zstd/releases.atom
+security:
+  # No known CPE, last checked 2024-03-27
+  cpe: ~

--- a/packages/z/zstd/package.yml
+++ b/packages/z/zstd/package.yml
@@ -1,8 +1,8 @@
 name       : zstd
-version    : 1.5.5
-release    : 30
+version    : 1.5.6
+release    : 31
 source     :
-    - https://github.com/facebook/zstd/releases/download/v1.5.5/zstd-1.5.5.tar.zst : ce264bca60eb2f0e99e4508cffd0d4d19dd362e84244d7fc941e79fa69ccf673
+    - https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-1.5.6.tar.zst : 4aa8dd1c1115c0fd6b6b66c35c7f6ce7bd58cc1dfd3e4f175b45b39e84b14352
 license    :
     - BSD-3-Clause
     - GPL-2.0-or-later
@@ -21,14 +21,19 @@ environment: |
     export PREFIX=/usr LIBDIR=%libdir%
 build      : |
     %make
-    %make manual
-    make zstd-dll -C programs
-    %make -C contrib/pzstd
+    if [ -z "${EMUL32BUILD+set}" ]; then
+        %make manual
+        make zstd-dll -C programs
+        %make -C contrib/pzstd
+    fi
 profile    : |
     %make check
 install    : |
     %make_install
-    install -m00755 contrib/pzstd/pzstd $installdir/usr/bin/pzstd
     rm -v $installdir/%libdir%/*.a
+
+    if [ -z "${EMUL32BUILD+set}" ]; then
+        install -m00755 contrib/pzstd/pzstd $installdir/usr/bin/pzstd
+    fi
 check      : |
     %make -C contrib/pzstd test

--- a/packages/z/zstd/pspec_x86_64.xml
+++ b/packages/z/zstd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>zstd</Name>
         <Homepage>https://facebook.github.io/zstd/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Reilly Brogan</Name>
+            <Email>solus@reillybrogan.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>GPL-2.0-or-later</License>
@@ -29,7 +29,7 @@
             <Path fileType="executable">/usr/bin/zstdless</Path>
             <Path fileType="executable">/usr/bin/zstdmt</Path>
             <Path fileType="library">/usr/lib64/libzstd.so.1</Path>
-            <Path fileType="library">/usr/lib64/libzstd.so.1.5.5</Path>
+            <Path fileType="library">/usr/lib64/libzstd.so.1.5.6</Path>
             <Path fileType="man">/usr/share/man/man1/unzstd.1</Path>
             <Path fileType="man">/usr/share/man/man1/zstd.1</Path>
             <Path fileType="man">/usr/share/man/man1/zstdcat.1</Path>
@@ -44,11 +44,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="30">zstd</Dependency>
+            <Dependency release="31">zstd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libzstd.so.1</Path>
-            <Path fileType="library">/usr/lib32/libzstd.so.1.5.5</Path>
+            <Path fileType="library">/usr/lib32/libzstd.so.1.5.6</Path>
         </Files>
     </Package>
     <Package>
@@ -58,8 +58,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="30">zstd-32bit</Dependency>
-            <Dependency release="30">zstd-devel</Dependency>
+            <Dependency release="31">zstd-32bit</Dependency>
+            <Dependency release="31">zstd-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libzstd.so</Path>
@@ -73,7 +73,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="30">zstd</Dependency>
+            <Dependency release="31">zstd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/zdict.h</Path>
@@ -84,12 +84,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="30">
-            <Date>2023-11-17</Date>
-            <Version>1.5.5</Version>
+        <Update release="31">
+            <Date>2024-03-28</Date>
+            <Version>1.5.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Reilly Brogan</Name>
+            <Email>solus@reillybrogan.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
Release notes available [here](https://github.com/facebook/zstd/releases/tag/v1.5.6)

Note that I had a build failure during the emul32 build in `make zstd-dll -C programs`. Rather than figure this out I opted to just skip that during the emul32 build since it's not needed anyway (we only care about the 32bit shared libs).