### PR TITLE
libvips: Update to 8.15.2 and add monitoring.yml

### DIFF
--- a/packages/l/libvips/abi_used_symbols
+++ b/packages/l/libvips/abi_used_symbols
@@ -320,7 +320,9 @@ libglib-2.0.so.0:g_mutex_lock
 libglib-2.0.so.0:g_mutex_unlock
 libglib-2.0.so.0:g_once_impl
 libglib-2.0.so.0:g_once_init_enter
+libglib-2.0.so.0:g_once_init_enter_pointer
 libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_group
 libglib-2.0.so.0:g_option_context_free
 libglib-2.0.so.0:g_option_context_get_help

--- a/packages/l/libvips/monitoring.yml
+++ b/packages/l/libvips/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 5097
+  rss: https://github.com/libvips/libvips/releases.atom
+security:
+  cpe:
+    - vendor: libvips_project
+      product: libvips

--- a/packages/l/libvips/package.yml
+++ b/packages/l/libvips/package.yml
@@ -1,8 +1,8 @@
 name       : libvips
-version    : 8.15.1
-release    : 45
+version    : 8.15.2
+release    : 46
 source     :
-    - https://github.com/libvips/libvips/archive/refs/tags/v8.15.1.tar.gz : 5701445a076465a3402a135d13c0660d909beb8efc4f00fbbe82392e243497f2
+    - https://github.com/libvips/libvips/archive/refs/tags/v8.15.2.tar.gz : 8c3ece7be367636fd676573a8ff22170c07e95e81fd94f2d1eb9966800522e1f
 homepage   : https://www.libvips.org/
 license    : LGPL-2.1-or-later
 component  : multimedia.library

--- a/packages/l/libvips/pspec_x86_64.xml
+++ b/packages/l/libvips/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libvips</Name>
         <Homepage>https://www.libvips.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>multimedia.library</PartOf>
@@ -27,9 +27,9 @@
             <Path fileType="executable">/usr/bin/vipsthumbnail</Path>
             <Path fileType="library">/usr/lib64/girepository-1.0/Vips-8.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libvips-cpp.so.42</Path>
-            <Path fileType="library">/usr/lib64/libvips-cpp.so.42.17.1</Path>
+            <Path fileType="library">/usr/lib64/libvips-cpp.so.42.17.2</Path>
             <Path fileType="library">/usr/lib64/libvips.so.42</Path>
-            <Path fileType="library">/usr/lib64/libvips.so.42.17.1</Path>
+            <Path fileType="library">/usr/lib64/libvips.so.42.17.2</Path>
             <Path fileType="library">/usr/lib64/vips-modules-8.15/vips-heif.so</Path>
             <Path fileType="library">/usr/lib64/vips-modules-8.15/vips-jxl.so</Path>
             <Path fileType="library">/usr/lib64/vips-modules-8.15/vips-magick.so</Path>
@@ -51,7 +51,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="45">libvips</Dependency>
+            <Dependency release="46">libvips</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/vips/VConnection8.h</Path>
@@ -196,12 +196,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="45">
-            <Date>2024-03-03</Date>
-            <Version>8.15.1</Version>
+        <Update release="46">
+            <Date>2024-06-09</Date>
+            <Version>8.15.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- fix deflate compression of tiff pyramids
- thumbnail always writes 8-bit thumbnails
- lower min scale factor to 0.0 in svgload and pdfload
- heifload: don't warn on images with nclx profiles
- ppmload: ensure multi-line comments are skipped
- fix arrayjoin with some pipelines
- fix high Q mono JPEG TIFF write with mozjpeg
- check linker for target_clones support

**Test Plan**

Changed a view image properties with `vips`

**Checklist**

- [x] Package was built and tested against unstable
