### PR TITLE
yaru-theme: Update to 24.04.2 and add monitoring.yml

### DIFF
--- a/packages/y/yaru-theme/monitoring.yml
+++ b/packages/y/yaru-theme/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 27542
+  rss: https://github.com/ubuntu/yaru/tags.atom
+# No known CPE, checked 20240423
+security:
+  cpe: ~

--- a/packages/y/yaru-theme/package.yml
+++ b/packages/y/yaru-theme/package.yml
@@ -1,8 +1,8 @@
 name       : yaru-theme
-version    : 23.10.0
-release    : 22
+version    : 24.04.2
+release    : 23
 source     :
-    - https://github.com/ubuntu/yaru/archive/refs/tags/23.10.0-0ubuntu2.tar.gz : 2cc53cefb8f899bf7100dedad674799caf478115aafa5a8ea504770c75278108
+    - https://github.com/ubuntu/yaru/archive/refs/tags/24.04.2-0ubuntu1.tar.gz : 920bf71f1f876f0c09e9250545248f523fb95dca41cbf95153ed600764441fbc
 license    :
     - CC-BY-SA-4.0
     - GPL-3.0-or-later
@@ -20,6 +20,7 @@ patterns   :
     - ^yaru-gtk-theme :
         - /usr/share/themes
         - /usr/share/gtksourceview-*
+        - /usr/share/libgedit-gtksourceview-*
 builddeps  :
     - sassc
 rundeps    :

--- a/packages/y/yaru-theme/pspec_x86_64.xml
+++ b/packages/y/yaru-theme/pspec_x86_64.xml
@@ -31,6 +31,8 @@
             <Path fileType="data">/usr/share/gtksourceview-4/styles/Yaru.xml</Path>
             <Path fileType="data">/usr/share/gtksourceview-5/styles/Yaru-dark.xml</Path>
             <Path fileType="data">/usr/share/gtksourceview-5/styles/Yaru.xml</Path>
+            <Path fileType="data">/usr/share/libgedit-gtksourceview-300/styles/Yaru-dark.xml</Path>
+            <Path fileType="data">/usr/share/libgedit-gtksourceview-300/styles/Yaru.xml</Path>
             <Path fileType="data">/usr/share/themes/Yaru-bark-dark/gtk-2.0/apps.rc</Path>
             <Path fileType="data">/usr/share/themes/Yaru-bark-dark/gtk-2.0/assets/border.png</Path>
             <Path fileType="data">/usr/share/themes/Yaru-bark-dark/gtk-2.0/assets/button-active.png</Path>
