### PR TITLE
pyenchant: update to 3.2.2

### DIFF
--- a/packages/py/pyenchant/package.yml
+++ b/packages/py/pyenchant/package.yml
@@ -1,8 +1,9 @@
 name       : pyenchant
-version    : 2.0.0
-release    : 13
+version    : 3.2.2
+release    : 14
 source     :
-    - https://files.pythonhosted.org/packages/source/p/pyenchant/pyenchant-2.0.0.tar.gz : fc31cda72ace001da8fe5d42f11c26e514a91fa8c70468739216ddd8de64e2a0
+    - https://files.pythonhosted.org/packages/source/p/pyenchant/pyenchant-3.2.2.tar.gz : 1cf830c6614362a78aab78d50eaf7c6c93831369c52e1bb64ffae1df0341e637  
+homepage   : https://pyenchant.github.io/pyenchant/ 
 license    : LGPL-2.1-or-later
 component  : programming.python
 summary    : Python language bindings for enchant
@@ -11,12 +12,9 @@ description: |
 builddeps  :
     - pkgconfig(enchant)
     - pkgconfig(python3)
-    - hunspell-en       #check
 rundeps    :
     - enchant16
 build      : |
     %python3_setup
 install    : |
     %python3_install
-check      : |
-    %python3_test

--- a/packages/py/pyenchant/pspec_x86_64.xml
+++ b/packages/py/pyenchant/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>pyenchant</Name>
+        <Homepage>https://pyenchant.github.io/pyenchant/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>programming.python</PartOf>
@@ -24,7 +25,6 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/__pycache__/_enchant.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/__pycache__/errors.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/__pycache__/pypwl.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/__pycache__/tests.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/__pycache__/utils.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/_enchant.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/checker/CmdLineChecker.py</Path>
@@ -33,34 +33,28 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/checker/__pycache__/CmdLineChecker.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/checker/__pycache__/GtkSpellCheckerDialog.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/checker/__pycache__/__init__.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/checker/__pycache__/tests.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/checker/__pycache__/wxSpellCheckerDialog.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/checker/tests.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/checker/wxSpellCheckerDialog.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/errors.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/pypwl.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/tests.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/tokenize/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/tokenize/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/tokenize/__pycache__/en.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/tokenize/__pycache__/tests.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/tokenize/en.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/tokenize/tests.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/enchant/utils.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pyenchant-2.0.0-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pyenchant-2.0.0-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pyenchant-2.0.0-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pyenchant-2.0.0-py3.11.egg-info/eager_resources.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pyenchant-2.0.0-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyenchant-3.2.2-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyenchant-3.2.2-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyenchant-3.2.2-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyenchant-3.2.2-py3.11.egg-info/top_level.txt</Path>
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2024-02-16</Date>
-            <Version>2.0.0</Version>
+        <Update release="14">
+            <Date>2024-03-31</Date>
+            <Version>3.2.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://pyenchant.github.io/pyenchant/changelog.html).

**Test plan**
- Installed and loaded rednotebook that is dependant on this and checked spell checking.

**Check list**
- [X] Package was built and tested against unstable.