### PR TITLE
libwebp: Update to 1.4.0

### DIFF
--- a/packages/l/libwebp/abi_symbols
+++ b/packages/l/libwebp/abi_symbols
@@ -1,8 +1,10 @@
 libsharpyuv.so.0:SharpYuvComputeConversionMatrix
 libsharpyuv.so.0:SharpYuvConvert
+libsharpyuv.so.0:SharpYuvConvertWithOptions
 libsharpyuv.so.0:SharpYuvGetConversionMatrix
 libsharpyuv.so.0:SharpYuvGetVersion
 libsharpyuv.so.0:SharpYuvInit
+libsharpyuv.so.0:SharpYuvOptionsInitInternal
 libwebp.so.7:VP8CheckSignature
 libwebp.so.7:VP8GetCPUInfo
 libwebp.so.7:VP8GetInfo
@@ -156,9 +158,12 @@ libwebpdemux.so.2:WebPGetDemuxVersion
 libwebpmux.so.3:WebPAnimEncoderAdd
 libwebpmux.so.3:WebPAnimEncoderAssemble
 libwebpmux.so.3:WebPAnimEncoderDelete
+libwebpmux.so.3:WebPAnimEncoderDeleteChunk
+libwebpmux.so.3:WebPAnimEncoderGetChunk
 libwebpmux.so.3:WebPAnimEncoderGetError
 libwebpmux.so.3:WebPAnimEncoderNewInternal
 libwebpmux.so.3:WebPAnimEncoderOptionsInitInternal
+libwebpmux.so.3:WebPAnimEncoderSetChunk
 libwebpmux.so.3:WebPGetMuxVersion
 libwebpmux.so.3:WebPMuxAssemble
 libwebpmux.so.3:WebPMuxCreateInternal

--- a/packages/l/libwebp/abi_symbols32
+++ b/packages/l/libwebp/abi_symbols32
@@ -1,8 +1,10 @@
 libsharpyuv.so.0:SharpYuvComputeConversionMatrix
 libsharpyuv.so.0:SharpYuvConvert
+libsharpyuv.so.0:SharpYuvConvertWithOptions
 libsharpyuv.so.0:SharpYuvGetConversionMatrix
 libsharpyuv.so.0:SharpYuvGetVersion
 libsharpyuv.so.0:SharpYuvInit
+libsharpyuv.so.0:SharpYuvOptionsInitInternal
 libwebp.so.7:VP8CheckSignature
 libwebp.so.7:VP8GetCPUInfo
 libwebp.so.7:VP8GetInfo
@@ -156,9 +158,12 @@ libwebpdemux.so.2:WebPGetDemuxVersion
 libwebpmux.so.3:WebPAnimEncoderAdd
 libwebpmux.so.3:WebPAnimEncoderAssemble
 libwebpmux.so.3:WebPAnimEncoderDelete
+libwebpmux.so.3:WebPAnimEncoderDeleteChunk
+libwebpmux.so.3:WebPAnimEncoderGetChunk
 libwebpmux.so.3:WebPAnimEncoderGetError
 libwebpmux.so.3:WebPAnimEncoderNewInternal
 libwebpmux.so.3:WebPAnimEncoderOptionsInitInternal
+libwebpmux.so.3:WebPAnimEncoderSetChunk
 libwebpmux.so.3:WebPGetMuxVersion
 libwebpmux.so.3:WebPMuxAssemble
 libwebpmux.so.3:WebPMuxCreateInternal

--- a/packages/l/libwebp/abi_used_symbols
+++ b/packages/l/libwebp/abi_used_symbols
@@ -108,8 +108,10 @@ libjpeg.so.8:jpeg_resync_to_restart
 libjpeg.so.8:jpeg_save_markers
 libjpeg.so.8:jpeg_start_decompress
 libjpeg.so.8:jpeg_std_error
+libm.so.6:expf
 libm.so.6:log
 libm.so.6:log10
+libm.so.6:logf
 libm.so.6:pow
 libpng16.so.16:png_create_info_struct
 libpng16.so.16:png_create_read_struct_2

--- a/packages/l/libwebp/abi_used_symbols32
+++ b/packages/l/libwebp/abi_used_symbols32
@@ -22,7 +22,9 @@ libc.so.6:pthread_mutex_lock
 libc.so.6:pthread_mutex_unlock
 libc.so.6:qsort
 libc.so.6:stderr
+libm.so.6:expf
 libm.so.6:floorf
 libm.so.6:log
 libm.so.6:log10
+libm.so.6:logf
 libm.so.6:pow

--- a/packages/l/libwebp/package.yml
+++ b/packages/l/libwebp/package.yml
@@ -1,8 +1,8 @@
 name       : libwebp
-version    : 1.3.2
-release    : 26
+version    : 1.4.0
+release    : 27
 source     :
-    - https://github.com/webmproject/libwebp/archive/refs/tags/v1.3.2.tar.gz : c2c2f521fa468e3c5949ab698c2da410f5dce1c5e99f5ad9e70e0e8446b86505
+    - https://github.com/webmproject/libwebp/archive/refs/tags/v1.4.0.tar.gz : 12af50c45530f0a292d39a88d952637e43fb2d4ab1883c44ae729840f7273381
 homepage   : https://developers.google.com/speed/webp/
 license    : BSD-3-Clause
 component  : multimedia.codecs

