### PR TITLE
svtplay-dl: update to 4.73

### DIFF
--- a/packages/s/svtplay-dl/package.yml
+++ b/packages/s/svtplay-dl/package.yml
@@ -1,8 +1,8 @@
 name       : svtplay-dl
-version    : '4.72'
-release    : 19
+version    : '4.73'
+release    : 20
 source     :
-    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.72.tar.gz : 7cf1b8f6cbe671e75e630cd32e879178580999671ac397f88239151ad8057b8d
+    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.73.tar.gz : 89e904a59038e7812cc5f5982561e8eebcdc409eae3a2783868186370f938e60
 homepage   : https://svtplay-dl.se/
 license    : MIT
 component  : network.download

--- a/packages/s/svtplay-dl/pspec_x86_64.xml
+++ b/packages/s/svtplay-dl/pspec_x86_64.xml
@@ -21,11 +21,11 @@
         <PartOf>network.download</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/svtplay-dl</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.72-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.72-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.72-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.72-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.72-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.73-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.73-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.73-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.73-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.73-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/__pycache__/__init__.cpython-311.pyc</Path>
@@ -169,9 +169,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2024-04-16</Date>
-            <Version>4.72</Version>
+        <Update release="20">
+            <Date>2024-04-29</Date>
+            <Version>4.73</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
- svtplay: fix crash on some clips
- removed –audio-role (all the interesting audio is in the –audio-language)
- added –video-role. works like –audio-role. but with some improvement. for example alternate-sign role for teckenspråkstolkat. some downloaded videos in 4.71 and 4.72 might have gotten the wrong video because of this….
- added -R for reversed download order with -A.

**Test Plan**
- Downloaded a movie and played it.

**Checklist**

- [X] Package was built and tested against unstable
