### PR TITLE
font-iosevka-ttf: Update to 29.2.0

### DIFF
--- a/packages/f/font-iosevka-ttf/package.yml
+++ b/packages/f/font-iosevka-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : font-iosevka-ttf
-version    : 29.1.0
-release    : 60
+version    : 29.2.0
+release    : 61
 source     :
-    - https://github.com/be5invis/Iosevka/releases/download/v29.1.0/PkgTTF-Iosevka-29.1.0.zip : 1f25390daea5b917fc798bee629a6bedd5c8f4b1b75b33216f459aefda7bf642
+    - https://github.com/be5invis/Iosevka/releases/download/v29.2.0/PkgTTF-Iosevka-29.2.0.zip : 1aa00314b9f40054a6538908986b432094d05390160c881219e3b2e415a0256e
 homepage   : https://typeof.net/Iosevka
 license    : OFL-1.1
 component  : desktop.font

--- a/packages/f/font-iosevka-ttf/pspec_x86_64.xml
+++ b/packages/f/font-iosevka-ttf/pspec_x86_64.xml
@@ -78,9 +78,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="60">
-            <Date>2024-04-06</Date>
-            <Version>29.1.0</Version>
+        <Update release="61">
+            <Date>2024-04-14</Date>
+            <Version>29.2.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Drop NWID glyphs for ligatures in quasi-proportionals
- Make presence of descender serif automatic for GREEK CAPITAL KAI SYMBOL
- Make presence of top-left serif automatic for CYRILLIC LETTER BASHKIR KA
- Make GREEK SMALL LETTER DIGAMMA respond to top-right serif variants of Greek Capital Gamma
- Make GREEK SMALL LETTER HETA respond to top-left serif variants of H
- Make CYRILLIC LIGATURE EN GHE respond to top-right serif variants of Greek Capital Gamma
- Make CYRILLIC LETTER STRAIGHT U follow variants of Cyrillic U
- Make the terminal of LETTER SCHWA a full hook under italics

**Test Plan**
- render text with the font

**Checklist**
- [X] Package was built and tested against unstable
