### PR TITLE
syncthing: update to 1.27.5

### DIFF
--- a/packages/s/syncthing/monitoring.yml
+++ b/packages/s/syncthing/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 11814
+  rss: https://github.com/syncthing/syncthing/tags.atom
+security:
+  cpe:
+   - vendor: syncthing
+     product: syncthing

--- a/packages/s/syncthing/package.yml
+++ b/packages/s/syncthing/package.yml
@@ -1,9 +1,9 @@
 name       : syncthing
-version    : 1.27.4
-release    : 94
+version    : 1.27.5
+release    : 95
 homepage   : https://syncthing.net
 source     :
-    - https://github.com/syncthing/syncthing/archive/refs/tags/v1.27.4.tar.gz : 65542335212f10703a8ace949b811744f96c1adaea6deed6d3d7399b9f398ecd
+    - https://github.com/syncthing/syncthing/archive/refs/tags/v1.27.5.tar.gz : 833dc5ade78250e3ee2b8ce73237a6e980f732a5a9d8fcfde6064be781fdaf30
 license    : MPL-2.0
 component  : network.util
 networking : yes

--- a/packages/s/syncthing/pspec_x86_64.xml
+++ b/packages/s/syncthing/pspec_x86_64.xml
@@ -50,9 +50,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="94">
-            <Date>2024-03-04</Date>
-            <Version>1.27.4</Version>
+        <Update release="95">
+            <Date>2024-04-04</Date>
+            <Version>1.27.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Tracey Clark</Name>
             <Email>traceyc.dev@tlcnet.info</Email>


### PR DESCRIPTION
**Summary**

Bugfixes:

- Deleting or renaming directories when syncing xattrs or ownership causes empty dir tree to get "put back" by ST
- IndexHandler can get stuck in an undesired loop
- CPU usage increases after folder scans (and hence, over time)
- Better wrapping for device and folder names in sharing lists

Enhancements:

- Open share settings when clicking 'shared with'
- Show encryption status for devices sharing folder

Full changelog available [here](https://github.com/syncthing/syncthing/releases/)

Solus: Add monitoring.yml

**Test Plan**
- Restart Syncthing-GTK and verify it can connect to the syncthing backend, all folders sync
- View syncthing gui in web browser, ensure everything looks good

**Checklist**

- [x] Package was built and tested against unstable