### PR TITLE
fakeroot: Update to 1.34

### DIFF
--- a/packages/f/fakeroot/abi_symbols
+++ b/packages/f/fakeroot/abi_symbols
@@ -116,6 +116,7 @@ libfakeroot-0.so:next_remove
 libfakeroot-0.so:next_removexattr
 libfakeroot-0.so:next_rename
 libfakeroot-0.so:next_renameat
+libfakeroot-0.so:next_renameat2
 libfakeroot-0.so:next_rmdir
 libfakeroot-0.so:next_setegid
 libfakeroot-0.so:next_seteuid
@@ -138,6 +139,7 @@ libfakeroot-0.so:remove
 libfakeroot-0.so:removexattr
 libfakeroot-0.so:rename
 libfakeroot-0.so:renameat
+libfakeroot-0.so:renameat2
 libfakeroot-0.so:rmdir
 libfakeroot-0.so:sem_id
 libfakeroot-0.so:semaphore_down
@@ -217,6 +219,7 @@ libfakeroot-0.so:tmp_remove
 libfakeroot-0.so:tmp_removexattr
 libfakeroot-0.so:tmp_rename
 libfakeroot-0.so:tmp_renameat
+libfakeroot-0.so:tmp_renameat2
 libfakeroot-0.so:tmp_rmdir
 libfakeroot-0.so:tmp_setegid
 libfakeroot-0.so:tmp_seteuid

--- a/packages/f/fakeroot/abi_symbols32
+++ b/packages/f/fakeroot/abi_symbols32
@@ -126,6 +126,7 @@ libfakeroot-0.so:next_remove
 libfakeroot-0.so:next_removexattr
 libfakeroot-0.so:next_rename
 libfakeroot-0.so:next_renameat
+libfakeroot-0.so:next_renameat2
 libfakeroot-0.so:next_rmdir
 libfakeroot-0.so:next_setegid
 libfakeroot-0.so:next_seteuid
@@ -148,6 +149,7 @@ libfakeroot-0.so:remove
 libfakeroot-0.so:removexattr
 libfakeroot-0.so:rename
 libfakeroot-0.so:renameat
+libfakeroot-0.so:renameat2
 libfakeroot-0.so:rmdir
 libfakeroot-0.so:sem_id
 libfakeroot-0.so:semaphore_down
@@ -232,6 +234,7 @@ libfakeroot-0.so:tmp_remove
 libfakeroot-0.so:tmp_removexattr
 libfakeroot-0.so:tmp_rename
 libfakeroot-0.so:tmp_renameat
+libfakeroot-0.so:tmp_renameat2
 libfakeroot-0.so:tmp_rmdir
 libfakeroot-0.so:tmp_setegid
 libfakeroot-0.so:tmp_seteuid

--- a/packages/f/fakeroot/abi_used_symbols
+++ b/packages/f/fakeroot/abi_used_symbols
@@ -1,4 +1,5 @@
 libc.so.6:__errno_location
+libc.so.6:__isoc23_strtol
 libc.so.6:__isoc99_scanf
 libc.so.6:__libc_start_main
 libc.so.6:__stack_chk_fail

--- a/packages/f/fakeroot/abi_used_symbols32
+++ b/packages/f/fakeroot/abi_used_symbols32
@@ -1,4 +1,5 @@
 libc.so.6:__errno_location
+libc.so.6:__isoc23_strtol
 libc.so.6:__stack_chk_fail
 libc.so.6:close
 libc.so.6:dlerror

--- a/packages/f/fakeroot/monitoring.yml
+++ b/packages/f/fakeroot/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 12048
+  rss: ~
+# No known CPE, checked 2024-04-08
+security:
+  cpe: ~

--- a/packages/f/fakeroot/package.yml
+++ b/packages/f/fakeroot/package.yml
@@ -1,8 +1,9 @@
 name       : fakeroot
-version    : 1.32.1
-release    : 18
+version    : '1.34'
+release    : 19
 source     :
-    - https://ftp.debian.org/debian/pool/main/f/fakeroot/fakeroot_1.32.1.orig.tar.gz : c072b0f65bafc4cc5b6112f7c61185f5170ce4cb0c410d1681c1af4a183e94e6
+    - https://ftp.debian.org/debian/pool/main/f/fakeroot/fakeroot_1.34.orig.tar.gz : 5727f16d8903792588efa7a9f8ef8ce71f8756e746b62e45162e7735662e56bb
+homepage   : https://tracker.debian.org/pkg/fakeroot
 license    : GPL-3.0-or-later
 summary    : Tool for simulating superuser privileges
 description: |

--- a/packages/f/fakeroot/pspec_x86_64.xml
+++ b/packages/f/fakeroot/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>fakeroot</Name>
+        <Homepage>https://tracker.debian.org/pkg/fakeroot</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.devel</PartOf>
         <Summary xml:lang="en">Tool for simulating superuser privileges</Summary>
         <Description xml:lang="en">Tool for simulating superuser privileges
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>fakeroot</Name>
@@ -36,6 +37,8 @@
             <Path fileType="man">/usr/share/man/nl/man1/fakeroot.1</Path>
             <Path fileType="man">/usr/share/man/pt/man1/faked.1</Path>
             <Path fileType="man">/usr/share/man/pt/man1/fakeroot.1</Path>
+            <Path fileType="man">/usr/share/man/ro/man1/faked.1</Path>
+            <Path fileType="man">/usr/share/man/ro/man1/fakeroot.1</Path>
             <Path fileType="man">/usr/share/man/sv/man1/faked.1</Path>
             <Path fileType="man">/usr/share/man/sv/man1/fakeroot.1</Path>
         </Files>
@@ -47,7 +50,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="18">fakeroot</Dependency>
+            <Dependency release="19">fakeroot</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libfakeroot/libfakeroot-0.so</Path>
@@ -55,12 +58,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2023-07-22</Date>
-            <Version>1.32.1</Version>
+        <Update release="19">
+            <Date>2024-04-07</Date>
+            <Version>1.34</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Changelog : 
  - 1.34 : faked now ignores SIGWINCH. 
  - 1.33 : Add renameat2 support. 
  - 1.32.2 : 
     - Romanian man page translation 
     - add missing wrapped.h dependency.
- Full changelog is [here](https://salsa.debian.org/clint/fakeroot/-/raw/51aafce59afeb0852805f3abf2926deb95c2172b/debian/changelog)
- Add `homepage` key to `package.yml` (Part of getsolus/packages#411)
- Add monitoring.yml

**Test Plan**

- Run `ypkg` to build packages
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable