### PR TITLE
font-intel-one-mono : Add at v1.3.0

### DIFF
--- a/packages/f/font-intel-one-mono-ttf/package.yml
+++ b/packages/f/font-intel-one-mono-ttf/package.yml
@@ -1,0 +1,14 @@
+name       : font-intel-one-mono-ttf
+version    : 1.3.0
+release    : 1
+source     :
+    - https://github.com/intel/intel-one-mono/archive/refs/tags/V1.3.0.tar.gz : 2d4f25aed51092d6396f97d6e828e83d8c814e6ac17e229710bd1adda29aceee
+homepage   : https://www.intel.com/content/www/us/en/company-overview/one-monospace-font.html
+license    : OFL-1.1
+component  : 
+    - desktop.font
+summary    : Monospaced font with developers in mind
+description: |
+   Intel-One-Mono is a monospaced font that is built with clarity, legibility, and the needs of developers in mind.
+install    : |
+    install -Dm00644 fonts/ttf/*.ttf -t $installdir/usr/share/fonts/truetype/intel-one-mono/

--- a/packages/f/font-intel-one-mono-ttf/pspec_x86_64.xml
+++ b/packages/f/font-intel-one-mono-ttf/pspec_x86_64.xml
@@ -1,0 +1,42 @@
+<PISI>
+    <Source>
+        <Name>font-intel-one-mono-ttf</Name>
+        <Homepage>https://www.intel.com/content/www/us/en/company-overview/one-monospace-font.html</Homepage>
+        <Packager>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
+        </Packager>
+        <License>OFL-1.1</License>
+        <PartOf>desktop.font</PartOf>
+        <Summary xml:lang="en">Monospaced font with developers in mind</Summary>
+        <Description xml:lang="en">Intel-One-Mono is a monospaced font that is built with clarity, legibility, and the needs of developers in mind.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>font-intel-one-mono-ttf</Name>
+        <Summary xml:lang="en">Monospaced font with developers in mind</Summary>
+        <Description xml:lang="en">Intel-One-Mono is a monospaced font that is built with clarity, legibility, and the needs of developers in mind.
+</Description>
+        <PartOf>desktop.font</PartOf>
+        <Files>
+            <Path fileType="data">/usr/share/fonts/truetype/intel-one-mono/IntelOneMono-Bold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/intel-one-mono/IntelOneMono-BoldItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/intel-one-mono/IntelOneMono-Italic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/intel-one-mono/IntelOneMono-Light.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/intel-one-mono/IntelOneMono-LightItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/intel-one-mono/IntelOneMono-Medium.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/intel-one-mono/IntelOneMono-MediumItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/intel-one-mono/IntelOneMono-Regular.ttf</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2024-05-15</Date>
+            <Version>1.3.0</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**

Add the intel-one-mono font, which is font intended for programmers

**Test Plan**

- Set font in terminal, your favorite text editor, or in all applications.

**Checklist**

- [x] Package was built and tested against unstable

Resolves https://github.com/getsolus/packages/issues/2580