### PR TITLE
libfprint: Update to 1.94.7

### DIFF
--- a/packages/l/libfprint/abi_used_symbols
+++ b/packages/l/libfprint/abi_used_symbols
@@ -1,6 +1,6 @@
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
 libc.so.6:__memcpy_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:calloc
@@ -14,9 +14,12 @@ libc.so.6:memmove
 libc.so.6:memset
 libc.so.6:open64
 libc.so.6:qsort
+libc.so.6:read
 libc.so.6:stderr
+libc.so.6:strcmp
 libc.so.6:strlen
 libc.so.6:strncmp
+libc.so.6:strncpy
 libc.so.6:strstr
 libc.so.6:write
 libgio-2.0.so.0:g_async_initable_get_type
@@ -28,7 +31,6 @@ libgio-2.0.so.0:g_cancellable_disconnect
 libgio-2.0.so.0:g_cancellable_is_cancelled
 libgio-2.0.so.0:g_cancellable_new
 libgio-2.0.so.0:g_cancellable_set_error_if_cancelled
-libgio-2.0.so.0:g_input_stream_get_type
 libgio-2.0.so.0:g_input_stream_read_all_async
 libgio-2.0.so.0:g_input_stream_read_all_finish
 libgio-2.0.so.0:g_input_stream_read_async
@@ -38,7 +40,6 @@ libgio-2.0.so.0:g_io_error_quark
 libgio-2.0.so.0:g_io_stream_close
 libgio-2.0.so.0:g_io_stream_get_input_stream
 libgio-2.0.so.0:g_io_stream_get_output_stream
-libgio-2.0.so.0:g_io_stream_get_type
 libgio-2.0.so.0:g_io_stream_is_closed
 libgio-2.0.so.0:g_output_stream_write_all
 libgio-2.0.so.0:g_socket_listener_accept_async
@@ -52,8 +53,8 @@ libgio-2.0.so.0:g_task_get_completed
 libgio-2.0.so.0:g_task_get_context
 libgio-2.0.so.0:g_task_get_priority
 libgio-2.0.so.0:g_task_get_source_object
+libgio-2.0.so.0:g_task_get_source_tag
 libgio-2.0.so.0:g_task_get_task_data
-libgio-2.0.so.0:g_task_get_type
 libgio-2.0.so.0:g_task_had_error
 libgio-2.0.so.0:g_task_is_valid
 libgio-2.0.so.0:g_task_new
@@ -68,6 +69,8 @@ libgio-2.0.so.0:g_task_return_new_error
 libgio-2.0.so.0:g_task_return_pointer
 libgio-2.0.so.0:g_task_run_in_thread
 libgio-2.0.so.0:g_task_run_in_thread_sync
+libgio-2.0.so.0:g_task_set_check_cancellable
+libgio-2.0.so.0:g_task_set_source_tag
 libgio-2.0.so.0:g_task_set_task_data
 libgio-2.0.so.0:g_unix_socket_address_new
 libglib-2.0.so.0:g_array_append_vals
@@ -84,6 +87,7 @@ libglib-2.0.so.0:g_byte_array_append
 libglib-2.0.so.0:g_byte_array_new
 libglib-2.0.so.0:g_byte_array_set_size
 libglib-2.0.so.0:g_byte_array_unref
+libglib-2.0.so.0:g_bytes_get_size
 libglib-2.0.so.0:g_clear_error
 libglib-2.0.so.0:g_date_copy
 libglib-2.0.so.0:g_date_free
@@ -127,7 +131,7 @@ libglib-2.0.so.0:g_main_context_iteration
 libglib-2.0.so.0:g_malloc
 libglib-2.0.so.0:g_malloc0
 libglib-2.0.so.0:g_malloc0_n
-libglib-2.0.so.0:g_memdup
+libglib-2.0.so.0:g_memdup2
 libglib-2.0.so.0:g_nullify_pointer
 libglib-2.0.so.0:g_once_init_enter
 libglib-2.0.so.0:g_once_init_leave
