### PR TITLE
m17n-db: update to 1.8.5

### DIFF
--- a/packages/m/m17n-db/files/0001-Add-support-for-zstd-compressed-charmaps.patch
+++ b/packages/m/m17n-db/files/0001-Add-support-for-zstd-compressed-charmaps.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Thomas Staudinger <Staudi.Kaos@gmail.com>
+Date: Fri, 10 May 2024 22:55:04 +0200
+Subject: [PATCH] Add support for zstd-compressed charmaps
+
+Signed-off-by: Thomas Staudinger <Staudi.Kaos@gmail.com>
+---
+ configure.ac | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 5abde50..a3fc526 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -65,7 +65,10 @@ else :
+ fi
+ 
+ if test "x$CHARMAPS" != "x"; then
+-  if test -r "$CHARMAPS/EUC-JP.gz"; then
++  if test -r "$CHARMAPS/EUC-JP.zst"; then
++    CHARMAP_EXT=".zst"
++    CHARMAP_CAT="zstdcat"
++  elif test -r "$CHARMAPS/EUC-JP.gz"; then
+     CHARMAP_EXT=".gz"
+     CHARMAP_CAT="zcat"
+   elif test -r "$CHARMAPS/EUC-JP"; then

--- a/packages/m/m17n-db/package.yml
+++ b/packages/m/m17n-db/package.yml
@@ -1,14 +1,16 @@
 name       : m17n-db
-version    : 1.7.0
-release    : 2
+version    : 1.8.5
+release    : 3
 source     :
-    - http://download.savannah.gnu.org/releases/m17n/m17n-db-1.7.0.tar.gz : a2ba9f80161433d5c06e57915a9cd51f26c6df4a8909723f952cdbb9b48508f0
+    - http://download.savannah.nongnu.org/releases/m17n/m17n-db-1.8.5.tar.gz : b68fff422c0a2864ee56e2c4517382133b981bb4ba39b53f47895cd8b1c0a736
+homepage   : https://www.nongnu.org/m17n/
 license    : LGPL-2.1
 component  : programming
 summary    : Database for the m17n library
 description: |
     Database for the m17n library
 setup      : |
+    %patch -p1 -i $pkgfiles/0001-Add-support-for-zstd-compressed-charmaps.patch
     %configure
 build      : |
     %make

--- a/packages/m/m17n-db/pspec_x86_64.xml
+++ b/packages/m/m17n-db/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>m17n-db</Name>
+        <Homepage>https://www.nongnu.org/m17n/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>LGPL-2.1</License>
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Database for the m17n library</Summary>
         <Description xml:lang="en">Database for the m17n library
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>m17n-db</Name>
@@ -209,6 +210,7 @@
             <Path fileType="data">/usr/share/m17n/ar-translit.mim</Path>
             <Path fileType="data">/usr/share/m17n/ar.lnm</Path>
             <Path fileType="data">/usr/share/m17n/as-inscript.mim</Path>
+            <Path fileType="data">/usr/share/m17n/as-inscript2.mim</Path>
             <Path fileType="data">/usr/share/m17n/as-itrans.mim</Path>
             <Path fileType="data">/usr/share/m17n/as-phonetic.mim</Path>
             <Path fileType="data">/usr/share/m17n/as.lnm</Path>
@@ -222,13 +224,16 @@
             <Path fileType="data">/usr/share/m17n/bla-phonetic.mim</Path>
             <Path fileType="data">/usr/share/m17n/bn-disha.mim</Path>
             <Path fileType="data">/usr/share/m17n/bn-inscript.mim</Path>
+            <Path fileType="data">/usr/share/m17n/bn-inscript2.mim</Path>
             <Path fileType="data">/usr/share/m17n/bn-itrans.mim</Path>
