### PR TITLE
pyg3t: Update to 0.6.0

### DIFF
--- a/packages/py/pyg3t/package.yml
+++ b/packages/py/pyg3t/package.yml
@@ -1,16 +1,19 @@
 name       : pyg3t
-version    : 0.5.0
-release    : 7
+version    : 0.6.0
+release    : 8
 source     :
-    - https://github.com/pyg3t/pyg3t/archive/0.5.0.tar.gz : 45bcdd4c8ee01491cc66f3e42c632245e9572e7fd1f2ae184fa1839db3e809ba
-license    : GPL-3.0
+    - https://gitlab.com/pyg3t/pyg3t/-/archive/0.6.0/pyg3t-0.6.0.tar.bz2 : bcdb91b9272961155b1901ae8e1bac86264b0138d2ac90f38aa0f7165a0f3db4
+homepage   : https://gitlab.com/pyg3t/pyg3t/
+license    : GPL-3.0-or-later
 component  : programming.python
 summary    : PyG3T, python gettext translation toolkit
 description: |
     PyG3T, the Python GetText Translation Toolkit, is a collection of tools for computer assisted translation using GNU gettext.
 builddeps  :
-    - pkgconfig(python3)
+    - python-build
+    - python-installer
     - python-setuptools
+    - python-wheel
 rundeps    :
     - python-dateutil
 build      : |

--- a/packages/py/pyg3t/pspec_x86_64.xml
+++ b/packages/py/pyg3t/pspec_x86_64.xml
@@ -1,11 +1,12 @@
 <PISI>
     <Source>
         <Name>pyg3t</Name>
+        <Homepage>https://gitlab.com/pyg3t/pyg3t/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
-        <License>GPL-3.0</License>
+        <License>GPL-3.0-or-later</License>
         <PartOf>programming.python</PartOf>
         <Summary xml:lang="en">PyG3T, python gettext translation toolkit</Summary>
         <Description xml:lang="en">PyG3T, the Python GetText Translation Toolkit, is a collection of tools for computer assisted translation using GNU gettext.
@@ -31,31 +32,56 @@
             <Path fileType="executable">/usr/bin/podiff</Path>
             <Path fileType="executable">/usr/bin/popatch</Path>
             <Path fileType="executable">/usr/bin/poselect</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t-0.5.0-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t-0.5.0-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t-0.5.0-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t-0.5.0-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t-0.6.0.dist-info/COPYING</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t-0.6.0.dist-info/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t-0.6.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t-0.6.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t-0.6.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t-0.6.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t-0.6.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/annotate.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/annotate.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/batch.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/batch.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/charsets.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/charsets.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/gtcat.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/gtcat.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/gtcheckargs.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/gtcheckargs.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/gtcompare.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/gtcompare.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/gtdifflib.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/gtdifflib.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/gtgrep.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/gtgrep.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/gtmerge.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/gtmerge.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/gtparse.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/gtparse.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/gtprevmsgdiff.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/gtprevmsgdiff.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/gtwdiff.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/gtwdiff.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/gtxml.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/gtxml.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/message.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/message.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/poabc.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/poabc.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/podiff.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/podiff.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/popatch.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/popatch.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/poselect.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/poselect.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/util.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/__pycache__/util.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/annotate.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/batch.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/charsets.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/gtcat.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyg3t/gtcheckargs.py</Path>
@@ -76,12 +102,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2024-02-16</Date>
-            <Version>0.5.0</Version>
+        <Update release="8">
+            <Date>2024-06-11</Date>
+            <Version>0.6.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- No upstream changelog, [here](https://gitlab.com/pyg3t/pyg3t/-/compare/0.5.0...0.6.0?from_project_id=15129414&straight=false) is git history
- Add `homepage` key to `package.yml` (Part of getsolus/packages#411)

**Test Plan**

<!-- Short description of how the package was tested -->
TBD

**Checklist**

- [x] Package was built and tested against unstable
