### PR TITLE
caddy: Update to 2.8.1

### DIFF
--- a/packages/c/caddy/monitoring.yml
+++ b/packages/c/caddy/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 15601
+  rss: https://github.com/caddyserver/caddy/tags.atom
+security:
+  cpe:
+    - vendor: caddyserver
+      product: caddy

--- a/packages/c/caddy/package.yml
+++ b/packages/c/caddy/package.yml
@@ -1,9 +1,9 @@
 name       : caddy
-version    : 2.7.6
-release    : 16
+version    : 2.8.1
+release    : 17
 source     :
-    - https://github.com/caddyserver/caddy/archive/refs/tags/v2.7.6.tar.gz : e1c524fc4f4bd2b0d39df51679d9d065bb811e381b7e4e51466ba39a0083e3ed
-    - git|https://github.com/caddyserver/dist.git : v2.7.6
+    - https://github.com/caddyserver/caddy/archive/refs/tags/v2.8.1.tar.gz : 1efd6aad92210288a89b76c1e639da7ba0009f2ab3ae7c78b5818b67257f732c
+    - git|https://github.com/caddyserver/dist.git : v2.8.1
 homepage   : https://caddyserver.com
 license    : Apache-2.0
 component  : programming

--- a/packages/c/caddy/pspec_x86_64.xml
+++ b/packages/c/caddy/pspec_x86_64.xml
@@ -34,9 +34,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2024-01-01</Date>
-            <Version>2.7.6</Version>
+        <Update release="17">
+            <Date>2024-05-30</Date>
+            <Version>2.8.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Release notes available [here](https://github.com/caddyserver/caddy/releases/tag/v2.8.0).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a Caddy server, send HTTP requests, and see that they were received

**Checklist**

- [x] Package was built and tested against unstable
