### PR TITLE
google-cloud-sdk: Update to 477.0.0

### DIFF
--- a/packages/g/google-cloud-sdk/package.yml
+++ b/packages/g/google-cloud-sdk/package.yml
@@ -1,8 +1,9 @@
 name       : google-cloud-sdk
-version    : 476.0.0
-release    : 33
+version    : 477.0.0
+release    : 34
 source     :
-    - https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/google-cloud-cli_476.0.0.orig_amd64.tar.gz : 05b8c2d8cb175329ca1014b650d899916968735f2f6017f1aed7b398908b2e6b
+    - https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/google-cloud-cli_477.0.0.orig_amd64.tar.gz : ab5c00bca7bfa80efe96c4813784f27640d086bbe98b06b5ef595e031c566b38
+    - https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/google-cloud-cli-gke-gcloud-auth-plugin_477.0.0.orig_amd64.tar.gz : 1c9a9268c0b865fb88325e2de0718da7d6ce2b3c5eb02c4a3c0d1bd1f7818f41
 extract    : no
 strip      : no
 license    : Apache-2.0
@@ -18,6 +19,7 @@ environment: |
 install    : |
     mkdir -p $CLOUDSDK_INSTALL_DIR
     tar -xzvf $sources/google-cloud-cli_%version%.orig_amd64.tar.gz -C $installdir/usr/share
+    tar -xzvf $sources/google-cloud-cli-gke-gcloud-auth-plugin_%version%.orig_amd64.tar.gz -C $installdir/usr/share
 
     cd $CLOUDSDK_INSTALL_DIR
 


### PR DESCRIPTION
**Summary**
Added gke-gcloud-auth-plugin

Release notes can be found [here](https://cloud.google.com/sdk/docs/release-notes#47700_2024-05-21).

**Test Plan**

Run few gcs commands and check that they work:
- `gsutil cp gs://cloud-sdk-release/for_packagers/linux/google-cloud-cli_477.0.0.orig_amd64.tar.gz .`
- `gcloud auth login`
- `gcloud config set project <PROJECT_ID>`

**Checklist**

- [x] Package was built and tested against unstable
