### PR TITLE
bolt: update to 0.9.7

### DIFF
--- a/packages/b/bolt/abi_used_symbols
+++ b/packages/b/bolt/abi_used_symbols
@@ -1,7 +1,7 @@
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__explicit_bzero_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
 libc.so.6:__libc_start_main
 libc.so.6:__stack_chk_fail
 libc.so.6:close
@@ -30,6 +30,7 @@ libc.so.6:lseek64
 libc.so.6:lstat64
 libc.so.6:memcmp
 libc.so.6:memcpy
+libc.so.6:memmove
 libc.so.6:mkdirat
 libc.so.6:mkfifo
 libc.so.6:open64
@@ -48,6 +49,7 @@ libc.so.6:socket
 libc.so.6:stderr
 libc.so.6:stdout
 libc.so.6:strchr
+libc.so.6:strcmp
 libc.so.6:strftime
 libc.so.6:strlen
 libc.so.6:strrchr
@@ -57,7 +59,6 @@ libc.so.6:time
 libc.so.6:unlink
 libc.so.6:unlinkat
 libc.so.6:write
-libgio-2.0.so.0:g_async_initable_get_type
 libgio-2.0.so.0:g_async_initable_new_async
 libgio-2.0.so.0:g_async_initable_new_finish
 libgio-2.0.so.0:g_async_result_get_source_object
@@ -286,7 +287,6 @@ libglib-2.0.so.0:g_source_set_callback
 libglib-2.0.so.0:g_source_unref
 libglib-2.0.so.0:g_str_equal
 libglib-2.0.so.0:g_str_has_prefix
-libglib-2.0.so.0:g_str_has_suffix
 libglib-2.0.so.0:g_str_hash
 libglib-2.0.so.0:g_strcanon
 libglib-2.0.so.0:g_strchomp
@@ -299,9 +299,10 @@ libglib-2.0.so.0:g_strdup_vprintf
 libglib-2.0.so.0:g_strdupv
 libglib-2.0.so.0:g_strerror
 libglib-2.0.so.0:g_strfreev
-libglib-2.0.so.0:g_string_append
+libglib-2.0.so.0:g_string_append_len
 libglib-2.0.so.0:g_string_append_printf
 libglib-2.0.so.0:g_string_free
+libglib-2.0.so.0:g_string_insert_len
 libglib-2.0.so.0:g_string_new
 libglib-2.0.so.0:g_strjoinv
 libglib-2.0.so.0:g_strsplit
@@ -393,9 +394,7 @@ libgobject-2.0.so.0:g_strv_get_type
 libgobject-2.0.so.0:g_type_add_class_private
 libgobject-2.0.so.0:g_type_add_instance_private
 libgobject-2.0.so.0:g_type_add_interface_static
-libgobject-2.0.so.0:g_type_check_class_cast
 libgobject-2.0.so.0:g_type_check_class_is_a
-libgobject-2.0.so.0:g_type_check_instance_cast
 libgobject-2.0.so.0:g_type_check_instance_is_a
 libgobject-2.0.so.0:g_type_check_instance_is_fundamentally_a
 libgobject-2.0.so.0:g_type_check_value

--- a/packages/b/bolt/package.yml
+++ b/packages/b/bolt/package.yml
@@ -1,9 +1,10 @@
 name       : bolt
-version    : 0.9.2
-release    : 7
+version    : 0.9.7
+release    : 8
 source     :
-    - https://gitlab.freedesktop.org/bolt/bolt/-/archive/0.9.2/bolt-0.9.2.tar.bz2 : 42c2a1f8cdf5bf7b7536c4c8278eff2aee985c6bb082a89be0ee248239c48d75
-license    : 
+    - https://gitlab.freedesktop.org/bolt/bolt/-/archive/0.9.7/bolt-0.9.7.tar.gz : 593c7e7d0ecebd7b9e2c3efabe33f8fec5501ff02ffd6d8563cfc14a91c31c1c
+homepage   : https://gitlab.freedesktop.org/bolt/bolt
+license    :
     - LGPL-2.1-or-later # Source code
     - GPL-2.0-or-later # Udev rules file
 component  : system.utils
@@ -11,6 +12,7 @@ summary    : Thunderbolt device manager
 description: |
     Userspace system daemon to enable security levels for Thunderbolt 3 on GNU/Linux.
 builddeps  :
+    - pkgconfig(libeconf)
     - pkgconfig(pygobject-3.0)
     - pkgconfig(umockdev-1.0)
     - asciidoc

--- a/packages/b/bolt/pspec_x86_64.xml
+++ b/packages/b/bolt/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>bolt</Name>
+        <Homepage>https://gitlab.freedesktop.org/bolt/bolt</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <License>GPL-2.0-or-later</License>
@@ -11,7 +12,7 @@
         <Summary xml:lang="en">Thunderbolt device manager</Summary>
         <Description xml:lang="en">Userspace system daemon to enable security levels for Thunderbolt 3 on GNU/Linux.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>bolt</Name>
@@ -35,12 +36,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2022-07-17</Date>
-            <Version>0.9.2</Version>
+        <Update release="8">
+            <Date>2024-03-31</Date>
+            <Version>0.9.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Add a nopcie security level since some devices report nopcie when Thunderbolt
is disabled through BIOS setting.
- Markdown lint styling is used for documents.
- Release notes can be found [here](https://gitlab.freedesktop.org/bolt/bolt/-/blob/master/CHANGELOG.md).

**Test plan**
- Installled and checked that it could see devices.

**Checklist**
- [X] Package was built and tested against unstable.