### PR TITLE
github-cli: Update to 2.49.1

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.49.0
-release    : 45
+version    : 2.49.1
+release    : 46
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.49.0.tar.gz : fc21c007219919da19f09180d3b966db95cd766bdb4123800d5ce292633a2132
+    - https://github.com/cli/cli/archive/refs/tags/v2.49.1.tar.gz : e898bcfec71ee1b5eba3bba0816eaca5f735e7443e11864dddbf753f8ecc3cf7
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -216,9 +216,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="45">
-            <Date>2024-04-30</Date>
-            <Version>2.49.0</Version>
+        <Update release="46">
+            <Date>2024-05-08</Date>
+            <Version>2.49.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Do not mutate headers when initialising tableprinter
- Document relationship between host and active account
- Added support for jobs with long filenames
- Fix `attestation verify` source repository check bug

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this pull request.

**Checklist**

- [x] Package was built and tested against unstable
