### PR TITLE
mbedtls: Update to 2.28.2

### DIFF
--- a/packages/m/mbedtls/abi_symbols
+++ b/packages/m/mbedtls/abi_symbols
@@ -639,6 +639,10 @@ libmbedcrypto.so.7:psa_close_key
 libmbedcrypto.so.7:psa_copy_key
 libmbedcrypto.so.7:psa_copy_key_material_into_slot
 libmbedcrypto.so.7:psa_crypto_init
+libmbedcrypto.so.7:psa_crypto_local_input_alloc
+libmbedcrypto.so.7:psa_crypto_local_input_free
+libmbedcrypto.so.7:psa_crypto_local_output_alloc
+libmbedcrypto.so.7:psa_crypto_local_output_free
 libmbedcrypto.so.7:psa_destroy_key
 libmbedcrypto.so.7:psa_destroy_persistent_key
 libmbedcrypto.so.7:psa_driver_wrapper_aead_decrypt

--- a/packages/m/mbedtls/files/revert-unconditional-third-party.patch
+++ b/packages/m/mbedtls/files/revert-unconditional-third-party.patch
@@ -1,0 +1,29 @@
+From 66a868b6afb7389db124c521d4ffb84a4ba2bbdf Mon Sep 17 00:00:00 2001
+From: Gilles Peskine <Gilles.Peskine@arm.com>
+Date: Fri, 29 Sep 2023 17:36:24 +0200
+Subject: [PATCH] CMake: fix build with 3rdparty module enabled through a
+ custom config
+
+Fixes #8165
+
+Signed-off-by: Gilles Peskine <Gilles.Peskine@arm.com>
+---
+ 3rdparty/CMakeLists.txt                          | 6 +-----
+
+diff --git a/3rdparty/CMakeLists.txt b/3rdparty/CMakeLists.txt
+index 18945e52ee75..37480f2cfd98 100644
+--- a/3rdparty/CMakeLists.txt
++++ b/3rdparty/CMakeLists.txt
+@@ -4,11 +4,7 @@ list (APPEND thirdparty_inc_public)
+ list (APPEND thirdparty_inc)
+ list (APPEND thirdparty_def)
+ 
+-execute_process(COMMAND ${MBEDTLS_PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/config.py -f ${CMAKE_CURRENT_SOURCE_DIR}/../include/mbedtls/config.h get MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED RESULT_VARIABLE result)
+-
+-if(${result} EQUAL 0)
+-    add_subdirectory(everest)
+-endif()
++add_subdirectory(everest)
+ 
+ set(thirdparty_src ${thirdparty_src} PARENT_SCOPE)
+ set(thirdparty_lib ${thirdparty_lib} PARENT_SCOPE)

--- a/packages/m/mbedtls/package.yml
+++ b/packages/m/mbedtls/package.yml
@@ -1,8 +1,8 @@
 name       : mbedtls
-version    : 2.28.7
-release    : 13
+version    : 2.28.8
+release    : 14
 source     :
-    - https://github.com/ARMmbed/mbedtls/archive/mbedtls-2.28.7.tar.gz : 4390bc4ab1ea9a1ddf3725f540d0f80838c656d1d7987a1cee8b4da43e4571de
+    - https://github.com/Mbed-TLS/mbedtls/archive/mbedtls-2.28.8.tar.gz : 98b91415d86311b9c08f383906f58332429605895b53bb598d61b0bc29128a1d
 homepage   : https://www.trustedfirmware.org/projects/mbed-tls/
 license    :
     - GPL-2.0-or-later
@@ -12,6 +12,9 @@ summary    : Flexible SSL library.
 description: |
     Portable, easy to use, readable and flexible SSL library.
 setup      : |
+    # Don't include third-party headers
+    %patch -Rp1 -i $pkgfiles/revert-unconditional-third-party.patch
+
     %cmake -DENABLE_PROGRAMS=OFF \
            -DENABLE_ZLIB_SUPPORT=ON \
            -DLIB_INSTALL_DIR=lib64 \

--- a/packages/m/mbedtls/pspec_x86_64.xml
+++ b/packages/m/mbedtls/pspec_x86_64.xml
@@ -21,12 +21,12 @@
 </Description>
         <PartOf>programming.library</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib64/libmbedcrypto.so.2.28.7</Path>
+            <Path fileType="library">/usr/lib64/libmbedcrypto.so.2.28.8</Path>
             <Path fileType="library">/usr/lib64/libmbedcrypto.so.7</Path>
             <Path fileType="library">/usr/lib64/libmbedtls.so.14</Path>
-            <Path fileType="library">/usr/lib64/libmbedtls.so.2.28.7</Path>
+            <Path fileType="library">/usr/lib64/libmbedtls.so.2.28.8</Path>
             <Path fileType="library">/usr/lib64/libmbedx509.so.1</Path>
-            <Path fileType="library">/usr/lib64/libmbedx509.so.2.28.7</Path>
+            <Path fileType="library">/usr/lib64/libmbedx509.so.2.28.8</Path>
         </Files>
     </Package>
     <Package>
@@ -36,7 +36,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="13">mbedtls</Dependency>
+            <Dependency release="14">mbedtls</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/mbedtls/aes.h</Path>
@@ -138,12 +138,15 @@
             <Path fileType="library">/usr/lib64/libmbedcrypto.so</Path>
             <Path fileType="library">/usr/lib64/libmbedtls.so</Path>
             <Path fileType="library">/usr/lib64/libmbedx509.so</Path>
+            <Path fileType="data">/usr/lib64/pkgconfig/mbedcrypto.pc</Path>
+            <Path fileType="data">/usr/lib64/pkgconfig/mbedtls.pc</Path>
+            <Path fileType="data">/usr/lib64/pkgconfig/mbedx509.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2024-02-09</Date>
-            <Version>2.28.7</Version>
+        <Update release="14">
+            <Date>2024-06-09</Date>
+            <Version>2.28.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Release notes available [here](https://github.com/Mbed-TLS/mbedtls/releases/tag/v2.28.8)

Fixes CVE-2024-28960

**Test Plan**

Rebuilt and used `dolphin-emu` with this version

**Checklist**

- [x] Package was built and tested against unstable
