### PR TITLE
snapd: Update to 2.62

### DIFF
--- a/packages/s/snapd/package.yml
+++ b/packages/s/snapd/package.yml
@@ -1,9 +1,9 @@
 name       : snapd
-version    : 2.61.2
+version    : 2.62
 homepage   : https://snapcraft.io/
-release    : 79
+release    : 80
 source     :
-    - https://github.com/snapcore/snapd/releases/download/2.61.2/snapd_2.61.2.vendor.tar.xz : d000725250a4d9c8a931b74df9733479a2851d03fe1e663a81fcb61b21509702
+    - https://github.com/snapcore/snapd/releases/download/2.62/snapd_2.62.vendor.tar.xz : e4bcf0d7677afdcb7256958fd382a5aad71db13474c08e5828e913614ee88ea8
 license    : GPL-3.0-only
 component  : desktop
 summary    : The snapd and snap tools enable systems to work with .snap files

--- a/packages/s/snapd/pspec_x86_64.xml
+++ b/packages/s/snapd/pspec_x86_64.xml
@@ -76,9 +76,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="79">
-            <Date>2024-02-20</Date>
-            <Version>2.61.2</Version>
+        <Update release="80">
+            <Date>2024-04-16</Date>
+            <Version>2.62</Version>
             <Comment>Packaging update</Comment>
             <Name>Zygmunt Krynicki</Name>
             <Email>me@zygoon.pl</Email>


### PR DESCRIPTION
**Summary**
New upstream release.

  * Aspects based configuration schema support (experimental)
  * Refresh app awareness support for UI (experimental)
  * Support for user daemons by introducing new control switches --user/--system/--users for service start/stop/restart (experimental)
  * Add AppArmor prompting experimental flag (feature currently unsupported)
  * Installation of local snap components of type test
  * Packaging of components with snap pack
  * Expose experimental features supported/enabled in snapd REST API endpoint /v2/system-info
  * Support creating and removing recovery systems for use by factory reset
  * Enable API route for creating and removing recovery systems using /v2/systems with action create and /v2/systems/{label} with action remove
  * Lift requirements for fde-setup hook for single boot install
  * Enable single reboot gadget update for UC20+
  * Allow core to be removed on classic systems
  * Support for remodeling on hybrid systems
  * Install desktop files on Ubuntu Core and update after snapd upgrade
  * Upgrade sandbox features to account for cgroup v2 device filtering
  * Support snaps to manage their own cgroups
  * Add support for AppArmor 4.0 unconfined profile mode
  * Add AppArmor based read access to /etc/default/keyboard
  * Upgrade to squashfuse 0.5.0
  * Support useradd utility to enable removing Perl dependency for UC24+
  * Support for recovery-chooser to use console-conf snap
  * Add support for --uid/--gid using strace-static
  * Add support for notices (from pebble) and expose via the snapd REST API endpoints /v2/notices and /v2/notice
  * Add polkit authentication for snapd REST API endpoints /v2/snaps/{snap}/conf and /v2/apps
  * Add refresh-inhibit field to snapd REST API endpoint /v2/snaps
  * Add refresh-inhibited select query to REST API endpoint /v2/snaps
  * Take into account validation sets during remodeling
  * Improve offline remodeling to use installed revisions of snaps to fulfill the remodel revision requirement
  * Add rpi configuration option sdtv_mode
  * When snapd snap is not installed, pin policy ABI to 4.0 or 3.0 if present on host
  * Fix gadget zero-sized disk mapping caused by not ignoring zero sized storage traits
  * Fix gadget install case where size of existing partition was not correctly taken into account
  * Fix trying to unmount early kernel mount if it does not exist
  * Fix restarting mount units on snapd start
  * Fix call to udev in preseed mode
  * Fix to ensure always setting up the device cgroup for base bare and core24+
  * Fix not copying data from newly set homedirs on revision change
  * Fix leaving behind empty snap home directories after snap is removed (resulting in broken symlink)
  * Fix to avoid using libzstd from host by adding to snapd snap
  * Fix autorefresh to correctly handle forever refresh hold
  * Fix username regex allowed for system-user assertion to not allow '+'
  * Fix incorrect application icon for notification after autorefresh completion
  * Fix to restart mount units when changed
  * Fix to support AppArmor running under incus
  * Fix case of snap-update-ns dropping synthetic mounts due to failure to match  desired mount dependencies
  * Fix parsing of base snap version to enable pre-seeding of Ubuntu Core Desktop
  * Fix packaging and tests for various distributions
  * Add remoteproc interface to allow developers to interact with Remote Processor Framework which enables snaps to load firmware to ARM Cortex microcontrollers
  * Add kernel-control interface to enable controlling the kernel firmware search path
  * Add nfs-mount interface to allow mounting of NFS shares
  * Add ros-opt-data interface to allow snaps to access the host /opt/ros/ paths
  * Add snap-refresh-observe interface that provides refresh-app-awareness clients access to relevant snapd API endpoints
  * steam-support interface: generalize Pressure Vessel root paths and allow access to driver information, features and container versions
  * steam-support interface: make implicit on Ubuntu Core Desktop
  * desktop interface: improved support for Ubuntu Core Desktop and limit autoconnection to implicit slots
  * cups-control interface: make autoconnect depend on presence of cupsd on host to ensure it works on classic systems
  * opengl interface: allow read access to /usr/share/nvidia
  * personal-files interface: extend to support automatic creation of missing parent directories in write paths
  * network-control interface: allow creating /run/resolveconf
  * network-setup-control and network-setup-observe interfaces: allow busctl bind as required for systemd 254+
  * libvirt interface: allow r/w access to /run/libvirt/libvirt-sock-ro and read access to /var/lib/libvirt/dnsmasq/**
  * fwupd interface: allow access to IMPI devices (including locking of device nodes), sysfs attributes needed by amdgpu and the COD capsule update directory
  * uio interface: allow configuring UIO drivers from userspace libraries
  * serial-port interface: add support for NXP Layerscape SoC
  * lxd-support interface: add attribute enable-unconfined-mode to require LXD to opt-in to run unconfined
  * block-devices interface: add support for ZFS volumes
  * system-packages-doc interface: add support for reading jquery and sphinx documentation
  * system-packages-doc interface: workaround to prevent autoconnect failure for snaps using base bare
  * microceph-support interface: allow more types of block devices to be added as an OSD
  * mount-observe interface: allow read access to /proc/{pid}/task/{tid}/mounts and proc/{pid}/task/{tid}/mountinfo
  * polkit interface: changed to not be implicit on core because installing policy files is not possible
  * upower-observe interface: allow stats refresh
  * gpg-public-keys interface: allow creating lock file for certain gpg operations
  * shutdown interface: allow access to SetRebootParameter method
  * media-control interface: allow device file locking
  * u2f-devices interface: support for Trustkey G310H, JaCarta U2F, Kensington VeriMark Guard, RSA DS100, Google Titan v2

**Summary**

This snapd release is rather larger, as 2.61 was made a long while ago (not counting point releases like 2.61.1 or .2) and there's a huge collection of new features and fixes.

**Test Plan**

I've updated in place and tested that all of my snap applications launch and work as expected. At the time of testing the kernel I used was:
```
Linux solus 6.8.6-285.current #1 SMP PREEMPT_DYNAMIC 0 x86_64 GNU/Linux
```
My system uses the GNOME desktop.

**Checklist**

- [x] Package was built and tested against unstable
