### PR TITLE
obs-vkcapture: Update to 1.5.0 and add monitoring.yml

### DIFF
--- a/packages/o/obs-vkcapture/MAINTAINERS.md
+++ b/packages/o/obs-vkcapture/MAINTAINERS.md
@@ -2,3 +2,4 @@ This file is used to indicate primary maintainership for this package. A package
 
 - Thomas Staudinger
   - Email: staudi.kaos@gmail.com
+  - Matrix: @staudey:matrix.org

--- a/packages/o/obs-vkcapture/abi_symbols
+++ b/packages/o/obs-vkcapture/abi_symbols
@@ -24,6 +24,7 @@ linux-vkcapture.so:obs_module_text
 linux-vkcapture.so:obs_module_unload
 linux-vkcapture.so:obs_module_ver
 linux-vkcapture.so:p_glGetUnsignedBytei_vEXT
+linux-vkcapture.so:vkcapture_get_color_space
 linux-vkcapture.so:wl_cursor_destroy
 linux-vkcapture.so:wl_cursor_init
 linux-vkcapture.so:wl_cursor_render

--- a/packages/o/obs-vkcapture/abi_used_symbols
+++ b/packages/o/obs-vkcapture/abi_used_symbols
@@ -66,11 +66,13 @@ libobs.so.0:gs_blend_state_push
 libobs.so.0:gs_draw_sprite
 libobs.so.0:gs_effect_get_param_by_name
 libobs.so.0:gs_effect_loop
+libobs.so.0:gs_effect_set_float
 libobs.so.0:gs_effect_set_texture
 libobs.so.0:gs_effect_set_texture_srgb
 libobs.so.0:gs_enable_color
 libobs.so.0:gs_enable_framebuffer_srgb
 libobs.so.0:gs_framebuffer_srgb_enabled
+libobs.so.0:gs_get_color_space
 libobs.so.0:gs_get_effect
 libobs.so.0:gs_get_linear_srgb
 libobs.so.0:gs_matrix_pop
@@ -86,6 +88,7 @@ libobs.so.0:obs_data_set_default_bool
 libobs.so.0:obs_enter_graphics
 libobs.so.0:obs_get_base_effect
 libobs.so.0:obs_get_nix_platform
+libobs.so.0:obs_get_video_sdr_white_level
 libobs.so.0:obs_leave_graphics
 libobs.so.0:obs_module_load_locale
 libobs.so.0:obs_properties_add_bool

--- a/packages/o/obs-vkcapture/monitoring.yml
+++ b/packages/o/obs-vkcapture/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 372168
+  rss: https://github.com/nowrep/obs-vkcapture/releases.atom
+# No known CPE, checked 2024-04-27
+security:
+  cpe: ~

--- a/packages/o/obs-vkcapture/package.yml
+++ b/packages/o/obs-vkcapture/package.yml
@@ -1,8 +1,8 @@
 name       : obs-vkcapture
-version    : 1.4.9
-release    : 8
+version    : 1.5.0
+release    : 9
 source     :
-    - https://github.com/nowrep/obs-vkcapture/archive/refs/tags/v1.4.9.tar.gz : f932bd81509f9749cba477349019513495087558604fcdfb76578a13a95c8ca1
+    - https://github.com/nowrep/obs-vkcapture/archive/refs/tags/v1.5.0.tar.gz : 338c407f2a795a12d16010416cadb7c402638dee54d9615343dccf8d104753f0
 license    : GPL-2.0-or-later
 homepage   : https://github.com/nowrep/obs-vkcapture
 component  : multimedia.video
@@ -16,7 +16,6 @@ builddeps  :
     - pkgconfig32(vulkan)
     - pkgconfig32(wayland-client)
     - pkgconfig(libobs)
-    - vulkan-headers
 setup      : |
     if [[ ! -z $EMUL32BUILD ]]; then
         %cmake_ninja -DCMAKE_INSTALL_LIBDIR=lib32 -DBUILD_PLUGIN=$OFF

--- a/packages/o/obs-vkcapture/pspec_x86_64.xml
+++ b/packages/o/obs-vkcapture/pspec_x86_64.xml
@@ -48,7 +48,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="8">obs-vkcapture</Dependency>
+            <Dependency release="9">obs-vkcapture</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libVkLayer_obs_vkcapture.so</Path>
@@ -56,9 +56,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2024-02-15</Date>
-            <Version>1.4.9</Version>
+        <Update release="9">
+            <Date>2024-04-27</Date>
+            <Version>1.5.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Dropped support for OBS 27
- Added initial support for HDR

**Test Plan**

Captured footage of the game "b"

**Checklist**

- [x] Package was built and tested against unstable
