### PR TITLE
opentabletdriver: Rebuild against 8.0.6

### DIFF
--- a/packages/o/opentabletdriver/files/use-dotnet-8.patch
+++ b/packages/o/opentabletdriver/files/use-dotnet-8.patch
@@ -24,8 +24,21 @@ index b77ce452..bd3a12e8 100644
      {
          private Thread threadTimer;
          private bool runTimer = true;
+diff --git a/OpenTabletDriver/OpenTabletDriver.csproj b/OpenTabletDriver/OpenTabletDriver.csproj
+index 56df617f..92fde71f 100644
+--- a/OpenTabletDriver/OpenTabletDriver.csproj
++++ b/OpenTabletDriver/OpenTabletDriver.csproj
+@@ -14,7 +14,7 @@
+ 
+   <ItemGroup Label="NuGet Packages">
+     <PackageReference Include="HidSharpCore" Version="1.2.1.1" />
+-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0-rc.1.21451.13" />
++    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+   </ItemGroup>
+ 
 diff --git a/eng/lib.sh b/eng/lib.sh
-index 2f112e3e..74c9e8da 100755
+index 2f112e3e..673b135c 100755
 --- a/eng/lib.sh
 +++ b/eng/lib.sh
 @@ -17,13 +17,13 @@ REPO_ROOT="$(readlink -f "${ENG_SCRIPT_ROOT}/../")"

--- a/packages/o/opentabletdriver/package.yml
+++ b/packages/o/opentabletdriver/package.yml
@@ -1,11 +1,11 @@
 name       : opentabletdriver
 version    : 0.6.4.0
-release    : 1
+release    : 2
 source     :
     - https://github.com/OpenTabletDriver/OpenTabletDriver/archive/refs/tags/v0.6.4.0.tar.gz : 1ad04f4a32b54b9b62bd944b0196abb6613873b19c269abcc9f9e94c1dc3027f
 homepage   : https://opentabletdriver.net/
 license    : LGPL-3.0-only
-component  : PLEASE FILL ME IN
+component  : multimedia.graphics
 summary    : An open source tablet driver
 description: |
     OpenTabletDriver is an open-source, user-friendly tablet driver designed to provide support for various drawing tablets on Linux. It offers advanced configuration options, customizable settings, and robust performance, ensuring a seamless experience for artists and designers.
@@ -40,7 +40,7 @@ install    : |
        eng/linux/Generic/usr/bin/otd \
        eng/linux/Generic/usr/bin/otd-gui \
        eng/linux/Generic/usr/bin/otd-daemon
-    
+
     install -Dm 644 eng/linux/Generic/usr/lib/systemd/user/opentabletdriver.service -t $installdir/usr/lib/systemd/user
     install -Dm 644 eng/linux/Generic/usr/lib/modules-load.d/opentabletdriver.conf -t $installdir/usr/lib/modules-load.d
     install -Dm 644 eng/linux/Generic/usr/lib/modprobe.d/99-opentabletdriver.conf -t $installdir/usr/lib/modprobe.d

--- a/packages/o/opentabletdriver/pspec_x86_64.xml
+++ b/packages/o/opentabletdriver/pspec_x86_64.xml
@@ -7,18 +7,18 @@
             <Email>nelson@truran.dev</Email>
         </Packager>
         <License>LGPL-3.0-only</License>
-        <PartOf>PLEASE FILL ME IN</PartOf>
+        <PartOf>multimedia.graphics</PartOf>
         <Summary xml:lang="en">An open source tablet driver</Summary>
-        <Description xml:lang="en">PLEASE FILL ME IN
+        <Description xml:lang="en">OpenTabletDriver is an open-source, user-friendly tablet driver designed to provide support for various drawing tablets on Linux. It offers advanced configuration options, customizable settings, and robust performance, ensuring a seamless experience for artists and designers.
 </Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>opentabletdriver</Name>
         <Summary xml:lang="en">An open source tablet driver</Summary>
-        <Description xml:lang="en">PLEASE FILL ME IN
+        <Description xml:lang="en">OpenTabletDriver is an open-source, user-friendly tablet driver designed to provide support for various drawing tablets on Linux. It offers advanced configuration options, customizable settings, and robust performance, ensuring a seamless experience for artists and designers.
 </Description>
-        <PartOf>PLEASE FILL ME IN</PartOf>
+        <PartOf>multimedia.graphics</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/otd</Path>
             <Path fileType="executable">/usr/bin/otd-daemon</Path>
@@ -36,8 +36,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-05-27</Date>
+        <Update release="2">
+            <Date>2024-06-20</Date>
             <Version>0.6.4.0</Version>
             <Comment>Packaging update</Comment>
             <Name>nelson truran</Name>


### PR DESCRIPTION
**Summary**

Previously built binaries are corrupted. Attempting to build against newest .net to fix.

**Test Plan**

 - use tablet
 - ensure GUI works
 - keymap using tablet button

**Checklist**

- [x] Package was built and tested against unstable