@@ -138,8 +142,10 @@ libglib-2.0.so.0:g_ptr_array_find_with_equal_func
 libglib-2.0.so.0:g_ptr_array_insert
 libglib-2.0.so.0:g_ptr_array_new_full
 libglib-2.0.so.0:g_ptr_array_new_with_free_func
+libglib-2.0.so.0:g_ptr_array_ref
 libglib-2.0.so.0:g_ptr_array_remove_index
 libglib-2.0.so.0:g_ptr_array_remove_index_fast
+libglib-2.0.so.0:g_ptr_array_sized_new
 libglib-2.0.so.0:g_ptr_array_unref
 libglib-2.0.so.0:g_qsort_with_data
 libglib-2.0.so.0:g_quark_from_static_string
@@ -176,8 +182,8 @@ libglib-2.0.so.0:g_source_set_ready_time
 libglib-2.0.so.0:g_source_unref
 libglib-2.0.so.0:g_str_equal
 libglib-2.0.so.0:g_str_has_prefix
-libglib-2.0.so.0:g_str_has_suffix
 libglib-2.0.so.0:g_str_hash
+libglib-2.0.so.0:g_strchomp
 libglib-2.0.so.0:g_strcmp0
 libglib-2.0.so.0:g_strconcat
 libglib-2.0.so.0:g_strdup
@@ -190,6 +196,7 @@ libglib-2.0.so.0:g_string_prepend
 libglib-2.0.so.0:g_string_set_size
 libglib-2.0.so.0:g_strndup
 libglib-2.0.so.0:g_strsplit
+libglib-2.0.so.0:g_strv_contains
 libglib-2.0.so.0:g_timeout_add
 libglib-2.0.so.0:g_timer_destroy
 libglib-2.0.so.0:g_timer_elapsed
@@ -258,9 +265,7 @@ libgobject-2.0.so.0:g_signal_emit_by_name
 libgobject-2.0.so.0:g_signal_new
 libgobject-2.0.so.0:g_type_add_instance_private
 libgobject-2.0.so.0:g_type_add_interface_static
-libgobject-2.0.so.0:g_type_check_class_cast
 libgobject-2.0.so.0:g_type_check_class_is_a
-libgobject-2.0.so.0:g_type_check_instance_cast
 libgobject-2.0.so.0:g_type_check_instance_is_a
 libgobject-2.0.so.0:g_type_class_adjust_private_offset
 libgobject-2.0.so.0:g_type_class_get_instance_private_offset
@@ -314,6 +319,7 @@ libgusb.so.2:g_usb_device_get_interfaces
 libgusb.so.2:g_usb_device_get_parent
 libgusb.so.2:g_usb_device_get_pid
 libgusb.so.2:g_usb_device_get_port_number
+libgusb.so.2:g_usb_device_get_product_index
 libgusb.so.2:g_usb_device_get_release
 libgusb.so.2:g_usb_device_get_serial_number_index
 libgusb.so.2:g_usb_device_get_string_descriptor
@@ -326,7 +332,17 @@ libgusb.so.2:g_usb_device_open
 libgusb.so.2:g_usb_device_release_interface
 libgusb.so.2:g_usb_device_reset
 libgusb.so.2:g_usb_device_set_configuration
+libgusb.so.2:g_usb_endpoint_get_address
+libgusb.so.2:g_usb_endpoint_get_direction
+libgusb.so.2:g_usb_endpoint_get_extra
+libgusb.so.2:g_usb_endpoint_get_kind
+libgusb.so.2:g_usb_endpoint_get_maximum_packet_size
+libgusb.so.2:g_usb_endpoint_get_number
+libgusb.so.2:g_usb_endpoint_get_polling_interval
+libgusb.so.2:g_usb_endpoint_get_refresh
+libgusb.so.2:g_usb_endpoint_get_synch_address
 libgusb.so.2:g_usb_interface_get_class
+libgusb.so.2:g_usb_interface_get_endpoints
 libgusb.so.2:g_usb_interface_get_number
 libgusb.so.2:g_usb_interface_get_protocol
 libgusb.so.2:g_usb_interface_get_subclass
