### PR TITLE
tailscale: Update to 1.62.1

### DIFF
--- a/packages/t/tailscale/package.yml
+++ b/packages/t/tailscale/package.yml
@@ -1,8 +1,8 @@
 name       : tailscale
-version    : 1.62.0
-release    : 12
+version    : 1.62.1
+release    : 13
 source     :
-    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.62.0.tar.gz : 19d91f208a7337b8f2caad030936112c641533d7c1d932a2a8732731e2e80ae5
+    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.62.1.tar.gz : 22737fae37e971fecdf49d6b741b99988868aa3f1e683e67e14b872a2c49ca1c
 homepage   : https://tailscale.com
 license    : BSD-3-Clause
 component  : network.clients

--- a/packages/t/tailscale/pspec_x86_64.xml
+++ b/packages/t/tailscale/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2024-03-16</Date>
-            <Version>1.62.0</Version>
+        <Update release="13">
+            <Date>2024-03-30</Date>
+            <Version>1.62.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Send load balancing hint HTTP request header
- [changelog](https://github.com/tailscale/tailscale/releases/tag/v1.62.1)

**Test Plan**
- tailscale web

**Checklist**
- [X] Package was built and tested against unstable
