### PR TITLE
eza: Update to 0.18.16

### DIFF
--- a/packages/e/eza/package.yml
+++ b/packages/e/eza/package.yml
@@ -1,8 +1,8 @@
 name       : eza
-version    : 0.18.14
-release    : 22
+version    : 0.18.16
+release    : 23
 source     :
-    - https://github.com/eza-community/eza/archive/refs/tags/v0.18.14.tar.gz : f8f42ed466c02eaaa2b157ef976d29f1c38a6ff13064be52baed70e4943f2481
+    - https://github.com/eza-community/eza/archive/refs/tags/v0.18.16.tar.gz : dd713474b902568cb2c7c8ea7db8e08db5818617e34908ae7142e9da9cefd17b
 homepage   : https://github.com/eza-community/eza
 license    : MIT
 component  : system.utils

--- a/packages/e/eza/pspec_x86_64.xml
+++ b/packages/e/eza/pspec_x86_64.xml
@@ -32,9 +32,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2024-05-08</Date>
-            <Version>0.18.14</Version>
+        <Update release="23">
+            <Date>2024-05-16</Date>
+            <Version>0.18.16</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Replace decay with color-scale
- Add how to find man pages in terminal and online

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `eza`, `eza -l`, and `eza -la`.

**Checklist**

- [x] Package was built and tested against unstable
