### PR TITLE
cf-cli: Update to 8.7.10

### DIFF
--- a/packages/c/cf-cli/package.yml
+++ b/packages/c/cf-cli/package.yml
@@ -1,8 +1,9 @@
 name       : cf-cli
-version    : 6.51.0
-release    : 8
+version    : 8.7.10
+release    : 9
 source     :
-    - git|https://github.com/cloudfoundry/cli.git : v6.51.0
+    - git|https://github.com/cloudfoundry/cli.git : v8.7.10
+homepage   : https://github.com/cloudfoundry/cli
 license    : Apache-2.0
 component  : network.util
 networking : yes
@@ -19,7 +20,6 @@ build      : |
     export GOPATH=$workdir
     export PATH=$PATH:$GOPATH/bin
     cd $workdir/src/code.cloudfoundry.org/cli/
-    bin/bootstrap
     %make build
 install    : |
     install -Dm000755 src/code.cloudfoundry.org/cli/out/cf $installdir/usr/bin/cf

--- a/packages/c/cf-cli/pspec_x86_64.xml
+++ b/packages/c/cf-cli/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>cf-cli</Name>
+        <Homepage>https://github.com/cloudfoundry/cli</Homepage>
         <Packager>
-            <Name>Joshua Strobl</Name>
-            <Email>joshua@streambits.io</Email>
+            <Name>Algent Albrahimi</Name>
+            <Email>algent@protonmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>network.util</PartOf>
         <Summary xml:lang="en">The official command line client for Cloud Foundry</Summary>
         <Description xml:lang="en">The official command line client for Cloud Foundry
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>cf-cli</Name>
@@ -23,12 +24,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2020-06-25</Date>
-            <Version>6.51.0</Version>
+        <Update release="9">
+            <Date>2024-05-29</Date>
+            <Version>8.7.10</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joshua Strobl</Name>
-            <Email>joshua@streambits.io</Email>
+            <Name>Algent Albrahimi</Name>
+            <Email>algent@protonmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Full changelog [here](https://github.com/cloudfoundry/cli/compare/v6.51.0...v8.7.10)
- Add homepage key

Resolves #2566

**Test Plan**

Run some simple commands such as `cf --help` and `cf -v`.
Need help for more tests by someone who uses this package.

**Checklist**

- [x] Package was built and tested against unstable
