### PR TITLE
libopenshot: Switch testing framework to Catch2

### DIFF
--- a/packages/l/libopenshot/package.yml
+++ b/packages/l/libopenshot/package.yml
@@ -1,6 +1,6 @@
 name       : libopenshot
 version    : 0.3.2
-release    : 35
+release    : 36
 source     :
     - https://github.com/OpenShot/libopenshot/archive/refs/tags/v0.3.2.tar.gz : 58765cfc8aec199814346e97ce31a5618a261260b380670a6fb2bf6f68733638
 homepage   : https://www.openshot.org/
@@ -13,7 +13,6 @@ builddeps  :
     - pkgconfig(ImageMagick)
     - pkgconfig(Qt5Multimedia)
     - pkgconfig(Qt5Svg)
-    - pkgconfig(UnitTest++)
     - pkgconfig(alsa)
     - pkgconfig(cppzmq)
     - pkgconfig(gl)
@@ -25,6 +24,8 @@ builddeps  :
     - doxygen
     - libopenshot-audio-devel
     - swig
+checkdeps  :
+    - pkgconfig(catch2)
 setup      : |
     # Sometimes build fails with ruby enabled.
     # Use -DENABLE_RUBY=OFF to disable it and reenable at a later date.

--- a/packages/l/libopenshot/pspec_x86_64.xml
+++ b/packages/l/libopenshot/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libopenshot</Name>
         <Homepage>https://www.openshot.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-3.0-or-later</License>
         <PartOf>multimedia.library</PartOf>
@@ -34,7 +34,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="35">libopenshot</Dependency>
+            <Dependency release="36">libopenshot</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libopenshot/AudioBufferSource.h</Path>
@@ -139,12 +139,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="35">
-            <Date>2024-02-16</Date>
+        <Update release="36">
+            <Date>2024-04-01</Date>
             <Version>0.3.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Switch unit testing framework to Catch2

Upstream migrated tests from UnitTest++ to Catch2 about three years ago. Once this is merged, `unittest-cpp` can be deprecated.

Ref https://github.com/getsolus/packages/issues/2045

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build the package and verify that the tests run.

**Checklist**

- [x] Package was built and tested against unstable