@@ -3419,7 +3421,8 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-bark-dark/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-bark-dark/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-bark-dark/pad-osd.css</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-bark-dark/process-working.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-bark-dark/process-working-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-bark-dark/process-working-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-bark-dark/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-bark-dark/toggle-off-bark-dark.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-bark-dark/toggle-on-bark-dark.svg</Path>
@@ -3434,7 +3437,8 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-bark/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-bark/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-bark/pad-osd.css</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-bark/process-working.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-bark/process-working-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-bark/process-working-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-bark/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-bark/toggle-off-bark.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-bark/toggle-on-bark.svg</Path>
@@ -3450,12 +3454,11 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/pad-osd.css</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/process-working.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/process-working-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/process-working-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/toggle-off-blue-dark.svg</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/toggle-off-hc-blue-dark.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/toggle-on-blue-dark.svg</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/toggle-on-hc-blue-dark.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue-dark/workspace-placeholder.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue/calendar-today-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue/calendar-today.svg</Path>
@@ -3467,7 +3470,8 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue/pad-osd.css</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue/process-working.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue/process-working-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue/process-working-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue/toggle-off-blue.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-blue/toggle-on-blue.svg</Path>
@@ -3482,7 +3486,8 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-dark/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-dark/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-dark/pad-osd.css</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-dark/process-working.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-dark/process-working-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-dark/process-working-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-dark/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-dark/toggle-off-dark.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-dark/toggle-on-dark.svg</Path>
@@ -3497,7 +3502,8 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-magenta-dark/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-magenta-dark/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-magenta-dark/pad-osd.css</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-magenta-dark/process-working.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-magenta-dark/process-working-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-magenta-dark/process-working-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-magenta-dark/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-magenta-dark/toggle-off-magenta-dark.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-magenta-dark/toggle-on-magenta-dark.svg</Path>
@@ -3512,7 +3518,8 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-magenta/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-magenta/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-magenta/pad-osd.css</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-magenta/process-working.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-magenta/process-working-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-magenta/process-working-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-magenta/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-magenta/toggle-off-magenta.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-magenta/toggle-on-magenta.svg</Path>
@@ -3527,7 +3534,8 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-olive-dark/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-olive-dark/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-olive-dark/pad-osd.css</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-olive-dark/process-working.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-olive-dark/process-working-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-olive-dark/process-working-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-olive-dark/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-olive-dark/toggle-off-olive-dark.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-olive-dark/toggle-on-olive-dark.svg</Path>
@@ -3542,7 +3550,8 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-olive/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-olive/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-olive/pad-osd.css</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-olive/process-working.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-olive/process-working-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-olive/process-working-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-olive/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-olive/toggle-off-olive.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-olive/toggle-on-olive.svg</Path>
@@ -3557,7 +3566,8 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-prussiangreen-dark/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-prussiangreen-dark/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-prussiangreen-dark/pad-osd.css</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-prussiangreen-dark/process-working.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-prussiangreen-dark/process-working-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-prussiangreen-dark/process-working-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-prussiangreen-dark/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-prussiangreen-dark/toggle-off-prussiangreen-dark.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-prussiangreen-dark/toggle-on-prussiangreen-dark.svg</Path>
@@ -3572,7 +3582,8 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-prussiangreen/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-prussiangreen/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-prussiangreen/pad-osd.css</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-prussiangreen/process-working.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-prussiangreen/process-working-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-prussiangreen/process-working-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-prussiangreen/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-prussiangreen/toggle-off-prussiangreen.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-prussiangreen/toggle-on-prussiangreen.svg</Path>
@@ -3587,7 +3598,8 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-purple-dark/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-purple-dark/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-purple-dark/pad-osd.css</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-purple-dark/process-working.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-purple-dark/process-working-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-purple-dark/process-working-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-purple-dark/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-purple-dark/toggle-off-purple-dark.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-purple-dark/toggle-on-purple-dark.svg</Path>
@@ -3602,7 +3614,8 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-purple/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-purple/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-purple/pad-osd.css</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-purple/process-working.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-purple/process-working-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-purple/process-working-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-purple/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-purple/toggle-off-purple.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-purple/toggle-on-purple.svg</Path>
@@ -3617,7 +3630,8 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-red-dark/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-red-dark/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-red-dark/pad-osd.css</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-red-dark/process-working.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-red-dark/process-working-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-red-dark/process-working-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-red-dark/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-red-dark/toggle-off-red-dark.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-red-dark/toggle-on-red-dark.svg</Path>
@@ -3632,7 +3646,8 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-red/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-red/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-red/pad-osd.css</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-red/process-working.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-red/process-working-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-red/process-working-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-red/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-red/toggle-off-red.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-red/toggle-on-red.svg</Path>
@@ -3647,7 +3662,8 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-sage-dark/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-sage-dark/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-sage-dark/pad-osd.css</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-sage-dark/process-working.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-sage-dark/process-working-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-sage-dark/process-working-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-sage-dark/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-sage-dark/toggle-off-sage-dark.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-sage-dark/toggle-on-sage-dark.svg</Path>
@@ -3662,7 +3678,8 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-sage/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-sage/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-sage/pad-osd.css</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-sage/process-working.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-sage/process-working-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-sage/process-working-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-sage/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-sage/toggle-off-sage.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-sage/toggle-on-sage.svg</Path>
@@ -3677,7 +3694,8 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-viridian-dark/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-viridian-dark/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-viridian-dark/pad-osd.css</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-viridian-dark/process-working.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-viridian-dark/process-working-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-viridian-dark/process-working-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-viridian-dark/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-viridian-dark/toggle-off-viridian-dark.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-viridian-dark/toggle-on-viridian-dark.svg</Path>
@@ -3692,7 +3710,8 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-viridian/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-viridian/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-viridian/pad-osd.css</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-viridian/process-working.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-viridian/process-working-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-viridian/process-working-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-viridian/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-viridian/toggle-off-viridian.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru-viridian/toggle-on-viridian.svg</Path>
@@ -3707,7 +3726,8 @@
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/gnome-shell-start.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/gnome-shell.css</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/pad-osd.css</Path>
-            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/process-working.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/process-working-dark.svg</Path>
+            <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/process-working-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/running-indicator.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/toggle-off-light.svg</Path>
             <Path fileType="data">/usr/share/themes/Yaru/Yaru-shell/Yaru/toggle-on-light.svg</Path>
