### PR TITLE
tslib: update to 1.23

### DIFF
--- a/packages/t/tslib/abi_libs
+++ b/packages/t/tslib/abi_libs
@@ -1,3 +1,4 @@
+crop.so
 debounce.so
 dejitter.so
 evthres.so

--- a/packages/t/tslib/abi_symbols
+++ b/packages/t/tslib/abi_symbols
@@ -1,3 +1,5 @@
+crop.so:crop_mod_init
+crop.so:mod_init
 debounce.so:debounce_mod_init
 debounce.so:mod_init
 dejitter.so:dejitter_mod_init

--- a/packages/t/tslib/abi_used_symbols
+++ b/packages/t/tslib/abi_used_symbols
@@ -2,6 +2,7 @@ libc.so.6:__asprintf_chk
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
 libc.so.6:__isoc99_fscanf
 libc.so.6:__isoc99_scanf
 libc.so.6:__libc_start_main

--- a/packages/t/tslib/package.yml
+++ b/packages/t/tslib/package.yml
@@ -1,8 +1,9 @@
 name       : tslib
-version    : '1.22'
-release    : 8
+version    : '1.23'
+release    : 9
 source     :
-    - https://github.com/libts/tslib/releases/download/1.22/tslib-1.22.tar.xz : aaf0aed410a268d7b51385d07fe4d9d64312038e87c447ec8a24c8db0a15617a
+    - https://github.com/libts/tslib/releases/download/1.23/tslib-1.23.tar.xz : 9b489a54d48006201f2fe955a88c3f857535ac93b6cf8e5a16c7b166c8991dac
+homepage   : http://www.tslib.org/
 license    : LGPL-2.1-or-later
 component  : programming.library
 summary    : C library for filtering touchscreen events

--- a/packages/t/tslib/pspec_x86_64.xml
+++ b/packages/t/tslib/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>tslib</Name>
+        <Homepage>http://www.tslib.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>programming.library</PartOf>
         <Summary xml:lang="en">C library for filtering touchscreen events</Summary>
         <Description xml:lang="en">C library for filtering touchscreen events
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>tslib</Name>
@@ -32,7 +33,8 @@
             <Path fileType="executable">/usr/bin/ts_uinput</Path>
             <Path fileType="executable">/usr/bin/ts_verify</Path>
             <Path fileType="library">/usr/lib64/libts.so.0</Path>
-            <Path fileType="library">/usr/lib64/libts.so.0.10.4</Path>
+            <Path fileType="library">/usr/lib64/libts.so.0.10.5</Path>
+            <Path fileType="library">/usr/lib64/ts/crop.so</Path>
             <Path fileType="library">/usr/lib64/ts/debounce.so</Path>
             <Path fileType="library">/usr/lib64/ts/dejitter.so</Path>
             <Path fileType="library">/usr/lib64/ts/evthres.so</Path>
@@ -68,7 +70,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="8">tslib</Dependency>
+            <Dependency release="9">tslib</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/tslib.h</Path>
@@ -95,12 +97,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2022-03-27</Date>
-            <Version>1.22</Version>
+        <Update release="9">
+            <Date>2024-06-22</Date>
+            <Version>1.23</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
This release includes libts version 0.10.5 and the following changes:
- new filter module: module crop
- some build and security fixes
- improved release procedure

**Test Plan**
- Checked it installed.

**Checklist**

- [X] Package was built and tested against unstable

**Packaging notes**
- Dependency of qt6-base.
