### PR TITLE
umockdev: update to 0.18.1

### DIFF
--- a/packages/u/umockdev/abi_symbols
+++ b/packages/u/umockdev/abi_symbols
@@ -1,10 +1,12 @@
 libumockdev-preload.so.0:__getcwd_chk
+libumockdev-preload.so.0:__ioctl_time64
 libumockdev-preload.so.0:__lxstat
 libumockdev-preload.so.0:__lxstat64
 libumockdev-preload.so.0:__open64_2
 libumockdev-preload.so.0:__open_2
 libumockdev-preload.so.0:__readlinkat_chk
 libumockdev-preload.so.0:__realpath_chk
+libumockdev-preload.so.0:__recvmsg64
 libumockdev-preload.so.0:__xstat
 libumockdev-preload.so.0:__xstat64
 libumockdev-preload.so.0:access

--- a/packages/u/umockdev/abi_used_symbols
+++ b/packages/u/umockdev/abi_used_symbols
@@ -2,8 +2,6 @@ libc.so.6:__assert_fail
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc23_sscanf
-libc.so.6:__isoc23_strtoul
 libc.so.6:__isoc99_fscanf
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
@@ -66,6 +64,7 @@ libc.so.6:sigaction
 libc.so.6:sigemptyset
 libc.so.6:sigfillset
 libc.so.6:socket
+libc.so.6:sscanf
 libc.so.6:stat64
 libc.so.6:stderr
 libc.so.6:stdout
@@ -190,7 +189,6 @@ libglib-2.0.so.0:g_main_loop_run
 libglib-2.0.so.0:g_main_loop_unref
 libglib-2.0.so.0:g_malloc
 libglib-2.0.so.0:g_malloc0
-libglib-2.0.so.0:g_malloc0_n
 libglib-2.0.so.0:g_match_info_fetch
 libglib-2.0.so.0:g_match_info_fetch_named
 libglib-2.0.so.0:g_match_info_fetch_pos
@@ -208,6 +206,7 @@ libglib-2.0.so.0:g_path_get_dirname
 libglib-2.0.so.0:g_propagate_error
 libglib-2.0.so.0:g_ptr_array_add
 libglib-2.0.so.0:g_ptr_array_new_full
+libglib-2.0.so.0:g_ptr_array_steal
 libglib-2.0.so.0:g_ptr_array_unref
 libglib-2.0.so.0:g_quark_from_static_string
 libglib-2.0.so.0:g_quark_to_string

--- a/packages/u/umockdev/package.yml
+++ b/packages/u/umockdev/package.yml
@@ -1,8 +1,9 @@
 name       : umockdev
-version    : 0.17.18
-release    : 10
+version    : 0.18.1
+release    : 11
 source     :
-    - https://github.com/martinpitt/umockdev/releases/download/0.17.18/umockdev-0.17.18.tar.xz : 466ad3e0c715e56f50ea6a965165823d073a84137acb8a1e39b66573648a985f
+    - https://github.com/martinpitt/umockdev/releases/download/0.18.1/umockdev-0.18.1.tar.xz : 651b6869033bb1488136ed73c58e9245f5b01856261e1cea041030b83fb1ed7c
+homepage   : https://github.com/martinpitt/umockdev
 license    : LGPL-2.1-or-later
 component  : programming.library
 summary    : Mock hardware devices for unit tests and bug reports

--- a/packages/u/umockdev/pspec_x86_64.xml
+++ b/packages/u/umockdev/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>umockdev</Name>
+        <Homepage>https://github.com/martinpitt/umockdev</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>programming.library</PartOf>
@@ -37,7 +38,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">umockdev</Dependency>
+            <Dependency release="11">umockdev</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/umockdev-1.0/umockdev.h</Path>
@@ -75,12 +76,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2024-02-15</Date>
-            <Version>0.17.18</Version>
+        <Update release="11">
+            <Date>2024-04-01</Date>
+            <Version>0.18.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/martinpitt/umockdev/releases).
- Added homepage to package.yml, part of https://github.com/getsolus/packages/issues/411

**Test plan**
- Did a recording with umockdev-record

**Checklist**
- [X] Package was built and tested against unstable.