### PR TITLE
kitty: Update to 0.34.1

### DIFF
--- a/packages/k/kitty/package.yml
+++ b/packages/k/kitty/package.yml
@@ -1,8 +1,8 @@
 name       : kitty
-version    : 0.34.0
-release    : 65
+version    : 0.34.1
+release    : 66
 source     :
-    - https://github.com/kovidgoyal/kitty/releases/download/v0.34.0/kitty-0.34.0.tar.xz : d65527a40f72bfd179582d1ab51c9730ac28400bff89e6bffac77c6ac3c2236f
+    - https://github.com/kovidgoyal/kitty/releases/download/v0.34.1/kitty-0.34.1.tar.xz : 9f6dbb30c018976e14bd959e8db6e5c34055b50f3729bff000bb4e86e283c03e
     - git|https://github.com/simd-everywhere/simde.git : v0.7.6
 license    : GPL-3.0-only
 component  : system.utils

--- a/packages/k/kitty/pspec_x86_64.xml
+++ b/packages/k/kitty/pspec_x86_64.xml
@@ -768,9 +768,9 @@ Kitty is designed from the ground up to support all modern terminal features, su
         </Files>
     </Package>
     <History>
-        <Update release="65">
-            <Date>2024-04-18</Date>
-            <Version>0.34.0</Version>
+        <Update release="66">
+            <Date>2024-04-25</Date>
+            <Version>0.34.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Fix window background blur not adapting when window is grown. Also fix turning it on and off not working
- Draw the titlebar buttons without using a font
- Fix a regression in the previous release that caused incorrect font selection when using variable fonts

**Test Plan**
- open TERM, run htop

**Checklist**
- [X] Package was built and tested against unstable
