### PR TITLE
gimp: update to 2.10.38

### DIFF
--- a/packages/g/gimp/abi_symbols
+++ b/packages/g/gimp/abi_symbols
@@ -2885,6 +2885,9 @@ gimp-2.10:gimp_dynamics_output_is_enabled
 gimp-2.10:gimp_dynamics_output_new
 gimp-2.10:gimp_dynamics_output_type_get_type
 gimp-2.10:gimp_dynamics_save
+gimp-2.10:gimp_early_rc_get_language
+gimp-2.10:gimp_early_rc_get_type
+gimp-2.10:gimp_early_rc_new
 gimp-2.10:gimp_edit_copy
 gimp-2.10:gimp_edit_copy_visible
 gimp-2.10:gimp_edit_cut
@@ -3960,9 +3963,6 @@ gimp-2.10:gimp_item_tree_view_new
 gimp-2.10:gimp_item_tree_view_set_image
 gimp-2.10:gimp_item_undo_get_type
 gimp-2.10:gimp_item_unset_removed
-gimp-2.10:gimp_lang_rc_get_language
-gimp-2.10:gimp_lang_rc_get_type
-gimp-2.10:gimp_lang_rc_new
 gimp-2.10:gimp_language_combo_box_get_code
 gimp-2.10:gimp_language_combo_box_get_type
 gimp-2.10:gimp_language_combo_box_new
@@ -6267,6 +6267,7 @@ gimp-2.10:gimp_widget_get_fully_opaque
 gimp-2.10:gimp_widget_load_icon
 gimp-2.10:gimp_widget_set_accel_help
 gimp-2.10:gimp_widget_set_fully_opaque
+gimp-2.10:gimp_win32_pointer_input_api_get_type
 gimp-2.10:gimp_window_get_native_id
 gimp-2.10:gimp_window_get_primary_focus_widget
 gimp-2.10:gimp_window_get_type
@@ -7629,6 +7630,9 @@ gimp-console-2.10:gimp_dynamics_output_is_enabled
 gimp-console-2.10:gimp_dynamics_output_new
 gimp-console-2.10:gimp_dynamics_output_type_get_type
 gimp-console-2.10:gimp_dynamics_save
+gimp-console-2.10:gimp_early_rc_get_language
+gimp-console-2.10:gimp_early_rc_get_type
+gimp-console-2.10:gimp_early_rc_new
 gimp-console-2.10:gimp_edit_copy
 gimp-console-2.10:gimp_edit_copy_visible
 gimp-console-2.10:gimp_edit_cut
@@ -8428,9 +8432,6 @@ gimp-console-2.10:gimp_item_tree_reorder_item
 gimp-console-2.10:gimp_item_tree_set_active_item
 gimp-console-2.10:gimp_item_undo_get_type
 gimp-console-2.10:gimp_item_unset_removed
-gimp-console-2.10:gimp_lang_rc_get_language
-gimp-console-2.10:gimp_lang_rc_get_type
-gimp-console-2.10:gimp_lang_rc_new
 gimp-console-2.10:gimp_layer_add_alpha
 gimp-console-2.10:gimp_layer_add_mask
 gimp-console-2.10:gimp_layer_apply_mask
@@ -9665,6 +9666,7 @@ gimp-console-2.10:gimp_waitable_try_wait
 gimp-console-2.10:gimp_waitable_wait
 gimp-console-2.10:gimp_waitable_wait_for
 gimp-console-2.10:gimp_waitable_wait_until
+gimp-console-2.10:gimp_win32_pointer_input_api_get_type
 gimp-console-2.10:gimp_window_hint_get_type
 gimp-console-2.10:gimp_xml_parser_free
 gimp-console-2.10:gimp_xml_parser_new

--- a/packages/g/gimp/abi_used_symbols
+++ b/packages/g/gimp/abi_used_symbols
@@ -1319,8 +1319,8 @@ libglib-2.0.so.0:g_mutex_init
 libglib-2.0.so.0:g_mutex_lock
 libglib-2.0.so.0:g_mutex_unlock
 libglib-2.0.so.0:g_nullify_pointer
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_group
 libglib-2.0.so.0:g_option_context_add_main_entries
 libglib-2.0.so.0:g_option_context_free
@@ -1328,6 +1328,8 @@ libglib-2.0.so.0:g_option_context_new
 libglib-2.0.so.0:g_option_context_parse
 libglib-2.0.so.0:g_option_context_parse_strv
 libglib-2.0.so.0:g_option_context_set_summary
+libglib-2.0.so.0:g_option_group_new
+libglib-2.0.so.0:g_option_group_set_parse_hooks
 libglib-2.0.so.0:g_parse_debug_string
 libglib-2.0.so.0:g_path_get_basename
 libglib-2.0.so.0:g_path_get_dirname
@@ -1623,6 +1625,7 @@ libgobject-2.0.so.0:g_cclosure_new
 libgobject-2.0.so.0:g_cclosure_new_object
 libgobject-2.0.so.0:g_cclosure_new_swap
 libgobject-2.0.so.0:g_closure_get_type
