### PR TITLE
antlr4-cpp-runtime: Remove additional gtest pkconfigs/includes

### DIFF
--- a/packages/a/antlr4-cpp-runtime/package.yml
+++ b/packages/a/antlr4-cpp-runtime/package.yml
@@ -1,6 +1,6 @@
 name       : antlr4-cpp-runtime
 version    : 4.13.1
-release    : 2
+release    : 3
 source     :
     - https://www.antlr.org/download/antlr4-cpp-runtime-4.13.1-source.zip : d350e09917a633b738c68e1d6dc7d7710e91f4d6543e154a78bb964cfd8eb4de
 homepage   : https://www.antlr.org/
@@ -11,8 +11,11 @@ component  : programming.library
 summary    : C++ Runtime for ANTLR4
 description: |
     C++ Runtime for ANTLR4
-networking : yes
+builddeps  :
+    - pkgconfig(gtest)
 setup      : |
+    # Don't download and install a separate copy of gtest
+    sed -i "s/FetchContent_MakeAvailable(googletest)//" runtime/CMakeLists.txt
     %cmake_ninja .
 build      : |
     %ninja_build

--- a/packages/a/antlr4-cpp-runtime/package.yml
+++ b/packages/a/antlr4-cpp-runtime/package.yml
@@ -14,10 +14,12 @@ description: |
 builddeps  :
     - pkgconfig(gtest)
 setup      : |
-    # Don't download and install a separate copy of gtest
-    sed -i "s/FetchContent_MakeAvailable(googletest)//" runtime/CMakeLists.txt
-    %cmake_ninja .
+    sed -i "s/FetchContent_MakeAvailable(googletest)/find_package(GTest)/" runtime/CMakeLists.txt
+    sed -i "s/gtest_main/GTest::gtest_main/" runtime/CMakeLists.txt
+    %cmake_ninja -DANTLR4_INSTALL=ON -DANTLR_BUILD_CPP_TESTS=ON
 build      : |
     %ninja_build
 install    : |
     %ninja_install
+check      : |
+    %ninja_check

--- a/packages/a/antlr4-cpp-runtime/pspec_x86_64.xml
+++ b/packages/a/antlr4-cpp-runtime/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>antlr4-cpp-runtime</Name>
         <Homepage>https://www.antlr.org/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>MIT</License>
@@ -21,7 +21,7 @@
 </Description>
         <PartOf>programming.library</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib64/libantlr4-runtime.so.4.13.1</Path>
+            <Path fileType="library">/usr/lib/libantlr4-runtime.so.4.13.1</Path>
             <Path fileType="doc">/usr/share/doc/libantlr4/LICENSE.txt</Path>
             <Path fileType="doc">/usr/share/doc/libantlr4/README.md</Path>
             <Path fileType="doc">/usr/share/doc/libantlr4/VERSION</Path>
@@ -34,7 +34,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">antlr4-cpp-runtime</Dependency>
+            <Dependency release="3">antlr4-cpp-runtime</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/antlr4-runtime/.idea</Path>
@@ -209,68 +209,17 @@
             <Path fileType="header">/usr/include/antlr4-runtime/tree/xpath/XPathTokenElement.h</Path>
             <Path fileType="header">/usr/include/antlr4-runtime/tree/xpath/XPathWildcardAnywhereElement.h</Path>
             <Path fileType="header">/usr/include/antlr4-runtime/tree/xpath/XPathWildcardElement.h</Path>
