### PR TITLE
calamares: Fix generation of kernel parameters

### DIFF
--- a/packages/c/calamares/abi_used_symbols
+++ b/packages/c/calamares/abi_used_symbols
@@ -69,7 +69,7 @@ libQt6Core.so.6:_Z20qEnvironmentVariablePKc
 libQt6Core.so.6:_Z21qRegisterResourceDataiPKhS0_S0_
 libQt6Core.so.6:_Z22qInstallMessageHandlerPFv9QtMsgTypeRK18QMessageLogContextRK7QStringE
 libQt6Core.so.6:_Z23qUnregisterResourceDataiPKhS0_S0_
-libQt6Core.so.6:_Z23qt_qFindChildren_helperPK7QObjectRK7QStringRK11QMetaObjectP5QListIPvE6QFlagsIN2Qt15FindChildOptionEE
+libQt6Core.so.6:_Z23qt_qFindChildren_helperPK7QObject14QAnyStringViewRK11QMetaObjectP5QListIPvE6QFlagsIN2Qt15FindChildOptionEE
 libQt6Core.so.6:_Z26qt_QMetaEnum_debugOperatorR6QDebugxPK11QMetaObjectPKc
 libQt6Core.so.6:_Z30qt_QMetaEnum_flagDebugOperatorR6QDebugyPK11QMetaObjectPKc
 libQt6Core.so.6:_Z5qHash11QStringViewm
@@ -87,6 +87,7 @@ libQt6Core.so.6:_ZN10QByteArray6_emptyE
 libQt6Core.so.6:_ZN10QByteArray6appendERKS_
 libQt6Core.so.6:_ZN10QByteArray6appendEc
 libQt6Core.so.6:_ZN10QByteArray6insertEx14QByteArrayView
+libQt6Core.so.6:_ZN10QByteArray6resizeEx
 libQt6Core.so.6:_ZN10QByteArrayC1EPKcx
 libQt6Core.so.6:_ZN10QByteArrayaSEPKc
 libQt6Core.so.6:_ZN10QEventLoop4execE6QFlagsINS_17ProcessEventsFlagEE
@@ -97,7 +98,7 @@ libQt6Core.so.6:_ZN11QBasicMutex12lockInternalEv
 libQt6Core.so.6:_ZN11QBasicMutex14unlockInternalEv
 libQt6Core.so.6:_ZN11QBasicMutex15destroyInternalEP13QMutexPrivate
 libQt6Core.so.6:_ZN11QDataStream11resetStatusEv
-libQt6Core.so.6:_ZN11QDataStream11skipRawDataEi
+libQt6Core.so.6:_ZN11QDataStream11skipRawDataEx
 libQt6Core.so.6:_ZN11QDataStream16startTransactionEv
 libQt6Core.so.6:_ZN11QDataStream17commitTransactionEv
 libQt6Core.so.6:_ZN11QDataStream9setStatusENS_6StatusE
@@ -106,8 +107,10 @@ libQt6Core.so.6:_ZN11QDataStreamC1ERK10QByteArray
 libQt6Core.so.6:_ZN11QDataStreamD1Ev
 libQt6Core.so.6:_ZN11QDataStreamlsEi
 libQt6Core.so.6:_ZN11QDataStreamlsEs
+libQt6Core.so.6:_ZN11QDataStreamlsEx
 libQt6Core.so.6:_ZN11QDataStreamrsERi
 libQt6Core.so.6:_ZN11QDataStreamrsERs
+libQt6Core.so.6:_ZN11QDataStreamrsERx
 libQt6Core.so.6:_ZN11QFileDevice4seekEx
 libQt6Core.so.6:_ZN11QFileDevice5closeEv
 libQt6Core.so.6:_ZN11QMetaMethod10invokeImplES_PvN2Qt14ConnectionTypeExPKPKvPKPKcPKPKN9QtPrivate18QMetaTypeInterfaceE
@@ -153,7 +156,6 @@ libQt6Core.so.6:_ZN13QTemporaryDirD1Ev
 libQt6Core.so.6:_ZN14QDeadlineTimerC1ExN2Qt9TimerTypeE
 libQt6Core.so.6:_ZN14QStandardPaths16writableLocationENS_16StandardLocationE
 libQt6Core.so.6:_ZN14QStandardPaths9locateAllENS_16StandardLocationERK7QString6QFlagsINS_12LocateOptionEE