+libgobject-2.0.so.0:g_closure_invalidate
 libgobject-2.0.so.0:g_closure_new_object
 libgobject-2.0.so.0:g_closure_set_marshal
 libgobject-2.0.so.0:g_closure_unref

--- a/packages/g/gimp/package.yml
+++ b/packages/g/gimp/package.yml
@@ -1,8 +1,8 @@
 name       : gimp
-version    : 2.10.36
-release    : 80
+version    : 2.10.38
+release    : 81
 source     :
-    - https://download.gimp.org/pub/gimp/v2.10/gimp-2.10.36.tar.bz2 : 3d3bc3c69a4bdb3aea9ba2d5385ed98ea03953f3857aafd1d6976011ed7cdbb2
+    - https://download.gimp.org/pub/gimp/v2.10/gimp-2.10.38.tar.bz2 : 50a845eec11c8831fe8661707950f5b8446e35f30edfb9acf98f85c1133f856e
 license    : GPL-3.0-or-later
 component  : multimedia.graphics
 homepage   : https://www.gimp.org/

--- a/packages/g/gimp/pspec_x86_64.xml
+++ b/packages/g/gimp/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gimp</Name>
         <Homepage>https://www.gimp.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Fabio db</Name>
+            <Email>fab7di@virgilio.it</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>multimedia.graphics</PartOf>
@@ -202,23 +202,23 @@
             <Path fileType="library">/usr/lib64/gimp/2.0/python/pygimp-logo.png</Path>
             <Path fileType="library">/usr/lib64/gimp/gimp-debug-tool-2.0</Path>
             <Path fileType="library">/usr/lib64/libgimp-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgimp-2.0.so.0.1000.36</Path>
+            <Path fileType="library">/usr/lib64/libgimp-2.0.so.0.1000.38</Path>
             <Path fileType="library">/usr/lib64/libgimpbase-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgimpbase-2.0.so.0.1000.36</Path>
+            <Path fileType="library">/usr/lib64/libgimpbase-2.0.so.0.1000.38</Path>
             <Path fileType="library">/usr/lib64/libgimpcolor-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgimpcolor-2.0.so.0.1000.36</Path>
+            <Path fileType="library">/usr/lib64/libgimpcolor-2.0.so.0.1000.38</Path>
             <Path fileType="library">/usr/lib64/libgimpconfig-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgimpconfig-2.0.so.0.1000.36</Path>
+            <Path fileType="library">/usr/lib64/libgimpconfig-2.0.so.0.1000.38</Path>
             <Path fileType="library">/usr/lib64/libgimpmath-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgimpmath-2.0.so.0.1000.36</Path>
+            <Path fileType="library">/usr/lib64/libgimpmath-2.0.so.0.1000.38</Path>
             <Path fileType="library">/usr/lib64/libgimpmodule-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgimpmodule-2.0.so.0.1000.36</Path>
+            <Path fileType="library">/usr/lib64/libgimpmodule-2.0.so.0.1000.38</Path>
             <Path fileType="library">/usr/lib64/libgimpthumb-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgimpthumb-2.0.so.0.1000.36</Path>
+            <Path fileType="library">/usr/lib64/libgimpthumb-2.0.so.0.1000.38</Path>
             <Path fileType="library">/usr/lib64/libgimpui-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgimpui-2.0.so.0.1000.36</Path>
+            <Path fileType="library">/usr/lib64/libgimpui-2.0.so.0.1000.38</Path>
             <Path fileType="library">/usr/lib64/libgimpwidgets-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgimpwidgets-2.0.so.0.1000.36</Path>
+            <Path fileType="library">/usr/lib64/libgimpwidgets-2.0.so.0.1000.38</Path>
             <Path fileType="data">/usr/share/applications/gimp.desktop</Path>
             <Path fileType="data">/usr/share/gimp/2.0/brushes/Basic/1-pixel.vbr</Path>
             <Path fileType="data">/usr/share/gimp/2.0/brushes/Basic/Block-01.vbr</Path>
@@ -4411,6 +4411,7 @@
             <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/gimp20-script-fu.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/gimp20-std-plug-ins.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/gimp20.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/kab/LC_MESSAGES/gimp20-libgimp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/kab/LC_MESSAGES/gimp20-python.mo</Path>
             <Path fileType="localedata">/usr/share/locale/kab/LC_MESSAGES/gimp20-std-plug-ins.mo</Path>
             <Path fileType="localedata">/usr/share/locale/kk/LC_MESSAGES/gimp20-libgimp.mo</Path>
@@ -4613,7 +4614,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="80">gimp</Dependency>
+            <Dependency release="81">gimp</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gimp-2.0/libgimp/gimp.h</Path>
@@ -5490,12 +5491,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="80">
-            <Date>2024-03-03</Date>
-            <Version>2.10.36</Version>
+        <Update release="81">
+            <Date>2024-05-11</Date>
+            <Version>2.10.38</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Fabio db</Name>
+            <Email>fab7di@virgilio.it</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Update to 2.10.38
- Release notes can be found [here] (https://www.gimp.org/news/2024/05/05/gimp-2-10-38-released/)
- The update fix a bug of Gimp (#2350)

**Test Plan**
- Test packages with Gimp in Solus unstable

**Checklist**
- [X] Package was built and tested against unstable

