### PR TITLE
mu: Update to 1.12.4

### DIFF
--- a/packages/m/mu/package.yml
+++ b/packages/m/mu/package.yml
@@ -1,8 +1,8 @@
 name       : mu
-version    : 1.12.3
-release    : 24
+version    : 1.12.4
+release    : 25
 source     :
-    - https://github.com/djcb/mu/releases/download/v1.12.3/mu-1.12.3.tar.xz : ce6edd5661ffe3de4c9e17a6c8cdaf233b3cd5e85c82ed876d87c064e6e7b7e0
+    - https://github.com/djcb/mu/releases/download/v1.12.4/mu-1.12.4.tar.xz : bd41136c5177c1645b878b9d55f384bed629e02e790881fe965f8493725a44c9
 license    : GPL-3.0-only
 homepage   : https://www.djcbsoftware.nl/code/mu/
 component  : editor

--- a/packages/m/mu/pspec_x86_64.xml
+++ b/packages/m/mu/pspec_x86_64.xml
@@ -104,9 +104,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2024-04-12</Date>
-            <Version>1.12.3</Version>
+        <Update release="25">
+            <Date>2024-04-18</Date>
+            <Version>1.12.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- query when quitting emacs with unhandled marks in a headers buffer
- fix mime-handling
- update sent handling (simplifying it)
- some internal improvements
- number of small fixes / updates
- documentation updates
- re-enable a specific database lock; this makes indexing a bit slower, but hopefully avoids some db corruption.

**Test Plan**
- reindex inbox with mu; search for and view message with mu4e

**Checklist**
- [X] Package was built and tested against unstable
