### PR TITLE
Merge /bin and /sbin into /usr

### DIFF
--- a/packages/b/baselayout/package.yml
+++ b/packages/b/baselayout/package.yml
@@ -1,6 +1,6 @@
 name       : baselayout
 version    : 1.9.0
-release    : 76
+release    : 77
 source     :
     - https://github.com/getsolus/baselayout/releases/download/v1.9.0/baselayout-1.9.0.tar.gz : a2a3e4fdb6349b479a16d9ffcf2335fb0f4d75d2cdd1cdbb80cb6c02652f37de
 homepage   : https://github.com/getsolus/baselayout
@@ -15,6 +15,8 @@ install    : |
     install -dm00755 %installroot%/usr
     install -dm00755 %installroot%/lib64
     install -dm00755 %installroot%/usr/lib64
+    install -dm00755 %installroot%/usr/bin
+    install -dm00755 %installroot%/usr/sbin
     install -dm00755 %installroot%/etc
     install -dm00755 %installroot%/boot
     install -dm00755 %installroot%/dev
@@ -38,6 +40,10 @@ install    : |
 
     ln -sv /proc/self/mounts %installroot%/etc/mtab
 
+    # /usr merge
+    ln -srv %installroot%/usr/bin %installroot%/bin
+    ln -srv %installroot%/usr/sbin %installroot%/sbin
+
     # Install our files
     cp -a $workdir/* $installdir/
     chmod 00600 $installdir/usr/share/baselayout/shadow
@@ -58,7 +64,9 @@ install    : |
 # Mark as permanent so eopkg doesn't nuke it.
 permanent  :
     - /usr
+    - /usr/bin
     - /usr/lib*
+    - /usr/sbin
     - /tmp
     - /etc
     - /dev/

--- a/packages/b/baselayout/pspec_x86_64.xml
+++ b/packages/b/baselayout/pspec_x86_64.xml
@@ -20,6 +20,7 @@
 </Description>
         <PartOf>system.base</PartOf>
         <Files>
+            <Path fileType="executable">/bin</Path>
             <Path fileType="data">/boot</Path>
             <Path fileType="data">/dev</Path>
             <Path fileType="config">/etc/filesystems</Path>
@@ -41,11 +42,14 @@
             <Path fileType="data">/proc</Path>
             <Path fileType="data">/root</Path>
             <Path fileType="data">/run/lock</Path>
+            <Path fileType="executable">/sbin</Path>
             <Path fileType="data">/sys</Path>
             <Path fileType="data">/tmp</Path>
+            <Path fileType="executable">/usr/bin</Path>
             <Path fileType="library">/usr/lib</Path>
             <Path fileType="library">/usr/lib64/os-release</Path>
             <Path fileType="library">/usr/lib64/tmpfiles.d/etc-nsswitch-conf.conf</Path>
+            <Path fileType="executable">/usr/sbin</Path>
             <Path fileType="data">/usr/share/baselayout/fstab</Path>
             <Path fileType="data">/usr/share/baselayout/group</Path>
             <Path fileType="data">/usr/share/baselayout/group-</Path>
@@ -66,8 +70,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="76">
-            <Date>2024-04-08</Date>
+        <Update release="77">
+            <Date>2024-04-29</Date>
             <Version>1.9.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Joey Riches</Name>

--- a/packages/b/bash/files/profile/10-path.sh
+++ b/packages/b/bash/files/profile/10-path.sh
@@ -1,6 +1,6 @@
 # Begin /usr/share/defaults/etc/profile.d/10-path.sh
 
-export PATH="/sbin:/bin:/usr/sbin:/usr/bin"
+export PATH="/usr/sbin:/usr/bin"
 if [ -d "/usr/local/sbin" ]; then
   export PATH="$PATH:/usr/local/sbin"
 fi

--- a/packages/b/bash/package.yml
+++ b/packages/b/bash/package.yml
@@ -1,6 +1,6 @@
 name       : bash
 version    : 5.2.26
-release    : 71
+release    : 72
 source     :
     - https://ftp.gnu.org/gnu/bash/bash-5.2.21.tar.gz : c8e31bdc59b69aaffc5b36509905ba3e5cbb12747091d27b4b977f078560d5b8
 license    :

--- a/packages/b/bash/pspec_x86_64.xml
+++ b/packages/b/bash/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>bash</Name>
         <Homepage>https://www.gnu.org/software/bash</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -133,7 +133,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="71">bash</Dependency>
+            <Dependency release="72">bash</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/bash/alias.h</Path>
@@ -199,12 +199,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="71">
-            <Date>2024-04-23</Date>
+        <Update release="72">
+            <Date>2024-04-29</Date>
             <Version>5.2.26</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Symlink {/bin,/sbin} to {/usr/bin,/usr/sbin}
- Any existing binaries in /bin or /sbin will be seemlessly moved over.
- Drop /bin and /sbin from default $PATH

Part of #293.

Note: that /lib will be merged to /usr in a follow up PR as `kernel-glue` and CBM will have to be investigated.

Note: this is a forward change only as our current baselayout never managed /bin or /sbin paths as they were created ad-hoc by packages.

**Test Plan**

- Create a new rootfs from scratch from this baselayout
- Create a new solbuild image from this baselayout and use it
- Build and launch ISOs from this baselayout
- Create custom binaries in `/bin` and `/sbin` and verify they get moved over to `/usr/bin` and `/usr/sbin` respectively
- `realpath /bin` -> `/usr/bin`
- `realpath /sbin` -> `/usr/sbin`
- `which touch` -> `/usr/bin/touch`

**Checklist**

- [x] Package was built and tested against unstable
