### PR TITLE
libfprint: Fix wrong rss url in monitoring.yml

### DIFF
--- a/packages/l/libfprint/monitoring.yml
+++ b/packages/l/libfprint/monitoring.yml
@@ -1,6 +1,6 @@
 releases:
   id: 1615
-  rss: https://gitlab.freedesktop.org/api/v4/projects/libfprint%2Flibfprint/repository/tags.atom
+  rss: https://gitlab.freedesktop.org/libfprint/libfprint/-/tags?format=atom
 # No known CPE, checked 2024-05-22
 security:
   cpe: ~


### PR DESCRIPTION
**Summary**
Fix wrong rss url in monitoring.yml
