### PR TITLE
fltk: Update to 1.3.9

### DIFF
--- a/packages/f/fltk/abi_used_symbols
+++ b/packages/f/fltk/abi_used_symbols
@@ -228,14 +228,16 @@ libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fgets_chk
 libc.so.6:__fprintf_chk
-libc.so.6:__fread_chk
-libc.so.6:__isoc99_fscanf
+libc.so.6:__isoc23_fscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoul
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
 libc.so.6:__longjmp_chk
-libc.so.6:__mbstowcs_chk
 libc.so.6:__memcpy_chk
 libc.so.6:__memmove_chk
+libc.so.6:__memset_chk
 libc.so.6:__open_2
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
@@ -243,6 +245,7 @@ libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__strcat_chk
 libc.so.6:__strcpy_chk
+libc.so.6:__strlcpy_chk
 libc.so.6:__strncat_chk
 libc.so.6:__strncpy_chk
 libc.so.6:__vfprintf_chk
@@ -335,6 +338,7 @@ libc.so.6:stat
 libc.so.6:stderr
 libc.so.6:stdin
 libc.so.6:stdout
+libc.so.6:stpcpy
 libc.so.6:strcasecmp
 libc.so.6:strcat
 libc.so.6:strchr
@@ -344,6 +348,8 @@ libc.so.6:strcspn
 libc.so.6:strdup
 libc.so.6:strerror
 libc.so.6:strftime
+libc.so.6:strlcat
+libc.so.6:strlcpy
 libc.so.6:strlen
 libc.so.6:strncasecmp
 libc.so.6:strncmp
@@ -353,8 +359,6 @@ libc.so.6:strspn
 libc.so.6:strstr
 libc.so.6:strtod
 libc.so.6:strtok
-libc.so.6:strtol
-libc.so.6:strtoul
 libc.so.6:system
 libc.so.6:time
 libc.so.6:tolower
@@ -390,7 +394,6 @@ libm.so.6:modf
 libm.so.6:pow
 libm.so.6:sin
 libm.so.6:sincos
-libm.so.6:sqrt
 libpng16.so.16:png_create_info_struct
 libpng16.so.16:png_create_read_struct
 libpng16.so.16:png_create_write_struct

--- a/packages/f/fltk/monitoring.yml
+++ b/packages/f/fltk/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 823
+  rss: https://github.com/fltk/fltk/tags.atom
+security:
+  cpe:
+    - vendor: fltk
+      product: fltk

--- a/packages/f/fltk/package.yml
+++ b/packages/f/fltk/package.yml
@@ -1,8 +1,8 @@
 name       : fltk
-version    : 1.3.8
-release    : 4
+version    : 1.3.9
+release    : 5
 source     :
-    - https://www.fltk.org/pub/fltk/1.3.8/fltk-1.3.8-source.tar.gz : f3c1102b07eb0e7a50538f9fc9037c18387165bc70d4b626e94ab725b9d4d1bf
+    - https://www.fltk.org/pub/fltk/1.3.9/fltk-1.3.9-source.tar.gz : d736b0445c50d607432c03d5ba5e82f3fba2660b10bc1618db8e077a42d9511b
 homepage   : https://www.fltk.org/
 license    : LGPL-2.0-or-later
 component  : programming.library

--- a/packages/f/fltk/pspec_x86_64.xml
+++ b/packages/f/fltk/pspec_x86_64.xml
@@ -3,20 +3,20 @@
         <Name>fltk</Name>
         <Homepage>https://www.fltk.org/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>LGPL-2.0-or-later</License>
         <PartOf>programming.library</PartOf>
         <Summary xml:lang="en">FLTK cross-platform C++ toolkit</Summary>
-        <Description xml:lang="en">FLTK (pronounced &quot;fulltick&quot;) is a cross-platform C++ GUI toolkit for UNIX®/Linux® (X11), Microsoft® Windows®, and MacOS® X. FLTK provides modern GUI functionality without the bloat and supports 3D graphics via OpenGL® and its built-in GLUT emulation.
+        <Description xml:lang="en">FLTK (pronounced &quot;fulltick&quot;) is a cross-platform C++ GUI toolkit for UNIX&#xae;/Linux&#xae; (X11), Microsoft&#xae; Windows&#xae;, and MacOS&#xae; X. FLTK provides modern GUI functionality without the bloat and supports 3D graphics via OpenGL&#xae; and its built-in GLUT emulation.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>fltk</Name>
         <Summary xml:lang="en">FLTK cross-platform C++ toolkit</Summary>
