### PR TITLE
man-pages: Update to 6.7

### DIFF
--- a/packages/m/man-pages/monitoring.yml
+++ b/packages/m/man-pages/monitoring.yml
@@ -1,5 +1,5 @@
 releases:
   id: 1883
-# No known CPE, checked 20240221
+# No known CPE, checked 2024-05-02
 security:
   cpe: ~

--- a/packages/m/man-pages/package.yml
+++ b/packages/m/man-pages/package.yml
@@ -1,8 +1,8 @@
 name       : man-pages
-version    : '6.06'
-release    : 19
+version    : '6.7'
+release    : 20
 source     :
-    - https://mirrors.edge.kernel.org/pub/linux/docs/man-pages/man-pages-6.06.tar.xz : bd6f89cf26d2262567dac41d2640fc3667f240cb658079530141e372c8581928
+    - https://mirrors.edge.kernel.org/pub/linux/docs/man-pages/man-pages-6.7.tar.xz : 82403ad4bc17aadb924f68638b79d6930b2cbd551531248a7a9688779db4efb2
 license    :
     - BSD-3-Clause
     - GPL-1.0-or-later

--- a/packages/m/man-pages/pspec_x86_64.xml
+++ b/packages/m/man-pages/pspec_x86_64.xml
@@ -665,6 +665,8 @@
             <Path fileType="man">/usr/share/man/man3/TAILQ_PREV.3.gz</Path>
             <Path fileType="man">/usr/share/man/man3/TAILQ_REMOVE.3.gz</Path>
             <Path fileType="man">/usr/share/man/man3/TAILQ_SWAP.3.gz</Path>
+            <Path fileType="man">/usr/share/man/man3/TIMESPEC_TO_TIMEVAL.3.gz</Path>
+            <Path fileType="man">/usr/share/man/man3/TIMEVAL_TO_TIMESPEC.3.gz</Path>
             <Path fileType="man">/usr/share/man/man3/_Generic.3.gz</Path>
             <Path fileType="man">/usr/share/man/man3/_Static_assert.3.gz</Path>
             <Path fileType="man">/usr/share/man/man3/__after_morecore_hook.3.gz</Path>
@@ -2695,9 +2697,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2024-02-21</Date>
-            <Version>6.06</Version>
+        <Update release="20">
+            <Date>2024-05-02</Date>
+            <Version>6.7</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

New and rewritten pages:
- TIMEVAL_TO_TIMESPEC.3

Newly documented interfaces in existing pages:
- process_madvise() glibc wrapper

New and changed links:
- TIMESPEC_TO_TIMEVAL.3 (TIMEVAL_TO_TIMESPEC(3))

Global changes:
- Updated and reorganized build system

Full release notes available [here](https://lwn.net/ml/linux-kernel/Zfna9TOEMqQdI88n@debian/)

**Test Plan**

Looked at a number of man pages (new and old)

**Checklist**

- [x] Package was built and tested against unstable
