### PR TITLE
zellij: Update to 0.40.1

### DIFF
--- a/packages/z/zellij/package.yml
+++ b/packages/z/zellij/package.yml
@@ -1,8 +1,8 @@
 name       : zellij
-version    : 0.40.0
-release    : 5
+version    : 0.40.1
+release    : 6
 source     :
-    - https://github.com/zellij-org/zellij/archive/refs/tags/v0.40.0.tar.gz : afb15afce6e37f850aff28a3a6b08abd78ef26a1c9fa3ed39426ef0853154438
+    - https://github.com/zellij-org/zellij/archive/refs/tags/v0.40.1.tar.gz : 1f0bfa13f2dbe657d76341a196f98a3b4caa47ac63abee06b39883a11ca220a8
 homepage   : https://zellij.dev
 license    : MIT
 component  : system.utils

--- a/packages/z/zellij/pspec_x86_64.xml
+++ b/packages/z/zellij/pspec_x86_64.xml
@@ -29,9 +29,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2024-04-16</Date>
-            <Version>0.40.0</Version>
+        <Update release="6">
+            <Date>2024-05-02</Date>
+            <Version>0.40.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- fix(sessions): issue where sessions would occasionally become unresponsive
- fix(cli): respect all options (eg. `default-layout`) when creating a session in the background from the CLI
- fix(cli): rename tab and pane from cli
- fix(plugins): respect `$SHELL` when opening a terminal from plugins
- fix(tabs): closing a tab no longer breaks tab movement
- feat(plugins): add API to open new tabs with a LayoutInfo
- feat(cli): add zellij action `list-clients` to allow listing the connected clients as well as their `pane_id` and running command
- feat(cli): allow binding Ctrl J

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new session with Zellij, create a new tab, move them around.

**Checklist**

- [x] Package was built and tested against unstable
