### PR TITLE
editorconfig-core-c: update to 0.12.7

### DIFF
--- a/packages/e/editorconfig-core-c/abi_used_symbols
+++ b/packages/e/editorconfig-core-c/abi_used_symbols
@@ -1,6 +1,7 @@
 libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_tolower_loc
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__stack_chk_fail
@@ -38,7 +39,6 @@ libc.so.6:strpbrk
 libc.so.6:strrchr
 libc.so.6:strstr
 libc.so.6:strtok
-libc.so.6:strtol
 libpcre2-8.so.0:pcre2_code_free_8
 libpcre2-8.so.0:pcre2_compile_8
 libpcre2-8.so.0:pcre2_get_ovector_pointer_8

--- a/packages/e/editorconfig-core-c/package.yml
+++ b/packages/e/editorconfig-core-c/package.yml
@@ -1,8 +1,9 @@
 name       : editorconfig-core-c
-version    : 0.12.5
-release    : 3
+version    : 0.12.7
+release    : 4
 source     :
-    - https://github.com/editorconfig/editorconfig-core-c/archive/refs/tags/v0.12.5.tar.gz : b2b212e52e7ea6245e21eaf818ee458ba1c16117811a41e4998f3f2a1df298d2
+    - https://github.com/editorconfig/editorconfig-core-c/archive/refs/tags/v0.12.7.tar.gz : f89d2e144fd67bdf0d7acfb2ac7618c6f087e1b3f2c3a707656b4180df422195
+homepage   : https://editorconfig.org/
 license    : BSD-2-Clause
 component  : programming.library
 summary    : EditorConfig core library written in C

--- a/packages/e/editorconfig-core-c/pspec_x86_64.xml
+++ b/packages/e/editorconfig-core-c/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>editorconfig-core-c</Name>
+        <Homepage>https://editorconfig.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>programming.library</PartOf>
         <Summary xml:lang="en">EditorConfig core library written in C</Summary>
         <Description xml:lang="en">EditorConfig makes it easy to maintain the correct coding style when switching between different text editors and between different projects. The EditorConfig project maintains a file format and plugins for various text editors which allow this file format to be read and used by those editors.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>editorconfig-core-c</Name>
@@ -20,12 +21,10 @@
         <PartOf>programming.library</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/editorconfig</Path>
-            <Path fileType="executable">/usr/bin/editorconfig-0.12.5</Path>
+            <Path fileType="executable">/usr/bin/editorconfig-0.12.7</Path>
             <Path fileType="library">/usr/lib64/libeditorconfig.so.0</Path>
-            <Path fileType="library">/usr/lib64/libeditorconfig.so.0.12.5</Path>
+            <Path fileType="library">/usr/lib64/libeditorconfig.so.0.12.7</Path>
             <Path fileType="man">/usr/share/man/man1/editorconfig.1</Path>
-            <Path fileType="man">/usr/share/man/man3/editorconfig.h.3</Path>
-            <Path fileType="man">/usr/share/man/man3/editorconfig_handle.h.3</Path>
             <Path fileType="man">/usr/share/man/man5/editorconfig-format.5</Path>
         </Files>
     </Package>
@@ -36,7 +35,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="3">editorconfig-core-c</Dependency>
+            <Dependency release="4">editorconfig-core-c</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/editorconfig/editorconfig.h</Path>
@@ -47,15 +46,17 @@
             <Path fileType="library">/usr/lib64/cmake/EditorConfig/EditorConfigTargets.cmake</Path>
             <Path fileType="library">/usr/lib64/libeditorconfig.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/editorconfig.pc</Path>
+            <Path fileType="man">/usr/share/man/man3/editorconfig.h.3</Path>
+            <Path fileType="man">/usr/share/man/man3/editorconfig_handle.h.3</Path>
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2022-10-07</Date>
-            <Version>0.12.5</Version>
+        <Update release="4">
+            <Date>2024-04-05</Date>
+            <Version>0.12.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fix pointer overflow in STRING_CAT.
- Fix a few more stack buffer overflows.
- Add license for FindPcre2 from LuaDist.
- Document and CI fixes.
- Release notes can be found [here](https://github.com/editorconfig/editorconfig-core-c/releases).

**Test Plan**
- Installed and checked it with gnome-text-editor

**Checklist**

- [X] Package was built and tested against unstable
