### PR TITLE
github-cli: Update to 2.51.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.50.0
-release    : 49
+version    : 2.51.0
+release    : 50
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.50.0.tar.gz : 683d0dee90e1d24a6673d13680e0d41963ddc6dd88580ab5119acec790d1b4d7
+    - https://github.com/cli/cli/archive/refs/tags/v2.51.0.tar.gz : babc66157676eadc30c150ab9151981792796d6f24663cebc6eb070eb14c390f
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>github-cli</Name>
         <Homepage>https://cli.github.com</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -217,12 +217,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="49">
-            <Date>2024-06-05</Date>
-            <Version>2.50.0</Version>
+        <Update release="50">
+            <Date>2024-06-14</Date>
+            <Version>2.51.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Add `signer-repo` and `signer-workflow` flags to `gh attestation verify`
- Replace `--json-result` flag with `--format=json` in the attestation cmd
- Bump go-keyring to fix keepassxc prompt confirmation
- watch - handle annotation errors gracefully

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list` in the packages repository, and make this pull request.

**Checklist**

- [x] Package was built and tested against unstable
