### PR TITLE
pciutils: Add homepage & monitoring.yml

### DIFF
--- a/packages/p/pciutils/abi_used_symbols
+++ b/packages/p/pciutils/abi_used_symbols
@@ -2,9 +2,10 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
 libc.so.6:__h_errno_location
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
-libc.so.6:__memcpy_chk
 libc.so.6:__open_2
 libc.so.6:__printf_chk
 libc.so.6:__res_init

--- a/packages/p/pciutils/abi_used_symbols32
+++ b/packages/p/pciutils/abi_used_symbols32
@@ -2,8 +2,9 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
 libc.so.6:__h_errno_location
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__isoc99_sscanf
-libc.so.6:__memcpy_chk
 libc.so.6:__open_2
 libc.so.6:__res_init
 libc.so.6:__snprintf_chk

--- a/packages/p/pciutils/monitoring.yml
+++ b/packages/p/pciutils/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 2605
+  rss: https://github.com/pciutils/pciutils/tags.atom
+# No known CPE, checked 2024-05-25
+security:
+  cpe: ~

--- a/packages/p/pciutils/package.yml
+++ b/packages/p/pciutils/package.yml
@@ -1,8 +1,9 @@
 name       : pciutils
 version    : 3.7.0
-release    : 12
+release    : 13
 source     :
     - https://mirrors.edge.kernel.org/pub/software/utils/pciutils/pciutils-3.7.0.tar.xz : 9d40b97be8b6a2cdf96aead5a61881d1f7e4e0da9544a9bac4fba1ae9dcd40eb
+homepage   : https://mj.ucw.cz/sw/pciutils/
 license    : GPL-2.0-only
 component  : system.utils
 emul32     : yes

--- a/packages/p/pciutils/pspec_x86_64.xml
+++ b/packages/p/pciutils/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>pciutils</Name>
+        <Homepage>https://mj.ucw.cz/sw/pciutils/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>antoine serveaux</Name>
+            <Email>solus@foxfire.mozmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">Utilities to deal with PCI bus</Summary>
         <Description xml:lang="en">The PCI Utilities are a collection of programs for inspecting and manipulating configuration of PCI devices, all based on a common portable library libpci which offers access to the PCI configuration space on a variety of operating systems.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>pciutils</Name>
@@ -38,7 +39,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="12">pciutils</Dependency>
+            <Dependency release="13">pciutils</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpci.so.3</Path>
@@ -52,8 +53,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="12">pciutils-32bit</Dependency>
-            <Dependency release="12">pciutils-devel</Dependency>
+            <Dependency release="13">pciutils-devel</Dependency>
+            <Dependency release="13">pciutils-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpci.so</Path>
@@ -67,7 +68,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="12">pciutils</Dependency>
+            <Dependency release="13">pciutils</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/pci/config.h</Path>
@@ -79,12 +80,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2022-04-06</Date>
+        <Update release="13">
+            <Date>2024-05-25</Date>
             <Version>3.7.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>antoine serveaux</Name>
+            <Email>solus@foxfire.mozmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Added `homepage` key to `package.yml` (part of getsolus/packages#411)
- Added `monitoring.yml` file (no CPE name found)

**Test Plan**

Built, installed, used `lspci` command line utility

**Checklist**

- [x] Package was built and tested against unstable

