### PR TITLE
caddy: Update to 2.8.4

### DIFF
--- a/packages/c/caddy/package.yml
+++ b/packages/c/caddy/package.yml
@@ -1,9 +1,9 @@
 name       : caddy
-version    : 2.8.1
-release    : 17
+version    : 2.8.4
+release    : 18
 source     :
-    - https://github.com/caddyserver/caddy/archive/refs/tags/v2.8.1.tar.gz : 1efd6aad92210288a89b76c1e639da7ba0009f2ab3ae7c78b5818b67257f732c
-    - git|https://github.com/caddyserver/dist.git : v2.8.1
+    - https://github.com/caddyserver/caddy/archive/refs/tags/v2.8.4.tar.gz : 5c2e95ad9e688a18dd9d9099c8c132331e01e0bebd401183e8d9123372cf4fcc
+    - git|https://github.com/caddyserver/dist.git : v2.8.4
 homepage   : https://caddyserver.com
 license    : Apache-2.0
 component  : programming

--- a/packages/c/caddy/pspec_x86_64.xml
+++ b/packages/c/caddy/pspec_x86_64.xml
@@ -34,9 +34,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2024-05-30</Date>
-            <Version>2.8.1</Version>
+        <Update release="18">
+            <Date>2024-06-04</Date>
+            <Version>2.8.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- caddyhttp: properly sanitize requests for root path
- caddytls: Implement `certmagic.RenewalInfoGetter`
- cmd: fix auto-detetction of .caddyfile extension
- cmd: fix regression in auto-detect of Caddyfile

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a webserver with Caddy, use curl to make requests to the server endpoints

**Checklist**

- [x] Package was built and tested against unstable
