### PR TITLE
common: Rework `package-publish-safety-catches.sh` to use the CI checks

### DIFF
--- a/.github/workflows/script_lint.yml
+++ b/.github/workflows/script_lint.yml
@@ -40,7 +40,6 @@ jobs:
           check_together: 'yes'
           ignore_paths: >-
             common/Legacy/**
-            common/Scripts/package-publish-safety-catches.sh
             common/Scripts/helpers.zsh
             common/Scripts/sync_licenses.sh
             common/Scripts/new-package.sh

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -162,7 +162,9 @@ tasks:
 
   # For staff and packagers with push access
   publish:
-    desc: Tag and publish a release
+    desc: >-
+      Publish the last commit for the current package to the repository and the build server.
+      The `run-safety-catches` task is used to check for common issues before pushing.
     dir: '{{ .USER_WORKING_DIR }}'
     preconditions:
       - sh: test $(git symbolic-ref HEAD 2>/dev/null) = "refs/heads/main"
@@ -175,7 +177,9 @@ tasks:
       - task: push
 
   republish:
-    desc: Rebuild existing tag
+    desc: >-
+      Retry the last commit for the current package on the build server.
+      The `run-safety-catches` task is used to check for common issues before pushing.
     dir: '{{ .USER_WORKING_DIR }}'
     preconditions:
       - sh: test $(git symbolic-ref HEAD 2>/dev/null) = "refs/heads/main"
@@ -185,7 +189,7 @@ tasks:
       - task: push
 
   run-safety-catches:
-    desc: Run safety catches script
+    desc: Check for issues in the currently staged commits using the CI package checks.
     dir: '{{ .USER_WORKING_DIR }}'
     cmds:
       - "{{ .TASKFILE_DIR }}/common/Scripts/package-publish-safety-catches.sh"

--- a/common/Scripts/package-publish-safety-catches.sh
+++ b/common/Scripts/package-publish-safety-catches.sh
@@ -1,51 +1,20 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# Safety catches when publishing packages. Not foolproof and there are edge cases where we don't want it which allows for force-pushing.
-# Currently:
-    # - Checks that the release has been bumped.
-    # - Warns if there are additions to abi_used_libs for system.{base,devel} packages.
+check_script="$(dirname "$0")/../CI/package_checks.py"
+check_args=(--base=origin/main --fail-on-warnings --results-only)
 
-# FIXME: Check for rundeps changes as well for system.{base,devel} packages.
-# FIXME: For the initial inclusion check that the release == 1
-
-LAST_COMMIT=$(git rev-list -1 HEAD .)
-
-LAST_COMMIT_DIFF=$(git log -u -1 ${LAST_COMMIT})
-
-PKG_BUMP=$(git log -u -1 ${LAST_COMMIT} package.yml | grep -w +release)
-
-# Check the release has been bumped
-if [[ $PKG_BUMP == "" ]]; then
-    echo "Warning: Cannot determine that the release has been bumped"
-    read -p "Press y to force-through. If unsure press any other key to abort." prompt
-    if [[ $prompt = "y" ]]; then
-        exit 0
-    else
-        exit 1
-    fi
+if python3 "${check_script}" "${check_args[@]}"
+then
+  exit 0
 fi
 
-# Checks for additions to abi_used_libs for system.{base,devel} packages.
+echo "Package checks failed. Press 'y' to continue, or any other key to abort."
+read -rp "Continue anyway? [yN] " prompt
 
-if [[ `git grep -E 'system.base|system.devel' pspec_x86_64.xml` ]]; then
-    SYSTEM_BASE_DEVEL_PKG=1
-fi
-
-if [[ `grep -E abi_used_libs <<< $LAST_COMMIT_DIFF` ]]; then
-    # Only if the change is an addition
-    ABI_ADDITION=`git log -u -1 ${LAST_COMMIT} -U0 --word-diff abi_used_libs | grep {+`
-    if [[ $ABI_ADDITION != "" ]]; then
-        CHANGED_ABI_USED_LIBS=1
-    fi
-fi
-
-if [[ ! -z "${SYSTEM_BASE_DEVEL_PKG}" && ! -z "${CHANGED_ABI_USED_LIBS}" ]]; then
-    echo "Found a system.base/system.devel pkg where" $ABI_ADDITION "has been added to abi_used_libs."
-    echo "Please ensure that the package containing" $ABI_ADDITION "is in system.base/system.devel BEFORE continuing."
-    read -p "Press y to continue. If unsure press any other key to abort." prompt
-    if [[ $prompt = "y" ]]; then
-        exit 0
-    else
-        exit 1
-    fi
+if [[ $prompt = "y" ]]
+then
+  exit 0
+else
+  exit 1
 fi


### PR DESCRIPTION
**Summary**

Run the CI checks in the safety catches instead of using a separate implementation.

Depends on #2038. Resolves #1496.

**Test Plan**

Run `go-task run-safety-catches` on a branch that is ahead of main (with these changes checked out):

![afbeelding](https://github.com/getsolus/packages/assets/5798032/6e12562c-a1e0-4163-93b8-c2486faf11e9)

**Checklist**

- [x] ~~Package was built and tested against unstable~~
