### PR TITLE
wget: update to 1.24.5 

### DIFF
--- a/packages/w/wget/package.yml
+++ b/packages/w/wget/package.yml
@@ -1,6 +1,6 @@
 name       : wget
-version    : 1.21.5
-release    : 31
+version    : 1.24.5
+release    : 32
 source     :
     - https://ftp.gnu.org/gnu/wget/wget-1.24.5.tar.gz : fa2dc35bab5184ecbc46a9ef83def2aaaa3f4c9f3c97d4bd19dcb07d4da637de
 homepage   : https://www.gnu.org/software/wget/

--- a/packages/w/wget/pspec_x86_64.xml
+++ b/packages/w/wget/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>wget</Name>
         <Homepage>https://www.gnu.org/software/wget/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.clients</PartOf>
@@ -106,12 +106,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2024-03-11</Date>
-            <Version>1.21.5</Version>
+        <Update release="32">
+            <Date>2024-05-09</Date>
+            <Version>1.24.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fix how subdomain matches are checked for HSTS.
- Fixes a minor issue where cookies may be leaked to the wrong domain
- Wget will now also parse the srcset attribute in <source> HTML tags
- Support reading fetchmail style "user" and "passwd" fields from netrc
- In some cases, prevent the confusing "Cannot write to... (success)" error messages
- Support extremely fast download speeds (TB/s).
- Previously this would cause Wget to crash when printing the speed
- Improve portability on OpenBSD to run the test suite
- Ensure that CSS URLs are corectly quoted

**Test Plan**
- Installed and downloaded a file.

**Checklist**

- [X] Package was built and tested against unstable
