### PR TITLE
wine: Update to 9.8

### DIFF
--- a/packages/w/wine/abi_libs
+++ b/packages/w/wine/abi_libs
@@ -1,5 +1,4 @@
 avicap32.so
-bcrypt.so
 crypt32.so
 ctapi32.so
 dnsapi.so
@@ -16,7 +15,6 @@ odbc32.so
 opencl.so
 opengl32.so
 qcap.so
-secur32.so
 win32u.so
 wine64
 winealsa.so

--- a/packages/w/wine/abi_libs32
+++ b/packages/w/wine/abi_libs32
@@ -1,5 +1,4 @@
 avicap32.so
-bcrypt.so
 crypt32.so
 ctapi32.so
 dnsapi.so
@@ -16,7 +15,6 @@ odbc32.so
 opencl.so
 opengl32.so
 qcap.so
-secur32.so
 win32u.so
 wine
 winealsa.so

--- a/packages/w/wine/abi_symbols
+++ b/packages/w/wine/abi_symbols
@@ -1,7 +1,5 @@
 avicap32.so:__wine_unix_call_funcs
 avicap32.so:__wine_unix_call_wow64_funcs
-bcrypt.so:__wine_unix_call_funcs
-bcrypt.so:__wine_unix_call_wow64_funcs
 crypt32.so:__wine_unix_call_funcs
 crypt32.so:__wine_unix_call_wow64_funcs
 ctapi32.so:__wine_unix_call_funcs
@@ -308,8 +306,6 @@ opengl32.so:__wine_unix_call_funcs
 opengl32.so:__wine_unix_call_wow64_funcs
 qcap.so:__wine_unix_call_funcs
 qcap.so:__wine_unix_call_wow64_funcs
-secur32.so:__wine_unix_call_funcs
-secur32.so:__wine_unix_call_wow64_funcs
 win32u.so:AdjustWindowRectEx
 win32u.so:CopyImage
 win32u.so:DrawTextW

--- a/packages/w/wine/abi_symbols32
+++ b/packages/w/wine/abi_symbols32
@@ -1,5 +1,4 @@
 avicap32.so:__wine_unix_call_funcs
-bcrypt.so:__wine_unix_call_funcs
 crypt32.so:__wine_unix_call_funcs
 ctapi32.so:__wine_unix_call_funcs
 dnsapi.so:__wine_unix_call_funcs
@@ -301,7 +300,6 @@ odbc32.so:__wine_unix_call_funcs
 opencl.so:__wine_unix_call_funcs
 opengl32.so:__wine_unix_call_funcs
 qcap.so:__wine_unix_call_funcs
-secur32.so:__wine_unix_call_funcs
 win32u.so:AdjustWindowRectEx
 win32u.so:CopyImage
 win32u.so:DrawTextW

--- a/packages/w/wine/abi_used_symbols
+++ b/packages/w/wine/abi_used_symbols
@@ -354,9 +354,6 @@ libc.so.6:asctime
 libc.so.6:asprintf
 libc.so.6:bind
 libc.so.6:calloc
-libc.so.6:cfgetospeed
-libc.so.6:cfsetispeed
-libc.so.6:cfsetospeed
 libc.so.6:chdir
 libc.so.6:chmod
 libc.so.6:clearerr
@@ -601,9 +598,6 @@ libc.so.6:syscall
 libc.so.6:sysconf
 libc.so.6:sysinfo
 libc.so.6:system
-libc.so.6:tcdrain
-libc.so.6:tcflow
-libc.so.6:tcflush
 libc.so.6:tcgetattr
 libc.so.6:tcsetattr
 libc.so.6:time
@@ -800,6 +794,7 @@ libgstreamer-1.0.so.0:gst_query_set_duration
 libgstreamer-1.0.so.0:gst_query_set_latency
 libgstreamer-1.0.so.0:gst_query_set_scheduling
 libgstreamer-1.0.so.0:gst_query_set_seeking
