### PR TITLE
sshguard: update to 2.3.4

### DIFF
--- a/packages/s/sshguard/abi_used_symbols
+++ b/packages/s/sshguard/abi_used_symbols
@@ -3,6 +3,8 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
 libc.so.6:__memset_chk

--- a/packages/s/sshguard/package.yml
+++ b/packages/s/sshguard/package.yml
@@ -1,8 +1,9 @@
 name       : sshguard
-version    : 2.4.2
-release    : 7
+version    : 2.4.3
+release    : 8
 source     :
-    - https://netcologne.dl.sourceforge.net/project/sshguard/sshguard/2.4.2/sshguard-2.4.2.tar.gz : 2770b776e5ea70a9bedfec4fd84d57400afa927f0f7522870d2dcbbe1ace37e8
+    - https://sourceforge.net/projects/sshguard/files/sshguard/2.4.3/sshguard-2.4.3.tar.gz : 64029deff6de90fdeefb1f497d414f0e4045076693a91da1a70eb7595e97efeb
+homepage   : https://sshguard.net/
 license    :
     - BSD-3-Clause
     - ISC

--- a/packages/s/sshguard/pspec_x86_64.xml
+++ b/packages/s/sshguard/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>sshguard</Name>
+        <Homepage>https://sshguard.net/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>ISC</License>
@@ -12,7 +13,7 @@
         <Summary xml:lang="en">SSH Server attack protection again SSH and other services.</Summary>
         <Description xml:lang="en">SSHGuard protects hosts from brute-force attacks against SSH and other services. It aggregates system logs and blocks repeat offenders using several firewall backends, including iptables, ipfw, and pf.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>sshguard</Name>
@@ -41,12 +42,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2022-03-28</Date>
-            <Version>2.4.2</Version>
+        <Update release="8">
+            <Date>2024-06-15</Date>
+            <Version>2.4.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Add signature for BIND
- Add signature for Gitea
- Add signature for Microsoft SQL Server for Linux
- Add signature for OpenVPN Portshare
- Add signature for user-defined HTTP attacks
- Update signatures for Dovecot
- Update signatures for Postfix
- Fix memset off-by-one
- Resolve DNS names in capability mode using casper

**Test Plan**
- Checked it installed correctly.

**Checklist**

-  [X] Package was built and tested against unstable
