### PR TITLE
minikube: Update to 1.33.1

### DIFF
--- a/packages/m/minikube/abi_used_symbols
+++ b/packages/m/minikube/abi_used_symbols
@@ -1,5 +1,10 @@
 libc.so.6:__errno_location
+libc.so.6:__libc_start_main
+libc.so.6:__stack_chk_fail
 libc.so.6:abort
+libc.so.6:close
+libc.so.6:exit
+libc.so.6:fork
 libc.so.6:fprintf
 libc.so.6:fputc
 libc.so.6:free
@@ -17,6 +22,7 @@ libc.so.6:malloc
 libc.so.6:mmap
 libc.so.6:munmap
 libc.so.6:nanosleep
+libc.so.6:open
 libc.so.6:pthread_attr_destroy
 libc.so.6:pthread_attr_getstack
 libc.so.6:pthread_attr_getstacksize
@@ -32,8 +38,19 @@ libc.so.6:pthread_mutex_unlock
 libc.so.6:pthread_self
 libc.so.6:pthread_setspecific
 libc.so.6:pthread_sigmask
+libc.so.6:read
 libc.so.6:res_search
+libc.so.6:setegid
 libc.so.6:setenv
+libc.so.6:seteuid
+libc.so.6:setgid
+libc.so.6:setgroups
+libc.so.6:setns
+libc.so.6:setregid
+libc.so.6:setresgid
+libc.so.6:setresuid
+libc.so.6:setreuid
+libc.so.6:setuid
 libc.so.6:sigaction
 libc.so.6:sigaddset
 libc.so.6:sigemptyset
@@ -43,4 +60,6 @@ libc.so.6:stderr
 libc.so.6:strerror
 libc.so.6:sysconf
 libc.so.6:unsetenv
+libc.so.6:vdprintf
 libc.so.6:vfprintf
+libc.so.6:write

--- a/packages/m/minikube/monitoring.yml
+++ b/packages/m/minikube/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 320530
+  rss: https://github.com/kubernetes/minikube/releases.atom
+security:
+  cpe:
+  - vendor: kubernetes
+    product: minikube

--- a/packages/m/minikube/package.yml
+++ b/packages/m/minikube/package.yml
@@ -1,38 +1,32 @@
 name       : minikube
-version    : 1.30.1
-release    : 47
+version    : 1.33.1
+release    : 48
 source     :
-    - git|https://github.com/kubernetes/minikube.git : v1.30.1
+    - https://github.com/kubernetes/minikube/archive/refs/tags/v1.33.1.tar.gz : c09715a884ffc9af49772e579d1932bdd0377c3346a5631d48ae23453ba6945b
 license    : Apache-2.0
 component  : system.utils
 summary    : Kubernetes development environment
+homepage   : https://minikube.sigs.k8s.io/
 networking : yes
-extract    : no
 description: |
     Minikube makes it easy to create all in one VirtualBox VMs with kubernetes for local development.
 builddeps  :
+    - git
     - golang
     - libvirt-devel
-environment: |
-    export GOPATH=$PKG_BUILD_DIR
-    export PATH=$PATH:$GOPATH/bin
-    export MINIKUBE=$GOPATH/src/k8s.io/minikube
-setup      : |
-    mkdir -p $MINIKUBE
-    cp -R $sources/minikube.git/* $MINIKUBE
 build      : |
-    cd $MINIKUBE
-    %make
+    set -e
+    GIT_COMMIT=$(git ls-remote https://github.com/kubernetes/minikube refs/tags/v$version | awk '{print $1}')
+    %make COMMIT="$GIT_COMMIT"
 check      : |
-    cd $MINIKUBE
     # This script needs to be run before `make test` to fix boilerplate for test
     hack/boilerplate/fix.sh
     %make -j2 test
 install    : |
     install -D -d -m 00755 $installdir/usr/bin
-    install -D -m 00755 $MINIKUBE/out/minikube $installdir/usr/bin/minikube
+    install -D -m 00755 out/minikube $installdir/usr/bin/minikube
     # Install completion scripts
-    $MINIKUBE/out/minikube completion bash > minikube-bash-completion
-    $MINIKUBE/out/minikube completion zsh > minikube-zsh-completion
+    out/minikube completion bash > minikube-bash-completion
+    out/minikube completion zsh > minikube-zsh-completion
     install -Dm00644 minikube-bash-completion $installdir/usr/share/bash-completion/completions/minikube
     install -Dm00644 minikube-zsh-completion $installdir/usr/share/zsh/site-functions/_minikube

--- a/packages/m/minikube/pspec_x86_64.xml
+++ b/packages/m/minikube/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>minikube</Name>
+        <Homepage>https://minikube.sigs.k8s.io/</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Mislav &#x10c;akari&#x107;</Name>
+            <Email>mcakaric@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">Kubernetes development environment</Summary>
         <Description xml:lang="en">Minikube makes it easy to create all in one VirtualBox VMs with kubernetes for local development.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>minikube</Name>
@@ -25,12 +26,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="47">
-            <Date>2023-09-16</Date>
-            <Version>1.30.1</Version>
+        <Update release="48">
+            <Date>2024-05-18</Date>
+            <Version>1.33.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Mislav &#x10c;akari&#x107;</Name>
+            <Email>mcakaric@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Simplified build (removed GOPATH)
Changed to tarball sources.
Added homepage
Added monitoring.yml

- Resolves #2598

Release notes can be found [here](https://github.com/kubernetes/minikube/blob/v1.33.1/CHANGELOG.md).

**Test Plan**
Run few minikube commands:
- `minikube start`
- list pods using kubectl: `kubectl get pods --all-namespaces`
- `minikube dashboard`
- `minikube stop`
- `minikube delete`

**Checklist**
- [x] Package was built and tested against unstable
