### PR TITLE
upx: update to 4.2.3

### DIFF
--- a/packages/u/upx/abi_used_symbols
+++ b/packages/u/upx/abi_used_symbols
@@ -29,8 +29,10 @@ libc.so.6:fstat64
 libc.so.6:fwrite
 libc.so.6:getenv
 libc.so.6:gettimeofday
+libc.so.6:gmtime
 libc.so.6:gmtime_r
 libc.so.6:isatty
+libc.so.6:localtime
 libc.so.6:lseek
 libc.so.6:lseek64
 libc.so.6:lstat64
@@ -73,7 +75,7 @@ libc.so.6:sysconf
 libc.so.6:time
 libc.so.6:tolower
 libc.so.6:unlink
-libc.so.6:utime
+libc.so.6:utimensat
 libc.so.6:write
 libgcc_s.so.1:_Unwind_Resume
 libm.so.6:log10

--- a/packages/u/upx/package.yml
+++ b/packages/u/upx/package.yml
@@ -1,8 +1,8 @@
 name       : upx
-version    : 4.1.0
-release    : 6
+version    : 4.2.3
+release    : 7
 source     :
-    - https://github.com/upx/upx/releases/download/v4.1.0/upx-4.1.0-src.tar.xz : 0582f78b517ea87ba1caa6e8c111474f58edd167e5f01f074d7d9ca2f81d47d0
+    - https://github.com/upx/upx/releases/download/v4.2.3/upx-4.2.3-src.tar.xz : d6357eec6ed4c1b51f40af2316b0958ff1b7fa6f53ef3de12da1d5c96d30e412
 homepage   : https://upx.github.io/
 license    : GPL-2.0-or-later
 component  : system.utils

--- a/packages/u/upx/pspec_x86_64.xml
+++ b/packages/u/upx/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>upx</Name>
         <Homepage>https://upx.github.io/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -25,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2023-10-18</Date>
-            <Version>4.1.0</Version>
+        <Update release="7">
+            <Date>2024-04-30</Date>
+            <Version>4.2.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/upx/upx/blob/master/NEWS).

**Test Plan**
- Installed and ran some commands.

**Checklist**

- [X] Package was built and tested against unstable
