### PR TITLE
nethogs: Update to 0.8.7

### DIFF
--- a/packages/n/nethogs/abi_used_symbols
+++ b/packages/n/nethogs/abi_used_symbols
@@ -3,13 +3,15 @@ libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__vfprintf_chk
+libc.so.6:clock_gettime
 libc.so.6:close
 libc.so.6:closedir
 libc.so.6:exit
@@ -26,7 +28,7 @@ libc.so.6:geteuid
 libc.so.6:getifaddrs
 libc.so.6:getopt
 libc.so.6:getpwuid
-libc.so.6:getxattr
+libc.so.6:index
 libc.so.6:inet_ntoa
 libc.so.6:inet_ntop
 libc.so.6:malloc
@@ -43,6 +45,7 @@ libc.so.6:qsort
 libc.so.6:read
 libc.so.6:readdir
 libc.so.6:readlink
+libc.so.6:rindex
 libc.so.6:select
 libc.so.6:signal
 libc.so.6:stat
@@ -53,7 +56,6 @@ libc.so.6:strdup
 libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncmp
-libc.so.6:strtol
 libc.so.6:time
 libc.so.6:usleep
 libc.so.6:write
@@ -62,6 +64,8 @@ libncursesw.so.6:cbreak
 libncursesw.so.6:clear
 libncursesw.so.6:endwin
 libncursesw.so.6:erase
+libncursesw.so.6:getmaxx
+libncursesw.so.6:getmaxy
 libncursesw.so.6:initscr
 libncursesw.so.6:mvprintw
 libncursesw.so.6:nodelay
@@ -105,8 +109,6 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createER
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEEC1Ev
 libstdc++.so.6:_ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEED1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitC1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitD1Ev
 libstdc++.so.6:_ZNSt8ios_baseC2Ev
 libstdc++.so.6:_ZNSt8ios_baseD2Ev
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE4initEPSt15basic_streambufIcS1_E
@@ -114,13 +116,15 @@ libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE5clearESt12_Ios_Iostate
 libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
 libstdc++.so.6:_ZSt16__throw_bad_castv
 libstdc++.so.6:_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
+libstdc++.so.6:_ZSt18_Rb_tree_incrementPKSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
+libstdc++.so.6:_ZSt21ios_base_library_initv
+libstdc++.so.6:_ZSt28_Rb_tree_rebalance_for_erasePSt18_Rb_tree_node_baseRS_
 libstdc++.so.6:_ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_
 libstdc++.so.6:_ZSt4cerr
 libstdc++.so.6:_ZSt4cout
-libstdc++.so.6:_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
 libstdc++.so.6:_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
 libstdc++.so.6:_ZTIPKc
 libstdc++.so.6:_ZTTNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEEE

--- a/packages/n/nethogs/monitoring.yml
+++ b/packages/n/nethogs/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 2065
+  rss: https://github.com/raboof/nethogs/tags.atom
+# No known CPE, checked 2024-05-18
+security:
+  cpe: ~

--- a/packages/n/nethogs/package.yml
+++ b/packages/n/nethogs/package.yml
@@ -1,8 +1,9 @@
 name       : nethogs
-version    : 0.8.6
-release    : 4
+version    : 0.8.7
+release    : 5
 source     :
-    - https://github.com/raboof/nethogs/archive/refs/tags/v0.8.6.tar.gz : 317c1d5235d4be677e494e931c41d063a783ac0ac51e35e345e621d261c2e5a0
+    - https://github.com/raboof/nethogs/archive/refs/tags/v0.8.7.tar.gz : 957d6afcc220dfbba44c819162f44818051c5b4fb793c47ba98294393986617d
+homepage   : https://github.com/raboof/nethogs/
 license    : GPL-2.0-or-later
 component  : network.util
 summary    : NetHogs is a small net top tool

--- a/packages/n/nethogs/pspec_x86_64.xml
+++ b/packages/n/nethogs/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>nethogs</Name>
+        <Homepage>https://github.com/raboof/nethogs/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>network.util</PartOf>
         <Summary xml:lang="en">NetHogs is a small net top tool</Summary>
         <Description xml:lang="en">NetHogs is a small net top tool
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>nethogs</Name>
@@ -24,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2022-03-25</Date>
-            <Version>0.8.6</Version>
+        <Update release="5">
+            <Date>2024-05-18</Date>
+            <Version>0.8.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Full release note can be found [here](https://github.com/raboof/nethogs/releases/tag/v0.8.7)
- Add `homepage` key to `package.yml` (Part of getsolus/packages#411)
- Add monitoring.yml

**Test Plan**

<!-- Short description of how the package was tested -->
Run `sudo nethogs -a enp2s0`

**Checklist**

- [x] Package was built and tested against unstable
