### PR TITLE
qtractor: Update to 0.9.90

### DIFF
--- a/packages/q/qtractor/abi_used_symbols
+++ b/packages/q/qtractor/abi_used_symbols
@@ -673,6 +673,7 @@ libQt6Gui.so.6:_ZN7QWindowC1EP7QScreen
 libQt6Gui.so.6:_ZN8QPainter10drawPixmapERK6QRectFRK7QPixmapS2_
 libQt6Gui.so.6:_ZN8QPainter10drawPixmapERK7QPointFRK7QPixmap
 libQt6Gui.so.6:_ZN8QPainter10strokePathERK12QPainterPathRK4QPen
+libQt6Gui.so.6:_ZN8QPainter11drawEllipseERK5QRect
 libQt6Gui.so.6:_ZN8QPainter11drawPolygonEPK6QPointiN2Qt8FillRuleE
 libQt6Gui.so.6:_ZN8QPainter13setRenderHintENS_10RenderHintEb
 libQt6Gui.so.6:_ZN8QPainter4saveEv
@@ -771,6 +772,7 @@ libQt6Gui.so.6:_ZNK7QPixmap6isNullEv
 libQt6Gui.so.6:_ZNK7QPixmap6scaledERK5QSizeN2Qt15AspectRatioModeENS3_18TransformationModeE
 libQt6Gui.so.6:_ZNK7QRegion10subtractedERKS_
 libQt6Gui.so.6:_ZNK7QRegion12boundingRectEv
+libQt6Gui.so.6:_ZNK7QScreen4sizeEv
 libQt6Gui.so.6:_ZNK7QWindow5winIdEv
 libQt6Gui.so.6:_ZNK8QPainter11fontMetricsEv
 libQt6Gui.so.6:_ZNK8QPainter3penEv
@@ -999,6 +1001,7 @@ libQt6Widgets.so.6:_ZN12QApplication11qt_metacallEN11QMetaObject4CallEiPPv
 libQt6Widgets.so.6:_ZN12QApplication11qt_metacastEPKc
 libQt6Widgets.so.6:_ZN12QApplication12activeWindowEv
 libQt6Widgets.so.6:_ZN12QApplication13compressEventEP6QEventP7QObjectP14QPostEventList
+libQt6Widgets.so.6:_ZN12QApplication13setStyleSheetERK7QString
 libQt6Widgets.so.6:_ZN12QApplication16staticMetaObjectE
 libQt6Widgets.so.6:_ZN12QApplication17startDragDistanceEv
 libQt6Widgets.so.6:_ZN12QApplication4execEv
@@ -1728,6 +1731,7 @@ libQt6Widgets.so.6:_ZNK14QDoubleSpinBox5valueEv
 libQt6Widgets.so.6:_ZNK14QDoubleSpinBox8validateER7QStringRi
 libQt6Widgets.so.6:_ZNK15QAbstractButton4textEv
 libQt6Widgets.so.6:_ZNK15QAbstractButton9isCheckedEv
+libQt6Widgets.so.6:_ZNK15QAbstractSlider10singleStepEv
 libQt6Widgets.so.6:_ZNK15QAbstractSlider14sliderPositionEv
 libQt6Widgets.so.6:_ZNK15QAbstractSlider5valueEv
 libQt6Widgets.so.6:_ZNK15QAbstractSlider7maximumEv
@@ -1821,6 +1825,7 @@ libQt6Widgets.so.6:_ZNK7QWidget5styleEv
 libQt6Widgets.so.6:_ZNK7QWidget5winIdEv
 libQt6Widgets.so.6:_ZNK7QWidget6layoutEv
 libQt6Widgets.so.6:_ZNK7QWidget6metricEN12QPaintDevice17PaintDeviceMetricE
+libQt6Widgets.so.6:_ZNK7QWidget6screenEv
 libQt6Widgets.so.6:_ZNK7QWidget6windowEv
 libQt6Widgets.so.6:_ZNK7QWidget7actionsEv
 libQt6Widgets.so.6:_ZNK7QWidget7devTypeEv

