### PR TITLE
python-google-auth-httplib2: Update to v0.2.0

### DIFF
--- a/packages/py/python-google-auth-httplib2/package.yml
+++ b/packages/py/python-google-auth-httplib2/package.yml
@@ -1,8 +1,9 @@
 name       : python-google-auth-httplib2
-version    : 0.1.0
-release    : 6
+version    : 0.2.0
+release    : 7
 source     :
-    - https://github.com/googleapis/google-auth-library-python-httplib2/archive/refs/tags/v0.1.0.tar.gz : 495ab3ded76145eb5568e26cf5f84a8cec6e769d4b39547cd228fc84d0417fac
+    - https://github.com/googleapis/google-auth-library-python-httplib2/archive/refs/tags/v0.2.0.tar.gz : 7e714ff7a4cd6c69b76f8c91dfe177cdce49ae8bfb398b22a7c1468f3915037d
+homepage   : https://github.com/googleapis/google-auth-library-python-httplib2
 license    : Apache-2.0
 component  : programming.python
 summary    : Provides an httplib2 transport for google-auth

--- a/packages/py/python-google-auth-httplib2/pspec_x86_64.xml
+++ b/packages/py/python-google-auth-httplib2/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>python-google-auth-httplib2</Name>
+        <Homepage>https://github.com/googleapis/google-auth-library-python-httplib2</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -20,21 +21,21 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="library">/usr/lib/python3.11/site-packages/__pycache__/google_auth_httplib2.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/google_auth_httplib2-0.1.0-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/google_auth_httplib2-0.1.0-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/google_auth_httplib2-0.1.0-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/google_auth_httplib2-0.1.0-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/google_auth_httplib2-0.1.0-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/google_auth_httplib2-0.2.0-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/google_auth_httplib2-0.2.0-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/google_auth_httplib2-0.2.0-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/google_auth_httplib2-0.2.0-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/google_auth_httplib2-0.2.0-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/google_auth_httplib2.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2024-02-14</Date>
-            <Version>0.1.0</Version>
+        <Update release="7">
+            <Date>2024-06-18</Date>
+            <Version>0.2.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Full changelog can be found [here](https://github.com/googleapis/google-auth-library-python-httplib2/blob/v0.2.0/CHANGELOG.md)
- Add `homepage` key to `package.yml` (Part of getsolus/packages#411)

**Test Plan**

<!-- Short description of how the package was tested -->
TBD

**Checklist**

- [x] Package was built and tested against unstable
