### PR TITLE
github-cli: Update to 2.50.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.49.2
-release    : 47
+version    : 2.50.0
+release    : 48
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.49.2.tar.gz : e839ea302ad99b70ce3efcb903f938ecbbb919798e49bc2f2034ad506ae0b0f5
+    - https://github.com/cli/cli/archive/refs/tags/v2.50.0.tar.gz : 683d0dee90e1d24a6673d13680e0d41963ddc6dd88580ab5119acec790d1b4d7
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -202,6 +202,7 @@
             <Path fileType="man">/usr/share/man/man1/gh-ssh-key.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-status.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-variable-delete.1</Path>
+            <Path fileType="man">/usr/share/man/man1/gh-variable-get.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-variable-list.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-variable-set.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-variable.1</Path>
@@ -216,9 +217,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="47">
-            <Date>2024-05-16</Date>
-            <Version>2.49.2</Version>
+        <Update release="48">
+            <Date>2024-05-30</Date>
+            <Version>2.50.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Refactor git credential flow code
- Add json output for `gh pr checks`
- List the various alias permutations for the command and subcommands
- Removed tty message when checking for extension upgrades
- Fix doc bug for `gh run watch`
- Add support for `stateReason` in `gh pr view`
- Rename the `Attempts` field to `Attempt`; expose in `gh run view` and `gh run ls`
- Update regex in `changedFilesNames` to handle quoted paths
- Add a `gh variable get FOO` command

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
