### PR TITLE
python-moddb: Update to 0.11.0

### DIFF
--- a/packages/py/python-moddb/monitoring.yml
+++ b/packages/py/python-moddb/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 254477
+  rss: https://github.com/ClementJ18/moddb/tags.atom
+# No known CPE, checked 20240423
+security:
+  cpe: ~

--- a/packages/py/python-moddb/package.yml
+++ b/packages/py/python-moddb/package.yml
@@ -1,8 +1,8 @@
 name       : python-moddb
-version    : 0.10.0
-release    : 5
+version    : 0.11.0
+release    : 6
 source     :
-    - https://pypi.io/packages/source/m/moddb/moddb-0.10.0.tar.gz : 42784e1b34328a87113ad2a51e8ba5c99e6169657a4117d2be37d61b26aaadb5
+    - https://pypi.io/packages/source/m/moddb/moddb-0.11.0.tar.gz : f119feeefd1f4b58c41c18ccc73f4e772c3724e320efe34f3ccb9ea0285c02d2
 homepage   : https://github.com/ClementJ18/moddb
 license    : MIT
 component  : programming.python
@@ -13,7 +13,6 @@ rundeps    :
     - python-beautifulsoup4
     - python-pyrate-limiter
     - python-requests
-    - python-toolz
 build      : |
     %python3_setup
 install    : |

--- a/packages/py/python-moddb/pspec_x86_64.xml
+++ b/packages/py/python-moddb/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-moddb</Name>
         <Homepage>https://github.com/ClementJ18/moddb</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,11 +20,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/moddb-0.10.0-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/moddb-0.10.0-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/moddb-0.10.0-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/moddb-0.10.0-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/moddb-0.10.0-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/moddb-0.11.0-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/moddb-0.11.0-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/moddb-0.11.0-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/moddb-0.11.0-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/moddb-0.11.0-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/moddb/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/moddb/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/moddb/__pycache__/base.cpython-311.pyc</Path>
@@ -70,12 +70,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2024-02-14</Date>
-            <Version>0.10.0</Version>
+        <Update release="6">
+            <Date>2024-04-23</Date>
+            <Version>0.11.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Fixed an edge case in comment parsing
- Added `FrontPage.get_poll` to get the poll on the front page
- Ratelimiting login request to to 1/5s
- Ratelimited requests that are asked to raise will now raise `moddb.errors.Ratelimited`
- Profiles now display the aggregated download count of mods and games (if they have one) under `download_count`
- Removed `FrontPage.poll` to reduce the number of requests used when calling `front_page()`

**Test Plan**

Executed some examples from the project documentation

**Checklist**

- [x] Package was built and tested against unstable
