### PR TITLE
file-roller: Update to 43.1

### DIFF
--- a/packages/f/file-roller/abi_used_symbols
+++ b/packages/f/file-roller/abi_used_symbols
@@ -66,7 +66,6 @@ libarchive.so.13:archive_write_open
 libarchive.so.13:archive_write_set_bytes_in_last_block
 libarchive.so.13:archive_write_set_filter_option
 libarchive.so.13:archive_write_set_format_7zip
-libarchive.so.13:archive_write_set_format_ar_svr4
 libarchive.so.13:archive_write_set_format_cpio
 libarchive.so.13:archive_write_set_format_iso9660
 libarchive.so.13:archive_write_set_format_pax_restricted

--- a/packages/f/file-roller/monitoring.yml
+++ b/packages/f/file-roller/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 5392
+  rss: https://gitlab.gnome.org/GNOME/file-roller/-/tags?format=atom
+security:
+  cpe:
+  - vendor: gnome
+    product: :file-roller

--- a/packages/f/file-roller/package.yml
+++ b/packages/f/file-roller/package.yml
@@ -1,8 +1,9 @@
 name       : file-roller
-version    : '43.0'
-release    : 41
+version    : '43.1'
+release    : 42
 source     :
-    - https://download.gnome.org/sources/file-roller/43/file-roller-43.0.tar.xz : 298729fdbdb9da8132c0bbc60907517d65685b05618ae05167335e6484f573a1
+    - https://download.gnome.org/sources/file-roller/43/file-roller-43.1.tar.xz : 84994023997293beb345d9793db8f5f0bbb41faa155c6ffb48328f203957ad08
+homepage   : https://wiki.gnome.org/Apps/FileRoller
 license    : GPL-2.0-or-later
 summary    : Archive manager for the GNOME desktop environment
 description: |
@@ -13,8 +14,8 @@ builddeps  :
     - pkgconfig(json-glib-1.0)
     - pkgconfig(libarchive)
     - pkgconfig(libhandy-1)
-    - pkgconfig(libportal)
     - pkgconfig(libnautilus-extension-4)
+    - pkgconfig(libportal)
     - desktop-file-utils
     - itstool
 rundeps    :

--- a/packages/f/file-roller/pspec_x86_64.xml
+++ b/packages/f/file-roller/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>file-roller</Name>
+        <Homepage>https://wiki.gnome.org/Apps/FileRoller</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.gnome</PartOf>
         <Summary xml:lang="en">Archive manager for the GNOME desktop environment</Summary>
         <Description xml:lang="en">File Roller is an archive manager for the GNOME desktop environment
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>file-roller</Name>
@@ -478,6 +479,7 @@
             <Path fileType="localedata">/usr/share/locale/hu/LC_MESSAGES/file-roller.mo</Path>
             <Path fileType="localedata">/usr/share/locale/hy/LC_MESSAGES/file-roller.mo</Path>
             <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/file-roller.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ie/LC_MESSAGES/file-roller.mo</Path>
             <Path fileType="localedata">/usr/share/locale/is/LC_MESSAGES/file-roller.mo</Path>
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/file-roller.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/file-roller.mo</Path>
@@ -539,12 +541,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="41">
-            <Date>2023-05-04</Date>
-            <Version>43.0</Version>
+        <Update release="42">
+            <Date>2024-04-15</Date>
+            <Version>43.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Fixed wrong filename when opening a files on Google Drive
- Full changelog can be found [here](https://download.gnome.org/sources/file-roller/43/file-roller-43.1.news)
- Add `homepage` key to `package.yml` (Part of getsolus/packages#411)
- Add monitoring.yml

**Test Plan**

- Rebuild `font-manager` against this package
- Extract a tarball
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable