### PR TITLE
yubikey-manager-qt: update to 1.2.6

### DIFF
--- a/packages/y/yubikey-manager-qt/abi_used_symbols
+++ b/packages/y/yubikey-manager-qt/abi_used_symbols
@@ -67,13 +67,13 @@ libQt5Widgets.so.5:_ZN12QApplicationD1Ev
 libQt5Widgets.so.5:_ZN7QDialog4execEv
 libc.so.6:__cxa_atexit
 libc.so.6:__libc_start_main
-libc.so.6:__printf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:memcpy
+libc.so.6:printf
 libc.so.6:sigaction
 libc.so.6:sigemptyset
-libc.so.6:strlen
 libgcc_s.so.1:_Unwind_Resume
+libstdc++.so.6:_ZSt9terminatev
 libstdc++.so.6:__cxa_begin_catch
 libstdc++.so.6:__cxa_end_catch
 libstdc++.so.6:__cxa_rethrow

--- a/packages/y/yubikey-manager-qt/monitoring.yml
+++ b/packages/y/yubikey-manager-qt/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 14844
+  rss: https://github.com/Yubico/yubikey-manager-qt/releases.atom
+# No known CPE, checked 20240404
+security:
+  cpe: ~

--- a/packages/y/yubikey-manager-qt/package.yml
+++ b/packages/y/yubikey-manager-qt/package.yml
@@ -1,14 +1,15 @@
 name       : yubikey-manager-qt
-version    : 1.2.5
-release    : 20
+version    : 1.2.6
+release    : 21
 source     :
-    - https://github.com/Yubico/yubikey-manager-qt/archive/refs/tags/yubikey-manager-qt-1.2.5.tar.gz : 7f7106f0447713203cfa055eefbb82e0c4a3e5df3e451646da772ca24b174008
+    - https://github.com/Yubico/yubikey-manager-qt/archive/refs/tags/yubikey-manager-qt-1.2.6.tar.gz : 58d78b536a1d1e7d8a2a33b9803fc710d551443c8a45c4bb9dee365937fd3b6d
 homepage   : https://developers.yubico.com/yubikey-manager-qt/
 license    : BSD-2-Clause
 component  : security
 summary    : Cross-platform application for configuring any YubiKey over all USB transports.
 description: |
     Cross-platform application for configuring any YubiKey over all USB transports.
+clang      : yes
 builddeps  :
     - pkgconfig(Qt5QuickControls2)
 rundeps    :
@@ -16,10 +17,11 @@ rundeps    :
     - qt5-quickcontrols
     - yubikey-manager
 setup      : |
-    %qmake
+    %qmake-qt5
 build      : |
     %make
 install    : |
     %make_install INSTALL_ROOT=$installdir
     install -Dm00644 $workdir/resources/ykman-gui.desktop $installdir/usr/share/applications/ykman-gui.desktop
     install -Dm00644 $workdir/resources/icons/ykman.png $installdir/usr/share/pixmaps/ykman.png
+    install -Dm00644 $workdir/resources/com.yubico.yubikey_manager.metainfo.xml $installdir/usr/share/metainfo/com.yubico.yubikey_manager.metainfo.xml

--- a/packages/y/yubikey-manager-qt/pspec_x86_64.xml
+++ b/packages/y/yubikey-manager-qt/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>yubikey-manager-qt</Name>
         <Homepage>https://developers.yubico.com/yubikey-manager-qt/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>security</PartOf>
@@ -22,16 +22,17 @@
         <Files>
             <Path fileType="executable">/usr/bin/ykman-gui</Path>
             <Path fileType="data">/usr/share/applications/ykman-gui.desktop</Path>
+            <Path fileType="data">/usr/share/metainfo/com.yubico.yubikey_manager.metainfo.xml</Path>
             <Path fileType="data">/usr/share/pixmaps/ykman.png</Path>
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2023-10-16</Date>
-            <Version>1.2.5</Version>
+        <Update release="21">
+            <Date>2024-04-04</Date>
+            <Version>1.2.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Changelog:**

- Windows-only security fix, see advisory: [https://www.yubico.com/support/security-advisories/ysa-2024-01/](https://www.yubico.com/support/security-advisories/ysa-2024-01/)

Full release notes available [here](https://github.com/Yubico/yubikey-manager-qt/releases)

Solus: Add metainfo and monitoring files. Change to build with clang.

**Test Plan**
- YubiKey Manager GUI can be run via menu / ykman-gui
- Program behaves as expected