### PR TITLE
Taskfile.yml: Add a task which runs the appstream progress report

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -268,6 +268,12 @@ tasks:
       - |
         {{ .NEWPKG }} {{.CLI_ARGS}}
 
+  check-appstream-progress:
+    desc: Generate a progress report detailing which packages still need appstream metadata added
+    dir: '{{ .TASKFILE_DIR }}'
+    cmds:
+      - common/Scripts/check_appstream_progress.py packages
+
   add-monitoring:
     desc: Add skeleton for monitoring.yml
     dir: '{{ .USER_WORKING_DIR }}'


### PR DESCRIPTION
**Summary**
Now that we have a script to check which packages need to have appstream data added, it seems prudent to have a task to trigger it.

**Test Plan**

Run `go-task check-appstream-progress` and make sure a list of packages is printed.

**Checklist**

- [ ] Package was built and tested against unstable
