### PR TITLE
pangox-compat: Add homepage & monitoring.yml

### DIFF
--- a/packages/p/pangox-compat/abi_used_symbols
+++ b/packages/p/pangox-compat/abi_used_symbols
@@ -102,8 +102,6 @@ libgobject-2.0.so.0:g_object_remove_weak_pointer
 libgobject-2.0.so.0:g_object_set_qdata_full
 libgobject-2.0.so.0:g_object_steal_qdata
 libgobject-2.0.so.0:g_object_unref
-libgobject-2.0.so.0:g_type_check_class_cast
-libgobject-2.0.so.0:g_type_check_instance_cast
 libgobject-2.0.so.0:g_type_check_instance_is_a
 libgobject-2.0.so.0:g_type_class_peek_parent
 libgobject-2.0.so.0:g_type_init

--- a/packages/p/pangox-compat/monitoring.yml
+++ b/packages/p/pangox-compat/monitoring.yml
@@ -1,0 +1,5 @@
+releases:
+  id: 230485
+# No known CPE, checked 2024-05-21
+security:
+  cpe: ~

--- a/packages/p/pangox-compat/package.yml
+++ b/packages/p/pangox-compat/package.yml
@@ -1,8 +1,9 @@
 name       : pangox-compat
 version    : 0.0.2
-release    : 3
+release    : 4
 source     :
     - git|https://gitlab.gnome.org/Archive/pangox-compat.git : edb9e0904d04d1da02bba7b78601a2aba05aaa47
+homepage   : https://gitlab.gnome.org/Archive/pangox-compat
 license    : LGPL-2.0
 component  : desktop.gtk
 summary    : X Window System font support for Pango

--- a/packages/p/pangox-compat/pspec_x86_64.xml
+++ b/packages/p/pangox-compat/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>pangox-compat</Name>
+        <Homepage>https://gitlab.gnome.org/Archive/pangox-compat</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>antoine serveaux</Name>
+            <Email>solus@foxfire.mozmail.com</Email>
         </Packager>
         <License>LGPL-2.0</License>
         <PartOf>desktop.gtk</PartOf>
         <Summary xml:lang="en">X Window System font support for Pango</Summary>
         <Description xml:lang="en">X Window System font support for Pango
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>pangox-compat</Name>
@@ -32,7 +33,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="3">pangox-compat</Dependency>
+            <Dependency release="4">pangox-compat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/pango-1.0/pango/pangox.h</Path>
@@ -40,12 +41,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2022-04-06</Date>
+        <Update release="4">
+            <Date>2024-05-21</Date>
             <Version>0.0.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>antoine serveaux</Name>
+            <Email>solus@foxfire.mozmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Added `homepage` key to `package.yml` (part of getsolus/packages#411)
- Added `monitoring.yml` file with `Anitya ID` (no other key found)

**Test Plan**

Built, used it to build only reverse depency `gtkglext`, used it with
package `celestia` without notable issue.

**Checklist**

- [x] Package was built and tested against unstable