@@ -338,6 +354,7 @@ libm.so.6:log
 libm.so.6:sincos
 libm.so.6:sqrt
 libnss3.so:NSS_NoDB_Init
+libnss3.so:NSS_Shutdown
 libnss3.so:PK11_CipherOp
 libnss3.so:PK11_CreateContextBySymKey
 libnss3.so:PK11_DestroyContext

--- a/packages/l/libfprint/monitoring.yml
+++ b/packages/l/libfprint/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 1615
+  rss: https://gitlab.freedesktop.org/api/v4/projects/libfprint%2Flibfprint/repository/tags.atom
+# No known CPE, checked 2024-05-22
+security:
+  cpe: ~

--- a/packages/l/libfprint/package.yml
+++ b/packages/l/libfprint/package.yml
@@ -1,21 +1,26 @@
 name       : libfprint
-version    : 1.94.3
-release    : 6
+version    : 1.94.7
+release    : 7
 source     :
-    - https://gitlab.freedesktop.org/libfprint/libfprint/-/archive/v1.94.3/libfprint-v1.94.3.tar.bz2 : bbd33aa6e92164289e85689e40162c3dfe8f11a8052f5cbd3021c00bfa1eb726
+    - https://gitlab.freedesktop.org/libfprint/libfprint/-/archive/v1.94.7/libfprint-v1.94.7.tar.bz2 : 632ddf4e294b12eb73d5971db7b9ec5e051c52131302fd34f539a20db4b0f9db
+homepage   : https://fprint.freedesktop.org/
 license    : LGPL-2.1-or-later
 component  : desktop.library
 summary    : Library for fingerprint readers
 description: |
     libfprint is an open source software library designed to make it easy for application developers to add support for consumer fingerprint readers to their software.
 builddeps  :
+    - pkgconfig(cairo)
     - pkgconfig(gtk-doc)
     - pkgconfig(gusb)
     - pkgconfig(nss)
     - pkgconfig(pixman-1)
     - pkgconfig(xv)
+    - python-cairo
+    - python-gobject
+    - umockdev
 setup      : |
-    %meson_configure -Ddrivers=all
+    %meson_configure -Ddrivers=all -Dinstalled-tests=false
 build      : |
     %ninja_build
 install    : |

--- a/packages/l/libfprint/pspec_x86_64.xml
+++ b/packages/l/libfprint/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>libfprint</Name>
+        <Homepage>https://fprint.freedesktop.org/</Homepage>
         <Packager>
-            <Name>F. von Gellhorn</Name>
-            <Email>flinux@vongellhorn.ch</Email>
+            <Name>Mislav &#x10c;akari&#x107;</Name>
+            <Email>mcakaric@gmail.com</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>desktop.library</PartOf>
         <Summary xml:lang="en">Library for fingerprint readers</Summary>
         <Description xml:lang="en">libfprint is an open source software library designed to make it easy for application developers to add support for consumer fingerprint readers to their software.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>libfprint</Name>
@@ -33,7 +34,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="6">libfprint</Dependency>
+            <Dependency release="7">libfprint</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libfprint-2/fp-context.h</Path>
@@ -94,12 +95,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2022-03-22</Date>
-            <Version>1.94.3</Version>
+        <Update release="7">
+            <Date>2024-05-22</Date>
+            <Version>1.94.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>F. von Gellhorn</Name>
-            <Email>flinux@vongellhorn.ch</Email>
+            <Name>Mislav &#x10c;akari&#x107;</Name>
+            <Email>mcakaric@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Added monitoring.yml
[Changelog 1.94.7](https://gitlab.freedesktop.org/libfprint/libfprint/-/releases/v1.94.7)
[Changelog 1.94.6](https://gitlab.freedesktop.org/libfprint/libfprint/-/releases/v1.94.6)
[Changelog 1.94.5](https://gitlab.freedesktop.org/libfprint/libfprint/-/releases/v1.94.5)
[Changelog 1.94.4](https://gitlab.freedesktop.org/libfprint/libfprint/-/releases/v1.94.4)

**Test Plan**
fprintd-enroll

**Checklist**

- [x] Package was built and tested against unstable
