### PR TITLE
zim-tools: Update to 3.4.1

### DIFF
--- a/packages/z/zim-tools/abi_used_symbols
+++ b/packages/z/zim-tools/abi_used_symbols
@@ -308,5 +308,6 @@ libzim.so.9:_ZNK3zim7Archive17getMainEntryIndexEv
 libzim.so.9:_ZNK3zim7Archive19getIllustrationItemEj
 libzim.so.9:_ZNK3zim7Archive20getIllustrationSizesEv
 libzim.so.9:_ZNK3zim7Archive21hasNewNamespaceSchemeEv
+libzim.so.9:_ZNK3zim7Archive27getEntryByPathWithNamespaceEcRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
 libzim.so.9:_ZNK3zim7Archive5checkEv
 libzim.so.9:_ZNK3zim7Archive7getUuidEv

--- a/packages/z/zim-tools/package.yml
+++ b/packages/z/zim-tools/package.yml
@@ -1,8 +1,8 @@
 name       : zim-tools
-version    : 3.4.0
-release    : 12
+version    : 3.4.1
+release    : 13
 source     :
-    - https://github.com/openzim/zim-tools/archive/refs/tags/3.4.0.tar.gz : 20e686e834867f33e35e6a48f5b4ddc5dc83842340ba3281c611fca9859e8f99
+    - https://github.com/openzim/zim-tools/archive/refs/tags/3.4.1.tar.gz : 0ee5a761c73dee4ec63263ba4b45cbedab77aff00bdeb765ae8250243b873928
     - git|https://github.com/kainjow/Mustache : v4.1
 homepage   : https://github.com/openzim/zim-tools/
 license    : GPL-3.0-only

--- a/packages/z/zim-tools/pspec_x86_64.xml
+++ b/packages/z/zim-tools/pspec_x86_64.xml
@@ -32,9 +32,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2024-05-04</Date>
-            <Version>3.4.0</Version>
+        <Update release="13">
+            <Date>2024-05-18</Date>
+            <Version>3.4.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- zimsplit: stop creating trailing empty chunk
- zimdump: Respecting the --ns option in zimdump show
- Introduce max libzim version check in compilation

**Test Plan**
- zimwriterfs -j -J 12 -w index.html -I logo.png -l ukr -n "${desc}" -t "${desc}" -d "${desc}" -L "${desc}" -c "${desc}" -p "${desc}" ./texts ./texts.zim

**Checklist**
- [X] Package was built and tested against unstable
