### PR TITLE
github-cli: Update to 2.47.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.46.0
-release    : 43
+version    : 2.47.0
+release    : 44
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.46.0.tar.gz : 663871687310c671ecc183a258fa573622e1e972c681982ac79a25c967fd40b2
+    - https://github.com/cli/cli/archive/refs/tags/v2.47.0.tar.gz : f87622443f143a84462a026534cf234b059c609a6053d7c9ff692c45b30e63f4
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -8,14 +8,14 @@
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
-        <Summary xml:lang="en">GitHub’s official command line tool</Summary>
+        <Summary xml:lang="en">GitHub&#x2019;s official command line tool</Summary>
         <Description xml:lang="en">github-cli is a tool that allows for GitHub concepts such as pull requests, issues, and gists to be used on the command line.
 </Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>github-cli</Name>
-        <Summary xml:lang="en">GitHub’s official command line tool</Summary>
+        <Summary xml:lang="en">GitHub&#x2019;s official command line tool</Summary>
         <Description xml:lang="en">github-cli is a tool that allows for GitHub concepts such as pull requests, issues, and gists to be used on the command line.
 </Description>
         <PartOf>system.utils</PartOf>
@@ -213,9 +213,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="43">
-            <Date>2024-03-21</Date>
-            <Version>2.46.0</Version>
+        <Update release="44">
+            <Date>2024-04-15</Date>
+            <Version>2.47.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Fix typo in `auth switch` help example
- gh-attestation cmd integration
- Fix segfault in error handling of `gh repo rename`

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list` in the packages repo, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
