### PR TITLE
diffstat: Update to 1.66

### DIFF
--- a/packages/d/diffstat/package.yml
+++ b/packages/d/diffstat/package.yml
@@ -1,12 +1,12 @@
 name       : diffstat
-version    : '1.63'
-release    : 11
+version    : '1.66'
+release    : 12
 source     :
-    - ftp://ftp.invisible-island.net/diffstat/diffstat-1.63.tgz : 7eddd53401b99b90bac3f7ebf23dd583d7d99c6106e67a4f1161b7a20110dc6f
+    - https://invisible-island.net/archives/diffstat/diffstat-1.66.tgz : f54531bbe32e8e0fa461f018b41e3af516b632080172f361f05e50367ecbb69e
+homepage   : https://invisible-island.net/diffstat/diffstat.html
 license    : MIT
 component  : system.devel
-summary    : diffstat reads the output of diff and displays a histogram of the insertions,
-    deletions, and modifications per-file
+summary    : diffstat reads the output of diff and displays a histogram of the insertions, deletions, and modifications per-file
 description: |
     diffstat reads the output of diff and displays a histogram of the insertions, deletions, and modifications per-file. It is useful for reviewing large, complex patch files.
 setup      : |

--- a/packages/d/diffstat/pspec_x86_64.xml
+++ b/packages/d/diffstat/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>diffstat</Name>
+        <Homepage>https://invisible-island.net/diffstat/diffstat.html</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.devel</PartOf>
         <Summary xml:lang="en">diffstat reads the output of diff and displays a histogram of the insertions, deletions, and modifications per-file</Summary>
         <Description xml:lang="en">diffstat reads the output of diff and displays a histogram of the insertions, deletions, and modifications per-file. It is useful for reviewing large, complex patch files.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>diffstat</Name>
@@ -24,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2021-06-17</Date>
-            <Version>1.63</Version>
+        <Update release="12">
+            <Date>2024-03-29</Date>
+            <Version>1.66</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Changelog can be found [here](https://invisible-island.net/diffstat/CHANGES)
- Add `homepage` key to `package.yml` (Part of getsolus/packages#411)

**Test Plan**

- Use `diffstat` on patch file
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable