### PR TITLE
appstream-data: Update Appstream Metainfo to v37

### DIFF
--- a/packages/a/appstream-data/package.yml
+++ b/packages/a/appstream-data/package.yml
@@ -1,8 +1,8 @@
 name       : appstream-data
-version    : '36'
-release    : 38
+version    : '37'
+release    : 39
 source     :
-    - https://github.com/getsolus/solus-appstream-data/archive/refs/tags/v36.tar.gz : 534202a0266227902b26bf8455c57f40453f7c796d1484f9f32e3fe3b30d73b1
+    - https://github.com/getsolus/solus-appstream-data/archive/refs/tags/v37.tar.gz : 7b0488dd89cd21ca51249f5c3778fd3d479c5f9a6e2e714c9977c9d9da7f38c6
 homepage   : https://www.freedesktop.org/wiki/Distributions/AppStream/
 license    :
     - CC-BY-SA-3.0

--- a/packages/a/appstream-data/pspec_x86_64.xml
+++ b/packages/a/appstream-data/pspec_x86_64.xml
@@ -102,6 +102,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.ultimaker.cura.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.uploadedlobster.peek.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.valvesoftware.Steam.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.yubico.yubikey_manager.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/conky-manager2.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/de.haeckerfelix.Shortwave.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/de.haeckerfelix.gradio.png</Path>
@@ -176,6 +177,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.otsaloma.gaupol.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.otsaloma.nfoview.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.sourceforge.deadbeef.deadbeef.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.sourceforge.doublecmd.double_commander.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.sourceforge.pentobi.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.sourceforge.pysolfc.PySolFC.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/liberation-circuit.png</Path>
@@ -651,6 +653,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.ultimaker.cura.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.uploadedlobster.peek.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.valvesoftware.Steam.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.yubico.yubikey_manager.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/conky-manager2.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/de.haeckerfelix.Shortwave.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/de.haeckerfelix.gradio.png</Path>
@@ -752,12 +755,15 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.stella_emu.Stella.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.streamlink.gui.twitch.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.thetumultuousunicornofdarkness.cpu-x.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.transgui.transgui.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.winff.winff.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.wxmaxima_developers.wxMaxima.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.mgba.mGBA.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.mpv.mpv.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.otsaloma.gaupol.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.otsaloma.nfoview.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.sourceforge.deadbeef.deadbeef.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.sourceforge.doublecmd.double_commander.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.sourceforge.pentobi.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.sourceforge.pysolfc.PySolFC.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/iosevka.png</Path>
@@ -1198,9 +1204,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="38">
-            <Date>2024-04-06</Date>
-            <Version>36</Version>
+        <Update release="39">
+            <Date>2024-04-14</Date>
+            <Version>37</Version>
             <Comment>Packaging update</Comment>
             <Name>Hans Kelson</Name>
             <Email>hans@communitycomputing.net</Email>


### PR DESCRIPTION
**Summary**
Update Appstream Metainfo to v37

**Test Plan**

1. Install package built per PR
2. See that deprecated packages no longer appear in Discover search

**Checklist**

- [x] Package was built and tested against unstable
