### PR TITLE
python-orjson: Update to 3.10.3

### DIFF
--- a/packages/py/python-orjson/abi_used_symbols
+++ b/packages/py/python-orjson/abi_used_symbols
@@ -89,6 +89,7 @@ libc.so.6:stat64
 libc.so.6:strlen
 libc.so.6:syscall
 libc.so.6:write
+libc.so.6:writev
 libgcc_s.so.1:_Unwind_Backtrace
 libgcc_s.so.1:_Unwind_GetDataRelBase
 libgcc_s.so.1:_Unwind_GetIP

--- a/packages/py/python-orjson/package.yml
+++ b/packages/py/python-orjson/package.yml
@@ -1,8 +1,8 @@
 name       : python-orjson
-version    : 3.10.2
-release    : 37
+version    : 3.10.3
+release    : 38
 source     :
-    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.2.tar.gz : 47affe9f704c23e49a0fbb9d441af41f602474721e8639e8814640198f9ae32f
+    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.3.tar.gz : 2b166507acae7ba2f7c315dcf185a9111ad5e992ac81f2d507aac39193c2c818
 license    :
     - Apache-2.0
     - MIT
@@ -23,7 +23,7 @@ checkdeps  :
     - python-pytest
     - python-pytz
 build      : |
-    maturin build --release --strip --manylinux off
+    maturin build --release --strip
 install    : |
     python3 -m installer --destdir=$installdir target/wheels/*.whl
 check      : |

--- a/packages/py/python-orjson/pspec_x86_64.xml
+++ b/packages/py/python-orjson/pspec_x86_64.xml
@@ -21,11 +21,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.2.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.2.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.2.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.2.dist-info/license_files/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.2.dist-info/license_files/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.3.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.3.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.3.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.3.dist-info/license_files/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.3.dist-info/license_files/LICENSE-MIT</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
@@ -35,9 +35,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="37">
-            <Date>2024-05-01</Date>
-            <Version>3.10.2</Version>
+        <Update release="38">
+            <Date>2024-06-03</Date>
+            <Version>3.10.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- `manylinux` amd64 builds include runtime-detected AVX-512 `str` implementation
- Tests now compatible with numpy v2

**Test Plan**

- Ran the examples from the project README

**Checklist**

- [x] Package was built and tested against unstable
