### PR TITLE
just: Update to 1.26.0

### DIFF
--- a/packages/j/just/abi_used_symbols
+++ b/packages/j/just/abi_used_symbols
@@ -22,6 +22,7 @@ libc.so.6:fdopendir
 libc.so.6:fork
 libc.so.6:free
 libc.so.6:fstat64
+libc.so.6:getauxval
 libc.so.6:getcwd
 libc.so.6:getenv
 libc.so.6:getpid
@@ -33,11 +34,9 @@ libc.so.6:isatty
 libc.so.6:lseek64
 libc.so.6:lstat64
 libc.so.6:malloc
-libc.so.6:memchr
 libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
-libc.so.6:memrchr
 libc.so.6:memset
 libc.so.6:mkdir
 libc.so.6:mmap64

--- a/packages/j/just/package.yml
+++ b/packages/j/just/package.yml
@@ -1,8 +1,8 @@
 name       : just
-version    : 1.25.2
-release    : 31
+version    : 1.26.0
+release    : 32
 source     :
-    - https://github.com/casey/just/archive/refs/tags/1.25.2.tar.gz : 5a005a4de9f99b297ba7b5dc02c3365c689e579148790660384afee0810a2342
+    - https://github.com/casey/just/archive/refs/tags/1.26.0.tar.gz : 20c4109bf30590e5633ae005329508c3fa772c3d86d0994bd2f770ade02dd6a7
 license    : CC0-1.0
 component  : programming.tools
 homepage   : https://github.com/casey/just/
@@ -13,9 +13,9 @@ networking : true
 builddeps  :
     - rust
 setup      : |
-    cargo fetch --locked
+    %cargo_fetch
 build      : |
-    cargo build --frozen --release
+    %cargo_build
 install    : |
     install -Dm00755 target/release/just $installdir/usr/bin/just
     install -Dm00644 man/just.1 $installdir/usr/share/man/man1/just.1
@@ -23,4 +23,4 @@ install    : |
     install -Dm00644 completions/just.fish $installdir/usr/share/fish/vendor_completions.d/just.fish
     install -Dm00644 completions/just.zsh $installdir/usr/share/zsh/site-functions/_just
 check      : |
-    cargo test --all -- --skip fmt::write_error
+    %cargo_test -- --skip fmt::write_error

--- a/packages/j/just/pspec_x86_64.xml
+++ b/packages/j/just/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>just</Name>
         <Homepage>https://github.com/casey/just/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>CC0-1.0</License>
         <PartOf>programming.tools</PartOf>
@@ -28,12 +28,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2024-04-29</Date>
-            <Version>1.25.2</Version>
+        <Update release="32">
+            <Date>2024-05-25</Date>
+            <Version>1.26.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Add --no-aliases to hide aliases in --list
- Add -E as alias for --dotenv-path

Full release notes
[here](https://github.com/casey/just/releases/tag/1.26.0)

**Test plan**

- Run just, see changelog

**Checklist**

- [x] Package was built and tested against unstable
