### PR TITLE
aisleriot: Remove dependency on pysolfc(-cardsets)

### DIFF
--- a/packages/a/aisleriot/abi_used_symbols
+++ b/packages/a/aisleriot/abi_used_symbols
@@ -113,7 +113,6 @@ libgio-2.0.so.0:g_zlib_decompressor_new
 libglib-2.0.so.0:g_access
 libglib-2.0.so.0:g_ascii_strcasecmp
 libglib-2.0.so.0:g_ascii_strdown
-libglib-2.0.so.0:g_ascii_strtoll
 libglib-2.0.so.0:g_ascii_strtoull
 libglib-2.0.so.0:g_ascii_table
 libglib-2.0.so.0:g_ascii_toupper
@@ -134,7 +133,6 @@ libglib-2.0.so.0:g_error_copy
 libglib-2.0.so.0:g_error_free
 libglib-2.0.so.0:g_error_matches
 libglib-2.0.so.0:g_file_error_quark
-libglib-2.0.so.0:g_file_get_contents
 libglib-2.0.so.0:g_file_open_tmp
 libglib-2.0.so.0:g_file_set_contents
 libglib-2.0.so.0:g_filename_display_name
@@ -220,7 +218,6 @@ libglib-2.0.so.0:g_snprintf
 libglib-2.0.so.0:g_source_remove
 libglib-2.0.so.0:g_spawn_async
 libglib-2.0.so.0:g_str_equal
-libglib-2.0.so.0:g_str_has_prefix
 libglib-2.0.so.0:g_str_has_suffix
 libglib-2.0.so.0:g_str_hash
 libglib-2.0.so.0:g_strchomp

--- a/packages/a/aisleriot/package.yml
+++ b/packages/a/aisleriot/package.yml
@@ -1,6 +1,6 @@
 name       : aisleriot
 version    : 3.22.32
-release    : 34
+release    : 35
 source     :
     - https://gitlab.gnome.org/GNOME/aisleriot/-/archive/3.22.32/aisleriot-3.22.32.tar.gz : ad5bb03841f508d6b7dfcfc308fd4b96c671a71ab2eafda89890f54f96e9d947
 license    :
@@ -21,20 +21,13 @@ builddeps  :
     - pkgconfig(librsvg-2.0)
     - desktop-file-utils
     - itstool
-    - pysolfc
-    - pysolfc-cardsets
-rundeps    :
-    - pysolfc
-    - pysolfc-cardsets
 setup      : |
     # Change file names that are not latin1 to fix eopkg creation
     %patch -p1 -i $pkgfiles/0001-Rename-non-latin1-files.patch
 
     %meson_configure \
         -Ddefault_theme_format=svg-rsvg \
-        -Dtheme_kde=false \
-        -Dtheme_pysol=true \
-        -Dtheme_pysol_path=/usr/share/PySolFC/
+        -Dtheme_kde=false
 build      : |
     %ninja_build
 install    : |

--- a/packages/a/aisleriot/pspec_x86_64.xml
+++ b/packages/a/aisleriot/pspec_x86_64.xml
@@ -2256,8 +2256,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="34">
-            <Date>2024-04-25</Date>
+        <Update release="35">
+            <Date>2024-05-11</Date>
             <Version>3.22.32</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>


### PR DESCRIPTION
**Summary**
The PySol cardsets use a different style and thus don't really fit in with the rest.

Additionally this saves more than 100 MB in combined install size, if you only install `aisleriot`

Resolves https://github.com/getsolus/packages/issues/2516

**Test Plan**

Switched through the remaining card styles; played a round of Klondike

**Checklist**

- [x] Package was built and tested against unstable