+            <Path fileType="data">/usr/share/m17n/bn-national-jatiya.mim</Path>
             <Path fileType="data">/usr/share/m17n/bn-probhat.mim</Path>
             <Path fileType="data">/usr/share/m17n/bn-unijoy.mim</Path>
             <Path fileType="data">/usr/share/m17n/bn.lnm</Path>
             <Path fileType="data">/usr/share/m17n/bo-ewts.mim</Path>
             <Path fileType="data">/usr/share/m17n/bo-tcrc.mim</Path>
             <Path fileType="data">/usr/share/m17n/bo-wylie.mim</Path>
+            <Path fileType="data">/usr/share/m17n/brx-inscript2-deva.mim</Path>
             <Path fileType="data">/usr/share/m17n/bs.lnm</Path>
             <Path fileType="data">/usr/share/m17n/byn.lnm</Path>
             <Path fileType="data">/usr/share/m17n/ca.lnm</Path>
@@ -242,18 +247,21 @@
             <Path fileType="data">/usr/share/m17n/da.lnm</Path>
             <Path fileType="data">/usr/share/m17n/de.lnm</Path>
             <Path fileType="data">/usr/share/m17n/default.fst</Path>
+            <Path fileType="data">/usr/share/m17n/doi-inscript2-deva.mim</Path>
+            <Path fileType="data">/usr/share/m17n/dra-iso-15919-itrans.mim</Path>
             <Path fileType="data">/usr/share/m17n/dv-phonetic.mim</Path>
             <Path fileType="data">/usr/share/m17n/dv.lnm</Path>
             <Path fileType="data">/usr/share/m17n/dz.lnm</Path>
             <Path fileType="data">/usr/share/m17n/el-kbd.mim</Path>
             <Path fileType="data">/usr/share/m17n/el.lnm</Path>
+            <Path fileType="data">/usr/share/m17n/en-pn-eqf.mim</Path>
             <Path fileType="data">/usr/share/m17n/en.lnm</Path>
-            <Path fileType="data">/usr/share/m17n/eo-h-f.mim</Path>
-            <Path fileType="data">/usr/share/m17n/eo-h.mim</Path>
+            <Path fileType="data">/usr/share/m17n/eo-h-fundamente.mim</Path>
+            <Path fileType="data">/usr/share/m17n/eo-h-sistemo.mim</Path>
             <Path fileType="data">/usr/share/m17n/eo-plena.mim</Path>
-            <Path fileType="data">/usr/share/m17n/eo-q.mim</Path>
-            <Path fileType="data">/usr/share/m17n/eo-vi.mim</Path>
-            <Path fileType="data">/usr/share/m17n/eo-x.mim</Path>
+            <Path fileType="data">/usr/share/m17n/eo-q-sistemo.mim</Path>
+            <Path fileType="data">/usr/share/m17n/eo-vi-sistemo.mim</Path>
+            <Path fileType="data">/usr/share/m17n/eo-x-sistemo.mim</Path>
             <Path fileType="data">/usr/share/m17n/eo.lnm</Path>
             <Path fileType="data">/usr/share/m17n/es.lnm</Path>
             <Path fileType="data">/usr/share/m17n/et.lnm</Path>
@@ -272,6 +280,7 @@
             <Path fileType="data">/usr/share/m17n/global.mim</Path>
             <Path fileType="data">/usr/share/m17n/grc-mizuochi.mim</Path>
             <Path fileType="data">/usr/share/m17n/gu-inscript.mim</Path>
+            <Path fileType="data">/usr/share/m17n/gu-inscript2.mim</Path>
             <Path fileType="data">/usr/share/m17n/gu-itrans.mim</Path>
             <Path fileType="data">/usr/share/m17n/gu-phonetic.mim</Path>
             <Path fileType="data">/usr/share/m17n/gu.lnm</Path>
@@ -279,8 +288,11 @@
             <Path fileType="data">/usr/share/m17n/haw.lnm</Path>
             <Path fileType="data">/usr/share/m17n/he-kbd.mim</Path>
             <Path fileType="data">/usr/share/m17n/he.lnm</Path>
+            <Path fileType="data">/usr/share/m17n/hi-brahmi-itrans.mim</Path>
             <Path fileType="data">/usr/share/m17n/hi-inscript.mim</Path>
