### PR TITLE
wxmaxima: Update to 24.05.0

### DIFF
--- a/packages/w/wxmaxima/abi_used_symbols
+++ b/packages/w/wxmaxima/abi_used_symbols
@@ -22,7 +22,6 @@ libc.so.6:iswprint
 libc.so.6:iswspace
 libc.so.6:iswupper
 libc.so.6:malloc
-libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset
@@ -144,7 +143,6 @@ libwx_baseu-3.2.so.0:_Z12wxRenameFileRK8wxStringS1_b
 libwx_baseu-3.2.so.0:_Z14wxBase64DecodePKcm18wxBase64DecodeModePm
 libwx_baseu-3.2.so.0:_Z14wxBase64EncodePcmPKvm
 libwx_baseu-3.2.so.0:_Z14wxGetOsVersionPiS_S_
-libwx_baseu-3.2.so.0:_Z14wxGetProcessIdv
 libwx_baseu-3.2.so.0:_Z14wxNewEventTypev
 libwx_baseu-3.2.so.0:_Z18wxFileNameFromPathRK8wxString
 libwx_baseu-3.2.so.0:_Z18wxGetOsDescriptionv
@@ -154,7 +152,6 @@ libwx_baseu-3.2.so.0:_Z19wxGet_wxConvUTF8Ptrv
 libwx_baseu-3.2.so.0:_Z20wxGet_wxConvLocalPtrv
 libwx_baseu-3.2.so.0:_Z21wxSetWorkingDirectoryRK8wxString
 libwx_baseu-3.2.so.0:_Z28wxGet_wxConvWhateverWorksPtrv
-libwx_baseu-3.2.so.0:_Z6wxExitv
 libwx_baseu-3.2.so.0:_Z6wxKilll8wxSignalP11wxKillErrori
 libwx_baseu-3.2.so.0:_Z7wxMkdirRK8wxStringi
 libwx_baseu-3.2.so.0:_Z7wxSleepi
@@ -166,6 +163,7 @@ libwx_baseu-3.2.so.0:_Z9wxExecuteRK8wxStringiP9wxProcessPK12wxExecuteEnv
 libwx_baseu-3.2.so.0:_ZN10wxDateTime3SetERK2tm
 libwx_baseu-3.2.so.0:_ZN10wxDateTime8GetTmNowEP2tm
 libwx_baseu-3.2.so.0:_ZN10wxDateTime8TimeZoneC1ENS_2TZE
+libwx_baseu-3.2.so.0:_ZN10wxFileName14SetPermissionsEi
 libwx_baseu-3.2.so.0:_ZN10wxFileName17GetPathSeparatorsE12wxPathFormat
 libwx_baseu-3.2.so.0:_ZN10wxFileName18CreateTempFileNameERK8wxString
 libwx_baseu-3.2.so.0:_ZN10wxFileName5ClearEv
@@ -569,12 +567,10 @@ libwx_baseu_xml-3.2.so.0:_ZNK9wxXmlNode14GetNodeContentEv
 libwx_baseu_xml-3.2.so.0:_ZTV13wxXmlDocument
 libwx_gtk3u_aui-3.2.so.0:_ZN12wxAuiManager15LoadPerspectiveERK8wxStringb
 libwx_gtk3u_aui-3.2.so.0:_ZN12wxAuiManager15SavePerspectiveEv
-libwx_gtk3u_aui-3.2.so.0:_ZN12wxAuiManager6UnInitEv
 libwx_gtk3u_aui-3.2.so.0:_ZN12wxAuiManager6UpdateEv
 libwx_gtk3u_aui-3.2.so.0:_ZN12wxAuiManager7AddPaneEP8wxWindowRK13wxAuiPaneInfo
 libwx_gtk3u_aui-3.2.so.0:_ZN12wxAuiManager7GetPaneERK8wxString
 libwx_gtk3u_aui-3.2.so.0:_ZN12wxAuiManagerC1EP8wxWindowj
-libwx_gtk3u_aui-3.2.so.0:_ZN12wxAuiManagerD1Ev
 libwx_gtk3u_aui-3.2.so.0:_ZN12wxAuiToolBar10AddControlEP9wxControlRK8wxString
 libwx_gtk3u_aui-3.2.so.0:_ZN12wxAuiToolBar10EnableToolEib
 libwx_gtk3u_aui-3.2.so.0:_ZN12wxAuiToolBar12AddSeparatorEv
@@ -1426,7 +1422,6 @@ libwx_gtk3u_core-3.2.so.0:_ZNK7wxImage4IsOkEv
 libwx_gtk3u_core-3.2.so.0:_ZNK7wxImage5ScaleEii20wxImageResizeQuality
 libwx_gtk3u_core-3.2.so.0:_ZNK7wxImage6GetRedEii
 libwx_gtk3u_core-3.2.so.0:_ZNK7wxImage7GetBlueEii
-libwx_gtk3u_core-3.2.so.0:_ZNK7wxImage7GetDataEv
 libwx_gtk3u_core-3.2.so.0:_ZNK7wxImage8GetGreenEii
 libwx_gtk3u_core-3.2.so.0:_ZNK7wxImage8GetWidthEv
 libwx_gtk3u_core-3.2.so.0:_ZNK7wxImage8SaveFileER14wxOutputStream12wxBitmapType

--- a/packages/w/wxmaxima/package.yml
+++ b/packages/w/wxmaxima/package.yml
@@ -1,8 +1,8 @@
 name       : wxmaxima
-version    : 24.02.2
-release    : 28
+version    : 24.05.0
+release    : 29
 source     :
-    - https://github.com/wxMaxima-developers/wxmaxima/archive/refs/tags/Version-24.02.2.tar.gz : ad0b3b7dca4cc554cd29bdf8261f4dce75a01df5898f7efde2c03d539fd074a9
+    - https://github.com/wxMaxima-developers/wxmaxima/archive/refs/tags/Version-24.05.0.tar.gz : 21dc8715b71372dc35743486307254a5a0285f35a6acbc68b894d432c4f14c98
 homepage   : https://wxmaxima-developers.github.io/wxmaxima/
 license    : GPL-2.0-or-later
 component  : office.maths

--- a/packages/w/wxmaxima/pspec_x86_64.xml
+++ b/packages/w/wxmaxima/pspec_x86_64.xml
@@ -114,9 +114,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2024-03-02</Date>
-            <Version>24.02.2</Version>
+        <Update release="29">
+            <Date>2024-05-10</Date>
+            <Version>24.05.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
             <Email>malfisya.dev@hotmail.com</Email>


### PR DESCRIPTION
**Summary**

- Faster discarding of maths that is too long to read
- Resolved a crash on closing the last window
- Now only wxWidgets builds with Unicode support (default) are allowed.
- Full changelog can be found [here](https://github.com/wxMaxima-developers/wxmaxima/releases/tag/Version-24.05.0)

**Test Plan**

- Load example file
- Do some calculation

**Checklist**

- [x] Package was built and tested against unstable