### PR TITLE
glib2: Backport patch for gmenuexporter

### DIFF
--- a/packages/g/glib2/files/0001-gmenuexporter-Fix-a-NULL-pointer-dereference.patch
+++ b/packages/g/glib2/files/0001-gmenuexporter-Fix-a-NULL-pointer-dereference.patch
@@ -1,0 +1,290 @@
+From 5f5667b2a0ae2cdf6d39f51afbc2bdca1947dfaf Mon Sep 17 00:00:00 2001
+From: Philip Withnall <pwithnall@gnome.org>
+Date: Wed, 15 May 2024 12:26:36 +0100
+Subject: [PATCH 1/2] gmenuexporter: Fix a NULL pointer dereference on an error
+ handling path
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This latent bug wasn’t triggered until commit 3f30ec86c (or its
+cherry-pick onto `glib-2-80`, 747e3af99, which was first released in
+2.80.1).
+
+That change means that `g_menu_exporter_free()` is now called on the
+registration failure path by `g_dbus_connection_register_object()`
+before it returns. The caller then tries to call `g_slice_free()` on the
+exporter again. The call to `g_menu_exporter_free()` tries to
+dereference/free members of the exporter which it expects to be
+initialised — but because this is happening in an error handling path,
+they are not initialised.
+
+If it were to get any further, the `g_slice_free()` would then be a
+double-free on the exporter allocation.
+
+Fix that by making `g_menu_exporter_free()` robust to some of the
+exporter members being `NULL`, and moving some of the initialisation
+code higher in `g_dbus_connection_export_menu_model()`, and removing the
+duplicate free code on the error handling path.
+
+This includes a unit test.
+
+Signed-off-by: Philip Withnall <pwithnall@gnome.org>
+
+Fixes: #3366
+---
+ gio/gmenuexporter.c    | 23 ++++++++---------------
+ gio/tests/gmenumodel.c | 37 +++++++++++++++++++++++++++++++++++++
+ 2 files changed, 45 insertions(+), 15 deletions(-)
+
+diff --git a/gio/gmenuexporter.c b/gio/gmenuexporter.c
+index 909780cb2c..1d4db13523 100644
+--- a/gio/gmenuexporter.c
++++ b/gio/gmenuexporter.c
+@@ -707,11 +707,9 @@ g_menu_exporter_create_group (GMenuExporter *exporter)
+ }
+ 
+ static void
+-g_menu_exporter_free (gpointer user_data)
++g_menu_exporter_free (GMenuExporter *exporter)
+ {
+-  GMenuExporter *exporter = user_data;
+-
+-  g_menu_exporter_menu_free (exporter->root);
++  g_clear_pointer (&exporter->root, g_menu_exporter_menu_free);
+   g_clear_pointer (&exporter->peer_remote, g_menu_exporter_remote_free);
+   g_hash_table_unref (exporter->remotes);
+   g_hash_table_unref (exporter->groups);
+@@ -794,21 +792,16 @@ g_dbus_connection_export_menu_model (GDBusConnection  *connection,
+   guint id;
+ 
+   exporter = g_slice_new0 (GMenuExporter);
+-
+-  id = g_dbus_connection_register_object (connection, object_path, org_gtk_Menus_get_interface (),
+-                                          &vtable, exporter, g_menu_exporter_free, error);
+-
+-  if (id == 0)
+-    {
+-      g_slice_free (GMenuExporter, exporter);
+-      return 0;
+-    }
+-
+   exporter->connection = g_object_ref (connection);
+   exporter->object_path = g_strdup (object_path);
+   exporter->groups = g_hash_table_new (NULL, NULL);
+   exporter->remotes = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_menu_exporter_remote_free);
+-  exporter->root = g_menu_exporter_group_add_menu (g_menu_exporter_create_group (exporter), menu);
++
++  id = g_dbus_connection_register_object (connection, object_path, org_gtk_Menus_get_interface (),
++                                          &vtable, exporter, (GDestroyNotify) g_menu_exporter_free, error);
++
++  if (id != 0)
++    exporter->root = g_menu_exporter_group_add_menu (g_menu_exporter_create_group (exporter), menu);
+ 
+   return id;
+ }
+diff --git a/gio/tests/gmenumodel.c b/gio/tests/gmenumodel.c
+index d75f36a297..22d1b4d61e 100644
+--- a/gio/tests/gmenumodel.c
++++ b/gio/tests/gmenumodel.c
+@@ -1159,6 +1159,42 @@ test_dbus_peer_subscriptions (void)
+ #endif
+ }
+ 
++static void
++test_dbus_export_error_handling (void)
++{
++  GRand *rand = NULL;
++  RandomMenu *menu = NULL;
++  GDBusConnection *bus;
++  GError *local_error = NULL;
++  guint id1, id2;
++
++  g_test_summary ("Test that error handling of menu model export failure works");
++  g_test_bug ("https://gitlab.gnome.org/GNOME/glib/-/issues/3366");
++
++  bus = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, NULL);
++
++  rand = g_rand_new_with_seed (g_test_rand_int ());
++  menu = random_menu_new (rand, 2);
++
++  id1 = g_dbus_connection_export_menu_model (bus, "/", G_MENU_MODEL (menu), &local_error);
++  g_assert_no_error (local_error);
++  g_assert_cmpuint (id1, !=, 0);
++
++  /* Trigger a failure by trying to export on a path which is already in use */
++  id2 = g_dbus_connection_export_menu_model (bus, "/", G_MENU_MODEL (menu), &local_error);
++  g_assert_error (local_error, G_IO_ERROR, G_IO_ERROR_EXISTS);
++  g_assert_cmpuint (id2, ==, 0);
++  g_clear_error (&local_error);
++
++  g_dbus_connection_unexport_menu_model (bus, id1);
++
++  while (g_main_context_iteration (NULL, FALSE));
++
++  g_clear_object (&menu);
++  g_rand_free (rand);
++  g_clear_object (&bus);
++}
++
+ static gpointer
+ do_modify (gpointer data)
+ {
+@@ -1658,6 +1694,7 @@ main (int argc, char **argv)
+   g_test_add_func ("/gmenu/dbus/threaded", test_dbus_threaded);
+   g_test_add_func ("/gmenu/dbus/peer/roundtrip", test_dbus_peer_roundtrip);
+   g_test_add_func ("/gmenu/dbus/peer/subscriptions", test_dbus_peer_subscriptions);
++  g_test_add_func ("/gmenu/dbus/export/error-handling", test_dbus_export_error_handling);
+   g_test_add_func ("/gmenu/attributes", test_attributes);
+   g_test_add_func ("/gmenu/attributes/iterate", test_attribute_iter);
+   g_test_add_func ("/gmenu/links", test_links);
+-- 
+GitLab
+
+
+From 043a06debb7a00530caa6194bf1b14b02200fae7 Mon Sep 17 00:00:00 2001
+From: Philip Withnall <pwithnall@gnome.org>
+Date: Wed, 15 May 2024 14:00:09 +0100
+Subject: [PATCH 2/2] gactiongroupexporter: Fix memory problems on an error
+ handling path
+
+Almost identically to the previous commit, fix a similar latent bug in
+`g_dbus_connection_export_action_group()`, which was not ready to handle
+the fledgling `GActionGroupExporter` being freed early on an error
+handling path.
+
+See the previous commit message for details of the approach.
+
+This includes a unit test.
+
+Signed-off-by: Philip Withnall <pwithnall@gnome.org>
+
+Fixes: #3366
+---
+ gio/gactiongroupexporter.c | 35 ++++++++++++++------------------
+ gio/tests/actions.c        | 41 ++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 56 insertions(+), 20 deletions(-)
+
+diff --git a/gio/gactiongroupexporter.c b/gio/gactiongroupexporter.c
+index 3ec1db224e..1e253ec88b 100644
+--- a/gio/gactiongroupexporter.c
++++ b/gio/gactiongroupexporter.c
+@@ -531,10 +531,8 @@ org_gtk_Actions_method_call (GDBusConnection       *connection,
+ }
+ 
+ static void
+-g_action_group_exporter_free (gpointer user_data)
++g_action_group_exporter_free (GActionGroupExporter *exporter)
+ {
+-  GActionGroupExporter *exporter = user_data;
+-
+   g_signal_handlers_disconnect_by_func (exporter->action_group,
+                                         g_action_group_exporter_action_added, exporter);
+   g_signal_handlers_disconnect_by_func (exporter->action_group,
+@@ -616,15 +614,6 @@ g_dbus_connection_export_action_group (GDBusConnection  *connection,
+     }
+ 
+   exporter = g_slice_new (GActionGroupExporter);
+-  id = g_dbus_connection_register_object (connection, object_path, org_gtk_Actions, &vtable,
+-                                          exporter, g_action_group_exporter_free, error);
+-
+-  if (id == 0)
+-    {
+-      g_slice_free (GActionGroupExporter, exporter);
+-      return 0;
+-    }
+-
+   exporter->context = g_main_context_ref_thread_default ();
+   exporter->pending_changes = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+   exporter->pending_source = NULL;
+@@ -632,14 +621,20 @@ g_dbus_connection_export_action_group (GDBusConnection  *connection,
+   exporter->connection = g_object_ref (connection);
+   exporter->object_path = g_strdup (object_path);
+ 
+-  g_signal_connect (action_group, "action-added",
+-                    G_CALLBACK (g_action_group_exporter_action_added), exporter);
+-  g_signal_connect (action_group, "action-removed",
+-                    G_CALLBACK (g_action_group_exporter_action_removed), exporter);
+-  g_signal_connect (action_group, "action-state-changed",
+-                    G_CALLBACK (g_action_group_exporter_action_state_changed), exporter);
+-  g_signal_connect (action_group, "action-enabled-changed",
+-                    G_CALLBACK (g_action_group_exporter_action_enabled_changed), exporter);
++  id = g_dbus_connection_register_object (connection, object_path, org_gtk_Actions, &vtable,
++                                          exporter, (GDestroyNotify) g_action_group_exporter_free, error);
++
++  if (id != 0)
++    {
++      g_signal_connect (action_group, "action-added",
++                        G_CALLBACK (g_action_group_exporter_action_added), exporter);
++      g_signal_connect (action_group, "action-removed",
++                        G_CALLBACK (g_action_group_exporter_action_removed), exporter);
++      g_signal_connect (action_group, "action-state-changed",
++                        G_CALLBACK (g_action_group_exporter_action_state_changed), exporter);
++      g_signal_connect (action_group, "action-enabled-changed",
++                        G_CALLBACK (g_action_group_exporter_action_enabled_changed), exporter);
++    }
+ 
+   return id;
+ }
+diff --git a/gio/tests/actions.c b/gio/tests/actions.c
+index a24c52c5e4..2b7a100fcf 100644
+--- a/gio/tests/actions.c
++++ b/gio/tests/actions.c
+@@ -1125,6 +1125,46 @@ test_dbus_export (void)
+   session_bus_down ();
+ }
+ 
++static void
++test_dbus_export_error_handling (void)
++{
++  GDBusConnection *bus = NULL;
++  GSimpleActionGroup *group = NULL;
++  GError *local_error = NULL;
++  guint id1, id2;
++
++  g_test_summary ("Test that error handling of action group export failure works");
++  g_test_bug ("https://gitlab.gnome.org/GNOME/glib/-/issues/3366");
++
++  session_bus_up ();
++  bus = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, NULL);
++
++  group = g_simple_action_group_new ();
++  g_simple_action_group_add_entries (group,
++                                     exported_entries,
++                                     G_N_ELEMENTS (exported_entries),
++                                     NULL);
++
++  id1 = g_dbus_connection_export_action_group (bus, "/", G_ACTION_GROUP (group), &local_error);
++  g_assert_no_error (local_error);
++  g_assert_cmpuint (id1, !=, 0);
++
++  /* Trigger a failure by trying to export on a path which is already in use */
++  id2 = g_dbus_connection_export_action_group (bus, "/", G_ACTION_GROUP (group), &local_error);
++  g_assert_error (local_error, G_IO_ERROR, G_IO_ERROR_EXISTS);
++  g_assert_cmpuint (id2, ==, 0);
++  g_clear_error (&local_error);
++
++  g_dbus_connection_unexport_action_group (bus, id1);
++
++  while (g_main_context_iteration (NULL, FALSE));
++
++  g_object_unref (group);
++  g_object_unref (bus);
++
++  session_bus_down ();
++}
++
+ static gpointer
+ do_export (gpointer data)
+ {
+@@ -1448,6 +1488,7 @@ main (int argc, char **argv)
+   g_test_add_func ("/actions/entries", test_entries);
+   g_test_add_func ("/actions/parse-detailed", test_parse_detailed);
+   g_test_add_func ("/actions/dbus/export", test_dbus_export);
++  g_test_add_func ("/actions/dbus/export/error-handling", test_dbus_export_error_handling);
+   g_test_add_func ("/actions/dbus/threaded", test_dbus_threaded);
+   g_test_add_func ("/actions/dbus/bug679509", test_bug679509);
+   g_test_add_func ("/actions/property", test_property_actions);
+-- 
+GitLab
+

--- a/packages/g/glib2/files/series
+++ b/packages/g/glib2/files/series
@@ -1,2 +1,3 @@
 0001-Support-stateless-XDG-and-snap-directories.patch
 0001-Add-additional-terminals-to-gio.patch
+0001-gmenuexporter-Fix-a-NULL-pointer-dereference.patch

--- a/packages/g/glib2/package.yml
+++ b/packages/g/glib2/package.yml
@@ -1,6 +1,6 @@
 name       : glib2
 version    : 2.80.2
-release    : 106
+release    : 107
 source     :
     - https://download.gnome.org/sources/glib/2.80/glib-2.80.2.tar.xz : b9cfb6f7a5bd5b31238fd5d56df226b2dda5ea37611475bf89f6a0f9400fe8bd
 homepage   : https://wiki.gnome.org/Projects/GLib

--- a/packages/g/glib2/pspec_x86_64.xml
+++ b/packages/g/glib2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>glib2</Name>
         <Homepage>https://wiki.gnome.org/Projects/GLib</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>system.base</PartOf>
@@ -204,7 +204,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="106">glib2</Dependency>
+            <Dependency release="107">glib2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/gio/modules</Path>
@@ -231,8 +231,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="106">glib2-32bit</Dependency>
-            <Dependency release="106">glib2-devel</Dependency>
+            <Dependency release="107">glib2-32bit</Dependency>
+            <Dependency release="107">glib2-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libgio-2.0.so</Path>
@@ -259,7 +259,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="106">glib2</Dependency>
+            <Dependency release="107">glib2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gio-unix-2.0/gio/gdesktopappinfo.h</Path>
@@ -589,12 +589,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="106">
-            <Date>2024-05-08</Date>
+        <Update release="107">
+            <Date>2024-05-17</Date>
             <Version>2.80.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Backport patch for a NULL dereference in gmenuexporter

Fixes https://github.com/getsolus/packages/issues/2532

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install this and `vala-panel-appmenu-budgie-desktop` and successfully open Inkscape.

**Checklist**

- [x] Package was built and tested against unstable