@@ -8336,6 +8356,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/16x16/apps/accessories-dictionary.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/apps/accessories-text-editor.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/apps/address-book-app.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/16x16/apps/app-center.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/apps/applets-screenshooter.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/apps/applications-multimedia.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16/apps/applications-office.png</Path>
@@ -9460,6 +9481,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/apps/accessories-dictionary.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/apps/accessories-text-editor.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/apps/address-book-app.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/apps/app-center.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/apps/applets-screenshooter.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/apps/applications-multimedia.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/16x16@2x/apps/applications-office.png</Path>
@@ -10622,6 +10644,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/24x24/apps/accessories-dictionary.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/apps/accessories-text-editor.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/apps/address-book-app.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/24x24/apps/app-center.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/apps/applets-screenshooter.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/apps/applications-multimedia.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24/apps/applications-office.png</Path>
@@ -11589,6 +11612,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/apps/accessories-dictionary.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/apps/accessories-text-editor.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/apps/address-book-app.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/apps/app-center.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/apps/applets-screenshooter.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/apps/applications-multimedia.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/24x24@2x/apps/applications-office.png</Path>
@@ -12505,6 +12529,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/256x256/apps/accessories-dictionary.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/apps/accessories-text-editor.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/apps/address-book-app.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/256x256/apps/app-center.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/apps/applets-screenshooter.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/apps/applications-multimedia.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256/apps/applications-office.png</Path>
@@ -13421,6 +13446,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/apps/accessories-dictionary.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/apps/accessories-text-editor.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/apps/address-book-app.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/apps/app-center.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/apps/applets-screenshooter.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/apps/applications-multimedia.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/256x256@2x/apps/applications-office.png</Path>
@@ -14337,6 +14363,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/32x32/apps/accessories-dictionary.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/apps/accessories-text-editor.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/apps/address-book-app.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/32x32/apps/app-center.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/apps/applets-screenshooter.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/apps/applications-multimedia.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32/apps/applications-office.png</Path>
@@ -15253,6 +15280,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/apps/accessories-dictionary.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/apps/accessories-text-editor.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/apps/address-book-app.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/apps/app-center.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/apps/applets-screenshooter.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/apps/applications-multimedia.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/32x32@2x/apps/applications-office.png</Path>
@@ -16169,6 +16197,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/48x48/apps/accessories-dictionary.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/apps/accessories-text-editor.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/apps/address-book-app.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/48x48/apps/app-center.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/apps/applets-screenshooter.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/apps/applications-multimedia.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48/apps/applications-office.png</Path>
@@ -17085,6 +17114,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/apps/accessories-dictionary.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/apps/accessories-text-editor.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/apps/address-book-app.png</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/apps/app-center.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/apps/applets-screenshooter.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/apps/applications-multimedia.png</Path>
             <Path fileType="data">/usr/share/icons/Yaru/48x48@2x/apps/applications-office.png</Path>
