### PR TITLE
exercism-cli: update to 3.3.0

### DIFF
--- a/packages/e/exercism-cli/abi_used_symbols
+++ b/packages/e/exercism-cli/abi_used_symbols
@@ -1,5 +1,4 @@
 libc.so.6:__errno_location
-libc.so.6:__stack_chk_fail
 libc.so.6:abort
 libc.so.6:fprintf
 libc.so.6:fputc
@@ -17,16 +16,20 @@ libc.so.6:mmap
 libc.so.6:munmap
 libc.so.6:nanosleep
 libc.so.6:pthread_attr_destroy
+libc.so.6:pthread_attr_getstack
 libc.so.6:pthread_attr_getstacksize
 libc.so.6:pthread_attr_init
 libc.so.6:pthread_cond_broadcast
 libc.so.6:pthread_cond_wait
 libc.so.6:pthread_create
 libc.so.6:pthread_detach
+libc.so.6:pthread_getattr_np
+libc.so.6:pthread_key_create
 libc.so.6:pthread_mutex_lock
 libc.so.6:pthread_mutex_unlock
+libc.so.6:pthread_self
+libc.so.6:pthread_setspecific
 libc.so.6:pthread_sigmask
-libc.so.6:realloc
 libc.so.6:setenv
 libc.so.6:sigaction
 libc.so.6:sigaddset

--- a/packages/e/exercism-cli/package.yml
+++ b/packages/e/exercism-cli/package.yml
@@ -1,8 +1,9 @@
 name       : exercism-cli
-version    : 3.0.13
-release    : 6
+version    : 3.3.0
+release    : 7
 source     :
-    - https://github.com/exercism/cli/archive/v3.0.13.tar.gz : ecc27f272792bc8909d14f11dd08f0d2e9bde4cc663b3769e00eab6e65328a9f
+    - https://github.com/exercism/cli/archive/refs/tags/v3.3.0.tar.gz : 65f960c23a2c423cd8dfa2d8fcc1a083c3d5bc483717c96b5c71d3549fbc0fb7
+homepage   : https://exercism.org/
 license    : MIT
 component  : programming
 summary    : A command line tool for exercism.io

--- a/packages/e/exercism-cli/pspec_x86_64.xml
+++ b/packages/e/exercism-cli/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>exercism-cli</Name>
+        <Homepage>https://exercism.org/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">A command line tool for exercism.io</Summary>
         <Description xml:lang="en">A command line tool for exercism.io, this provides a way to do the problems on exercism.io.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>exercism-cli</Name>
@@ -23,12 +24,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2022-04-08</Date>
-            <Version>3.0.13</Version>
+        <Update release="7">
+            <Date>2024-04-05</Date>
+            <Version>3.3.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- This release fixes the exercism test command not working for the 8th and emacs-lisp tracks. The root command description is also simplified and the correct domain is used for the FAQ link.
- Full release notes can be found [here](https://github.com/exercism/cli/releases).

**Test Plan**
- Installed and ran some commands.

**Checklist**

- [X] Package was built and tested against unstable
