### PR TITLE
worklog.py: Add CVE links and a `security-updates` command.

### DIFF
--- a/common/Scripts/worklog.py
+++ b/common/Scripts/worklog.py
@@ -3,6 +3,7 @@ import argparse
 import html
 import json
 import os.path
+import re
 import subprocess
 import sys
 import tempfile
@@ -107,6 +108,14 @@ class GitHubCommit:
             return str(author.get('login', 'Unknown'))
 
         return str(self._data['commit']['author']['name'])
+
+    @property
+    def message(self) -> str:
+        return str(self._data['commit']['message'])
+
+    @property
+    def cves(self) -> List[str]:
+        return re.findall(r'CVE-\d{4}-\d{4,7}', self.message)
 
     @staticmethod
     def __tempfile(ref: str) -> str:
@@ -283,25 +292,49 @@ class Update(Listable):
     def _successful_builds(self) -> Iterable[Build]:
         return [build for build in self.builds if build.status == "OK"]
 
+    @property
+    def cves(self) -> List[str]:
+        return [cve for build in self._successful_builds
+                for cve in build.commit().cves]
+
     def to_tty(self) -> str:
         authors = [TTY.url(f'@{build.commit().author}', build.tag_url)
                    for build in self._successful_builds]
+        cves = [TTY.url(cve, f'https://nvd.nist.gov/vuln/detail/{cve}')
+                for cve in self.cves]
 
