### PR TITLE
 google-api-python-client: update to 2.125.0 

### DIFF
--- a/packages/g/google-api-python-client/package.yml
+++ b/packages/g/google-api-python-client/package.yml
@@ -1,8 +1,9 @@
 name       : google-api-python-client
-version    : 2.48.0
-release    : 9
+version    : 2.125.0
+release    : 10
 source     :
-    - https://github.com/googleapis/google-api-python-client/archive/refs/tags/v2.48.0.tar.gz : 720236b6a383d5c56ac733ebf05891fe63eb7a9006e45144be6ea75a5cb8e080
+    - https://github.com/googleapis/google-api-python-client/archive/refs/tags/v2.125.0.tar.gz : c9939d2e2e33f2a91fb419e24689c5594b525accf1b8e05aed75ec5727c1d1e7
+homepage   : https://googleapis.github.io/google-api-python-client/docs/
 license    : Apache-2.0
 component  : programming.python
 summary    : Google APIs Python Client

--- a/packages/g/google-api-python-client/pspec_x86_64.xml
+++ b/packages/g/google-api-python-client/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>google-api-python-client</Name>
+        <Homepage>https://googleapis.github.io/google-api-python-client/docs/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -21,11 +22,11 @@
         <Files>
             <Path fileType="library">/usr/lib/python3.11/site-packages/apiclient/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/apiclient/__pycache__/__init__.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/google_api_python_client-2.48.0-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/google_api_python_client-2.48.0-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/google_api_python_client-2.48.0-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/google_api_python_client-2.48.0-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/google_api_python_client-2.48.0-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/google_api_python_client-2.125.0-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/google_api_python_client-2.125.0-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/google_api_python_client-2.125.0-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/google_api_python_client-2.125.0-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/google_api_python_client-2.125.0-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/__pycache__/_auth.cpython-311.pyc</Path>
