### PR TITLE
Taskfile: List *.eopkg files in tree before removal

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -219,17 +219,29 @@ tasks:
       - "{{ .TASKFILE_DIR }}/common/CI/package_checks.py --modified --untracked --base origin/main {{.CLI_ARGS}}"
 
   clean:
-    desc: Clean current tree
+    desc: Clean .eopkgs found in the current directory
     dir: '{{ .USER_WORKING_DIR }}'
     cmds:
       - rm *.eopkg -fv
 
   clean-all:
-    desc: WARNING - Clean ALL eopkgs found in the monorepo
+    desc: List all .eopkgs found in the monorepo, ask before deleting them.
+    cmds:
+      - task: list-all-eopkgs   # first show all found .eopkg files
+      - task: delete-all-eopkgs # then prompt before deleting them
+
+  delete-all-eopkgs:
+    desc: Ask before deleting all .eopkgs found in the monorepo.
     dir: '{{ .TASKFILE_DIR }}'
-    prompt: This will clean ALL eopkgs found in the monorepo. Do you wish to continue?
+    prompt: This will delete ALL .eopkgs found in the monorepo. Do you wish to continue?
     cmds:
       - find $(git rev-parse --show-toplevel) -type f -name '*.eopkg' -delete
+
+  list-all-eopkgs:
+    desc: List all .eopkgs found in the monorepo
+    dir: '{{ .TASKFILE_DIR }}'
+    cmds:
+      - find $(git rev-parse --show-toplevel) -type f -name '*.eopkg' -print
 
   init:
     desc: Initialize the packages repo


### PR DESCRIPTION
**Summary**
To give people a chance to see exactly which .eopkgs would be deleted in the tree if they run `go-task clean-all`, the clean-all task is now composed of two subtasks (list-all-eopkgs and delete-all-eopkgs), with the latter being gated behind a prompt for safety to help avoid losing potentially many hours of work due to being too quick on the trigger.

Output:

    $ go-task clean-all
    task: [list-all-eopkgs] find $(git rev-parse --show-toplevel) -type f -name '*.eopkg' -print
    (... list of all .eopkgs found in the repo ...)
    This will delete ALL .eopkgs found in the monorepo. Do you wish to continue? [y/N]
    y
    task: [delete-all-eopkgs] find $(git rev-parse --show-toplevel) -type f -name '*.eopkg' -delete

**Summary**

<!-- Info on what this pull request updates/changes/etc -->

**Test Plan**

<!-- Short description of how the package was tested -->

**Checklist**

- [ ] Package was built and tested against unstable
