### PR TITLE
skaffold: update to 2.12.0

### DIFF
--- a/packages/s/skaffold/package.yml
+++ b/packages/s/skaffold/package.yml
@@ -1,8 +1,9 @@
 name       : skaffold
-version    : 0.11.0
-release    : 1
+version    : 2.12.0
+release    : 2
 source     :
-    - https://github.com/GoogleContainerTools/skaffold/archive/v0.11.0.tar.gz : 253b7c15684e48cfbc90e002eb1dcb64f491f9fd5733fc7e015be212c48aaff3
+    - https://github.com/GoogleContainerTools/skaffold/archive/refs/tags/v2.12.0.tar.gz : 3c0900ce41df0f3ec7956c15b66af73dbbf5eedd5077f7136eb69225cfa9bfa8
+homepage   : https://skaffold.dev/
 license    : Apache-2.0
 component  : programming.tools
 summary    : Skaffold is a command line tool that facilitates continuous development for Kubernetes applications.

--- a/packages/s/skaffold/pspec_x86_64.xml
+++ b/packages/s/skaffold/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>skaffold</Name>
+        <Homepage>https://skaffold.dev/</Homepage>
         <Packager>
-            <Name>Andrija Čehko</Name>
-            <Email>andrija.cehko@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.tools</PartOf>
         <Summary xml:lang="en">Skaffold is a command line tool that facilitates continuous development for Kubernetes applications.</Summary>
         <Description xml:lang="en">Skaffold is a command line tool that facilitates continuous development for Kubernetes applications.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://solus-project.com/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>skaffold</Name>
@@ -23,12 +24,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2018-08-13</Date>
-            <Version>0.11.0</Version>
+        <Update release="2">
+            <Date>2024-06-07</Date>
+            <Version>2.12.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Andrija Čehko</Name>
-            <Email>andrija.cehko@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/GoogleContainerTools/skaffold/releases).

**Test Plan**
- Ran some commands.

**Checklist**

- [X] Package was built and tested against unstable
