### PR TITLE
weechat: Update to 4.3.1

### DIFF
--- a/packages/w/weechat/abi_used_symbols
+++ b/packages/w/weechat/abi_used_symbols
@@ -576,6 +576,7 @@ libtcl8.6.so:Tcl_NewListObj
 libtcl8.6.so:Tcl_NewLongObj
 libtcl8.6.so:Tcl_NewObj
 libtcl8.6.so:Tcl_NewStringObj
+libtcl8.6.so:Tcl_NewWideIntObj
 libtcl8.6.so:Tcl_SetObjResult
 libtcl8.6.so:Tcl_SetVar2
 libtcl8.6.so:Tcl_SetVar2Ex

--- a/packages/w/weechat/package.yml
+++ b/packages/w/weechat/package.yml
@@ -1,8 +1,8 @@
 name       : weechat
-version    : 4.3.0
-release    : 80
+version    : 4.3.1
+release    : 81
 source     :
-    - https://github.com/weechat/weechat/archive/refs/tags/v4.3.0.tar.gz : 38bbe7fa8c58609ff91004c3253ce99fadc71e74821124dc2f29252fd4f8725c
+    - https://github.com/weechat/weechat/archive/refs/tags/v4.3.1.tar.gz : fd0672b0f4c501f685cff705f14ec499c8d307e9453dddeb0344207eb6b2a58a
 homepage   : https://weechat.org
 license    : GPL-3.0-or-later
 summary    : WeeChat is a fast, light and extensible chat client.

--- a/packages/w/weechat/pspec_x86_64.xml
+++ b/packages/w/weechat/pspec_x86_64.xml
@@ -72,7 +72,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="80">weechat</Dependency>
+            <Dependency release="81">weechat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/weechat/weechat-plugin.h</Path>
@@ -80,9 +80,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="80">
-            <Date>2024-05-30</Date>
-            <Version>4.3.0</Version>
+        <Update release="81">
+            <Date>2024-06-01</Date>
+            <Version>4.3.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- irc: close /list buffer when the server buffer is closed
- xfer: fix send of data on the DCC chat buffer after `/upgrade` if the buffer was opened before the upgrade
- php: fix return value of function `hdata_longlong`
- core, relay: fix include directory of libcjson and libzstd

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Connect to Libera, join a channel, send and receive messages.

**Checklist**

- [x] Package was built and tested against unstable
