### PR TITLE
tailscale: Update to 1.66.0

### DIFF
--- a/packages/t/tailscale/package.yml
+++ b/packages/t/tailscale/package.yml
@@ -1,8 +1,8 @@
 name       : tailscale
-version    : 1.64.2
-release    : 15
+version    : 1.66.0
+release    : 16
 source     :
-    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.64.2.tar.gz : e5e46f6b6b716b2c4696dce0b92dc2e36f02b06b7ad9f055042a820ad61b2a47
+    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.66.0.tar.gz : f26641a421b77e360dfb4ca7c3bc27ad2a4f3c537923eaff1d82d7fafd244682
 homepage   : https://tailscale.com
 license    : BSD-3-Clause
 component  : network.clients

--- a/packages/t/tailscale/pspec_x86_64.xml
+++ b/packages/t/tailscale/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2024-04-18</Date>
-            <Version>1.64.2</Version>
+        <Update release="16">
+            <Date>2024-05-09</Date>
+            <Version>1.66.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- [changelog](https://tailscale.com/changelog#2024-05-08-client)

**Test Plan**
- tailscale netcheck

**Checklist**
- [X] Package was built and tested against unstable
