### PR TITLE
keepass: Update to 2.57

### DIFF
--- a/packages/k/keepass/package.yml
+++ b/packages/k/keepass/package.yml
@@ -1,8 +1,8 @@
 name       : keepass
-version    : '2.56'
-release    : 42
+version    : '2.57'
+release    : 43
 source     :
-    - https://downloads.sourceforge.net/project/keepass/KeePass%202.x/2.56/KeePass-2.56-Source.zip : 7bafb3dccdfa2e24b4fd4a2724ebc3deaebe21cdf5b8c8b12fc0e830bd148444
+    - https://downloads.sourceforge.net/project/keepass/KeePass%202.x/2.57/KeePass-2.57-Source.zip : 7a6278421848694a301b848053344aea151e9dd73f1fa247d3d26cd898bd3d0d
 homepage   : https://keepass.info/
 license    : GPL-2.0-or-later
 component  : security

--- a/packages/k/keepass/pspec_x86_64.xml
+++ b/packages/k/keepass/pspec_x86_64.xml
@@ -43,9 +43,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="42">
-            <Date>2024-02-15</Date>
-            <Version>2.56</Version>
+        <Update release="43">
+            <Date>2024-06-09</Date>
+            <Version>2.57</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Release notes available [here](https://keepass.info/news/n240601_2.57.html)

**Test Plan**
- Open my password database
- Edited and saved a password
- Used auto-type to enter a password into browser window

**Checklist**

- [x] Package was built and tested against unstable
