### PR TITLE
qutebrowser: update to 3.2.0

### DIFF
--- a/packages/q/qutebrowser/package.yml
+++ b/packages/q/qutebrowser/package.yml
@@ -1,8 +1,8 @@
 name       : qutebrowser
-version    : 3.1.0
-release    : 44
+version    : 3.2.0
+release    : 45
 source     :
-    - https://github.com/qutebrowser/qutebrowser/archive/refs/tags/v3.1.0.tar.gz : 9307d55f1d9157b7906ac08566e3951bffd6f5b753432deaa9a13681995ba3ca
+    - https://github.com/qutebrowser/qutebrowser/archive/refs/tags/v3.2.0.tar.gz : 6558bc55bdd7d7a5cefbb9166eea14cd7eaa53ba3e97f6814eb3ebaa548f68e2
 homepage   : https://qutebrowser.org
 license    : GPL-3.0-or-later
 component  : network.web.browser

--- a/packages/q/qutebrowser/pspec_x86_64.xml
+++ b/packages/q/qutebrowser/pspec_x86_64.xml
@@ -21,13 +21,13 @@
         <PartOf>network.web.browser</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/qutebrowser</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.1.0-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.1.0-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.1.0-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.1.0-py3.11.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.1.0-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.1.0-py3.11.egg-info/top_level.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.1.0-py3.11.egg-info/zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.0-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.0-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.0-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.0-py3.11.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.0-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.0-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.0-py3.11.egg-info/zip-safe</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
@@ -183,8 +183,8 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/browser/webkit/__pycache__/certificateerror.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/browser/webkit/__pycache__/cookies.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/browser/webkit/__pycache__/cookies.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/browser/webkit/__pycache__/http.cpython-311.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/browser/webkit/__pycache__/http.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/browser/webkit/__pycache__/httpheaders.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/browser/webkit/__pycache__/httpheaders.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/browser/webkit/__pycache__/mhtml.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/browser/webkit/__pycache__/mhtml.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/browser/webkit/__pycache__/tabhistory.cpython-311.opt-1.pyc</Path>
@@ -206,7 +206,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/browser/webkit/cache.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/browser/webkit/certificateerror.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/browser/webkit/cookies.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/browser/webkit/http.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/browser/webkit/httpheaders.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/browser/webkit/mhtml.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/browser/webkit/network/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/browser/webkit/network/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
@@ -758,9 +758,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="44">
-            <Date>2024-03-13</Date>
-            <Version>3.1.0</Version>
+        <Update release="45">
+            <Date>2024-06-03</Date>
+            <Version>3.2.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/qutebrowser/qutebrowser/blob/main/doc/changelog.asciidoc).

**Test Plan**
- Installed and surfed the web.

**Checklist**

- [X] Package was built and tested against unstable
