### PR TITLE
ypkg: Control which binaries to use via symlinks

### DIFF
--- a/packages/y/ypkg/package.yml
+++ b/packages/y/ypkg/package.yml
@@ -1,8 +1,8 @@
 name       : ypkg
 version    : '31'
-release    : 180
+release    : 181
 source     :
-    - git|https://github.com/getsolus/ypkg.git : e72d8de945703d4c756d7f43f9a000f6a14b5851
+    - git|https://github.com/getsolus/ypkg.git : 58855294f24abde004a4fae651e5d73ee744af5f
 homepage   : https://github.com/getsolus/ypkg
 license    : GPL-3.0-or-later
 component  : system.devel
@@ -20,6 +20,7 @@ builddeps  :
     - patchelf
     - python-eopkg
     - python-zstandard
+    - tree
 rundeps    :
     - fakeroot
 environment: |
@@ -40,5 +41,11 @@ install    : |
     # now override bins with our nuitka'd variants
     for b in ypkg ypkg-build ypkg-install-deps ypkg-gen-history ybump yupdate
     do
-        install -Dm0755 $workdir/$b.bin $installdir/usr/bin/$b
+        install -Dm0755 $installdir/usr/bin/$b $installdir/usr/bin/$b.py
+        install -Dm0755 $workdir/$b.bin $installdir/usr/bin/$b.bin
+        # this can be used to switch the used version between the nuitka .bin ones and the pure .py ones
+        #ln -srvf $installdir/usr/bin/$b.py $installdir/usr/bin/$b
+        ln -srvf $installdir/usr/bin/$b.bin $installdir/usr/bin/$b
     done
+    # show the current symlink targets for convenience
+    tree -P 'y*' $installdir/usr/bin/

--- a/packages/y/ypkg/pspec_x86_64.xml
+++ b/packages/y/ypkg/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ypkg</Name>
         <Homepage>https://github.com/getsolus/ypkg</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.devel</PartOf>
@@ -25,11 +25,23 @@ Simply put, it is a tool to convert a build process into a packaging operation.
         <PartOf>system.devel</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/ybump</Path>
+            <Path fileType="executable">/usr/bin/ybump.bin</Path>
+            <Path fileType="executable">/usr/bin/ybump.py</Path>
             <Path fileType="executable">/usr/bin/ypkg</Path>
             <Path fileType="executable">/usr/bin/ypkg-build</Path>
+            <Path fileType="executable">/usr/bin/ypkg-build.bin</Path>
+            <Path fileType="executable">/usr/bin/ypkg-build.py</Path>
             <Path fileType="executable">/usr/bin/ypkg-gen-history</Path>
+            <Path fileType="executable">/usr/bin/ypkg-gen-history.bin</Path>
+            <Path fileType="executable">/usr/bin/ypkg-gen-history.py</Path>
             <Path fileType="executable">/usr/bin/ypkg-install-deps</Path>
+            <Path fileType="executable">/usr/bin/ypkg-install-deps.bin</Path>
+            <Path fileType="executable">/usr/bin/ypkg-install-deps.py</Path>
+            <Path fileType="executable">/usr/bin/ypkg.bin</Path>
+            <Path fileType="executable">/usr/bin/ypkg.py</Path>
             <Path fileType="executable">/usr/bin/yupdate</Path>
+            <Path fileType="executable">/usr/bin/yupdate.bin</Path>
+            <Path fileType="executable">/usr/bin/yupdate.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/ypkg2-31.0.0-py3.11.egg-info/PKG-INFO</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/ypkg2-31.0.0-py3.11.egg-info/SOURCES.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/ypkg2-31.0.0-py3.11.egg-info/dependency_links.txt</Path>
@@ -70,12 +82,12 @@ Simply put, it is a tool to convert a build process into a packaging operation.
         </Files>
     </Package>
     <History>
-        <Update release="180">
-            <Date>2024-04-03</Date>
+        <Update release="181">
+            <Date>2024-04-05</Date>
             <Version>31</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
This commit renames the pure python executables to name.py and then names the nuitka-compiled binaries name.bin.

In turn, it symlinks name to name.bin as a matter of packaging policy, which in turns enables us to trivially test and/or switch to/from the pure python implementations by default via a simple release bump.

This has the benefit of always giving people the ability to inspect the source code of the current version of ypkg residing on their systems, and enables Solus to trivially do performance tests of the pure python versions vs. the nuitka compiled versions for any given package release.

**Test Plan**
Build eopkg4-bin with the updated ypkg in an enabled local repo and see that the build completes.

**Checklist**

- [x] Package was built and tested against unstable
