### PR TITLE
font-inter-ttf: Initial inclusion at 4.0

### DIFF
--- a/packages/f/font-inter-ttf/files/inter.metainfo.xml
+++ b/packages/f/font-inter-ttf/files/inter.metainfo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2024 Solus Developers <copyright@getsol.us> -->
+<component type="font">
+  <id>font-inter</id>
+  <metadata>CC0-1.0</metadata>
+  <name>Inter</name>
+  <url type="homepage">https://rsms.me/inter/</url>
+  <summary>The Inter font family</summary>
+</component>

--- a/packages/f/font-inter-ttf/package.yml
+++ b/packages/f/font-inter-ttf/package.yml
@@ -1,0 +1,14 @@
+name       : font-inter-ttf
+version    : 4.0
+release    : 1
+source     :
+    - https://github.com/rsms/inter/releases/download/v4.0/Inter-4.0.zip : ff970a5d4561a04f102a7cb781adbd6ac4e9b6c460914c7a101f15acb7f7d1a4
+homepage   : https://rsms.me/inter/
+license    : OFL-1.1
+component  : desktop.font
+summary    : The Inter font family
+description: |
+    Inter is a workhorse of a typeface carefully crafted & designed for a wide range of applications, from detailed user interfaces to marketing & signage.
+install    : |
+    install -Dm00644 extras/ttf/Inter-*.ttf -t $installdir/usr/share/fonts/truetype/inter/
+    install -Dm00644 $pkgfiles/inter.metainfo.xml $installdir/usr/share/metainfo/inter.metainfo.xml

--- a/packages/f/font-inter-ttf/pspec_x86_64.xml
+++ b/packages/f/font-inter-ttf/pspec_x86_64.xml
@@ -1,0 +1,53 @@
+<PISI>
+    <Source>
+        <Name>font-inter-ttf</Name>
+        <Homepage>https://rsms.me/inter/</Homepage>
+        <Packager>
+            <Name>Denis Garaev</Name>
+            <Email>garaevdi@outlook.com</Email>
+        </Packager>
+        <License>OFL-1.1</License>
+        <PartOf>desktop.font</PartOf>
+        <Summary xml:lang="en">The Inter font family</Summary>
+        <Description xml:lang="en">Inter is a workhorse of a typeface carefully crafted &amp; designed for a wide range of applications, from detailed user interfaces to marketing &amp; signage.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>font-inter-ttf</Name>
+        <Summary xml:lang="en">The Inter font family</Summary>
+        <Description xml:lang="en">Inter is a workhorse of a typeface carefully crafted &amp; designed for a wide range of applications, from detailed user interfaces to marketing &amp; signage.
+</Description>
+        <PartOf>desktop.font</PartOf>
+        <Files>
+            <Path fileType="data">/usr/share/fonts/truetype/inter/Inter-Black.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/inter/Inter-BlackItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/inter/Inter-Bold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/inter/Inter-BoldItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/inter/Inter-ExtraBold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/inter/Inter-ExtraBoldItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/inter/Inter-ExtraLight.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/inter/Inter-ExtraLightItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/inter/Inter-Italic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/inter/Inter-Light.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/inter/Inter-LightItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/inter/Inter-Medium.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/inter/Inter-MediumItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/inter/Inter-Regular.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/inter/Inter-SemiBold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/inter/Inter-SemiBoldItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/inter/Inter-Thin.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/inter/Inter-ThinItalic.ttf</Path>
+            <Path fileType="data">/usr/share/metainfo/inter.metainfo.xml</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2024-06-21</Date>
+            <Version>4.0</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Denis Garaev</Name>
+            <Email>garaevdi@outlook.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**

- Add `font-inter-ttf` at 4.0
- Resolves getsolus/packages#2980

**Test plan**

- Change GNOME's interface font via GNOME Tweaks
- Change Budgie's interface font via Budgie desktop settings

**Checklist**

- [x] Package was built and tested against unstable