### PR TITLE
tailscale: Update to 1.66.4

### DIFF
--- a/packages/t/tailscale/package.yml
+++ b/packages/t/tailscale/package.yml
@@ -1,8 +1,8 @@
 name       : tailscale
-version    : 1.66.3
-release    : 17
+version    : 1.66.4
+release    : 18
 source     :
-    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.66.3.tar.gz : 51f26a6fcc8b4b6156354bd12a9f029e93c200de9b753ac72d10f70828fb6277
+    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.66.4.tar.gz : db94df254a263110439aa9d6cf6e1e64a5644b6e6e459ab5298ba6e478a988cf
 homepage   : https://tailscale.com
 license    : BSD-3-Clause
 component  : network.clients

--- a/packages/t/tailscale/pspec_x86_64.xml
+++ b/packages/t/tailscale/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2024-05-18</Date>
-            <Version>1.66.3</Version>
+        <Update release="18">
+            <Date>2024-05-25</Date>
+            <Version>1.66.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Fixed: Restored UDP connectivity through Mullvad exit nodes.
- Changed: Stateful filtering is now off by default
- [changelog](https://tailscale.com/changelog/#2024-05-20-client)

**Test Plan**
- tailscale netcheck

**Checklist**
- [X] Package was built and tested against unstable