+            <Path fileType="data">/usr/share/m17n/hi-inscript2.mim</Path>
             <Path fileType="data">/usr/share/m17n/hi-itrans.mim</Path>
+            <Path fileType="data">/usr/share/m17n/hi-optitransv2.mim</Path>
             <Path fileType="data">/usr/share/m17n/hi-phonetic.mim</Path>
             <Path fileType="data">/usr/share/m17n/hi-remington.mim</Path>
             <Path fileType="data">/usr/share/m17n/hi-typewriter.mim</Path>
@@ -288,104 +300,187 @@
             <Path fileType="data">/usr/share/m17n/hi.lnm</Path>
             <Path fileType="data">/usr/share/m17n/hr-kbd.mim</Path>
             <Path fileType="data">/usr/share/m17n/hr.lnm</Path>
+            <Path fileType="data">/usr/share/m17n/hu-rovas-post.mim</Path>
             <Path fileType="data">/usr/share/m17n/hu.lnm</Path>
             <Path fileType="data">/usr/share/m17n/hy-kbd.mim</Path>
             <Path fileType="data">/usr/share/m17n/hy.lnm</Path>
             <Path fileType="data">/usr/share/m17n/icons/am-sera.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ar-kbd.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/ar-translit.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/as-inscript.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/as-inscript2.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/as-itrans.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/as-phonetic.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/ath-phonetic.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/be-kbd.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/bla-phonetic.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/bn-disha.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/bn-inscript.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/bn-inscript2.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/bn-itrans.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/bn-national-jatiya.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/bn-probhat.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/bn-unijoy.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/bo-ewts.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/bo-tcrc.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/bo-wylie.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/bopo-kbd.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/brx-inscript2-deva.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/cmc-kbd.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/cr-western.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/cs-kbd.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/da-post.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/doi-inscript2-deva.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/dra-iso-15919-itrans.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/dv-phonetic.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/el-kbd.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/en-ispell.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/en-pn-eqf.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/eo-h-fundamente.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/eo-h-sistemo.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/eo-plena.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/eo-q-sistemo.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/eo-vi-sistemo.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/eo-x-sistemo.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/fa-isiri.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/fr-azerty.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/grc-mizuochi.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/gu-inscript.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/gu-inscript2.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/gu-itrans.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/gu-phonetic.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/he-kbd.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/hi-brahmi-itrans.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/hi-inscript.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/hi-inscript2.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/hi-itrans.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/hi-optitransv2.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/hi-phonetic.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/hi-remington.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/hi-typewriter.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/hi-vedmata.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/hr-kbd.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/hu-rovas-post.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/hy-kbd.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ii-phonetic.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/iu-phonetic.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ja-anthy.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ja-tcode.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/ja-trycode.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ka-kbd.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/kk-arabic.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/kk-kbd.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/km-yannis.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/kn-inscript.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/kn-inscript2.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/kn-itrans.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/kn-kgp.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/kn-optitransv2.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/kn-typewriter.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ko-han2.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ko-romaja.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/kok-inscript2-deva.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/ks-inscript.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/ks-inscript2-deva.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/ks-kbd.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/ks-sharada-itrans.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/latn-post.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/latn-pre.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/latn1-pre.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/lo-kbd.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/lo-lrt.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/lsymbol.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/mai-inscript.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/mai-inscript2.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/math-latex.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/ml-enhanced-inscript.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ml-inscript.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/ml-inscript2.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ml-itrans.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ml-mozhi.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/ml-pn-c.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ml-remington.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ml-swanalekha.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/mni-inscript2-beng.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/mni-inscript2-mtei.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/mr-gamabhana.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/mr-inscript.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/mr-inscript2.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/mr-itrans.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/mr-modi-itrans.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/mr-phonetic.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/mr-remington.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/mr-typewriter.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/my-kbd.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/ne-inscript2-deva.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/ne-rom-translit.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ne-rom.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/ne-trad-ttf.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ne-trad.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/new-newa-traditional-extended.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/new-newa-traditional.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/nsk-phonetic.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/oj-phonetic.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/or-inscript.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/or-inscript2.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/or-itrans.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/or-phonetic.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/pa-anmollipi.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/pa-inscript.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/pa-inscript2-guru.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/pa-itrans.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/pa-jhelum.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/pa-phonetic.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/pa-remington.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ps-phonetic.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/rfc1345.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ru-kbd.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ru-phonetic.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/ru-translit.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ru-yawerty.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/sa-IAST-vedic.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/sa-IAST.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/sa-brahmi-itrans.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/sa-grantha-itrans.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/sa-harvard-kyoto.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/sa-inscript.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/sa-inscript2.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/sa-iso-15919-itrans.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/sa-itrans.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/sa-sharada-itrans.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/sa-vedic-itrans.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/sat-inscript2-deva.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/sat-inscript2-olck.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/sd-inscript.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/sd-inscript2-deva.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/si-phonetic-dynamic.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/si-samanala.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/si-sayura.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/si-singlish.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/si-sumihiri.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/si-transliteration.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/si-wijesekera.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/sk-kbd.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/sr-kbd.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/ssymbol.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/sv-post.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/syrc-phonetic.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ta-inscript.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/ta-inscript2.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ta-itrans.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/ta-lk-renganathan.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ta-phonetic.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/ta-remington.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ta-tamil99.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ta-typewriter.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ta-vutam.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/tai-sonla-kbd.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/te-apple.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/te-inscript.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/te-inscript2.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/te-itrans.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/te-pothana.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/te-rts.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/te-sarala.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/th-kesmanee-2.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/th-kesmanee.png</Path>
