### PR TITLE
freerdp: update to 3.5.1

### DIFF
--- a/packages/f/freerdp/abi_symbols
+++ b/packages/f/freerdp/abi_symbols
@@ -188,6 +188,7 @@ libfreerdp-client3.so.3:rail_VirtualChannelEntryEx
 libfreerdp-client3.so.3:rail_get_client_interface
 libfreerdp-client3.so.3:rail_get_order_type_string
 libfreerdp-client3.so.3:rail_get_order_type_string_full
+libfreerdp-client3.so.3:rail_handshake_ex_flags_to_string
 libfreerdp-client3.so.3:rail_is_extended_spi_supported
 libfreerdp-client3.so.3:rail_order_recv
 libfreerdp-client3.so.3:rail_pdu_init
@@ -359,6 +360,7 @@ libfreerdp-server3.so.3:pen_event_reset
 libfreerdp-server3.so.3:pen_frame_reset
 libfreerdp-server3.so.3:rail_get_order_type_string
 libfreerdp-server3.so.3:rail_get_order_type_string_full
+libfreerdp-server3.so.3:rail_handshake_ex_flags_to_string
 libfreerdp-server3.so.3:rail_is_extended_spi_supported
 libfreerdp-server3.so.3:rail_pdu_init
 libfreerdp-server3.so.3:rail_read_handshake_ex_order
@@ -960,6 +962,7 @@ libfreerdp3.so.3:freerdp_rail_support_flags_to_string
 libfreerdp3.so.3:freerdp_rdp_version_string
 libfreerdp3.so.3:freerdp_rdpdr_dtyp_string
 libfreerdp3.so.3:freerdp_read_four_byte_float
+libfreerdp3.so.3:freerdp_read_four_byte_float_exp
 libfreerdp3.so.3:freerdp_read_four_byte_signed_integer
 libfreerdp3.so.3:freerdp_reconnect
 libfreerdp3.so.3:freerdp_register_addin_provider

--- a/packages/f/freerdp/abi_used_symbols
+++ b/packages/f/freerdp/abi_used_symbols
@@ -336,6 +336,7 @@ libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_sscanf
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_single_threaded
 libc.so.6:__libc_start_main
@@ -577,7 +578,6 @@ libc.so.6:unlink
 libc.so.6:unsetenv
 libc.so.6:usleep
 libc.so.6:waitpid
-libc.so.6:wcslen
 libc.so.6:write
 libcjson.so.1:cJSON_AddNullToObject
 libcjson.so.1:cJSON_AddStringToObject
@@ -934,15 +934,14 @@ libkrb5.so.3:krb5_realm_compare
 libkrb5.so.3:krb5_set_default_realm
 libkrb5.so.3:krb5_set_principal_realm
 libkrb5.so.3:krb5_sname_to_principal
+libkrb5.so.3:profile_abandon
 libkrb5.so.3:profile_add_relation
 libkrb5.so.3:profile_clear_relation
 libkrb5.so.3:profile_flush_to_file
 libkrb5.so.3:profile_init_path
-libkrb5.so.3:profile_release
 libm.so.6:ceil
 libm.so.6:floor
-libm.so.6:frexp
-libm.so.6:ldexp
+libm.so.6:modf
 libm.so.6:pow
 libm.so.6:round
 libm.so.6:sqrt
@@ -1037,6 +1036,7 @@ libstdc++.so.6:_ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEEC1ERKNS_12basic_stringIcS2_S3_EESt13_Ios_Openmode
 libstdc++.so.6:_ZNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx117collateIcE2idE
+libstdc++.so.6:_ZNSt8__detail15_List_node_base7_M_hookEPS0_
 libstdc++.so.6:_ZNSt8ios_baseD2Ev
 libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
 libstdc++.so.6:_ZSt16__throw_bad_castv

--- a/packages/f/freerdp/package.yml
+++ b/packages/f/freerdp/package.yml
@@ -1,8 +1,8 @@
 name       : freerdp
-version    : 3.4.0
-release    : 36
+version    : 3.5.1
+release    : 37
 source     :
-    - https://github.com/FreeRDP/FreeRDP/releases/download/3.4.0/freerdp-3.4.0.tar.gz : e44fec047d69c728178a21cdc3d5a55d1dac57e4c104e7318d27cba247232133
+    - https://pub.freerdp.com/releases/freerdp-3.5.1.tar.gz : 28036fd3c7d23ad320fd3eb2463119d1bde0dddb624b5a8353bf43197f1044c0
 homepage   : https://www.freerdp.com/
 license    : Apache-2.0
 component  : network.util

--- a/packages/f/freerdp/pspec_x86_64.xml
+++ b/packages/f/freerdp/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>freerdp</Name>
         <Homepage>https://www.freerdp.com/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>network.util</PartOf>
@@ -33,23 +33,23 @@
             <Path fileType="library">/usr/lib64/freerdp3/proxy/proxy-demo-plugin.so</Path>
             <Path fileType="library">/usr/lib64/freerdp3/proxy/proxy-dyn-channel-dump-plugin.so</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-client3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-client3.so.3.4.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-client3.so.3.5.1</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-server-proxy3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-server-proxy3.so.3.4.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-server-proxy3.so.3.5.1</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-server3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-server3.so.3.4.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-server3.so.3.5.1</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-shadow-subsystem3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-shadow-subsystem3.so.3.4.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-shadow-subsystem3.so.3.5.1</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-shadow3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-shadow3.so.3.4.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-shadow3.so.3.5.1</Path>
             <Path fileType="library">/usr/lib64/libfreerdp3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp3.so.3.4.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp3.so.3.5.1</Path>
             <Path fileType="library">/usr/lib64/librdtk0.so.0</Path>
             <Path fileType="library">/usr/lib64/librdtk0.so.0.2.0</Path>
             <Path fileType="library">/usr/lib64/libwinpr-tools3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libwinpr-tools3.so.3.4.0</Path>
+            <Path fileType="library">/usr/lib64/libwinpr-tools3.so.3.5.1</Path>
             <Path fileType="library">/usr/lib64/libwinpr3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libwinpr3.so.3.4.0</Path>
+            <Path fileType="library">/usr/lib64/libwinpr3.so.3.5.1</Path>
             <Path fileType="data">/usr/share/FreeRDP3/images/test_icon.bmp</Path>
             <Path fileType="data">/usr/share/FreeRDP3/images/test_icon.jpg</Path>
             <Path fileType="data">/usr/share/FreeRDP3/images/test_icon.png</Path>
@@ -71,7 +71,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="36">freerdp</Dependency>
+            <Dependency release="37">freerdp</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/freerdp3/freerdp/addin.h</Path>
@@ -384,12 +384,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2024-03-22</Date>
-            <Version>3.4.0</Version>
+        <Update release="37">
+            <Date>2024-04-30</Date>
+            <Version>3.5.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
This release eliminates a bunch of issues detected during oss-fuzz runs. The test coverage was increased and detected issues eliminates, so an update is highly recommended.

Noteworthy changes:
- Lots of fixes for oss-fuzz reports
- Timezone detection fixes
- SDL key remapping support
- Improved help
- FreeBSD epoll detection fix

**Test Plan**
- Started remmina and made an connection.

**Checklist**

- [X] Package was built and tested against unstable
