### PR TITLE
nvidia-vaapi-driver: Update to 0.0.12 and add monitoring.yml

### DIFF
--- a/packages/n/nvidia-vaapi-driver/abi_used_symbols
+++ b/packages/n/nvidia-vaapi-driver/abi_used_symbols
@@ -46,6 +46,7 @@ libc.so.6:realloc
 libc.so.6:stat64
 libc.so.6:stderr
 libc.so.6:stdout
+libc.so.6:strcmp
 libc.so.6:strdup
 libc.so.6:strncmp
 libgstcodecparsers-1.0.so.0:gst_vp9_parser_new

--- a/packages/n/nvidia-vaapi-driver/monitoring.yml
+++ b/packages/n/nvidia-vaapi-driver/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 242346
+  rss: https://github.com/elFarto/nvidia-vaapi-driver/releases.atom
+# No known CPE, checked 2024-05-06
+security:
+  cpe: ~

--- a/packages/n/nvidia-vaapi-driver/package.yml
+++ b/packages/n/nvidia-vaapi-driver/package.yml
@@ -1,9 +1,9 @@
 name       : nvidia-vaapi-driver
-version    : 0.0.11
-release    : 14
+version    : 0.0.12
+release    : 15
 homepage   : https://github.com/elFarto/nvidia-vaapi-driver
 source     :
-    - git|https://github.com/elFarto/nvidia-vaapi-driver.git : v0.0.11
+    - git|https://github.com/elFarto/nvidia-vaapi-driver.git : v0.0.12
 license    : MIT
 component  : xorg.display
 summary    : A VA-API implemention using NVIDIA's NVDEC as the backend (UNSUPPORTED)

--- a/packages/n/nvidia-vaapi-driver/pspec_x86_64.xml
+++ b/packages/n/nvidia-vaapi-driver/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Conflicts>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2023-11-06</Date>
-            <Version>0.0.11</Version>
+        <Update release="15">
+            <Date>2024-05-06</Date>
+            <Version>0.0.12</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Single buffer export
- direct: Fix drm index loop condition
- Fix building with musl
- Unbreak build on FreeBSD
- src: Increase num_render_targets to 32 for Chromium
- Fix undefined reference to 'gettid'

**Test Plan**

Confirmed video acceleration in `firefox` on a bunch of different websites, using `nvidia-smi`

**Checklist**

- [x] Package was built and tested against unstable
