### PR TITLE
tailscale: Update to 1.64.0

### DIFF
--- a/packages/t/tailscale/files/defaults.patch
+++ b/packages/t/tailscale/files/defaults.patch
@@ -1,14 +1,13 @@
 diff --git a/cmd/tailscaled/tailscaled.service b/cmd/tailscaled/tailscaled.service
-index d5a65a4..2a3825a 100644
+index 719a3c0..cc2f569 100644
 --- a/cmd/tailscaled/tailscaled.service
 +++ b/cmd/tailscaled/tailscaled.service
-@@ -5,7 +5,8 @@ Wants=network-pre.target
+@@ -5,6 +5,7 @@ Wants=network-pre.target
  After=network-pre.target NetworkManager.service systemd-resolved.service
  
  [Service]
 -EnvironmentFile=/etc/default/tailscaled
-+EnvironmentFile=/usr/share/defaults/tailscale/tailscaled
 +EnvironmentFile=-/etc/default/tailscaled
- ExecStartPre=/usr/sbin/tailscaled --cleanup
++EnvironmentFile=/usr/share/defaults/tailscale/tailscaled
  ExecStart=/usr/sbin/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/run/tailscale/tailscaled.sock --port=${PORT} $FLAGS
  ExecStopPost=/usr/sbin/tailscaled --cleanup

--- a/packages/t/tailscale/package.yml
+++ b/packages/t/tailscale/package.yml
@@ -1,8 +1,8 @@
 name       : tailscale
-version    : 1.62.1
-release    : 13
+version    : 1.64.0
+release    : 14
 source     :
-    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.62.1.tar.gz : 22737fae37e971fecdf49d6b741b99988868aa3f1e683e67e14b872a2c49ca1c
+    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.64.0.tar.gz : a0b9b84fef37316a9eee2490668811cafb85b227839eca97bbff88f7ce58a815
 homepage   : https://tailscale.com
 license    : BSD-3-Clause
 component  : network.clients

--- a/packages/t/tailscale/pspec_x86_64.xml
+++ b/packages/t/tailscale/pspec_x86_64.xml
@@ -8,14 +8,14 @@
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>network.clients</PartOf>
-        <Summary xml:lang="en">Private WireGuard® networks made easy</Summary>
+        <Summary xml:lang="en">Private WireGuard&#xae; networks made easy</Summary>
         <Description xml:lang="en">The easiest, most secure way to use WireGuard and 2FA.
 </Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>tailscale</Name>
-        <Summary xml:lang="en">Private WireGuard® networks made easy</Summary>
+        <Summary xml:lang="en">Private WireGuard&#xae; networks made easy</Summary>
         <Description xml:lang="en">The easiest, most secure way to use WireGuard and 2FA.
 </Description>
         <PartOf>network.clients</PartOf>
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2024-03-30</Date>
-            <Version>1.62.1</Version>
+        <Update release="14">
+            <Date>2024-04-14</Date>
+            <Version>1.64.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Changed: tailscale serve headers are now RFC 2047 Q-encoded

**Test Plan**
- tailscale web

**Checklist**
- [X] Package was built and tested against unstable
