### PR TITLE
weechat: Update to 4.3.2

### DIFF
--- a/packages/w/weechat/abi_symbols
+++ b/packages/w/weechat/abi_symbols
@@ -915,6 +915,7 @@ irc.so:irc_channel_display_nick_back_in_pv
 irc.so:irc_channel_free
 irc.so:irc_channel_free_all
 irc.so:irc_channel_get_auto_chantype
+irc.so:irc_channel_get_buffer_input_prompt
 irc.so:irc_channel_hdata_channel_cb
 irc.so:irc_channel_hdata_channel_speaking_cb
 irc.so:irc_channel_is_channel
@@ -2836,6 +2837,7 @@ relay.so:relay_config_irc_backlog_time_format
 relay.so:relay_config_look_auto_open_buffer
 relay.so:relay_config_look_display_clients
 relay.so:relay_config_look_raw_messages
+relay.so:relay_config_look_raw_messages_max_length
 relay.so:relay_config_network_allow_empty_password
 relay.so:relay_config_network_allowed_ips
 relay.so:relay_config_network_auth_timeout

--- a/packages/w/weechat/package.yml
+++ b/packages/w/weechat/package.yml
@@ -1,8 +1,8 @@
 name       : weechat
-version    : 4.3.1
-release    : 82
+version    : 4.3.2
+release    : 83
 source     :
-    - https://github.com/weechat/weechat/archive/refs/tags/v4.3.1.tar.gz : fd0672b0f4c501f685cff705f14ec499c8d307e9453dddeb0344207eb6b2a58a
+    - https://github.com/weechat/weechat/archive/refs/tags/v4.3.2.tar.gz : f3311a523d4b19c1ebed15dab7a2913bd0edabf69be345fe2095ff4e64506537
 homepage   : https://weechat.org
 license    : GPL-3.0-or-later
 summary    : WeeChat is a fast, light and extensible chat client.

--- a/packages/w/weechat/pspec_x86_64.xml
+++ b/packages/w/weechat/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>weechat</Name>
         <Homepage>https://weechat.org</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.irc</PartOf>
@@ -72,7 +72,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="82">weechat</Dependency>
+            <Dependency release="83">weechat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/weechat/weechat-plugin.h</Path>
@@ -80,12 +80,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="82">
-            <Date>2024-06-05</Date>
-            <Version>4.3.1</Version>
+        <Update release="83">
+            <Date>2024-06-06</Date>
+            <Version>4.3.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- relay: enable websocket extension "permessage-deflate" with "api" relay only
- relay: add option `relay.look.raw_messages_max_length`
- irc, xfer: fix display of input prompt in IRC private buffers and DCC chat buffers
- irc: don't return pointer to irc server if the channel or nick is not found in info "irc_buffer"
- relay: fix websocket permessage-deflate extension when the client doesn't send the max window bits parameters
- relay: fix allocation and reinit of field "client_context_takeover" in websocket deflate structure

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Connect to Libera, join a channel, send and receive messages.

**Checklist**

- [x] Package was built and tested against unstable
