### PR TITLE
imath: update to 3.1.11

### DIFF
--- a/packages/i/imath/abi_used_symbols
+++ b/packages/i/imath/abi_used_symbols
@@ -1,9 +1,8 @@
-libc.so.6:__cxa_atexit
 libc.so.6:__stack_chk_fail
-libm.so.6:sqrt
-libm.so.6:sqrtf
+libm.so.6:nextafter
+libm.so.6:nextafterf
 libstdc++.so.6:_ZNSi10_M_extractIfEERSiRT_
+libstdc++.so.6:_ZNSo3putEc
 libstdc++.so.6:_ZNSo9_M_insertIdEERSoT_
-libstdc++.so.6:_ZNSt8ios_base4InitC1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitD1Ev
 libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
+libstdc++.so.6:_ZSt21ios_base_library_initv

--- a/packages/i/imath/package.yml
+++ b/packages/i/imath/package.yml
@@ -1,8 +1,9 @@
 name       : imath
-version    : 3.1.3
-release    : 2
+version    : 3.1.11
+release    : 3
 source     :
-    - https://github.com/AcademySoftwareFoundation/Imath/archive/refs/tags/v3.1.3.tar.gz : 0bf7ec51162c4d17a4c5b850fb3f6f7a195cff9fa71f4da7735f74d7b5124320
+    - https://github.com/AcademySoftwareFoundation/Imath/releases/download/v3.1.11/Imath-3.1.11.tar.gz : 9057849585e49b8b85abe7cc1e76e22963b01bfdc3b6d83eac90c499cd760063
+homepage   : https://imath.readthedocs.io/
 license    : BSD-3-Clause
 component  : multimedia.library
 summary    : Imath is a library of 2D and 3D vector, matrix, and math operations for computer graphics

--- a/packages/i/imath/pspec_x86_64.xml
+++ b/packages/i/imath/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>imath</Name>
+        <Homepage>https://imath.readthedocs.io/</Homepage>
         <Packager>
-            <Name>Martin Reboredo</Name>
-            <Email>yakoyoku@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>multimedia.library</PartOf>
         <Summary xml:lang="en">Imath is a library of 2D and 3D vector, matrix, and math operations for computer graphics</Summary>
         <Description xml:lang="en">Imath is a basic, light-weight, and efficient C++ representation of 2D and 3D vectors and matrices and other simple but useful mathematical objects, functions, and data types common in computer graphics applications, including the &quot;half&quot; 16-bit floating-point type.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>imath</Name>
@@ -20,7 +21,7 @@
         <PartOf>multimedia.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libImath-3_1.so.29</Path>
-            <Path fileType="library">/usr/lib64/libImath-3_1.so.29.2.0</Path>
+            <Path fileType="library">/usr/lib64/libImath-3_1.so.29.10.0</Path>
         </Files>
         <Replaces>
             <Package>ilmbase</Package>
@@ -33,7 +34,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">imath</Dependency>
+            <Dependency release="3">imath</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/Imath/ImathBox.h</Path>
@@ -84,12 +85,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2021-10-26</Date>
-            <Version>3.1.3</Version>
+        <Update release="3">
+            <Date>2024-04-21</Date>
+            <Version>3.1.11</Version>
             <Comment>Packaging update</Comment>
-            <Name>Martin Reboredo</Name>
-            <Email>yakoyoku@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Patch release with two small build fixes/features:

- Add explicit `std::` namespace for `isfinite` in `ImathFun.cpp`
- Add `uninstall` target

This release also introduces the practice of signing release artifacts via [sigstore](https://www.sigstore.dev).

**Test Plan**
- Installed and started Krita which is dependant on this.

**Checklist**

- [X] Package was built and tested against unstable
