### PR TITLE
github-cli: Update to 2.49.2

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.49.1
-release    : 46
+version    : 2.49.2
+release    : 47
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.49.1.tar.gz : e898bcfec71ee1b5eba3bba0816eaca5f735e7443e11864dddbf753f8ecc3cf7
+    - https://github.com/cli/cli/archive/refs/tags/v2.49.2.tar.gz : e839ea302ad99b70ce3efcb903f938ecbbb919798e49bc2f2034ad506ae0b0f5
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -216,9 +216,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="46">
-            <Date>2024-05-08</Date>
-            <Version>2.49.1</Version>
+        <Update release="47">
+            <Date>2024-05-16</Date>
+            <Version>2.49.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Improve `run list` doc with available `--json` fields
- Fix typos
- Move config interfaces into gh package
- Creating doc to capture Codespace usage guidance
- Fix repo fork regression
- Add `--latest=false` to `gh release create` docs

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this pull request.

**Checklist**

- [x] Package was built and tested against unstable
