### PR TITLE
grub2: Enable os-prober by default

### DIFF
--- a/packages/g/grub2/files/0001-Allow-Solus-to-remain-named-Solus.patch
+++ b/packages/g/grub2/files/0001-Allow-Solus-to-remain-named-Solus.patch
@@ -1,14 +1,14 @@
-From 3861e78c3e50a521cbdb9699c67f0d678bd2fee2 Mon Sep 17 00:00:00 2001
+From e4d02c47621b8ee2a6c4f865f54af71d8c612ea7 Mon Sep 17 00:00:00 2001
 From: Ikey Doherty <ikey@solusos.com>
 Date: Mon, 9 Sep 2013 19:47:21 +0100
-Subject: [PATCH] Allow Solus to remain named "Solus"
+Subject: [PATCH 1/2] Allow Solus to remain named "Solus"
 
 ---
  util/grub.d/10_linux.in | 3 +++
  1 file changed, 3 insertions(+)
 
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index 14402e8..32c575d 100644
+index cc393be7e..e0f1ac582 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -30,6 +30,9 @@ CLASS="--class gnu-linux --class gnu --class os"
@@ -20,7 +20,7 @@ index 14402e8..32c575d 100644
 +  CLASS="--class $(echo ${GRUB_DISTRIBUTOR} | tr 'A-Z' 'a-z' | cut -d' ' -f1) ${CLASS}"
  else
    OS="${GRUB_DISTRIBUTOR} GNU/Linux"
-   CLASS="--class $(echo ${GRUB_DISTRIBUTOR} | tr 'A-Z' 'a-z' | cut -d' ' -f1) ${CLASS}"
+   CLASS="--class $(echo ${GRUB_DISTRIBUTOR} | tr 'A-Z' 'a-z' | cut -d' ' -f1|LC_ALL=C sed 's,[^[:alnum:]_],_,g') ${CLASS}"
 -- 
-1.8.3.2
+2.45.1
 

--- a/packages/g/grub2/files/0002-Enable-os-prober-by-default.patch
+++ b/packages/g/grub2/files/0002-Enable-os-prober-by-default.patch
@@ -1,0 +1,27 @@
+From 9bf5f76c8c74fdb59d0bb00161220ac7f3c47c45 Mon Sep 17 00:00:00 2001
+From: Silke Hofstra <silke@slxh.eu>
+Date: Thu, 30 May 2024 20:16:50 +0200
+Subject: [PATCH 2/2] Enable os-prober by default
+
+---
+ util/grub-mkconfig.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/util/grub-mkconfig.in b/util/grub-mkconfig.in
+index 32c480dae..4ee9367d9 100644
+--- a/util/grub-mkconfig.in
++++ b/util/grub-mkconfig.in
+@@ -140,8 +140,8 @@ GRUB_DEVICE_PARTUUID="`${grub_probe} --device ${GRUB_DEVICE} --target=partuuid 2
+ GRUB_DEVICE_BOOT="`${grub_probe} --target=device /boot`"
+ GRUB_DEVICE_BOOT_UUID="`${grub_probe} --device ${GRUB_DEVICE_BOOT} --target=fs_uuid 2> /dev/null`" || true
+ 
+-# Disable os-prober by default due to security reasons.
+-GRUB_DISABLE_OS_PROBER="true"
++# Enable os-prober by default for user experience
++GRUB_DISABLE_OS_PROBER="false"
+ 
+ # Filesystem for the device containing our userland.  Used for stuff like
+ # choosing Hurd filesystem module.
+-- 
+2.45.1
+

--- a/packages/g/grub2/files/series
+++ b/packages/g/grub2/files/series
@@ -1,1 +1,2 @@
-brand.patch
+0001-Allow-Solus-to-remain-named-Solus.patch
+0002-Enable-os-prober-by-default.patch

--- a/packages/g/grub2/package.yml
+++ b/packages/g/grub2/package.yml
@@ -1,6 +1,6 @@
 name       : grub2
 version    : '2.12'
-release    : 38
+release    : 39
 source     :
     - git|https://git.savannah.gnu.org/git/grub.git : 5ca9db22e8ed0dbebb2aec53722972de0680a463
 homepage   : https://www.gnu.org/software/grub/

--- a/packages/g/grub2/pspec_x86_64.xml
+++ b/packages/g/grub2/pspec_x86_64.xml
@@ -648,8 +648,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="38">
-            <Date>2024-05-01</Date>
+        <Update release="39">
+            <Date>2024-05-30</Date>
             <Version>2.12</Version>
             <Comment>Packaging update</Comment>
             <Name>Silke Hofstra</Name>


### PR DESCRIPTION
**Summary**

Enable os-prober by default to restore the behaviour from Grub 2.0.4.

Resolves #2797

**Test Plan**

Install on dual boot system and run `clr-boot-manager update`.

**Checklist**

- [x] Package was built and tested against unstable
