### PR TITLE
opentabletdriver: Enable service by default

### DIFF
--- a/packages/o/opentabletdriver/package.yml
+++ b/packages/o/opentabletdriver/package.yml
@@ -1,6 +1,6 @@
 name       : opentabletdriver
 version    : 0.6.4.0
-release    : 3
+release    : 4
 source     :
     - https://github.com/OpenTabletDriver/OpenTabletDriver/archive/refs/tags/v0.6.4.0.tar.gz : 1ad04f4a32b54b9b62bd944b0196abb6613873b19c269abcc9f9e94c1dc3027f
 homepage   : https://opentabletdriver.net/
@@ -29,10 +29,10 @@ build      : |
     ./eng/linux/package.sh -- /p:DebugType=None /p:DebugSymbols=false
     OTD_CONFIGURATIONS="${PWD}/OpenTabletDriver.Configurations/Configurations" ./generate-rules.sh > 70-opentabletdriver.rules
 install    : |
-    install -Dm 644 -t $installdir/usr/lib/udev/rules.d 70-opentabletdriver.rules
+    install -Dm 644 -t $installdir/%libdir%/udev/rules.d 70-opentabletdriver.rules
     install -Dm 644 OpenTabletDriver.UX/Assets/otd.png -t $installdir/usr/share/pixmaps
 
-    install -Dm 755 -t $installdir/usr/lib/opentabletdriver \
+    install -Dm 755 -t $installdir/%libdir%/opentabletdriver \
         dist/OpenTabletDriver.Console \
         dist/OpenTabletDriver.Daemon \
         dist/OpenTabletDriver.UX.Gtk
@@ -42,9 +42,11 @@ install    : |
        eng/linux/Generic/usr/bin/otd-gui \
        eng/linux/Generic/usr/bin/otd-daemon
 
-    install -Dm 644 eng/linux/Generic/usr/lib/systemd/user/opentabletdriver.service -t $installdir/usr/lib/systemd/user
-    install -Dm 644 eng/linux/Generic/usr/lib/modules-load.d/opentabletdriver.conf -t $installdir/usr/lib/modules-load.d
-    install -Dm 644 eng/linux/Generic/usr/lib/modprobe.d/99-opentabletdriver.conf -t $installdir/usr/lib/modprobe.d
+    install -Dm 644 eng/linux/Generic/usr/lib/systemd/user/opentabletdriver.service -t $installdir/%libdir%/systemd/user
+    mkdir -p $installdir/%libdir%/systemd/user/graphical-session.target.wants
+    ln -s /usr/lib/systemd/user/opentabletdriver.service $installdir/%libdir%/systemd/user/graphical-session.target.wants/opentabletdriver.service
+    install -Dm 644 eng/linux/Generic/usr/lib/modules-load.d/opentabletdriver.conf -t $installdir/%libdir%/modules-load.d
+    install -Dm 644 eng/linux/Generic/usr/lib/modprobe.d/99-opentabletdriver.conf -t $installdir/%libdir%/modprobe.d
 
     install -Dm 644 $pkgfiles/opentabletdriver.desktop -t $installdir/usr/share/applications
     install -Dm 644 docs/manpages/opentabletdriver.8 -t $installdir/usr/share/man/man8

--- a/packages/o/opentabletdriver/pspec_x86_64.xml
+++ b/packages/o/opentabletdriver/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>opentabletdriver</Name>
         <Homepage>https://opentabletdriver.net/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>nelson truran</Name>
+            <Email>nelson@truran.dev</Email>
         </Packager>
         <License>LGPL-3.0-only</License>
         <PartOf>multimedia.graphics</PartOf>
@@ -23,25 +23,26 @@
             <Path fileType="executable">/usr/bin/otd</Path>
             <Path fileType="executable">/usr/bin/otd-daemon</Path>
             <Path fileType="executable">/usr/bin/otd-gui</Path>
-            <Path fileType="library">/usr/lib/modprobe.d/99-opentabletdriver.conf</Path>
-            <Path fileType="library">/usr/lib/modules-load.d/opentabletdriver.conf</Path>
-            <Path fileType="library">/usr/lib/opentabletdriver/OpenTabletDriver.Console</Path>
-            <Path fileType="library">/usr/lib/opentabletdriver/OpenTabletDriver.Daemon</Path>
-            <Path fileType="library">/usr/lib/opentabletdriver/OpenTabletDriver.UX.Gtk</Path>
-            <Path fileType="library">/usr/lib/systemd/user/opentabletdriver.service</Path>
-            <Path fileType="library">/usr/lib/udev/rules.d/70-opentabletdriver.rules</Path>
+            <Path fileType="library">/usr/lib64/modprobe.d/99-opentabletdriver.conf</Path>
+            <Path fileType="library">/usr/lib64/modules-load.d/opentabletdriver.conf</Path>
+            <Path fileType="library">/usr/lib64/opentabletdriver/OpenTabletDriver.Console</Path>
+            <Path fileType="library">/usr/lib64/opentabletdriver/OpenTabletDriver.Daemon</Path>
+            <Path fileType="library">/usr/lib64/opentabletdriver/OpenTabletDriver.UX.Gtk</Path>
+            <Path fileType="library">/usr/lib64/systemd/user/graphical-session.target.wants/opentabletdriver.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/user/opentabletdriver.service</Path>
+            <Path fileType="library">/usr/lib64/udev/rules.d/70-opentabletdriver.rules</Path>
             <Path fileType="data">/usr/share/applications/opentabletdriver.desktop</Path>
             <Path fileType="man">/usr/share/man/man8/opentabletdriver.8</Path>
             <Path fileType="data">/usr/share/pixmaps/otd.png</Path>
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-06-21</Date>
+        <Update release="4">
+            <Date>2024-06-29</Date>
             <Version>0.6.4.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>nelson truran</Name>
+            <Email>nelson@truran.dev</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

This update will enable the opentabletdriver.service by default.

**Test Plan**

 - check service status is enabled and running
 - check OpenTabletDriver opens and maps tablet keys

**Checklist**

- [x] Package was built and tested against unstable
