### PR TITLE
arc-gtk-theme: Sync with git

### DIFF
--- a/packages/a/arc-gtk-theme/package.yml
+++ b/packages/a/arc-gtk-theme/package.yml
@@ -1,8 +1,8 @@
 name       : arc-gtk-theme
 version    : '20221218'
-release    : 33
+release    : 34
 source     :
-    - https://github.com/jnsh/arc-theme/archive/refs/tags/20221218.tar.gz : aa32825da7e2329fdaac64d35f0afab85e2e2f3c71cc41547bafafa379444ccf
+    - git|https://github.com/jnsh/arc-theme.git : b99424e909e722a1f976df09744fd2dadbead24f
 homepage   : https://github.com/jnsh/arc-theme/
 license    : GPL-3.0-or-later
 summary    : Arc GTK Theme
@@ -21,12 +21,12 @@ replaces   :
 setup      : |
     meson --prefix=/usr transparent \
                         -Dthemes=gtk2,gtk3,gtk4,gnome-shell,xfwm,metacity,plank \
-                        -Dgnome_shell_version=43 \
+                        -Dgnome_shell_version=46 \
                         -Dgnome_shell_gresource=true
 
     meson --prefix=/usr solid \
                         -Dthemes=gtk2,gtk3,gtk4,gnome-shell,xfwm,metacity,plank \
-                        -Dgnome_shell_version=43 \
+                        -Dgnome_shell_version=46 \
                         -Dgnome_shell_gresource=true \
                         -Dtransparency=false
 

--- a/packages/a/arc-gtk-theme/pspec_x86_64.xml
+++ b/packages/a/arc-gtk-theme/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>arc-gtk-theme</Name>
         <Homepage>https://github.com/jnsh/arc-theme/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop.theme</PartOf>
@@ -31,8 +31,6 @@
             <Path fileType="data">/usr/share/themes/Arc-Dark-solid/gnome-shell/common-assets/dash/running4.svg</Path>
             <Path fileType="data">/usr/share/themes/Arc-Dark-solid/gnome-shell/common-assets/misc/calendar-today-active.svg</Path>
             <Path fileType="data">/usr/share/themes/Arc-Dark-solid/gnome-shell/common-assets/misc/calendar-today.svg</Path>
-            <Path fileType="data">/usr/share/themes/Arc-Dark-solid/gnome-shell/common-assets/panel/activities-active.svg</Path>
-            <Path fileType="data">/usr/share/themes/Arc-Dark-solid/gnome-shell/common-assets/panel/activities.svg</Path>
             <Path fileType="data">/usr/share/themes/Arc-Dark-solid/gnome-shell/common-assets/switch/switch-off-selected.svg</Path>
             <Path fileType="data">/usr/share/themes/Arc-Dark-solid/gnome-shell/common-assets/switch/switch-on-selected.svg</Path>
             <Path fileType="data">/usr/share/themes/Arc-Dark-solid/gnome-shell/dark-assets/checkbox/checkbox-checked-focused.svg</Path>
@@ -272,8 +270,6 @@
             <Path fileType="data">/usr/share/themes/Arc-Dark/gnome-shell/common-assets/dash/running4.svg</Path>
             <Path fileType="data">/usr/share/themes/Arc-Dark/gnome-shell/common-assets/misc/calendar-today-active.svg</Path>
             <Path fileType="data">/usr/share/themes/Arc-Dark/gnome-shell/common-assets/misc/calendar-today.svg</Path>
-            <Path fileType="data">/usr/share/themes/Arc-Dark/gnome-shell/common-assets/panel/activities-active.svg</Path>
-            <Path fileType="data">/usr/share/themes/Arc-Dark/gnome-shell/common-assets/panel/activities.svg</Path>
             <Path fileType="data">/usr/share/themes/Arc-Dark/gnome-shell/common-assets/switch/switch-off-selected.svg</Path>
             <Path fileType="data">/usr/share/themes/Arc-Dark/gnome-shell/common-assets/switch/switch-on-selected.svg</Path>
             <Path fileType="data">/usr/share/themes/Arc-Dark/gnome-shell/dark-assets/checkbox/checkbox-checked-focused.svg</Path>
@@ -1361,8 +1357,6 @@
             <Path fileType="data">/usr/share/themes/Arc-solid/gnome-shell/common-assets/dash/running4.svg</Path>
             <Path fileType="data">/usr/share/themes/Arc-solid/gnome-shell/common-assets/misc/calendar-today-active.svg</Path>
             <Path fileType="data">/usr/share/themes/Arc-solid/gnome-shell/common-assets/misc/calendar-today.svg</Path>
-            <Path fileType="data">/usr/share/themes/Arc-solid/gnome-shell/common-assets/panel/activities-active.svg</Path>
-            <Path fileType="data">/usr/share/themes/Arc-solid/gnome-shell/common-assets/panel/activities.svg</Path>
             <Path fileType="data">/usr/share/themes/Arc-solid/gnome-shell/common-assets/switch/switch-off-selected.svg</Path>
             <Path fileType="data">/usr/share/themes/Arc-solid/gnome-shell/common-assets/switch/switch-on-selected.svg</Path>
             <Path fileType="data">/usr/share/themes/Arc-solid/gnome-shell/gnome-shell-theme.gresource</Path>
@@ -1598,8 +1592,6 @@
             <Path fileType="data">/usr/share/themes/Arc/gnome-shell/common-assets/dash/running4.svg</Path>
             <Path fileType="data">/usr/share/themes/Arc/gnome-shell/common-assets/misc/calendar-today-active.svg</Path>
             <Path fileType="data">/usr/share/themes/Arc/gnome-shell/common-assets/misc/calendar-today.svg</Path>
-            <Path fileType="data">/usr/share/themes/Arc/gnome-shell/common-assets/panel/activities-active.svg</Path>
-            <Path fileType="data">/usr/share/themes/Arc/gnome-shell/common-assets/panel/activities.svg</Path>
             <Path fileType="data">/usr/share/themes/Arc/gnome-shell/common-assets/switch/switch-off-selected.svg</Path>
             <Path fileType="data">/usr/share/themes/Arc/gnome-shell/common-assets/switch/switch-on-selected.svg</Path>
             <Path fileType="data">/usr/share/themes/Arc/gnome-shell/gnome-shell-theme.gresource</Path>
@@ -1830,12 +1822,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2023-11-20</Date>
+        <Update release="34">
+            <Date>2024-06-14</Date>
             <Version>20221218</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Many fixes and updates for newer desktop environement versions

This theme hasn't had a tagged release in a couple of years, but is still actively worked on; thus I chose to use the latest commit instead of the last tagged release for support for newer desktops like GNOME 45, etc.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Switched to the themes on Budgie and see that the stylesheets load.

**Checklist**

- [x] Package was built and tested against unstable
