### PR TITLE
kitty: Update to 0.34.0

### DIFF
--- a/packages/k/kitty/abi_symbols
+++ b/packages/k/kitty/abi_symbols
@@ -120,6 +120,7 @@ glfw-wayland.so:glfwSetScrollCallback
 glfw-wayland.so:glfwSetSystemColorThemeChangeCallback
 glfw-wayland.so:glfwSetWindowAspectRatio
 glfw-wayland.so:glfwSetWindowAttrib
+glfw-wayland.so:glfwSetWindowBlur
 glfw-wayland.so:glfwSetWindowCloseCallback
 glfw-wayland.so:glfwSetWindowContentScaleCallback
 glfw-wayland.so:glfwSetWindowFocusCallback
@@ -150,10 +151,12 @@ glfw-wayland.so:glfwUpdateIMEState
 glfw-wayland.so:glfwUpdateTimer
 glfw-wayland.so:glfwVulkanSupported
 glfw-wayland.so:glfwWaylandActivateWindow
-glfw-wayland.so:glfwWaylandCheckForServerSideDecorations
+glfw-wayland.so:glfwWaylandCompositorPID
+glfw-wayland.so:glfwWaylandMissingCapabilities
 glfw-wayland.so:glfwWaylandRedrawCSDWindowTitle
 glfw-wayland.so:glfwWaylandRunWithActivationToken
 glfw-wayland.so:glfwWaylandSetTitlebarColor
+glfw-wayland.so:glfwWaylandSetupLayerShellForNextWindow
 glfw-wayland.so:glfwWindowBell
 glfw-wayland.so:glfwWindowHint
 glfw-wayland.so:glfwWindowHintString
@@ -275,6 +278,7 @@ glfw-x11.so:glfwSetScrollCallback
 glfw-x11.so:glfwSetSystemColorThemeChangeCallback
 glfw-x11.so:glfwSetWindowAspectRatio
 glfw-x11.so:glfwSetWindowAttrib
+glfw-x11.so:glfwSetWindowBlur
 glfw-x11.so:glfwSetWindowCloseCallback
 glfw-x11.so:glfwSetWindowContentScaleCallback
 glfw-x11.so:glfwSetWindowFocusCallback
@@ -296,7 +300,6 @@ glfw-x11.so:glfwSetWindowTitle
 glfw-x11.so:glfwSetWindowUserPointer
 glfw-x11.so:glfwSetX11LaunchCommand
 glfw-x11.so:glfwSetX11WindowAsDock
-glfw-x11.so:glfwSetX11WindowBlurred
 glfw-x11.so:glfwSetX11WindowStrut
 glfw-x11.so:glfwShowWindow
 glfw-x11.so:glfwStopMainLoop

--- a/packages/k/kitty/abi_used_symbols
+++ b/packages/k/kitty/abi_used_symbols
@@ -10,7 +10,6 @@ UNKNOWN:fcntl
 UNKNOWN:fcntl64
 UNKNOWN:feof
 UNKNOWN:ferror
-UNKNOWN:fflush
 UNKNOWN:fgets
 UNKNOWN:fileno
 UNKNOWN:fopen64
@@ -24,10 +23,8 @@ UNKNOWN:getpgid
 UNKNOWN:getpid
 UNKNOWN:getrandom
 UNKNOWN:getsockopt
-UNKNOWN:gettimeofday
 UNKNOWN:ioctl
 UNKNOWN:kill
-UNKNOWN:localtime_r
 UNKNOWN:lseek64
 UNKNOWN:mkostemp64
 UNKNOWN:mmap
@@ -304,7 +301,6 @@ libc.so.6:strcmp
 libc.so.6:strcpy
 libc.so.6:strcspn
 libc.so.6:strerror
-libc.so.6:strftime
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strncpy
@@ -458,6 +454,7 @@ libm.so.6:fmaxf
 libm.so.6:fminf
 libm.so.6:powf
 libm.so.6:round
+libm.so.6:roundf
 libpython3.11.so.1.0:PyBuffer_Release
 libpython3.11.so.1.0:PyByteArray_Type
 libpython3.11.so.1.0:PyBytes_FromStringAndSize
@@ -500,6 +497,7 @@ libpython3.11.so.1.0:PyExc_ValueError
 libpython3.11.so.1.0:PyFloat_AsDouble
 libpython3.11.so.1.0:PyFloat_FromDouble
 libpython3.11.so.1.0:PyFloat_FromString
+libpython3.11.so.1.0:PyFloat_Type
 libpython3.11.so.1.0:PyImport_ImportModule
 libpython3.11.so.1.0:PyIter_Next
 libpython3.11.so.1.0:PyList_Append

--- a/packages/k/kitty/package.yml
+++ b/packages/k/kitty/package.yml
@@ -1,8 +1,8 @@
 name       : kitty
-version    : 0.33.1
-release    : 64
+version    : 0.34.0
+release    : 65
 source     :
-    - https://github.com/kovidgoyal/kitty/releases/download/v0.33.1/kitty-0.33.1.tar.xz : b7c9af1bdac066099142d3cdf212bf36b83d5610a22c648b66f27b95d5537c7c
+    - https://github.com/kovidgoyal/kitty/releases/download/v0.34.0/kitty-0.34.0.tar.xz : d65527a40f72bfd179582d1ab51c9730ac28400bff89e6bffac77c6ac3c2236f
     - git|https://github.com/simd-everywhere/simde.git : v0.7.6
 license    : GPL-3.0-only
 component  : system.utils

--- a/packages/k/kitty/pspec_x86_64.xml
+++ b/packages/k/kitty/pspec_x86_64.xml
@@ -768,9 +768,9 @@ Kitty is designed from the ground up to support all modern terminal features, su
         </Files>
     </Package>
     <History>
-        <Update release="64">
-            <Date>2024-03-23</Date>
-            <Version>0.33.1</Version>
+        <Update release="65">
+            <Date>2024-04-18</Date>
+            <Version>0.34.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Show a small scrollback indicator along the right window edge when viewing the scrollback to keep track of scroll position
- A new option terminfo_type to allow passing the terminfo database embedded into the TERMINFO env var directly instead of via a file
- Mouse reporting: Fix drag release event outside the window not being reported in legacy mouse reporting modes
- Fix handling of tab character when cursor is at end of line and wrapping is enabled
- Splits layout: Fix move_window_forward not working
- fish shell integration: Fix clicking at the prompt causing autosuggestions to be accepted, needs fish >= 3.8.0
- Fix for a regression in 0.32.0 that caused some CJK fonts to not render glyphs
- When asking for quit confirmation because of a running program, mention the program name
- Fix flickering of prompt during window resize
- Wayland enhancements and fixes
- [changelog](https://sw.kovidgoyal.net/kitty/changelog/#id1)

**Test Plan**
- run CLI command; C-S-g to open output in pager

**Checklist**
- [X] Package was built and tested against unstable
