### PR TITLE
anki: Update to 24.06.2

### DIFF
--- a/packages/a/anki/package.yml
+++ b/packages/a/anki/package.yml
@@ -1,8 +1,8 @@
 name       : anki
-version    : 24.06.1
-release    : 37
+version    : 24.06.2
+release    : 38
 source     :
-    - git|https://github.com/ankitects/anki.git : 24.06.1
+    - git|https://github.com/ankitects/anki.git : 24.06.2
 license    : AGPL-3.0-or-later
 component  : office.notes
 homepage   : https://apps.ankiweb.net/index.html

--- a/packages/a/anki/pspec_x86_64.xml
+++ b/packages/a/anki/pspec_x86_64.xml
@@ -224,7 +224,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/context-keys.O6kwXuuk.mjs</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/cross-browser.a5UeKJFq.mjs</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/each.AJyTDN0I.mjs</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/entry.6_EGYGGA.mjs</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/entry.rg5DUUH-.mjs</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/ftl.IxHLS1AB.mjs</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/functional.qOciT07A.mjs</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/helpers.Gx5FBjbA.mjs</Path>
@@ -234,17 +234,17 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/isObject.u1V2KUQz.mjs</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/progress.RWW24KP_.mjs</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/runtime-require.2UnWAaTy.mjs</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/stores.6D2ChdPd.mjs</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/stores.8hRVRZp7.mjs</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/theme.FGcaMnTR.mjs</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/time.dB5-GOAi.mjs</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/utils.zgoumLgx.mjs</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/entry/app.8xnu7dHE.mjs</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/entry/start.DiA1rdl7.mjs</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/entry/app.4Jq60T8R.mjs</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/entry/start.AOyAMq7S.mjs</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/0.84fQbphY.mjs</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/1.SUjeAnfZ.mjs</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/1.3zpIC9ku.mjs</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/10.T7ZvzDGI.mjs</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/11.RT75v3Xg.mjs</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/2.39SdUIcc.mjs</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/2.eglN7ej7.mjs</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/3.qMjCZXZb.mjs</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/4.x-cVHfPS.mjs</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/5.oN1PfiQ-.mjs</Path>
@@ -425,12 +425,12 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/hooks.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/props.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/_aqt/py.typed</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-24.06.1.dist-info/INSTALLER</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-24.06.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-24.06.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-24.06.1.dist-info/REQUESTED</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-24.06.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-24.06.1.dist-info/direct_url.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-24.06.2.dist-info/INSTALLER</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-24.06.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-24.06.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-24.06.2.dist-info/REQUESTED</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-24.06.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/anki-24.06.2.dist-info/direct_url.json</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/anki/__pycache__/_backend.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/anki/__pycache__/_backend_generated.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/anki/__pycache__/_fluent.cpython-311.pyc</Path>
@@ -609,14 +609,14 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/anki/template.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/anki/types.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/anki/utils.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.06.1.dist-info/INSTALLER</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.06.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.06.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.06.1.dist-info/REQUESTED</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.06.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.06.1.dist-info/direct_url.json</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.06.1.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.06.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.06.2.dist-info/INSTALLER</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.06.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.06.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.06.2.dist-info/REQUESTED</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.06.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.06.2.dist-info/direct_url.json</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.06.2.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/aqt-24.06.2.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aqt/__pycache__/_macos_helper.cpython-311.pyc</Path>
@@ -900,9 +900,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="37">
-            <Date>2024-06-08</Date>
-            <Version>24.06.1</Version>
+        <Update release="38">
+            <Date>2024-06-12</Date>
+            <Version>24.06.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fix image occlusion errors in previewer and card template editor

**Test Plan**

Played through a few cards of a Japanese deck, with audio and images

**Checklist**

- [x] Package was built and tested against unstable
