### PR TITLE
webp-pixbuf-loader: Update to 0.2.7 and add monitoring.yml

### DIFF
--- a/packages/w/webp-pixbuf-loader/MAINTAINERS.md
+++ b/packages/w/webp-pixbuf-loader/MAINTAINERS.md
@@ -1,4 +1,5 @@
 This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
 
-- Julie Hakimi
-  - Email: phantop@tuta.io
+- Thomas Staudinger
+  - Email: staudi.kaos@gmail.com
+  - Matrix: @staudey:matrix.org

--- a/packages/w/webp-pixbuf-loader/abi_used_symbols
+++ b/packages/w/webp-pixbuf-loader/abi_used_symbols
@@ -31,8 +31,8 @@ libglib-2.0.so.0:g_get_current_time
 libglib-2.0.so.0:g_intern_static_string
 libglib-2.0.so.0:g_log
 libglib-2.0.so.0:g_malloc0
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_set_error
 libglib-2.0.so.0:g_strcmp0
 libgobject-2.0.so.0:g_object_new

--- a/packages/w/webp-pixbuf-loader/monitoring.yml
+++ b/packages/w/webp-pixbuf-loader/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 141609
+  rss: https://github.com/aruiz/webp-pixbuf-loader/releases.atom
+# No known CPE, checked 2024-04-25
+security:
+  cpe: ~

--- a/packages/w/webp-pixbuf-loader/package.yml
+++ b/packages/w/webp-pixbuf-loader/package.yml
@@ -1,8 +1,8 @@
 name       : webp-pixbuf-loader
-version    : 0.2.4
-release    : 2
+version    : 0.2.7
+release    : 3
 source     :
-    - https://github.com/aruiz/webp-pixbuf-loader/archive/refs/tags/0.2.4.tar.gz : 54f448383d1c384409bd1690cdde9b44535c346855902e29bd37a18a7237c547
+    - https://github.com/aruiz/webp-pixbuf-loader/archive/refs/tags/0.2.7.tar.gz : 61ce5e8e036043f9d0e78c1596a621788e879c52aedf72ab5e78a8c44849411a
 license    : LGPL-2.0-or-later
 homepage   : https://github.com/aruiz/webp-pixbuf-loader/
 component  : multimedia.codecs

--- a/packages/w/webp-pixbuf-loader/pspec_x86_64.xml
+++ b/packages/w/webp-pixbuf-loader/pspec_x86_64.xml
@@ -11,7 +11,7 @@
         <Summary xml:lang="en">WebP GDK Pixbuf Loader library</Summary>
         <Description xml:lang="en">WebP Image format GdkPixbuf loader
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>webp-pixbuf-loader</Name>
@@ -25,9 +25,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2023-09-18</Date>
-            <Version>0.2.4</Version>
+        <Update release="3">
+            <Date>2024-04-25</Date>
+            <Version>0.2.7</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- libwebp 1.3.2 onwards is a requirement now due to security vulnerability
- Update signal emissions and support for 0ms frames

Note: Added myself as maintainer as old one is no longer active

**Test Plan**

Checked thumbnails for .webp images in file manager

**Checklist**

- [x] Package was built and tested against unstable
