### PR TITLE
libexttextcat: Update to 3.4.6

### DIFF
--- a/packages/l/libexttextcat/monitoring.yml
+++ b/packages/l/libexttextcat/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 1609
+  rss: https://github.com/LibreOffice/libexttextcat/tags.atom
+# No known CPE, checked 2024-05-29
+security:
+  cpe: ~

--- a/packages/l/libexttextcat/package.yml
+++ b/packages/l/libexttextcat/package.yml
@@ -1,8 +1,9 @@
 name       : libexttextcat
-version    : 3.4.5
-release    : 3
+version    : 3.4.6
+release    : 4
 source     :
-    - https://dev-www.libreoffice.org/src/libexttextcat/libexttextcat-3.4.5.tar.xz : 13fdbc9d4c489a4d0519e51933a1aa21fe3fb9eb7da191b87f7a63e82797dac8
+    - https://dev-www.libreoffice.org/src/libexttextcat/libexttextcat-3.4.6.tar.xz : 6d77eace20e9ea106c1330e268ede70c9a4a89744ddc25715682754eca3368df
+homepage   : https://wiki.documentfoundation.org/Libexttextcat
 license    : BSD-3-Clause
 component  : programming
 summary    : Text Categorization library for language guessing

--- a/packages/l/libexttextcat/pspec_x86_64.xml
+++ b/packages/l/libexttextcat/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>libexttextcat</Name>
+        <Homepage>https://wiki.documentfoundation.org/Libexttextcat</Homepage>
         <Packager>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming</PartOf>
@@ -47,13 +48,16 @@
             <Path fileType="data">/usr/share/libexttextcat/bo.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/br.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/bs.lm</Path>
+            <Path fileType="data">/usr/share/libexttextcat/buc.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/ca.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/ckb.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/cs.lm</Path>
+            <Path fileType="data">/usr/share/libexttextcat/cv.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/cy.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/da.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/de.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/dv.lm</Path>
+            <Path fileType="data">/usr/share/libexttextcat/dz.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/ee.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/el.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/emk-Latn.lm</Path>
@@ -65,7 +69,9 @@
             <Path fileType="data">/usr/share/libexttextcat/fa.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/fi.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/fj.lm</Path>
+            <Path fileType="data">/usr/share/libexttextcat/fkv.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/fo.lm</Path>
+            <Path fileType="data">/usr/share/libexttextcat/fon.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/fpdb.conf</Path>
             <Path fileType="data">/usr/share/libexttextcat/fr.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/fur.lm</Path>
@@ -93,23 +99,28 @@
             <Path fileType="data">/usr/share/libexttextcat/it.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/ja.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/ka.lm</Path>
+            <Path fileType="data">/usr/share/libexttextcat/kbd.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/kk.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/kl.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/km.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/kn.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/kng.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/ko.lm</Path>
+            <Path fileType="data">/usr/share/libexttextcat/koi.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/ktu.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/ky.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/la.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/lb.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/lg.lm</Path>
+            <Path fileType="data">/usr/share/libexttextcat/lij.lm</Path>
+            <Path fileType="data">/usr/share/libexttextcat/lld.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/ln.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/lo.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/lt.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/lv.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/mai.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/mi.lm</Path>
+            <Path fileType="data">/usr/share/libexttextcat/min.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/mk.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/ml.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/mn.lm</Path>
@@ -121,6 +132,7 @@
             <Path fileType="data">/usr/share/libexttextcat/nb.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/nds.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/ne.lm</Path>
+            <Path fileType="data">/usr/share/libexttextcat/nio.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/nl.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/nn.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/nr.lm</Path>
@@ -129,11 +141,12 @@
             <Path fileType="data">/usr/share/libexttextcat/oc.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/om.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/pa.lm</Path>
+            <Path fileType="data">/usr/share/libexttextcat/pap.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/pl.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/plt.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/pt.lm</Path>
+            <Path fileType="data">/usr/share/libexttextcat/quh.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/quz.lm</Path>
-            <Path fileType="data">/usr/share/libexttextcat/qxa.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/rm.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/ro.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/ru.lm</Path>
@@ -155,8 +168,10 @@
             <Path fileType="data">/usr/share/libexttextcat/sr-Latn.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/ss.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/st.lm</Path>
+            <Path fileType="data">/usr/share/libexttextcat/sun.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/sv.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/sw.lm</Path>
+            <Path fileType="data">/usr/share/libexttextcat/swb.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/ta.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/tet.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/tg.lm</Path>
@@ -177,6 +192,7 @@
             <Path fileType="data">/usr/share/libexttextcat/uz-Cyrl.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/uz.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/ve.lm</Path>
+            <Path fileType="data">/usr/share/libexttextcat/vec.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/vep.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/vi.lm</Path>
             <Path fileType="data">/usr/share/libexttextcat/wa.lm</Path>
@@ -195,7 +211,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="3">libexttextcat</Dependency>
+            <Dependency release="4">libexttextcat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libexttextcat/common.h</Path>
@@ -211,12 +227,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2023-11-30</Date>
-            <Version>3.4.5</Version>
+        <Update release="4">
+            <Date>2024-05-29</Date>
+            <Version>3.4.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- No upstream changelog
- Add `homepage` key to `package.yml` (Part of getsolus/packages#411)
- Add monitoring.yml

**Test Plan**

<!-- Short description of how the package was tested -->
TBD

**Checklist**

- [x] Package was built and tested against unstable