-libQt6Core.so.6:_ZN15QtSharedPointer20ExternalRefCountData16setQObjectSharedEPK7QObjectb
 libQt6Core.so.6:_ZN15QtSharedPointer20ExternalRefCountData9getAndRefEPK7QObject
 libQt6Core.so.6:_ZN15QtSharedPointer22internalSafetyCheckAddEPKvPVKv
 libQt6Core.so.6:_ZN15QtSharedPointer25internalSafetyCheckRemoveEPKv
@@ -400,6 +402,7 @@ libQt6Core.so.6:_ZN7QString6_emptyE
 libQt6Core.so.6:_ZN7QString6appendE20QBasicUtf8StringViewILb0EE
 libQt6Core.so.6:_ZN7QString6appendE5QChar
 libQt6Core.so.6:_ZN7QString6appendERKS_
+libQt6Core.so.6:_ZN7QString6assignE14QAnyStringView
 libQt6Core.so.6:_ZN7QString6insertEx20QBasicUtf8StringViewILb0EE
 libQt6Core.so.6:_ZN7QString6insertExPK5QCharx
 libQt6Core.so.6:_ZN7QString6numberEdci
@@ -418,6 +421,7 @@ libQt6Core.so.6:_ZN7QString8fromUtf8E14QByteArrayView
 libQt6Core.so.6:_ZN7QString8truncateEx
 libQt6Core.so.6:_ZN7QString9fromUtf16EPKDsx
 libQt6Core.so.6:_ZN7QStringC1E5QChar
+libQt6Core.so.6:_ZN7QStringC1EPK5QCharx
 libQt6Core.so.6:_ZN7QStringaSERKS_
 libQt6Core.so.6:_ZN7QThread11qt_metacallEN11QMetaObject4CallEiPPv
 libQt6Core.so.6:_ZN7QThread11qt_metacastEPKc
@@ -471,7 +475,6 @@ libQt6Core.so.6:_ZN8QVariantC1Ex
 libQt6Core.so.6:_ZN8QVariantC1Ey
 libQt6Core.so.6:_ZN8QVariantD1Ev
 libQt6Core.so.6:_ZN8QVariantaSERKS_
-libQt6Core.so.6:_ZN9QCalendarC1Ev
 libQt6Core.so.6:_ZN9QDateTime15currentDateTimeEv
 libQt6Core.so.6:_ZN9QDateTime18currentDateTimeUtcEv
 libQt6Core.so.6:_ZN9QDateTimeD1Ev
@@ -538,8 +541,6 @@ libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperIxE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperIyE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate28QStringList_removeDuplicatesEP5QListI7QStringE
 libQt6Core.so.6:_ZNK10QByteArray11toStdStringB5cxx11Ev
-libQt6Core.so.6:_ZNK10QByteArray3midExx
-libQt6Core.so.6:_ZNK10QByteArray5rightEx
 libQt6Core.so.6:_ZNK10QByteArray5splitEc
 libQt6Core.so.6:_ZNK10QByteArray5toIntEPbi
 libQt6Core.so.6:_ZNK10QByteArray7indexOfEcx
@@ -683,12 +684,12 @@ libQt6Core.so.6:_ZNK6QTimer8intervalEv
 libQt6Core.so.6:_ZNK6QTimer8isActiveEv
 libQt6Core.so.6:_ZNK7QLocale17nativeCountryNameEv
 libQt6Core.so.6:_ZNK7QLocale18nativeLanguageNameEv
-libQt6Core.so.6:_ZNK7QLocale4nameEv
+libQt6Core.so.6:_ZNK7QLocale4nameENS_12TagSeparatorE
 libQt6Core.so.6:_ZNK7QLocale6equalsERKS_
 libQt6Core.so.6:_ZNK7QLocale6scriptEv
 libQt6Core.so.6:_ZNK7QLocale7countryEv
 libQt6Core.so.6:_ZNK7QLocale8languageEv
-libQt6Core.so.6:_ZNK7QLocale9bcp47NameEv
+libQt6Core.so.6:_ZNK7QLocale9bcp47NameENS_12TagSeparatorE
 libQt6Core.so.6:_ZNK7QObject10objectNameEv
 libQt6Core.so.6:_ZNK7QObject6senderEv
 libQt6Core.so.6:_ZNK7QObject8propertyEPKc