-        return (f'{TTY.Green}{self.package}{TTY.Reset} {self.v} ' +
+        line = (f'{TTY.Green}{self.package}{TTY.Reset} {self.v} ' +
                 f'{TTY.Blue}[{", ".join(authors)}]{TTY.Reset}')
+
+        if len(cves) > 0:
+            line += f' {TTY.Red}[{", ".join(cves)}]{TTY.Reset}'
+
+        return line
 
     def to_md(self) -> str:
         authors = [f'[@{build.commit().author}]({build.tag_url})'
                    for build in self._successful_builds]
+        cves = [f'[{cve}](https://nvd.nist.gov/vuln/detail/{cve})'
+                for cve in self.cves]
+        line = f'**{self.package}** was updated to **{self.v}** ({", ".join(authors)}).'
 
-        return f'**{self.package}** was updated to **{self.v}** ({", ".join(authors)})'
+        if len(cves) > 0:
+            line += f' Includes security fixes for {", ".join(cves)}.'
+
+        return line
 
     def to_html(self) -> str:
         authors = [f'<a href="{html.escape(build.tag_url, quote=True)}">@{html.escape(build.commit().author)}</a>'
                    for build in self._successful_builds]
+        cves = [f'<a href="https://nvd.nist.gov/vuln/detail/{cve}">{cve}</a>'
+                for cve in self.cves]
+        line = (f'<strong>{html.escape(self.package)}</strong> was updated to <strong>{html.escape(self.v)}</strong> '
+                f'({", ".join(authors)}).')
 
-        return (f'<strong>{html.escape(self.package)}</strong> was updated to <strong>{html.escape(self.v)}</strong> '
-                f'({", ".join(authors)})')
+        if len(cves) > 0:
+            line += f' Includes security fixes for {", ".join(cves)}.'
+
+        return line
 
 
 class Builds:


### PR DESCRIPTION
**Summary**

- Add links to CVEs mentioned in the commits to the update output.
- Add a command for listing all updates that include security fixes.

**Test Plan**

```
$ ./common/Scripts/worklog.py security-updates "2024-03-29T17:45:11Z" --format=tty
5 security-updates:
wireshark 4.2.4-85 [@silkeh] [CVE-2024-2955]
capnproto 1.0.2-6 [@algent-al] [CVE-2023-48230]
golang 1.22.2-112 [@silkeh] [CVE-2023-45288]
xorg-server 21.1.12-100 [@EbonJaeger] [CVE-2024-31080, CVE-2024-31081, CVE-2024-31082, CVE-2024-31083]
xorg-xwayland 23.2.5-24 [@EbonJaeger] [CVE-2024-31080, CVE-2024-31081, CVE-2024-31083]
```

```
$ ./common/Scripts/worklog.py security-updates "2024-03-29T17:45:11Z" --format=md
5 security-updates:
- **wireshark** was updated to **4.2.4-85** ([@silkeh](https://github.com/getsolus/packages/commit/5ad8e37aa8fb9bba87e372e6fa432b3572e77da3)). Includes security fixes for [CVE-2024-2955](https://nvd.nist.gov/vuln/detail/CVE-2024-2955).
- **capnproto** was updated to **1.0.2-6** ([@algent-al](https://github.com/getsolus/packages/commit/7d0cc1e4bd84553d420e62b286601d2b12a8a472)). Includes security fixes for [CVE-2023-48230](https://nvd.nist.gov/vuln/detail/CVE-2023-48230).
- **golang** was updated to **1.22.2-112** ([@silkeh](https://github.com/getsolus/packages/commit/86bf291972087e9184bc4d9c9e1a97d87e37fb57)). Includes security fixes for [CVE-2023-45288](https://nvd.nist.gov/vuln/detail/CVE-2023-45288).
- **xorg-server** was updated to **21.1.12-100** ([@EbonJaeger](https://github.com/getsolus/packages/commit/2145a6ba683e5fa4b8070fa025056df3a2f656cd)). Includes security fixes for [CVE-2024-31080](https://nvd.nist.gov/vuln/detail/CVE-2024-31080), [CVE-2024-31081](https://nvd.nist.gov/vuln/detail/CVE-2024-31081), [CVE-2024-31082](https://nvd.nist.gov/vuln/detail/CVE-2024-31082), [CVE-2024-31083](https://nvd.nist.gov/vuln/detail/CVE-2024-31083).
- **xorg-xwayland** was updated to **23.2.5-24** ([@EbonJaeger](https://github.com/getsolus/packages/commit/7befcce416bbdecf1a5feb8afbdae82567a9f389)). Includes security fixes for [CVE-2024-31080](https://nvd.nist.gov/vuln/detail/CVE-2024-31080), [CVE-2024-31081](https://nvd.nist.gov/vuln/detail/CVE-2024-31081), [CVE-2024-31083](https://nvd.nist.gov/vuln/detail/CVE-2024-31083).
```

```
$ ./common/Scripts/worklog.py security-updates "2024-03-29T17:45:11Z" --format=html
<p>5 security-updates:</p>
<ul>
<li><strong>wireshark</strong> was updated to <strong>4.2.4-85</strong> (<a href="https://github.com/getsolus/packages/commit/5ad8e37aa8fb9bba87e372e6fa432b3572e77da3">@silkeh</a>). Includes security fixes for <a href="https://nvd.nist.gov/vuln/detail/CVE-2024-2955">CVE-2024-2955</a>.</li>
<li><strong>capnproto</strong> was updated to <strong>1.0.2-6</strong> (<a href="https://github.com/getsolus/packages/commit/7d0cc1e4bd84553d420e62b286601d2b12a8a472">@algent-al</a>). Includes security fixes for <a href="https://nvd.nist.gov/vuln/detail/CVE-2023-48230">CVE-2023-48230</a>.</li>
<li><strong>golang</strong> was updated to <strong>1.22.2-112</strong> (<a href="https://github.com/getsolus/packages/commit/86bf291972087e9184bc4d9c9e1a97d87e37fb57">@silkeh</a>). Includes security fixes for <a href="https://nvd.nist.gov/vuln/detail/CVE-2023-45288">CVE-2023-45288</a>.</li>
<li><strong>xorg-server</strong> was updated to <strong>21.1.12-100</strong> (<a href="https://github.com/getsolus/packages/commit/2145a6ba683e5fa4b8070fa025056df3a2f656cd">@EbonJaeger</a>). Includes security fixes for <a href="https://nvd.nist.gov/vuln/detail/CVE-2024-31080">CVE-2024-31080</a>, <a href="https://nvd.nist.gov/vuln/detail/CVE-2024-31081">CVE-2024-31081</a>, <a href="https://nvd.nist.gov/vuln/detail/CVE-2024-31082">CVE-2024-31082</a>, <a href="https://nvd.nist.gov/vuln/detail/CVE-2024-31083">CVE-2024-31083</a>.</li>
<li><strong>xorg-xwayland</strong> was updated to <strong>23.2.5-24</strong> (<a href="https://github.com/getsolus/packages/commit/7befcce416bbdecf1a5feb8afbdae82567a9f389">@EbonJaeger</a>). Includes security fixes for <a href="https://nvd.nist.gov/vuln/detail/CVE-2024-31080">CVE-2024-31080</a>, <a href="https://nvd.nist.gov/vuln/detail/CVE-2024-31081">CVE-2024-31081</a>, <a href="https://nvd.nist.gov/vuln/detail/CVE-2024-31083">CVE-2024-31083</a>.</li>
</ul>
```

**Checklist**

- [x] ~~Package was built and tested against unstable~~
