### PR TITLE
svtplay-dl: update to 4.83

### DIFF
--- a/packages/s/svtplay-dl/package.yml
+++ b/packages/s/svtplay-dl/package.yml
@@ -1,8 +1,8 @@
 name       : svtplay-dl
-version    : '4.79'
-release    : 21
+version    : '4.83'
+release    : 22
 source     :
-    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.79.tar.gz : c48ffeed6a88a7e4ea66b0fb77b48bc858d832ccf4c5e3a86dceda15ecdbd387
+    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.83.tar.gz : 3be8191aab68b46b385630ed854dd59251cce91672903711977e82f6d0a5f505
 homepage   : https://svtplay-dl.se/
 license    : MIT
 component  : network.download

--- a/packages/s/svtplay-dl/pspec_x86_64.xml
+++ b/packages/s/svtplay-dl/pspec_x86_64.xml
@@ -21,11 +21,11 @@
         <PartOf>network.download</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/svtplay-dl</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.79-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.79-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.79-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.79-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.79-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.83-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.83-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.83-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.83-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.83-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/__pycache__/__init__.cpython-311.pyc</Path>
@@ -169,9 +169,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2024-05-26</Date>
-            <Version>4.79</Version>
+        <Update release="22">
+            <Date>2024-06-15</Date>
+            <Version>4.83</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
- svtplay: fix a crash getting season / episode info
- svtplay: fix a special case not finding newly released news videos
- plutotv: fix getting movies

**Test Plan**
- Installed and downloaded a video.

**Checklist**

- [X] Package was built and tested against unstable
