### PR TITLE
CI/hooks: Bring py3 scripts under test per request

### DIFF
--- a/.github/workflows/script_lint.yml
+++ b/.github/workflows/script_lint.yml
@@ -20,8 +20,11 @@ jobs:
           python-version: "3.10"
       - name: flake8 Lint
         uses: py-actions/flake8@v2
-        with:
-           path: common/CI common/Hooks common/Scripts/worklog.py
+        with: 
+           path: >-
+              common/CI
+              common/Hooks
+              common/Scripts
       - name: mypy lint
         uses: jpetrucciani/mypy-check@master
         with:

--- a/common/Scripts/yauto.py
+++ b/common/Scripts/yauto.py
@@ -335,10 +335,6 @@ description: |
                 setup = "%perl_setup"
                 build = "%perl_build"
                 install = "%perl_install"
-                # Unused, but left in for historical purposes
-                #sample_actions = os.path.join(
-                #    self.template_dir, "actions.perlmodules.sample.py"
-                #)
             elif self.compile_type == CABAL:
                 setup = "%cabal_configure"
                 build = "%cabal_build"


### PR DESCRIPTION
**Summary**
1st attempt at ensuring that all available common/Scripts/*.py files get linted as part of commits.

**Test Plan**
Run `go-task init && go-task check` and observe that nothing blows up when git hooks are run.

**Checklist**

~~- [x] Package was built and tested against unstable~~
