### PR TITLE
openfortivpn: update to 1.22.0

### DIFF
--- a/packages/o/openfortivpn/abi_used_symbols
+++ b/packages/o/openfortivpn/abi_used_symbols
@@ -4,7 +4,9 @@ libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
 libc.so.6:__getdelim
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoul
 libc.so.6:__libc_start_main
 libc.so.6:__memmove_chk
 libc.so.6:__printf_chk
@@ -55,7 +57,6 @@ libc.so.6:getenv
 libc.so.6:geteuid
 libc.so.6:getifaddrs
 libc.so.6:getopt_long
-libc.so.6:getsockopt
 libc.so.6:inet_addr
 libc.so.6:inet_ntoa
 libc.so.6:ioctl
@@ -121,8 +122,6 @@ libc.so.6:strpbrk
 libc.so.6:strsignal
 libc.so.6:strstr
 libc.so.6:strtok_r
-libc.so.6:strtol
-libc.so.6:strtoul
 libc.so.6:system
 libc.so.6:tcgetattr
 libc.so.6:tcsetattr

--- a/packages/o/openfortivpn/package.yml
+++ b/packages/o/openfortivpn/package.yml
@@ -1,8 +1,9 @@
 name       : openfortivpn
-version    : 1.20.2
-release    : 12
+version    : 1.22.0
+release    : 13
 source     :
-    - https://github.com/adrienverge/openfortivpn/archive/refs/tags/v1.20.2.tar.gz : 0f8db4217ac9973f4815a2c18a7ab04d2714deec5f8cb6530b171bae17ae38a6
+    - https://github.com/adrienverge/openfortivpn/archive/refs/tags/v1.22.0.tar.gz : 473b31d643ecbd227f5cabd800a7bf75b44d262170957418edaa72d64df8fef4
+homepage   : https://github.com/adrienverge/openfortivpn
 license    :
     - GPL-3.0-or-later
     - OpenSSL

--- a/packages/o/openfortivpn/pspec_x86_64.xml
+++ b/packages/o/openfortivpn/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>openfortivpn</Name>
+        <Homepage>https://github.com/adrienverge/openfortivpn</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <License>OpenSSL</License>
@@ -11,7 +12,7 @@
         <Summary xml:lang="en">openfortivpn is a client for PPP+SSL VPN tunnel services.</Summary>
         <Description xml:lang="en">openfortivpn is a client for PPP+SSL VPN tunnel services. It spawns a pppd process and operates the communication between the gateway and this process. It is compatible with Fortinet VPNs.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>openfortivpn</Name>
@@ -28,12 +29,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2023-08-21</Date>
-            <Version>1.20.2</Version>
+        <Update release="13">
+            <Date>2024-05-26</Date>
+            <Version>1.22.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
* [~] do not print TLS socket options in log (revert change from 1.16.0)
* [+] add option to specify SNI
* [~] change most occurrences of "SSL" to "TLS" in user-visible text

**Test Plan**
- Installed and ran some commands.

**Checklist**

- [X] Package was built and tested against unstable
