### PR TITLE
font-iosevka-ttf: Update to 29.0.4

### DIFF
--- a/packages/f/font-iosevka-ttf/package.yml
+++ b/packages/f/font-iosevka-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : font-iosevka-ttf
-version    : 29.0.3
-release    : 57
+version    : 29.0.4
+release    : 58
 source     :
-    - https://github.com/be5invis/Iosevka/releases/download/v29.0.3/PkgTTF-Iosevka-29.0.3.zip : 7f4a53df7ffd5a82a295501e5fd78dc0c1d4004787582a2e3d4417622f66c483
+    - https://github.com/be5invis/Iosevka/releases/download/v29.0.4/PkgTTF-Iosevka-29.0.4.zip : a96d988e195d0c98d931df15693e855a4f3b104d8fea4eefc54eeb361738220b
 homepage   : https://typeof.net/Iosevka
 license    : OFL-1.1
 component  : desktop.font

--- a/packages/f/font-iosevka-ttf/pspec_x86_64.xml
+++ b/packages/f/font-iosevka-ttf/pspec_x86_64.xml
@@ -78,9 +78,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="57">
-            <Date>2024-03-24</Date>
-            <Version>29.0.3</Version>
+        <Update release="58">
+            <Date>2024-03-30</Date>
+            <Version>29.0.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Make U+2980 respond to VSAM.
- U+2AFC will no longer respond to VSAM.
- [changelog](https://github.com/be5invis/Iosevka/releases/tag/v29.0.4)

**Test Plan**
- render text with the font

**Checklist**
- [X] Package was built and tested against unstable
