### PR TITLE
python-colour: Fix build and drop python-d2to1 dependency

### DIFF
--- a/packages/py/python-colour/files/drop-d2to1-requirement.patch
+++ b/packages/py/python-colour/files/drop-d2to1-requirement.patch
@@ -1,0 +1,54 @@
+diff -aur colour-0.1.5.old/setup.py colour-0.1.5/setup.py
+--- colour-0.1.5.old/setup.py	2017-11-20 00:15:25.000000000 +0100
++++ colour-0.1.5/setup.py	2024-04-10 12:15:57.461751912 +0200
+@@ -16,50 +16,6 @@
+     use_setuptools()
+     from setuptools import setup
+ 
+-##
+-## Ensure that ``./autogen.sh`` is run prior to using ``setup.py``
+-##
+-
+-if "0.1.5".startswith("%%"):
+-    import os.path
+-    import sys
+-    WIN32 = sys.platform == 'win32'
+-    autogen = os.path.join(".", "autogen.sh")
+-    if not os.path.exists(autogen):
+-        sys.stderr.write(
+-            "This source repository was not configured.\n"
+-            "Please ensure ``./autogen.sh`` exists and that you are running "
+-            "``setup.py`` from the project root directory.\n")
+-        sys.exit(1)
+-    if os.path.exists('.autogen.sh.output'):
+-        sys.stderr.write(
+-            "It seems that ``./autogen.sh`` couldn't do its job as expected.\n"
+-            "Please try to launch ``./autogen.sh`` manualy, and send the "
+-            "results to the\nmaintainer of this package.\n"
+-            "Package will not be installed !\n")
+-        sys.exit(1)
+-    sys.stderr.write("Missing version information: "
+-                     "running './autogen.sh'...\n")
+-    import os
+-    import subprocess
+-    os.system('%s%s > .autogen.sh.output'
+-              % ("bash " if WIN32 else "",
+-                 autogen))
+-    cmdline = sys.argv[:]
+-    if cmdline[0] == "-c":
+-        ## for some reason, this is needed when launched from pip
+-        cmdline[0] = "setup.py"
+-    errlvl = subprocess.call(["python", ] + cmdline)
+-    os.unlink(".autogen.sh.output")
+-    sys.exit(errlvl)
+-
+-
+-##
+-## Normal d2to1 setup
+-##
+-
+ setup(
+-    setup_requires=['d2to1'],
+     extras_require={'test': ['nose', ]},
+-    d2to1=True
+ )

--- a/packages/py/python-colour/package.yml
+++ b/packages/py/python-colour/package.yml
@@ -1,17 +1,19 @@
 name       : python-colour
 version    : 0.1.5
-release    : 7
+release    : 8
 source     :
     - https://files.pythonhosted.org/packages/source/c/colour/colour-0.1.5.tar.gz : af20120fefd2afede8b001fbef2ea9da70ad7d49fafdb6489025dae8745c3aee
+homepage   : https://github.com/vaab/colour
 license    : BSD-2-Clause
 component  : programming.python
 summary    : Colour representations manipulation library (RGB, HSL, web, ...)
 description: |
     Colour representations manipulation library (RGB, HSL, web, ...)
 builddeps  :
-    - python-d2to1
     - python-nose
 setup      : |
+    %patch -p1 -i $pkgfiles/drop-d2to1-requirement.patch
+build      : |
     %python3_setup
 install    : |
     %python3_install

--- a/packages/py/python-colour/pspec_x86_64.xml
+++ b/packages/py/python-colour/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>python-colour</Name>
+        <Homepage>https://github.com/vaab/colour</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Algent Albrahimi</Name>
+            <Email>algent@protonmail.com</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -23,19 +24,18 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/colour-0.1.5-py3.11.egg-info/PKG-INFO</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/colour-0.1.5-py3.11.egg-info/SOURCES.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/colour-0.1.5-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/colour-0.1.5-py3.11.egg-info/not-zip-safe</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/colour-0.1.5-py3.11.egg-info/requires.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/colour-0.1.5-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/colour.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2024-02-14</Date>
+        <Update release="8">
+            <Date>2024-06-21</Date>
             <Version>0.1.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Algent Albrahimi</Name>
+            <Email>algent@protonmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Drop python-d2to1 dependency
- Add homepage
- Resolves #2969
- Part of #2973

**Test Plan**

- Run `rapid-photo-downloader` and check some photos

**Checklist**

- [x] Package was built and tested against unstable
