### PR TITLE
ci/package_checks: Add exception for `EULA` as a package license

### DIFF
--- a/common/CI/package_checks.py
+++ b/common/CI/package_checks.py
@@ -540,7 +540,7 @@ class SPDXLicense(PullRequestCheck):
     _exceptions_url = 'https://raw.githubusercontent.com/spdx/license-list-data/main/json/exceptions.json'
     _licenses: Optional[List[str]] = None
     _exceptions: Optional[List[str]] = None
-    _extra_licenses = ['Distributable', 'Public-Domain']
+    _extra_licenses = ['Distributable', 'EULA', 'Public-Domain']
     _error = 'Invalid license identifier: '
     _level = Level.WARNING
 


### PR DESCRIPTION
**Summary**

Add an exception for `EULA`, as that is used by the following packages:

```
hsa-amd-aqlprofile
intel-microcode
nvidia-470-glx-driver
nvidia-beta-driver
nvidia-developer-driver
nvidia-glx-driver
opencv
```

This is not a valid SPDX license identifier, but there is no valid alternative.

Resolves #2423

**Test Plan**

Verify the warning is no longer there:

```
$ ./common/CI/package_checks.py packages/i/intel-microcode/package.yml
Checking files: packages/i/intel-microcode/package.yml
Found 2 result(s), 1 warnings and 0 error(s)
INF packages/i/intel-microcode/package.yml:1: This package is included in the ISO. Consider validating the functionality in a newly built ISO.
WRN packages/i/intel-microcode/package.yml:1: Package release is not incremented by 1
```
