### PR TITLE
mate-themes: Update to 3.22.26

### DIFF
--- a/packages/m/mate-themes/package.yml
+++ b/packages/m/mate-themes/package.yml
@@ -1,16 +1,17 @@
 name       : mate-themes
-version    : 3.22.23
-release    : 16
+version    : 3.22.26
+release    : 17
 source     :
-    - https://github.com/mate-desktop/mate-themes/releases/download/v3.22.23/mate-themes-3.22.23.tar.xz : 61e5ad626c9841f5763c908f1769139b2a812687b98f6b330afee4da18fb6fab
+    - https://github.com/mate-desktop/mate-themes/releases/download/v3.22.26/mate-themes-3.22.26.tar.xz : 224e89d364eb3b73f1cf756d05494a98421a93cbf54349a2c85fc607eb755ed7
+homepage   : https://mate-desktop.org/
 license    : LGPL-2.1-or-later
 component  : desktop.mate
 summary    : MATE Desktop themes
 description: |
     Themes for the MATE Desktop
 builddeps  :
-    - pkgconfig(gtk+-2.0)
     - pkgconfig(gdk-pixbuf-2.0)
+    - pkgconfig(gtk+-2.0)
     - pkgconfig(gtk+-3.0)
 rundeps    :
     - gnome-icon-theme

--- a/packages/m/mate-themes/pspec_x86_64.xml
+++ b/packages/m/mate-themes/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>mate-themes</Name>
+        <Homepage>https://mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>desktop.mate</PartOf>
         <Summary xml:lang="en">MATE Desktop themes</Summary>
         <Description xml:lang="en">Themes for the MATE Desktop
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>mate-themes</Name>
@@ -3570,9 +3571,11 @@
             <Path fileType="localedata">/usr/share/locale/dz/LC_MESSAGES</Path>
             <Path fileType="localedata">/usr/share/locale/el/LC_MESSAGES</Path>
             <Path fileType="localedata">/usr/share/locale/en_AU/LC_MESSAGES</Path>
+            <Path fileType="localedata">/usr/share/locale/en_BR/LC_MESSAGES</Path>
             <Path fileType="localedata">/usr/share/locale/en_CA/LC_MESSAGES</Path>
             <Path fileType="localedata">/usr/share/locale/en_DE/LC_MESSAGES</Path>
             <Path fileType="localedata">/usr/share/locale/en_GB/LC_MESSAGES</Path>
+            <Path fileType="localedata">/usr/share/locale/en_US/LC_MESSAGES</Path>
             <Path fileType="localedata">/usr/share/locale/eo/LC_MESSAGES</Path>
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES</Path>
             <Path fileType="localedata">/usr/share/locale/es_419/LC_MESSAGES</Path>
@@ -3635,9 +3638,10 @@
             <Path fileType="localedata">/usr/share/locale/ky/LC_MESSAGES</Path>
             <Path fileType="localedata">/usr/share/locale/la/LC_MESSAGES</Path>
             <Path fileType="localedata">/usr/share/locale/lb/LC_MESSAGES</Path>
-            <Path fileType="localedata">/usr/share/locale/li/LC_MESSAGES</Path>
+            <Path fileType="localedata">/usr/share/locale/lfn/LC_MESSAGES</Path>
             <Path fileType="localedata">/usr/share/locale/lo/LC_MESSAGES</Path>
             <Path fileType="localedata">/usr/share/locale/lt/LC_MESSAGES</Path>
+            <Path fileType="localedata">/usr/share/locale/lt_LT/LC_MESSAGES</Path>
             <Path fileType="localedata">/usr/share/locale/lv/LC_MESSAGES</Path>
             <Path fileType="localedata">/usr/share/locale/mai/LC_MESSAGES</Path>
             <Path fileType="localedata">/usr/share/locale/mg/LC_MESSAGES</Path>
@@ -5678,12 +5682,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2021-10-08</Date>
-            <Version>3.22.23</Version>
+        <Update release="17">
+            <Date>2024-05-02</Date>
+            <Version>3.22.26</Version>
             <Comment>Packaging update</Comment>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Changelog [here](https://github.com/mate-desktop/mate-themes/releases/tag/v3.22.26)
- Part of getsolus/packages#2124

**Test Plan**

Apply theme on mate install

**Checklist**

- [x] Package was built and tested against unstable