### PR TITLE
Taskfile: Use more uniform syntax and tweak output

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -20,14 +20,14 @@ tasks:
   # Ensure people new to go-task and used to 'make help' have an easier time
   help:
     desc: Show how to list available tasks
+    silent: true
     cmds:
-      - |
-        echo "Use 'go-task -l/--list' to list available tasks."
+      - echo "Use 'go-task -l/--list' to list available tasks."
 
   # Utility tasks, mainly for precondition checks
   package-file:
     internal: true
-    desc: |
+    desc: >-
       Check that either `package.yml` or `pspec.xml` exists in the current directory
     dir: '{{ .USER_WORKING_DIR }}'
     requires:
@@ -37,7 +37,7 @@ tasks:
         msg: Either `package.yml` or `pspec.xml` must exists in the current directory
 
   solbuild-reset:
-    desc: |
+    desc: >-
       Delete all existing solbuild cache and images, then download fresh solbuild images + cache updates
     cmds: 
       - sudo solbuild delete-cache --all --images
@@ -54,8 +54,7 @@ tasks:
     deps:
       - package-file
     cmds:
-      - |
-        sudo solbuild build {{ .SPECFILE }} -p {{ .PROFILE }} {{ .CLI_ARGS }}
+      - sudo solbuild build {{ .SPECFILE }} -p {{ .PROFILE }} {{ .CLI_ARGS }}
 
   build-local:
     desc: "Build the current package against the unstable and the default local repo"
@@ -72,8 +71,7 @@ tasks:
     aliases: [localcp]
     cmds:
       - task: build-local
-      - |
-        sudo cp -fv {{ .USER_WORKING_DIR }}/*.eopkg /var/lib/solbuild/local/
+      - sudo cp -fv {{ .USER_WORKING_DIR }}/*.eopkg /var/lib/solbuild/local/
       # Ensure that the freshly built package is picked up by the local repo index
       - task: build-localindex
 
@@ -111,8 +109,7 @@ tasks:
     deps:
       - package-file
     cmds:
-      - |
-        {{ .BUMP_SCRIPT }} {{ .SPECFILE }}
+      - "{{ .BUMP_SCRIPT }} {{ .SPECFILE }}"
 
   convert:
     desc: Convert pspec to package.yml
@@ -121,14 +118,13 @@ tasks:
       - sh: test -f pspec.xml
         msg: "`pspec.xml` must exist in the current directory to perform conversion"
     cmds:
-      - |
-        {{ .TASKFILE_DIR }}/common/Scripts/yconvert.py pspec.xml
+      - '{{ .TASKFILE_DIR }}/common/Scripts/yconvert.py pspec.xml'
 
   cvecheck:
     desc: Check package for CVEs
     dir: '{{ .USER_WORKING_DIR }}'
     cmds:
-      - cve-check-tool {{ .PSPECFILE }} -M {{ .TASKFILE_DIR }}/common/mapping -o report.html
+      - 'cve-check-tool {{ .PSPECFILE }} -M {{ .TASKFILE_DIR }}/common/mapping -o report.html'
 
   notify-complete:
     desc: Get a notification when the build has finished on the buildserver
@@ -139,26 +135,22 @@ tasks:
       - "{{ .TASKFILE_DIR }}/common/Scripts/buildserver-notification.sh"
 
   pkgconfig:
-    desc: |
+    desc: >-
       Find which package provides a given pkgconfig target.
-
       Example usage: `go-task pkgconfig -- Qt5Core Qt6Core`
     cmds:
-      - |
-        {{ .TASKFILE_DIR }}/common/Scripts/epcsearch.py {{ .CLI_ARGS }}
+      - '{{ .TASKFILE_DIR }}/common/Scripts/epcsearch.py {{ .CLI_ARGS }}'
 
   update:
-    desc: |
+    desc: >-
       Update an existing package.yml recipe to a new version given a version and a download URI.
-
       Example usage: `go-task update -- 7.2 https://www.nano-editor.org/dist/v7/nano-7.2.tar.xz`
     dir: '{{ .USER_WORKING_DIR }}'
     preconditions:
       - sh: test -f package.yml
         msg: "`package.yml` must exist in the current directory"
     cmds:
-      - |
-        yupdate {{ .CLI_ARGS }}
+      - 'yupdate {{ .CLI_ARGS }}'
 
   # For staff and packagers with push access
   publish:
@@ -282,8 +274,7 @@ tasks:
     vars:
       NEWPKG: "{{ .TASKFILE_DIR }}/common/Scripts/new-package.sh"
     cmds:
-      - |
-        {{ .NEWPKG }} {{.CLI_ARGS}}
+      - '{{ .NEWPKG }} {{.CLI_ARGS}}'
 
   check-appstream-progress:
     desc: Generate a progress report detailing which packages still need appstream metadata added


### PR DESCRIPTION
**Summary**

Make `go-task -l` output easier to read.

Tweak cmd syntax to be more uniform and only use multi-line syntax when necessary.

**Test Plan**

Run different go-task tasks successfully.

**Checklist**

- [x] Update was tested against unstable