### PR TITLE
languagetool: Update to 6.4

### DIFF
--- a/packages/l/languagetool/files/git.properties
+++ b/packages/l/languagetool/files/git.properties
@@ -1,0 +1,4 @@
+git.build.version=6.4
+git.build.id=0e9362bdd0dfded52f11bd1333cead51d049d71f
+git.build.time=2024-03-28T12:00:00Z
+git.commit.id.abbrev=0e9362b

--- a/packages/l/languagetool/package.yml
+++ b/packages/l/languagetool/package.yml
@@ -1,8 +1,8 @@
 name       : languagetool
-version    : '6.3'
-release    : 8
+version    : '6.4'
+release    : 9
 source     :
-    - https://github.com/languagetool-org/languagetool/archive/refs/tags/v6.3-branch.tar.gz : c15c0dbb9ef889e40e7d88129f90e1570319904214f27d707c92577ab8865c86
+    - https://github.com/languagetool-org/languagetool/archive/refs/tags/v6.4.tar.gz : dd0eb9bfe6b85fcbe31f33bc7c8186dc9c8e1cbae1bbab5a26476029036ab93f
 homepage   : https://languagetool.org
 license    : LGPL-2.1-only
 component  : office.viewers
@@ -11,6 +11,7 @@ description: |
     LanguageTool is an Open Source proofreading software for English, French, German, Polish, Russian, and more than 20 other languages. It finds many errors that a simple spell checker cannot detect.
 builddeps  :
     - apache-maven
+    - git
     - openjdk-17
 rundeps    :
     - openjdk-17
@@ -18,6 +19,8 @@ networking : yes
 environment: |
     JAVA_HOME=/usr/lib64/openjdk-17
     PATH=$JAVA_HOME/bin:$PATH
+setup      : |
+    cp $pkgfiles/git.properties $workdir/languagetool-core/src/main/resources/
 build      : |
     $workdir/build.sh languagetool-standalone package -DskipTests -Dmaven.repo.local=$workdir/.m2 -Dmaven.gitcommitid.skip=true
 install    : |
