### PR TITLE
transmission: Update to 4.0.6

### DIFF
--- a/packages/t/transmission/abi_used_libs
+++ b/packages/t/transmission/abi_used_libs
@@ -17,6 +17,7 @@ libgobject-2.0.so.0
 libgtk-3.so.0
 libgtkmm-3.0.so.1
 libm.so.6
+libminiupnpc.so.17
 libpangomm-1.4.so.1
 libsigc-2.0.so.0
 libssl.so.3

--- a/packages/t/transmission/abi_used_symbols
+++ b/packages/t/transmission/abi_used_symbols
@@ -57,7 +57,6 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_tolower_loc
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
-libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
 libc.so.6:__isoc23_strtol
 libc.so.6:__isoc23_strtoll
@@ -118,7 +117,6 @@ libc.so.6:getaddrinfo
 libc.so.6:getcwd
 libc.so.6:getenv
 libc.so.6:getmntent
-libc.so.6:getnameinfo
 libc.so.6:getpid
 libc.so.6:getpwuid_r
 libc.so.6:getsockname
@@ -127,10 +125,6 @@ libc.so.6:gettext
 libc.so.6:gettimeofday
 libc.so.6:getuid
 libc.so.6:gmtime_r
-libc.so.6:if_indextoname
-libc.so.6:if_nametoindex
-libc.so.6:in6addr_any
-libc.so.6:inet_addr
 libc.so.6:inet_ntop
 libc.so.6:inet_pton
 libc.so.6:inotify_add_watch
@@ -160,9 +154,7 @@ libc.so.6:ngettext
 libc.so.6:open
 libc.so.6:opendir
 libc.so.6:openlog
-libc.so.6:perror
 libc.so.6:pipe
-libc.so.6:poll
 libc.so.6:posix_fadvise
 libc.so.6:posix_fallocate
 libc.so.6:pread
@@ -183,11 +175,9 @@ libc.so.6:random
 libc.so.6:read
 libc.so.6:readdir
 libc.so.6:realloc
-libc.so.6:recv
 libc.so.6:recvfrom
 libc.so.6:remove
 libc.so.6:rename
-libc.so.6:select
 libc.so.6:send
 libc.so.6:sendto
 libc.so.6:setenv
@@ -210,16 +200,13 @@ libc.so.6:strcspn
 libc.so.6:strdup
 libc.so.6:strerror
 libc.so.6:strlen
-libc.so.6:strncasecmp
 libc.so.6:strncmp
-libc.so.6:strncpy
 libc.so.6:strrchr
 libc.so.6:strstr
 libc.so.6:strtod
 libc.so.6:strtof
 libc.so.6:strtol
 libc.so.6:strtoul
-libc.so.6:strtoull
 libc.so.6:textdomain
 libc.so.6:time
 libc.so.6:tolower
@@ -1211,6 +1198,13 @@ libm.so.6:log2
 libm.so.6:lround
 libm.so.6:pow
 libm.so.6:roundf
+libminiupnpc.so.17:FreeUPNPUrls
+libminiupnpc.so.17:UPNP_AddPortMapping
+libminiupnpc.so.17:UPNP_DeletePortMapping
+libminiupnpc.so.17:UPNP_GetSpecificPortMappingEntry
+libminiupnpc.so.17:UPNP_GetValidIGD
+libminiupnpc.so.17:freeUPNPDevlist
+libminiupnpc.so.17:upnpDiscover
 libpangomm-1.4.so.1:_ZN4Glib5ValueIN5Pango13EllipsizeModeEE10value_typeEv
 libpangomm-1.4.so.1:_ZN4Glib5ValueIN5Pango9AlignmentEE10value_typeEv
 libpangomm-1.4.so.1:_ZN5Pango15FontDescription17set_absolute_sizeEd
@@ -1312,6 +1306,7 @@ libstdc++.so.6:_ZNSt28__atomic_futex_unsigned_base26_M_futex_wait_until_steadyEP
 libstdc++.so.6:_ZNSt3_V216generic_categoryEv
 libstdc++.so.6:_ZNSt6chrono3_V212steady_clock3nowEv
 libstdc++.so.6:_ZNSt6chrono3_V212system_clock3nowEv
+libstdc++.so.6:_ZNSt6locale5facetD2Ev
 libstdc++.so.6:_ZNSt6locale6globalERKS_
 libstdc++.so.6:_ZNSt6locale7classicEv
 libstdc++.so.6:_ZNSt6localeC1EPKc
@@ -1388,6 +1383,7 @@ libstdc++.so.6:_ZSt9terminatev
 libstdc++.so.6:_ZStrsIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EE
 libstdc++.so.6:_ZTIN10__cxxabiv115__forced_unwindE
 libstdc++.so.6:_ZTINSt13__future_base12_Result_baseE
+libstdc++.so.6:_ZTINSt6locale5facetE
 libstdc++.so.6:_ZTINSt6thread6_StateE
 libstdc++.so.6:_ZTINSt8ios_base7failureB5cxx11E
 libstdc++.so.6:_ZTISt12bad_weak_ptr

--- a/packages/t/transmission/package.yml
+++ b/packages/t/transmission/package.yml
@@ -1,8 +1,8 @@
 name       : transmission
-version    : 4.0.5
-release    : 26
+version    : 4.0.6
+release    : 27
 source     :
-    - https://github.com/transmission/transmission/releases/download/4.0.5/transmission-4.0.5.tar.xz : fd68ff114a479200043c30c7e69dba4c1932f7af36ca4c5b5d2edcb5866e6357
+    - https://github.com/transmission/transmission/releases/download/4.0.6/transmission-4.0.6.tar.xz : 2a38fe6d8a23991680b691c277a335f8875bdeca2b97c6b26b598bc9c7b0c45f
 homepage   : https://transmissionbt.com/
 license    : GPL-2.0-or-later
 component  : network.download
@@ -15,6 +15,7 @@ builddeps  :
     - pkgconfig(gtkmm-3.0)
     - pkgconfig(libcurl)
     - pkgconfig(libevent)
+    - pkgconfig(miniupnpc)
 setup      : |
     %cmake_ninja
 build      : |

--- a/packages/t/transmission/pspec_x86_64.xml
+++ b/packages/t/transmission/pspec_x86_64.xml
@@ -139,9 +139,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2024-03-25</Date>
-            <Version>4.0.5</Version>
+        <Update release="27">
+            <Date>2024-06-03</Date>
+            <Version>4.0.6</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Release notes available [here](https://github.com/transmission/transmission/releases/tag/4.0.6)

**Packager's notes:** Not using gtkmm-4.0 yet as it caused the tray icon to disappear

Depends on https://github.com/getsolus/packages/pull/2840

**Test Plan**
- Checked my active torrents
- Added and removed a torrent 

**Checklist**

- [x] Package was built and tested against unstable