--- a/packages/l/libwebp/pspec_x86_64.xml
+++ b/packages/l/libwebp/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libwebp</Name>
         <Homepage>https://developers.google.com/speed/webp/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>multimedia.codecs</PartOf>
@@ -28,17 +28,17 @@
             <Path fileType="executable">/usr/bin/webpinfo</Path>
             <Path fileType="executable">/usr/bin/webpmux</Path>
             <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libwebp.so.7</Path>
-            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libwebp.so.7.1.8</Path>
+            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libwebp.so.7.1.9</Path>
             <Path fileType="library">/usr/lib64/libsharpyuv.so.0</Path>
-            <Path fileType="library">/usr/lib64/libsharpyuv.so.0.0.1</Path>
+            <Path fileType="library">/usr/lib64/libsharpyuv.so.0.1.0</Path>
             <Path fileType="library">/usr/lib64/libwebp.so.7</Path>
-            <Path fileType="library">/usr/lib64/libwebp.so.7.1.8</Path>
+            <Path fileType="library">/usr/lib64/libwebp.so.7.1.9</Path>
             <Path fileType="library">/usr/lib64/libwebpdecoder.so.3</Path>
-            <Path fileType="library">/usr/lib64/libwebpdecoder.so.3.1.8</Path>
+            <Path fileType="library">/usr/lib64/libwebpdecoder.so.3.1.9</Path>
             <Path fileType="library">/usr/lib64/libwebpdemux.so.2</Path>
-            <Path fileType="library">/usr/lib64/libwebpdemux.so.2.0.14</Path>
+            <Path fileType="library">/usr/lib64/libwebpdemux.so.2.0.15</Path>
             <Path fileType="library">/usr/lib64/libwebpmux.so.3</Path>
-            <Path fileType="library">/usr/lib64/libwebpmux.so.3.0.13</Path>
+            <Path fileType="library">/usr/lib64/libwebpmux.so.3.1.0</Path>
         </Files>
     </Package>
     <Package>
@@ -48,19 +48,19 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="26">libwebp</Dependency>
+            <Dependency release="27">libwebp</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libsharpyuv.so.0</Path>
-            <Path fileType="library">/usr/lib32/libsharpyuv.so.0.0.1</Path>
+            <Path fileType="library">/usr/lib32/libsharpyuv.so.0.1.0</Path>
             <Path fileType="library">/usr/lib32/libwebp.so.7</Path>
-            <Path fileType="library">/usr/lib32/libwebp.so.7.1.8</Path>
+            <Path fileType="library">/usr/lib32/libwebp.so.7.1.9</Path>
             <Path fileType="library">/usr/lib32/libwebpdecoder.so.3</Path>
-            <Path fileType="library">/usr/lib32/libwebpdecoder.so.3.1.8</Path>
+            <Path fileType="library">/usr/lib32/libwebpdecoder.so.3.1.9</Path>
             <Path fileType="library">/usr/lib32/libwebpdemux.so.2</Path>
-            <Path fileType="library">/usr/lib32/libwebpdemux.so.2.0.14</Path>
+            <Path fileType="library">/usr/lib32/libwebpdemux.so.2.0.15</Path>
             <Path fileType="library">/usr/lib32/libwebpmux.so.3</Path>
-            <Path fileType="library">/usr/lib32/libwebpmux.so.3.0.13</Path>
+            <Path fileType="library">/usr/lib32/libwebpmux.so.3.1.0</Path>
         </Files>
     </Package>
     <Package>
@@ -70,8 +70,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="26">libwebp-32bit</Dependency>
-            <Dependency release="26">libwebp-devel</Dependency>
+            <Dependency release="27">libwebp-32bit</Dependency>
+            <Dependency release="27">libwebp-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libsharpyuv.so</Path>
@@ -93,7 +93,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="26">libwebp</Dependency>
+            <Dependency release="27">libwebp</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/webp/decode.h</Path>
@@ -124,12 +124,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2024-02-10</Date>
-            <Version>1.3.2</Version>
+        <Update release="27">
+            <Date>2024-06-09</Date>
+            <Version>1.4.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- API changes:
 - libwebpmux: WebPAnimEncoderSetChunk, WebPAnimEncoderGetChunk, WebPAnimEncoderDeleteChunk
 - libsharpyuv: SharpYuvOptionsInit, SharpYuvConvertWithOptions
 - extras: SharpYuvEstimate420Risk
- further security related hardening in libwebp & examples
- some minor optimizations in the lossless encoder
- added WEBP_NODISCARD to report unused result warnings
- improvements and corrections in webp-container-spec.txt and webp-lossless-bitstream-spec.txt
- miscellaneous warning, bug & build fixes

**Test Plan**

Converted a bunch of images and gif animations to webp format and viewed them

**Checklist**

- [x] Package was built and tested against unstable
