### PR TITLE
freeimage: Build with fatfakeroot to fix symlinks

### DIFF
--- a/packages/f/freeimage/package.yml
+++ b/packages/f/freeimage/package.yml
@@ -1,6 +1,6 @@
 name       : freeimage
 version    : 3.18.0
-release    : 10
+release    : 11
 source     :
     - https://netcologne.dl.sourceforge.net/project/freeimage/Source%20Distribution/3.18.0/FreeImage3180.zip : f41379682f9ada94ea7b34fe86bf9ee00935a3147be41b6569c9605a53e438fd
 homepage   : https://freeimage.sourceforge.io/
@@ -21,6 +21,7 @@ builddeps  :
     - doxygen
     - jxrlib-devel
 libsplit   : no
+fatfakeroot: yes
 setup      : |
     %apply_patches
 

--- a/packages/f/freeimage/pspec_x86_64.xml
+++ b/packages/f/freeimage/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>freeimage</Name>
         <Homepage>https://freeimage.sourceforge.io/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>multimedia.library</PartOf>
@@ -35,7 +35,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">freeimage</Dependency>
+            <Dependency release="11">freeimage</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/FreeImage.h</Path>
@@ -45,12 +45,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2024-05-14</Date>
+        <Update release="11">
+            <Date>2024-05-19</Date>
             <Version>3.18.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Without this `ypkg` option the resulting symlinks get mangled

Issue found by @cmarincia:matrix.org during `freecad` build

tree view before:
```
/home/build/YPKG/root/freeimage/install
└── usr
    ├── include
    │   ├── FreeImage.h
    │   └── FreeImagePlus.h
    └── lib
        ├── libfreeimage-3.18.0.so
        ├── libfreeimage.a
        ├── libfreeimageplus-3.18.0.so
        ├── libfreeimageplus.a
        ├── libfreeimageplus.so
        ├── libfreeimageplus.so.3
        ├── libfreeimage.so
        └── libfreeimage.so.3 -> libfreeimage-3.18.0.so
```
tree view after:
```
/home/build/YPKG/root/freeimage/install
└── usr
    ├── include
    │   ├── FreeImage.h
    │   └── FreeImagePlus.h
    └── lib64
        ├── libfreeimage-3.18.0.so
        ├── libfreeimage.a
        ├── libfreeimageplus-3.18.0.so
        ├── libfreeimageplus.a
        ├── libfreeimageplus.so -> libfreeimageplus-3.18.0.so
        ├── libfreeimageplus.so.3 -> libfreeimageplus-3.18.0.so
        ├── libfreeimage.so -> libfreeimage-3.18.0.so
        └── libfreeimage.so.3 -> libfreeimage-3.18.0.so
```

**Test Plan**

- Confirmed symlinks are created
- Started a freecad built and confirmed it went past the point of error caused by original symlink issue

**Checklist**

- [x] Package was built and tested against unstable
