### PR TITLE
ftgl: Update to 2.1.5

### DIFF
--- a/packages/f/ftgl/MAINTAINERS.md
+++ b/packages/f/ftgl/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Alexander Zhirov
+  - Telegram: alexanderzhirov
+  - Email: azhirov1991@gmail.com

--- a/packages/f/ftgl/abi_symbols
+++ b/packages/f/ftgl/abi_symbols
@@ -5,8 +5,11 @@ libftgl.so.2:_Z9ftglBeginjP6FTMesh
 libftgl.so.2:_Z9ftglErrorjP6FTMesh
 libftgl.so.2:_ZN10FTFontImpl10CheckGlyphEj
 libftgl.so.2:_ZN10FTFontImpl11CharMapListEv
+libftgl.so.2:_ZN10FTFontImpl11SetEncodingE12FT_Encoding_
 libftgl.so.2:_ZN10FTFontImpl14GlyphLoadFlagsEi
+libftgl.so.2:_ZN10FTFontImpl14SetEnableBlendEb
 libftgl.so.2:_ZN10FTFontImpl14UseDisplayListEb
+libftgl.so.2:_ZN10FTFontImpl16SetNearestFilterEb
 libftgl.so.2:_ZN10FTFontImpl4BBoxEPKci7FTPointS2_
 libftgl.so.2:_ZN10FTFontImpl4BBoxEPKwi7FTPointS2_
 libftgl.so.2:_ZN10FTFontImpl5DepthEf
@@ -284,8 +287,11 @@ libftgl.so.2:_ZN6FTFaceD0Ev
 libftgl.so.2:_ZN6FTFaceD1Ev
 libftgl.so.2:_ZN6FTFaceD2Ev
 libftgl.so.2:_ZN6FTFont11CharMapListEv
+libftgl.so.2:_ZN6FTFont11SetEncodingE12FT_Encoding_
 libftgl.so.2:_ZN6FTFont14GlyphLoadFlagsEi
+libftgl.so.2:_ZN6FTFont14SetEnableBlendEb
 libftgl.so.2:_ZN6FTFont14UseDisplayListEb
+libftgl.so.2:_ZN6FTFont16SetNearestFilterEb
 libftgl.so.2:_ZN6FTFont4BBoxEPKci7FTPointS2_
 libftgl.so.2:_ZN6FTFont4BBoxEPKwi7FTPointS2_
 libftgl.so.2:_ZN6FTFont5DepthEf
@@ -364,8 +370,12 @@ libftgl.so.2:_ZN9FTLibraryD1Ev
 libftgl.so.2:_ZN9FTLibraryD2Ev
 libftgl.so.2:_ZNK10FTFontImpl10LineHeightEv
 libftgl.so.2:_ZNK10FTFontImpl12CharMapCountEv
+libftgl.so.2:_ZNK10FTFontImpl13GetFamilyNameEv
+libftgl.so.2:_ZNK10FTFontImpl6IsBoldEv
 libftgl.so.2:_ZNK10FTFontImpl8AscenderEv
 libftgl.so.2:_ZNK10FTFontImpl8FaceSizeEv
+libftgl.so.2:_ZNK10FTFontImpl8IsItalicEv
+libftgl.so.2:_ZNK10FTFontImpl8MaxWidthEv
 libftgl.so.2:_ZNK10FTFontImpl9DescenderEv
 libftgl.so.2:_ZNK11FTGlyphImpl4BBoxEv
 libftgl.so.2:_ZNK11FTGlyphImpl5ErrorEv
@@ -380,9 +390,13 @@ libftgl.so.2:_ZNK16FTGlyphContainer9FontIndexEj
 libftgl.so.2:_ZNK6FTFace12CharMapCountEv
 libftgl.so.2:_ZNK6FTFont10LineHeightEv
 libftgl.so.2:_ZNK6FTFont12CharMapCountEv
+libftgl.so.2:_ZNK6FTFont13GetFamilyNameEv
 libftgl.so.2:_ZNK6FTFont5ErrorEv
+libftgl.so.2:_ZNK6FTFont6IsBoldEv
 libftgl.so.2:_ZNK6FTFont8AscenderEv
 libftgl.so.2:_ZNK6FTFont8FaceSizeEv
