### PR TITLE
bash: Build with PGO, don't build with Os

### DIFF
--- a/packages/b/bash/abi_used_symbols
+++ b/packages/b/bash/abi_used_symbols
@@ -2,6 +2,7 @@ libc.so.6:__asprintf_chk
 libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_get_mb_cur_max
 libc.so.6:__ctype_tolower_loc
+libc.so.6:__ctype_toupper_loc
 libc.so.6:__environ
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
@@ -13,6 +14,7 @@ libc.so.6:__libc_current_sigrtmax
 libc.so.6:__libc_current_sigrtmin
 libc.so.6:__libc_start_main
 libc.so.6:__longjmp_chk
+libc.so.6:__mbrlen
 libc.so.6:__memcpy_chk
 libc.so.6:__memmove_chk
 libc.so.6:__printf_chk
@@ -30,7 +32,6 @@ libc.so.6:accept
 libc.so.6:access
 libc.so.6:alarm
 libc.so.6:arc4random
-libc.so.6:atoi
 libc.so.6:bind
 libc.so.6:bindtextdomain
 libc.so.6:chdir
@@ -73,6 +74,7 @@ libc.so.6:fputs
 libc.so.6:free
 libc.so.6:freeaddrinfo
 libc.so.6:fstat
+libc.so.6:fwrite
 libc.so.6:gai_strerror
 libc.so.6:getaddrinfo
 libc.so.6:getc
@@ -98,9 +100,6 @@ libc.so.6:getrusage
 libc.so.6:getservent
 libc.so.6:gettimeofday
 libc.so.6:getuid
-libc.so.6:gnu_dev_major
-libc.so.6:gnu_dev_makedev
-libc.so.6:gnu_dev_minor
 libc.so.6:iconv
 libc.so.6:iconv_close
 libc.so.6:iconv_open
@@ -124,7 +123,6 @@ libc.so.6:lseek
 libc.so.6:lstat
 libc.so.6:malloc
 libc.so.6:mblen
-libc.so.6:mbrlen
 libc.so.6:mbrtowc
 libc.so.6:mbsinit
 libc.so.6:mbsnrtowcs
@@ -132,7 +130,9 @@ libc.so.6:mbsrtowcs
 libc.so.6:mbstowcs
 libc.so.6:mbtowc
 libc.so.6:memchr
+libc.so.6:memcpy
 libc.so.6:memmove
+libc.so.6:memset
 libc.so.6:mkdir
 libc.so.6:mkdtemp
 libc.so.6:mkfifo
@@ -215,8 +215,6 @@ libc.so.6:tcsetattr
 libc.so.6:tcsetpgrp
 libc.so.6:textdomain
 libc.so.6:time
-libc.so.6:tolower
-libc.so.6:toupper
 libc.so.6:towlower
 libc.so.6:towupper
 libc.so.6:ttyname

--- a/packages/b/bash/package.yml
+++ b/packages/b/bash/package.yml
@@ -1,6 +1,6 @@
 name       : bash
 version    : 5.2.26
-release    : 76
+release    : 77
 source     :
     - https://ftp.gnu.org/gnu/bash/bash-5.2.21.tar.gz : c8e31bdc59b69aaffc5b36509905ba3e5cbb12747091d27b4b977f078560d5b8
 license    :
@@ -13,11 +13,13 @@ summary    :
 description: |
     bash (sh-compatible shell) The GNU Bourne-Again SHell.  Bash is a sh-compatible command interpreter that executes commands read from the standard input or from a file.  Bash also incorporates useful features from the Korn and C shells (ksh and csh).  Bash is ultimately intended to be a conformant implementation of the IEEE Posix Shell and Tools specification (IEEE Working Group 1003.2). Bash must be present for the system to boot properly.
 optimize   :
-    - size
     - lto
 environment: |
     export CFLAGS="$CFLAGS -DRECYCLES_PIDS -DSYSLOG_HISTORY -DSYSLOG_SHOPT=0"
 setup      : |
+    # often hangs
+    rm tests/run-jobs
+
     %apply_patches
     %configure \
                --with-curses \
@@ -29,6 +31,8 @@ setup      : |
                --docdir=/usr/share/doc/bash
 build      : |
     %make
+profile    : |
+    %make check
 install    : |
     %make_install
 
@@ -52,3 +56,6 @@ install    : |
 
     # Use tmpfiles to create the symlink in order to make this completely stateless
     install -Dm00644 $pkgfiles/bash.tmpfiles $installdir/%libdir%/tmpfiles.d/bash.conf
+check    : |
+    unset LD_PRELOAD
+    %make check

--- a/packages/b/bash/pspec_x86_64.xml
+++ b/packages/b/bash/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>bash</Name>
         <Homepage>https://www.gnu.org/software/bash</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -133,7 +133,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="76">bash</Dependency>
+            <Dependency release="77">bash</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/bash/alias.h</Path>
@@ -199,12 +199,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="76">
-            <Date>2024-05-13</Date>
+        <Update release="77">
+            <Date>2024-05-22</Date>
             <Version>5.2.26</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Package Size**
- Before: 9.68 MB | Now: 9.82 MB

**Benchmarks**
1. Startup speed
```
for i in $(seq 1 1000); do bash -c ":" ; done
```

Before: 1.409 s | Now: 1.366 s

2. [Shellbench](https://github.com/shellspec/shellbench/tree/master)
```
                                  Before  Now
assign.sh: positional params      316,022 507,648
assign.sh: variable               451,756 725,583
assign.sh: local var              446,787 701,773
assign.sh: local var (typeset)    439,330 702,822
cmp.sh: [ ]                       250,852 395,695
cmp.sh: [[ ]]                     338,354 554,369
cmp.sh: case                      436,122 711,621
count.sh: posix                   332,163 527,900
count.sh: typeset -i              316,652 496,712
count.sh: increment               407,441 661,571
eval.sh: direct assign            226,263 339,881
eval.sh: eval assign              131,076 196,883
eval.sh: command subs               2,321 2,317
func.sh: no func                  431,823 688,870
func.sh: func                     244,420 382,132
null.sh: blank                      error error
null.sh: assign variable          461,359 736,605
null.sh: define function          491,123 753,272
null.sh: undefined variable       368,451 590,069
null.sh: : command                417,390 707,977
output.sh: echo                   277,341 424,113
output.sh: printf                 269,745 413,718
output.sh: print                    error error
subshell.sh: no subshell          401,630 644,312
subshell.sh: brace                394,647 643,771
subshell.sh: subshell               2,323 2,332
subshell.sh: command subs           2,015 2,151
subshell.sh: external command       1,272 1,336
```

**Test Plan**

Use as normal

**Checklist**

- [x] Package was built and tested against unstable
