### PR TITLE
font-iosevka-ttf: Update to 29.1.0

### DIFF
--- a/packages/f/font-iosevka-ttf/package.yml
+++ b/packages/f/font-iosevka-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : font-iosevka-ttf
-version    : 29.0.5
-release    : 59
+version    : 29.1.0
+release    : 60
 source     :
-    - https://github.com/be5invis/Iosevka/releases/download/v29.0.5/PkgTTF-Iosevka-29.0.5.zip : 4b5827cd98b3a3793c8db28ce52f72757f5841a80bf999f249bccc66c443ff84
+    - https://github.com/be5invis/Iosevka/releases/download/v29.1.0/PkgTTF-Iosevka-29.1.0.zip : 1f25390daea5b917fc798bee629a6bedd5c8f4b1b75b33216f459aefda7bf642
 homepage   : https://typeof.net/Iosevka
 license    : OFL-1.1
 component  : desktop.font

--- a/packages/f/font-iosevka-ttf/pspec_x86_64.xml
+++ b/packages/f/font-iosevka-ttf/pspec_x86_64.xml
@@ -78,9 +78,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="59">
-            <Date>2024-04-04</Date>
-            <Version>29.0.5</Version>
+        <Update release="60">
+            <Date>2024-04-06</Date>
+            <Version>29.1.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Add support for naming override
- Fix broken glyphs for serifed variants of LATIN SMALL LETTER S WITH CURL (U+1DF1E).
- Improve glyph visual for Bulgarian localization form for CYRILLIC CAPITAL LETTER EF (U+0424) under slab.
- Make descender serif of CYRILLIC {CAPITAL|SMALL} LETTER KOPPA (U+0480..U+0481) appear under any serifed variants for C/c.
- Make presence of descender serif automatic for LATIN CAPTITAL LETTER BETA (U+A7B4).
- Remove tailless variants for TURNED GREEK SMALL LETTER IOTA (U+2129).
- Make presence of top-right serif automatic for CYRILLIC SMALL LIGATURE EN GHE (U+04A5) under cyrl/en=tailed-top-left-serifed.
- Fix broken geometry of tailed i/l under heavy oblique quasi-proportional.
- Make Cyrillic Lower Em (cv74) use flat-bottom-serifless for sans and flat-bottom-serifed for slab by default.
- Make Latin-1 Macron (U+00AF) slightly wider.
- Add characters

**Test Plan**
- render text with the font

**Checklist**
- [X] Package was built and tested against unstable