@@ -55,6 +56,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/accessapproval.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/accesscontextmanager.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/accesscontextmanager.v1beta.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/acmedns.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/adexchangebuyer.v1.2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/adexchangebuyer.v1.3.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/adexchangebuyer.v1.4.json</Path>
@@ -70,11 +72,19 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/admob.v1beta.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/adsense.v2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/adsensehost.v4.1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/advisorynotifications.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/aiplatform.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/aiplatform.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/alertcenter.v1beta1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/alloydb.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/alloydb.v1alpha.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/alloydb.v1beta.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/analytics.v3.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/analyticsadmin.v1alpha.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/analyticsadmin.v1beta.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/analyticsdata.v1alpha.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/analyticsdata.v1beta.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/analyticshub.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/analyticshub.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/analyticsreporting.v4.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/androiddeviceprovisioning.v1.json</Path>
@@ -91,18 +101,27 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/appengine.v1beta.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/appengine.v1beta4.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/appengine.v1beta5.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/apphub.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/apphub.v1alpha.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/area120tables.v1alpha1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/artifactregistry.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/artifactregistry.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/artifactregistry.v1beta2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/assuredworkloads.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/assuredworkloads.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/authorizedbuyersmarketplace.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/backupdr.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/baremetalsolution.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/baremetalsolution.v1alpha1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/baremetalsolution.v2.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/batch.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/beyondcorp.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/beyondcorp.v1alpha.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/biglake.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/bigquery.v2.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/bigqueryconnection.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/bigqueryconnection.v1beta1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/bigquerydatapolicy.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/bigquerydatatransfer.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/bigqueryreservation.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/bigqueryreservation.v1alpha2.json</Path>
@@ -113,12 +132,15 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/billingbudgets.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/binaryauthorization.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/binaryauthorization.v1beta1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/blockchainnodeengine.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/blogger.v2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/blogger.v3.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/books.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/businessprofileperformance.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/calendar.v3.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/certificatemanager.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/chat.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/checks.v1alpha.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/chromemanagement.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/chromepolicy.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/chromeuxreport.v1.json</Path>
@@ -131,12 +153,16 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/cloudasset.v1p5beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/cloudasset.v1p7beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/cloudbilling.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/cloudbilling.v1beta.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/cloudbuild.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/cloudbuild.v1alpha1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/cloudbuild.v1alpha2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/cloudbuild.v1beta1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/cloudbuild.v2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/cloudchannel.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/cloudcommerceprocurement.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/cloudcontrolspartner.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/cloudcontrolspartner.v1beta.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/clouddebugger.v2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/clouddeploy.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/clouderrorreporting.v1beta1.json</Path>
@@ -159,6 +185,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/cloudsearch.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/cloudshell.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/cloudshell.v1alpha1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/cloudsupport.v2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/cloudsupport.v2beta.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/cloudtasks.v2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/cloudtasks.v2beta2.json</Path>
@@ -172,6 +199,8 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/compute.beta.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/compute.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/connectors.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/connectors.v2.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/contactcenteraiplatform.v1alpha1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/contactcenterinsights.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/container.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/container.v1beta1.json</Path>
@@ -180,17 +209,22 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/containeranalysis.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/content.v2.1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/content.v2.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/contentwarehouse.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/customsearch.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/datacatalog.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/datacatalog.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/dataflow.v1b3.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/dataform.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/datafusion.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/datafusion.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/datalabeling.v1beta1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/datalineage.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/datamigration.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/datamigration.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/datapipelines.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/dataplex.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/dataportability.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/dataportability.v1beta.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/dataproc.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/dataproc.v1beta2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/datastore.v1.json</Path>
@@ -204,13 +238,19 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/dfareporting.v3.3.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/dfareporting.v3.4.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/dfareporting.v3.5.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/dfareporting.v4.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/dialogflow.v2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/dialogflow.v2beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/dialogflow.v3.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/dialogflow.v3beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/digitalassetlinks.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/discovery.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/discoveryengine.v1alpha.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/discoveryengine.v1beta.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/displayvideo.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/displayvideo.v2.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/displayvideo.v3.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/displayvideo.v4.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/dlp.v2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/dns.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/dns.v1beta2.json</Path>
@@ -225,10 +265,13 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/domainsrdap.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/doubleclickbidmanager.v1.1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/doubleclickbidmanager.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/doubleclickbidmanager.v2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/doubleclicksearch.v2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/drive.v2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/drive.v3.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/driveactivity.v2.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/drivelabels.v2.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/drivelabels.v2beta.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/essentialcontacts.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/eventarc.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/eventarc.v1beta1.json</Path>
@@ -240,6 +283,8 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/firebase.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/firebaseappcheck.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/firebaseappcheck.v1beta.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/firebaseappdistribution.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/firebaseappdistribution.v1alpha.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/firebasedatabase.v1beta.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/firebasedynamiclinks.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/firebasehosting.v1.json</Path>
@@ -268,6 +313,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/gkehub.v1beta.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/gkehub.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/gkehub.v2alpha.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/gkeonprem.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/gmail.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/gmailpostmastertools.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/gmailpostmastertools.v1beta1.json</Path>
@@ -277,38 +323,50 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/healthcare.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/homegraph.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/iam.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/iam.v2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/iam.v2beta.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/iamcredentials.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/iap.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/iap.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/ideahub.v1alpha.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/ideahub.v1beta.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/identitytoolkit.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/identitytoolkit.v2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/identitytoolkit.v3.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/ids.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/index.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/indexing.v3.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/integrations.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/integrations.v1alpha.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/jobs.v2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/jobs.v3.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/jobs.v3p1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/jobs.v4.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/keep.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/kgsearch.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/kmsinventory.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/language.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/language.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/language.v1beta2.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/language.v2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/libraryagent.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/licensing.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/lifesciences.v2beta.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/localservices.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/logging.v2.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/looker.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/managedidentities.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/managedidentities.v1alpha1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/managedidentities.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/manufacturers.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/marketingplatformadmin.v1alpha.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/memcache.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/memcache.v1beta2.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/metastore.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/metastore.v1alpha.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/metastore.v1beta.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/migrationcenter.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/migrationcenter.v1alpha1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/ml.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/monitoring.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/monitoring.v3.json</Path>
@@ -329,6 +387,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/networkservices.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/networkservices.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/notebooks.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/notebooks.v2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/oauth2.v2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/ondemandscanning.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/ondemandscanning.v1beta1.json</Path>
@@ -342,14 +401,18 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/pagespeedonline.v5.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/paymentsresellersubscription.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/people.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/places.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/playablelocations.v3.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/playcustomapp.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/playdeveloperreporting.v1alpha1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/playdeveloperreporting.v1beta1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/playgrouping.v1alpha1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/playintegrity.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/policyanalyzer.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/policyanalyzer.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/policysimulator.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/policysimulator.v1alpha.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/policysimulator.v1beta.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/policysimulator.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/policytroubleshooter.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/policytroubleshooter.v1beta.json</Path>
@@ -357,10 +420,15 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/privateca.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/privateca.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/prod_tt_sasportal.v1alpha1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/publicca.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/publicca.v1alpha1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/publicca.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/pubsub.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/pubsub.v1beta1a.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/pubsub.v1beta2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/pubsublite.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/rapidmigrationassessment.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/readerrevenuesubscriptionlinking.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/realtimebidding.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/realtimebidding.v1alpha.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/recaptchaenterprise.v1.json</Path>
@@ -384,11 +452,14 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/runtimeconfig.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/runtimeconfig.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/safebrowsing.v4.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/safebrowsing.v5.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/sasportal.v1alpha1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/script.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/searchads360.v0.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/searchconsole.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/secretmanager.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/secretmanager.v1beta1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/secretmanager.v1beta2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/securitycenter.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/securitycenter.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/securitycenter.v1beta2.json</Path>
@@ -407,6 +478,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/siteVerification.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/slides.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/smartdevicemanagement.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/solar.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/sourcerepo.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/spanner.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/speech.v1.json</Path>
@@ -428,13 +500,16 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/toolresults.v1beta3.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/tpu.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/tpu.v1alpha1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/tpu.v2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/tpu.v2alpha1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/trafficdirector.v2.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/trafficdirector.v3.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/transcoder.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/transcoder.v1beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/translate.v2.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/translate.v3.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/translate.v3beta1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/travelimpactmodel.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/vault.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/vectortile.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/verifiedaccess.v1.json</Path>
@@ -450,6 +525,10 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/vision.v1p2beta1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/vmmigration.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/vmmigration.v1alpha1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/vmwareengine.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/vpcaccess.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/vpcaccess.v1beta1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/walletobjects.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/webfonts.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/webmasters.v3.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/webrisk.v1.json</Path>
@@ -460,6 +539,10 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/workflowexecutions.v1beta.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/workflows.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/workflows.v1beta.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/workloadmanager.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/workspaceevents.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/workstations.v1.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/workstations.v1beta.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/youtube.v3.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/youtubeAnalytics.v1.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/googleapiclient/discovery_cache/documents/youtubeAnalytics.v2.json</Path>
@@ -475,12 +558,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2024-02-15</Date>
-            <Version>2.48.0</Version>
+        <Update release="10">
+            <Date>2024-04-15</Date>
+            <Version>2.125.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/py/python-pydrive2/package.yml
+++ b/packages/py/python-pydrive2/package.yml
@@ -1,8 +1,8 @@
 name       : python-pydrive2
