### PR TITLE
pytest-subtests: Update to 0.12.1

### DIFF
--- a/packages/py/pytest-subtests/monitoring.yml
+++ b/packages/py/pytest-subtests/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 66961
+  rss: https://github.com/pytest-dev/pytest-subtests/tags.atom
+# No known CPE, checked 2024-06-12
+security:
+  cpe: ~

--- a/packages/py/pytest-subtests/package.yml
+++ b/packages/py/pytest-subtests/package.yml
@@ -1,15 +1,19 @@
 name       : pytest-subtests
-version    : 0.5.0
-release    : 3
+version    : 0.12.1
+release    : 4
 source     :
-    - https://pypi.io/packages/source/p/pytest-subtests/pytest-subtests-0.5.0.tar.gz : 5bd1e4bf0eda4c89a6cd42b0ee28e1d2ca0848de3fd67ad8cdd6d559ed00f120
+    - https://pypi.io/packages/source/p/pytest-subtests/pytest-subtests-0.12.1.tar.gz : d6605dcb88647e0b7c1889d027f8ef1c17d7a2c60927ebfdc09c7b0d8120476d
+homepage   : https://pypi.org/project/pytest-subtests/
 license    : MIT
 component  : programming.python
 summary    : unittest subTest() support and subtests fixture
 description: |
     unittest subTest() support and subtests fixture
 builddeps  :
+    - python-build
+    - python-installer
     - python-setuptools-scm
+    - python-wheel
 rundeps    :
     - python-pytest
 setup      : |

--- a/packages/py/pytest-subtests/pspec_x86_64.xml
+++ b/packages/py/pytest-subtests/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>pytest-subtests</Name>
+        <Homepage>https://pypi.org/project/pytest-subtests/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -19,23 +20,28 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/__pycache__/pytest_subtests.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pytest_subtests-0.5.0-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pytest_subtests-0.5.0-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pytest_subtests-0.5.0-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pytest_subtests-0.5.0-py3.11.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pytest_subtests-0.5.0-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pytest_subtests-0.5.0-py3.11.egg-info/top_level.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pytest_subtests.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pytest_subtests-0.12.1.dist-info/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pytest_subtests-0.12.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pytest_subtests-0.12.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pytest_subtests-0.12.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pytest_subtests-0.12.1.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pytest_subtests-0.12.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pytest_subtests/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pytest_subtests/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pytest_subtests/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pytest_subtests/__pycache__/plugin.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pytest_subtests/__pycache__/plugin.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pytest_subtests/plugin.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pytest_subtests/py.typed</Path>
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-02-14</Date>
-            <Version>0.5.0</Version>
+        <Update release="4">
+            <Date>2024-06-12</Date>
+            <Version>0.12.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Changelog can be found [here](https://github.com/pytest-dev/pytest-subtests/blob/v0.12.1/CHANGELOG.rst)
- Add `homepage` key to `package.yml` (Part of getsolus/packages#411)
- Add monitoring.yml

**Test Plan**

<!-- Short description of how the package was tested -->
Rebuild python-cryptography against this package (Passed test suite)

**Checklist**

-  [x] Package was built and tested against unstable
