### PR TITLE
mate-calc: Update to 1.28.0

### DIFF
--- a/packages/m/mate-calc/abi_used_symbols
+++ b/packages/m/mate-calc/abi_used_symbols
@@ -102,8 +102,8 @@ libglib-2.0.so.0:g_log
 libglib-2.0.so.0:g_malloc
 libglib-2.0.so.0:g_malloc0
 libglib-2.0.so.0:g_mkdir_with_parents
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_path_get_basename
 libglib-2.0.so.0:g_path_get_dirname
 libglib-2.0.so.0:g_return_if_fail_warning

--- a/packages/m/mate-calc/package.yml
+++ b/packages/m/mate-calc/package.yml
@@ -1,8 +1,9 @@
 name       : mate-calc
-version    : 1.27.0
-release    : 16
+version    : 1.28.0
+release    : 17
 source     :
-    - https://github.com/mate-desktop/mate-calc/releases/download/v1.27.0/mate-calc-1.27.0.tar.xz : 6431675f69f938ca783f9ac90ff1cf3fcc788791b369a6b64a48a909ca7ab177
+    - https://github.com/mate-desktop/mate-calc/releases/download/v1.28.0/mate-calc-1.28.0.tar.xz : 804b125d1e2864b1e74af816da9b2ab8b19472b9af974437ee7355ada5e628f5
+homepage   : https://mate-desktop.org/
 license    : GPL-2.0-or-later
 component  : desktop.mate
 summary    : Calculator tool for the MATE desktop

--- a/packages/m/mate-calc/pspec_x86_64.xml
+++ b/packages/m/mate-calc/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>mate-calc</Name>
+        <Homepage>https://mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.mate</PartOf>
@@ -12,7 +13,7 @@
 
 It incorporates a multiple precision arithmetic packages based on the work of Professor Richard Brent, who has also kindly given me permission to make it available.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>mate-calc</Name>
@@ -3329,12 +3330,12 @@ It incorporates a multiple precision arithmetic packages based on the work of Pr
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2023-07-13</Date>
-            <Version>1.27.0</Version>
+        <Update release="17">
+            <Date>2024-05-02</Date>
+            <Version>1.28.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Translations update
- Fix implicit function declarations with `libxml2` 2.12
- tx: fix warning in Japanese translations
- Part of getsolus/packages#2124

**Test Plan**

Do some calculations

**Checklist**

- [x] Package was built and tested against unstable