### PR TITLE
sdl2-ttf: update to 2.22.0

### DIFF
--- a/packages/s/sdl2-ttf/package.yml
+++ b/packages/s/sdl2-ttf/package.yml
@@ -1,8 +1,9 @@
 name       : sdl2-ttf
-version    : 2.20.2
-release    : 10
+version    : 2.22.0
+release    : 11
 source     :
-    - https://github.com/libsdl-org/SDL_ttf/archive/refs/tags/release-2.20.2.tar.gz : 0fe9d587cdc4e6754b647536d0803bea8ca6ac77146c4209e0bed22391cf8241
+    - https://github.com/libsdl-org/SDL_ttf/archive/refs/tags/release-2.22.0.tar.gz : 2275d0ddfffa53f0efa628bc1621f662dacbd42467b5a44db99e38255fbb575a
+homepage   : https://www.libsdl.org/
 license    : Zlib
 component  : multimedia.library
 summary    : A sample library which allows you to use TrueType fonts in SDL applications.

--- a/packages/s/sdl2-ttf/pspec_x86_64.xml
+++ b/packages/s/sdl2-ttf/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>sdl2-ttf</Name>
+        <Homepage>https://www.libsdl.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>Zlib</License>
         <PartOf>multimedia.library</PartOf>
         <Summary xml:lang="en">A sample library which allows you to use TrueType fonts in SDL applications.</Summary>
         <Description xml:lang="en">A sample library which allows you to use TrueType fonts in SDL applications.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>sdl2-ttf</Name>
@@ -20,7 +21,7 @@
         <PartOf>multimedia.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libSDL2_ttf-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libSDL2_ttf-2.0.so.0.2000.2</Path>
+            <Path fileType="library">/usr/lib64/libSDL2_ttf-2.0.so.0.2200.0</Path>
         </Files>
     </Package>
     <Package>
@@ -30,13 +31,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">sdl2-ttf</Dependency>
+            <Dependency release="11">sdl2-ttf</Dependency>
         </RuntimeDependencies>
         <Files>
-            <Path fileType="library">/usr/lib32/cmake/SDL2_ttf/sdl2_ttf-config-version.cmake</Path>
-            <Path fileType="library">/usr/lib32/cmake/SDL2_ttf/sdl2_ttf-config.cmake</Path>
             <Path fileType="library">/usr/lib32/libSDL2_ttf-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libSDL2_ttf-2.0.so.0.2000.2</Path>
+            <Path fileType="library">/usr/lib32/libSDL2_ttf-2.0.so.0.2200.0</Path>
         </Files>
     </Package>
     <Package>
@@ -46,10 +45,12 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">sdl2-ttf-32bit</Dependency>
-            <Dependency release="10">sdl2-ttf-devel</Dependency>
+            <Dependency release="11">sdl2-ttf-32bit</Dependency>
+            <Dependency release="11">sdl2-ttf-devel</Dependency>
         </RuntimeDependencies>
         <Files>
+            <Path fileType="library">/usr/lib32/cmake/SDL2_ttf/sdl2_ttf-config-version.cmake</Path>
+            <Path fileType="library">/usr/lib32/cmake/SDL2_ttf/sdl2_ttf-config.cmake</Path>
             <Path fileType="library">/usr/lib32/libSDL2_ttf.so</Path>
             <Path fileType="data">/usr/lib32/pkgconfig/SDL2_ttf.pc</Path>
         </Files>
@@ -61,7 +62,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">sdl2-ttf</Dependency>
+            <Dependency release="11">sdl2-ttf</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/SDL2/SDL_ttf.h</Path>
@@ -72,12 +73,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2023-02-10</Date>
-            <Version>2.20.2</Version>
+        <Update release="11">
+            <Date>2024-06-05</Date>
+            <Version>2.22.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

In addition to bug fixes, here are the major changes in this release:
- Updated to FreeType version 2.13.2 and HarfBuzz version 8.1.1

**Test Plan**
- Installed and started Solarus which is dependent on this.

**Checklist**

- [X] Package was built and tested against unstable
