### PR TITLE
kildclient: update to 3.2.1

### DIFF
--- a/packages/k/kildclient/abi_symbols
+++ b/packages/k/kildclient/abi_symbols
@@ -153,6 +153,7 @@ kildclient:kc_error_dialog_with_title
 kildclient:kc_g_string_append_escaped
 kildclient:kc_recv
 kildclient:kc_send
+kildclient:kildclient_get_resource
 kildclient:list_aliases
 kildclient:list_hook
 kildclient:list_hooks

--- a/packages/k/kildclient/abi_used_libs
+++ b/packages/k/kildclient/abi_used_libs
@@ -1,6 +1,7 @@
 ld-linux-x86-64.so.2
 libc.so.6
 libgdk-3.so.0
+libgio-2.0.so.0
 libglib-2.0.so.0
 libgnutls.so.30
 libgobject-2.0.so.0

--- a/packages/k/kildclient/abi_used_symbols
+++ b/packages/k/kildclient/abi_used_symbols
@@ -2,7 +2,8 @@ ld-linux-x86-64.so.2:__tls_get_addr
 libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__printf_chk
@@ -68,7 +69,6 @@ libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strstr
 libc.so.6:strtod
-libc.so.6:strtol
 libc.so.6:system
 libc.so.6:textdomain
 libc.so.6:time
@@ -85,6 +85,9 @@ libgdk-3.so.0:gdk_window_get_origin
 libgdk-3.so.0:gdk_window_get_root_origin
 libgdk-3.so.0:gdk_window_set_cursor
 libgdk-3.so.0:gdk_window_set_events
+libgio-2.0.so.0:g_static_resource_fini
+libgio-2.0.so.0:g_static_resource_get_resource
+libgio-2.0.so.0:g_static_resource_init
 libglib-2.0.so.0:g_async_queue_new_full
 libglib-2.0.so.0:g_async_queue_pop
 libglib-2.0.so.0:g_async_queue_push
@@ -218,8 +221,6 @@ libgnutls.so.30:gnutls_certificate_type_get
 libgnutls.so.30:gnutls_certificate_type_get_name
 libgnutls.so.30:gnutls_cipher_get
 libgnutls.so.30:gnutls_cipher_get_name
-libgnutls.so.30:gnutls_compression_get
-libgnutls.so.30:gnutls_compression_get_name
 libgnutls.so.30:gnutls_credentials_set
 libgnutls.so.30:gnutls_deinit
 libgnutls.so.30:gnutls_error_is_fatal
@@ -296,8 +297,8 @@ libgtk-3.so.0:gtk_box_pack_end
 libgtk-3.so.0:gtk_box_pack_start
 libgtk-3.so.0:gtk_box_reorder_child
 libgtk-3.so.0:gtk_box_set_homogeneous
-libgtk-3.so.0:gtk_builder_add_from_file
-libgtk-3.so.0:gtk_builder_add_objects_from_file
+libgtk-3.so.0:gtk_builder_add_from_resource
+libgtk-3.so.0:gtk_builder_add_objects_from_resource
 libgtk-3.so.0:gtk_builder_connect_signals
 libgtk-3.so.0:gtk_builder_get_object
 libgtk-3.so.0:gtk_builder_new
@@ -363,8 +364,8 @@ libgtk-3.so.0:gtk_file_chooser_set_current_folder
 libgtk-3.so.0:gtk_file_chooser_set_extra_widget
 libgtk-3.so.0:gtk_file_chooser_set_filename
 libgtk-3.so.0:gtk_file_chooser_unselect_all
-libgtk-3.so.0:gtk_font_button_get_font_name
-libgtk-3.so.0:gtk_font_button_set_font_name
+libgtk-3.so.0:gtk_font_chooser_get_font
+libgtk-3.so.0:gtk_font_chooser_set_font
 libgtk-3.so.0:gtk_frame_new
 libgtk-3.so.0:gtk_frame_set_shadow_type
 libgtk-3.so.0:gtk_get_option_group
@@ -566,6 +567,7 @@ libgtk-3.so.0:gtk_widget_hide
 libgtk-3.so.0:gtk_widget_queue_resize
 libgtk-3.so.0:gtk_widget_realize
 libgtk-3.so.0:gtk_widget_set_can_default
+libgtk-3.so.0:gtk_widget_set_can_focus
 libgtk-3.so.0:gtk_widget_set_focus_on_click
 libgtk-3.so.0:gtk_widget_set_halign
 libgtk-3.so.0:gtk_widget_set_has_tooltip
@@ -603,7 +605,6 @@ libm.so.6:log10
 libpango-1.0.so.0:pango_context_get_language
 libpango-1.0.so.0:pango_context_load_font
 libpango-1.0.so.0:pango_coverage_get
