### PR TITLE
snapd: update to 2.63

### DIFF
--- a/packages/s/snapd/abi_used_symbols
+++ b/packages/s/snapd/abi_used_symbols
@@ -52,6 +52,7 @@ libc.so.6:ferror
 libc.so.6:fexecve
 libc.so.6:fflush
 libc.so.6:fgets
+libc.so.6:fileno
 libc.so.6:flock
 libc.so.6:fnmatch
 libc.so.6:fopen
@@ -131,6 +132,7 @@ libc.so.6:regcomp
 libc.so.6:regexec
 libc.so.6:regfree
 libc.so.6:res_search
+libc.so.6:rewind
 libc.so.6:rmdir
 libc.so.6:secure_getenv
 libc.so.6:setegid

--- a/packages/s/snapd/package.yml
+++ b/packages/s/snapd/package.yml
@@ -1,9 +1,9 @@
 name       : snapd
-version    : 2.62
+version    : 2.63
 homepage   : https://snapcraft.io/
-release    : 80
+release    : 81
 source     :
-    - https://github.com/snapcore/snapd/releases/download/2.62/snapd_2.62.vendor.tar.xz : e4bcf0d7677afdcb7256958fd382a5aad71db13474c08e5828e913614ee88ea8
+    - https://github.com/snapcore/snapd/releases/download/2.63/snapd_2.63.vendor.tar.xz : 2f0083d2c4e087c29f48cd1abb8a92eb2e63cf04cd433256c86fac05d0b28cab
 license    : GPL-3.0-only
 component  : desktop
 summary    : The snapd and snap tools enable systems to work with .snap files

--- a/packages/s/snapd/pspec_x86_64.xml
+++ b/packages/s/snapd/pspec_x86_64.xml
@@ -76,9 +76,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="80">
-            <Date>2024-04-16</Date>
-            <Version>2.62</Version>
+        <Update release="81">
+            <Date>2024-05-27</Date>
+            <Version>2.63</Version>
             <Comment>Packaging update</Comment>
             <Name>Zygmunt Krynicki</Name>
             <Email>me@zygoon.pl</Email>


### PR DESCRIPTION
**Summary**

New in snapd 2.63:

* Support for snap services to show the current status of user services (experimental)
* Refresh app awareness: record snap-run-inhibit notice when starting app from snap that is busy with refresh (experimental)
* Refresh app awareness: use warnings as fallback for desktop notifications (experimental)
* Aspect based configuration: make request fields in the aspect-bundle's rules optional (experimental)
* Aspect based configuration: make map keys conform to the same format as path sub-keys (experimental)
* Aspect based configuration: make unset and set behaviour similar to configuration options (experimental)
* Aspect based configuration: limit nesting level for setting value (experimental)
* Components: use symlinks to point active snap component revisions
* Components: add model assertion support for components
* Components: fix to ensure local component installation always gets a new revision number
* Add basic support for a CIFS remote filesystem-based home directory
* Add support for AppArmor profile kill mode to avoid snap-confine error
* Allow more than one interface to grant access to the same API endpoint or notice type
* Allow all snapd service's control group processes to send systemd notifications to prevent warnings flooding the log
* Enable not preseeded single boot install
* Update secboot to handle new sbatlevel
* Fix to not use cgroup for non-strict confined snaps (devmode, classic)
* Fix two race conditions relating to freedesktop notifications
* Fix missing tunables in snap-update-ns AppArmor template
* Fix rejection of snapd snap udev command line by older host snap-device-helper
* Rework seccomp allow/deny list
* Clean up files removed by gadgets
* Remove non-viable boot chains to avoid secboot failure
* posix_mq interface: add support for missing time64 mqueue syscalls mq_timedreceive_time64 and mq_timedsend_time64
* password-manager-service interface: allow kwalletd version 6
* kubernetes-support interface: allow SOCK_SEQPACKET sockets
* system-observe interface: allow listing systemd units and their properties
* opengl interface: enable use of nvidia container toolkit CDI config generation

**Test Plan**

I've tested the updated on an up-to-date unstable with a collection of personal and test snaps. No issues were noticed.

**Checklist**

- [x] Package was built and tested against unstable