@@ -701,11 +702,8 @@ libQt6Core.so.6:_ZNK7QString3argERKS_i5QChar
 libQt6Core.so.6:_ZNK7QString3argEdici5QChar
 libQt6Core.so.6:_ZNK7QString3argExii5QChar
 libQt6Core.so.6:_ZNK7QString3argEyii5QChar
-libQt6Core.so.6:_ZNK7QString3midExx
-libQt6Core.so.6:_ZNK7QString4leftEx
 libQt6Core.so.6:_ZNK7QString5countE5QCharN2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString5countERK18QRegularExpression
-libQt6Core.so.6:_ZNK7QString5rightEx
 libQt6Core.so.6:_ZNK7QString5splitE5QChar6QFlagsIN2Qt18SplitBehaviorFlagsEENS2_15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString5splitERK18QRegularExpression6QFlagsIN2Qt18SplitBehaviorFlagsEE
 libQt6Core.so.6:_ZNK7QString5splitERKS_6QFlagsIN2Qt18SplitBehaviorFlagsEENS3_15CaseSensitivityE
@@ -738,8 +736,8 @@ libQt6Core.so.6:_ZNK8QVariant8metaTypeEv
 libQt6Core.so.6:_ZNK8QVariant8toDoubleEPb
 libQt6Core.so.6:_ZNK8QVariant8toStringEv
 libQt6Core.so.6:_ZNK8QVariant8typeNameEv
-libQt6Core.so.6:_ZNK9QDateTime8toStringE11QStringView9QCalendar
 libQt6Core.so.6:_ZNK9QDateTime8toStringEN2Qt10DateFormatE
+libQt6Core.so.6:_ZNK9QDateTime8toStringERK7QString
 libQt6Core.so.6:_ZNK9QFileInfo10isReadableEv
 libQt6Core.so.6:_ZNK9QFileInfo10isWritableEv
 libQt6Core.so.6:_ZNK9QFileInfo11absoluteDirEv
@@ -764,6 +762,8 @@ libQt6Core.so.6:_ZNK9QtPrivate15ResultStoreBase10filterModeEv
 libQt6Core.so.6:_ZNK9QtPrivate15ResultStoreBase23containsValidResultItemEi
 libQt6Core.so.6:_ZNK9QtPrivate15ResultStoreBase5countEv
 libQt6Core.so.6:_ZNK9QtPrivate15ResultStoreBase8resultAtEi
+libQt6Core.so.6:_ZNKR10QByteArray3midExx
+libQt6Core.so.6:_ZNKR7QString3midExx
 libQt6Core.so.6:_ZTI10QException
 libQt6Core.so.6:_ZTI18QAbstractItemModel
 libQt6Core.so.6:_ZTI18QAbstractListModel

