### PR TITLE
python-betamax: Update to 0.9.0

### DIFF
--- a/packages/py/python-betamax/monitoring.yml
+++ b/packages/py/python-betamax/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 9469
+  rss: https://github.com/betamaxpy/betamax/tags.atom
+# No known CPE, checked 2024-06-13
+security:
+  cpe: ~

--- a/packages/py/python-betamax/package.yml
+++ b/packages/py/python-betamax/package.yml
@@ -1,8 +1,9 @@
 name       : python-betamax
-version    : 0.8.1
-release    : 6
+version    : 0.9.0
+release    : 7
 source     :
-    - https://github.com/betamaxpy/betamax/archive/0.8.1.tar.gz : 69b4e14e36273211e5a392da5c9ed572dd8b0c446b35204f57dca81765ed2fc1
+    - https://github.com/betamaxpy/betamax/archive/refs/tags/0.9.0.tar.gz : 971bcaffce5ce8fdc67fb207fb0d12657d2ac169e0086428b5acdf8d54d8a8d5
+homepage   : https://betamax.readthedocs.io/
 license    : Apache-2.0
 component  : programming.python
 summary    : A VCR imitation designed only for python-requests

--- a/packages/py/python-betamax/pspec_x86_64.xml
+++ b/packages/py/python-betamax/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>python-betamax</Name>
+        <Homepage>https://betamax.readthedocs.io/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -19,12 +20,12 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/betamax-0.8.1-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/betamax-0.8.1-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/betamax-0.8.1-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/betamax-0.8.1-py3.11.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/betamax-0.8.1-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/betamax-0.8.1-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/betamax-0.9.0-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/betamax-0.9.0-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/betamax-0.9.0-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/betamax-0.9.0-py3.11.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/betamax-0.9.0-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/betamax-0.9.0-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/betamax/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/betamax/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/betamax/__pycache__/adapter.cpython-311.pyc</Path>
@@ -88,12 +89,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2024-02-14</Date>
-            <Version>0.8.1</Version>
+        <Update release="7">
+            <Date>2024-06-13</Date>
+            <Version>0.9.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Full changelog can be found [here](https://raw.githubusercontent.com/betamaxpy/betamax/0.9.0/HISTORY.rst)
- Add `homepage` key to `package.yml` (Part of getsolus/packages#411)
- Add monitoring.yml

**Test Plan**

<!-- Short description of how the package was tested -->
TBD

**Checklist**

- [x] Package was built and tested against unstable
