### PR TITLE
fdk-aac: Update to 2.0.3

### DIFF
--- a/packages/f/fdk-aac/monitoring.yml
+++ b/packages/f/fdk-aac/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 16208
+  rss: https://github.com/mstorsjo/fdk-aac/tags.atom
+# No known CPE, checked 2024-04-15
+security:
+  cpe: ~

--- a/packages/f/fdk-aac/package.yml
+++ b/packages/f/fdk-aac/package.yml
@@ -1,8 +1,9 @@
 name       : fdk-aac
-version    : 2.0.2
-release    : 6
+version    : 2.0.3
+release    : 7
 source     :
-    - https://github.com/mstorsjo/fdk-aac/archive/refs/tags/v2.0.2.tar.gz : 7812b4f0cf66acda0d0fe4302545339517e702af7674dd04e5fe22a5ade16a90
+    - https://netix.dl.sourceforge.net/project/opencore-amr/fdk-aac/fdk-aac-2.0.3.tar.gz : 829b6b89eef382409cda6857fd82af84fabb63417b08ede9ea7a553f811cb79e
+homepage   : https://sourceforge.net/projects/opencore-amr/
 license    : BSD-3-Clause
 component  : multimedia.codecs
 summary    : Fraunhofer FDK AAC codec library

--- a/packages/f/fdk-aac/pspec_x86_64.xml
+++ b/packages/f/fdk-aac/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>fdk-aac</Name>
+        <Homepage>https://sourceforge.net/projects/opencore-amr/</Homepage>
         <Packager>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>multimedia.codecs</PartOf>
         <Summary xml:lang="en">Fraunhofer FDK AAC codec library</Summary>
         <Description xml:lang="en">Library of OpenCORE Framework implementation of Adaptive Multi Rate Narrowband and Wideband (AMR-NB and AMR-WB) speech codec. Library of VisualOn implementation of Adaptive Multi Rate Wideband (AMR-WB) encoder and Advanced Audio Coding (AAC) encoder. Modified library of Fraunhofer AAC decoder and encoder.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>fdk-aac</Name>
@@ -20,7 +21,7 @@
         <PartOf>multimedia.codecs</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libfdk-aac.so.2</Path>
-            <Path fileType="library">/usr/lib64/libfdk-aac.so.2.0.2</Path>
+            <Path fileType="library">/usr/lib64/libfdk-aac.so.2.0.3</Path>
         </Files>
     </Package>
     <Package>
@@ -30,7 +31,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="6">fdk-aac</Dependency>
+            <Dependency release="7">fdk-aac</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/fdk-aac/FDK_audio.h</Path>
@@ -44,12 +45,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2021-10-06</Date>
-            <Version>2.0.2</Version>
+        <Update release="7">
+            <Date>2024-04-15</Date>
+            <Version>2.0.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Fixed one case of a failed assert in SBR encoding
- Added build support for s390x
- Full changelog can be found [here](https://raw.githubusercontent.com/mstorsjo/fdk-aac/v2.0.3/ChangeLog)
- Add `homepage` key to `package.yml` (Part of getsolus/packages#411)
- Add monitoring.yml

**Test Plan**

- Rebuild `gnome-remote-dekstop` and `gstreamer-1.0-plugins-bad` against this package
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable