### PR TITLE
pavucontrol: Add homepage & monitoring.yml

### DIFF
--- a/packages/p/pavucontrol/abi_used_symbols
+++ b/packages/p/pavucontrol/abi_used_symbols
@@ -478,6 +478,7 @@ libstdc++.so.6:_ZNKSt8__detail20_Prime_rehash_policy14_M_need_rehashEmmm
 libstdc++.so.6:_ZNSo9_M_insertImEERSoT_
 libstdc++.so.6:_ZNSt6localeC1Ev
 libstdc++.so.6:_ZNSt6localeD1Ev
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_disposeEv
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7reserveEm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_appendEPKcm

--- a/packages/p/pavucontrol/monitoring.yml
+++ b/packages/p/pavucontrol/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 8636
+  rss: https://gitlab.freedesktop.org/pulseaudio/pavucontrol/-/tags?format=atom
+# No known CPE, checked 2024-05-24
+security:
+  cpe: ~

--- a/packages/p/pavucontrol/package.yml
+++ b/packages/p/pavucontrol/package.yml
@@ -1,8 +1,9 @@
 name       : pavucontrol
 version    : '5.0'
-release    : 11
+release    : 12
 source     :
     - https://gitlab.freedesktop.org/pulseaudio/pavucontrol/-/archive/v5.0/pavucontrol-v5.0.tar.bz2 : 965e6a4c280c1bc47fdc903d35d2483564a323a7afb1768f0eb58f0722062bd6
+homepage   : https://freedesktop.org/software/pulseaudio/pavucontrol/
 license    : GPL-2.0-or-later
 component  : multimedia.audio
 summary    : A GTK volume control for PulseAudio

--- a/packages/p/pavucontrol/pspec_x86_64.xml
+++ b/packages/p/pavucontrol/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>pavucontrol</Name>
+        <Homepage>https://freedesktop.org/software/pulseaudio/pavucontrol/</Homepage>
         <Packager>
-            <Name>Tracey Clark</Name>
-            <Email>tracey_dev@tlcnet.info</Email>
+            <Name>antoine serveaux</Name>
+            <Email>solus@foxfire.mozmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>multimedia.audio</PartOf>
         <Summary xml:lang="en">A GTK volume control for PulseAudio</Summary>
         <Description xml:lang="en">A GTK volume control for PulseAudio
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>pavucontrol</Name>
@@ -78,12 +79,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2023-07-24</Date>
+        <Update release="12">
+            <Date>2024-05-24</Date>
             <Version>5.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Tracey Clark</Name>
-            <Email>tracey_dev@tlcnet.info</Email>
+            <Name>antoine serveaux</Name>
+            <Email>solus@foxfire.mozmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Added `homepage` key to `package.yml` (part of getsolus/packages#411)
- Added `monitoring.yml` file (no CPE found)

**Test Plan**

Built, installed, used software

**Checklist**

- [x] Package was built and tested against unstable

