### PR TITLE
Taskfile: Add go-task command to create monitoring.yml skeleton

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -254,3 +254,19 @@ tasks:
     cmds:
       - |
         {{ .NEWPKG }} {{.CLI_ARGS}}
+
+  add-monitoring:
+    desc: Add skeleton for monitoring.yml
+    dir: '{{ .USER_WORKING_DIR }}'
+    vars:
+      DATE:
+        sh: date -u +%Y-%m-%d
+      COMMENT: "# No known CPE, checked {{ .DATE }}"
+    cmds:
+      - touch monitoring.yml
+      - yq --inplace '
+          .releases.id line_comment = "# Check https://release-monitoring.org/" |
+          .releases.rss line_comment = "# For example https://github.com/PyO3/maturin/releases.atom" |
+          (.security | key) head_comment = "{{ .COMMENT }}" |
+          .security.cpe = ~
+        '  monitoring.yml


### PR DESCRIPTION
**Summary**

This adds a go-task command to create a monitoring.yml skeleton file that can then be manually filled in

**Test Plan**

Created a new `monitoring.yml` using `go-task add-monitoring`