### PR TITLE
gaupol: Update to 1.15

### DIFF
--- a/packages/g/gaupol/package.yml
+++ b/packages/g/gaupol/package.yml
@@ -1,8 +1,8 @@
 name       : gaupol
-version    : 1.14.1
-release    : 22
+version    : '1.15'
+release    : 23
 source     :
-    - https://github.com/otsaloma/gaupol/archive/refs/tags/1.14.1.tar.gz : fa88d60620796800c4408dfdf7148b1abd3d97483e536dd020e35234885eb90b
+    - https://github.com/otsaloma/gaupol/archive/refs/tags/1.15.tar.gz : 4128aa01f2ed3ecbcf12676e99087351251a9f105c14567786b31e77ba9fbfd7
 license    : GPL-3.0-or-later
 homepage   : https://otsaloma.io/gaupol/
 component  : multimedia.video
@@ -16,7 +16,7 @@ rundeps    :
     - gstreamer-1.0-plugins-bad
     - gstreamer-1.0-plugins-good
     - iso-codes
-    - python-chardet
+    - python-charset-normalizer
     - python-gobject
 build      : |
     %python3_setup

--- a/packages/g/gaupol/pspec_x86_64.xml
+++ b/packages/g/gaupol/pspec_x86_64.xml
@@ -159,10 +159,10 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/aeidon/temp.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aeidon/unittest.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/aeidon/util.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/gaupol-1.14.1-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/gaupol-1.14.1-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/gaupol-1.14.1-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/gaupol-1.14.1-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/gaupol-1.15-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/gaupol-1.15-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/gaupol-1.15-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/gaupol-1.15-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/gaupol/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/gaupol/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/gaupol/__pycache__/action.cpython-311.pyc</Path>
@@ -408,9 +408,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2024-06-09</Date>
-            <Version>1.14.1</Version>
+        <Update release="23">
+            <Date>2024-06-12</Date>
+            <Version>1.15</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Don't merge font tags with different values
- Drop dependency on chardet
- Add dependency on charset-normalizer
- Raise Python dependency to >= 3.5

**Test Plan**

Edited some subtitles for the film The Fifth Element

**Checklist**

- [x] Package was built and tested against unstable
