### PR TITLE
xfce4-panel-profiles: Add missing rundep and monitoring.yml

### DIFF
--- a/packages/x/xfce4-panel-profiles/monitoring.yml
+++ b/packages/x/xfce4-panel-profiles/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 232008
+  rss: https://gitlab.xfce.org/apps/xfce4-panel-profiles/-/tags?format=atom
+# No known CPE, checked 2024-05-06
+security:
+  cpe: ~

--- a/packages/x/xfce4-panel-profiles/package.yml
+++ b/packages/x/xfce4-panel-profiles/package.yml
@@ -1,6 +1,6 @@
 name       : xfce4-panel-profiles
 version    : 1.0.14
-release    : 3
+release    : 4
 source     :
     - https://archive.xfce.org/src/apps/xfce4-panel-profiles/1.0/xfce4-panel-profiles-1.0.14.tar.bz2 : 6d08354e8c44d4b0370150809c1ed601d09c8b488b68986477260609a78be3f9
 homepage   : https://docs.xfce.org/apps/xfce4-panel-profiles/start
@@ -9,6 +9,8 @@ component  : desktop.xfce
 summary    : Xfce4-panel-profiles is a simple application to manage Xfce panel layouts.
 description: |
     Xfce4-panel-profiles is a simple application to manage Xfce panel layouts.
+rundeps    :
+    - python-psutil
 setup      : |
     %patch -p1 -i $pkgfiles/0001-data-metadata-rename-id-to-fix-generation-with-appst.patch
     #Ugly I know, this doesn't use a standard autoconf configure script.

--- a/packages/x/xfce4-panel-profiles/pspec_x86_64.xml
+++ b/packages/x/xfce4-panel-profiles/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xfce4-panel-profiles</Name>
         <Homepage>https://docs.xfce.org/apps/xfce4-panel-profiles/start</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop.xfce</PartOf>
@@ -100,12 +100,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-02-17</Date>
+        <Update release="4">
+            <Date>2024-05-06</Date>
             <Version>1.0.14</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

This adds the `python-psutil` dependency without which the app fails to start.

Thanks to @celiopy for the hint [here](https://discuss.getsol.us/d/10580-few-issues-with-xfce)

**Test Plan**

Confirmed app now launches on a fresh install

**Checklist**

- [x] Package was built and tested against unstable
