### PR TITLE
miniupnpc: Update to 2.2.7 and add monitoring.yml

### DIFF
--- a/packages/m/miniupnpc/abi_symbols
+++ b/packages/m/miniupnpc/abi_symbols
@@ -34,6 +34,7 @@ libminiupnpc.so.17:UPNP_GetTotalPacketsReceived
 libminiupnpc.so.17:UPNP_GetTotalPacketsSent
 libminiupnpc.so.17:UPNP_GetValidIGD
 libminiupnpc.so.17:UPNP_UpdatePinhole
+libminiupnpc.so.17:addr_is_reserved
 libminiupnpc.so.17:connectToMiniSSDPD
 libminiupnpc.so.17:connecthostport
 libminiupnpc.so.17:disconnectFromMiniSSDPD

--- a/packages/m/miniupnpc/abi_used_symbols
+++ b/packages/m/miniupnpc/abi_used_symbols
@@ -10,6 +10,7 @@ libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:bind
 libc.so.6:calloc
+libc.so.6:clock_gettime
 libc.so.6:close
 libc.so.6:connect
 libc.so.6:ctime
@@ -24,13 +25,15 @@ libc.so.6:getsockopt
 libc.so.6:if_indextoname
 libc.so.6:if_nametoindex
 libc.so.6:in6addr_any
-libc.so.6:inet_addr
+libc.so.6:inet_pton
+libc.so.6:ioctl
 libc.so.6:malloc
 libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:perror
 libc.so.6:poll
+libc.so.6:putc
 libc.so.6:putchar
 libc.so.6:puts
 libc.so.6:read
@@ -42,6 +45,7 @@ libc.so.6:sendto
 libc.so.6:setsockopt
 libc.so.6:socket
 libc.so.6:stderr
+libc.so.6:stdout
 libc.so.6:strchr
 libc.so.6:strcmp
 libc.so.6:strdup

--- a/packages/m/miniupnpc/monitoring.yml
+++ b/packages/m/miniupnpc/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 1986
+  rss: https://github.com/miniupnp/miniupnp/tags.atom
+security:
+  cpe:
+    - vendor: miniupnp_project
+      product: miniupnpc

--- a/packages/m/miniupnpc/package.yml
+++ b/packages/m/miniupnpc/package.yml
@@ -1,8 +1,8 @@
 name       : miniupnpc
-version    : '2.1'
-release    : 5
+version    : 2.2.7
+release    : 6
 source     :
-    - https://github.com/miniupnp/miniupnp/archive/miniupnpc_2_1.tar.gz : 19c5b6cf8f3fc31d5e641c797b36ecca585909c7f3685a5c1a64325340537c94
+    - https://github.com/miniupnp/miniupnp/archive/refs/tags/miniupnpc_2_2_7.tar.gz : c57f3e78f9d2e97d62c0f50dc88cbed7e8c883d0364cae605a35595931301beb
 homepage   : http://miniupnp.free.fr/
 license    : BSD-3-Clause
 component  : programming.library

--- a/packages/m/miniupnpc/pspec_x86_64.xml
+++ b/packages/m/miniupnpc/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>miniupnpc</Name>
         <Homepage>http://miniupnp.free.fr/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.library</PartOf>
@@ -21,6 +21,7 @@
         <PartOf>programming.library</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/external-ip</Path>
+            <Path fileType="executable">/usr/bin/upnp-listdevices</Path>
             <Path fileType="executable">/usr/bin/upnpc</Path>
             <Path fileType="library">/usr/lib/libminiupnpc.so.17</Path>
         </Files>
@@ -32,7 +33,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="5">miniupnpc</Dependency>
+            <Dependency release="6">miniupnpc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/miniupnpc/igd_desc_parse.h</Path>
@@ -51,12 +52,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2024-05-17</Date>
-            <Version>2.1</Version>
+        <Update release="6">
+            <Date>2024-06-08</Date>
+            <Version>2.2.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changelog available [here](https://raw.githubusercontent.com/miniupnp/miniupnp/miniupnpc_2_2_7/miniupnpc/Changelog.txt)

**Test Plan**

Rebuilt and used transmission and dolphin-emu with this version

**Checklist**

- [x] Package was built and tested against unstable
