### PR TITLE
budgie-desktop: Fix notification close button issue

### DIFF
--- a/packages/b/budgie-desktop/files/0001-daemon-notifications-Fix-default-notification-action.patch
+++ b/packages/b/budgie-desktop/files/0001-daemon-notifications-Fix-default-notification-action.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Evan Maddock <maddock.evan@vivaldi.net>
+Date: Mon, 1 Apr 2024 12:41:51 -0400
+Subject: [PATCH] daemon/notifications: Fix default notification action being
+ performed when close button is clicked
+
+Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
+---
+ src/daemon/notifications/popup.vala | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/daemon/notifications/popup.vala b/src/daemon/notifications/popup.vala
+index 60ae0cc3..29e42db4 100644
+--- a/src/daemon/notifications/popup.vala
++++ b/src/daemon/notifications/popup.vala
+@@ -85,9 +85,10 @@ namespace Budgie.Notifications {
+ 			this.add(revealer);
+ 
+ 			// Hook up the close button
+-			close_button.clicked.connect(() => {
++			close_button.button_release_event.connect(() => {
+ 				this.Closed(NotificationCloseReason.DISMISSED);
+ 				this.dismiss();
++				return Gdk.EVENT_STOP;
+ 			});
+ 		}
+ 

--- a/packages/b/budgie-desktop/package.yml
+++ b/packages/b/budgie-desktop/package.yml
@@ -1,6 +1,6 @@
 name       : budgie-desktop
 version    : 10.9.1
-release    : 271
+release    : 272
 source     :
     - https://github.com/BuddiesOfBudgie/budgie-desktop/releases/download/v10.9.1/budgie-desktop-v10.9.1.tar.xz : 6971be6e64612e63f460cbd4d37cde8cfa201ebb3b21a4230ffaea1a7abf075a
 homepage   : https://blog.buddiesofbudgie.org
@@ -45,6 +45,7 @@ rundeps    :
 setup      : |
     %patch -p1 -i $pkgfiles/fix-run-dialog-in-tasklist.patch
     %patch -p1 -i $pkgfiles/workspace-switcher-fix.patch
+    %patch -p1 -i $pkgfiles/0001-daemon-notifications-Fix-default-notification-action.patch
 
     %meson_configure -Dwith-stateless=true -Duse-old-zenity=true
 build      : |

--- a/packages/b/budgie-desktop/pspec_x86_64.xml
+++ b/packages/b/budgie-desktop/pspec_x86_64.xml
@@ -250,7 +250,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="271">budgie-desktop</Dependency>
+            <Dependency release="272">budgie-desktop</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/budgie-desktop/applet-info.h</Path>
@@ -309,8 +309,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="271">
-            <Date>2024-03-23</Date>
+        <Update release="272">
+            <Date>2024-04-01</Date>
             <Version>10.9.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
- Fix notification close button performing default action

Fixes https://github.com/getsolus/packages/issues/990

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Restart Budgie Desktop, mount a USB drive, unmount USB drive, click notification close button and see no new Nemo window appear.

**Checklist**

- [x] Package was built and tested against unstable
