### PR TITLE
yubikey-manager: update to 5.4.0

### DIFF
--- a/packages/y/yubikey-manager/package.yml
+++ b/packages/y/yubikey-manager/package.yml
@@ -1,8 +1,8 @@
 name       : yubikey-manager
-version    : 5.3.0
-release    : 41
+version    : 5.4.0
+release    : 42
 source     :
-    - https://github.com/Yubico/yubikey-manager/releases/download/5.3.0/yubikey_manager-5.3.0.tar.gz : 5492c36a10ce6a5995b8ea1d32cf5bd60db7587201b2aa3e63e0c1da2334b8b6
+    - https://github.com/Yubico/yubikey-manager/releases/download/5.4.0/yubikey_manager-5.4.0.tar.gz : 53726a186722cd2683b2f5fd781fc0a2861f47ce62ba9d3527960832c8fabec8
 homepage   : https://developers.yubico.com/yubikey-manager/
 license    : BSD-2-Clause
 component  : security

--- a/packages/y/yubikey-manager/pspec_x86_64.xml
+++ b/packages/y/yubikey-manager/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>yubikey-manager</Name>
         <Homepage>https://developers.yubico.com/yubikey-manager/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>security</PartOf>
@@ -157,11 +157,11 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/ykman/scripting.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/ykman/settings.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/ykman/util.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/yubikey_manager-5.3.0.dist-info/COPYING</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/yubikey_manager-5.3.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/yubikey_manager-5.3.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/yubikey_manager-5.3.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/yubikey_manager-5.3.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/yubikey_manager-5.4.0.dist-info/COPYING</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/yubikey_manager-5.4.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/yubikey_manager-5.4.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/yubikey_manager-5.4.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/yubikey_manager-5.4.0.dist-info/entry_points.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/yubikit/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/yubikit/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/yubikit/__pycache__/__init__.cpython-311.pyc</Path>
@@ -206,12 +206,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="41">
-            <Date>2024-02-17</Date>
-            <Version>5.3.0</Version>
+        <Update release="42">
+            <Date>2024-04-04</Date>
+            <Version>5.4.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Changelog:**

- Support for YubiKey Bio Multi-protocol Edition.
- CLI: Improve error messages for several failures.
- Attempt to send SIGHUP to yubikey-agent if it is blocking the connection.
- Bugfix: Allow "fido config" to work when no PIN is set on the YubiKey.
- Bugfix: Linux - Fix error when listing OTP devices when no YubiKeys are attached.
- Bugfix: OpenPGP - Fix RSA key generation on YubiKey NEO.

Full release notes available [here](https://github.com/Yubico/yubikey-manager/releases)

**Test Plan**
- YubiKey Manager can be run with `ykman`
- Program behaves as expected