### PR TITLE
kitty: Update to 0.35.1

### DIFF
--- a/packages/k/kitty/package.yml
+++ b/packages/k/kitty/package.yml
@@ -1,8 +1,8 @@
 name       : kitty
-version    : 0.35.0
-release    : 67
+version    : 0.35.1
+release    : 68
 source     :
-    - https://github.com/kovidgoyal/kitty/releases/download/v0.35.0/kitty-0.35.0.tar.xz : 68718f9dcb2e6bbc206badce5f4dfec845e893edf6ca13189c24600635c687f7
+    - https://github.com/kovidgoyal/kitty/releases/download/v0.35.1/kitty-0.35.1.tar.xz : a9a4a5b06040b72f11f5f1c7bafe0f78b1e6a50dffb1903830f492aee42a63e4
     - git|https://github.com/simd-everywhere/simde.git : v0.7.6
 license    : GPL-3.0-only
 component  : system.utils

--- a/packages/k/kitty/pspec_x86_64.xml
+++ b/packages/k/kitty/pspec_x86_64.xml
@@ -773,9 +773,9 @@ Kitty is designed from the ground up to support all modern terminal features, su
         </Files>
     </Package>
     <History>
-        <Update release="67">
-            <Date>2024-05-25</Date>
-            <Version>0.35.0</Version>
+        <Update release="68">
+            <Date>2024-06-01</Date>
+            <Version>0.35.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Fix tab bar to not render in second and subsequent wayland windows
- Fix horizontal scrolling via touchpad in fullscreen applications to be reversed
- Fix an error when setting background_opacity to zero
- Fix cursor movement for image placements that specify only rows or columns

**Test Plan**
- kitty -v

**Checklist**
- [X] Package was built and tested against unstable
