### PR TITLE
python2-ordered-set: Add at 3.1.1

### DIFF
--- a/packages/py/python2-ordered-set/package.yml
+++ b/packages/py/python2-ordered-set/package.yml
@@ -1,0 +1,21 @@
+name       : python2-ordered-set
+version    : 3.1.1
+release    : 1
+source     :
+    - https://files.pythonhosted.org/packages/a3/b7/d4d69641cbe707a45c23b190f2d717466ba5accc4c70b5f7a8a450387895/ordered-set-3.1.1.tar.gz : a7bfa858748c73b096e43db14eb23e2bc714a503f990c89fac8fab9b0ee79724
+homepage   : https://pypi.org/project/ordered-set/3.1.1/#description
+license    : MIT
+component  : programming.python
+summary    : A MutableSet that remembers its order, so that every entry has an index.
+description: |
+    An OrderedSet is a mutable data structure that is a hybrid of a list and a set. It remembers the order of its entries, and every entry has an index number that can be looked up.
+builddeps  :
+    - python-build
+    - python-installer
+    - python-packaging
+    - python-setuptools
+    - python-wheel
+setup      : |
+    %python_setup
+install    : |
+    %python_install

--- a/packages/py/python2-ordered-set/pspec_x86_64.xml
+++ b/packages/py/python2-ordered-set/pspec_x86_64.xml
@@ -1,0 +1,40 @@
+<PISI>
+    <Source>
+        <Name>python2-ordered-set</Name>
+        <Homepage>https://pypi.org/project/ordered-set/3.1.1/#description</Homepage>
+        <Packager>
+            <Name>Hans Kelson</Name>
+            <Email>hans@communitycomputing.net</Email>
+        </Packager>
+        <License>MIT</License>
+        <PartOf>programming.python</PartOf>
+        <Summary xml:lang="en">A MutableSet that remembers its order, so that every entry has an index.</Summary>
+        <Description xml:lang="en">An OrderedSet is a mutable data structure that is a hybrid of a list and a set. It remembers the order of its entries, and every entry has an index number that can be looked up.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>python2-ordered-set</Name>
+        <Summary xml:lang="en">A MutableSet that remembers its order, so that every entry has an index.</Summary>
+        <Description xml:lang="en">An OrderedSet is a mutable data structure that is a hybrid of a list and a set. It remembers the order of its entries, and every entry has an index number that can be looked up.
+</Description>
+        <PartOf>programming.python</PartOf>
+        <Files>
+            <Path fileType="library">/usr/lib/python2.7/site-packages/ordered_set-3.1.1-py2.7.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python2.7/site-packages/ordered_set-3.1.1-py2.7.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python2.7/site-packages/ordered_set-3.1.1-py2.7.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python2.7/site-packages/ordered_set-3.1.1-py2.7.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python2.7/site-packages/ordered_set.py</Path>
+            <Path fileType="library">/usr/lib/python2.7/site-packages/ordered_set.pyc</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2024-06-22</Date>
+            <Version>3.1.1</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Hans Kelson</Name>
+            <Email>hans@communitycomputing.net</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**
This is an old version of the PyPI ordered-set which works with python2. It is required to enable a deterministic install order for some packages in eopkg py2.

**Test Plan**

1. Build package from this PR.
2. Install it.
3. Run a `python` REPL.
4. Type `import ordered_set` and see that the module is available, even in python2.

**Checklist**

- [x] Package was built and tested against unstable