@@ -394,11 +489,14 @@
             <Path fileType="data">/usr/share/m17n/icons/th-tis820-2.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/th-tis820.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ua-kbd.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/ug-kbd.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/uk-kbd.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/unicode.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/ur-phonetic.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/uz-kbd.png</Path>
-            <Path fileType="data">/usr/share/m17n/icons/vi-nom-vni.png</Path>
-            <Path fileType="data">/usr/share/m17n/icons/vi-nom.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/vi-han.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/vi-nomtelex.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/vi-nomvni.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/vi-tcvn.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/vi-telex.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/vi-viqr.png</Path>
@@ -406,6 +504,7 @@
             <Path fileType="data">/usr/share/m17n/icons/yi-yivo.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/zh-bopomofo.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/zh-cangjie.png</Path>
+            <Path fileType="data">/usr/share/m17n/icons/zh-pinyin-vi.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/zh-pinyin.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/zh-py-b5.png</Path>
             <Path fileType="data">/usr/share/m17n/icons/zh-py-gb.png</Path>
@@ -435,16 +534,21 @@
             <Path fileType="data">/usr/share/m17n/km-yannis.mim</Path>
             <Path fileType="data">/usr/share/m17n/km.lnm</Path>
             <Path fileType="data">/usr/share/m17n/kn-inscript.mim</Path>
+            <Path fileType="data">/usr/share/m17n/kn-inscript2.mim</Path>
             <Path fileType="data">/usr/share/m17n/kn-itrans.mim</Path>
             <Path fileType="data">/usr/share/m17n/kn-kgp.mim</Path>
+            <Path fileType="data">/usr/share/m17n/kn-optitransv2.mim</Path>
             <Path fileType="data">/usr/share/m17n/kn-typewriter.mim</Path>
             <Path fileType="data">/usr/share/m17n/kn.lnm</Path>
             <Path fileType="data">/usr/share/m17n/ko-han2.mim</Path>
             <Path fileType="data">/usr/share/m17n/ko-romaja.mim</Path>
             <Path fileType="data">/usr/share/m17n/ko.lnm</Path>
+            <Path fileType="data">/usr/share/m17n/kok-inscript2-deva.mim</Path>
             <Path fileType="data">/usr/share/m17n/kok.lnm</Path>
             <Path fileType="data">/usr/share/m17n/ks-inscript.mim</Path>
+            <Path fileType="data">/usr/share/m17n/ks-inscript2-deva.mim</Path>
             <Path fileType="data">/usr/share/m17n/ks-kbd.mim</Path>
