### PR TITLE
libreoffice: Use the Elementary icon theme by default

### DIFF
--- a/packages/l/libreoffice/abi_used_symbols
+++ b/packages/l/libreoffice/abi_used_symbols
@@ -2047,8 +2047,8 @@ libglib-2.0.so.0:g_main_loop_run
 libglib-2.0.so.0:g_main_loop_unref
 libglib-2.0.so.0:g_malloc
 libglib-2.0.so.0:g_malloc_n
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_poll
 libglib-2.0.so.0:g_ptr_array_add
 libglib-2.0.so.0:g_ptr_array_new

--- a/packages/l/libreoffice/files/0001-Use-the-Elementary-icons-by-default.patch
+++ b/packages/l/libreoffice/files/0001-Use-the-Elementary-icons-by-default.patch
@@ -1,26 +1,23 @@
-From 7b209fde17db60720c4ccfa88f9d189bd131e7d8 Mon Sep 17 00:00:00 2001
-From: Ikey Doherty <ikey@solus-project.com>
-Date: Thu, 23 Jun 2016 20:37:06 +0100
-Subject: [PATCH] Use the Sifr style by default
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Evan Maddock <maddock.evan@vivaldi.net>
+Date: Fri, 17 May 2024 12:05:18 -0400
+Subject: [PATCH] Use the Elementary icons by default
 
-Signed-off-by: Ikey Doherty <ikey@solus-project.com>
+Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
 ---
  officecfg/registry/schema/org/openoffice/Office/Common.xcs | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/officecfg/registry/schema/org/openoffice/Office/Common.xcs b/officecfg/registry/schema/org/openoffice/Office/Common.xcs
-index 732ba89..6e0f862 100644
+index 53aa213ac80d..ea27e3b0466f 100644
 --- a/officecfg/registry/schema/org/openoffice/Office/Common.xcs
 +++ b/officecfg/registry/schema/org/openoffice/Office/Common.xcs
-@@ -5686,7 +5686,7 @@
+@@ -5424,7 +5424,7 @@
            names of the various icon themes ("breeze", "crystal", "elementary",
            etc.).</desc>
          </info>
 -        <value>auto</value>
-+        <value>sifr_dark</value>
++        <value>elementary</value>
        </prop>
        <prop oor:name="Persona" oor:type="xs:string" oor:nillable="false">
          <!-- UIHints: Tools  Options General Personalization -->
--- 
-2.35.4
-

--- a/packages/l/libreoffice/package.yml
+++ b/packages/l/libreoffice/package.yml
@@ -1,6 +1,6 @@
 name       : libreoffice
 version    : 24.2.2.2
-release    : 180
+release    : 181
 source     :
     - https://download.documentfoundation.org/libreoffice/src/24.2.2/libreoffice-24.2.2.2.tar.xz : c205a65042f65c94b54ea310344b851043633c3eb5259f4e567d9341aae5e45e
     - https://download.documentfoundation.org/libreoffice/src/24.2.2/libreoffice-dictionaries-24.2.2.2.tar.xz : a4606997cbb04d5aa0043ccdc55abad802d8fe6aab78b1166ef562fb678f130d
@@ -303,7 +303,7 @@ setup      : |
     tar --strip-components=1 -xvf $sources/libreoffice-translations-$version.tar.xz
 
     chmod +x bin/unpack-sources
-    %patch -p1 -i $pkgfiles/0001-Use-the-Sifr-style-by-default.patch
+    %patch -p1 -i $pkgfiles/0001-Use-the-Elementary-icons-by-default.patch
     %patch -p1 -i $pkgfiles/0001-solus-Add-path-to-client-libjvm.patch
     %patch -p1 -i $pkgfiles/0001-Remove-check-if-root-due-to-issue-with-fakeroot.patch
     %patch -p1 -i $pkgfiles/0001-Fix-KDE-build.patch

--- a/packages/l/libreoffice/pspec_x86_64.xml
+++ b/packages/l/libreoffice/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libreoffice</Name>
         <Homepage>https://www.libreoffice.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>BSD-2-Clause</License>
