### PR TITLE
glibc: Revert to fix ld linker issues

### DIFF
--- a/packages/g/glibc/package.yml
+++ b/packages/g/glibc/package.yml
@@ -1,9 +1,9 @@
 name       : glibc
 version    : '2.39'
-release    : 113
+release    : 114
 source     :
     # release/2.39/master
-    - git|git://sourceware.org/git/glibc.git : 70f560fc22212f733647c9121c26bbb2307f2e10
+    - git|git://sourceware.org/git/glibc.git : 26e7005728f0eea2972474e6be2905c467661237
 homepage   : https://www.gnu.org/software/libc/
 license    : GPL-3.0-or-later
 summary    :

--- a/packages/g/glibc/pspec_x86_64.xml
+++ b/packages/g/glibc/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>glibc</Name>
         <Homepage>https://www.gnu.org/software/libc/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -6976,7 +6976,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="113">glibc</Dependency>
+            <Dependency release="114">glibc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib/ld-linux.so.2</Path>
@@ -7285,8 +7285,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="113">glibc-32bit</Dependency>
-            <Dependency release="113">glibc-devel</Dependency>
+            <Dependency release="114">glibc-32bit</Dependency>
+            <Dependency release="114">glibc-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libBrokenLocale.a</Path>
@@ -7734,7 +7734,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="113">glibc</Dependency>
+            <Dependency release="114">glibc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/a.out.h</Path>
@@ -8235,12 +8235,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="113">
-            <Date>2024-05-30</Date>
+        <Update release="114">
+            <Date>2024-06-03</Date>
             <Version>2.39</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Recently package builds have started showing ld linker issues of the form `undefined reference to __pthread_timedjoin_np64` and similar. Examples of affected packages: `open-vm-tools`, `transmission`, `fastfetch`

The workaround was switching the build to clang tooling, but the actual cause seems to be this `glibc` commit: https://sourceware.org/git/?p=glibc.git;a=commit;h=dd535f4f19ef2b5c367a362af445ecadcf45401e

This patch changes our `glibc` build from the latest commit to the one right before the affected one, fixing the other package builds.

**Test Plan**

Built `fastfetch` and `transmission` against this version

**Checklist**

- [x] Package was built and tested against unstable
