### PR TITLE
python-orjson: Update to 3.10.1

### DIFF
--- a/packages/py/python-orjson/abi_used_symbols
+++ b/packages/py/python-orjson/abi_used_symbols
@@ -89,7 +89,6 @@ libc.so.6:stat64
 libc.so.6:strlen
 libc.so.6:syscall
 libc.so.6:write
-libc.so.6:writev
 libgcc_s.so.1:_Unwind_Backtrace
 libgcc_s.so.1:_Unwind_GetDataRelBase
 libgcc_s.so.1:_Unwind_GetIP

--- a/packages/py/python-orjson/package.yml
+++ b/packages/py/python-orjson/package.yml
@@ -1,8 +1,8 @@
 name       : python-orjson
-version    : 3.9.15
-release    : 35
+version    : 3.10.1
+release    : 36
 source     :
-    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.9.15.tar.gz : 95cae920959d772f30ab36d3b25f83bb0f3be671e986c72ce22f8fa700dae061
+    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.1.tar.gz : a883b28d73370df23ed995c466b4f6c708c1f7a9bdc400fe89165c96c7603204
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-orjson/pspec_x86_64.xml
+++ b/packages/py/python-orjson/pspec_x86_64.xml
@@ -21,11 +21,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.9.15.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.9.15.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.9.15.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.9.15.dist-info/license_files/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.9.15.dist-info/license_files/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.1.dist-info/license_files/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.1.dist-info/license_files/LICENSE-MIT</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
@@ -35,9 +35,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="35">
-            <Date>2024-02-26</Date>
-            <Version>3.9.15</Version>
+        <Update release="36">
+            <Date>2024-04-23</Date>
+            <Version>3.10.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Support serializing `numpy.float16` (`numpy.half`)
- sdist uses metadata 2.3 instead of 2.1
- Fix: Serializing `numpy.ndarray` with non-native endianness raises `orjson.JSONEncodeError`
- Improve performance of serializing

**Test Plan**

Ran through the examples in the project README

**Checklist**

- [x] Package was built and tested against unstable
