### PR TITLE
noto-sans-ttf: Update to 24.5.1 and add monitoring.yml

### DIFF
--- a/packages/n/noto-sans-ttf/monitoring.yml
+++ b/packages/n/noto-sans-ttf/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 10671
+  rss: https://github.com/notofonts/notofonts.github.io/releases.atom
+# No known CPE, checked 2024-05-13
+security:
+  cpe: ~

--- a/packages/n/noto-sans-ttf/package.yml
+++ b/packages/n/noto-sans-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : noto-sans-ttf
-version    : 24.4.1
-release    : 27
+version    : 24.5.1
+release    : 28
 source     :
-    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-24.4.1.tar.gz : 501beb5b4b930f959546790b0c51c4544cdd97bc02c7193f50774323c49167fc
+    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-24.5.1.tar.gz : 431ef733310362b54732c7abc66b23e4c6751c3f8e6134efc64a4eed81188af6
     - https://github.com/googlefonts/noto-emoji/archive/refs/tags/v2.042.tar.gz : b56bd2fa4029d0f057b66b742ac59af243dbc91067fed3eb4929dac762440fc9
 homepage   : https://fonts.google.com/noto
 extract    : no

--- a/packages/n/noto-sans-ttf/pspec_x86_64.xml
+++ b/packages/n/noto-sans-ttf/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>noto-sans-ttf</Name>
         <Homepage>https://fonts.google.com/noto</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>OFL-1.1</License>
         <PartOf>desktop.font</PartOf>
@@ -747,7 +747,6 @@
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansPahawhHmong-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansPalmyrene-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansPauCinHau-Regular.ttf</Path>
-            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansPhags-Pa-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansPhagsPa-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansPhoenician-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansPsalterPahlavi-Regular.ttf</Path>
@@ -1514,12 +1513,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2024-04-25</Date>
-            <Version>24.4.1</Version>
+        <Update release="28">
+            <Date>2024-05-13</Date>
+            <Version>24.5.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Remove duplicated NotoSansPhags-Pa-Regular font

Full commit log available [here](https://github.com/notofonts/notofonts.github.io/compare/noto-monthly-release-24.4.1...noto-monthly-release-24.5.1)

**Test Plan**
- Confirmed my system font still looked okay
- Tested a number of Noto fonts in LibreOffice Writer

**Checklist**

- [x] Package was built and tested against unstable
