### PR TITLE
mu: Update to 1.12.3

### DIFF
--- a/packages/m/mu/abi_used_symbols
+++ b/packages/m/mu/abi_used_symbols
@@ -73,7 +73,6 @@ libc.so.6:symlink
 libc.so.6:time
 libc.so.6:tolower
 libc.so.6:unlink
-libc.so.6:vsnprintf
 libc.so.6:wcswidth
 libc.so.6:wordexp
 libc.so.6:wordfree
@@ -372,6 +371,7 @@ libstdc++.so.6:_ZNSt15basic_streambufIcSt11char_traitsIcEE9underflowEv
 libstdc++.so.6:_ZNSt15basic_streambufIcSt11char_traitsIcEEC2ERKS2_
 libstdc++.so.6:_ZNSt15basic_streambufIcSt11char_traitsIcEEaSERKS2_
 libstdc++.so.6:_ZNSt16invalid_argumentC1EPKc
+libstdc++.so.6:_ZNSt16invalid_argumentC1ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
 libstdc++.so.6:_ZNSt16invalid_argumentD1Ev
 libstdc++.so.6:_ZNSt18condition_variable10notify_oneEv
 libstdc++.so.6:_ZNSt18condition_variableC1Ev
@@ -428,7 +428,6 @@ libstdc++.so.6:_ZSt20__throw_out_of_rangePKc
 libstdc++.so.6:_ZSt20__throw_system_errori
 libstdc++.so.6:_ZSt21__glibcxx_assert_failPKciS0_S0_
 libstdc++.so.6:_ZSt21ios_base_library_initv
-libstdc++.so.6:_ZSt24__throw_invalid_argumentPKc
 libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
 libstdc++.so.6:_ZSt25__throw_bad_function_callv
 libstdc++.so.6:_ZSt28_Rb_tree_rebalance_for_erasePSt18_Rb_tree_node_baseRS_
@@ -447,7 +446,6 @@ libstdc++.so.6:_ZTINSt6thread6_StateE
 libstdc++.so.6:_ZTISt11logic_error
 libstdc++.so.6:_ZTISt11range_error
 libstdc++.so.6:_ZTISt12bad_weak_ptr
-libstdc++.so.6:_ZTISt12out_of_range
 libstdc++.so.6:_ZTISt12system_error
 libstdc++.so.6:_ZTISt13runtime_error
 libstdc++.so.6:_ZTISt15basic_streambufIcSt11char_traitsIcEE

--- a/packages/m/mu/package.yml
+++ b/packages/m/mu/package.yml
@@ -1,8 +1,8 @@
 name       : mu
-version    : 1.12.2
-release    : 23
+version    : 1.12.3
+release    : 24
 source     :
-    - https://github.com/djcb/mu/releases/download/v1.12.2/mu-1.12.2.tar.xz : 7b1a1d840f120a1e777b366e6d52bda5a203dd31d831a5a285fbaef275c6b618
+    - https://github.com/djcb/mu/releases/download/v1.12.3/mu-1.12.3.tar.xz : ce6edd5661ffe3de4c9e17a6c8cdaf233b3cd5e85c82ed876d87c064e6e7b7e0
 license    : GPL-3.0-only
 homepage   : https://www.djcbsoftware.nl/code/mu/
 component  : editor

--- a/packages/m/mu/pspec_x86_64.xml
+++ b/packages/m/mu/pspec_x86_64.xml
@@ -9,14 +9,14 @@
         <License>GPL-3.0-only</License>
         <PartOf>editor</PartOf>
         <Summary xml:lang="en">maildir indexer/searcher + emacs mail client + guile bindings</Summary>
-        <Description xml:lang="en">mu is a tool for dealing with e-mail messages stored in the Maildir-format. mu’s purpose in life is to help you to quickly find the messages you need; in addition, it allows you to view messages, extract attachments, create new maildirs, and so on. See the mu cheatsheet for some examples. mu is fully documented.
+        <Description xml:lang="en">mu is a tool for dealing with e-mail messages stored in the Maildir-format. mu&#x2019;s purpose in life is to help you to quickly find the messages you need; in addition, it allows you to view messages, extract attachments, create new maildirs, and so on. See the mu cheatsheet for some examples. mu is fully documented.
 </Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>mu</Name>
         <Summary xml:lang="en">maildir indexer/searcher + emacs mail client + guile bindings</Summary>
-        <Description xml:lang="en">mu is a tool for dealing with e-mail messages stored in the Maildir-format. mu’s purpose in life is to help you to quickly find the messages you need; in addition, it allows you to view messages, extract attachments, create new maildirs, and so on. See the mu cheatsheet for some examples. mu is fully documented.
+        <Description xml:lang="en">mu is a tool for dealing with e-mail messages stored in the Maildir-format. mu&#x2019;s purpose in life is to help you to quickly find the messages you need; in addition, it allows you to view messages, extract attachments, create new maildirs, and so on. See the mu cheatsheet for some examples. mu is fully documented.
 </Description>
         <PartOf>editor</PartOf>
         <Files>
@@ -104,9 +104,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2024-03-23</Date>
-            <Version>1.12.2</Version>
+        <Update release="24">
+            <Date>2024-04-12</Date>
+            <Version>1.12.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- improve documentation / manpages
- add --reindex option to 'mu index'
- split off mu4e-complete-contact (for wider use)
- work around some mail rendering issues with some emacs version
- update some dependencies
- fix some build warnings on older emacsen
- fix musl build

**Test Plan**
- search and view message

**Checklist**
- [X] Package was built and tested against unstable
