### PR TITLE
python-orjson: Update to 3.10.2

### DIFF
--- a/packages/py/python-orjson/package.yml
+++ b/packages/py/python-orjson/package.yml
@@ -1,8 +1,8 @@
 name       : python-orjson
-version    : 3.10.1
-release    : 36
+version    : 3.10.2
+release    : 37
 source     :
-    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.1.tar.gz : a883b28d73370df23ed995c466b4f6c708c1f7a9bdc400fe89165c96c7603204
+    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.2.tar.gz : 47affe9f704c23e49a0fbb9d441af41f602474721e8639e8814640198f9ae32f
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-orjson/pspec_x86_64.xml
+++ b/packages/py/python-orjson/pspec_x86_64.xml
@@ -21,11 +21,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.1.dist-info/license_files/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.1.dist-info/license_files/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.2.dist-info/license_files/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.2.dist-info/license_files/LICENSE-MIT</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
@@ -35,9 +35,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2024-04-23</Date>
-            <Version>3.10.1</Version>
+        <Update release="37">
+            <Date>2024-05-01</Date>
+            <Version>3.10.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fix crash serializing `str` introduced in 3.10.1
- Improve performance
- Drop support for arm7

**Test Plan**

Ran through the examples in the project README

**Checklist**

- [x] Package was built and tested against unstable
