### PR TITLE
gptfdisk: update to 1.0.10

### DIFF
--- a/packages/g/gptfdisk/abi_used_symbols
+++ b/packages/g/gptfdisk/abi_used_symbols
@@ -1,6 +1,6 @@
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
 libc.so.6:__libc_start_main
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
@@ -23,6 +23,7 @@ libc.so.6:srand
 libc.so.6:stderr
 libc.so.6:strchr
 libc.so.6:strcmp
+libc.so.6:strdup
 libc.so.6:strlen
 libc.so.6:sync
 libc.so.6:time
@@ -68,7 +69,6 @@ libstdc++.so.6:_ZNKSt12__basic_fileIcE7is_openEv
 libstdc++.so.6:_ZNKSt5ctypeIcE13_M_widen_initEv
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEcm
-libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7compareEPKc
 libstdc++.so.6:_ZNSi10_M_extractIjEERSiRT_
 libstdc++.so.6:_ZNSi10_M_extractImEERSiRT_
 libstdc++.so.6:_ZNSi3getERc
@@ -91,18 +91,18 @@ libstdc++.so.6:_ZNSt6localeD1Ev
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_disposeEv
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE13_S_copy_charsEPcPKcS7_
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6appendEPKc
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7reserveEm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE8_M_eraseEmm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_appendEPKcm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_assignERKS4_
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createERmm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_mutateEmmPKcm
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1EOS4_
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1ERKS4_
 libstdc++.so.6:_ZNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE7_M_syncEPcmm
 libstdc++.so.6:_ZNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEED1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitC1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitD1Ev
 libstdc++.so.6:_ZNSt8ios_baseC2Ev
 libstdc++.so.6:_ZNSt8ios_baseD2Ev
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE4initEPSt15basic_streambufIcS1_E
@@ -111,6 +111,7 @@ libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T
 libstdc++.so.6:_ZSt16__throw_bad_castv
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
+libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
 libstdc++.so.6:_ZSt3cin
 libstdc++.so.6:_ZSt4cerr

--- a/packages/g/gptfdisk/package.yml
+++ b/packages/g/gptfdisk/package.yml
@@ -1,8 +1,9 @@
 name       : gptfdisk
-version    : 1.0.8
-release    : 6
+version    : 1.0.10
+release    : 7
 source     :
-    - https://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.8/gptfdisk-1.0.8.tar.gz/download : 95d19856f004dabc4b8c342b2612e8d0a9eebdd52004297188369f152e9dc6df
+    - https://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.10/gptfdisk-1.0.10.tar.gz/download : 2abed61bc6d2b9ec498973c0440b8b804b7a72d7144069b5a9209b2ad693a282
+homepage   : https://www.rodsbooks.com/gdisk/
 license    : GPL-2.0-or-later
 component  : system.utils
 summary    : GPT fdisk-like utility

--- a/packages/g/gptfdisk/pspec_x86_64.xml
+++ b/packages/g/gptfdisk/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>gptfdisk</Name>
+        <Homepage>https://www.rodsbooks.com/gdisk/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">GPT fdisk-like utility</Summary>
         <Description xml:lang="en">GPT fdisk is a disk partitioning tool loosely modeled on Linux fdisk, but used for modifying GUID Partition Table (GPT) disks. The related FixParts utility fixes some common problems on Master Boot Record (MBR) disks.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>gptfdisk</Name>
@@ -30,12 +31,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2022-03-25</Date>
-            <Version>1.0.8</Version>
+        <Update release="7">
+            <Date>2024-04-18</Date>
+            <Version>1.0.10</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fixed problem that caused sgdisk to crash with errors about being unable to read the disk's partition table when compiled with the latest popt (commit 740, which is pre-release as I type; presumably version 1.19 and later once released).

- Updated guid.cc to deal with minor change in libuuid.

- Fixed potential NULL derefernce bug in sgdisk. Thanks to Damian Kurek for this fix.

- The partition number of "0" can now be used to reference newly-created partitions when the --largest-new=0 option to sgdisk is used. Thanks to David Joaquín Shourabi Porcel for this improvement.

- Make explicit casts in gptcurses.cc to eliminate compiler warnings about mis-matched types in printw() statements.

- Minor code cleanup based on valgrind analysis.

- In previous versions, GPT fdisk accepted only integer values for partition start points, end points, and sizes, and it interpreted decimal values incorrectly. That is, if you typed "+9.5G" as the partition end point, you'd end up with something just 9 sectors in size. This version now truncates decimal numbers to their integral values, so you'd get a 9 GiB partition instead.

- Changes to optimize disk handling, particularly on Windows, courtesy of Frediano Ziglio.

- Added numerous new partition type codes from Discoverable Partitions Specification (https://uapi-group.org/specifications/specs/discoverable_partitions_specification/).

- Added new sgdisk -k/--move-backup-table and gdisk k (on the experts' menu) option to relocate the backup partition table. This is the counterpart of the sgdisk -j/--move-main-table and gdisk j (on the experts' menu) option to move the main partition table. This code comes from Niklas Gollenstede.

**Test Plan**

- Installed started and verified it could see my disks.

**Checklist**

- [X] Package was built and tested against unstable
