### PR TITLE
kodi: Add required rundep

### DIFF
--- a/packages/k/kodi/package.yml
+++ b/packages/k/kodi/package.yml
@@ -1,6 +1,6 @@
 name       : kodi
 version    : '21.0'
-release    : 99
+release    : 100
 source     :
     - https://github.com/xbmc/xbmc/archive/refs/tags/21.0-Omega.tar.gz : 7f54c1fd8456ac46221fbc85e447362bdc209163c6cb19fca98d106560071b7c
 license    : GPL-2.0-or-later
@@ -93,6 +93,7 @@ builddeps  :
     - sndio-devel
     - swig
 rundeps    :
+    - crossguid-devel
     - libmodplug
     - libva-intel-driver
     - shairplay

--- a/packages/k/kodi/pspec_x86_64.xml
+++ b/packages/k/kodi/pspec_x86_64.xml
@@ -119,7 +119,7 @@
             <Path fileType="library">/usr/lib/kodi/addons/imagedecoder.raw/imagedecoder.raw.so.21.0.0</Path>
             <Path fileType="library">/usr/lib/kodi/addons/inputstream.adaptive/inputstream.adaptive.so</Path>
             <Path fileType="library">/usr/lib/kodi/addons/inputstream.adaptive/inputstream.adaptive.so.21.0</Path>
-            <Path fileType="library">/usr/lib/kodi/addons/inputstream.adaptive/inputstream.adaptive.so.21.4.4</Path>
+            <Path fileType="library">/usr/lib/kodi/addons/inputstream.adaptive/inputstream.adaptive.so.21.4.5</Path>
             <Path fileType="library">/usr/lib/kodi/addons/inputstream.rtmp/inputstream.rtmp.so</Path>
             <Path fileType="library">/usr/lib/kodi/addons/inputstream.rtmp/inputstream.rtmp.so.21.0</Path>
             <Path fileType="library">/usr/lib/kodi/addons/inputstream.rtmp/inputstream.rtmp.so.21.1.0</Path>
@@ -9358,7 +9358,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="99">kodi</Dependency>
+            <Dependency release="100">kodi</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/dumb.h</Path>
@@ -9497,8 +9497,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="99">
-            <Date>2024-04-06</Date>
+        <Update release="100">
+            <Date>2024-04-16</Date>
             <Version>21.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>


### PR DESCRIPTION
**Summary**
- Kodi will not start unless crossguid lib installed

**Test Plan**
- remove crossguid
- reinstall and start kodi

**Checklist**
- [X] Package was built and tested against unstable
