### PR TITLE
eza: Update to 0.18.10

### DIFF
--- a/packages/e/eza/package.yml
+++ b/packages/e/eza/package.yml
@@ -1,8 +1,8 @@
 name       : eza
-version    : 0.18.8
-release    : 20
+version    : 0.18.10
+release    : 21
 source     :
-    - https://github.com/eza-community/eza/archive/refs/tags/v0.18.8.tar.gz : 4169f57c522cd17e195a7bc36a9ea671e5b1d905f9ab57c66a49f6edf343179c
+    - https://github.com/eza-community/eza/archive/refs/tags/v0.18.10.tar.gz : b0b59a7bdd7536941fac210ca25d30f904657f906aa2c01411fb390d4bdcd139
 homepage   : https://github.com/eza-community/eza
 license    : MIT
 component  : system.utils

--- a/packages/e/eza/pspec_x86_64.xml
+++ b/packages/e/eza/pspec_x86_64.xml
@@ -9,14 +9,14 @@
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">A modern, maintained replacement for ls</Summary>
-        <Description xml:lang="en">eza is a modern, maintained replacement for the venerable file-listing command-line program ls that ships with Unix and Linux operating systems, giving it more features and better defaults. It uses colours to distinguish file types and metadata. It knows about symlinks, extended attributes, and Git. And it’s small, fast, and just one single binary.
+        <Description xml:lang="en">eza is a modern, maintained replacement for the venerable file-listing command-line program ls that ships with Unix and Linux operating systems, giving it more features and better defaults. It uses colours to distinguish file types and metadata. It knows about symlinks, extended attributes, and Git. And it&#x2019;s small, fast, and just one single binary.
 </Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>eza</Name>
         <Summary xml:lang="en">A modern, maintained replacement for ls</Summary>
-        <Description xml:lang="en">eza is a modern, maintained replacement for the venerable file-listing command-line program ls that ships with Unix and Linux operating systems, giving it more features and better defaults. It uses colours to distinguish file types and metadata. It knows about symlinks, extended attributes, and Git. And it’s small, fast, and just one single binary.
+        <Description xml:lang="en">eza is a modern, maintained replacement for the venerable file-listing command-line program ls that ships with Unix and Linux operating systems, giving it more features and better defaults. It uses colours to distinguish file types and metadata. It knows about symlinks, extended attributes, and Git. And it&#x2019;s small, fast, and just one single binary.
 </Description>
         <PartOf>system.utils</PartOf>
         <Files>
@@ -32,9 +32,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2024-03-21</Date>
-            <Version>0.18.8</Version>
+        <Update release="21">
+            <Date>2024-04-15</Date>
+            <Version>0.18.10</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Switch out `ansiterm` crate for `nu_ansi_term`
- Bump `trycmd` from 0.15.0 to 0.15.1

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `eza` without options, with the list option, and with the color option.

**Checklist**

- [x] Package was built and tested against unstable
