### PR TITLE
gnome-control-center: Add missing runtime dependency

### DIFF
--- a/packages/g/gnome-control-center/package.yml
+++ b/packages/g/gnome-control-center/package.yml
@@ -1,6 +1,6 @@
 name       : gnome-control-center
 version    : 46.0.1
-release    : 156
+release    : 157
 source     :
     - https://download.gnome.org/sources/gnome-control-center/46/gnome-control-center-46.0.1.tar.xz : 53cfbc25156b5ca0b302531ebaeefd7f915f39b08aca143d5b0ec80855221fe4
 homepage   : https://apps.gnome.org/Settings/
@@ -22,6 +22,7 @@ builddeps  :
     - pkgconfig(gnome-bluetooth-3.0)
     - pkgconfig(gnome-desktop-3.0)
     - pkgconfig(gnome-settings-daemon)
+    - pkgconfig(gnutls)
     - pkgconfig(goa-backend-1.0)
     - pkgconfig(gsettings-desktop-schemas)
     - pkgconfig(gsound)
@@ -55,6 +56,7 @@ rundeps    :
     - glib-networking
     - gnome-color-manager
     - gnome-keyring
+    - gnome-remote-desktop
     - gvfs-goa
     - libgnomekbd
     - power-profiles-daemon

--- a/packages/g/gnome-control-center/pspec_x86_64.xml
+++ b/packages/g/gnome-control-center/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-control-center</Name>
         <Homepage>https://apps.gnome.org/Settings/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.gnome</PartOf>
@@ -357,19 +357,19 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="156">gnome-control-center</Dependency>
+            <Dependency release="157">gnome-control-center</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/pkgconfig/gnome-keybindings.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="156">
-            <Date>2024-04-19</Date>
+        <Update release="157">
+            <Date>2024-05-30</Date>
             <Version>46.0.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fixes the Remote Desktop panel not showing

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install the updated package, open GNOME Control Center, go to System > Remote Desktop, see that the Remote Desktop panel has options

**Checklist**

- [x] Package was built and tested against unstable