-        <Description xml:lang="en">FLTK (pronounced &quot;fulltick&quot;) is a cross-platform C++ GUI toolkit for UNIX®/Linux® (X11), Microsoft® Windows®, and MacOS® X. FLTK provides modern GUI functionality without the bloat and supports 3D graphics via OpenGL® and its built-in GLUT emulation.
+        <Description xml:lang="en">FLTK (pronounced &quot;fulltick&quot;) is a cross-platform C++ GUI toolkit for UNIX&#xae;/Linux&#xae; (X11), Microsoft&#xae; Windows&#xae;, and MacOS&#xae; X. FLTK provides modern GUI functionality without the bloat and supports 3D graphics via OpenGL&#xae; and its built-in GLUT emulation.
 </Description>
         <PartOf>programming.library</PartOf>
         <Files>
@@ -191,17 +191,16 @@
             <Path fileType="man">/usr/share/man/cat3/fltk.3</Path>
             <Path fileType="man">/usr/share/man/man1/fltk-config.1</Path>
             <Path fileType="man">/usr/share/man/man1/fluid.1</Path>
-            <Path fileType="man">/usr/share/man/man3/fltk.3</Path>
         </Files>
     </Package>
     <Package>
         <Name>fltk-devel</Name>
         <Summary xml:lang="en">Development files for fltk</Summary>
-        <Description xml:lang="en">FLTK (pronounced &quot;fulltick&quot;) is a cross-platform C++ GUI toolkit for UNIX®/Linux® (X11), Microsoft® Windows®, and MacOS® X. FLTK provides modern GUI functionality without the bloat and supports 3D graphics via OpenGL® and its built-in GLUT emulation.
+        <Description xml:lang="en">FLTK (pronounced &quot;fulltick&quot;) is a cross-platform C++ GUI toolkit for UNIX&#xae;/Linux&#xae; (X11), Microsoft&#xae; Windows&#xae;, and MacOS&#xae; X. FLTK provides modern GUI functionality without the bloat and supports 3D graphics via OpenGL&#xae; and its built-in GLUT emulation.
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="4">fltk</Dependency>
+            <Dependency release="5">fltk</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/FL/Enumerations.H</Path>
@@ -343,6 +342,7 @@
             <Path fileType="header">/usr/include/FL/gl_draw.H</Path>
             <Path fileType="header">/usr/include/FL/glu.h</Path>
             <Path fileType="header">/usr/include/FL/glut.H</Path>
+            <Path fileType="header">/usr/include/FL/images/fltk_jpeg_prefix.h</Path>
             <Path fileType="header">/usr/include/FL/images/jconfig.h</Path>
             <Path fileType="header">/usr/include/FL/images/jerror.h</Path>
             <Path fileType="header">/usr/include/FL/images/jmorecfg.h</Path>
@@ -358,15 +358,16 @@
             <Path fileType="library">/usr/lib64/libfltk_gl.so</Path>
             <Path fileType="library">/usr/lib64/libfltk_images.so</Path>
             <Path fileType="library">/usr/lib64/libfltk_jpeg.so</Path>
+            <Path fileType="man">/usr/share/man/man3/fltk.3</Path>
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2022-04-07</Date>
-            <Version>1.3.8</Version>
+        <Update release="5">
+            <Date>2024-05-08</Date>
+            <Version>1.3.9</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Update bundled libraries to current versions (README.bundled-libs.txt).
- Introduce bundled image library "prefixing" to avoid conflicts with system libraries.

Full release notes [here](https://www.fltk.org/articles.php?L1898) and [here](https://github.com/fltk/fltk/blob/a66273e72621887fcbd0ee5dca2dd133356d5d8a/CHANGES)

**Test Plan**

- Rev deps work still (octave, tigervnc, carla)


**Checklist**

- [x] Package was built and tested against unstable
