### PR TITLE
mtr: update to 0.95

### DIFF
--- a/packages/m/mtr/abi_used_symbols
+++ b/packages/m/mtr/abi_used_symbols
@@ -5,7 +5,9 @@ libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fpending
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoul
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__memmove_chk
@@ -38,6 +40,7 @@ libc.so.6:fopen
 libc.so.6:fork
 libc.so.6:fputc
 libc.so.6:free
+libc.so.6:freeaddrinfo
 libc.so.6:freeifaddrs
 libc.so.6:fstat
 libc.so.6:fwrite
@@ -48,7 +51,6 @@ libc.so.6:getenv
 libc.so.6:geteuid
 libc.so.6:getgid
 libc.so.6:gethostbyaddr
-libc.so.6:gethostbyname
 libc.so.6:gethostname
 libc.so.6:getifaddrs
 libc.so.6:getnameinfo
@@ -104,13 +106,16 @@ libc.so.6:strncpy
 libc.so.6:strtod
 libc.so.6:strtok
 libc.so.6:strtol
-libc.so.6:strtoul
 libc.so.6:time
 libc.so.6:waitpid
 libc.so.6:write
 libm.so.6:pow
 libm.so.6:sqrt
 libncursesw.so.6:endwin
+libncursesw.so.6:getcurx
+libncursesw.so.6:getcury
+libncursesw.so.6:getmaxx
+libncursesw.so.6:getmaxy
 libncursesw.so.6:init_pair
 libncursesw.so.6:initscr
 libncursesw.so.6:mvprintw
@@ -122,6 +127,7 @@ libncursesw.so.6:stdscr
 libncursesw.so.6:use_default_colors
 libncursesw.so.6:wattr_off
 libncursesw.so.6:wattr_on
+libncursesw.so.6:wattrset
 libncursesw.so.6:werase
 libncursesw.so.6:wgetch
 libncursesw.so.6:wmove

--- a/packages/m/mtr/package.yml
+++ b/packages/m/mtr/package.yml
@@ -1,8 +1,9 @@
 name       : mtr
-version    : '0.94'
-release    : 7
+version    : '0.95'
+release    : 8
 source     :
-    - https://github.com/traviscross/mtr/archive/refs/tags/v0.94.tar.gz : ea036fdd45da488c241603f6ea59a06bbcfe6c26177ebd34fff54336a44494b8
+    - https://github.com/traviscross/mtr/archive/refs/tags/v0.95.tar.gz : 12490fb660ba5fb34df8c06a0f62b4f9cbd11a584fc3f6eceda0a99124e8596f
+homepage   : https://www.bitwizard.nl/mtr/ 
 license    : GPL-2.0-or-later
 component  : network.utils
 summary    : Combines the functionality of traceroute and ping into one tool (CLI version)

--- a/packages/m/mtr/pspec_x86_64.xml
+++ b/packages/m/mtr/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>mtr</Name>
+        <Homepage>https://www.bitwizard.nl/mtr/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>network.utils</PartOf>
         <Summary xml:lang="en">Combines the functionality of traceroute and ping into one tool (CLI version)</Summary>
         <Description xml:lang="en">Combines the functionality of traceroute and ping into one tool (CLI version)
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>mtr</Name>
@@ -27,12 +28,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2022-03-25</Date>
-            <Version>0.94</Version>
+        <Update release="8">
+            <Date>2024-03-29</Date>
+            <Version>0.95</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/traviscross/mtr/blob/master/NEWS).
- Inclusion of "homepage" to package.yml
- Part of https://github.com/getsolus/packages/issues/411

**Test plan**
- Installed and did som trace routes

**Check list**
- [X] Package was built and tested against unstable