-version    : 1.17.0
-release    : 4
+version    : 1.19.0
+release    : 5
 source     :
-    - https://files.pythonhosted.org/packages/source/P/PyDrive2/PyDrive2-1.17.0.tar.gz : 68fea934347bb612b7a848811d48149db840bcfb5fa4d7a8b6161b2d2adfec70
+    - https://files.pythonhosted.org/packages/source/P/PyDrive2/PyDrive2-1.19.0.tar.gz : 21aea7da27635c2c3f7050e020206191f3b0305c6550315e6e8e3dd526f8b531
 homepage   : https://github.com/iterative/PyDrive2
 license    : Apache-2.0
 component  : programming.python

--- a/packages/py/python-pydrive2/pspec_x86_64.xml
+++ b/packages/py/python-pydrive2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-pydrive2</Name>
         <Homepage>https://github.com/iterative/PyDrive2</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -20,12 +20,12 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/PyDrive2-1.17.0-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/PyDrive2-1.17.0-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/PyDrive2-1.17.0-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/PyDrive2-1.17.0-py3.11.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/PyDrive2-1.17.0-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/PyDrive2-1.17.0-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/PyDrive2-1.19.0-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/PyDrive2-1.19.0-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/PyDrive2-1.19.0-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/PyDrive2-1.19.0-py3.11.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/PyDrive2-1.19.0-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/PyDrive2-1.19.0-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pydrive2/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pydrive2/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pydrive2/__pycache__/apiattr.cpython-311.pyc</Path>
@@ -69,12 +69,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-02-14</Date>
-            <Version>1.17.0</Version>
+        <Update release="5">
+            <Date>2024-04-16</Date>
+            <Version>1.19.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/googleapis/google-api-python-client/releases/tag/v2.125.0).

**Test Plan**
- Updated python-pydrive2 against this

**Checklist**

- [X] Package was built and tested against unstable
