### PR TITLE
packages: Enable debuginfod

### DIFF
--- a/packages/g/gdb/abi_used_libs
+++ b/packages/g/gdb/abi_used_libs
@@ -1,5 +1,6 @@
 ld-linux-x86-64.so.2
 libc.so.6
+libdebuginfod.so.1
 libexpat.so.1
 libgcc_s.so.1
 libgmp.so.10

--- a/packages/g/gdb/abi_used_symbols
+++ b/packages/g/gdb/abi_used_symbols
@@ -292,6 +292,15 @@ libc.so.6:wcrtomb
 libc.so.6:wcslen
 libc.so.6:wcwidth
 libc.so.6:write
+libdebuginfod.so.1:debuginfod_begin
+libdebuginfod.so.1:debuginfod_end
+libdebuginfod.so.1:debuginfod_find_debuginfo
+libdebuginfod.so.1:debuginfod_find_executable
+libdebuginfod.so.1:debuginfod_find_section
+libdebuginfod.so.1:debuginfod_find_source
+libdebuginfod.so.1:debuginfod_get_user_data
+libdebuginfod.so.1:debuginfod_set_progressfn
+libdebuginfod.so.1:debuginfod_set_user_data
 libexpat.so.1:XML_DefaultCurrent
 libexpat.so.1:XML_ErrorString
 libexpat.so.1:XML_ExternalEntityParserCreate

--- a/packages/g/gdb/package.yml
+++ b/packages/g/gdb/package.yml
@@ -1,6 +1,6 @@
 name       : gdb
 version    : '14.2'
-release    : 26
+release    : 27
 source     :
     - https://ftp.gnu.org/gnu/gdb/gdb-14.2.tar.xz : 2d4dd8061d8ded12b6c63f55e45344881e8226105f4d2a9b234040efa5ce7772
 homepage   : https://www.gnu.org/software/gdb/
@@ -13,6 +13,7 @@ patterns   :
     - /usr/include
     - /usr/lib64
 builddeps  :
+    - pkgconfig(libdebuginfod)
     - pkgconfig(liblzma)
     - pkgconfig(libxxhash)
     - pkgconfig(libzstd)

--- a/packages/g/gdb/pspec_x86_64.xml
+++ b/packages/g/gdb/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gdb</Name>
         <Homepage>https://www.gnu.org/software/gdb/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Justin Zobel</Name>
+            <Email>justin@1707.io</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>programming.tools</PartOf>
@@ -111,12 +111,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2024-03-03</Date>
+        <Update release="27">
+            <Date>2024-04-23</Date>
             <Version>14.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Justin Zobel</Name>
+            <Email>justin@1707.io</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Adds debuginfod support to gdb

**Test Plan**

Tested by using the in-testing debuginfod server to download symbols that were missing from a crash.

**Checklist**

- [x] Package was built and tested against unstable