### PR TITLE
wine: Update to 9.7

### DIFF
--- a/packages/w/wine/abi_symbols
+++ b/packages/w/wine/abi_symbols
@@ -116,6 +116,7 @@ ntdll.so:NtLoadKey2
 ntdll.so:NtLoadKeyEx
 ntdll.so:NtLockFile
 ntdll.so:NtLockVirtualMemory
+ntdll.so:NtMakePermanentObject
 ntdll.so:NtMakeTemporaryObject
 ntdll.so:NtMapViewOfSection
 ntdll.so:NtMapViewOfSectionEx
@@ -184,6 +185,7 @@ ntdll.so:NtQueryValueKey
 ntdll.so:NtQueryVirtualMemory
 ntdll.so:NtQueryVolumeInformationFile
 ntdll.so:NtQueueApcThread
+ntdll.so:NtQueueApcThreadEx
 ntdll.so:NtRaiseException
 ntdll.so:NtRaiseHardError
 ntdll.so:NtReadFile
@@ -284,6 +286,7 @@ ntdll.so:__wine_unix_spawnvp
 ntdll.so:alloc_fs_sel
 ntdll.so:call_user_mode_callback
 ntdll.so:do_cpuid
+ntdll.so:do_xgetbv
 ntdll.so:ntdll_get_build_dir
 ntdll.so:ntdll_get_data_dir
 ntdll.so:ntdll_set_exception_jmp_buf

--- a/packages/w/wine/abi_symbols32
+++ b/packages/w/wine/abi_symbols32
@@ -105,6 +105,7 @@ ntdll.so:NtLoadKey2
 ntdll.so:NtLoadKeyEx
 ntdll.so:NtLockFile
 ntdll.so:NtLockVirtualMemory
+ntdll.so:NtMakePermanentObject
 ntdll.so:NtMakeTemporaryObject
 ntdll.so:NtMapViewOfSection
 ntdll.so:NtMapViewOfSectionEx
@@ -173,6 +174,7 @@ ntdll.so:NtQueryValueKey
 ntdll.so:NtQueryVirtualMemory
 ntdll.so:NtQueryVolumeInformationFile
 ntdll.so:NtQueueApcThread
+ntdll.so:NtQueueApcThreadEx
 ntdll.so:NtRaiseException
 ntdll.so:NtRaiseHardError
 ntdll.so:NtReadFile
@@ -278,6 +280,7 @@ ntdll.so:__wine_unix_spawnvp
 ntdll.so:call_user_mode_callback
 ntdll.so:clear_alignment_flag
 ntdll.so:do_cpuid
+ntdll.so:do_xgetbv
 ntdll.so:have_cpuid
 ntdll.so:ntdll_get_build_dir
 ntdll.so:ntdll_get_data_dir

--- a/packages/w/wine/abi_used_symbols
+++ b/packages/w/wine/abi_used_symbols
@@ -432,6 +432,7 @@ libc.so.6:getpid
 libc.so.6:getpwuid
 libc.so.6:getrandom
 libc.so.6:getrlimit
+libc.so.6:getrusage
 libc.so.6:getsockname
 libc.so.6:getsockopt
 libc.so.6:gettimeofday
@@ -623,8 +624,8 @@ libglib-2.0.so.0:g_free
 libglib-2.0.so.0:g_intern_static_string
 libglib-2.0.so.0:g_list_sort
 libglib-2.0.so.0:g_malloc
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_slice_alloc
 libglib-2.0.so.0:g_slice_free1
 libglib-2.0.so.0:g_str_has_prefix

--- a/packages/w/wine/abi_used_symbols32
+++ b/packages/w/wine/abi_used_symbols32
@@ -337,6 +337,7 @@ libc.so.6:__fcntl_time64
 libc.so.6:__fstat64_time64
 libc.so.6:__fstatat64_time64
 libc.so.6:__futimens64