-libpango-1.0.so.0:pango_coverage_unref
 libpango-1.0.so.0:pango_font_description_free
 libpango-1.0.so.0:pango_font_description_from_string
 libpango-1.0.so.0:pango_font_description_get_family

--- a/packages/k/kildclient/package.yml
+++ b/packages/k/kildclient/package.yml
@@ -1,8 +1,9 @@
 name       : kildclient
-version    : 3.2.0
-release    : 10
+version    : 3.2.1
+release    : 11
 source     :
-    - https://master.dl.sourceforge.net/project/kildclient/kildclient/3.2.0/kildclient-3.2.0.tar.gz : b1c2119cb208056e3bee9ee8f8b8ac1dcd8197d088b2341a90554e9fa9ac159d
+    - https://sourceforge.net/projects/kildclient/files/kildclient/3.2.1/kildclient-3.2.1.tar.gz/download : cd045c30d2c45e1295a453eacd78c239e7adc28ebaf71bc1a759be4fd73f9f19
+homepage   : https://www.kildclient.org/
 license    : GPL-2.0-or-later
 component  : network.clients
 summary    : KildClient is a MUD client using the GTK+ toolkit

--- a/packages/k/kildclient/pspec_x86_64.xml
+++ b/packages/k/kildclient/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>kildclient</Name>
+        <Homepage>https://www.kildclient.org/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>network.clients</PartOf>
         <Summary xml:lang="en">KildClient is a MUD client using the GTK+ toolkit</Summary>
         <Description xml:lang="en">KildClient is a MUD client using the GTK+ toolkit
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>kildclient</Name>
@@ -25,177 +26,6 @@
             <Path fileType="doc">/usr/share/doc/kildclient/COPYING</Path>
             <Path fileType="doc">/usr/share/doc/kildclient/NEWS</Path>
             <Path fileType="doc">/usr/share/doc/kildclient/README</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/apb.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/apc.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/apds01.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ape.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/apes01.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/apes02.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/apes03.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/apes04.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/apes05.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/apes06.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/apes07.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/app_KCWin.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/app_functions.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch01.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch03.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch04s02.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch05s01.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch06.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch06s01.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch06s02.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch06s03.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch06s04.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch06s05.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch06s06.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch07s02.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch07s04.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch07s05.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch08s01.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch08s02.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch08s04.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch09s01.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch09s02.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch10s01.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch11.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch11s01.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch12s01.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch13s01.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch13s02.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch13s03.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch15s01.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch15s02.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch15s03.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/ch16s01.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/chap_aliases.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/chap_chat.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/chap_hooks.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/chap_logging.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/chap_macros.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/chap_perl.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/chap_plugins.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/chap_preferences.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/chap_running.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/chap_serverdata.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/chap_triggers.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/chap_world_editor.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/docbook.css</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_KCWin_feed.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_KCWin_get_text.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_KCWin_set_text.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_colorize.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_getclientname.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_getversion.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_getworld.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_gotow.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_help.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_play.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_quit.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_stripansi.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_stripcolorize.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_window_getsize.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_window_minimize.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_window_settitle.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_window_seturgencyhint.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_alias.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_aliasenabled.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_close.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_cmdseparator.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_commandecho.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_connectother.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_dc.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_delalias.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_delhook.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_delmacro.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_deltimer.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_deltrigger.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_disalias.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_dishook.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_dismacro.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_displugin.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_distimer.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_distrigger.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_echo.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_echonl.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_echonlandlog.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_enaalias.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_enahook.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_enamacro.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_enaplugin.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_enatimer.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_enatrigger.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_expandalias.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_gag.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_getaliasnumber.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_getcharacter.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_getconntime.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_getentryfont.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_gethooknumber.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_getidletime.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_getinput.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_getkeycode.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_getline.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_getlogfile.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_getmacronumber.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_getmainfont.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_getname.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_getpluginversion.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_gettimernumber.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_gettriggernumber.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_hook.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_hookenabled.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_interpret.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_ispermanent.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_listalias.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_listhook.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_listmacro.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_listpermanent.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_listplugin.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_listtimer.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_listtrigger.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_loadplugin.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_logfile.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_macro.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_macroenabled.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_makepermanent.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_maketemporary.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_mlsend.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_movealias.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_movehook.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_movemacro.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_movetimer.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_movetrigger.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_next.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_path.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_prev.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_reconnect.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_requireplugin.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_save.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_send.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_sendecho.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_sendfile.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_sendlines.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_sendmsdpcommand.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_sendnoecho.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_sendserverdata.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_setinput.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_setstatus.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_silentdisalias.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_silentdishook.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_silentdismacro.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_silentdistimer.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_silentdistrigger.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_silentenaalias.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_silentenahook.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_silentenamacro.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_silentenatimer.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_silentenatrigger.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_timer.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_timerenabled.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_trigger.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_triggerenabled.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/func_world_writetolog.xhtml</Path>
             <Path fileType="doc">/usr/share/doc/kildclient/html/images/cmdhistory.png</Path>
             <Path fileType="doc">/usr/share/doc/kildclient/html/images/firstscreen.png</Path>
             <Path fileType="doc">/usr/share/doc/kildclient/html/images/mlsend.png</Path>