@@ -25,13 +25,13 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="180">libreoffice-base</Dependency>
-            <Dependency releaseFrom="180">libreoffice-calc</Dependency>
-            <Dependency releaseFrom="180">libreoffice-common</Dependency>
-            <Dependency releaseFrom="180">libreoffice-common-dictionaries</Dependency>
-            <Dependency releaseFrom="180">libreoffice-draw</Dependency>
-            <Dependency releaseFrom="180">libreoffice-impress</Dependency>
-            <Dependency releaseFrom="180">libreoffice-math</Dependency>
+            <Dependency releaseFrom="181">libreoffice-base</Dependency>
+            <Dependency releaseFrom="181">libreoffice-calc</Dependency>
+            <Dependency releaseFrom="181">libreoffice-common</Dependency>
+            <Dependency releaseFrom="181">libreoffice-common-dictionaries</Dependency>
+            <Dependency releaseFrom="181">libreoffice-draw</Dependency>
+            <Dependency releaseFrom="181">libreoffice-impress</Dependency>
+            <Dependency releaseFrom="181">libreoffice-math</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="doc">/usr/share/doc/libreoffice-all</Path>
@@ -43,8 +43,8 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency release="180">libreoffice-common</Dependency>
-            <Dependency releaseFrom="180">libreoffice-writer</Dependency>
+            <Dependency release="181">libreoffice-common</Dependency>
+            <Dependency releaseFrom="181">libreoffice-writer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/lobase</Path>
@@ -73,7 +73,7 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="180">libreoffice-common-help</Dependency>
+            <Dependency releaseFrom="181">libreoffice-common-help</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/help/am/sdatabase.cfg</Path>
@@ -687,7 +687,7 @@
         <Description xml:lang="en">Calc is the spreadsheet program you&apos;ve always needed.</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="180">libreoffice-writer</Dependency>
+            <Dependency releaseFrom="181">libreoffice-writer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/localc</Path>
@@ -963,7 +963,7 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="180">libreoffice-common-help</Dependency>
+            <Dependency releaseFrom="181">libreoffice-common-help</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/help/am/scalc.cfg</Path>
@@ -14713,7 +14713,7 @@
         <Description xml:lang="en">KDE integration for LibreOffice.</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency release="180">libreoffice-common</Dependency>
+            <Dependency release="181">libreoffice-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/program/libvclplug_kf6lo.so</Path>
@@ -14727,7 +14727,7 @@
         <Description xml:lang="en">Draw lets you produce anything from a quick sketch to a complex plan and gives you the means to communicate with graphics and diagrams.</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="180">libreoffice-writer</Dependency>
+            <Dependency releaseFrom="181">libreoffice-writer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/lodraw</Path>
@@ -14855,7 +14855,7 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="180">libreoffice-common-help</Dependency>
+            <Dependency releaseFrom="181">libreoffice-common-help</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/help/am/sdraw.cfg</Path>
@@ -15469,8 +15469,8 @@
         <Description xml:lang="en">Impress is a truly outstanding tool for creating effective multimedia presentations.</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="180">libreoffice-draw</Dependency>
-            <Dependency releaseFrom="180">libreoffice-writer</Dependency>
+            <Dependency releaseFrom="181">libreoffice-draw</Dependency>
+            <Dependency releaseFrom="181">libreoffice-writer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/loimpress</Path>
@@ -15652,7 +15652,7 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="180">libreoffice-common-help</Dependency>
+            <Dependency releaseFrom="181">libreoffice-common-help</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/help/am/simpress.cfg</Path>
@@ -16266,7 +16266,7 @@
         <Description xml:lang="en">Math is LibreOffice&apos;s formula editor.</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="180">libreoffice-writer</Dependency>
+            <Dependency releaseFrom="181">libreoffice-writer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/lomath</Path>
@@ -16313,7 +16313,7 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="180">libreoffice-common-help</Dependency>
+            <Dependency releaseFrom="181">libreoffice-common-help</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/help/am/smath.cfg</Path>
@@ -16927,7 +16927,7 @@
         <Description xml:lang="en">Writer has all the features you need from a modern, full-featured word processing and desktop publishing tool.</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="180">libreoffice-common</Dependency>
+            <Dependency releaseFrom="181">libreoffice-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/loweb</Path>
@@ -17261,7 +17261,7 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="180">libreoffice-common-help</Dependency>
+            <Dependency releaseFrom="181">libreoffice-common-help</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/help/am/swriter.cfg</Path>
@@ -17870,12 +17870,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="180">
-            <Date>2024-04-18</Date>
+        <Update release="181">
+            <Date>2024-05-17</Date>
             <Version>24.2.2.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Use the Elementary icon theme by default

Fixes https://github.com/getsolus/packages/issues/311

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Open Writer and switch the GTK theme on Budgie between different light and dark themes.

**Checklist**

- [x] Package was built and tested against unstable