+libftgl.so.2:_ZNK6FTFont8IsItalicEv
+libftgl.so.2:_ZNK6FTFont8MaxWidthEv
 libftgl.so.2:_ZNK6FTFont9DescenderEv
 libftgl.so.2:_ZNK6FTMesh11TesselationEm
 libftgl.so.2:_ZNK6FTSize5WidthEv
@@ -428,6 +442,7 @@ libftgl.so.2:ftglGetFontDescender
 libftgl.so.2:ftglGetFontError
 libftgl.so.2:ftglGetFontFaceSize
 libftgl.so.2:ftglGetFontLineHeight
+libftgl.so.2:ftglGetFontMaxWidth
 libftgl.so.2:ftglGetGlyphAdvance
 libftgl.so.2:ftglGetGlyphBBox
 libftgl.so.2:ftglGetGlyphError
@@ -448,3 +463,4 @@ libftgl.so.2:ftglSetLayoutAlignment
 libftgl.so.2:ftglSetLayoutFont
 libftgl.so.2:ftglSetLayoutLineLength
 libftgl.so.2:ftglSetLayoutLineSpacing
+libftgl.so.2:ftglSetNearestFilter

--- a/packages/f/ftgl/abi_used_symbols
+++ b/packages/f/ftgl/abi_used_symbols
@@ -42,11 +42,10 @@ libGLU.so.1:gluTessEndPolygon
 libGLU.so.1:gluTessNormal
 libGLU.so.1:gluTessProperty
 libGLU.so.1:gluTessVertex
-libc.so.6:__assert_fail
 libc.so.6:__cxa_atexit
-libc.so.6:__fprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:div
+libc.so.6:fprintf
 libc.so.6:free
 libc.so.6:iswspace
 libc.so.6:malloc
@@ -56,9 +55,8 @@ libc.so.6:stderr
 libc.so.6:strcmp
 libc.so.6:strdup
 libc.so.6:strncmp
-libc.so.6:strndup
 libc.so.6:wcscmp
-libc.so.6:wcsdup
+libc.so.6:wcslen
 libc.so.6:wcsncmp
 libfreetype.so.6:FT_Attach_File
 libfreetype.so.6:FT_Attach_Stream

--- a/packages/f/ftgl/files/0001-shared-links.patch
+++ b/packages/f/ftgl/files/0001-shared-links.patch
@@ -1,0 +1,15 @@
+diff --git a/tecmake.mak b/tecmake.mak
+index 48991a4..b56e14b 100755
+--- a/tecmake.mak
++++ b/tecmake.mak
+@@ -1667,7 +1667,9 @@ dynamic-lib: $(TARGETDIR)/$(TARGETDLIBNAME)
+ 
+ $(TARGETDIR)/$(TARGETDLIBNAME) : $(LUAS) $(OBJS) $(EXTRADEPS)
+ 	@echo ''; echo Tecmake: linking $(@F) ...
+-	$(ECHO)$(LD) $(STDLDFLAGS) -o $@ $(OBJS) $(SLIB) $(LFLAGS)
++	$(ECHO)$(LD) $(STDLDFLAGS) -Wl,-soname,$(@F).2 -o $@.2.1.5 $(OBJS) $(SLIB) $(LFLAGS)
++	@echo ''; ln -sv $(@F).2.1.5 $@.2
++	@echo ''; ln -sv $(@F).2.1.5 $@
+ 	@echo ''; echo 'Tecmake: Dynamic Library ($@) Done.'; echo ''
+ 
+ 

--- a/packages/f/ftgl/files/ftgl.pc
+++ b/packages/f/ftgl/files/ftgl.pc
@@ -1,0 +1,12 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=/usr/lib64
+includedir=${prefix}/include
+
+Name: FTGL
+Description: OpenGL frontend to Freetype 2
+Version: 2.1.5
+Libs: -L${libdir} -lftgl
+Requires.private: freetype2
+Libs.private: -lGLU -lGL -lm
+Cflags: -I${includedir} -I${includedir}/FTGL

--- a/packages/f/ftgl/package.yml
+++ b/packages/f/ftgl/package.yml
@@ -1,10 +1,10 @@
 name       : ftgl
-version    : 2.1.3
-release    : 3
+version    : 2.1.5
+release    : 4
 source     :
