### PR TITLE
Taskfile: Improve ergonomics by adding aliases

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -224,8 +224,24 @@ tasks:
     cmds:
       - rm *.eopkg -fv
 
+  clean-local:
+    desc: WARNING - Clean ALL eopkgs found in solbuild local repository /var/lib/solbuild/local
+    aliases: [rmlocal, rml]
+    prompt: This will clean ALL eopkgs found in solbuild local repository /var/lib/solbuild/local. Continue?
+    cmds:
+      - task: list-local
+      - sudo rm /var/lib/solbuild/local/*.eopkg
+      - task: build-localindex
+
+  list-local:
+    desc: List all .eopkgs in the local repo (/var/lib/solbuild/local/*.eopkg)
+    aliases: [lslocal, lsl]
+    cmds:
+      - ls -lh /var/lib/solbuild/local/
+
   clean-all:
     desc: List all .eopkgs found in the monorepo, ask before deleting them.
+    aliases: [rmall, rma]
     cmds:
       - task: list-all-eopkgs   # first show all found .eopkg files
       - task: delete-all-eopkgs # then prompt before deleting them
@@ -239,16 +255,10 @@ tasks:
 
   list-all-eopkgs:
     desc: List all .eopkgs found in the monorepo
+    aliases: [lsall, lsa]
     dir: '{{ .TASKFILE_DIR }}'
     cmds:
       - find $(git rev-parse --show-toplevel) -type f -name '*.eopkg' -print
-  
-  clean-local:
-    desc: WARNING - Clean ALL eopkgs found in solbuild local repository /var/lib/solbuild/local
-    prompt: This will clean ALL eopkgs found in solbuild local repository /var/lib/solbuild/local. Continue?
-    cmds:
-      - sudo rm /var/lib/solbuild/local/*.eopkg
-      - task: build-localindex
 
   init:
     desc: Initialize the packages repo


### PR DESCRIPTION
**Summary**

In addition, list files in long form in local repo before asking to clean it out, as it can be useful to be able to see sizes and dates before they get removed (to avoid losing hours of work).

**Test Plan**

- `go-task -l` (to ensure aliases show up) 
-  `go-task clean-all` (to clean my tree of .eopkgs)
- `go-task clean-local` (to clean my local repo)

**Checklist**

- [x] Package was built and tested against unstable
