### PR TITLE
tailscale: Update to 1.68.0

### DIFF
--- a/packages/t/tailscale/package.yml
+++ b/packages/t/tailscale/package.yml
@@ -1,8 +1,8 @@
 name       : tailscale
-version    : 1.66.4
-release    : 18
+version    : 1.68.0
+release    : 19
 source     :
-    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.66.4.tar.gz : db94df254a263110439aa9d6cf6e1e64a5644b6e6e459ab5298ba6e478a988cf
+    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.68.0.tar.gz : b217e4190e38b9b9799c7749307d207385979ee6da95a16634fc7279d1658314
 homepage   : https://tailscale.com
 license    : BSD-3-Clause
 component  : network.clients

--- a/packages/t/tailscale/pspec_x86_64.xml
+++ b/packages/t/tailscale/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2024-05-25</Date>
-            <Version>1.66.4</Version>
+        <Update release="19">
+            <Date>2024-06-13</Date>
+            <Version>1.68.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- [changelog](https://tailscale.com/changelog#2024-06-12)

**Test Plan**
- tailscale netcheck

**Checklist**
- [X] Package was built and tested against unstable
