### PR TITLE
gpxsee: Update to 13.22

### DIFF
--- a/packages/g/gpxsee/abi_used_symbols
+++ b/packages/g/gpxsee/abi_used_symbols
@@ -178,6 +178,7 @@ libQt5Core.so.5:_ZN5QFileD1Ev
 libQt5Core.so.5:_ZN5QTimeC1Eiiii
 libQt5Core.so.5:_ZN6QMutex4lockEv
 libQt5Core.so.5:_ZN6QMutex6unlockEv
+libQt5Core.so.5:_ZN6QMutex7tryLockEi
 libQt5Core.so.5:_ZN6QMutexD1Ev
 libQt5Core.so.5:_ZN7QBufferC1EP10QByteArrayP7QObject
 libQt5Core.so.5:_ZN7QBufferD1Ev

--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.21'
-release    : 40
+version    : '13.22'
+release    : 41
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.21.tar.gz : aff8d0ab876523cc157ded956362b60390a70d88436783f0cb006f41dbc9e091
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.22.tar.gz : 34eccacac18b8a3c5145eff9f256f76fafcc3d9d5070191a673b27ea5a0aadda
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gpxsee</Name>
         <Homepage>https://www.gpxsee.org</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Nazar Stasiv</Name>
+            <Email>nazar@autistici.org</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop</PartOf>
@@ -172,12 +172,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="40">
-            <Date>2024-06-05</Date>
-            <Version>13.21</Version>
+        <Update release="41">
+            <Date>2024-06-16</Date>
+            <Version>13.22</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Nazar Stasiv</Name>
+            <Email>nazar@autistici.org</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Improved marine maps (ENC & IMG) rendering.
- Fixed multiple IMG DEM/hilshading issues.
- Added (zoomed) graph scrolling using the mouse.

**Test Plan**
- open map, zoom in and out

**Checklist**
- [X] Package was built and tested against unstable
