### PR TITLE
gpxsee: Update to 13.21

### DIFF
--- a/packages/g/gpxsee/abi_used_symbols
+++ b/packages/g/gpxsee/abi_used_symbols
@@ -442,7 +442,6 @@ libQt5Core.so.5:_ZNK6QRectF8containsERK7QPointF
 libQt5Core.so.5:_ZNK6QRectF8containsERKS_
 libQt5Core.so.5:_ZNK6QRectFanERKS_
 libQt5Core.so.5:_ZNK6QRectForERKS_
-libQt5Core.so.5:_ZNK7QLocale10dateFormatENS_10FormatTypeE
 libQt5Core.so.5:_ZNK7QLocale10toDateTimeERK7QStringS2_
 libQt5Core.so.5:_ZNK7QLocale17measurementSystemEv
 libQt5Core.so.5:_ZNK7QLocale6toDateERK7QStringS2_
@@ -501,7 +500,6 @@ libQt5Core.so.5:_ZNK9QDateTime7isValidEv
 libQt5Core.so.5:_ZNK9QDateTime7msecsToERKS_
 libQt5Core.so.5:_ZNK9QDateTime8addMSecsEx
 libQt5Core.so.5:_ZNK9QDateTime8toStringEN2Qt10DateFormatE
-libQt5Core.so.5:_ZNK9QDateTime8toStringERK7QString
 libQt5Core.so.5:_ZNK9QDateTimeeqERKS_
 libQt5Core.so.5:_ZNK9QDateTimeltERKS_
 libQt5Core.so.5:_ZNK9QFileInfo10isRelativeEv

--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.20'
-release    : 38
+version    : '13.21'
+release    : 39
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.20.tar.gz : f390d0d1ea360730915a2c8526b196b56a8ec68c2f6009f50e686428cb8ebb8e
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.21.tar.gz : aff8d0ab876523cc157ded956362b60390a70d88436783f0cb006f41dbc9e091
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -172,9 +172,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="38">
-            <Date>2024-05-25</Date>
-            <Version>13.20</Version>
+        <Update release="39">
+            <Date>2024-06-01</Date>
+            <Version>13.21</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Added hillshading settings
- Fixed render issues with Qt 6.7
- Fixed issues with dates not respecting the system format

**Test Plan**
- open map file, zoom in and out

**Checklist**
- [X] Package was built and tested against unstable