+libgstreamer-1.0.so.0:gst_query_set_uri
 libgstreamer-1.0.so.0:gst_query_type_get_name
 libgstreamer-1.0.so.0:gst_sample_get_buffer
 libgstreamer-1.0.so.0:gst_sample_get_caps

--- a/packages/w/wine/abi_used_symbols32
+++ b/packages/w/wine/abi_used_symbols32
@@ -371,9 +371,6 @@ libc.so.6:asctime
 libc.so.6:asprintf
 libc.so.6:bind
 libc.so.6:calloc
-libc.so.6:cfgetospeed
-libc.so.6:cfsetispeed
-libc.so.6:cfsetospeed
 libc.so.6:chdir
 libc.so.6:close
 libc.so.6:closedir
@@ -557,11 +554,6 @@ libc.so.6:syscall
 libc.so.6:sysconf
 libc.so.6:sysinfo
 libc.so.6:system
-libc.so.6:tcdrain
-libc.so.6:tcflow
-libc.so.6:tcflush
-libc.so.6:tcgetattr
-libc.so.6:tcsetattr
 libc.so.6:times
 libc.so.6:umask
 libc.so.6:uname
@@ -755,6 +747,7 @@ libgstreamer-1.0.so.0:gst_query_set_duration
 libgstreamer-1.0.so.0:gst_query_set_latency
 libgstreamer-1.0.so.0:gst_query_set_scheduling
 libgstreamer-1.0.so.0:gst_query_set_seeking
+libgstreamer-1.0.so.0:gst_query_set_uri
 libgstreamer-1.0.so.0:gst_query_type_get_name
 libgstreamer-1.0.so.0:gst_sample_get_buffer
 libgstreamer-1.0.so.0:gst_sample_get_caps

--- a/packages/w/wine/package.yml
+++ b/packages/w/wine/package.yml
@@ -1,8 +1,8 @@
 name       : wine
-version    : '9.7'
-release    : 172
+version    : '9.8'
+release    : 173
 source     :
-    - https://dl.winehq.org/wine/source/9.x/wine-9.7.tar.xz : d9f3c333656e88bd4cef5331f34b1c8b69c964a52759eef745d8ddae51a15353
+    - https://dl.winehq.org/wine/source/9.x/wine-9.8.tar.xz : 86943c838eda8fad9a7940d4099703394bf1d1be9a1014342fed879c7dc3b993
 license    : LGPL-2.1-or-later
 component  : virt
 homepage   : https://www.winehq.org/

--- a/packages/w/wine/pspec_x86_64.xml
+++ b/packages/w/wine/pspec_x86_64.xml
@@ -980,7 +980,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="172">wine</Dependency>
+            <Dependency release="173">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/wine</Path>
@@ -1810,7 +1810,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="172">wine</Dependency>
+            <Dependency release="173">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wine/debug.h</Path>
@@ -1923,6 +1923,7 @@
             <Path fileType="header">/usr/include/wine/windows/asysta.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/atlbase.h</Path>
             <Path fileType="header">/usr/include/wine/windows/atlcom.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/atldef.h</Path>
             <Path fileType="header">/usr/include/wine/windows/atliface.h</Path>
             <Path fileType="header">/usr/include/wine/windows/atliface.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/atlthunk.h</Path>
@@ -3111,9 +3112,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="172">
-            <Date>2024-04-23</Date>
-            <Version>9.7</Version>
+        <Update release="173">
+            <Date>2024-05-04</Date>
+            <Version>9.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Highlighted changes:
- Mono engine updated to version 9.1.0
- IDL-generated files use fully interpreted stubs
- Improved RPC/COM support on ARM platforms
- Various bug fixes

Full release notes available [here](https://gitlab.winehq.org/wine/wine/-/releases/wine-9.8)

**Test Plan**
- Ran `winefile`, `wineconsole`, `winecfg`, `winemine`
- Played Age of Empires I trial version

**Checklist**

- [x] Package was built and tested against unstable
