### PR TITLE
mate-user-admin: Update config and add monitoring.yml

### DIFF
--- a/packages/m/mate-user-admin/abi_used_symbols
+++ b/packages/m/mate-user-admin/abi_used_symbols
@@ -163,8 +163,8 @@ libglib-2.0.so.0:g_list_free
 libglib-2.0.so.0:g_log
 libglib-2.0.so.0:g_malloc
 libglib-2.0.so.0:g_mkstemp
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_return_if_fail_warning
 libglib-2.0.so.0:g_slist_append
 libglib-2.0.so.0:g_slist_foreach

--- a/packages/m/mate-user-admin/files/nuconfig
+++ b/packages/m/mate-user-admin/files/nuconfig
@@ -3,8 +3,5 @@
 nulanguage = en_US.utf8
 
 #Default Type for New User, 0 Ordinary User 1 Manage User
-nutype = 0    
-
-#Default Add Groups for New Users
-nugroups = audio;cdrom;fuse;lpadmin;plugdev;scanner;users;video
+nutype = 0
 

--- a/packages/m/mate-user-admin/monitoring.yml
+++ b/packages/m/mate-user-admin/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 372293
+  rss: https://github.com/zhuyaliang/user-admin/tags.atom
+# No known CPE, checked 2024-05-07
+security:
+  cpe: ~

--- a/packages/m/mate-user-admin/package.yml
+++ b/packages/m/mate-user-admin/package.yml
@@ -1,6 +1,6 @@
 name       : mate-user-admin
 version    : 1.7.0
-release    : 8
+release    : 9
 source     :
     - https://github.com/zhuyaliang/user-admin/archive/refs/tags/v1.7.0.tar.gz : b4eb0783b382ed9405c76b765148d105dd113e20f66e61ad63d6fb7de7cafe1d
 homepage   : https://github.com/zhuyaliang/user-admin

--- a/packages/m/mate-user-admin/pspec_x86_64.xml
+++ b/packages/m/mate-user-admin/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mate-user-admin</Name>
         <Homepage>https://github.com/zhuyaliang/user-admin</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop.mate</PartOf>
@@ -160,12 +160,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2023-12-16</Date>
+        <Update release="9">
+            <Date>2024-05-07</Date>
             <Version>1.7.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

The project has changed their config structure to differentiate between admin users and regular users.
See [this commit](https://github.com/zhuyaliang/user-admin/commit/7011404a23ea3d54b43d1b3a9e8ae24501a0b205)

Additionally some of the user groups were no longer up-to-date with our `accountsservice` config.

Simply remove the `mate-user-admin`-specific config, so it grabs the defaults from `accountsservice`. This way we don't have to update this file when changes to our defaults happen.

**Test Plan**
- Created new admin and standard users and observed that there were no more error messages
- Confirmed users were in the correct groups

**Checklist**

- [x] Package was built and tested against unstable
