### PR TITLE
lbreakouthd: Update to 1.1.8

### DIFF
--- a/packages/l/lbreakouthd/files/icon-location.patch
+++ b/packages/l/lbreakouthd/files/icon-location.patch
@@ -1,0 +1,23 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -5,14 +5,17 @@
+ 	lbreakouthd.desktop lbreakouthd256.png lbreakouthd48.png
+ 
+ install-data-local:
+-	$(mkinstalldirs) $(DESTDIR)$(datadir)/icons
++	$(mkinstalldirs) $(DESTDIR)$(datadir)/icons/hicolor/256x256/apps
++	$(mkinstalldirs) $(DESTDIR)$(datadir)/icons/hicolor/48x48/apps
+ 	$(mkinstalldirs) $(DESTDIR)$(datadir)/applications
+-	$(INSTALL_DATA) lbreakouthd256.png $(DESTDIR)$(datadir)/icons/lbreakouthd.png
++	$(INSTALL_DATA) lbreakouthd256.png $(DESTDIR)$(datadir)/icons/hicolor/256x256/apps/lbreakouthd.png
++	$(INSTALL_DATA) lbreakouthd48.png $(DESTDIR)$(datadir)/icons/hicolor/48x48/apps/lbreakouthd.png
+ 	$(INSTALL_DATA) lbreakouthd.desktop $(DESTDIR)$(datadir)/applications
+ 	
+ 
+ uninstall-local:
+-	rm $(DESTDIR)$(datadir)/icons/lbreakouthd.png
++	rm $(DESTDIR)$(datadir)/icons/hicolor/256x256/apps/lbreakouthd.png
++	rm $(DESTDIR)$(datadir)/icons/hicolor/48x48/apps/lbreakouthd.png
+ 	rm $(DESTDIR)$(datadir)/applications/lbreakouthd.desktop
+ 
+ ACLOCAL_AMFLAGS = -I m4

--- a/packages/l/lbreakouthd/package.yml
+++ b/packages/l/lbreakouthd/package.yml
@@ -1,8 +1,8 @@
 name       : lbreakouthd
-version    : 1.1.7
-release    : 2
+version    : 1.1.8
+release    : 3
 source     :
-    - https://sourceforge.net/projects/lgames/files/lbreakouthd/lbreakouthd-1.1.7.tar.gz/download : 8af813f3260414ae24109922963dcd3f838eda6064936671e88f8495d7b44e41
+    - https://sourceforge.net/projects/lgames/files/lbreakouthd/lbreakouthd-1.1.8.tar.gz : dd667beca543362b5d21c5cf15fd02317b630ef1178bdd49afb9a9795d3d5ade
 homepage   : https://lgames.sourceforge.io/LBreakoutHD/
 license    : GPL-3.0-or-later
 component  : games.arcade
@@ -14,6 +14,8 @@ builddeps  :
     - pkgconfig(SDL2_mixer)
     - pkgconfig(SDL2_ttf)
 setup      : |
+    # Fix icon location. Remove next version(1.1.9)
+    %patch -p1 -i $pkgfiles/icon-location.patch
     %configure
 build      : |
     %make

--- a/packages/l/lbreakouthd/pspec_x86_64.xml
+++ b/packages/l/lbreakouthd/pspec_x86_64.xml
@@ -232,9 +232,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-04-07</Date>
-            <Version>1.1.7</Version>
+        <Update release="3">
+            <Date>2024-05-02</Date>
+            <Version>1.1.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
             <Email>malfisya.dev@hotmail.com</Email>


### PR DESCRIPTION
**Summary**

- Added simplified ball get target algorithm
- Properly install icon
- Fixed another bug in ball reflection
- Properly read windows files in preview and editor

**Test Plan**

Play some levels

**Checklist**

- [x] Package was built and tested against unstable