### PR TITLE
mu: Update to 1.12.5

### DIFF
--- a/packages/m/mu/abi_used_symbols
+++ b/packages/m/mu/abi_used_symbols
@@ -446,6 +446,7 @@ libstdc++.so.6:_ZTINSt6thread6_StateE
 libstdc++.so.6:_ZTISt11logic_error
 libstdc++.so.6:_ZTISt11range_error
 libstdc++.so.6:_ZTISt12bad_weak_ptr
+libstdc++.so.6:_ZTISt12out_of_range
 libstdc++.so.6:_ZTISt12system_error
 libstdc++.so.6:_ZTISt13runtime_error
 libstdc++.so.6:_ZTISt15basic_streambufIcSt11char_traitsIcEE

--- a/packages/m/mu/package.yml
+++ b/packages/m/mu/package.yml
@@ -1,8 +1,8 @@
 name       : mu
-version    : 1.12.4
-release    : 25
+version    : 1.12.5
+release    : 26
 source     :
-    - https://github.com/djcb/mu/releases/download/v1.12.4/mu-1.12.4.tar.xz : bd41136c5177c1645b878b9d55f384bed629e02e790881fe965f8493725a44c9
+    - https://github.com/djcb/mu/releases/download/v1.12.5/mu-1.12.5.tar.xz : 770b92e3072adae8777bd4e985c8b027c66ce0b7ef7cbb8eab4497b92ba68acb
 license    : GPL-3.0-only
 homepage   : https://www.djcbsoftware.nl/code/mu/
 component  : editor

--- a/packages/m/mu/pspec_x86_64.xml
+++ b/packages/m/mu/pspec_x86_64.xml
@@ -35,6 +35,8 @@
             <Path fileType="data">/usr/share/emacs/site-lisp/mu4e/mu4e-context.elc</Path>
             <Path fileType="data">/usr/share/emacs/site-lisp/mu4e/mu4e-contrib.el</Path>
             <Path fileType="data">/usr/share/emacs/site-lisp/mu4e/mu4e-contrib.elc</Path>
+            <Path fileType="data">/usr/share/emacs/site-lisp/mu4e/mu4e-draft.el</Path>
+            <Path fileType="data">/usr/share/emacs/site-lisp/mu4e/mu4e-draft.elc</Path>
             <Path fileType="data">/usr/share/emacs/site-lisp/mu4e/mu4e-folders.el</Path>
             <Path fileType="data">/usr/share/emacs/site-lisp/mu4e/mu4e-folders.elc</Path>
             <Path fileType="data">/usr/share/emacs/site-lisp/mu4e/mu4e-headers.el</Path>
@@ -104,9 +106,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="25">
-            <Date>2024-04-18</Date>
-            <Version>1.12.4</Version>
+        <Update release="26">
+            <Date>2024-05-04</Date>
+            <Version>1.12.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Split off parts into mu4e-draft.el to maintain the current buffer as expected
- New hook mu4e-compose-post-hook for tweaking what mu4e does when we're done with a message
- Better handle forwarding of encoded messages
- Don't remove non-mu4e completion in composer
- Integrate iCalendar support with message-composition
- Handle mu4e-sent-messages-behavior correctly when it's a function
- Support some file systems that don't put the file type in d_type
- Improve documentation

**Test Plan**
- index mailbox; search for and view message

**Checklist**
- [X] Package was built and tested against unstable
