### PR TITLE
m17n-lib: update to 1.8.3

### DIFF
--- a/packages/i/ibus-m17n/abi_used_symbols
+++ b/packages/i/ibus-m17n/abi_used_symbols
@@ -7,6 +7,7 @@ libc.so.6:exit
 libc.so.6:fputs
 libc.so.6:memcpy
 libc.so.6:memmove
+libc.so.6:nanosleep
 libc.so.6:setlocale
 libc.so.6:stdout
 libc.so.6:strlen
@@ -39,6 +40,7 @@ libglib-2.0.so.0:g_spawn_command_line_async
 libglib-2.0.so.0:g_str_has_prefix
 libglib-2.0.so.0:g_str_has_suffix
 libglib-2.0.so.0:g_strcmp0
+libglib-2.0.so.0:g_strconcat
 libglib-2.0.so.0:g_strdup
 libglib-2.0.so.0:g_strdup_printf
 libglib-2.0.so.0:g_strfreev
@@ -84,7 +86,7 @@ libibus-1.0.so.5:ibus_engine_hide_auxiliary_text
 libibus-1.0.so.5:ibus_engine_hide_lookup_table
 libibus-1.0.so.5:ibus_engine_hide_preedit_text
 libibus-1.0.so.5:ibus_engine_register_properties
-libibus-1.0.so.5:ibus_engine_show_preedit_text
+libibus-1.0.so.5:ibus_engine_simple_add_table_by_locale
 libibus-1.0.so.5:ibus_engine_simple_get_type
 libibus-1.0.so.5:ibus_engine_update_auxiliary_text
 libibus-1.0.so.5:ibus_engine_update_lookup_table

--- a/packages/i/ibus-m17n/package.yml
+++ b/packages/i/ibus-m17n/package.yml
@@ -1,8 +1,8 @@
 name       : ibus-m17n
-version    : 1.4.22
-release    : 5
+version    : 1.4.29
+release    : 6
 source     :
-    - https://github.com/ibus/ibus-m17n/releases/download/1.4.22/ibus-m17n-1.4.22.tar.gz : ce54f981dfc4758fb71a7b26ba546eb8142f24221fb8e76dcb3ede8243c8b619
+    - https://github.com/ibus/ibus-m17n/releases/download/1.4.29/ibus-m17n-1.4.29.tar.gz : 26722dce2b652199fe27b8f4bff3cd96d9b2f5d2f5c8ac2bbc95a1e980bffda8
 homepage   : https://github.com/ibus/ibus-m17n
 license    : GPL-2.0
 component  : desktop.library

--- a/packages/i/ibus-m17n/pspec_x86_64.xml
+++ b/packages/i/ibus-m17n/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ibus-m17n</Name>
         <Homepage>https://github.com/ibus/ibus-m17n</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0</License>
         <PartOf>desktop.library</PartOf>
@@ -42,11 +42,14 @@
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/ibus-m17n.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fa/LC_MESSAGES/ibus-m17n.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/ibus-m17n.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/hi/LC_MESSAGES/ibus-m17n.mo</Path>
             <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/ibus-m17n.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/ibus-m17n.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/ibus-m17n.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lt/LC_MESSAGES/ibus-m17n.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ml/LC_MESSAGES/ibus-m17n.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/ibus-m17n.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ru/LC_MESSAGES/ibus-m17n.mo</Path>
             <Path fileType="localedata">/usr/share/locale/si/LC_MESSAGES/ibus-m17n.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/ibus-m17n.mo</Path>
             <Path fileType="localedata">/usr/share/locale/tr/LC_MESSAGES/ibus-m17n.mo</Path>
@@ -57,12 +60,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2024-03-23</Date>
-            <Version>1.4.22</Version>
+        <Update release="6">
+            <Date>2024-05-10</Date>
+            <Version>1.4.29</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/m/m17n-lib/abi_used_symbols
+++ b/packages/m/m17n-lib/abi_used_symbols
@@ -80,7 +80,8 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_tolower_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__printf_chk

