### PR TITLE
lbreakouthd: Update to 1.1.7

### DIFF
--- a/packages/l/lbreakouthd/monitoring.yml
+++ b/packages/l/lbreakouthd/monitoring.yml
@@ -1,6 +1,6 @@
 releases:
   id: 308921
   rss: https://sourceforge.net/projects/lgames/rss?path=/lbreakouthd
-# No known CPE, checked 2024-03-27
+# No known CPE, checked 2024-04-07
 security:
   cpe: ~

--- a/packages/l/lbreakouthd/package.yml
+++ b/packages/l/lbreakouthd/package.yml
@@ -1,8 +1,8 @@
 name       : lbreakouthd
-version    : 1.1.6
-release    : 1
+version    : 1.1.7
+release    : 2
 source     :
-    - https://sourceforge.net/projects/lgames/files/lbreakouthd/lbreakouthd-1.1.6.tar.gz : 1a8af62e733cbe2eac9096f37d1e74db7275dc6c6fa9ca48aee6bd4be9d3fd2d
+    - https://sourceforge.net/projects/lgames/files/lbreakouthd/lbreakouthd-1.1.7.tar.gz/download : 8af813f3260414ae24109922963dcd3f838eda6064936671e88f8495d7b44e41
 homepage   : https://lgames.sourceforge.io/LBreakoutHD/
 license    : GPL-3.0-or-later
 component  : games.arcade

--- a/packages/l/lbreakouthd/pspec_x86_64.xml
+++ b/packages/l/lbreakouthd/pspec_x86_64.xml
@@ -93,6 +93,7 @@
             <Path fileType="data">/usr/share/lbreakouthd/levels/Izusiowe</Path>
             <Path fileType="data">/usr/share/lbreakouthd/levels/JediAdventure</Path>
             <Path fileType="data">/usr/share/lbreakouthd/levels/JustForFun</Path>
+            <Path fileType="data">/usr/share/lbreakouthd/levels/JustGoForIt</Path>
             <Path fileType="data">/usr/share/lbreakouthd/levels/Karnickel</Path>
             <Path fileType="data">/usr/share/lbreakouthd/levels/Kazan-1</Path>
             <Path fileType="data">/usr/share/lbreakouthd/levels/Kevin</Path>
@@ -231,9 +232,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-03-10</Date>
-            <Version>1.1.6</Version>
+        <Update release="2">
+            <Date>2024-04-07</Date>
+            <Version>1.1.7</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
             <Email>malfisya.dev@hotmail.com</Email>


### PR DESCRIPTION
**Summary**

- Added new levelset JustGoForIt by unknown
- Workaround: return ball to paddle for illegal targets
- Fixed mini game Invaders
- Workaround: reset ball if in brick before getting target
- Show trajectory of balls with debugging enabled
- Reenabled bug report as configureable option
- Properly handle \r for levelsets made in windows
- Added xgettext comment to prevent wrong c-format

**Test Plan**

Play a few rounds

**Checklist**

- [x] Package was built and tested against unstable