### PR TITLE
ci/package_checks: Improve linter feedback and bump check

### DIFF
--- a/common/Hooks/pre-commit.py
+++ b/common/Hooks/pre-commit.py
@@ -8,11 +8,9 @@ package_checks = os.path.join(common_dir, 'common', 'CI', 'package_checks.py')
 
 
 def _run(name: str, *args: str) -> bool:
-    res = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    res = subprocess.run(args, stdout=subprocess.PIPE, text=True)
     if res.returncode != 0:
         print(f'{name} failed: {" ".join(args)}')
-        print('Output:')
-        print("\n".join(['  ' + line for line in res.stdout.split("\n")]))
 
     return res.returncode == 0
 


### PR DESCRIPTION
**Summary**

This PR:

- Improves the output format when not running in CI.
- Shows this output when being called via a hook.
- Extends the package bump check so that pspec files must always be bumped.

Resolves #1888.

**Test Plan**

Run CI checks locally using `go-task check` in a fairly dirty working directory:

![image](https://github.com/getsolus/packages/assets/5798032/817d8e39-a269-44d2-8e19-80d75e4698a2)

Try to commit a changed pspec file:

```
$ gotopkg nano
$ go-task build
$ git add pspec_x86_64.xml
$ git commit
ERR packages/n/nano/pspec_x86_64.xml:1: Package release is not incremented by 1
Package checks failed: <snip>/packages/common/CI/package_checks.py packages/n/nano/pspec_x86_64.xml
```

**Checklist**

- [x] ~~Package was built and tested against unstable~~
