### PR TITLE
iksemel: Fix encoding of emoji

### DIFF
--- a/packages/i/iksemel/abi_used_symbols
+++ b/packages/i/iksemel/abi_used_symbols
@@ -20,8 +20,10 @@ UNKNOWN:_PyObject_New
 UNKNOWN:_Py_BuildValue_SizeT
 UNKNOWN:_Py_Dealloc
 UNKNOWN:_Py_NoneStruct
+libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
+libc.so.6:__snprintf_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:close
@@ -35,6 +37,7 @@ libc.so.6:free
 libc.so.6:freeaddrinfo
 libc.so.6:getaddrinfo
 libc.so.6:malloc
+libc.so.6:mbrtoc32
 libc.so.6:memcpy
 libc.so.6:memset
 libc.so.6:recv

--- a/packages/i/iksemel/files/0001-Escape-non-ASCII-characters.patch
+++ b/packages/i/iksemel/files/0001-Escape-non-ASCII-characters.patch
@@ -1,0 +1,143 @@
+From f27050677e11fa387d084932bc3ee57957708262 Mon Sep 17 00:00:00 2001
+From: Silke Hofstra <silke@slxh.eu>
+Date: Tue, 2 Apr 2024 22:13:31 +0200
+Subject: [PATCH 1/2] Escape non-ASCII characters
+
+Escape characters that are not contained in ASCII by encoding them to their HTML/Hex representation.
+---
+ src/iks.c           | 28 ++++++++++++++++++++++++++++
+ test/meson.build    |  5 +++++
+ test/tst-iks-utf8.c | 38 ++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 71 insertions(+)
+ create mode 100644 test/tst-iks-utf8.c
+
+diff --git a/src/iks.c b/src/iks.c
+index d1a1a93..ceef571 100644
+--- a/src/iks.c
++++ b/src/iks.c
+@@ -4,6 +4,7 @@
+ ** modify it under the terms of GNU Lesser General Public License.
+ */
+ 
++#include <uchar.h>
+ #include "common.h"
+ #include "iksemel.h"
+ 
+@@ -569,10 +570,21 @@ escape_size (char *src, size_t len)
+ 	size_t sz;
+ 	char c;
+ 	int i;
++	char32_t mb;
++	mbstate_t state = {0};
+ 
+ 	sz = 0;
+ 	for (i = 0; i < len; i++) {
+ 		c = src[i];
++
++		int rc = (int)mbrtoc32(&mb, src+i, len - i, &state);
++		if (rc != 1) {
++			if (rc > 1) {
++				sz += (2*rc) + 4;
++			}
++			continue;
++		}
++
+ 		switch (c) {
+ 			case '&': sz += 5; break;
+ 			case '\'': sz += 6; break;
+@@ -599,9 +611,25 @@ escape (char *dest, char *src, size_t len)
+ 	char c;
+ 	int i;
+ 	int j = 0;
++	char32_t mb;
++	char buf[13] = {0};
++	mbstate_t state = {0};
+ 
+ 	for (i = 0; i < len; i++) {
+ 		c = src[i];
++
++		int rc = (int)mbrtoc32(&mb, src+i, len - i, &state);
++		if (rc != 1) {
++			if (i - j > 0) dest = my_strcat(dest, src + j, i - j);
++			j = i + 1;
++
++			if (rc > 1) {
++				dest = my_strcat(dest, buf, snprintf(buf, sizeof buf, "&#x%x;", mb));
++			}
++
++			continue;
++		}
++
+ 		if ('&' == c || '<' == c || '>' == c || '\'' == c || '"' == c) {
+ 			if (i - j > 0) dest = my_strcat (dest, src + j, i - j);
+ 			j = i + 1;
+diff --git a/test/meson.build b/test/meson.build
+index e993364..b92082c 100644
+--- a/test/meson.build
++++ b/test/meson.build
+@@ -6,6 +6,10 @@ iks_test = executable('test-iks', 'tst-iks.c',
+                     include_directories : include_dir,
+                     link_with : libiksemel)
+ 
++iks_test_utf8 = executable('test-iks-utf8', 'tst-iks-utf8.c',
++                           include_directories : include_dir,
++                           link_with : libiksemel)
++
+ ikstack_test = executable('test-ikstack', 'tst-ikstack.c',
+                     include_directories : include_dir,
+                     link_with : libiksemel)
+@@ -24,6 +28,7 @@ sha_test = executable('test-sha', 'tst-sha.c',
+ 
+ test('Iksemel Test Suite - DOM Test', dom_test, is_parallel : true)
+ test('Iksemel Test Suite - IKS Test', iks_test, is_parallel : true)
++test('Iksemel Test Suite - IKS UTF-8 Test', iks_test_utf8, is_parallel : true)
+ test('Iksemel Test Suite - IkStack Test', ikstack_test, is_parallel : true)
+ test('Iksemel Test Suite - MD5 Test', md5_test, is_parallel : true)
+ test('Iksemel Test Suite - SAX Test', sax_test, is_parallel : true)
+diff --git a/test/tst-iks-utf8.c b/test/tst-iks-utf8.c
+new file mode 100644
+index 0000000..1443e6f
+--- /dev/null
++++ b/test/tst-iks-utf8.c
+@@ -0,0 +1,38 @@
++/* iksemel (XML parser for Jabber)
++** Copyright (C) 2000-2003 Gurer Ozen
++** This code is free software; you can redistribute it and/or
++** modify it under the terms of GNU Lesser General Public License.
++*/
++
++#include <stdio.h>
++#include <string.h>
++#include <locale.h>
++
++#include "iksemel.h"
++
++int main (int argc, char *argv[])
++{
++	setlocale (LC_ALL, "");
++	static char xml[] = "<test>"
++						"<text>Hello, &#x4e16;&#x754c;</text>"
++						"<emoji>&#x1f4a9;</emoji>"
++						"<invalid></invalid>"
++						"<null></null>"
++						"</test>";
++
++	iks *x = iks_new ("test");
++	iks_insert_cdata (iks_insert (x, "text"), "Hello, 世界", 13);
++	iks_insert_cdata (iks_insert (x, "emoji"), "\U0001F4A9", 4);
++	iks_insert_cdata (iks_insert (x, "invalid"), "\x80\x81", 2);
++	iks_insert_cdata (iks_insert (x, "null"), "\0", 1);
++
++	char *t = iks_string (iks_stack (x), x);
++	if(!t || strcmp(t, xml) != 0) {
++		printf("Result:   %s\n", t);
++		printf("Expected: %s\n", xml);
++		return 1;
++	}
++	iks_delete(x);
++
++	return 0;
++}
+-- 
+2.44.0
+

--- a/packages/i/iksemel/files/0002-Escape-non-printable-ASCII-characters.patch
+++ b/packages/i/iksemel/files/0002-Escape-non-printable-ASCII-characters.patch
@@ -1,0 +1,86 @@
+From 9a5a0b4f3ee7a48e3a812e9ed37ecf441f63f7da Mon Sep 17 00:00:00 2001
+From: Silke Hofstra <silke@slxh.eu>
+Date: Wed, 3 Apr 2024 12:23:42 +0200
+Subject: [PATCH 2/2] Escape non-printable ASCII characters
+
+Escape characers from ASCII that are not allowed in XML (codepoints 0-8, 11-12, 14-31, 127).
+---
+ src/iks.c           | 20 ++++++++++++++++++++
+ test/tst-iks-utf8.c |  2 ++
+ 2 files changed, 22 insertions(+)
+
+diff --git a/src/iks.c b/src/iks.c
+index ceef571..b7125f1 100644
+--- a/src/iks.c
++++ b/src/iks.c
+@@ -5,6 +5,8 @@
+ */
+ 
+ #include <uchar.h>
++#include <ctype.h>
++#include <stdbool.h>
+ #include "common.h"
+ #include "iksemel.h"
+ 
+@@ -563,6 +565,11 @@ iks_has_attribs (iks *x)
+ }
+ 
+ /*****  Serializing  *****/
++static bool
++is_print(char c)
++{
++	return isprint(c) ||  c == '\t' || c == '\n' || c == '\r';
++}
+ 
+ static size_t
+ escape_size (char *src, size_t len)
+@@ -585,6 +592,11 @@ escape_size (char *src, size_t len)
+ 			continue;
+ 		}
+ 
++		if (!is_print(c)) {
++			sz += 6;
++			continue;
++		}
++
+ 		switch (c) {
+ 			case '&': sz += 5; break;
+ 			case '\'': sz += 6; break;
+@@ -630,6 +642,14 @@ escape (char *dest, char *src, size_t len)
+ 			continue;
+ 		}
+ 
++		if (!is_print(c)) {
++			if (i - j > 0) dest = my_strcat(dest, src + j, i - j);
++			j = i + 1;
++
++			dest = my_strcat(dest, buf, snprintf(buf, sizeof buf, "&#x%02x;", c));
++			continue;
++		}
++
+ 		if ('&' == c || '<' == c || '>' == c || '\'' == c || '"' == c) {
+ 			if (i - j > 0) dest = my_strcat (dest, src + j, i - j);
+ 			j = i + 1;
+diff --git a/test/tst-iks-utf8.c b/test/tst-iks-utf8.c
+index 1443e6f..f177546 100644
+--- a/test/tst-iks-utf8.c
++++ b/test/tst-iks-utf8.c
+@@ -18,6 +18,7 @@ int main (int argc, char *argv[])
+ 						"<emoji>&#x1f4a9;</emoji>"
+ 						"<invalid></invalid>"
+ 						"<null></null>"
++						"<nonprint>&#x01;&#x07;&#x0b;&#x7f;</nonprint>"
+ 						"</test>";
+ 
+ 	iks *x = iks_new ("test");
+@@ -25,6 +26,7 @@ int main (int argc, char *argv[])
+ 	iks_insert_cdata (iks_insert (x, "emoji"), "\U0001F4A9", 4);
+ 	iks_insert_cdata (iks_insert (x, "invalid"), "\x80\x81", 2);
+ 	iks_insert_cdata (iks_insert (x, "null"), "\0", 1);
++	iks_insert_cdata (iks_insert (x, "nonprint"), "\x1\a\v\x7F", 4);
+ 
+ 	char *t = iks_string (iks_stack (x), x);
+ 	if(!t || strcmp(t, xml) != 0) {
+-- 
+2.44.0
+

--- a/packages/i/iksemel/files/series
+++ b/packages/i/iksemel/files/series
@@ -1,0 +1,3 @@
+0001-src-iks.c-Retain-py2-piksemel-behaviour.patch
+0001-Escape-non-ASCII-characters.patch
+0002-Escape-non-printable-ASCII-characters.patch

--- a/packages/i/iksemel/package.yml
+++ b/packages/i/iksemel/package.yml
@@ -1,6 +1,6 @@
 name       : iksemel
 version    : 1.6.1
-release    : 1
+release    : 2
 source     :
     - https://github.com/Zaryob/iksemel/archive/refs/tags/1.6.1.tar.gz : c4a20e23020760a49d470571fc3e3d5bbe0096324cf07b2fd4c724496ca12c8d
 homepage   : https://github.com/Zaryob/iksemel
@@ -14,7 +14,7 @@ builddeps  :
     - pkgconfig(openssl)
     - pkgconfig(python3)
 setup      : |
-    %patch -p1 -i $pkgfiles/0001-src-iks.c-Retain-py2-piksemel-behaviour.patch
+    %apply_patches
     %meson_configure -Dwith_python=true
 build      : |
     %ninja_build

--- a/packages/i/iksemel/pspec_x86_64.xml
+++ b/packages/i/iksemel/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>iksemel</Name>
         <Homepage>https://github.com/Zaryob/iksemel</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>programming.library</PartOf>
@@ -31,7 +31,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="1">iksemel</Dependency>
+            <Dependency release="2">iksemel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/common.h</Path>
@@ -41,12 +41,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-03-31</Date>
+        <Update release="2">
+            <Date>2024-04-03</Date>
             <Version>1.6.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/y/ypkg/package.yml
+++ b/packages/y/ypkg/package.yml
@@ -1,6 +1,6 @@
 name       : ypkg
 version    : '31'
-release    : 179
+release    : 180
 source     :
     - git|https://github.com/getsolus/ypkg.git : e72d8de945703d4c756d7f43f9a000f6a14b5851
 homepage   : https://github.com/getsolus/ypkg

--- a/packages/y/ypkg/pspec_x86_64.xml
+++ b/packages/y/ypkg/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ypkg</Name>
         <Homepage>https://github.com/getsolus/ypkg</Homepage>
         <Packager>
-            <Name>Rune Morling</Name>
-            <Email>ermo@serpentos.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.devel</PartOf>
@@ -70,12 +70,12 @@ Simply put, it is a tool to convert a build process into a packaging operation.
         </Files>
     </Package>
     <History>
-        <Update release="179">
+        <Update release="180">
             <Date>2024-04-03</Date>
             <Version>31</Version>
             <Comment>Packaging update</Comment>
-            <Name>Rune Morling</Name>
-            <Email>ermo@serpentos.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add a patch to escape non-ASCII characters.

**Test Plan**

Build this stack and run solbuild with history and verify that polari now includes an encoded emoji:

```
$ gotopkg polari
$ sudo solbuild build -h -d -p local-unstable-x86_64
$ grep Remove pspec_x86_64.xml
* Remove GNOME from networks list &#x1f622; [Jeremy]
```

**Checklist**

- [x] Package was built and tested against unstable
