### PR TITLE
font-ibm-plex: Update to 6.4.0

### DIFF
--- a/packages/f/font-ibm-plex/package.yml
+++ b/packages/f/font-ibm-plex/package.yml
@@ -1,8 +1,8 @@
 name       : font-ibm-plex
-version    : 6.3.0
-release    : 11
+version    : 6.4.0
+release    : 12
 source     :
-    - https://github.com/IBM/plex/archive/refs/tags/v6.3.0.tar.gz : 079bc7182720719df90908a6519d4a9e998b580451960912ae16fe7b71e44261
+    - https://github.com/IBM/plex/archive/refs/tags/v6.4.0.tar.gz : af624686c1290c3d7dadd517851a744dda2c001ae0a49c46dc4f84974d1928e9
 homepage   : https://www.ibm.com/plex/
 license    : OFL-1.1
 component  :

--- a/packages/f/font-ibm-plex/pspec_x86_64.xml
+++ b/packages/f/font-ibm-plex/pspec_x86_64.xml
@@ -278,9 +278,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2023-12-09</Date>
-            <Version>6.3.0</Version>
+        <Update release="12">
+            <Date>2024-03-30</Date>
+            <Version>6.4.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Added old-style numerals, Bulgarian Cyrillic forms, support for Abkhaz and pre-1918 Cyrillic
- Fixed Rendering of certain Cyrillic glyphs
- Fixed Difference in lineheight for SemiBold weight in some situations
- Improved shapes for U+0473 CYRILLIC SMALL LETTER FITA and U+0472 CYRILLIC CAPITAL LETTER FITA
- Changed U+00AD SOFT HYPHEN to empty non-spacing character
- Improved shapes for U+04AA CYRILLIC CAPITAL ES WITH DESCENDER and U+04AB CYRILLIC LOWERCASE ES WITH DESCENDER
- Added Kerning for glyph /rreh-ar.fina (U+FB8D)
- Removed substitutions to glyph /allah-ar (U+FDF2) in rlig feature
- Changed /softhyphen (U+00AD) to empty non-spacing character
- [changelog](https://github.com/IBM/plex/releases/tag/v6.4.0)

**Test Plan**
- render text with the font

**Checklist**
- [X] Package was built and tested against unstable
