### PR TITLE
gpxsee: Update to 13.20

### DIFF
--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.19'
-release    : 37
+version    : '13.20'
+release    : 38
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.19.tar.gz : e35d1bbc2b562969bb356cd6a5515f70696a870ac8255a590a55c15fc2f1f52a
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.20.tar.gz : f390d0d1ea360730915a2c8526b196b56a8ec68c2f6009f50e686428cb8ebb8e
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -172,9 +172,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="37">
-            <Date>2024-04-25</Date>
-            <Version>13.19</Version>
+        <Update release="38">
+            <Date>2024-05-25</Date>
+            <Version>13.20</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Improved hillshading rendering.
- Use the map DEM data for hillshading on IMG maps.
- Added support for TCX course points icons.
- Various DEM related fixes.

**Test Plan**
- open map file; zoom in and out

**Checklist**
- [X] Package was built and tested against unstable
