### PR TITLE
python-maturin: Update to 1.6.0

### DIFF
--- a/packages/py/python-maturin/abi_used_symbols
+++ b/packages/py/python-maturin/abi_used_symbols
@@ -1,5 +1,4 @@
 ld-linux-x86-64.so.2:__tls_get_addr
-libc.so.6:__environ
 libc.so.6:__errno_location
 libc.so.6:__libc_start_main
 libc.so.6:__stack_chk_fail
@@ -26,6 +25,7 @@ libc.so.6:fork
 libc.so.6:free
 libc.so.6:fstat64
 libc.so.6:fstatat64
+libc.so.6:getauxval
 libc.so.6:getcwd
 libc.so.6:getenv
 libc.so.6:getpid
@@ -37,11 +37,9 @@ libc.so.6:isatty
 libc.so.6:lseek64
 libc.so.6:lstat64
 libc.so.6:malloc
-libc.so.6:memchr
 libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
-libc.so.6:memrchr
 libc.so.6:memset
 libc.so.6:mkdir
 libc.so.6:mmap64
@@ -78,6 +76,7 @@ libc.so.6:realloc
 libc.so.6:realpath
 libc.so.6:recv
 libc.so.6:recvmsg
+libc.so.6:sched_yield
 libc.so.6:sendmsg
 libc.so.6:setenv
 libc.so.6:setgid

--- a/packages/py/python-maturin/package.yml
+++ b/packages/py/python-maturin/package.yml
@@ -1,8 +1,8 @@
 name       : python-maturin
-version    : 1.5.1
-release    : 42
+version    : 1.6.0
+release    : 43
 source     :
-    - https://github.com/PyO3/maturin/archive/refs/tags/v1.5.1.tar.gz : 18198cc9421d04933586b9730abcdd80fe3484e209d2b8223aa7dc1f12c4c3fe
+    - https://github.com/PyO3/maturin/archive/refs/tags/v1.6.0.tar.gz : 10809d4df85532cb70d9f186117cac8b2d2fa9b03c8f2fb53a8dc8a531f5afeb
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-maturin/pspec_x86_64.xml
+++ b/packages/py/python-maturin/pspec_x86_64.xml
@@ -22,12 +22,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/maturin</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.5.1-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.5.1-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.5.1-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.5.1-py3.11.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.5.1-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.5.1-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.6.0-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.6.0-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.6.0-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.6.0-py3.11.egg-info/not-zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.6.0-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.6.0-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/__pycache__/__init__.cpython-311.pyc</Path>
@@ -37,9 +37,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="42">
-            <Date>2024-04-23</Date>
-            <Version>1.5.1</Version>
+        <Update release="43">
+            <Date>2024-06-05</Date>
+            <Version>1.6.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Release notes available [here](https://github.com/PyO3/maturin/releases/tag/v1.6.0)

**Test Plan**

Built `python-orjson` with this version

**Checklist**

- [x] Package was built and tested against unstable