+            <Path fileType="data">/usr/share/m17n/ks-sharada-itrans.mim</Path>
             <Path fileType="data">/usr/share/m17n/ku.lnm</Path>
             <Path fileType="data">/usr/share/m17n/kw.lnm</Path>
             <Path fileType="data">/usr/share/m17n/ky.lnm</Path>
@@ -459,40 +563,59 @@
             <Path fileType="data">/usr/share/m17n/lt.lnm</Path>
             <Path fileType="data">/usr/share/m17n/lv.lnm</Path>
             <Path fileType="data">/usr/share/m17n/mai-inscript.mim</Path>
+            <Path fileType="data">/usr/share/m17n/mai-inscript2.mim</Path>
             <Path fileType="data">/usr/share/m17n/math-latex.mim</Path>
             <Path fileType="data">/usr/share/m17n/mdb.dir</Path>
             <Path fileType="data">/usr/share/m17n/mk.lnm</Path>
+            <Path fileType="data">/usr/share/m17n/ml-enhanced-inscript.mim</Path>
             <Path fileType="data">/usr/share/m17n/ml-inscript.mim</Path>
+            <Path fileType="data">/usr/share/m17n/ml-inscript2.mim</Path>
             <Path fileType="data">/usr/share/m17n/ml-itrans.mim</Path>
             <Path fileType="data">/usr/share/m17n/ml-mozhi.mim</Path>
+            <Path fileType="data">/usr/share/m17n/ml-pn-c.mim</Path>
             <Path fileType="data">/usr/share/m17n/ml-remington.mim</Path>
             <Path fileType="data">/usr/share/m17n/ml-swanalekha.mim</Path>
             <Path fileType="data">/usr/share/m17n/ml.lnm</Path>
             <Path fileType="data">/usr/share/m17n/mn.lnm</Path>
+            <Path fileType="data">/usr/share/m17n/mni-inscript2-beng.mim</Path>
+            <Path fileType="data">/usr/share/m17n/mni-inscript2-mtei.mim</Path>
+            <Path fileType="data">/usr/share/m17n/mr-gamabhana.mim</Path>
             <Path fileType="data">/usr/share/m17n/mr-inscript.mim</Path>
+            <Path fileType="data">/usr/share/m17n/mr-inscript2.mim</Path>
             <Path fileType="data">/usr/share/m17n/mr-itrans.mim</Path>
+            <Path fileType="data">/usr/share/m17n/mr-modi-itrans.mim</Path>
             <Path fileType="data">/usr/share/m17n/mr-phonetic.mim</Path>
+            <Path fileType="data">/usr/share/m17n/mr-remington.mim</Path>
+            <Path fileType="data">/usr/share/m17n/mr-typewriter.mim</Path>
             <Path fileType="data">/usr/share/m17n/mr.lnm</Path>
             <Path fileType="data">/usr/share/m17n/ms.lnm</Path>
             <Path fileType="data">/usr/share/m17n/mt.lnm</Path>
             <Path fileType="data">/usr/share/m17n/my-kbd.mim</Path>
             <Path fileType="data">/usr/share/m17n/nb.lnm</Path>
+            <Path fileType="data">/usr/share/m17n/ne-inscript2-deva.mim</Path>
+            <Path fileType="data">/usr/share/m17n/ne-rom-translit.mim</Path>
             <Path fileType="data">/usr/share/m17n/ne-rom.mim</Path>
+            <Path fileType="data">/usr/share/m17n/ne-trad-ttf.mim</Path>
             <Path fileType="data">/usr/share/m17n/ne-trad.mim</Path>
+            <Path fileType="data">/usr/share/m17n/new-newa-traditional-extended.mim</Path>
+            <Path fileType="data">/usr/share/m17n/new-newa-traditional.mim</Path>
             <Path fileType="data">/usr/share/m17n/nl.lnm</Path>
             <Path fileType="data">/usr/share/m17n/nn.lnm</Path>
             <Path fileType="data">/usr/share/m17n/nsk-phonetic.mim</Path>
             <Path fileType="data">/usr/share/m17n/oj-phonetic.mim</Path>
             <Path fileType="data">/usr/share/m17n/om.lnm</Path>
             <Path fileType="data">/usr/share/m17n/or-inscript.mim</Path>
