### PR TITLE
nautilus-dropbox: Update to 2024.04.17

### DIFF
--- a/packages/n/nautilus-dropbox/abi_used_symbols
+++ b/packages/n/nautilus-dropbox/abi_used_symbols
@@ -64,6 +64,7 @@ libglib-2.0.so.0:g_io_channel_unref
 libglib-2.0.so.0:g_io_channel_write_chars
 libglib-2.0.so.0:g_list_append
 libglib-2.0.so.0:g_list_free
+libglib-2.0.so.0:g_list_free_full
 libglib-2.0.so.0:g_list_length
 libglib-2.0.so.0:g_malloc
 libglib-2.0.so.0:g_malloc0
@@ -120,6 +121,7 @@ libnautilus-extension.so.4:nautilus_file_info_list_free
 libnautilus-extension.so.4:nautilus_info_provider_get_type
 libnautilus-extension.so.4:nautilus_info_provider_update_complete_invoke
 libnautilus-extension.so.4:nautilus_menu_append_item
+libnautilus-extension.so.4:nautilus_menu_get_items
 libnautilus-extension.so.4:nautilus_menu_item_new
 libnautilus-extension.so.4:nautilus_menu_item_set_submenu
 libnautilus-extension.so.4:nautilus_menu_new

--- a/packages/n/nautilus-dropbox/package.yml
+++ b/packages/n/nautilus-dropbox/package.yml
@@ -1,8 +1,8 @@
 name       : nautilus-dropbox
-version    : 2023.09.06
-release    : 29
+version    : 2024.04.17
+release    : 30
 source     :
-    - git|https://github.com/dropbox/nautilus-dropbox.git : a4f6269d03b11b5db1496578de8330381cf6d1ba
+    - git|https://github.com/dropbox/nautilus-dropbox.git : v2024.04.17
 homepage   : https://github.com/dropbox/nautilus-dropbox
 license    :
     - CC-BY-ND-3.0

--- a/packages/n/nautilus-dropbox/pspec_x86_64.xml
+++ b/packages/n/nautilus-dropbox/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nautilus-dropbox</Name>
         <Homepage>https://github.com/dropbox/nautilus-dropbox</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>CC-BY-ND-3.0</License>
         <License>GPL-3.0-or-later</License>
@@ -21,7 +21,7 @@
 </Description>
         <PartOf>desktop.gnome</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="29">dropbox</Dependency>
+            <Dependency releaseFrom="30">dropbox</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/nautilus/extensions-4/libnautilus-dropbox.so</Path>
@@ -53,12 +53,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="29">
-            <Date>2024-02-16</Date>
-            <Version>2023.09.06</Version>
+        <Update release="30">
+            <Date>2024-04-22</Date>
+            <Version>2024.04.17</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changelog can be found [here](https://raw.githubusercontent.com/dropbox/nautilus-dropbox/v2024.04.17/ChangeLog)

**Test Plan**

Sync file from pc to cloud

**Checklist**

- [x] Package was built and tested against unstable