### PR TITLE
protontricks: Update to 1.11.1

### DIFF
--- a/packages/p/protontricks/package.yml
+++ b/packages/p/protontricks/package.yml
@@ -1,8 +1,8 @@
 name       : protontricks
-version    : 1.11.0
-release    : 24
+version    : 1.11.1
+release    : 25
 source     :
-    - git|https://github.com/Matoking/protontricks.git : 1.11.0
+    - https://files.pythonhosted.org/packages/source/p/protontricks/protontricks-1.11.1.tar.gz : aa4141a0d63d27540946318346280b657a3a7523f98f82aee86f2301fe1e2014
 homepage   : https://github.com/Matoking/protontricks
 license    : GPL-3.0-or-later
 component  : virt
@@ -15,6 +15,7 @@ builddeps  :
     - python-vdf
 checkdeps  :
     - python-pytest
+    - python-wheel
 rundeps    :
     - python-pillow
     - python-vdf

--- a/packages/p/protontricks/pspec_x86_64.xml
+++ b/packages/p/protontricks/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>protontricks</Name>
         <Homepage>https://github.com/Matoking/protontricks</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>virt</PartOf>
@@ -23,12 +23,12 @@
             <Path fileType="executable">/usr/bin/protontricks</Path>
             <Path fileType="executable">/usr/bin/protontricks-desktop-install</Path>
             <Path fileType="executable">/usr/bin/protontricks-launch</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/protontricks-1.11.0-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/protontricks-1.11.0-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/protontricks-1.11.0-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/protontricks-1.11.0-py3.11.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/protontricks-1.11.0-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/protontricks-1.11.0-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/protontricks-1.11.1-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/protontricks-1.11.1-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/protontricks-1.11.1-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/protontricks-1.11.1-py3.11.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/protontricks-1.11.1-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/protontricks-1.11.1-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/protontricks/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/protontricks/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/protontricks/__pycache__/_version.cpython-311.pyc</Path>
@@ -67,12 +67,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2024-02-16</Date>
-            <Version>1.11.0</Version>
+        <Update release="25">
+            <Date>2024-06-11</Date>
+            <Version>1.11.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Ignore empty compatibilitytool.vdf
- Fix crash w/ GUI if Proton install is incomplete
- CLI Launch: Shlex executable path
- Fix tests for new pytest
- Refactor subprocess mocking in tests
- Check for successful steam-runtime-launcher launch
- Tolerate compatibilitytool.vdf parsing issues

**Test Plan**

Used `protontricks --gui` to configure a game's Proton environment

**Checklist**

- [x] Package was built and tested against unstable