+            <Path fileType="data">/usr/share/m17n/or-inscript2.mim</Path>
             <Path fileType="data">/usr/share/m17n/or-itrans.mim</Path>
             <Path fileType="data">/usr/share/m17n/or-phonetic.mim</Path>
             <Path fileType="data">/usr/share/m17n/or.lnm</Path>
             <Path fileType="data">/usr/share/m17n/pa-anmollipi.mim</Path>
             <Path fileType="data">/usr/share/m17n/pa-inscript.mim</Path>
+            <Path fileType="data">/usr/share/m17n/pa-inscript2-guru.mim</Path>
             <Path fileType="data">/usr/share/m17n/pa-itrans.mim</Path>
             <Path fileType="data">/usr/share/m17n/pa-jhelum.mim</Path>
             <Path fileType="data">/usr/share/m17n/pa-phonetic.mim</Path>
+            <Path fileType="data">/usr/share/m17n/pa-remington.mim</Path>
             <Path fileType="data">/usr/share/m17n/pa.lnm</Path>
             <Path fileType="data">/usr/share/m17n/pl.lnm</Path>
             <Path fileType="data">/usr/share/m17n/ps-phonetic.mim</Path>
@@ -505,15 +628,27 @@
             <Path fileType="data">/usr/share/m17n/ru-translit.mim</Path>
             <Path fileType="data">/usr/share/m17n/ru-yawerty.mim</Path>
             <Path fileType="data">/usr/share/m17n/ru.lnm</Path>
+            <Path fileType="data">/usr/share/m17n/sa-brahmi-itrans.mim</Path>
+            <Path fileType="data">/usr/share/m17n/sa-grantha-itrans.mim</Path>
             <Path fileType="data">/usr/share/m17n/sa-harvard-kyoto.mim</Path>
+            <Path fileType="data">/usr/share/m17n/sa-iast-vedic.mim</Path>
             <Path fileType="data">/usr/share/m17n/sa-iast.mim</Path>
+            <Path fileType="data">/usr/share/m17n/sa-inscript.mim</Path>
+            <Path fileType="data">/usr/share/m17n/sa-inscript2.mim</Path>
+            <Path fileType="data">/usr/share/m17n/sa-iso-15919-itrans.mim</Path>
             <Path fileType="data">/usr/share/m17n/sa-itrans.mim</Path>
+            <Path fileType="data">/usr/share/m17n/sa-sharada-itrans.mim</Path>
+            <Path fileType="data">/usr/share/m17n/sa-vedic-itrans.mim</Path>
             <Path fileType="data">/usr/share/m17n/sa.lnm</Path>
+            <Path fileType="data">/usr/share/m17n/sat-inscript2-deva.mim</Path>
+            <Path fileType="data">/usr/share/m17n/sat-inscript2-olck.mim</Path>
             <Path fileType="data">/usr/share/m17n/scripts/tbl2mim.awk</Path>
             <Path fileType="data">/usr/share/m17n/sd-inscript.mim</Path>
+            <Path fileType="data">/usr/share/m17n/sd-inscript2-deva.mim</Path>
             <Path fileType="data">/usr/share/m17n/se.lnm</Path>
             <Path fileType="data">/usr/share/m17n/si-phonetic-dynamic.mim</Path>
             <Path fileType="data">/usr/share/m17n/si-samanala.mim</Path>
+            <Path fileType="data">/usr/share/m17n/si-sayura.mim</Path>
             <Path fileType="data">/usr/share/m17n/si-singlish.mim</Path>
             <Path fileType="data">/usr/share/m17n/si-sumihiri.mim</Path>
             <Path fileType="data">/usr/share/m17n/si-trans.mim</Path>
