### PR TITLE
i2c-tools: update to 4.3

### DIFF
--- a/packages/i/i2c-tools/abi_used_symbols
+++ b/packages/i/i2c-tools/abi_used_symbols
@@ -4,7 +4,6 @@ libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
-libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__strcat_chk
 libc.so.6:calloc
@@ -25,6 +24,7 @@ libc.so.6:open
 libc.so.6:opendir
 libc.so.6:putchar
 libc.so.6:puts
+libc.so.6:qsort
 libc.so.6:readdir
 libc.so.6:realloc
 libc.so.6:stderr
@@ -37,6 +37,7 @@ libc.so.6:strcpy
 libc.so.6:strdup
 libc.so.6:strerror
 libc.so.6:strlen
+libc.so.6:strncmp
 libc.so.6:strrchr
 libc.so.6:strtol
 libc.so.6:strtoul

--- a/packages/i/i2c-tools/package.yml
+++ b/packages/i/i2c-tools/package.yml
@@ -1,8 +1,9 @@
 name       : i2c-tools
-version    : '4.1'
-release    : 3
+version    : '4.3'
+release    : 4
 source     :
-    - https://git.kernel.org/pub/scm/utils/i2c-tools/i2c-tools.git/snapshot/i2c-tools-4.1.tar.gz : 18170379ef36dd703c9adf1b019ea4f21772149817c102a9b9aea9b34f374fd4
+    - https://git.kernel.org/pub/scm/utils/i2c-tools/i2c-tools.git/snapshot/i2c-tools-4.3.tar.gz : b4f63b9f8d74e89a010f1d6e4748659df2f556717dfa273cedc144be451758b9
+homepage   : https://archive.kernel.org/oldwiki/i2c.wiki.kernel.org/index.php/I2C_Tools.html
 license    :
     - GPL-2.0-or-later
     - LGPL-2.1-or-later
@@ -14,5 +15,4 @@ build      : |
     %make
 install    : |
     # Don't ask why, but BUILD_STATIC_LIB doesn't work in build phase
-    # Fortunately, it looks like they're reworking the build system in master branch
     %make_install PREFIX="/usr" DESTDIR=$installdir libdir=%libdir% BUILD_STATIC_LIB=0

--- a/packages/i/i2c-tools/pspec_x86_64.xml
+++ b/packages/i/i2c-tools/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>i2c-tools</Name>
+        <Homepage>https://archive.kernel.org/oldwiki/i2c.wiki.kernel.org/index.php/I2C_Tools.html</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -11,7 +12,7 @@
         <Summary xml:lang="en">I2C and SMBus user-space tools</Summary>
         <Description xml:lang="en">I2C tools for bus probing, chip dumping, EEPROM decoding, display communication and more.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>i2c-tools</Name>
@@ -49,20 +50,21 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="3">i2c-tools</Dependency>
+            <Dependency release="4">i2c-tools</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/i2c/smbus.h</Path>
             <Path fileType="library">/usr/lib64/libi2c.so</Path>
+            <Path fileType="man">/usr/share/man/man3/libi2c.3</Path>
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2020-03-18</Date>
-            <Version>4.1</Version>
+        <Update release="4">
+            <Date>2024-04-25</Date>
+            <Version>4.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- decode-dimms: Attempt to decode LPDDR3 modules
- eeprom, eepromer: Removed the tools in favor of eeprog
-  i2cdetect: Sort the bus list by number
-  i2cdump: Add range support to I2C block mode
 -  Deprecate SMBus block mode
-  i2cget: Add support for I2C block read 
- Add support for SMBus block read
- i2ctransfer: Reverted check for returned length from driver

**Test Plan**
- Checked it installed.

**Checklist**

- [X] Package was built and tested against unstable