-    - https://sourceforge.net/projects/ftgl/files/FTGL%20Source/2.1.3%7Erc5/ftgl-2.1.3-rc5.tar.gz : 5458d62122454869572d39f8aa85745fc05d5518001bcefa63bd6cbb8d26565b
-homepage   : https://sourceforge.net/projects/ftgl/
-license    : MIT
+    - https://sourceforge.net/projects/iup/files/3.31/Docs%20and%20Sources/ftgl-2.1.5_Sources.tar.gz : 511211897851fe6a80e07884a0e33bf55981a0757fe933c74eeb31c2f1373eff
+homepage   : https://sourceforge.net/projects/iup/files/3.31/Docs%20and%20Sources/
+license    : LGPL-2.0-or-later
 component  : programming
 summary    : c++ library to simplify font rendering in openGL applications
 description: |
@@ -14,9 +14,24 @@ builddeps  :
     - pkgconfig(freetype2)
     - pkgconfig(gl)
     - pkgconfig(glu)
+    - pkgconfig(lua)
+    - lsb-release
+environment:
+    export USE_PKGCONFIG=Yes
+    export USE_LUA_VERSION=53
+    export LIBLUA_SFX=
+    export LUA_SFX=
+    export LUA_INC=/usr/include
+    export LUA_LIB=/usr/lib
+    export LUA_BIN=/usr/bin/lua
 setup      : |
-    %configure_no_runstatedir --disable-static
+    %patch -p 1 -i $pkgfiles/0001-shared-links.patch
 build      : |
-    %make
+    %make -j1
 install    : |
-    %make_install
+    install -dm00755 $installdir/usr/{lib64/pkgconfig,include/FTGL}
+    install -Dm00644 $pkgfiles/ftgl.pc $installdir/usr/lib64/pkgconfig
+    rm lib/Linux*/*.a
+    chmod 00755 lib/Linux*/*
+    mv lib/Linux*/* $installdir/usr/lib64/
+    install -Dm00644 include/FTGL/* $installdir/usr/include/FTGL

--- a/packages/f/ftgl/pspec_x86_64.xml
+++ b/packages/f/ftgl/pspec_x86_64.xml
@@ -1,12 +1,12 @@
 <PISI>
     <Source>
         <Name>ftgl</Name>
-        <Homepage>https://sourceforge.net/projects/ftgl/</Homepage>
+        <Homepage>https://sourceforge.net/projects/iup/files/3.31/Docs%20and%20Sources/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Alexander Zhirov</Name>
+            <Email>azhirov1991@gmail.com</Email>
         </Packager>
-        <License>MIT</License>
+        <License>LGPL-2.0-or-later</License>
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">c++ library to simplify font rendering in openGL applications</Summary>
         <Description xml:lang="en">FTGL is a free cross-platform Open Source C++ library that uses Freetype2 to simplify rendering fonts in OpenGL applications. FTGL supports bitmaps, pixmaps, texture maps, outlines, polygon mesh, and extruded polygon rendering modes.
@@ -21,8 +21,7 @@
         <PartOf>programming</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libftgl.so.2</Path>
-            <Path fileType="library">/usr/lib64/libftgl.so.2.1.3</Path>
-            <Path fileType="doc">/usr/share/doc/ftgl/projects_using_ftgl.txt</Path>
+            <Path fileType="library">/usr/lib64/libftgl.so.2.1.5</Path>
         </Files>
     </Package>
     <Package>
@@ -32,7 +31,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="3">ftgl</Dependency>
+            <Dependency release="4">ftgl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/FTGL/FTBBox.h</Path>
@@ -62,12 +61,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-05-15</Date>
-            <Version>2.1.3</Version>
+        <Update release="4">
+            <Date>2024-06-08</Date>
+            <Version>2.1.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Alexander Zhirov</Name>
+            <Email>azhirov1991@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes

- [2.1.3-rc5 with tecgraf changes](https://sourceforge.net/projects/canvasdraw/files/5.14/Docs%20and%20Sources/)

**Checklist**

- [X] `libcaca`, `setbfree`, `x42-plugins`, `megaglest` were builded when using this library

This is the first update to build the library, as a dependency https://github.com/getsolus/packages/issues/241