### PR TITLE
a2ps: update to 4.15.6

### DIFF
--- a/packages/a/a2ps/abi_used_symbols
+++ b/packages/a/a2ps/abi_used_symbols
@@ -6,7 +6,8 @@ libc.so.6:__ctype_toupper_loc
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_current_sigrtmax
 libc.so.6:__libc_current_sigrtmin
 libc.so.6:__libc_start_main
@@ -104,7 +105,6 @@ libc.so.6:strrchr
 libc.so.6:strspn
 libc.so.6:strtod
 libc.so.6:strtok
-libc.so.6:strtol
 libc.so.6:strverscmp
 libc.so.6:textdomain
 libc.so.6:time

--- a/packages/a/a2ps/package.yml
+++ b/packages/a/a2ps/package.yml
@@ -1,8 +1,8 @@
 name       : a2ps
-version    : 4.15.5
-release    : 12
+version    : 4.15.6
+release    : 13
 source     :
-    - https://ftp.gnu.org/gnu/a2ps/a2ps-4.15.5.tar.gz : 81bb1b4104e7c2639762451edc9786daf3dfeb3884adfc7dc6ac9d208f30da7f
+    - https://ftp.gnu.org/gnu/a2ps/a2ps-4.15.6.tar.gz : 87ff9d801cb11969181d5b8cf8b65e65e5b24bb0c76a1b825e8098f2906fbdf4
 homepage   : https://www.gnu.org/software/a2ps/
 license    : GPL-3.0-or-later
 component  : programming

--- a/packages/a/a2ps/pspec_x86_64.xml
+++ b/packages/a/a2ps/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>a2ps</Name>
         <Homepage>https://www.gnu.org/software/a2ps/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Format files for printing on a PostScript printer</Summary>
         <Description xml:lang="en">Convert FILE(s) or standard input to PostScript. By default, the output is sent to the default printer. An output file may be specified with -o.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>a2ps</Name>
@@ -256,6 +256,7 @@
             <Path fileType="localedata">/usr/share/locale/gl/LC_MESSAGES/a2ps.mo</Path>
             <Path fileType="localedata">/usr/share/locale/hr/LC_MESSAGES/a2ps.mo</Path>
             <Path fileType="localedata">/usr/share/locale/hu/LC_MESSAGES/a2ps-gnulib.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/hu/LC_MESSAGES/a2ps.mo</Path>
             <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/a2ps.mo</Path>
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/a2ps-gnulib.mo</Path>
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/a2ps.mo</Path>
@@ -364,12 +365,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2023-09-15</Date>
-            <Version>4.15.5</Version>
+        <Update release="13">
+            <Date>2024-05-09</Date>
+            <Version>4.15.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fix a2ps-lpr-wrapper to work with no arguments, as a2ps requires.
- Minor fixes & improvements to sheets.map for image types and PDF.
- Minor fixes and improvements.

**Test Plan**
- Installed and ran some commands.

**Checklist**

- [X] Package was built and tested against unstable
