### PR TITLE
steam: Split udev rules into a separate package

### DIFF
--- a/packages/s/steam/package.yml
+++ b/packages/s/steam/package.yml
@@ -1,14 +1,22 @@
 name       : steam
 version    : 1.0.0.79
-release    : 94
+release    : 95
 source     :
     - https://repo.steampowered.com/steam/pool/steam/s/steam/steam_1.0.0.79.tar.gz : 3a0012daf5889311c2e1dcf33a587b409019b66d893a52192df6947e18f1ec46
 homepage   : https://store.steampowered.com
 license    : Distributable
-component  : games
-summary    : Launcher for the Steam software distribution service
-description: |
-    Launcher for the Steam software distribution service
+component  :
+    - games
+    - udev-rules: games
+summary    :
+    - Launcher for the Steam software distribution service
+    - udev-rules: udev rules for Steam and SteamVR
+description:
+    - Launcher for the Steam software distribution service
+    - udev-rules: udev rules for Steam and SteamVR
+patterns   :
+    - udev-rules :
+        - /usr/lib64/udev/rules.d/
 rundeps    :
     - acl-32bit
     - alsa-plugins-32bit
@@ -84,6 +92,7 @@ rundeps    :
     - sdl2-mixer-32bit
     - sdl2-net-32bit
     - sdl2-ttf-32bit
+    - steam-udev-rules
     - tcp_wrappers-32bit
     - vulkan-32bit
     - zenity

--- a/packages/s/steam/pspec_x86_64.xml
+++ b/packages/s/steam/pspec_x86_64.xml
@@ -3,22 +3,23 @@
         <Name>steam</Name>
         <Homepage>https://store.steampowered.com</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>Distributable</License>
         <PartOf>games</PartOf>
         <Summary xml:lang="en">Launcher for the Steam software distribution service</Summary>
-        <Description xml:lang="en">Launcher for the Steam software distribution service
-</Description>
+        <Description xml:lang="en">Launcher for the Steam software distribution service</Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>steam</Name>
         <Summary xml:lang="en">Launcher for the Steam software distribution service</Summary>
-        <Description xml:lang="en">Launcher for the Steam software distribution service
-</Description>
+        <Description xml:lang="en">Launcher for the Steam software distribution service</Description>
         <PartOf>games</PartOf>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="95">steam-udev-rules</Dependency>
+        </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/steamdeps</Path>
             <Path fileType="library">/usr/lib/steam/bin_steam.sh</Path>
@@ -28,8 +29,6 @@
             <Path fileType="library">/usr/lib/steam/steam.desktop</Path>
             <Path fileType="library">/usr/lib/steam/steam_launcher/__init__.py</Path>
             <Path fileType="library">/usr/lib/steam/steam_launcher/launcherutils.py</Path>
-            <Path fileType="library">/usr/lib64/udev/rules.d/60-steam-input.rules</Path>
-            <Path fileType="library">/usr/lib64/udev/rules.d/60-steam-vr.rules</Path>
             <Path fileType="data">/usr/share/applications/steam.desktop</Path>
             <Path fileType="doc">/usr/share/doc/steam/README</Path>
             <Path fileType="doc">/usr/share/doc/steam/steam_subscriber_agreement.txt</Path>
@@ -44,13 +43,23 @@
             <Path fileType="data">/usr/share/pixmaps/steam_tray_mono.png</Path>
         </Files>
     </Package>
+    <Package>
+        <Name>steam-udev-rules</Name>
+        <Summary xml:lang="en">udev rules for Steam and SteamVR</Summary>
+        <Description xml:lang="en">udev rules for Steam and SteamVR</Description>
+        <PartOf>games</PartOf>
+        <Files>
+            <Path fileType="library">/usr/lib64/udev/rules.d/60-steam-input.rules</Path>
+            <Path fileType="library">/usr/lib64/udev/rules.d/60-steam-vr.rules</Path>
+        </Files>
+    </Package>
     <History>
-        <Update release="94">
-            <Date>2024-05-07</Date>
+        <Update release="95">
+            <Date>2024-06-16</Date>
             <Version>1.0.0.79</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Split out the udev rules into `steam-udev-rules` so they can be installed separately.

Resolves #2805.

**Test Plan**

Install udev rules without Steam.

**Checklist**

- [x] Package was built and tested against unstable