@@ -227,50 +57,11 @@
             <Path fileType="doc">/usr/share/doc/kildclient/html/images/we_trigger_highlight.png</Path>
             <Path fileType="doc">/usr/share/doc/kildclient/html/images/we_triggers.png</Path>
             <Path fileType="doc">/usr/share/doc/kildclient/html/images/we_vars.png</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/index.xhtml</Path>
             <Path fileType="doc">/usr/share/doc/kildclient/html/kildclient.css</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/pt01.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/pt02.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_alias_cmdline.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_closing_worlds.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_hook_cmdline.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_import_export.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_interacting.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_macro_cmdline.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_perl_basics.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_pref_progs.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_pref_proxy.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_pref_sending.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_searching.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_sending_server_data.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_sounds.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_test_triggers.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_timer_cmdline.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_trigger_cmdline.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_trigger_highlight.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_trigger_other.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_we_advanced.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_we_automation.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_we_general.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_we_input.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_we_logging.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_we_protocols.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/sec_world-selector.xhtml</Path>
-            <Path fileType="doc">/usr/share/doc/kildclient/html/var_world_SILENT.xhtml</Path>
             <Path fileType="data">/usr/share/kildclient/MSDP.pm</Path>
-            <Path fileType="data">/usr/share/kildclient/dlgAbout.ui</Path>
-            <Path fileType="data">/usr/share/kildclient/dlgCmdHistory.ui</Path>
-            <Path fileType="data">/usr/share/kildclient/dlgEditWorld.ui</Path>
-            <Path fileType="data">/usr/share/kildclient/dlgMLSend.ui</Path>
-            <Path fileType="data">/usr/share/kildclient/dlgPreferences.ui</Path>
-            <Path fileType="data">/usr/share/kildclient/dlgSelectWorld.ui</Path>
-            <Path fileType="data">/usr/share/kildclient/dlgStatistics.ui</Path>
-            <Path fileType="data">/usr/share/kildclient/dlgTestTriggers.ui</Path>
             <Path fileType="data">/usr/share/kildclient/kcworld.dtd</Path>
             <Path fileType="data">/usr/share/kildclient/kildclient.hlp</Path>
             <Path fileType="data">/usr/share/kildclient/kildclient.pl</Path>
-            <Path fileType="data">/usr/share/kildclient/kildclient.ui</Path>
-            <Path fileType="data">/usr/share/kildclient/mnuPopupURL.ui</Path>
             <Path fileType="data">/usr/share/kildclient/plugins/KCWin.pl</Path>
             <Path fileType="data">/usr/share/kildclient/plugins/channels.pl</Path>
             <Path fileType="data">/usr/share/kildclient/plugins/chat.pl</Path>
@@ -279,7 +70,6 @@
             <Path fileType="data">/usr/share/kildclient/plugins/keypad.pl</Path>
             <Path fileType="data">/usr/share/kildclient/plugins/notes.pl</Path>
             <Path fileType="data">/usr/share/kildclient/plugins/serverdatadumper.pl</Path>
-            <Path fileType="data">/usr/share/kildclient/wndmain.ui</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/kildclient.mo</Path>
             <Path fileType="localedata">/usr/share/locale/eo/LC_MESSAGES/kildclient.mo</Path>
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/kildclient.mo</Path>
@@ -291,12 +81,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2023-07-29</Date>
-            <Version>3.2.0</Version>
+        <Update release="11">
+            <Date>2024-04-26</Date>
+            <Version>3.2.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Bug fixed: $world->hookenabled now works correctly when checking status of hook 0.
- Bug fixed: KCWin's are again scrolled when text is added to them.
- Bug fixed: if called with a command-line argument that is not the  name of a saved world, KildClient tries to interpret that as a  hostname, instead of crashing.
- Bug fixed: it is now possible to copy text via the output area context menu again.

**Test Plan**
- Check homepage was added.

**Checklist**

- [X] Package was built and tested against unstable
