### PR TITLE
anki: Update to 24.04.1 and add monitoring.yml

### DIFF
--- a/packages/a/anki/abi_used_symbols
+++ b/packages/a/anki/abi_used_symbols
@@ -232,12 +232,12 @@ libm.so.6:cos
 libm.so.6:exp
 libm.so.6:expf
 libm.so.6:expm1f
+libm.so.6:floor
 libm.so.6:floorf
 libm.so.6:fma
 libm.so.6:fmod
 libm.so.6:log
-libm.so.6:log10f
-libm.so.6:logf
 libm.so.6:pow
 libm.so.6:powf
+libm.so.6:round
 libm.so.6:roundf

--- a/packages/a/anki/monitoring.yml
+++ b/packages/a/anki/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 49
+  rss: https://github.com/ankitects/anki/releases.atom
+# No known CPE, checked 2024-04-25
+security:
+  cpe: ~

--- a/packages/a/anki/package.yml
+++ b/packages/a/anki/package.yml
@@ -1,8 +1,8 @@
 name       : anki
-version    : 23.12.1
-release    : 34
+version    : 24.04.1
+release    : 35
 source     :
-    - git|https://github.com/ankitects/anki.git : 23.12.1
+    - git|https://github.com/ankitects/anki.git : 24.04.1
 license    : AGPL-3.0-or-later
 component  : office.notes
 homepage   : https://apps.ankiweb.net/index.html
@@ -31,7 +31,10 @@ rundeps    :
     - python-send2trash
     - python-waitress
 ccache     : no
-environment: export PYTHON_BINARY=/usr/bin/python3 export YARN_BINARY=/usr/bin/yarn export PROTOC_BINARY=/usr/bin/protoc
+environment: |
+     export PYTHON_BINARY=/usr/bin/python3
+     export YARN_BINARY=/usr/bin/yarn
+     export PROTOC_BINARY=/usr/bin/protoc
 build      : |
     ./tools/build
 install    : |

--- a/packages/a/anki/pspec_x86_64.xml
+++ b/packages/a/anki/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>anki</Name>
         <Homepage>https://apps.ankiweb.net/index.html</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>AGPL-3.0-or-later</License>
         <PartOf>office.notes</PartOf>
@@ -215,8 +215,6 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/forms/__pycache__/dconf_qt6.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/forms/__pycache__/debug_qt5.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/forms/__pycache__/debug_qt6.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/forms/__pycache__/editaddon_qt5.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/forms/__pycache__/editaddon_qt6.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/forms/__pycache__/editcurrent_qt5.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/forms/__pycache__/editcurrent_qt6.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/forms/__pycache__/edithtml_qt5.cpython-311.pyc</Path>
@@ -301,8 +299,6 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/forms/dconf_qt6.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/forms/debug_qt5.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/forms/debug_qt6.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/forms/editaddon_qt5.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/forms/editaddon_qt6.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/forms/editcurrent_qt5.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/forms/editcurrent_qt6.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/forms/edithtml_qt5.py</Path>
@@ -360,12 +356,12 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/hooks.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/props.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/py.typed</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-23.12.1.dist-info/INSTALLER</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-23.12.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-23.12.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-23.12.1.dist-info/REQUESTED</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-23.12.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-23.12.1.dist-info/direct_url.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-24.04.1.dist-info/INSTALLER</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-24.04.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-24.04.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-24.04.1.dist-info/REQUESTED</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-24.04.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-24.04.1.dist-info/direct_url.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/anki/__pycache__/_backend.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/anki/__pycache__/_backend_generated.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/anki/__pycache__/_fluent.cpython-311.pyc</Path>
@@ -544,14 +540,14 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/anki/template.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/anki/types.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/anki/utils.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-23.12.1.dist-info/INSTALLER</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-23.12.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-23.12.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-23.12.1.dist-info/REQUESTED</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-23.12.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-23.12.1.dist-info/direct_url.json</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-23.12.1.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-23.12.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.04.1.dist-info/INSTALLER</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.04.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.04.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.04.1.dist-info/REQUESTED</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.04.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.04.1.dist-info/direct_url.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.04.1.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.04.1.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/__pycache__/_macos_helper.cpython-311.pyc</Path>
@@ -580,6 +576,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/__pycache__/gui_hooks.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/__pycache__/importing.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/__pycache__/legacy.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/__pycache__/log.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/__pycache__/main.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/__pycache__/mediacheck.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/__pycache__/mediasrv.cpython-311.pyc</Path>
@@ -688,7 +685,6 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/forms/__pycache__/customstudy.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/forms/__pycache__/dconf.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/forms/__pycache__/debug.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/forms/__pycache__/editaddon.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/forms/__pycache__/editcurrent.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/forms/__pycache__/edithtml.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/forms/__pycache__/emptycards.cpython-311.pyc</Path>
@@ -731,7 +727,6 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/forms/customstudy.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/forms/dconf.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/forms/debug.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/forms/editaddon.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/forms/editcurrent.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/forms/edithtml.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/forms/emptycards.py</Path>
@@ -770,6 +765,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/import_export/importing.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/importing.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/legacy.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/log.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/main.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/mediacheck.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/mediasrv.py</Path>
@@ -835,12 +831,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="34">
-            <Date>2024-02-15</Date>
-            <Version>23.12.1</Version>
+        <Update release="35">
+            <Date>2024-04-25</Date>
+            <Version>24.04.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Release notes:
- [24.04](https://github.com/ankitects/anki/releases/tag/24.04)
- [24.04.1](https://github.com/ankitects/anki/releases/tag/24.04.1)

**Test Plan**

Played through a couple of cards in a Japanese deck, with audio and images

**Checklist**

- [x] Package was built and tested against unstable
