### PR TITLE
libslirp: Update to 4.8.0

### DIFF
--- a/packages/l/libslirp/abi_used_symbols
+++ b/packages/l/libslirp/abi_used_symbols
@@ -11,6 +11,7 @@ libc.so.6:fclose
 libc.so.6:fcntl64
 libc.so.6:fgets
 libc.so.6:fopen64
+libc.so.6:getenv
 libc.so.6:getnameinfo
 libc.so.6:getpeername
 libc.so.6:getsockname
@@ -43,13 +44,13 @@ libc.so.6:signal
 libc.so.6:sigprocmask
 libc.so.6:socket
 libc.so.6:stat64
-libc.so.6:strcasecmp
 libc.so.6:strchr
 libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strstr
 libc.so.6:strtol
+libglib-2.0.so.0:g_ascii_strcasecmp
 libglib-2.0.so.0:g_assertion_message_expr
 libglib-2.0.so.0:g_error_free
 libglib-2.0.so.0:g_free
@@ -66,12 +67,11 @@ libglib-2.0.so.0:g_return_if_fail_warning
 libglib-2.0.so.0:g_shell_parse_argv
 libglib-2.0.so.0:g_snprintf
 libglib-2.0.so.0:g_spawn_async_with_fds
-libglib-2.0.so.0:g_str_has_prefix
 libglib-2.0.so.0:g_strdup
 libglib-2.0.so.0:g_strerror
 libglib-2.0.so.0:g_strfreev
 libglib-2.0.so.0:g_string_append_printf
-libglib-2.0.so.0:g_string_free
+libglib-2.0.so.0:g_string_free_and_steal
 libglib-2.0.so.0:g_string_new
 libglib-2.0.so.0:g_strlcpy
 libglib-2.0.so.0:g_strstr_len

--- a/packages/l/libslirp/monitoring.yml
+++ b/packages/l/libslirp/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 96796
+  rss: https://gitlab.freedesktop.org/slirp/libslirp/-/tags?format=atom
+security:
+  cpe:
+  - vendor: libslirp_project
+    product: libslirp

--- a/packages/l/libslirp/package.yml
+++ b/packages/l/libslirp/package.yml
@@ -1,8 +1,9 @@
 name       : libslirp
-version    : 4.7.0
-release    : 7
+version    : 4.8.0
+release    : 8
 source     :
-    - git|https://gitlab.freedesktop.org/slirp/libslirp.git : v4.7.0
+    - https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v4.8.0/libslirp-v4.8.0.tar.gz : 2a98852e65666db313481943e7a1997abff0183bd9bea80caec1b5da89fda28c
+homepage   : https://gitlab.freedesktop.org/slirp/libslirp
 license    : GPL-2.0-or-later
 component  : virt
 summary    : User-mode networking for unprivileged network namespaces

--- a/packages/l/libslirp/pspec_x86_64.xml
+++ b/packages/l/libslirp/pspec_x86_64.xml
@@ -1,8 +1,9 @@
 <PISI>
     <Source>
         <Name>libslirp</Name>
+        <Homepage>https://gitlab.freedesktop.org/slirp/libslirp</Homepage>
         <Packager>
-            <Name>Mislav Čakarić</Name>
+            <Name>Mislav &#x10c;akari&#x107;</Name>
             <Email>mcakaric@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
@@ -10,7 +11,7 @@
         <Summary xml:lang="en">User-mode networking for unprivileged network namespaces</Summary>
         <Description xml:lang="en">A general purpose TCP-IP emulator used by virtual machine hypervisors to provide virtual networking services.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>libslirp</Name>
@@ -30,7 +31,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="7">libslirp</Dependency>
+            <Dependency release="8">libslirp</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/slirp/libslirp-version.h</Path>
@@ -40,11 +41,11 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2022-08-10</Date>
-            <Version>4.7.0</Version>
+        <Update release="8">
+            <Date>2024-05-22</Date>
+            <Version>4.8.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Mislav Čakarić</Name>
+            <Name>Mislav &#x10c;akari&#x107;</Name>
             <Email>mcakaric@gmail.com</Email>
         </Update>
     </History>


### PR DESCRIPTION
**Summary**
Added monitoring.yml
Added homepage

Release notes can be found [here](https://gitlab.freedesktop.org/slirp/libslirp/-/blob/v4.8.0/CHANGELOG.md).

**Test Plan**

Rebuilt one of reverse-dependencies (e.g. qemu)

**Checklist**

- [x] Package was built and tested against unstable
