### PR TITLE
syncthing: update to 1.27.7

### DIFF
--- a/packages/s/syncthing/package.yml
+++ b/packages/s/syncthing/package.yml
@@ -1,9 +1,9 @@
 name       : syncthing
-version    : 1.27.6
-release    : 95
+version    : 1.27.7
+release    : 96
 homepage   : https://syncthing.net
 source     :
-    - https://github.com/syncthing/syncthing/archive/refs/tags/v1.27.6.tar.gz : 7db43491488263379d7e240207eb3c3e4eff7bdbefe5fd3b8f902c154e338e30
+    - https://github.com/syncthing/syncthing/archive/refs/tags/v1.27.7.tar.gz : 26c57b75663fb892ea19f077124a2dcf89fbc1cf55bd9e94b5e0495af41c9ff2
 license    : MPL-2.0
 component  : network.util
 networking : yes

--- a/packages/s/syncthing/pspec_x86_64.xml
+++ b/packages/s/syncthing/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>syncthing</Name>
         <Homepage>https://syncthing.net</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>MPL-2.0</License>
         <PartOf>network.util</PartOf>
@@ -50,12 +50,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="95">
-            <Date>2024-04-10</Date>
-            <Version>1.27.6</Version>
+        <Update release="96">
+            <Date>2024-05-23</Date>
+            <Version>1.27.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Bugfixes:

- lib/nat: panic: runtime error: index out of range

Full changelog available [here](https://github.com/syncthing/syncthing/releases/)

**Test Plan**
- Restart Syncthing-GTK and verify it can connect to the syncthing backend, all folders sync
- View syncthing gui in web browser, ensure everything looks good

**Checklist**

- [x] pkg was built and tested against unstable