### PR TITLE
yaru-theme: Fix compatibility with libgedit-gtksourceview 299.2

### DIFF
--- a/packages/y/yaru-theme/files/0001-gtksourceview-Add-support-for-new-libgedit-gtksource.patch
+++ b/packages/y/yaru-theme/files/0001-gtksourceview-Add-support-for-new-libgedit-gtksource.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Thomas Staudinger <Staudi.Kaos@gmail.com>
+Date: Sat, 11 May 2024 22:32:02 +0200
+Subject: [PATCH] gtksourceview: Add support for new libgedit-gtksourceview xml
+ scheme
+
+The `kind` attribute is now mandatory, `version` and `underline-color` removed
+
+Signed-off-by: Thomas Staudinger <Staudi.Kaos@gmail.com>
+---
+ gtksourceview/gtksourceview/dark.xml.in    | 4 ++--
+ gtksourceview/gtksourceview/default.xml.in | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/gtksourceview/gtksourceview/dark.xml.in b/gtksourceview/gtksourceview/dark.xml.in
+index 8b7584839..ff3b67d4f 100644
+--- a/gtksourceview/gtksourceview/dark.xml.in
++++ b/gtksourceview/gtksourceview/dark.xml.in
+@@ -1,5 +1,5 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+-<style-scheme id="@FlavourThemeName@" _name="@FlavourThemeName@" version="1.0">
++<style-scheme id="@FlavourThemeName@" _name="@FlavourThemeName@" kind="dark">
+   <_description>A GtkSourceView style to match @FlavourThemeName@</_description>
+ 
+   <!-- Yaru palette -->
+@@ -94,7 +94,7 @@
+   <style name="def:strong-emphasis"        bold="true"/>
+   <style name="def:type"                   foreground="blue_2" bold="true"/>
+   <style name="def:underlined"             underline="single"/>
+-  <style name="def:warning"                underline="error" underline-color="yellow_4"/>
++  <style name="def:warning"                underline="error"/>
+   
+   <!-- C# -->
+   <style name="c-sharp:format"             foreground="purple_2"/>
+diff --git a/gtksourceview/gtksourceview/default.xml.in b/gtksourceview/gtksourceview/default.xml.in
+index e6cad5c5d..7d753e037 100644
+--- a/gtksourceview/gtksourceview/default.xml.in
++++ b/gtksourceview/gtksourceview/default.xml.in
+@@ -1,5 +1,5 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+-<style-scheme id="@FlavourThemeName@" _name="@FlavourThemeName@" version="1.0">
++<style-scheme id="@FlavourThemeName@" _name="@FlavourThemeName@" kind="light">
+   <_description>A GtkSourceView style to match @FlavourThemeName@</_description>
+ 
+   <!-- Yaru palette -->
+@@ -92,7 +92,7 @@
+   <style name="def:strong-emphasis"        bold="true"/>
+   <style name="def:type"                   foreground="blue_4" bold="true"/>
+   <style name="def:underlined"             underline="single"/>
+-  <style name="def:warning"                underline="error" underline-color="yellow_4"/>
++  <style name="def:warning"                underline="error"/>
+ 
+   <!-- C# -->
+   <style name="c-sharp:format"             foreground="purple_4"/>

--- a/packages/y/yaru-theme/package.yml
+++ b/packages/y/yaru-theme/package.yml
@@ -1,6 +1,6 @@
 name       : yaru-theme
 version    : 24.04.2
-release    : 23
+release    : 24
 source     :
     - https://github.com/ubuntu/yaru/archive/refs/tags/24.04.2-0ubuntu1.tar.gz : 920bf71f1f876f0c09e9250545248f523fb95dca41cbf95153ed600764441fbc
 license    :
@@ -29,6 +29,7 @@ rundeps    :
         - gtk2-engine-murrine
 setup      : |
     %patch -p1 -i $pkgfiles/0001-fix-gnome-shell-install-dir.patch
+    %patch -p1 -i $pkgfiles/0001-gtksourceview-Add-support-for-new-libgedit-gtksource.patch
     %meson_configure \
         -Dsessions=false \
         -Dsounds=false

--- a/packages/y/yaru-theme/pspec_x86_64.xml
+++ b/packages/y/yaru-theme/pspec_x86_64.xml
@@ -19486,8 +19486,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2024-04-23</Date>
+        <Update release="24">
+            <Date>2024-05-12</Date>
             <Version>24.04.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>


### PR DESCRIPTION
**Summary**

The xml scheme changed in 299.2 which lead to import errors for the theme

This adjusts the stylesheet for Yaru and Yaru-Dark to conform to the new requirements

**Test Plan**
- Ran `gedit` and confirmed no errors for theme imports popped up
- Selected Yaru and Yaru-Dark themes in `gedit`

**Checklist**

- [x] Package was built and tested against unstable