@@ -18466,6 +18496,8 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/value-decrease-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/value-increase-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/view-app-grid-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/view-app-grid-ubiquity-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/view-app-grid-ubuntu-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/view-conceal-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/view-continuous-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/view-dual-symbolic.svg</Path>
@@ -18641,14 +18673,11 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Maps-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Mines-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Music-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Nautilus-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Photos-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.PowerStats-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Rhythmbox-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Rhythmbox3-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Screenshot-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Settings-multitasking-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Settings-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Shell.Extensions-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Shotwell-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.SimpleScan-symbolic.svg</Path>
@@ -18770,7 +18799,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/calendar-today-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/calendar-week-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/calendar-year-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/camera-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/characters-arrow-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/characters-bullet-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/characters-currency-symbolic.svg</Path>
@@ -18792,37 +18820,10 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/emoji-symbols-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/emoji-travel-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/goa-panel-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/hearing-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/location-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/lock-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/microphone-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/multitasking-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-about-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-accessibility-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-appearance-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-applications-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-bluetooth-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-color-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-default-apps-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-display-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-keyboard-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-mobile-network-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-mouse-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-network-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-notifications-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-online-accounts-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-power-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-printers-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-privacy-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-region-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-removable-media-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-search-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-sharing-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-sound-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-time-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-users-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-wacom-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/pointing-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/preferences-color-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/preferences-desktop-accessibility-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/preferences-desktop-appearance-symbolic.svg</Path>
@@ -18836,13 +18837,10 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/preferences-system-network-proxy-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/preferences-system-parental-controls-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/preferences-ubuntu-panel-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/seeing-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/trash-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/typing-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/view-tasks-today-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/view-tasks-week-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/yelp-page-tip-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/zoom-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/devices/ac-adapter-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/devices/audio-card-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/devices/audio-headphones-symbolic.svg</Path>
@@ -19050,6 +19048,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/mimetypes/package-x-generic-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/mimetypes/text-x-generic-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/mimetypes/video-x-generic-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/mimetypes/x-office-address-book-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/mimetypes/x-office-calendar-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/mimetypes/x-office-document-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/mimetypes/x-office-drawing-symbolic.svg</Path>
@@ -19076,6 +19075,55 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/multimedia/stop-large-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/multimedia/stop-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/multimedia/subtitles-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Nautilus/cancel-operation-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Nautilus/file-operation-cancelled-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Nautilus/file-operation-finished-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Nautilus/nautilus-folder-search-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Nautilus/nautilus-search-filters-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Nautilus/network-computer-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Nautilus/org.gnome.Nautilus-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Nautilus/remove-custom-icon-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/camera-access-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/device-diagnostics-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/device-security-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/hearing-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/location-access-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/microphone-access-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-about-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-accessibility-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-appearance-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-applications-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-bluetooth-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-color-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-display-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-keyboard-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-mobile-network-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-mouse-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-multitasking-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-network-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-notifications-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-online-accounts-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-power-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-printers-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-privacy-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-region-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-remote-desktop-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-search-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-sharing-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-sound-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-system-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-time-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-users-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/org.gnome.Settings-wacom-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/pointing-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/screen-lock-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/seeing-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/thunderbolt-access-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/trash-file-history-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/typing-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/update-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/org.gnome.Settings/zoom-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/phosh/feedback-quiet-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/phosh/org.gnome.Shell.Extensions.GSConnect-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/phosh/phone-docked-symbolic.svg</Path>
@@ -19438,9 +19486,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2023-10-16</Date>
-            <Version>23.10.0</Version>
+        <Update release="23">
+            <Date>2024-04-23</Date>
+            <Version>24.04.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changelog available [here](https://github.com/ubuntu/yaru/blob/24.04.2-0ubuntu1/debian/changelog)

**Test Plan**

Switched widget/icon theme to several Yaru variants and looked at the result

**Checklist**

- [x] Package was built and tested against unstable
