### PR TITLE
[NFC] many: migrate some python packages to use checkdeps

### DIFF
--- a/packages/py/python-chardet/package.yml
+++ b/packages/py/python-chardet/package.yml
@@ -12,8 +12,9 @@ description: |
 builddeps  :
     - python-build
     - python-installer
-    - python-pytest
     - python-wheel
+checkdeps  :
+    - python-pytest
 build      : |
     %python3_setup
 install    : |

--- a/packages/py/python-jeepney/package.yml
+++ b/packages/py/python-jeepney/package.yml
@@ -10,11 +10,12 @@ summary    : Pure Python DBus interface
 description: |
     Low-level, pure Python DBus protocol client. It has an I/O-free core, and integration modules for different event loops.
 builddeps  :
-    - python-async_timeout  # check
     - python-build
     - python-installer
     - python-flit-core
     - python-packaging
+checkdeps  :
+    - python-async_timeout  # check
     - python-pytest-asyncio # check
     - python-testpath       # check
     - python-trio           # check

--- a/packages/py/python-jinja/package.yml
+++ b/packages/py/python-jinja/package.yml
@@ -9,7 +9,7 @@ component  : programming.python
 summary    : Jinja2 is a template engine written in pure Python.
 description: |
     Jinja2 is a template engine written in pure Python.
-builddeps  :
+checkdeps  :
     - python-markupsafe # check
     - python-pytest     # check
 rundeps    :

--- a/packages/py/python-jsonschema-specifications/package.yml
+++ b/packages/py/python-jsonschema-specifications/package.yml
@@ -13,6 +13,7 @@ builddeps  :
     - python-build
     - python-hatch-vcs
     - python-installer
+checkdeps  :
     - python-pytest      # check
     - python-referencing # chek
 rundeps    :

--- a/packages/py/python-jsonschema/package.yml
+++ b/packages/py/python-jsonschema/package.yml
@@ -14,15 +14,16 @@ builddeps  :
     - python-hatch-fancy-pypi-readme
     - python-hatch-vcs
     - python-installer
-    - python-jsonschema-specifications # check
-    - python-pyrsistent                # check
-    - python-pytest                    # check
     - python-setuptools-scm
     - python-wheel
 rundeps    :
     - python-jsonschema-specifications
     - python-pyrsistent
     - python-six
+checkdeps  :
+    - python-jsonschema-specifications # check
+    - python-pyrsistent                # check
+    - python-pytest                    # check
 environment: |
     export SETUPTOOLS_SCM_PRETEND_VERSION=$version
 setup      : |

--- a/packages/py/python-keyring/package.yml
+++ b/packages/py/python-keyring/package.yml
@@ -15,15 +15,16 @@ builddeps  :
     - python-build
     - python-importlib-metadata
     - python-installer
-    - python-jaraco.classes     # check
     - python-packaging
-    - python-pytest-cov         # check
     - python-setuptools-scm
     - python-wheel
 rundeps    :
     - python-importlib-metadata
     - python-jaraco.classes
     - python-secretstorage
+checkdeps  :
+    - python-jaraco.classes     # check
+    - python-pytest-cov         # check
 setup      : |
     %python3_setup
 install    : |

--- a/packages/py/python-markupsafe/package.yml
+++ b/packages/py/python-markupsafe/package.yml
@@ -11,6 +11,7 @@ description: |
     MarkupSafe implements a text object that escapes characters so it is safe to use in HTML and XML. Characters that have special meanings are replaced so that they display as the actual characters. This mitigates injection attacks, meaning untrusted user input can safely be displayed on a page. Escaping is implemented in C so it is as efficient as possible.
 builddeps  :
     - pkgconfig(python3)
+checkdeps  :
     - python-pytest
 build      : |
     %python3_setup

--- a/packages/py/python-more-itertools/package.yml
+++ b/packages/py/python-more-itertools/package.yml
@@ -13,8 +13,9 @@ builddeps  :
     - python-build
     - python-flit-core
     - python-installer
-    - python-pytest
     - python-wheel
+checkdeps  :
+    - python-pytest
 setup      : |
     rm -f setup.py
 build      : |

--- a/packages/py/python-requests/package.yml
+++ b/packages/py/python-requests/package.yml
@@ -13,7 +13,6 @@ builddeps  :
     - python-certifi
     - python-chardet
     - python-idna
-    - python-pytest
     - python-urllib3
 rundeps    :
     - python-certifi
@@ -21,6 +20,8 @@ rundeps    :
     - python-charset-normalizer
     - python-idna
     - python-urllib3
+checkdeps  :
+    - python-pytest
 build      : |
     %python3_setup
 install    : |

--- a/packages/py/python-semanticversion/package.yml
+++ b/packages/py/python-semanticversion/package.yml
@@ -9,7 +9,7 @@ component  : programming.python
 summary    : Semantic version comparison for Python
 description: |
     This small python library provides a few tools to handle SemVer in Python. It follows strictly the 2.0.0 version of the SemVer scheme.
-builddeps  :
+checkdeps  :
     - python-django # check
     - python-pytest # check
 build      : |

--- a/packages/py/python-sortedcontainers/package.yml
+++ b/packages/py/python-sortedcontainers/package.yml
@@ -11,6 +11,7 @@ description: |
     SortedContainers is an Apache2 licensed sorted collections library, written in pure-Python, and fast as C-extensions.
 builddeps  :
     - pkgconfig(python3)
+checkdeps  :
     - matplotlib
     - python-pytest
     - scipy

--- a/packages/py/python-wheel/package.yml
+++ b/packages/py/python-wheel/package.yml
@@ -13,9 +13,10 @@ builddeps  :
     - pkgconfig(python3)
     - python-jsonschema
     - python-keyring
-    - python-pytest
     - python-setuptools
     - pyxdg
+checkdeps  :
+    - python-pytest
 setup      : |
     # Don't require pytest-cov for tests
     sed -i 's/--cov//' setup.cfg


### PR DESCRIPTION
**Summary**

Mass update of python packages to move test dependencies to checkdeps. This would allow `autobuild` to resolve build order correctly by ignoring test dependencies during order calculation.

**Test Plan**

Not needed, should be NFC.

**Checklist**

- [x] Package was built and tested against unstable
