### PR TITLE
wine: Update to 9.10

### DIFF
--- a/packages/w/wine/abi_symbols
+++ b/packages/w/wine/abi_symbols
@@ -712,7 +712,6 @@ win32u.so:NtUserWaitForInputIdle
 win32u.so:NtUserWaitMessage
 win32u.so:NtUserWindowFromDC
 win32u.so:NtUserWindowFromPoint
-win32u.so:SetThreadDpiAwarenessContext
 win32u.so:__wine_get_file_outline_text_metric
 win32u.so:__wine_get_icm_profile
 win32u.so:__wine_get_vulkan_driver
@@ -721,6 +720,13 @@ win32u.so:__wine_set_user_driver
 win32u.so:__wine_unix_call_funcs
 win32u.so:win32u_get_window_pixel_format
 win32u.so:win32u_set_window_pixel_format
+win32u.so:window_surface_add_ref
+win32u.so:window_surface_flush
+win32u.so:window_surface_init
+win32u.so:window_surface_lock
+win32u.so:window_surface_release
+win32u.so:window_surface_set_clip
+win32u.so:window_surface_unlock
 wine64:_IO_stdin_used
 wine64:__bss_start
 wine64:__data_start

--- a/packages/w/wine/abi_symbols32
+++ b/packages/w/wine/abi_symbols32
@@ -705,7 +705,6 @@ win32u.so:NtUserWaitForInputIdle
 win32u.so:NtUserWaitMessage
 win32u.so:NtUserWindowFromDC
 win32u.so:NtUserWindowFromPoint
-win32u.so:SetThreadDpiAwarenessContext
 win32u.so:__wine_get_file_outline_text_metric
 win32u.so:__wine_get_icm_profile
 win32u.so:__wine_get_vulkan_driver
@@ -714,6 +713,13 @@ win32u.so:__wine_set_user_driver
 win32u.so:__wine_unix_call_funcs
 win32u.so:win32u_get_window_pixel_format
 win32u.so:win32u_set_window_pixel_format
+win32u.so:window_surface_add_ref
+win32u.so:window_surface_flush
+win32u.so:window_surface_init
+win32u.so:window_surface_lock
+win32u.so:window_surface_release
+win32u.so:window_surface_set_clip
+win32u.so:window_surface_unlock
 wine:_IO_stdin_used
 wine:__bss_start
 wine:__data_start

--- a/packages/w/wine/package.yml
+++ b/packages/w/wine/package.yml
@@ -1,8 +1,8 @@
 name       : wine
-version    : '9.9'
-release    : 174
+version    : '9.10'
+release    : 175
 source     :
-    - https://dl.winehq.org/wine/source/9.x/wine-9.9.tar.xz : 4d67a7812c4abd4a3de923238e60f5a86b16ac7fb20f6294e0dc6ef9e8beca36
+    - https://dl.winehq.org/wine/source/9.x/wine-9.10.tar.xz : afc34b491bfa14c62c3fdf627dd2b5dcac5e7e9f3f145adb14332578af8cf1c0
 license    : LGPL-2.1-or-later
 component  : virt
 homepage   : https://www.winehq.org/

--- a/packages/w/wine/pspec_x86_64.xml
+++ b/packages/w/wine/pspec_x86_64.xml
@@ -980,7 +980,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="174">wine</Dependency>
+            <Dependency release="175">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/wine</Path>
@@ -1810,7 +1810,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="174">wine</Dependency>
+            <Dependency release="175">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wine/debug.h</Path>
@@ -3112,9 +3112,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="174">
-            <Date>2024-05-18</Date>
-            <Version>9.9</Version>
+        <Update release="175">
+            <Date>2024-06-02</Date>
+            <Version>9.10</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Highlighted changes:
- Bundled vkd3d upgraded to version 1.12
- DPI Awareness support improvements
- C++ RTTI support on ARM platforms
- More obsolete features removed in WineD3D
- Various bug fixes

Full release notes available [here](https://gitlab.winehq.org/wine/wine/-/releases/wine-9.10)

**Test Plan**
- Ran `winefile`, `winemine`, `winecfg`, `wineconsole`
- Played Age of Empires I Trial

**Checklist**

- [x] Package was built and tested against unstable
