### PR TITLE
[RFC] cpesearch: Use NIST api to filter out deprecated CPEs

### DIFF
--- a/common/Scripts/helpers.fish
+++ b/common/Scripts/helpers.fish
@@ -11,9 +11,11 @@ function cpesearch -d "Search for known CPE entries for a program or library"
     if test "$argv[1]" = "--help"; or test "$argv[1]" = "-h"; or test (count $argv) -ne 1
         echo "usage: cpesearch <package-name>"
     else
-        curl -s -X POST https://cpe-guesser.cve-search.org/search -d "{\"query\": [\"$argv[1]\"]}" | jq .
+        curl -s "https://services.nvd.nist.gov/rest/json/cpes/2.0?cpeMatchString=cpe:2.3:*:*:$argv[1]*" |\
+        jq 'del(.products.[] | select(.cpe.deprecated == true))' | jq -r '.products.[].cpe.cpeName' |\
+        cut -d":" -f1-5 | sort -u
         
-        echo "Verify successful hits by visiting https://cve.circl.lu/search/\$VENDOR/\$PRODUCT"
+        echo -e "\nVerify successful hits by visiting https://cve.circl.lu/search/\$VENDOR/\$PRODUCT"
         echo "- CPE entries for software applications have the form 'cpe:2.3:a:\$VENDOR:\$PRODUCT"        
     end
 end

--- a/common/Scripts/helpers.sh
+++ b/common/Scripts/helpers.sh
@@ -3,9 +3,11 @@
 # Primitive CPE search tool
 function cpesearch() {
     function search() {
-        curl -s -X POST https://cpe-guesser.cve-search.org/search -d "{\"query\": [\"$1\"]}" | jq .
+        curl -s "https://services.nvd.nist.gov/rest/json/cpes/2.0?cpeMatchString=cpe:2.3:*:*:$1*" |\
+        jq 'del(.products.[] | select(.cpe.deprecated == true))' | jq -r '.products.[].cpe.cpeName' |\
+        cut -d":" -f1-5 | sort -u
 
-        echo "Verify successful hits by visiting https://cve.circl.lu/search/\$VENDOR/\$PRODUCT"
+        echo -e "\nVerify successful hits by visiting https://cve.circl.lu/search/\$VENDOR/\$PRODUCT"
         echo "- CPE entries for software applications have the form 'cpe:2.3:a:\$VENDOR:\$PRODUCT'"
     }
 

--- a/common/Scripts/helpers.zsh
+++ b/common/Scripts/helpers.zsh
@@ -8,9 +8,11 @@ function cpesearch() {
     if [[ -z $1 || $1 == "--help" || $1 == "-h" ]]; then
         echo "usage: cpesearch <package-name>"
     else
-        curl -s -X POST https://cpe-guesser.cve-search.org/search -d "{\"query\": [\"$1\"]}" | jq .
+        curl -s "https://services.nvd.nist.gov/rest/json/cpes/2.0?cpeMatchString=cpe:2.3:*:*:$1*" |\
+        jq 'del(.products.[] | select(.cpe.deprecated == true))' | jq -r '.products.[].cpe.cpeName' |\
+        cut -d":" -f1-5 | sort -u
         
-        echo "Verify successful hits by visiting https://cve.circl.lu/search/\$VENDOR/\$PRODUCT"
+        echo -e "\nVerify successful hits by visiting https://cve.circl.lu/search/\$VENDOR/\$PRODUCT"
         echo "- CPE entries for software applications have the form 'cpe:2.3:a:\$VENDOR:\$PRODUCT'"
     fi
 }


### PR DESCRIPTION
**Summary**

This makes the `cpesearch` helper function use the NIST website API instead of cve-search.org to enable the filtering out of deprecated CPEs.

Example output:

```
cpe:2.3:a:steam_group_viewer_project:steam_group_viewer
cpe:2.3:a:valvesoftware:steam_client
cpe:2.3:h:valvesoftware:steam_link
cpe:2.3:o:valvesoftware:steam_link_firmware
cpe:2.3:o:valvesoftware:steamos

Verify successful hits by visiting https://cve.circl.lu/search/$VENDOR/$PRODUCT
- CPE entries for software applications have the form 'cpe:2.3:a:$VENDOR:$PRODUCT'
```

Old output:

```
[
  [
    27283,
    "cpe:2.3:a:valve:steam"
  ],
  [
    57210,
    "cpe:2.3:h:valvesoftware:steam_link"
  ],
  [
    88067,
    "cpe:2.3:a:valvesoftware:steam"
  ],
  [
    102861,
    "cpe:2.3:a:steam_group_viewer_project:steam_group_viewer"
  ],
  [
    116769,
    "cpe:2.3:a:valvesoftware:steam_client"
  ],
  [
    119716,
    "cpe:2.3:o:valvesoftware:steam_link_firmware"
  ]
]
```

Note that `cpe:2.3:a:valvesoftware:steam` and `cpe:2.3:a:valve:steam` are deprecated
- https://nvd.nist.gov/products/cpe/detail/B962342D-3003-46CC-A356-FEE20B986AFF?namingFormat=2.3&orderBy=CPEURI&keyword=cpe%3A2.3%3Aa%3Avalvesoftware&status=FINAL%2CDEPRECATED
- https://nvd.nist.gov/products/cpe/detail/F4018889-0220-4EAB-B0DC-1FE96BD4F35D?namingFormat=2.3&orderBy=CPEURI&status=FINAL


**Considerations:**


- Hardcode ":a:" in `cpeMatchString` to only match applications?
I'm not sure if we need e.g. ":h:" in some cases (for drivers?) 

- Also search vendor part of the CPEs?
 This would require a second request as far as I can see
 
- Allow matches with a prefix?
With the current version only suffixes to the searched string are allowed (to catch things like `_client` and so on). This could be an issue with libraries that may or may not start with `lib` at times. On the other hand extending the wildcarding so prefixes are allowed produces A LOT of matches at times. I don't think the API itself allows finer-grained controls but additional filtering could be done in `jq` which has regex support
Example of searching for `steam` with prefixes allowed:
```
cpe:2.3:a:archisteamfarm_project:archisteamfarm
cpe:2.3:a:dalmark:systeam_enterprise_resource_planning
cpe:2.3:a:jenkins:msteams_webhook_trigger
cpe:2.3:a:steam_group_viewer_project:steam_group_viewer
cpe:2.3:a:valvesoftware:steam_client
cpe:2.3:h:valvesoftware:steam_link
cpe:2.3:o:valvesoftware:steam_link_firmware
cpe:2.3:o:valvesoftware:steamos
```