### PR TITLE
tlp: update to 1.6.1

### DIFF
--- a/packages/t/tlp/package.yml
+++ b/packages/t/tlp/package.yml
@@ -1,8 +1,9 @@
 name       : tlp
-version    : 1.6.0
-release    : 19
+version    : 1.6.1
+release    : 20
 source     :
-    - https://github.com/linrunner/TLP/archive/1.6.0.tar.gz : e34ded54c14d2cc0ad86cfda1e9e05bcc7b9c5c47c14114109423f20c7a2f96c
+    - https://github.com/linrunner/TLP/archive/refs/tags/1.6.1.tar.gz : f7d013691a92ffcf42ef1648565dbc24a33202046d3c8138dad1963a3169a0f5
+homepage   : https://linrunner.de/tlp/
 license    : GPL-2.0-only
 component  : system.utils
 summary    : Linux Advanced Power Management

--- a/packages/t/tlp/pspec_x86_64.xml
+++ b/packages/t/tlp/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>tlp</Name>
+        <Homepage>https://linrunner.de/tlp/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>system.utils</PartOf>
@@ -102,12 +103,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2023-10-21</Date>
-            <Version>1.6.0</Version>
+        <Update release="20">
+            <Date>2024-04-01</Date>
+            <Version>1.6.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/linrunner/TLP/releases/tag/1.6.1).
- Fixes getsolus/packages/issues/983

**Test plan**
- Installed and checked that it loaded.

**Checklist**
- [X] Package was built and tested against unstable.