### PR TITLE
font-noto-cjk: Update to 20230817

### DIFF
--- a/packages/f/font-noto-cjk/files/70-noto-cjk.conf
+++ b/packages/f/font-noto-cjk/files/70-noto-cjk.conf
@@ -32,7 +32,7 @@
         <test name="family">
             <string>serif</string>
         </test>
-        <edit name="family" mode="prepend">
+        <edit name="family" mode="prepend" binding="strong">
             <string>Noto Serif CJK SC</string>
         </edit>
     </match>
@@ -44,8 +44,20 @@
         <test name="family">
             <string>serif</string>
         </test>
-        <edit name="family" mode="prepend">
+        <edit name="family" mode="prepend" binding="strong">
             <string>Noto Serif CJK TC</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-hk</string>
+        </test>
+        <test name="family">
+            <string>serif</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Serif CJK HK</string>
         </edit>
     </match>
 
@@ -80,7 +92,7 @@
         <test name="family">
             <string>sans-serif</string>
         </test>
-        <edit name="family" mode="prepend">
+        <edit name="family" mode="prepend" binding="strong">
             <string>Noto Sans CJK SC</string>
         </edit>
     </match>
@@ -92,8 +104,20 @@
         <test name="family">
             <string>sans-serif</string>
         </test>
-        <edit name="family" mode="prepend">
+        <edit name="family" mode="prepend" binding="strong">
             <string>Noto Sans CJK TC</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-hk</string>
+        </test>
+        <test name="family">
+            <string>sans-serif</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Sans CJK HK</string>
         </edit>
     </match>
 
@@ -128,7 +152,7 @@
         <test name="family">
             <string>monospace</string>
         </test>
-        <edit name="family" mode="prepend">
+        <edit name="family" mode="prepend" binding="strong">
             <string>Noto Sans Mono CJK SC</string>
         </edit>
     </match>
@@ -140,8 +164,20 @@
         <test name="family">
             <string>monospace</string>
         </test>
-        <edit name="family" mode="prepend">
+        <edit name="family" mode="prepend" binding="strong">
             <string>Noto Sans Mono CJK TC</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-hk</string>
+        </test>
+        <test name="family">
+            <string>monospace</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Sans Mono CJK HK</string>
         </edit>
     </match>
 </fontconfig>

--- a/packages/f/font-noto-cjk/files/font-noto-cjk.metainfo.xml
+++ b/packages/f/font-noto-cjk/files/font-noto-cjk.metainfo.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2024 Solus Developers <copyright@getsol.us -->
+<component type="font">
+  <id>font-noto-cjk</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Noto CJK</name>
+  <url type="homepage">https://fonts.google.com/noto/</url>
+  <summary>Noto CJK fonts, supporting Simplified Chinese, Traditional Chinese, Japanese, and Korean.</summary>
+  <description>
+    <p>
+      Noto CJK fonts, supporting Simplified Chinese, Traditional Chinese, Japanese, and Korean.
+    </p>
+  </description>
+</component>

--- a/packages/f/font-noto-cjk/package.yml
+++ b/packages/f/font-noto-cjk/package.yml
@@ -1,15 +1,17 @@
 name       : font-noto-cjk
-version    : '2.001'
-release    : 2
+version    : '20230817'
+release    : 3
 source     :
-    - https://github.com/googlefonts/noto-cjk/archive/NotoSansV2.001.tar.gz : 3b18859b3efe3ac36d8d5273e93cc07b61a9480ac09c5b52edf4dd8aaab74187
+    - git|https://github.com/googlefonts/noto-cjk.git : 4efc595762d1f4b4fa504bccfe8e59de91fda063
+homepage   : https://fonts.google.com/noto/fonts
 license    : OFL-1.1
 component  : desktop.font
 summary    : Noto CJK fonts
 description: |
     Noto CJK fonts, supporting Simplified Chinese, Traditional Chinese, Japanese, and Korean.
 install    : |
-    install -D -m00644 *.ttc -t $installdir/usr/share/fonts/truetype/noto-cjk
-
+    install -Dm00644 $workdir/*/OTC/*.ttc -t $installdir/usr/share/fonts/truetype/noto-cjk
     # Borrowed from ArchLinux
-    install -D -m00644 $pkgfiles/70-noto-cjk.conf -t $installdir/usr/share/fonts/conf.d
+    install -Dm00644 $pkgfiles/70-noto-cjk.conf -t $installdir/usr/share/fonts/conf.d
+    # Install appstream metainfo
+    install -Dm00644 $pkgfiles/font-noto-cjk.metainfo.xml -t $installdir/usr/share/metainfo

--- a/packages/f/font-noto-cjk/pspec_x86_64.xml
+++ b/packages/f/font-noto-cjk/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>font-noto-cjk</Name>
+        <Homepage>https://fonts.google.com/noto/fonts</Homepage>
         <Packager>
-            <Name>F. von Gellhorn</Name>
-            <Email>flinux@vongellhorn.ch</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>OFL-1.1</License>
         <PartOf>desktop.font</PartOf>
         <Summary xml:lang="en">Noto CJK fonts</Summary>
         <Description xml:lang="en">Noto CJK fonts, supporting Simplified Chinese, Traditional Chinese, Japanese, and Korean.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>font-noto-cjk</Name>
@@ -34,15 +35,16 @@
             <Path fileType="data">/usr/share/fonts/truetype/noto-cjk/NotoSerifCJK-Medium.ttc</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-cjk/NotoSerifCJK-Regular.ttc</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-cjk/NotoSerifCJK-SemiBold.ttc</Path>
+            <Path fileType="data">/usr/share/metainfo/font-noto-cjk.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2019-05-20</Date>
-            <Version>2.001</Version>
+        <Update release="3">
+            <Date>2024-05-09</Date>
+            <Version>20230817</Version>
             <Comment>Packaging update</Comment>
-            <Name>F. von Gellhorn</Name>
-            <Email>flinux@vongellhorn.ch</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Sync recipe with Archlinux
- Add `homepage` key to `package.yml` (Part of getsolus/packages#411)
- Add appstream metainfo to font packages (Part of getsolus/packages#449)

**Test Plan**

- Verify metainfo with `appstream-builder --packages-dir=. --include-failed -v`
- Verified the added homepage loads information about the package

**Checklist**

- [x] Package was built and tested against unstable