### PR TITLE
amfora: Update to 1.10.0 and add monitoring.yml

### DIFF
--- a/packages/a/amfora/monitoring.yml
+++ b/packages/a/amfora/monitoring.yml
@@ -1,0 +1,6 @@
+greleases:
+  id: 157051
+  rss: https://github.com/makew0rld/amfora/releases.atom
+# No known CPE, checked 2024-05-22
+security:
+  cpe: ~

--- a/packages/a/amfora/package.yml
+++ b/packages/a/amfora/package.yml
@@ -1,8 +1,8 @@
 name       : amfora
-version    : 1.9.2
-release    : 5
+version    : 1.10.0
+release    : 6
 source     :
-    - https://github.com/makeworld-the-better-one/amfora/archive/refs/tags/v1.9.2.tar.gz : 81bb4605920955ddbeb0e7236be4f89979ab543fd41b34ea4a4846ac947147e2
+    - https://github.com/makeworld-the-better-one/amfora/archive/refs/tags/v1.10.0.tar.gz : 0bc9964ccefb3ea0d66944231492f66c3b0009ab0040e19cc115d0b4cd9b8078
 homepage   : https://github.com/makew0rld/amfora
 license    : GPL-3.0-or-later
 component  : network.clients

--- a/packages/a/amfora/pspec_x86_64.xml
+++ b/packages/a/amfora/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>amfora</Name>
         <Homepage>https://github.com/makew0rld/amfora</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.clients</PartOf>
@@ -25,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2023-11-18</Date>
-            <Version>1.9.2</Version>
+        <Update release="6">
+            <Date>2024-05-22</Date>
+            <Version>1.10.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Release notes available [here](https://github.com/makew0rld/amfora/releases/tag/v1.10.0)

Note: This will likely be the final release. See release notes for more info.

**Test Plan**

Openend a couple of Gemini pages

**Checklist**

- [x] Package was built and tested against unstable