+libc.so.6:__getrusage64
 libc.so.6:__getsockopt64
 libc.so.6:__gettimeofday64
 libc.so.6:__gmtime64
@@ -578,8 +579,8 @@ libglib-2.0.so.0:g_free
 libglib-2.0.so.0:g_intern_static_string
 libglib-2.0.so.0:g_list_sort
 libglib-2.0.so.0:g_malloc
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_slice_alloc
 libglib-2.0.so.0:g_slice_free1
 libglib-2.0.so.0:g_str_has_prefix

--- a/packages/w/wine/package.yml
+++ b/packages/w/wine/package.yml
@@ -1,8 +1,8 @@
 name       : wine
-version    : '9.4'
-release    : 171
+version    : '9.7'
+release    : 172
 source     :
-    - https://dl.winehq.org/wine/source/9.x/wine-9.4.tar.xz : c55ff9957612549b8c7df7cddc79d7a00d19157d05b371148bf08d4ddf768ec6
+    - https://dl.winehq.org/wine/source/9.x/wine-9.7.tar.xz : d9f3c333656e88bd4cef5331f34b1c8b69c964a52759eef745d8ddae51a15353
 license    : LGPL-2.1-or-later
 component  : virt
 homepage   : https://www.winehq.org/

--- a/packages/w/wine/pspec_x86_64.xml
+++ b/packages/w/wine/pspec_x86_64.xml
@@ -980,7 +980,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="171">wine</Dependency>
+            <Dependency release="172">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/wine</Path>
@@ -1810,7 +1810,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="171">wine</Dependency>
+            <Dependency release="172">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wine/debug.h</Path>
@@ -2328,6 +2328,8 @@
             <Path fileType="header">/usr/include/wine/windows/hlguids.h</Path>
             <Path fileType="header">/usr/include/wine/windows/hlink.h</Path>
             <Path fileType="header">/usr/include/wine/windows/hlink.idl</Path>
+            <Path fileType="header">/usr/include/wine/windows/holographicspaceinterop.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/holographicspaceinterop.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/hrtfapoapi.h</Path>
             <Path fileType="header">/usr/include/wine/windows/hrtfapoapi.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/hstring.h</Path>
@@ -2409,6 +2411,7 @@
             <Path fileType="header">/usr/include/wine/windows/lmerr.h</Path>
             <Path fileType="header">/usr/include/wine/windows/lmjoin.h</Path>
             <Path fileType="header">/usr/include/wine/windows/lmmsg.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/lmremutl.h</Path>
             <Path fileType="header">/usr/include/wine/windows/lmserver.h</Path>
             <Path fileType="header">/usr/include/wine/windows/lmshare.h</Path>
             <Path fileType="header">/usr/include/wine/windows/lmstats.h</Path>
@@ -3108,9 +3111,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="171">
-            <Date>2024-03-10</Date>
-            <Version>9.4</Version>
+        <Update release="172">
+            <Date>2024-04-23</Date>
+            <Version>9.7</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Highlighted changes:
- Initial SLTG-format typelib support in widl
- Exception handling on ARM64EC
- Improvements to Minidump support
- Support for advanced AVX features in register contexts
- More Direct2D effects work
- Support for RSA OAEP padding in BCrypt
- Interpreted mode fixes in WIDL
- Build system support for ARM64X
- Some restructuration of the Vulkan driver interface
- WIDL improvements for ARM support as well as SLTG typelibs

Full release notes:
- [9.5](https://gitlab.winehq.org/wine/wine/-/releases/wine-9.5)
- [9.6](https://gitlab.winehq.org/wine/wine/-/releases/wine-9.6)
- [9.7](https://gitlab.winehq.org/wine/wine/-/releases/wine-9.7)

**Test Plan**
- Ran `winecfg`, `wineconsole`, `winemine`, `winefile`
- Played Age of Empires I Trial

**Checklist**

- [x] Package was built and tested against unstable
