### PR TITLE
pcsc-lite: Add homepage & monitoring.yml

### DIFF
--- a/packages/p/pcsc-lite/abi_used_symbols
+++ b/packages/p/pcsc-lite/abi_used_symbols
@@ -3,6 +3,7 @@ libc.so.6:__asprintf_chk
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk

--- a/packages/p/pcsc-lite/monitoring.yml
+++ b/packages/p/pcsc-lite/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 2611
+  rss: https://github.com/LudovicRousseau/PCSC/releases.atom
+# No known CPE, checked 2024-05-25
+security:
+  cpe: ~

--- a/packages/p/pcsc-lite/package.yml
+++ b/packages/p/pcsc-lite/package.yml
@@ -1,8 +1,9 @@
 name       : pcsc-lite
 version    : 1.9.9
-release    : 15
+release    : 16
 source     :
     - https://github.com/LudovicRousseau/PCSC/archive/refs/tags/1.9.9.tar.gz : 856a1daed9a5ae1ac265c75ce9f81743e66a972e5be5a1d3a2196ed23f75ea26
+homepage   : https://pcsclite.apdu.fr/
 license    :
     - BSD-3-Clause
     - GPL-3.0-or-later

--- a/packages/p/pcsc-lite/pspec_x86_64.xml
+++ b/packages/p/pcsc-lite/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>pcsc-lite</Name>
+        <Homepage>https://pcsclite.apdu.fr/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>antoine serveaux</Name>
+            <Email>solus@foxfire.mozmail.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>GPL-3.0-or-later</License>
@@ -11,7 +12,7 @@
         <Summary xml:lang="en">PC/SC Architecture smartcard middleware library</Summary>
         <Description xml:lang="en">Middleware to access a smart card using SCard API (PC/SC)
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>pcsc-lite</Name>
@@ -43,7 +44,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="15">pcsc-lite</Dependency>
+            <Dependency release="16">pcsc-lite</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/PCSC/debuglog.h</Path>
@@ -58,12 +59,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2023-04-21</Date>
+        <Update release="16">
+            <Date>2024-05-25</Date>
             <Version>1.9.9</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>antoine serveaux</Name>
+            <Email>solus@foxfire.mozmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Added `homepage` key to `package.yml` (part of getsolus/packages#411)
- Added `monitoring.yml` file (no CPE name found)

**Test Plan**

Built, installed

**Checklist**

- [x] Package was built and tested against unstable