@@ -26,6 +29,7 @@ install    : |
     cp $workdir/languagetool-standalone/target/LanguageTool-$version/LanguageTool-$version/libs/*.jar $installdir/usr/share/languagetool/libs/
     cp -R $workdir/languagetool-standalone/target/LanguageTool-$version/LanguageTool-$version/META-INF/* $installdir/usr/share/languagetool/META-INF/
     cp -R $workdir/languagetool-standalone/target/LanguageTool-$version/LanguageTool-$version/org/* $installdir/usr/share/languagetool/org/
+    cp $pkgfiles/server.properties $installdir/usr/share/languagetool/
     install -Dm00755 $pkgfiles/languagetool -t $installdir/usr/bin
 check      : |
     #mvn test -Dmaven.repo.local=$workdir/.m2

--- a/packages/l/languagetool/pspec_x86_64.xml
+++ b/packages/l/languagetool/pspec_x86_64.xml
@@ -34,6 +34,8 @@
             <Path fileType="data">/usr/share/languagetool/META-INF/maven/org.languagetool/language-br/pom.xml</Path>
             <Path fileType="data">/usr/share/languagetool/META-INF/maven/org.languagetool/language-ca/pom.properties</Path>
             <Path fileType="data">/usr/share/languagetool/META-INF/maven/org.languagetool/language-ca/pom.xml</Path>
+            <Path fileType="data">/usr/share/languagetool/META-INF/maven/org.languagetool/language-crh/pom.properties</Path>
+            <Path fileType="data">/usr/share/languagetool/META-INF/maven/org.languagetool/language-crh/pom.xml</Path>
             <Path fileType="data">/usr/share/languagetool/META-INF/maven/org.languagetool/language-da/pom.properties</Path>
             <Path fileType="data">/usr/share/languagetool/META-INF/maven/org.languagetool/language-da/pom.xml</Path>
             <Path fileType="data">/usr/share/languagetool/META-INF/maven/org.languagetool/language-de-DE-x-simple-language/pom.properties</Path>
@@ -95,6 +97,7 @@
             <Path fileType="data">/usr/share/languagetool/libs/LatencyUtils.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/aho-corasick-double-array-trie.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/annotations.jar</Path>
+            <Path fileType="data">/usr/share/languagetool/libs/asturian-pos-dict.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/bcrypt.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/bytes.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/catalan-pos-dict.jar</Path>
@@ -111,9 +114,10 @@
             <Path fileType="data">/usr/share/languagetool/libs/commons-validator.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/dutch-pos-dict.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/ecs-logging-core.jar</Path>
-            <Path fileType="data">/usr/share/languagetool/libs/emoji-java.jar</Path>
+            <Path fileType="data">/usr/share/languagetool/libs/english-pos-dict.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/error_prone_annotations.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/failureaccess.jar</Path>
+            <Path fileType="data">/usr/share/languagetool/libs/fastutil-core.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/french-pos-dict.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/german-pos-dict.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/grpc-api.jar</Path>
@@ -123,6 +127,7 @@
             <Path fileType="data">/usr/share/languagetool/libs/grpc-protobuf-lite.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/grpc-protobuf.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/grpc-stub.jar</Path>
+            <Path fileType="data">/usr/share/languagetool/libs/grpc-util.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/gson.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/guava.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/hamcrest-core.jar</Path>
@@ -157,6 +162,7 @@
             <Path fileType="data">/usr/share/languagetool/libs/languagetool-gui-commons.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/languagetool-tools.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/lettuce-core.jar</Path>
+            <Path fileType="data">/usr/share/languagetool/libs/linguistics.grammardb.spell.languagetool.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/listenablefuture.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/logback-classic.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/logback-core.jar</Path>
@@ -167,6 +173,7 @@
             <Path fileType="data">/usr/share/languagetool/libs/mariadb-java-client.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/micrometer-core.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/micrometer-registry-prometheus.jar</Path>
+            <Path fileType="data">/usr/share/languagetool/libs/morfologik-crh-lt.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/morfologik-fsa-builders.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/morfologik-fsa.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/morfologik-speller.jar</Path>
@@ -211,7 +218,6 @@
             <Path fileType="data">/usr/share/languagetool/libs/slf4j-api.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/spanish-pos-dict.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/stax-ex.jar</Path>
-            <Path fileType="data">/usr/share/languagetool/libs/trove4j.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/txw2.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/unit-api.jar</Path>
             <Path fileType="data">/usr/share/languagetool/libs/uom-lib-common.jar</Path>
@@ -276,6 +282,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/CanadianFrench.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/Catalan.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/Chinese.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/language/CrimeanTatar.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/Danish.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/Dutch.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/English$1.class</Path>
@@ -311,7 +318,6 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/Tagalog.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/Tamil.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/Ukrainian.class</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/language/Ukrainian1992.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/ValencianCatalan.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/rules/ast/MorfologikAsturianSpellerRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/language/tagging/TamilTagger.class</Path>
@@ -350,13 +356,8 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ast/added_custom.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ast/ast.profile</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ast/ast.profile.README</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ast/asturian.dict</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ast/asturian.info</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ast/common_words.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ast/hunspell/LICENCES-ast.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ast/hunspell/LICENSES-en.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ast/hunspell/ast_ES.dict</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ast/hunspell/ast_ES.info</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ast/hunspell/create_dict.sh</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ast/hunspell/ignore.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ast/hunspell/spelling.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ast/removed.txt</Path>
@@ -364,9 +365,6 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/be/added.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/be/added_custom.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/be/common_words.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/be/hunspell/README.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/be/hunspell/be_BY.dict</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/be/hunspell/be_BY.info</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/be/hunspell/ignore.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/be/hunspell/spelling.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/be/removed.txt</Path>
@@ -400,11 +398,18 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ca/entities.ent</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ca/hunspell/ignore.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ca/hunspell/prohibit.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ca/hyphenated_words.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ca/multiwords.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ca/removed.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ca/removed_custom.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ca/spelling-special.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ca/spelling.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ca/tagset.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/crh/added.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/crh/common_words.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/crh/hunspell/ignore.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/crh/hunspell/spelling.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/crh/removed.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/da/README.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/da/added.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/da/added_custom.txt</Path>
@@ -437,6 +442,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/do-not-synthesize.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/eigennamen_gross.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/errors.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/german_prefix.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/hunspell/COPYING_GPLv2.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/hunspell/COPYING_GPLv3.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/hunspell/create_dict.sh</Path>
@@ -468,6 +474,8 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/hunspell/spelling_custom.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/hunspell/spelling_merged.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/hunspell/spelling_recommendation.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/multitoken-ignore.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/multitoken-suggest.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/removed.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/removed_custom.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/de/spelling_correction_model.bin</Path>
@@ -513,37 +521,8 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/do-not-synthesize.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/en-US-GB.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/en.sor</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/english.dict</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/english.info</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/english_synth.dict</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/english_synth.info</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/english_tags.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/errors.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/README_en_AU.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/README_en_CA.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/README_en_GB.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/README_en_NZ.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/README_en_US.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/README_en_ZA.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/en_AU.dict</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/en_AU.info</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/en_CA.dict</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/en_CA.info</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/en_GB.dict</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/en_GB.dict.header</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/en_GB.info</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/en_NZ.dict</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/en_NZ.info</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/en_US.dict</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/en_US.info</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/en_ZA.dict</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/en_ZA.info</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/ignore.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/make_en_au_dict.sh</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/make_en_ca_dict.sh</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/make_en_gb_dict.sh</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/make_en_us_dict.sh</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/make_en_za_dict.sh</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/prohibit.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/prohibit_custom.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/en/hunspell/spelling.txt</Path>
@@ -574,7 +553,6 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/eo/hunspell/spelling.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/eo/manual-tagger.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/eo/tagset.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/README.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/added.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/added_custom.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/common_words.txt</Path>
@@ -585,8 +563,10 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/entities.ent</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/es.sor</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/etiquetas-eagles.md</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/hunspell/ignore.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/hunspell/prohibit.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/hunspell/spelling.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/hyphenated_words.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/multiwords.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/removed.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/es/removed_custom.txt</Path>
@@ -609,6 +589,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/fr/hunspell/prohibit.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/fr/hunspell/spelling.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/fr/hunspell/spelling_custom.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/fr/hyphenated_words.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/fr/multiwords.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/fr/removed.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/fr/removed_custom.txt</Path>
@@ -696,10 +677,19 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/added.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/added_custom.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/common_words.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/compound_acceptor/acronym_exceptions.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/compound_acceptor/always_needs_hyphen.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/compound_acceptor/always_needs_s.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/compound_acceptor/directions.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/compound_acceptor/needs_s.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/compound_acceptor/no_s.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/compound_acceptor/part1_exceptions.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/compound_acceptor/part2_exceptions.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/compounds.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/confusion_sets.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/disambiguation.xml</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/multipartcompounds.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/multiwords.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/nl.sor</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/preferredwords.csv</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/nl/removed.txt</Path>
@@ -729,15 +719,46 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pl/removed.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pl/removed_custom.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pl/tagset.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/abbreviations.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/added.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/added_custom.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/blacklist.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/AC.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/AL.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/AM.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/AP.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/BA.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/CE.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/DF.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/ES.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/GO.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/MA.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/MG.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/MS.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/MT.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/PA.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/PB.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/PE.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/PI.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/PR.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/RJ.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/RN.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/RO.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/RR.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/RS.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/SC.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/SE.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/SP.tsv</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/brazilian_municipalities/TO.tsv</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/common_words.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/compound_colours.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/confusion_set_candidates.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/confusion_sets.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/dialect_alternations.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/disambiguation.xml</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/do_not_suggest.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/entities/abbrev.ent</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/entities/chars.ent</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/entities/datetime.ent</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/entities/hyphenised.ent</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/entities/languages.ent</Path>
@@ -746,28 +767,18 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/entities/paronyms.ent</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/entities/postal.ent</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/entities/verbs.ent</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/hunspell/README_pt_AO.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/hunspell/README_pt_BR.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/hunspell/README_pt_MZ.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/hunspell/README_pt_PT.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/hunspell/ignore.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/hunspell/prohibit.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/hunspell/pt_AO.aff</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/hunspell/pt_AO.dic</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/hunspell/pt_BR.aff</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/hunspell/pt_BR.dic</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/hunspell/pt_MZ.aff</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/hunspell/pt_MZ.dic</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/hunspell/pt_PT.aff</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/hunspell/pt_PT.dic</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/hunspell/spelling.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/hyphenated_words.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/ignore.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/multiwords.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/post-reform-compounds-inactive.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/post-reform-compounds.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/pre-reform-compounds.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/prohibit.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/pt.sor</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/removed.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/removed_custom.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/spelling.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/state_name_mapping.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/pt/tagset.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ro/README.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/ro/added.txt</Path>
@@ -919,7 +930,6 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/uk/multiwords.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/uk/removed.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/uk/removed_custom.txt</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/uk/tagset.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/zh/common_words.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/resource/zh/confusion_sets.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ar/ArabicCommaWhitespaceRule.class</Path>
@@ -982,6 +992,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/AdjustPronounsFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/AdvancedSynthesizerFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/AnarASuggestionsFilter.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/CatalanMultitokenSpeller.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/CatalanNumberInWordFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/CatalanNumberSpellerFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/CatalanRepeatedWordsRule.class</Path>
@@ -999,12 +1010,14 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/DateFilterHelper.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/DiacriticsCheckFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/DonarTempsSuggestionsFilter.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/EndOfParagraphPunctuationRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/FindSuggestionsEsFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/FindSuggestionsFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/MorfologikCatalanSpellerRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/NewYearDateFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/OblidarseSugestionsFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/PortarTempsSuggestionsFilter.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/PossessiusRedundantsFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/PostponedAdjectiveConcordanceFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/PronomFebleDuplicateRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/PronomsFeblesHelper$PronounPosition.class</Path>
@@ -1023,11 +1036,14 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/SimpleReplaceMultiwordsRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/SimpleReplaceRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/SimpleReplaceVerbsRule.class</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/SuppressIfAnyRuleMatchesFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/SynthesizeWithDeterminerFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/TextToNumberFilter.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/WordCoherencyRule.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/WordCoherencyValencianRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/ca-ES-valencia/grammar.xml</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/check_case.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/coherency-valencia.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/coherency.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/confusion_pairs.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/grammar.xml</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/replace.txt</Path>
@@ -1046,6 +1062,8 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/verb_senseaccent_adj_ambaccent.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/verb_senseaccent_nom_ambaccent.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/ca/wrongWordInContext.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/crh/MorfologikCrimeanTatarSpellerRule.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/crh/grammar.xml</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/da/grammar.xml</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de-DE-x-simple-language/grammar.xml</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/AdaptSuggestionFilter.class</Path>
@@ -1080,6 +1098,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/GermanDoublePunctuationRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/GermanFillerWordsRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/GermanHelper.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/GermanMultitokenSpeller.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/GermanNumberInWordFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/GermanParagraphRepeatBeginningRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/GermanReadabilityRule.class</Path>
@@ -1088,7 +1107,9 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/GermanSpellerRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/GermanStyleRepeatedWordRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/GermanSuppressMisspelledSuggestionsFilter.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/GermanTools.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/GermanUnpairedBracketsRule.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/GermanUnpairedQuotesRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/GermanWordRepeatBeginningRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/GermanWordRepeatRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/de/GermanWrongWordInContextRule.class</Path>
@@ -1188,6 +1209,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/EnglishForGermansFalseFriendRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/EnglishForL2SpeakersFalseFriendRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/EnglishForSpaniardsFalseFriendRule.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/EnglishMultitokenSpeller.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/EnglishNgramProbabilityRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/EnglishNumberInWordFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/EnglishPartialPosTagFilter.class</Path>
@@ -1197,6 +1219,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/EnglishSpecificCaseRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/EnglishSuppressMisspelledSuggestionsFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/EnglishUnpairedBracketsRule.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/EnglishUnpairedQuotesRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/EnglishWordRepeatBeginningRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/EnglishWordRepeatRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/EnglishWrongWordInContextRule.class</Path>
@@ -1214,6 +1237,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/NewZealandReplaceRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/NoDisambiguationEnglishPartialPosTagFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/OrdinalSuffixFilter.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/SimpleReplaceProfanityRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/SimpleReplaceRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/StyleTooOftenUsedAdjectiveRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/StyleTooOftenUsedNounRule.class</Path>
@@ -1249,6 +1273,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/remote-rule-filters.xml</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/replace.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/replace_custom.txt</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/replace_profanity.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/style.xml</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/synonyms.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/en/translation/BeoLingusTranslator.class</Path>
@@ -1274,6 +1299,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/es/SimpleReplaceRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/es/SimpleReplaceVerbsRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/es/SpanishConfusionProbabilityRule.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/es/SpanishMultitokenSpeller.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/es/SpanishNumberInWordFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/es/SpanishRepeatedWordsRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/es/SpanishSuppressMisspelledSuggestionsFilter.class</Path>
@@ -1282,7 +1308,6 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/es/SpanishWordRepeatBeginningRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/es/SpanishWordRepeatRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/es/SpanishWrongWordInContextRule.class</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/es/SuppressIfAnyRuleMatchesFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/es/TextToNumberFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/es/confusion_pairs.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/es/el.txt</Path>
@@ -1312,6 +1337,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/fr/DateFilterHelper.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/fr/FindSuggestionsFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/fr/FrenchConfusionProbabilityRule.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/fr/FrenchMultitokenSpeller.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/fr/FrenchNumberInWordFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/fr/FrenchPartialPosTagFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/fr/FrenchRepeatedWordsRule.class</Path>
@@ -1392,10 +1418,12 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/km/grammar.xml</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/km/replace.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/nl/CheckCaseRule.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/nl/CompoundAcceptor.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/nl/CompoundFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/nl/CompoundRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/nl/DateCheckFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/nl/DutchConfusionProbabilityRule.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/nl/DutchMultitokenSpeller.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/nl/DutchNumberInWordFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/nl/DutchSuppressMisspelledSuggestionsFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/nl/DutchWrongWordInContextRule.class</Path>
@@ -1416,7 +1444,6 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/nl/remote-rule-filters.xml</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/nl/replace.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/nl/style.xml</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/nl/volzin.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/nl/wrongWordInContext.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pl/CompoundRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pl/DashRule.class</Path>
@@ -1434,11 +1461,15 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/AOreplace.txt</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/AdvancedSynthesizerFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/BrazilianPortugueseReplaceRule.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/BrazilianToponymFilter.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/BrazilianToponymMap.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/BrazilianToponymMapLoader.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/ConfusionCheckFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/ConfusionPairsDataLoader.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/DateCheckFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/DateFilterHelper.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/FutureDateFilter.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/MorfologikPortugueseSpellerRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/NewYearDateFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/NoDisambiguationPortuguesePartialPosTagFilter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/PortugalPortugueseReplaceRule.class</Path>
@@ -1452,6 +1483,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/PortugueseConfusionProbabilityRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/PortugueseDiacriticsRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/PortugueseFillerWordsRule.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/PortugueseMultitokenSpeller.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/PortugueseReadabilityRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/PortugueseRedundancyRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/pt/PortugueseReplaceRule.class</Path>
@@ -1574,6 +1606,8 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/uk/MixedAlphabetsRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/uk/MorfologikUkrainianSpellerRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/uk/PunctuationCheckRule.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/uk/RuleException$Type.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/uk/RuleException.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/uk/SearchHelper$Condition.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/uk/SearchHelper$Context.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/uk/SearchHelper$Match.class</Path>
@@ -1596,10 +1630,9 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/uk/TokenAgreementNumrNounExceptionHelper.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/uk/TokenAgreementNumrNounRule$State.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/uk/TokenAgreementNumrNounRule.class</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/uk/TokenAgreementPrepNounExceptionHelper$RuleException.class</Path>
-            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/uk/TokenAgreementPrepNounExceptionHelper$Type.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/uk/TokenAgreementPrepNounExceptionHelper.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/uk/TokenAgreementPrepNounRule$1.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/uk/TokenAgreementPrepNounRule$State.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/uk/TokenAgreementPrepNounRule.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/uk/TokenAgreementVerbNounExceptionHelper.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/rules/uk/TokenAgreementVerbNounRule$State.class</Path>
@@ -1628,8 +1661,11 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/synthesis/ca/CatalanSynthesizer$1.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/synthesis/ca/CatalanSynthesizer$PostagComparator.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/synthesis/ca/CatalanSynthesizer.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/synthesis/crh/CrimeanTatarSynthesizer.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/synthesis/el/GreekSynthesizer.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/synthesis/en/EnglishSynthesizer.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/synthesis/es/SpanishSynthesizer$1.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/synthesis/es/SpanishSynthesizer$PostagComparator.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/synthesis/es/SpanishSynthesizer.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/synthesis/ga/IrishSynthesizer.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/synthesis/gl/GalicianSynthesizer.class</Path>
@@ -1648,6 +1684,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/ast/AsturianTagger.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/br/BretonTagger.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/ca/CatalanTagger.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/crh/CrimeanTatarTagger.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/da/DanishTagger.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/de/AdjectiveTags.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/de/AnalyzedGermanToken.class</Path>
@@ -1695,6 +1732,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/it/ItalianTagger.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/ja/JapaneseTagger.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/km/KhmerTagger.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/nl/DutchHybridDisambiguator.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/nl/DutchTagger.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/pl/PolishTagger.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tagging/pt/PortugueseTagger.class</Path>
@@ -1716,6 +1754,7 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tokenizers/be/BelarusianWordTokenizer.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tokenizers/br/BretonWordTokenizer.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tokenizers/ca/CatalanWordTokenizer.class</Path>
+            <Path fileType="data">/usr/share/languagetool/org/languagetool/tokenizers/crh/CrimeanTatarWordTokenizer.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tokenizers/de/GermanCompoundTokenizer$ExtendedGermanWordSplitter.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tokenizers/de/GermanCompoundTokenizer.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tokenizers/de/GermanWordTokenizer.class</Path>
@@ -1743,12 +1782,13 @@
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tools/ArabicStringTools.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tools/ArabicUnitsHelper.class</Path>
             <Path fileType="data">/usr/share/languagetool/org/languagetool/tools/ArabicWordMaps.class</Path>
+            <Path fileType="data">/usr/share/languagetool/server.properties</Path>
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2023-10-08</Date>
-            <Version>6.3</Version>
+        <Update release="9">
+            <Date>2024-03-30</Date>
+            <Version>6.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Asturian tagger and spelling dictionaries have been moved to an external dependency
- added and improved rules for Catalan and updated dictionary (spanish-pos-dict-2.25)
- added and improved Dutch rules
- English tagger and spelling dictionaries have been moved to an external dependency (english-pos-dict v 0.3)
- added and improved French rules
- added and improved German rules, extended dictionary
- small Polish rule improvements
- added and improved Portuguese rules
- added and improved Spanish rules and updated dictionary (spanish-pos-dict-2.2)
- new rules and words in Ukrainian POS dictionary, tagging and disambiguation improvements
- [changelog](https://raw.githubusercontent.com/languagetool-org/languagetool/v6.4/languagetool-standalone/CHANGES.md)

**Test Plan**
- proofread text

**Checklist**
- [X] Package was built and tested against unstable
