### PR TITLE
nvtop: update to 3.1.0

### DIFF
--- a/packages/n/nvtop/abi_used_symbols
+++ b/packages/n/nvtop/abi_used_symbols
@@ -14,6 +14,7 @@ libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__strcpy_chk
+libc.so.6:abort
 libc.so.6:calloc
 libc.so.6:clock_gettime
 libc.so.6:close
@@ -38,6 +39,7 @@ libc.so.6:fopen
 libc.so.6:fputc
 libc.so.6:fread
 libc.so.6:free
+libc.so.6:fstat
 libc.so.6:fstatat
 libc.so.6:fwrite
 libc.so.6:getenv
@@ -83,7 +85,6 @@ libc.so.6:strstr
 libc.so.6:strtod
 libc.so.6:syscall
 libc.so.6:sysconf
-libc.so.6:sysinfo
 libc.so.6:uname
 libm.so.6:nearbyint
 libm.so.6:round
@@ -94,6 +95,10 @@ libncursesw.so.6:curs_set
 libncursesw.so.6:delwin
 libncursesw.so.6:doupdate
 libncursesw.so.6:endwin
+libncursesw.so.6:getcurx
+libncursesw.so.6:getcury
+libncursesw.so.6:getmaxx
+libncursesw.so.6:getmaxy
 libncursesw.so.6:has_colors
 libncursesw.so.6:init_pair
 libncursesw.so.6:initscr
@@ -106,6 +111,8 @@ libncursesw.so.6:start_color
 libncursesw.so.6:stdscr
 libncursesw.so.6:use_default_colors
 libncursesw.so.6:waddch
+libncursesw.so.6:wattr_set
+libncursesw.so.6:wattrset
 libncursesw.so.6:wchgat
 libncursesw.so.6:wclear
 libncursesw.so.6:wclrtobot

--- a/packages/n/nvtop/monitoring.yml
+++ b/packages/n/nvtop/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 226779
+  rss: https://github.com/Syllo/nvtop/tags.atom
+# No known CPE, checked 20240330
+security:
+  cpe: ~

--- a/packages/n/nvtop/package.yml
+++ b/packages/n/nvtop/package.yml
@@ -1,8 +1,8 @@
 name       : nvtop
-version    : 3.0.2
-release    : 2
+version    : 3.7.1
+release    : 3
 source     :
-    - https://github.com/Syllo/nvtop/archive/refs/tags/3.0.2.tar.gz : 63fa45a2d675fe5320704850c216da6a6bb2edaf09821c26b3800fa7744bae00
+    - https://github.com/Syllo/nvtop/archive/refs/tags/3.1.0.tar.gz : 9481c45c136163574f1f16d87789859430bc90a1dc62f181b269b5edd92f01f3
 homepage   : https://github.com/Syllo/nvtop/
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/n/nvtop/pspec_x86_64.xml
+++ b/packages/n/nvtop/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nvtop</Name>
         <Homepage>https://github.com/Syllo/nvtop/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -28,12 +28,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-01-22</Date>
-            <Version>3.0.2</Version>
+        <Update release="3">
+            <Date>2024-03-30</Date>
+            <Version>3.7.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Changelog:**

Added support for the following hardware accelerators/GPUs:

- More `Adreno GPUs` thanks to the panfrost linux driver
- `Mac GPUs` (tested on M1 and M2 by the community)
- `Huawei Ascend accelerators`

Bugfixes and improvements:

- Don't call handlers for GPUs that are marked as not to be monitored
- Fix crash when the configuration file path could not be discovered through user environment variables (XDG_HOME etc)

Full release notes available [here](https://github.com/Syllo/nvtop/releases)

Solus: Add monitoring.yml

**Test Plan**
Tested with:
Device 0 [TigerLake-H GT1 (UHD Graphics)]
Device 1 [NVIDIA GeForce RTX 3060 Laptop GPU]
- Open `nvtop` and run `glxgears`, also play a video file.
- Make sure the processes are shown and there is activity in `nvtop`

**Summary**

<!-- Info on what this pull request updates/changes/etc -->

**Test Plan**

<!-- Short description of how the package was tested -->

**Checklist**

- [ ] Package was built and tested against unstable
