### PR TITLE
gpxsee: Update to 13.19

### DIFF
--- a/packages/g/gpxsee/abi_used_symbols
+++ b/packages/g/gpxsee/abi_used_symbols
@@ -226,6 +226,7 @@ libQt5Core.so.5:_ZN7QString6numberEdci
 libQt5Core.so.5:_ZN7QString6numberEii
 libQt5Core.so.5:_ZN7QString6numberEji
 libQt5Core.so.5:_ZN7QString6numberExi
+libQt5Core.so.5:_ZN7QString6resizeEi
 libQt5Core.so.5:_ZN7QString6resizeEi5QChar
 libQt5Core.so.5:_ZN7QString7replaceE5QCharRKS_N2Qt15CaseSensitivityE
 libQt5Core.so.5:_ZN7QString7replaceE5QCharS0_N2Qt15CaseSensitivityE

--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.18'
-release    : 36
+version    : '13.19'
+release    : 37
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.18.tar.gz : d80d77a271c5ac1857f87c7f5be2c7c1264b7c35a8f4e8f21e225c2b14e3b7da
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.19.tar.gz : e35d1bbc2b562969bb356cd6a5515f70696a870ac8255a590a55c15fc2f1f52a
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -34,6 +34,7 @@
             <Path fileType="data">/usr/share/gpxsee/maps/mtbmap-cz.xml</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/ATV.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Airport.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Alert.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Amusement Park.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Anchor.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Ballpark.png</Path>
@@ -51,41 +52,54 @@
             <Path fileType="data">/usr/share/gpxsee/symbols/Car Repair.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Car.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Cemetary.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Checkpoint.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Church.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Crossing.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Dam.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Danger.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Drinking Water.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Fastfood.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Ferry.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/First Aid.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/First Category.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Fishing Area.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Flag, Blue.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Flag, Green.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Flag, Red.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Flag.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Food.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Forest.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Fourth Category.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Funicular.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Furbearer.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Gas Station.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Gear.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Geocache Found.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Geocache.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Ghost Town.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Golf Course.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Ground Transportation.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Heliport.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Hors Category.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Hunting Area.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Iceskating.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Info.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Information.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Left.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Library.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Live Theater.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Lodge.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Lodging.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Marina.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Medical Facility.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Meeting Spot.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Military.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Mine.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Movie Theater.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Museum.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Obstacle.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Oil Field.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Overlook.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Parachute Area.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Park.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Parking Area.png</Path>
@@ -98,29 +112,51 @@
             <Path fileType="data">/usr/share/gpxsee/symbols/Radio Beacon.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Railway.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Residence.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Rest Area.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Restaurant.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Restroom.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Right.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Scenic Area.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/School.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Second Category.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Segment End.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Segment Start.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Service.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Sharp Curve.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Sharp Left.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Sharp Right.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Shelter.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Shipwreck.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Shopping Center.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Shower.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Ski Resort.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Skiing Area.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Skull and Crossbones.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Slight Left.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Slight Right.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Small Game.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Sprint.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Stadium.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Steep Incline.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Store.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Straight.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Summit.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Tall Tower.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Telephone.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Third Category.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Toilet.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Trail Head.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Transport.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Truck Stop.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Truck.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Tunnel.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/U-Turn.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Ultralight Area.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Upland Game.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Valley.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Water Hydrant.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Water Source.png</Path>
+            <Path fileType="data">/usr/share/gpxsee/symbols/Water.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Waterfowl.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Waypoint.png</Path>
             <Path fileType="data">/usr/share/gpxsee/symbols/Winery.png</Path>
@@ -136,9 +172,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2024-03-24</Date>
-            <Version>13.18</Version>
+        <Update release="37">
+            <Date>2024-04-25</Date>
+            <Version>13.19</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Added support for FIT course icons.
- Added support for GPX water temperature extension.
- Multiple minor map fixes (IMG & Mapsforge).

**Test Plan**
- open map file, zoom in and out

**Checklist**
- [X] Package was built and tested against unstable
