### PR TITLE
sc-im: update to 0.8.3

### DIFF
--- a/packages/s/sc-im/abi_used_symbols
+++ b/packages/s/sc-im/abi_used_symbols
@@ -2,9 +2,9 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_tolower_loc
 libc.so.6:__ctype_toupper_loc
 libc.so.6:__errno_location
-libc.so.6:__fgets_chk
 libc.so.6:__fprintf_chk
 libc.so.6:__fwprintf_chk
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__longjmp_chk
 libc.so.6:__mbstowcs_chk
@@ -20,7 +20,6 @@ libc.so.6:__strcpy_chk
 libc.so.6:__swprintf_chk
 libc.so.6:__vsprintf_chk
 libc.so.6:__wcscpy_chk
-libc.so.6:__wmemset_chk
 libc.so.6:__wprintf_chk
 libc.so.6:_setjmp
 libc.so.6:calloc
@@ -32,6 +31,7 @@ libc.so.6:dlsym
 libc.so.6:dup
 libc.so.6:dup2
 libc.so.6:execl
+libc.so.6:execlp
 libc.so.6:execvp
 libc.so.6:exit
 libc.so.6:fclose
@@ -114,11 +114,11 @@ libc.so.6:strrchr
 libc.so.6:strsep
 libc.so.6:strstr
 libc.so.6:strtod
-libc.so.6:strtol
 libc.so.6:system
 libc.so.6:time
 libc.so.6:unlink
 libc.so.6:wait
+libc.so.6:waitpid
 libc.so.6:wcscat
 libc.so.6:wcschr
 libc.so.6:wcscmp
@@ -158,6 +158,8 @@ libncursesw.so.6:curs_set
 libncursesw.so.6:def_prog_mode
 libncursesw.so.6:endwin
 libncursesw.so.6:flushinp
+libncursesw.so.6:getcurx
+libncursesw.so.6:getcury
 libncursesw.so.6:getmouse
 libncursesw.so.6:has_colors
 libncursesw.so.6:init_extended_color
@@ -181,6 +183,8 @@ libncursesw.so.6:start_color
 libncursesw.so.6:stdscr
 libncursesw.so.6:use_default_colors
 libncursesw.so.6:waddnstr
+libncursesw.so.6:wattr_get
+libncursesw.so.6:wattr_set
 libncursesw.so.6:wbkgd
 libncursesw.so.6:wclear
 libncursesw.so.6:wclrtobot

--- a/packages/s/sc-im/package.yml
+++ b/packages/s/sc-im/package.yml
@@ -1,8 +1,9 @@
 name       : sc-im
-version    : 0.8.2
-release    : 2
+version    : 0.8.3
+release    : 3
 source     :
-    - https://github.com/andmarti1424/sc-im/archive/refs/tags/v0.8.2.tar.gz : 7f00c98601e7f7709431fb4cbb83707c87016a3b015d48e5a7c2f018eff4b7f7
+    - https://github.com/andmarti1424/sc-im/archive/refs/tags/v0.8.3.tar.gz : 5568f9987b6d26535c0e7a427158848f1bc03d829f74e41cbcf007d8704e9bd3
+homepage   : https://github.com/andmarti1424/sc-im
 license    : BSD-4-Clause
 component  : office
 summary    : SC-IM - Spreadsheet Calculator Improvised -- An ncurses spreadsheet program for the terminal

--- a/packages/s/sc-im/pspec_x86_64.xml
+++ b/packages/s/sc-im/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>sc-im</Name>
+        <Homepage>https://github.com/andmarti1424/sc-im</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>BSD-4-Clause</License>
         <PartOf>office</PartOf>
         <Summary xml:lang="en">SC-IM - Spreadsheet Calculator Improvised -- An ncurses spreadsheet program for the terminal</Summary>
         <Description xml:lang="en">Terminal-based spreadsheet program with vi-like key bindings
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>sc-im</Name>
@@ -30,12 +31,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2022-03-25</Date>
-            <Version>0.8.2</Version>
+        <Update release="3">
+            <Date>2024-06-01</Date>
+            <Version>0.8.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/andmarti1424/sc-im/releases/tag/v0.8.3).

**Test Plan**
- Installed and edited a spreadsheet.

**Checklist**

- [X] Package was built and tested against unstable
