### PR TITLE
Taskfile.yml: Add clean-local command

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -242,6 +242,13 @@ tasks:
     dir: '{{ .TASKFILE_DIR }}'
     cmds:
       - find $(git rev-parse --show-toplevel) -type f -name '*.eopkg' -print
+  
+  clean-local:
+    desc: WARNING - Clean ALL eopkgs found in solbuild local repository /var/lib/solbuild/local
+    prompt: This will clean ALL eopkgs found in solbuild local repository /var/lib/solbuild/local. Continue?
+    cmds:
+      - sudo rm /var/lib/solbuild/local/*.eopkg
+      - task: build-localindex
 
   init:
     desc: Initialize the packages repo


### PR DESCRIPTION
Add a new go-task command that nukes eopkgs from local repository and then rebuilds the local repository.
