### PR TITLE
weechat: Update to 4.2.2

### DIFF
--- a/packages/w/weechat/abi_used_symbols
+++ b/packages/w/weechat/abi_used_symbols
@@ -468,7 +468,7 @@ libpython3.11.so.1.0:PyImport_AppendInittab
 libpython3.11.so.1.0:PyList_Insert
 libpython3.11.so.1.0:PyLong_AsLong
 libpython3.11.so.1.0:PyLong_FromLong
-libpython3.11.so.1.0:PyLong_FromLongLong
+libpython3.11.so.1.0:PyLong_FromUnsignedLongLong
 libpython3.11.so.1.0:PyModule_Create2
 libpython3.11.so.1.0:PyModule_GetDict
 libpython3.11.so.1.0:PyObject_CallFunction

--- a/packages/w/weechat/monitoring.yml
+++ b/packages/w/weechat/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 5122
+  rss: https://github.com/weechat/weechat/tags.atom
+security:
+  cpe:
+    - vendor: weechat
+      product: weechat

--- a/packages/w/weechat/package.yml
+++ b/packages/w/weechat/package.yml
@@ -1,8 +1,8 @@
 name       : weechat
-version    : 4.2.0
-release    : 78
+version    : 4.2.2
+release    : 79
 source     :
-    - https://github.com/weechat/weechat/archive/refs/tags/v4.2.0.tar.gz : f53591a586dcbb5055485bd8ddcff0104b1ce142a7adca7ae7834beb7e1fbb96
+    - https://github.com/weechat/weechat/archive/refs/tags/v4.2.2.tar.gz : 064856ae2b999ab13e5eb6c40d15333d3afe428d636ed3849f2d48a825379706
 homepage   : https://weechat.org
 license    : GPL-3.0-or-later
 summary    : WeeChat is a fast, light and extensible chat client.

--- a/packages/w/weechat/pspec_x86_64.xml
+++ b/packages/w/weechat/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>weechat</Name>
         <Homepage>https://weechat.org</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.irc</PartOf>
@@ -72,7 +72,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="78">weechat</Dependency>
+            <Dependency release="79">weechat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/weechat/weechat-plugin.h</Path>
@@ -80,12 +80,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="78">
-            <Date>2024-04-14</Date>
-            <Version>4.2.0</Version>
+        <Update release="79">
+            <Date>2024-04-15</Date>
+            <Version>4.2.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- core: fix reset to initial scroll position after search of text in buffer
- core: add missing mouse events "alt-ctrl-button2" and "alt-ctrl-button3"
- exec: remove trailing space on buffers with free content when line numbers are not displayed
- exec: add missing exec tags in lines of buffers with free content
- irc: fix random date displayed when a received message contains tags but no "time"
- irc: add missing tags on self action messages when capability echo-message is enabled
- python: fix truncation of unsigned long long integer returned by function string_parse_size
- relay: set the last IRC client disconnection time only after a successful connection
- script: always display list of scripts when searching scripts with `/script search`
- script: fix default mouse keys
- scripts: fix crash on script unload when a hook is created in a buffer close callback
- tcl: fix truncation of long integer returned by function hdata_long
- trigger: fix memory leak when adding a new trigger with `/trigger` command

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Set up Libera as an IRC server, connect to it, and join the Libera room.

**Checklist**

- [x] Package was built and tested against unstable
