### PR TITLE
foliate: Update to 3.1.1

### DIFF
--- a/packages/f/foliate/package.yml
+++ b/packages/f/foliate/package.yml
@@ -1,8 +1,8 @@
 name       : foliate
-version    : 3.1.0
-release    : 2
+version    : 3.1.1
+release    : 3
 source     :
-    - https://github.com/johnfactotum/foliate/releases/download/3.1.0/com.github.johnfactotum.Foliate-3.1.0.tar.xz : 87f8a14dcb730a585f7b9ce47d3fa6dbbe03733bf134d40423b20931b3b429dc
+    - https://github.com/johnfactotum/foliate/releases/download/3.1.1/com.github.johnfactotum.Foliate-3.1.1.tar.xz : 1bda9cd32b4d9a2480b0fc4f9884ad04450bd96fdb30a48ab9c1e7b6ec625144
 homepage   : https://johnfactotum.github.io/foliate/
 license    : GPL-3.0-or-later
 component  : office.viewers

--- a/packages/f/foliate/pspec_x86_64.xml
+++ b/packages/f/foliate/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>foliate</Name>
         <Homepage>https://johnfactotum.github.io/foliate/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Daksh Vashisht</Name>
+            <Email>vashishtdakksh@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>office.viewers</PartOf>
@@ -44,6 +44,7 @@
             <Path fileType="localedata">/usr/share/locale/nb/LC_MESSAGES/com.github.johnfactotum.Foliate.mo</Path>
             <Path fileType="localedata">/usr/share/locale/nl/LC_MESSAGES/com.github.johnfactotum.Foliate.mo</Path>
             <Path fileType="localedata">/usr/share/locale/nn/LC_MESSAGES/com.github.johnfactotum.Foliate.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/oc/LC_MESSAGES/com.github.johnfactotum.Foliate.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/com.github.johnfactotum.Foliate.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ru/LC_MESSAGES/com.github.johnfactotum.Foliate.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/com.github.johnfactotum.Foliate.mo</Path>
@@ -55,12 +56,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-02-24</Date>
-            <Version>3.1.0</Version>
+        <Update release="3">
+            <Date>2024-04-05</Date>
+            <Version>3.1.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Daksh Vashisht</Name>
+            <Email>vashishtdakksh@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Bugfixes:

- Fixed end of chapter cut off when chapter starts with page break
- Fixed incorrect text wrapping in tables
- Fixed a performance issue with OPDS catalogs

Full release notes:

- [3.1.1](https://github.com/johnfactotum/foliate/releases/tag/3.1.1)

**Test Plan**

- Launched the application
- Tried opening and reading a few books
- Tried changing themes, fonts and other settings
- Tried downloading books from the OPDS catalog

**Checklist**

- [x] Package was built and tested against unstable