### PR TITLE
blueprint-compiler: Update to 0.12.0 and add monitoring.yml

### DIFF
--- a/packages/b/blueprint-compiler/monitoring.yml
+++ b/packages/b/blueprint-compiler/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 279929
+  rss: https://gitlab.gnome.org/jwestman/blueprint-compiler/-/tags?format=atom
+# No known CPE, checked 2024-06-09
+security:
+  cpe: ~

--- a/packages/b/blueprint-compiler/package.yml
+++ b/packages/b/blueprint-compiler/package.yml
@@ -1,8 +1,8 @@
 name       : blueprint-compiler
-version    : 0.10.0
-release    : 5
+version    : 0.12.0
+release    : 6
 source     :
-    - https://gitlab.gnome.org/jwestman/blueprint-compiler/-/archive/v0.10.0/blueprint-compiler-v0.10.0.tar.bz2 : 9c3c6eecef9eb54ad43b9ef786697a9f99b21e35240e9ddc8541a2cbd9ea79ba
+    - https://gitlab.gnome.org/jwestman/blueprint-compiler/-/archive/v0.12.0/blueprint-compiler-v0.12.0.tar.bz2 : 0f762e8a0dfef9aa46b4bddf8ed4bbc09b5d2fa2baff5dec109ccc513c6e9e00
 license    : GPL-3.0-or-later
 homepage   : https://jwestman.pages.gitlab.gnome.org/blueprint-compiler/
 component  : programming.tools

--- a/packages/b/blueprint-compiler/pspec_x86_64.xml
+++ b/packages/b/blueprint-compiler/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>blueprint-compiler</Name>
         <Homepage>https://jwestman.pages.gitlab.gnome.org/blueprint-compiler/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>programming.tools</PartOf>
@@ -28,6 +28,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/__pycache__/completions_utils.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/__pycache__/decompiler.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/__pycache__/errors.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/__pycache__/formatter.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/__pycache__/gir.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/__pycache__/interactive_port.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/__pycache__/lsp.cpython-311.pyc</Path>
@@ -44,12 +45,13 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/completions_utils.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/decompiler.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/errors.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/formatter.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/gir.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/interactive_port.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/__pycache__/adw_breakpoint.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/__pycache__/adw_message_dialog.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/__pycache__/adw_response_dialog.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/__pycache__/attributes.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/__pycache__/binding.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/__pycache__/common.cpython-311.pyc</Path>
@@ -72,11 +74,12 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/__pycache__/gtkbuilder_template.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/__pycache__/imports.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/__pycache__/response_id.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/__pycache__/translation_domain.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/__pycache__/types.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/__pycache__/ui.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/__pycache__/values.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/adw_breakpoint.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/adw_message_dialog.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/adw_response_dialog.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/attributes.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/binding.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/common.py</Path>
@@ -99,6 +102,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/gtkbuilder_template.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/imports.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/response_id.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/translation_domain.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/types.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/ui.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/blueprintcompiler/language/values.py</Path>
@@ -121,12 +125,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2024-02-15</Date>
-            <Version>0.10.0</Version>
+        <Update release="6">
+            <Date>2024-06-09</Date>
+            <Version>0.12.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Release notes available [here](https://gitlab.gnome.org/jwestman/blueprint-compiler/-/releases/v0.12.0)

**Test Plan**

Built `gradience` using this version

**Checklist**

- [x] Package was built and tested against unstable
