### PR TITLE
font-iosevka-ttf: Update to 30.0.1

### DIFF
--- a/packages/f/font-iosevka-ttf/package.yml
+++ b/packages/f/font-iosevka-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : font-iosevka-ttf
-version    : 30.0.0
-release    : 63
+version    : 30.0.1
+release    : 64
 source     :
-    - https://github.com/be5invis/Iosevka/releases/download/v30.0.0/PkgTTF-Iosevka-30.0.0.zip : 7365563dd665967117541316c723fecfc4aa0bd46192b1fc4342a15b87c7b868
+    - https://github.com/be5invis/Iosevka/releases/download/v30.0.1/PkgTTF-Iosevka-30.0.1.zip : 06754e59e752ba25d16c1c7d0fe602878288065505ac7bfb1f43b5e9a8044870
 homepage   : https://typeof.net/Iosevka
 license    : OFL-1.1
 component  : desktop.font

--- a/packages/f/font-iosevka-ttf/pspec_x86_64.xml
+++ b/packages/f/font-iosevka-ttf/pspec_x86_64.xml
@@ -78,9 +78,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="63">
-            <Date>2024-05-04</Date>
-            <Version>30.0.0</Version>
+        <Update release="64">
+            <Date>2024-05-25</Date>
+            <Version>30.0.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Remove top-left serifs of z-parts of phonetic digraphs involving d
- Fix stroke width of hook part of LATIN CAPITAL LETTER ENG under heavy weight
- Add new characters
- [changelog](https://github.com/be5invis/Iosevka/blob/v30.0.1/CHANGELOG.md)

**Test Plan**
- render text with the font

**Checklist**
- [X] Package was built and tested against unstable
