### PR TITLE
semantik: update to 1.2.11

### DIFF
--- a/packages/s/semantik/abi_symbols
+++ b/packages/s/semantik/abi_symbols
@@ -774,6 +774,3 @@ libsemantik.so.1:_ZThn56_N8box_item11commit_sizeEP16box_resize_point
 libsemantik.so.1:_ZThn56_N8box_item14validate_pointEP16box_resize_pointRK7QPointF
 libsemantik.so.1:_ZThn56_N8box_item6freezeEb
 semantik:_Z8grid_inti
-semantik:__bss_start
-semantik:_edata
-semantik:_end

--- a/packages/s/semantik/package.yml
+++ b/packages/s/semantik/package.yml
@@ -1,18 +1,19 @@
 name       : semantik
-version    : 1.2.10
-release    : 13
+version    : 1.2.11
+release    : 14
 source     :
-    - https://waf.io/semantik-1.2.10.tar.bz2 : e5a33968461d1a47731fe0a5ce265ce507c5000a1f8b5a4ac5314f1ca055f2af
+    - https://gitlab.com/ita1024/semantik/-/archive/semantik-1.2.11/semantik-semantik-1.2.11.tar.gz : 28369e77182fa3b4d944d3b020ad10f9a1472af9266220a3a734e4136f9ed45e
+homepage   : https://waf.io/semantik.html
 license    : GPL-3.0-or-later
 component  : desktop.kde
 summary    : A mind-mapping application for KDE
 description: |
     Semantik (formerly kdissert) is a mind-mapping application for KDE that helps creating documents such as reports or presentations.
 builddeps  :
-    - pkgconfig(python3)
     - pkgconfig(Qt5Svg)
     - pkgconfig(Qt5UiTools)
     - pkgconfig(Qt5WebEngine)
+    - pkgconfig(python3)
     - kdelibs4support-devel
 setup      : |
     %waf_configure

--- a/packages/s/semantik/pspec_x86_64.xml
+++ b/packages/s/semantik/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>semantik</Name>
+        <Homepage>https://waf.io/semantik.html</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop.kde</PartOf>
@@ -22,7 +23,7 @@
             <Path fileType="executable">/usr/bin/semantik</Path>
             <Path fileType="executable">/usr/bin/semantik-d</Path>
             <Path fileType="library">/usr/lib64/libsemantik.so.1</Path>
-            <Path fileType="library">/usr/lib64/libsemantik.so.1.2.10</Path>
+            <Path fileType="library">/usr/lib64/libsemantik.so.1.2.11</Path>
             <Path fileType="data">/usr/share/applications/semantik-d.desktop</Path>
             <Path fileType="data">/usr/share/applications/semantik.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/semantik-d.svg</Path>
@@ -124,19 +125,19 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="13">semantik</Dependency>
+            <Dependency release="14">semantik</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libsemantik.so</Path>
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2024-02-17</Date>
-            <Version>1.2.10</Version>
+        <Update release="14">
+            <Date>2024-06-06</Date>
+            <Version>1.2.11</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
* Fix a Sonnet-related crash
* Cosmetic changes
* Update the build file so that generated LaTeX documents are easier to work with

**Test Plan**
- Installed and created a mindmap.

**Checklist**

- [X] Package was built and tested against unstable
