### PR TITLE
hunspell-pt-br: update to 3.2.15

### DIFF
--- a/packages/h/hunspell-pt-br/package.yml
+++ b/packages/h/hunspell-pt-br/package.yml
@@ -1,8 +1,9 @@
 name       : hunspell-pt-br
-version    : 2013.10.30
-release    : 2
+version    : 3.2.15
+release    : 3
 source     :
-    - https://pt-br.libreoffice.org/assets/Uploads/PT-BR-Documents/VERO/ptBR-2013-10-30AOC-2.zip : ff20a997e4296b8b0bef2e6c19be437fa99442e7d7b3ea55cf9e0e1a6ab52a56
+    - https://pt-br.libreoffice.org/assets/Uploads/PT-BR-Documents/VERO/VeroptBR3215AOC.oxt : 7571a3d8aaa0d5699f8b572d2fc613189876fa4fa87dcbda9a99bd63500210ee
+homepage   : https://pt-br.libreoffice.org/projetos/vero
 license    :
     - LGPL-3.0-or-later
     - MPL-1.1
@@ -10,5 +11,7 @@ component  : office.spelling
 summary    : Portuguese (Brazil) hunspell dictionary
 description: |
     Brazilian Portuguese dictionary for hunspell.
+setup      : |
+    unzip -o $sources/VeroptBR3215AOC.oxt
 install    : |
     install -Dm00644 pt_BR.{aff,dic} -t $installdir/usr/share/hunspell

--- a/packages/h/hunspell-pt-br/pspec_x86_64.xml
+++ b/packages/h/hunspell-pt-br/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>hunspell-pt-br</Name>
+        <Homepage>https://pt-br.libreoffice.org/projetos/vero</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>LGPL-3.0-or-later</License>
         <License>MPL-1.1</License>
@@ -11,7 +12,7 @@
         <Summary xml:lang="en">Portuguese (Brazil) hunspell dictionary</Summary>
         <Description xml:lang="en">Brazilian Portuguese dictionary for hunspell.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>hunspell-pt-br</Name>
@@ -25,12 +26,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2023-09-16</Date>
-            <Version>2013.10.30</Version>
+        <Update release="3">
+            <Date>2024-04-01</Date>
+            <Version>3.2.15</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://pt-br.libreoffice.org/projetos/vero).
- Inclusion of "homepage" to package.yml
- Part of https://github.com/getsolus/packages/issues/411

**Test plan**
- Loaded in Libre Office and did some spell checking.

**Check list**
- [X] Package was built and tested against unstable