### PR TITLE
gnome-desktop-branding: Sync with git

### DIFF
--- a/packages/g/gnome-desktop-branding/package.yml
+++ b/packages/g/gnome-desktop-branding/package.yml
@@ -1,8 +1,8 @@
 name       : gnome-desktop-branding
 version    : '19'
-release    : 54
+release    : 55
 source     :
-    - git|https://github.com/getsolus/gnome-desktop-branding.git : 8ed32839e162ac722baa8a1fc507061399e2b2a9
+    - git|https://github.com/getsolus/gnome-desktop-branding.git : 0d5c6c97da6710acbf4e69a797069ec57ef1714c
 homepage   : https://github.com/getsolus/gnome-desktop-branding
 license    : GPL-2.0-only
 component  :
@@ -51,4 +51,3 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
-    mv $installdir/usr/share/applications/mimeapps.list $installdir/usr/share/applications/gnome-mimeapps.list

--- a/packages/g/gnome-desktop-branding/pspec_x86_64.xml
+++ b/packages/g/gnome-desktop-branding/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-desktop-branding</Name>
         <Homepage>https://github.com/getsolus/gnome-desktop-branding</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>desktop.gnome</PartOf>
@@ -36,19 +36,19 @@
         <Description xml:lang="en">Solus 4.0 LiveCD configuration.</Description>
         <PartOf>desktop.gnome</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="54">gnome-desktop-branding</Dependency>
+            <Dependency releaseFrom="55">gnome-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/glib-2.0/schemas/50_gnome_livecd.gschema.override</Path>
         </Files>
     </Package>
     <History>
-        <Update release="54">
-            <Date>2024-05-13</Date>
+        <Update release="55">
+            <Date>2024-06-07</Date>
             <Version>19</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Light theme by default for better compat with Qt app theming
- mimeapps: Prefer loupe to eog for 4.6
- mimeapps: Prefer gnome-text-editor to gedit for 4.6

Merge for Solus 4.6 only due to appearance changing

**Test Plan**

- New installs use light theme by default
- Mime now defaults to loupe if installed otherwise falls back to eog
- Mime now defaults to gnome-text-editor if installed otherwise falls back to gedit

**Checklist**

- [x] Package was built and tested against unstable