--- a/packages/q/qtractor/monitoring.yml
+++ b/packages/q/qtractor/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 8938
+  rss: https://github.com/rncbc/qtractor/tags.atom
+# No known CPE, checked 2024-05-02
+security:
+  cpe: ~

--- a/packages/q/qtractor/package.yml
+++ b/packages/q/qtractor/package.yml
@@ -1,8 +1,8 @@
 name       : qtractor
-version    : 0.9.38
-release    : 32
+version    : 0.9.90
+release    : 33
 source     :
-    - https://sourceforge.net/projects/qtractor/files/qtractor/0.9.38/qtractor-0.9.38.tar.gz/download : 68050ecfd833b64f729d0611abe9a789493efab33a45d9def54d5033b8ca3dc5
+    - https://sourceforge.net/projects/qtractor/files/qtractor/0.9.90/qtractor-0.9.90.tar.gz : f231c0c06da54c22ab0cdeb8b87ee9499eda683c798983e1cd159898699f7476
 homepage   : https://qtractor.org/
 license    : GPL-2.0-or-later
 component  : multimedia.audio
@@ -15,14 +15,13 @@ builddeps  :
     - pkgconfig(Qt6Svg)
     - pkgconfig(alsa)
     - pkgconfig(aubio)
-    - pkgconfig(gtk+-2.0)
     - pkgconfig(jack)
     - pkgconfig(liblo)
     - pkgconfig(lilv-0)
     - pkgconfig(mad)
+    - pkgconfig(rubberband)
     - pkgconfig(samplerate)
     - pkgconfig(sndfile)
-    - pkgconfig(rubberband)
     - pkgconfig(suil-0)
     - pkgconfig(vorbis)
     - ladspa-devel

--- a/packages/q/qtractor/pspec_x86_64.xml
+++ b/packages/q/qtractor/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>qtractor</Name>
         <Homepage>https://qtractor.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>multimedia.audio</PartOf>
@@ -37,24 +37,27 @@
             <Path fileType="data">/usr/share/mime/packages/org.rncbc.qtractor.xml</Path>
             <Path fileType="data">/usr/share/qtractor/audio/metro_bar.wav</Path>
             <Path fileType="data">/usr/share/qtractor/audio/metro_beat.wav</Path>
+            <Path fileType="data">/usr/share/qtractor/instruments/Standard1.ins</Path>
+            <Path fileType="data">/usr/share/qtractor/palette/KXStudio.conf</Path>
+            <Path fileType="data">/usr/share/qtractor/palette/Wonton Soup.conf</Path>
             <Path fileType="data">/usr/share/qtractor/translations/qtractor_cs.qm</Path>
             <Path fileType="data">/usr/share/qtractor/translations/qtractor_de.qm</Path>
             <Path fileType="data">/usr/share/qtractor/translations/qtractor_es.qm</Path>
             <Path fileType="data">/usr/share/qtractor/translations/qtractor_fr.qm</Path>
             <Path fileType="data">/usr/share/qtractor/translations/qtractor_it.qm</Path>
             <Path fileType="data">/usr/share/qtractor/translations/qtractor_ja.qm</Path>
-            <Path fileType="data">/usr/share/qtractor/translations/qtractor_pt.qm</Path>
+            <Path fileType="data">/usr/share/qtractor/translations/qtractor_pt_BR.qm</Path>
             <Path fileType="data">/usr/share/qtractor/translations/qtractor_ru.qm</Path>
             <Path fileType="data">/usr/share/qtractor/translations/qtractor_uk.qm</Path>
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2024-02-15</Date>
-            <Version>0.9.38</Version>
+        <Update release="33">
+            <Date>2024-05-02</Date>
+            <Version>0.9.90</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Prepping the unthinkable (aka. v1.0.0-rc1)
- MIDI Controller mappings are now shown on floating tool-tips.
- Custom color themes are now file based (*.conf); legacy still  preserved ntl.
- Add default GM, GS and XG standard instruments definition file.
- Full changelog can be found [here](https://sourceforge.net/p/qtractor/code/ci/qtractor_0_9_90/tree/ChangeLog)
- Add monitoring.yml
- Resolves getsolus/packages#2372

**Test Plan**

Play some MIDI files

**Checklist**

- [x] Package was built and tested against unstable