### PR TITLE
md4c: update to 0.5.2

### DIFF
--- a/packages/m/md4c/abi_used_symbols
+++ b/packages/m/md4c/abi_used_symbols
@@ -3,7 +3,6 @@ libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
-libc.so.6:__strncpy_chk
 libc.so.6:calloc
 libc.so.6:clock
 libc.so.6:exit
@@ -23,6 +22,8 @@ libc.so.6:stderr
 libc.so.6:stdin
 libc.so.6:stdout
 libc.so.6:strchr
+libc.so.6:strcmp
 libc.so.6:strcspn
 libc.so.6:strlen
 libc.so.6:strncmp
+libc.so.6:strncpy

--- a/packages/m/md4c/package.yml
+++ b/packages/m/md4c/package.yml
@@ -1,8 +1,9 @@
 name       : md4c
-version    : 0.4.8
-release    : 1
+version    : 0.5.2
+release    : 2
 source     :
-    - https://github.com/mity/md4c/archive/refs/tags/release-0.4.8.tar.gz : 4a457df853425b6bb6e3457aa1d1a13bccec587a04c38c622b1013a0da41439f
+    - https://github.com/mity/md4c/archive/refs/tags/release-0.5.2.tar.gz : 55d0111d48fb11883aaee91465e642b8b640775a4d6993c2d0e7a8092758ef21
+homepage   : https://github.com/mity/md4c
 license    : MIT
 component  : programming.library
 summary    : C Markdown parser and library

--- a/packages/m/md4c/pspec_x86_64.xml
+++ b/packages/m/md4c/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>md4c</Name>
+        <Homepage>https://github.com/mity/md4c</Homepage>
         <Packager>
-            <Name>Martin Reboredo</Name>
-            <Email>yakoyoku@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.library</PartOf>
         <Summary xml:lang="en">C Markdown parser and library</Summary>
         <Description xml:lang="en">C Markdown parser. Fast. SAX-like interface. Compliant to CommonMark specification.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>md4c</Name>
@@ -21,9 +22,9 @@
         <Files>
             <Path fileType="executable">/usr/bin/md2html</Path>
             <Path fileType="library">/usr/lib64/libmd4c-html.so.0</Path>
-            <Path fileType="library">/usr/lib64/libmd4c-html.so.0.4.8</Path>
+            <Path fileType="library">/usr/lib64/libmd4c-html.so.0.5.2</Path>
             <Path fileType="library">/usr/lib64/libmd4c.so.0</Path>
-            <Path fileType="library">/usr/lib64/libmd4c.so.0.4.8</Path>
+            <Path fileType="library">/usr/lib64/libmd4c.so.0.5.2</Path>
             <Path fileType="man">/usr/share/man/man1/md2html.1</Path>
         </Files>
     </Package>
@@ -34,7 +35,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="1">md4c</Dependency>
+            <Dependency release="2">md4c</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/md4c-html.h</Path>
@@ -48,12 +49,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2021-09-30</Date>
-            <Version>0.4.8</Version>
+        <Update release="2">
+            <Date>2024-05-11</Date>
+            <Version>0.5.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Martin Reboredo</Name>
-            <Email>yakoyoku@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/mity/md4c/blob/master/CHANGELOG.md).

**Test Plan**
- Checked it installed correctly.

**Checklist**

- [X] Package was built and tested against unstable
