### PR TITLE
mate-panel: Update to 1.28.2

### DIFF
--- a/packages/m/mate-panel/abi_used_symbols
+++ b/packages/m/mate-panel/abi_used_symbols
@@ -646,8 +646,8 @@ libglib-2.0.so.0:g_mutex_clear
 libglib-2.0.so.0:g_mutex_init
 libglib-2.0.so.0:g_mutex_lock
 libglib-2.0.so.0:g_mutex_unlock
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_group
 libglib-2.0.so.0:g_option_context_add_main_entries
 libglib-2.0.so.0:g_option_context_free

--- a/packages/m/mate-panel/package.yml
+++ b/packages/m/mate-panel/package.yml
@@ -1,8 +1,8 @@
 name       : mate-panel
-version    : 1.28.0
-release    : 38
+version    : 1.28.1
+release    : 39
 source     :
-    - https://github.com/mate-desktop/mate-panel/releases/download/v1.28.0/mate-panel-1.28.0.tar.xz : b3bd04a094d0eb5bd7dc3380ef6f0c49d9a9d5209733d7ccd7b46d066a208cba
+    - https://github.com/mate-desktop/mate-panel/releases/download/v1.28.1/mate-panel-1.28.1.tar.xz : 5133c64f5969ae8eeebe6e8bba450dea792cb0be06d9ae1c36e8569d2f8524ba
 homepage   : https://mate-desktop.org/
 license    :
     - GPL-2.0-or-later

--- a/packages/m/mate-panel/pspec_x86_64.xml
+++ b/packages/m/mate-panel/pspec_x86_64.xml
@@ -1108,7 +1108,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="38">mate-panel</Dependency>
+            <Dependency release="39">mate-panel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/mate-panel-4.0/libmate-panel-applet/mate-panel-applet-enums.h</Path>
@@ -1147,9 +1147,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="38">
-            <Date>2024-03-07</Date>
-            <Version>1.28.0</Version>
+        <Update release="39">
+            <Date>2024-04-23</Date>
+            <Version>1.28.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

This release makes use of the fixes in mate-desktop 1.28.2

Changes:
- Build: require mate-desktop 1.28.2
- Use MateImageMenuItem properly

**Test Plan**

Launched MATE session and confirmed panel plus applets were still working correctly

**Checklist**

- [x] Package was built and tested against unstable