--- a/packages/c/calamares/files/patches/downstream/0001-bootloader-Fix-clr-boot-manager-cmdline-parameters.patch
+++ b/packages/c/calamares/files/patches/downstream/0001-bootloader-Fix-clr-boot-manager-cmdline-parameters.patch
@@ -1,0 +1,82 @@
+From 659403f283b030a7d4af6c2822efe84f5d35b2ac Mon Sep 17 00:00:00 2001
+From: Silke Hofstra <silke@slxh.eu>
+Date: Wed, 5 Jun 2024 18:43:24 +0200
+Subject: [PATCH] bootloader: Fix clr-boot-manager cmdline parameters
+
+CBM detects most kernel parameters automatically.
+Only set the parameters not detected by CBM: `resume` and `rd.luks.uuid` for the swap partition.
+
+Co-authored-by: Evan Maddock <maddock.evan@vivaldi.net>
+---
+ src/modules/bootloader/main.py | 46 +++++++++++++++++++++++++++-------
+ 1 file changed, 37 insertions(+), 9 deletions(-)
+
+diff --git a/src/modules/bootloader/main.py b/src/modules/bootloader/main.py
+index 0a9e96598..5cbca1902 100644
+--- a/src/modules/bootloader/main.py
++++ b/src/modules/bootloader/main.py
+@@ -507,6 +507,36 @@ def get_kernels(installation_root_path):
+     return kernel_list
+ 
+ 
++def _find_swap_params(partitions):
++    """
++    Finds the swap parameters. Based on `get_kernel_params`.
++    """
++    swap_id = None
++    luks_uuid = None
++
++    for partition in partitions:
++        if partition["fs"] == "linuxswap" and not partition.get("claimed", None):
++            # Skip foreign swap
++            continue
++        has_luks = "luksMapperName" in partition
++        if partition["fs"] == "linuxswap" and not has_luks:
++            swap_id = 'UUID=' + partition["uuid"]
++
++        if partition["fs"] == "linuxswap" and has_luks:
++            swap_id = os.path.join('/dev', 'mapper', partition["luksMapperName"])
++            luks_uuid = partition["luksUuid"]
++
++    return swap_id, luks_uuid
++
++
++def _write_resume_file(path, swap_uuid, luks_uuid):
++    with open(path, "w") as resume_file:
++        if luks_uuid:
++            resume_file.write(f"rd.luks.uuid={luks_uuid}\n")
++
++        resume_file.write(f"resume={swap_uuid}\n")
++
++
+ def install_clr_boot_manager():
+     """
+     Installs clr-boot-manager as the bootloader for EFI systems
+@@ -514,17 +544,15 @@ def install_clr_boot_manager():
+     libcalamares.utils.debug("Bootloader: clr-boot-manager")
+ 
+     installation_root_path = libcalamares.globalstorage.value("rootMountPoint")
+-    kernel_config_path = os.path.join(installation_root_path, "etc", "kernel")
++    kernel_config_path = os.path.join(installation_root_path, "etc", "kernel", "cmdline.d")
+     os.makedirs(kernel_config_path, exist_ok=True)
+-    cmdline_path = os.path.join(kernel_config_path, "cmdline")
+ 
+-    # Get the kernel params
+-    uuid = get_uuid()
+-    kernel_params = " ".join(get_kernel_params(uuid))
+-
+-    # Write out the cmdline file for clr-boot-manager
+-    with open(cmdline_path, "w") as cmdline_file:
+-        cmdline_file.write(kernel_params)
++    # Write out the resume= parameter for clr-boot-manager
++    kernel_resume_file = os.path.join(kernel_config_path, "10_resume.conf")
++    partitions = libcalamares.globalstorage.value("partitions")
++    swap_id, swap_luks_uuid = _find_swap_params(partitions)
++    if swap_id:
++        _write_resume_file(kernel_resume_file, swap_id, swap_luks_uuid)
+ 
+     check_target_env_call(["clr-boot-manager", "update"])
+ 
+-- 
+2.45.1
+

--- a/packages/c/calamares/files/series
+++ b/packages/c/calamares/files/series
@@ -2,3 +2,4 @@ patches/downstream/0001-Don-t-spawn-a-new-shell-when-starting.patch
 patches/downstream/0001-Solus-Skip-adding-boot-partition.patch
 patches/downstream/0001-Solus-Create-boot-partition-for-BIOS-installs.patch
 patches/downstream/0001-partition-Hide-Volume-Group-buttons.patch
+patches/downstream/0001-bootloader-Fix-clr-boot-manager-cmdline-parameters.patch

--- a/packages/c/calamares/package.yml
+++ b/packages/c/calamares/package.yml
@@ -1,6 +1,6 @@
 name       : calamares
 version    : 3.3.6
-release    : 19
+release    : 20
 source     :
     - https://github.com/calamares/calamares/releases/download/v3.3.6/calamares-3.3.6.tar.gz : ba7e8314ac45a30570597a13efc7ec79450c2df803096c941a8e9a8ffbd92eeb
 homepage   : https://calamares.io

--- a/packages/c/calamares/pspec_x86_64.xml
+++ b/packages/c/calamares/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>calamares</Name>
         <Homepage>https://calamares.io</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <License>CC-BY-4.0</License>
@@ -289,7 +289,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="19">calamares</Dependency>
+            <Dependency release="20">calamares</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libcalamares/Branding.h</Path>
@@ -409,12 +409,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2024-04-16</Date>
+        <Update release="20">
+            <Date>2024-06-05</Date>
             <Version>3.3.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add a patch to only write add hibernation parameters to the kernel cmdline, instead of various settings already managed by clr-boot-manager.

Resolves #2813.

**Test Plan**

Generate an ISO that includes the patched Calamares and install with the following parameters:

- desktop=budgie
- firmware=uefi 
- swap=swap_hibernate 
- fs=ext4 
- lvm=False
- luks=True

**Checklist**

- [x] Package was built and tested against unstable
