### PR TITLE
pycups: update to 2.0.1

### DIFF
--- a/packages/py/pycups/abi_used_symbols
+++ b/packages/py/pycups/abi_used_symbols
@@ -24,6 +24,8 @@ UNKNOWN:PyExc_TypeError
 UNKNOWN:PyFloat_AsDouble
 UNKNOWN:PyFloat_FromDouble
 UNKNOWN:PyFloat_Type
+UNKNOWN:PyGILState_Ensure
+UNKNOWN:PyGILState_Release
 UNKNOWN:PyList_Append
 UNKNOWN:PyList_GetItem
 UNKNOWN:PyList_New
@@ -53,7 +55,7 @@ UNKNOWN:PyUnicode_DecodeUTF8
 UNKNOWN:PyUnicode_FromEncodedObject
 UNKNOWN:PyUnicode_FromObject
 UNKNOWN:PyUnicode_FromString
-UNKNOWN:PyUnicode_GetSize
+UNKNOWN:PyUnicode_GetLength
 UNKNOWN:Py_BuildValue
 UNKNOWN:_Py_Dealloc
 UNKNOWN:_Py_FalseStruct
@@ -150,7 +152,7 @@ libcups.so.2:cupsStartDocument
 libcups.so.2:cupsUser
 libcups.so.2:cupsWriteRequestData
 libcups.so.2:httpClose
-libcups.so.2:httpConnectEncrypt
+libcups.so.2:httpConnect2
 libcups.so.2:ippAddBoolean
 libcups.so.2:ippAddBooleans
 libcups.so.2:ippAddInteger

--- a/packages/py/pycups/package.yml
+++ b/packages/py/pycups/package.yml
@@ -1,10 +1,11 @@
 name       : pycups
-version    : 1.9.74
-release    : 13
+version    : 2.0.1 
+release    : 14
 source     :
-    - https://pypi.python.org/packages/source/p/pycups/pycups-1.9.74.tar.bz2 : 86090f259a7c5d0d5caa3407a0e57c9e134027620cbc8f90bf4e37c8b53ed7b9
+    - https://files.pythonhosted.org/packages/0c/bb/82546806a86dc16f5eeb76f62ffdc42cce3d43aacd4e25a8b5300eec0263/pycups-2.0.1.tar.gz : 57434ce5f62548eb12949ca8217f066f4eeb21a5d6ab8b13471dce350e380c90  
+homepage   : https://pypi.org/project/pycups/ 
 license    : GPL-2.0-or-later
-component  : desktop.core
+component  : programming.python 
 summary    : Python bindings for cups
 description: |
     This is a set of Python bindings for the libcups library from the CUPS project.

--- a/packages/py/pycups/pspec_x86_64.xml
+++ b/packages/py/pycups/pspec_x86_64.xml
@@ -1,12 +1,13 @@
 <PISI>
     <Source>
         <Name>pycups</Name>
+        <Homepage>https://pypi.org/project/pycups/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
-        <PartOf>desktop.core</PartOf>
+        <PartOf>programming.python</PartOf>
         <Summary xml:lang="en">Python bindings for cups</Summary>
         <Description xml:lang="en">This is a set of Python bindings for the libcups library from the CUPS project.
 </Description>
@@ -17,22 +18,22 @@
         <Summary xml:lang="en">Python bindings for cups</Summary>
         <Description xml:lang="en">This is a set of Python bindings for the libcups library from the CUPS project.
 </Description>
-        <PartOf>desktop.core</PartOf>
+        <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="library">/usr/lib/python3.11/site-packages/cups.cpython-311-x86_64-linux-gnu.so</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pycups-1.9.74-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pycups-1.9.74-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pycups-1.9.74-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pycups-1.9.74-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pycups-2.0.1-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pycups-2.0.1-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pycups-2.0.1-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pycups-2.0.1-py3.11.egg-info/top_level.txt</Path>
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2024-02-16</Date>
-            <Version>1.9.74</Version>
+        <Update release="14">
+            <Date>2024-03-29</Date>
+            <Version>2.0.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/OpenPrinting/pycups/blob/master/NEWS).
- Inclusion of "homepage" to package.yml
- Part of https://github.com/getsolus/packages/issues/411

**Test plan**
- Built system-config-printer against this.

**Check list**
- [X] Package was built and tested against unstable