@@ -534,9 +669,11 @@
             <Path fileType="data">/usr/share/m17n/syr.lnm</Path>
             <Path fileType="data">/usr/share/m17n/syrc-phonetic.mim</Path>
             <Path fileType="data">/usr/share/m17n/ta-inscript.mim</Path>
+            <Path fileType="data">/usr/share/m17n/ta-inscript2.mim</Path>
             <Path fileType="data">/usr/share/m17n/ta-itrans.mim</Path>
             <Path fileType="data">/usr/share/m17n/ta-lk-renganathan.mim</Path>
             <Path fileType="data">/usr/share/m17n/ta-phonetic.mim</Path>
+            <Path fileType="data">/usr/share/m17n/ta-remington.mim</Path>
             <Path fileType="data">/usr/share/m17n/ta-tamil99.mim</Path>
             <Path fileType="data">/usr/share/m17n/ta-typewriter.mim</Path>
             <Path fileType="data">/usr/share/m17n/ta-vutam.mim</Path>
@@ -544,6 +681,7 @@
             <Path fileType="data">/usr/share/m17n/tai-sonla.mim</Path>
             <Path fileType="data">/usr/share/m17n/te-apple.mim</Path>
             <Path fileType="data">/usr/share/m17n/te-inscript.mim</Path>
+            <Path fileType="data">/usr/share/m17n/te-inscript2.mim</Path>
             <Path fileType="data">/usr/share/m17n/te-itrans.mim</Path>
             <Path fileType="data">/usr/share/m17n/te-pothana.mim</Path>
             <Path fileType="data">/usr/share/m17n/te-rts.mim</Path>
@@ -559,8 +697,8 @@
             <Path fileType="data">/usr/share/m17n/tr.lnm</Path>
             <Path fileType="data">/usr/share/m17n/truetype.fst</Path>
             <Path fileType="data">/usr/share/m17n/tt.lnm</Path>
-            <Path fileType="data">/usr/share/m17n/ua-kbd.mim</Path>
             <Path fileType="data">/usr/share/m17n/ug-kbd.mim</Path>
+            <Path fileType="data">/usr/share/m17n/uk-kbd.mim</Path>
             <Path fileType="data">/usr/share/m17n/uk.lnm</Path>
             <Path fileType="data">/usr/share/m17n/unicode.mim</Path>
             <Path fileType="data">/usr/share/m17n/ur-phonetic.mim</Path>
@@ -571,8 +709,8 @@
             <Path fileType="data">/usr/share/m17n/uz_Latn.lnm</Path>
             <Path fileType="data">/usr/share/m17n/vi-base.mim</Path>
             <Path fileType="data">/usr/share/m17n/vi-han.mim</Path>
-            <Path fileType="data">/usr/share/m17n/vi-nom-vni.mim</Path>
-            <Path fileType="data">/usr/share/m17n/vi-nom.mim</Path>
+            <Path fileType="data">/usr/share/m17n/vi-nomtelex.mim</Path>
+            <Path fileType="data">/usr/share/m17n/vi-nomvni.mim</Path>
             <Path fileType="data">/usr/share/m17n/vi-tcvn.mim</Path>
             <Path fileType="data">/usr/share/m17n/vi-telex.mim</Path>
             <Path fileType="data">/usr/share/m17n/vi-viqr.mim</Path>
@@ -606,19 +744,19 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">m17n-db</Dependency>
+            <Dependency release="3">m17n-db</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/pkgconfig/m17n-db.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2021-06-25</Date>
-            <Version>1.7.0</Version>
+        <Update release="3">
+            <Date>2024-05-11</Date>
+            <Version>1.8.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- configure.ac: Version changed to 1.8.5
- NEWS: Update for the 1.8.5 release
- MIM/new-newa-traditional-extended.mim: New input method
- icons/new-newa-traditional-extended.png: icon for new input method
- MIM/{en-pn-eqf,ml-pn-c}.mim: New input method for Malayalam
- icons/{en-pn-eqf,ml-pn-c}.png: icons for the new input method for Malayalam

**Test Plan**
- Checked it installed correctly.

**Checklist**

- [X] Package was built and tested against unstable