-            <Path fileType="header">/usr/include/gmock/gmock-actions.h</Path>
-            <Path fileType="header">/usr/include/gmock/gmock-cardinalities.h</Path>
-            <Path fileType="header">/usr/include/gmock/gmock-function-mocker.h</Path>
-            <Path fileType="header">/usr/include/gmock/gmock-matchers.h</Path>
-            <Path fileType="header">/usr/include/gmock/gmock-more-actions.h</Path>
-            <Path fileType="header">/usr/include/gmock/gmock-more-matchers.h</Path>
-            <Path fileType="header">/usr/include/gmock/gmock-nice-strict.h</Path>
-            <Path fileType="header">/usr/include/gmock/gmock-spec-builders.h</Path>
-            <Path fileType="header">/usr/include/gmock/gmock.h</Path>
-            <Path fileType="header">/usr/include/gmock/internal/custom/README.md</Path>
-            <Path fileType="header">/usr/include/gmock/internal/custom/gmock-generated-actions.h</Path>
-            <Path fileType="header">/usr/include/gmock/internal/custom/gmock-matchers.h</Path>
-            <Path fileType="header">/usr/include/gmock/internal/custom/gmock-port.h</Path>
-            <Path fileType="header">/usr/include/gmock/internal/gmock-internal-utils.h</Path>
-            <Path fileType="header">/usr/include/gmock/internal/gmock-port.h</Path>
-            <Path fileType="header">/usr/include/gmock/internal/gmock-pp.h</Path>
-            <Path fileType="header">/usr/include/gtest/gtest-death-test.h</Path>
-            <Path fileType="header">/usr/include/gtest/gtest-matchers.h</Path>
-            <Path fileType="header">/usr/include/gtest/gtest-message.h</Path>
-            <Path fileType="header">/usr/include/gtest/gtest-param-test.h</Path>
-            <Path fileType="header">/usr/include/gtest/gtest-printers.h</Path>
-            <Path fileType="header">/usr/include/gtest/gtest-spi.h</Path>
-            <Path fileType="header">/usr/include/gtest/gtest-test-part.h</Path>
-            <Path fileType="header">/usr/include/gtest/gtest-typed-test.h</Path>
-            <Path fileType="header">/usr/include/gtest/gtest.h</Path>
-            <Path fileType="header">/usr/include/gtest/gtest_pred_impl.h</Path>
-            <Path fileType="header">/usr/include/gtest/gtest_prod.h</Path>
-            <Path fileType="header">/usr/include/gtest/internal/custom/README.md</Path>
-            <Path fileType="header">/usr/include/gtest/internal/custom/gtest-port.h</Path>
-            <Path fileType="header">/usr/include/gtest/internal/custom/gtest-printers.h</Path>
-            <Path fileType="header">/usr/include/gtest/internal/custom/gtest.h</Path>
-            <Path fileType="header">/usr/include/gtest/internal/gtest-death-test-internal.h</Path>
-            <Path fileType="header">/usr/include/gtest/internal/gtest-filepath.h</Path>
-            <Path fileType="header">/usr/include/gtest/internal/gtest-internal.h</Path>
-            <Path fileType="header">/usr/include/gtest/internal/gtest-param-util.h</Path>
-            <Path fileType="header">/usr/include/gtest/internal/gtest-port-arch.h</Path>
-            <Path fileType="header">/usr/include/gtest/internal/gtest-port.h</Path>
-            <Path fileType="header">/usr/include/gtest/internal/gtest-string.h</Path>
-            <Path fileType="header">/usr/include/gtest/internal/gtest-type-util.h</Path>
-            <Path fileType="library">/usr/lib64/cmake/GTest/GTestConfig.cmake</Path>
-            <Path fileType="library">/usr/lib64/cmake/GTest/GTestConfigVersion.cmake</Path>
-            <Path fileType="library">/usr/lib64/cmake/GTest/GTestTargets-relwithdebinfo.cmake</Path>
-            <Path fileType="library">/usr/lib64/cmake/GTest/GTestTargets.cmake</Path>
-            <Path fileType="library">/usr/lib64/libantlr4-runtime.a</Path>
-            <Path fileType="library">/usr/lib64/libantlr4-runtime.so</Path>
-            <Path fileType="library">/usr/lib64/libgmock.a</Path>
-            <Path fileType="library">/usr/lib64/libgmock_main.a</Path>
-            <Path fileType="library">/usr/lib64/libgtest.a</Path>
-            <Path fileType="library">/usr/lib64/libgtest_main.a</Path>
-            <Path fileType="data">/usr/lib64/pkgconfig/gmock.pc</Path>
-            <Path fileType="data">/usr/lib64/pkgconfig/gmock_main.pc</Path>
-            <Path fileType="data">/usr/lib64/pkgconfig/gtest.pc</Path>
-            <Path fileType="data">/usr/lib64/pkgconfig/gtest_main.pc</Path>
+            <Path fileType="library">/usr/lib/libantlr4-runtime.a</Path>
+            <Path fileType="library">/usr/lib/libantlr4-runtime.so</Path>
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2023-11-19</Date>
+        <Update release="3">
+            <Date>2024-06-05</Date>
             <Version>4.13.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/a/antlr4-cpp-runtime/pspec_x86_64.xml
+++ b/packages/a/antlr4-cpp-runtime/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>antlr4-cpp-runtime</Name>
         <Homepage>https://www.antlr.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Gavin Zhao</Name>
+            <Email>me@gzgz.dev</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>MIT</License>
@@ -211,6 +211,12 @@
             <Path fileType="header">/usr/include/antlr4-runtime/tree/xpath/XPathWildcardElement.h</Path>
             <Path fileType="library">/usr/lib/libantlr4-runtime.a</Path>
             <Path fileType="library">/usr/lib/libantlr4-runtime.so</Path>
+            <Path fileType="library">/usr/lib64/cmake/antlr4-generator/antlr4-generator-config-version.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/antlr4-generator/antlr4-generator-config.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/antlr4-runtime/antlr4-runtime-config-version.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/antlr4-runtime/antlr4-runtime-config.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/antlr4-runtime/antlr4-targets-relwithdebinfo.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/antlr4-runtime/antlr4-targets.cmake</Path>
         </Files>
     </Package>
     <History>
@@ -218,8 +224,8 @@
             <Date>2024-06-05</Date>
             <Version>4.13.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Gavin Zhao</Name>
+            <Email>me@gzgz.dev</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

The build previously downloaded its own copy of googletest and installed its pkgconfigs/includes. This removes the fetching part, so it uses the system `gtest` instead, thus also no longer requiring networking.

**Test Plan**

Confirmed gtest/gmock files are no longer installed.

**Checklist**

- [x] Package was built and tested against unstable
