### PR TITLE
svtplay-dl: update to 4.72

### DIFF
--- a/packages/s/svtplay-dl/package.yml
+++ b/packages/s/svtplay-dl/package.yml
@@ -1,8 +1,8 @@
 name       : svtplay-dl
-version    : '4.69'
-release    : 18
+version    : '4.72'
+release    : 19
 source     :
-    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.69.tar.gz : eb48a2f47d1d779cff042013da00b5f499e19ad200c3bfb482b5355dc16ce78a
+    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.72.tar.gz : 7cf1b8f6cbe671e75e630cd32e879178580999671ac397f88239151ad8057b8d
 homepage   : https://svtplay-dl.se/
 license    : MIT
 component  : network.download

--- a/packages/s/svtplay-dl/pspec_x86_64.xml
+++ b/packages/s/svtplay-dl/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>svtplay-dl</Name>
         <Homepage>https://svtplay-dl.se/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>network.download</PartOf>
@@ -21,11 +21,11 @@
         <PartOf>network.download</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/svtplay-dl</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.69-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.69-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.69-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.69-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.69-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.72-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.72-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.72-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.72-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.72-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/__pycache__/__init__.cpython-311.pyc</Path>
@@ -78,6 +78,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/pokemon.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/radioplay.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/raw.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/regeringen.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/riksdagen.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/ruv.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/services.cpython-311.pyc</Path>
@@ -89,6 +90,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/tv4play.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/twitch.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/urplay.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/vasaloppet.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/vg.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/viaplay.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/viasatsport.cpython-311.pyc</Path>
@@ -122,6 +124,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/pokemon.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/radioplay.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/raw.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/regeringen.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/riksdagen.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/ruv.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/services.py</Path>
@@ -133,6 +136,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/tv4play.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/twitch.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/urplay.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/vasaloppet.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/vg.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/viaplay.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/viasatsport.py</Path>
@@ -165,12 +169,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2024-02-17</Date>
-            <Version>4.69</Version>
+        <Update release="19">
+            <Date>2024-04-16</Date>
+            <Version>4.72</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- tv4play and svtplay will have the corret order in -A again
- support for regeringen.se
- support for vasaloppet.se
- postprocessing should work better with dolby vision HDR
- removed support for subtitles for pluto.tv because their ads makes their mess up with timecodes..
- tv4play handle upcoming videos better so it wont show a error message
- svtplay improved support for syntolkat (sv-x-ad language)

**Test Plan**

- Installed, downloaded a video and watched it.

**Checklist**

- [X] Package was built and tested against unstable
