### PR TITLE
teckit: update to 2.5.12

### DIFF
--- a/packages/t/teckit/abi_used_symbols
+++ b/packages/t/teckit/abi_used_symbols
@@ -55,8 +55,6 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_assignER
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createERmm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_mutateEmmPKcm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitC1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitD1Ev
 libstdc++.so.6:_ZNSt9bad_allocD1Ev
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE5clearESt12_Ios_Iostate
 libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
@@ -67,6 +65,8 @@ libstdc++.so.6:_ZSt18_Rb_tree_incrementPKSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
+libstdc++.so.6:_ZSt21ios_base_library_initv
+libstdc++.so.6:_ZSt28__throw_bad_array_new_lengthv
 libstdc++.so.6:_ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_
 libstdc++.so.6:_ZSt4cerr
 libstdc++.so.6:_ZSt4cout
@@ -86,7 +86,6 @@ libstdc++.so.6:__cxa_end_catch
 libstdc++.so.6:__cxa_get_exception_ptr
 libstdc++.so.6:__cxa_guard_acquire
 libstdc++.so.6:__cxa_guard_release
-libstdc++.so.6:__cxa_pure_virtual
 libstdc++.so.6:__cxa_rethrow
 libstdc++.so.6:__cxa_throw
 libstdc++.so.6:__cxa_throw_bad_array_new_length

--- a/packages/t/teckit/package.yml
+++ b/packages/t/teckit/package.yml
@@ -1,8 +1,9 @@
 name       : teckit
-version    : 2.5.10
-release    : 1
+version    : 2.5.12
+release    : 2
 source     :
-    - https://github.com/silnrsi/teckit/releases/download/v2.5.10/teckit-2.5.10.tar.gz : 269d12311bc37c57ebdec4aa539201c588030ddb4307c06e6924fb0e2d72168b
+    - https://github.com/silnrsi/teckit/releases/download/v2.5.12/teckit-2.5.12.tar.gz : 7ef10e5bb79ea6437b7a06b4a92b314d3f142292758288efce50e12a455b6e7f
+homepage   : https://software.sil.org/teckit/
 license    :
     - CPL-1.0
     - LGPL-2.1-or-later

--- a/packages/t/teckit/pspec_x86_64.xml
+++ b/packages/t/teckit/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>teckit</Name>
+        <Homepage>https://software.sil.org/teckit/</Homepage>
         <Packager>
-            <Name>Martin Reboredo</Name>
-            <Email>yakoyoku@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>CPL-1.0</License>
         <License>LGPL-2.1-or-later</License>
@@ -13,7 +14,7 @@
 
 The primary component of TECkit is a library, the TECkit engine. The engine relies on mapping tables in a specific, documented binary format. The TECkit compiler creates these tables from plain-text, human-readable descriptions.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>teckit</Name>
@@ -28,9 +29,9 @@ The primary component of TECkit is a library, the TECkit engine. The engine reli
             <Path fileType="executable">/usr/bin/teckit_compile</Path>
             <Path fileType="executable">/usr/bin/txtconv</Path>
             <Path fileType="library">/usr/lib64/libTECkit.so.2</Path>
-            <Path fileType="library">/usr/lib64/libTECkit.so.2.0.26</Path>
+            <Path fileType="library">/usr/lib64/libTECkit.so.2.0.28</Path>
             <Path fileType="library">/usr/lib64/libTECkit_Compiler.so.2</Path>
-            <Path fileType="library">/usr/lib64/libTECkit_Compiler.so.2.0.26</Path>
+            <Path fileType="library">/usr/lib64/libTECkit_Compiler.so.2.0.28</Path>
             <Path fileType="man">/usr/share/man/man1/sfconv.1</Path>
             <Path fileType="man">/usr/share/man/man1/teckit_compile.1</Path>
             <Path fileType="man">/usr/share/man/man1/txtconv.1</Path>
@@ -45,7 +46,7 @@ The primary component of TECkit is a library, the TECkit engine. The engine reli
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="1">teckit</Dependency>
+            <Dependency release="2">teckit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/teckit/TECkit_Common.h</Path>
@@ -57,12 +58,12 @@ The primary component of TECkit is a library, the TECkit engine. The engine reli
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2021-04-10</Date>
-            <Version>2.5.10</Version>
+        <Update release="2">
+            <Date>2024-06-21</Date>
+            <Version>2.5.12</Version>
             <Comment>Packaging update</Comment>
-            <Name>Martin Reboredo</Name>
-            <Email>yakoyoku@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Updated Unicode character names and normalization data to 15.0.0
- Updated zlib to version 1.2.13
- Updated documentation

**Test Plan**
- Checked texlive worked that is dependent on this.

**Checklist**

- [X] Package was built and tested against unstable