--- a/packages/m/m17n-lib/package.yml
+++ b/packages/m/m17n-lib/package.yml
@@ -1,8 +1,9 @@
 name       : m17n-lib
-version    : 1.7.0
-release    : 4
+version    : 1.8.3
+release    : 5
 source     :
-    - http://download.savannah.gnu.org/releases/m17n/m17n-lib-1.7.0.tar.gz : 8eb853e1e0c86a70a09871f3264f950e5d62bba98960b3ffcde11511c138db83
+    - http://download.savannah.nongnu.org/releases/m17n/m17n-lib-1.8.3.tar.gz : f64aee2a9b47ac1d89b0392739e1e712ff9c9c74e07e2e7fea5c51cf802d8715
+homepage   : https://www.nongnu.org/m17n/
 license    : LGPL-2.1
 component  : programming
 summary    : The m17n library is a multilingual text processing library for the C language

--- a/packages/m/m17n-lib/pspec_x86_64.xml
+++ b/packages/m/m17n-lib/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>m17n-lib</Name>
+        <Homepage>https://www.nongnu.org/m17n/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>LGPL-2.1</License>
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">The m17n library is a multilingual text processing library for the C language</Summary>
         <Description xml:lang="en">The m17n library is a multilingual text processing library for the C language
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>m17n-lib</Name>
@@ -19,20 +20,19 @@
 </Description>
         <PartOf>programming</PartOf>
         <Files>
-            <Path fileType="executable">/usr/bin/m17n-config</Path>
             <Path fileType="executable">/usr/bin/m17n-conv</Path>
             <Path fileType="executable">/usr/bin/m17n-date</Path>
             <Path fileType="executable">/usr/bin/m17n-dump</Path>
             <Path fileType="executable">/usr/bin/m17n-edit</Path>
             <Path fileType="executable">/usr/bin/m17n-view</Path>
             <Path fileType="library">/usr/lib64/libm17n-core.so.0</Path>
-            <Path fileType="library">/usr/lib64/libm17n-core.so.0.4.1</Path>
+            <Path fileType="library">/usr/lib64/libm17n-core.so.0.4.2</Path>
             <Path fileType="library">/usr/lib64/libm17n-flt.so.0</Path>
-            <Path fileType="library">/usr/lib64/libm17n-flt.so.0.4.1</Path>
+            <Path fileType="library">/usr/lib64/libm17n-flt.so.0.4.2</Path>
             <Path fileType="library">/usr/lib64/libm17n-gui.so.0</Path>
-            <Path fileType="library">/usr/lib64/libm17n-gui.so.0.4.1</Path>
+            <Path fileType="library">/usr/lib64/libm17n-gui.so.0.4.2</Path>
             <Path fileType="library">/usr/lib64/libm17n.so.0</Path>
-            <Path fileType="library">/usr/lib64/libm17n.so.0.4.1</Path>
+            <Path fileType="library">/usr/lib64/libm17n.so.0.4.2</Path>
             <Path fileType="library">/usr/lib64/m17n/1.0/libm17n-X.so</Path>
             <Path fileType="library">/usr/lib64/m17n/1.0/libm17n-gd.so</Path>
             <Path fileType="library">/usr/lib64/m17n/1.0/libmimx-anthy.so</Path>
@@ -46,7 +46,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="4">m17n-lib</Dependency>
+            <Dependency release="5">m17n-lib</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/m17n-X.h</Path>
@@ -66,12 +66,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2022-03-27</Date>
-            <Version>1.7.0</Version>
+        <Update release="5">
+            <Date>2024-05-10</Date>
+            <Version>1.8.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](http://git.savannah.nongnu.org/cgit/m17n/m17n-lib.git/tree/ChangeLog?h=REL-1-8-4).

**Test Plan**
- Rebuilt ibus-m17n against this.

**Checklist**

- [X] Package was built and tested against unstable
