### PR TITLE
clojure-tools: Update to clojure CLI 1.11.3.1463

### DIFF
--- a/packages/c/clojure-tools/package.yml
+++ b/packages/c/clojure-tools/package.yml
@@ -1,8 +1,8 @@
 name       : clojure-tools
-version    : 1.11.1.1386
-release    : 9
+version    : 1.11.3.1463
+release    : 10
 source     :
-    - https://download.clojure.org/install/clojure-tools-1.11.1.1386.tar.gz : 7b944b9ecc9d099291bfa3ffc82f05c4ae4080ad068fa609c3b138d6778662c3
+    - https://download.clojure.org/install/clojure-tools-1.11.3.1463.tar.gz : dba419de3e785f3b695b6589d7183419cf8ec2bb2f99f2b88afd06b0b57c1487
 homepage   : https://clojure.org/
 license    : EPL-1.0
 component  : programming.tools

--- a/packages/c/clojure-tools/pspec_x86_64.xml
+++ b/packages/c/clojure-tools/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>clojure-tools</Name>
         <Homepage>https://clojure.org/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Oliver Marks</Name>
+            <Email>oly@digitaloctave.com</Email>
         </Packager>
         <License>EPL-1.0</License>
         <PartOf>programming.tools</PartOf>
@@ -24,7 +24,7 @@
             <Path fileType="executable">/usr/bin/clojure</Path>
             <Path fileType="library">/usr/lib/clojure/deps.edn</Path>
             <Path fileType="library">/usr/lib/clojure/example-deps.edn</Path>
-            <Path fileType="library">/usr/lib/clojure/libexec/clojure-tools-1.11.1.1386.jar</Path>
+            <Path fileType="library">/usr/lib/clojure/libexec/clojure-tools-1.11.3.1463.jar</Path>
             <Path fileType="library">/usr/lib/clojure/libexec/exec.jar</Path>
             <Path fileType="library">/usr/lib/clojure/tools.edn</Path>
             <Path fileType="man">/usr/share/man/man1/clj.1</Path>
@@ -32,12 +32,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2024-01-04</Date>
-            <Version>1.11.1.1386</Version>
+        <Update release="10">
+            <Date>2024-05-06</Date>
+            <Version>1.11.3.1463</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Oliver Marks</Name>
+            <Email>oly@digitaloctave.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Release notes can be found [here](https://github.com/clojure/brew-install/blob/1.11.3/CHANGELOG.md)

**Test Plan**

Installed and ran clojure --version followed by clojure running a basic print statement in the repl.

**Checklist**

- [X] Package was built and tested against unstable
