### PR TITLE
tuxpaint-stamps: update to 2024.01.29

### DIFF
--- a/packages/t/tuxpaint-stamps/package.yml
+++ b/packages/t/tuxpaint-stamps/package.yml
@@ -1,8 +1,9 @@
 name       : tuxpaint-stamps
-version    : 2018.08.01
-release    : 2
+version    : 2024.01.29
+release    : 3
 source     :
-    - https://sourceforge.net/projects/tuxpaint/files/tuxpaint-stamps/2018-09-01/tuxpaint-stamps-2018.09.01.tar.gz : d78f55e7fde6abc3fb1a79e6fed0114a2c0ad2edff7ee5f8db43fa23e61079ea
+    - https://sourceforge.net/projects/tuxpaint/files/tuxpaint-stamps/2024-01-29/tuxpaint-stamps-2024.01.29.tar.gz : 1b0271f6da9a5fb23adb7b494183b9de289a02966d62c4cb430da9b4120594a9
+homepage   : https://tuxpaint.org/
 license    : GPL-2.0-or-later
 component  : games.learning
 summary    : Additional stamps for Tux Paint

--- a/packages/t/tuxpaint-stamps/pspec_x86_64.xml
+++ b/packages/t/tuxpaint-stamps/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>tuxpaint-stamps</Name>
+        <Homepage>https://tuxpaint.org/</Homepage>
         <Packager>
-            <Name>Bryan T. Meyers</Name>
-            <Email>bmeyers@datadrake.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>games.learning</PartOf>
         <Summary xml:lang="en">Additional stamps for Tux Paint</Summary>
         <Description xml:lang="en">Additional stamps for Tux Paint
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://solus-project.com/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>tuxpaint-stamps</Name>
@@ -27,6 +28,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/amphibians/frog-1_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/amphibians/frog-1_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/amphibians/frog-1_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/amphibians/frog-1_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/amphibians/frog-1_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/amphibians/frog-1_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/amphibians/frog.dat</Path>
@@ -42,6 +44,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/amphibians/frog_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/amphibians/frog_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/amphibians/frog_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/amphibians/frog_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/amphibians/frog_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/amphibians/frog_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/adelaide-rosella.png</Path>
@@ -53,6 +56,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/adelaide-rosella_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/adelaide-rosella_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/adelaide-rosella_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/adelaide-rosella_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/adelaide-rosella_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/adelaide-rosella_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/albino_peahen.dat</Path>
@@ -65,6 +69,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/albino_peahen_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/albino_peahen_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/albino_peahen_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/albino_peahen_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/albino_peahen_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/albino_peahen_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/blackbird.dat</Path>
@@ -80,12 +85,15 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/blackbird_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/blackbird_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/blackbird_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/blackbird_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/blackbird_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/blackbird_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cartoon/penguin_with_spider.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cartoon/penguin_with_spider.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cartoon/penguin_with_spider_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cartoon/pengwin.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cartoon/pengwin.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cartoon/pengwin_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cartoon/tux.dat</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cartoon/tux.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cartoon/tux.txt</Path>
@@ -94,6 +102,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cartoon/tux_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cartoon/tux_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cartoon/tux_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cartoon/tux_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cartoon/tux_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cartoon/tux_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/chicken_profile.dat</Path>
@@ -105,6 +114,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/chicken_profile_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/chicken_profile_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/chicken_profile_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/chicken_profile_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/chicken_profile_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/chicken_profile_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/crow.dat</Path>
@@ -120,6 +130,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/crow_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/crow_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/crow_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/crow_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/crow_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/crow_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/crowned_crane.dat</Path>
@@ -131,6 +142,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/crowned_crane_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/crowned_crane_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/crowned_crane_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/crowned_crane_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/crowned_crane_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/crowned_crane_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cuckoo.dat</Path>
@@ -146,6 +158,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cuckoo_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cuckoo_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cuckoo_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cuckoo_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cuckoo_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/cuckoo_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/drake.dat</Path>
@@ -159,6 +172,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/drake_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/drake_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/drake_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/drake_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/drake_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/drake_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/duck.dat</Path>
@@ -174,6 +188,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/duck_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/duck_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/duck_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/duck_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/duck_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/duck_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/gander.dat</Path>
@@ -189,6 +204,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/gander_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/gander_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/gander_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/gander_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/gander_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/gander_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/guineafowl.dat</Path>
@@ -201,6 +217,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/guineafowl_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/guineafowl_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/guineafowl_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/guineafowl_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/guineafowl_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/guineafowl_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/helmeted_guineafowl.dat</Path>
@@ -213,6 +230,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/helmeted_guineafowl_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/helmeted_guineafowl_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/helmeted_guineafowl_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/helmeted_guineafowl_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/helmeted_guineafowl_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/helmeted_guineafowl_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/hen.dat</Path>
@@ -228,6 +246,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/hen_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/hen_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/hen_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/hen_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/hen_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/hen_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/heron_greatblue.png</Path>
@@ -238,6 +257,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/heron_greatblue_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/heron_greatblue_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/heron_greatblue_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/heron_greatblue_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/heron_greatblue_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/heron_greatblue_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/heron_greatblue_flying.ogg</Path>
@@ -249,6 +269,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/heron_greatblue_flying_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/heron_greatblue_flying_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/heron_greatblue_flying_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/heron_greatblue_flying_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/heron_greatblue_flying_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/heron_greatblue_flying_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/lark.dat</Path>
@@ -264,6 +285,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/lark_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/lark_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/lark_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/lark_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/lark_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/lark_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/little-penguin.png</Path>
@@ -275,6 +297,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/little-penguin_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/little-penguin_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/little-penguin_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/little-penguin_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/little-penguin_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/little-penguin_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/magellanic_penguin.dat</Path>
@@ -287,6 +310,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/magellanic_penguin_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/magellanic_penguin_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/magellanic_penguin_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/magellanic_penguin_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/magellanic_penguin_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/magellanic_penguin_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/magpie.png</Path>
@@ -298,6 +322,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/magpie_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/magpie_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/magpie_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/magpie_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/magpie_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/magpie_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/nandou.dat</Path>
@@ -313,6 +338,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/nandou_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/nandou_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/nandou_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/nandou_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/nandou_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/nandou_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/ostrich.dat</Path>
@@ -325,6 +351,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/ostrich_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/ostrich_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/ostrich_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/ostrich_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/ostrich_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/ostrich_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/owl.dat</Path>
@@ -340,6 +367,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/owl_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/owl_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/owl_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/owl_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/owl_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/owl_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/peacock.dat</Path>
@@ -352,6 +380,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/peacock_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/peacock_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/peacock_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/peacock_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/peacock_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/peacock_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pelican.png</Path>
@@ -362,6 +391,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pelican_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pelican_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pelican_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pelican_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pelican_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pelican_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/penguin.dat</Path>
@@ -377,6 +407,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/penguin_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/penguin_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/penguin_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/penguin_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/penguin_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/penguin_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pigeon.dat</Path>
@@ -391,6 +422,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pigeon_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pigeon_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pigeon_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pigeon_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pigeon_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pigeon_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pink_flamingo.dat</Path>
@@ -403,6 +435,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pink_flamingo_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pink_flamingo_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pink_flamingo_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pink_flamingo_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pink_flamingo_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/pink_flamingo_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/quetzal.dat</Path>
@@ -418,6 +451,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/quetzal_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/quetzal_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/quetzal_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/quetzal_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/quetzal_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/quetzal_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/rainbow-lorikeet.png</Path>
@@ -429,6 +463,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/rainbow-lorikeet_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/rainbow-lorikeet_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/rainbow-lorikeet_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/rainbow-lorikeet_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/rainbow-lorikeet_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/rainbow-lorikeet_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/rooster.dat</Path>
@@ -442,6 +477,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/rooster_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/rooster_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/rooster_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/rooster_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/rooster_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/rooster_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/seagull.dat</Path>
@@ -457,6 +493,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/seagull_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/seagull_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/seagull_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/seagull_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/seagull_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/seagull_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/silver-gull.png</Path>
@@ -468,8 +505,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/silver-gull_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/silver-gull_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/silver-gull_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/silver-gull_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/silver-gull_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/silver-gull_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/swallow.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/swallow.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/swallow.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/swallow_desc_be.ogg</Path>
@@ -477,6 +516,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/swallow_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/swallow_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/swallow_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/swallow_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/swallow_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/swallow_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/tucan.dat</Path>
@@ -492,6 +532,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/tucan_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/tucan_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/tucan_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/tucan_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/tucan_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/tucan_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/turkey.dat</Path>
@@ -507,6 +548,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/turkey_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/turkey_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/turkey_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/turkey_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/turkey_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/turkey_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/vulture.dat</Path>
@@ -522,6 +564,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/vulture_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/vulture_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/vulture_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/vulture_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/vulture_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/birds/vulture_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/dinosaur/cartoon/dinosaurSings.dat</Path>
@@ -534,6 +577,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/dinosaur/cartoon/dinosaurSings_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/dinosaur/cartoon/dinosaurSings_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/dinosaur/cartoon/dinosaurSings_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/dinosaur/cartoon/dinosaurSings_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/dinosaur/cartoon/dinosaurSings_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/dinosaur/cartoon/dinosaurSings_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/fish/bluegroper.png</Path>
@@ -567,6 +611,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/fish/clownfish_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/fish/clownfish_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/fish/clownfish_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/fish/clownfish_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/fish/clownfish_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/fish/clownfish_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/fish/coraltrout.png</Path>
@@ -666,6 +711,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/Brown_slug_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/Brown_slug_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/Brown_slug_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/Brown_slug_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/Brown_slug_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/Brown_slug_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/Woodlouse.png</Path>
@@ -675,6 +721,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/Woodlouse_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/Woodlouse_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/Woodlouse_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/Woodlouse_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/Woodlouse_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/Woodlouse_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/bee.dat</Path>
@@ -691,9 +738,11 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/bee_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/bee_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/bee_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/bee_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/bee_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/bee_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/brownslug_desc_el.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ant.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ant.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ant.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ant_desc_be.ogg</Path>
@@ -701,6 +750,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ant_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ant_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ant_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ant_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ant_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ant_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/butterfly.dat</Path>
@@ -713,6 +763,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/butterfly_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/butterfly_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/butterfly_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/butterfly_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/butterfly_desc_pt_BR.wav</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/butterfly_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/butterfly_desc_ru.ogg</Path>
@@ -726,6 +777,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/dragonfly_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/dragonfly_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/dragonfly_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/dragonfly_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/dragonfly_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/dragonfly_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/fly.png</Path>
@@ -737,10 +789,12 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/fly_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/fly_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/fly_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/fly_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/fly_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/fly_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ladybug-2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ladybug-2.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ladybug-2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ladybug.dat</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ladybug.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ladybug.svg</Path>
@@ -752,8 +806,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ladybug_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ladybug_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ladybug_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ladybug_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ladybug_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/ladybug_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/monarchbutterfly.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/monarchbutterfly.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/monarchbutterfly.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/monarchbutterfly_desc_be.ogg</Path>
@@ -761,6 +817,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/monarchbutterfly_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/monarchbutterfly_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/monarchbutterfly_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/monarchbutterfly_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/monarchbutterfly_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/monarchbutterfly_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/snail.dat</Path>
@@ -768,6 +825,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/snail.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/snail2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/snail2.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/snail2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/snail_desc_be.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/snail_desc_bg.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/snail_desc_ca.ogg</Path>
@@ -775,10 +833,13 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/snail_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/snail_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/snail_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/snail_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/snail_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/snail_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider2_desc_be.ogg</Path>
@@ -786,23 +847,29 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider2_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider_computer.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider_computer.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider_computer_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider_desc_be.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider_desc_bg.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider_fly.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider_fly.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider_fly_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider_football.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider_football.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/spider_football_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/wings.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/wings.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/cartoon/wings_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/fly.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/fly.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/fly_desc.ogg</Path>
@@ -814,6 +881,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/fly_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/fly_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/fly_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/fly_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/fly_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/fly_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/grasshopper.dat</Path>
@@ -829,6 +897,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/grasshopper_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/grasshopper_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/grasshopper_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/grasshopper_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/grasshopper_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/grasshopper_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/hornet.dat</Path>
@@ -844,6 +913,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/hornet_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/hornet_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/hornet_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/hornet_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/hornet_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/hornet_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/hoverfly.dat</Path>
@@ -854,6 +924,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/hoverfly_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/hoverfly_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/hoverfly_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/hoverfly_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/hoverfly_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/hoverfly_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/mantis.dat</Path>
@@ -865,6 +936,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/mantis_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/mantis_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/mantis_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/mantis_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/mantis_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/mantis_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/mosquito.ogg</Path>
@@ -882,6 +954,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/xanthia_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/xanthia_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/xanthia_desc_nl.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/xanthia_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/xanthia_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/insects/xanthia_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/lizards/iguana.dat</Path>
@@ -1313,6 +1386,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/cats/cartoon/lion_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/cats/cartoon/lion_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/cats/cartoon/lion_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/cats/cheetah.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/cats/cheetah.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/cats/cheetah.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/cats/cheetah_desc_be.ogg</Path>
@@ -1322,6 +1396,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/cats/cheetah_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/cats/cheetah_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/cats/cheetah_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/cats/kitten.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/cats/kitten.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/cats/kitten.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/cats/kitten_desc_be.ogg</Path>
@@ -1544,6 +1619,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/equines/zebra.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/equines/zebra.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/equines/zebra.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/equines/zebra2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/equines/zebra2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/equines/zebra2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/animals/mammals/equines/zebra2_desc_be.ogg</Path>
@@ -1875,6 +1951,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/armor/cartoon/knight_helmet_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/armor/cartoon/knight_helmet_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/armor/cartoon/knight_helmet_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bellbottoms.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bellbottoms.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bellbottoms.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bellbottoms_desc_be.ogg</Path>
@@ -1884,6 +1961,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bellbottoms_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bellbottoms_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bellbottoms_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bikini.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bikini.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bikini.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bikini_desc_be.ogg</Path>
@@ -1893,6 +1971,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bikini_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bikini_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bikini_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/black_dress.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/black_dress.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/black_dress.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/black_dress_desc_be.ogg</Path>
@@ -1902,6 +1981,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/black_dress_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/black_dress_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/black_dress_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bluejeans1.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bluejeans1.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bluejeans1.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bluejeans1_desc_be.ogg</Path>
@@ -1911,6 +1991,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bluejeans1_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bluejeans1_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bluejeans1_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bluejeans2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bluejeans2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bluejeans2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bluejeans2_desc_be.ogg</Path>
@@ -1920,6 +2001,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bluejeans2_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bluejeans2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bluejeans2_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bowtie.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bowtie.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bowtie.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bowtie_desc_be.ogg</Path>
@@ -1931,6 +2013,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/bowtie_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/button.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/button.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/clotheshanger.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/clotheshanger.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/clotheshanger.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/clotheshanger_desc_be.ogg</Path>
@@ -1960,6 +2043,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/clothespin_old_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/clothespin_old_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/clothespin_old_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/glasses1.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/glasses1.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/glasses1.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/glasses1_desc_be.ogg</Path>
@@ -1969,6 +2053,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/glasses1_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/glasses1_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/glasses1_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/glasses2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/glasses2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/glasses2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/glasses2_desc_be.ogg</Path>
@@ -1990,8 +2075,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/blue_fedora_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/blue_fedora_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/blue_fedora_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/brownhat.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/brownhat.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/brownhat.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/brownhat2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/brownhat2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/brownhat2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/brownhat2_desc_be.ogg</Path>
@@ -2008,6 +2095,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/brownhat_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/brownhat_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/brownhat_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/cowboy_hat.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/cowboy_hat.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/cowboy_hat.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/cowboy_hat_desc_be.ogg</Path>
@@ -2017,6 +2105,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/cowboy_hat_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/cowboy_hat_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/cowboy_hat_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/crown1.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/crown1.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/crown1.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/crown1_desc_be.ogg</Path>
@@ -2026,6 +2115,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/crown1_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/crown1_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/crown1_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/crown2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/crown2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/crown2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/crown2_desc_be.ogg</Path>
@@ -2035,6 +2125,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/crown2_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/crown2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/crown2_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/elfhat.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/elfhat.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/elfhat.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/elfhat_desc_be.ogg</Path>
@@ -2068,6 +2159,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/green_fedora_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/green_fedora_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/green_fedora_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/greenhat.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/greenhat.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/greenhat.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/greenhat_desc_be.ogg</Path>
@@ -2077,6 +2169,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/greenhat_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/greenhat_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/greenhat_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/hardhat.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/hardhat.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/hardhat.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/hardhat_desc_be.ogg</Path>
@@ -2086,6 +2179,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/hardhat_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/hardhat_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/hardhat_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/mortarboard.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/mortarboard.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/mortarboard.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/mortarboard_desc_be.ogg</Path>
@@ -2107,6 +2201,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/propeller_hat_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/propeller_hat_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/propeller_hat_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/purplehat.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/purplehat.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/purplehat.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/purplehat_desc_be.ogg</Path>
@@ -2140,6 +2235,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/tophat_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/tophat_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/tophat_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/wizardhat.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/wizardhat.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/wizardhat.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/wizardhat_desc_be.ogg</Path>
@@ -2149,6 +2245,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/wizardhat_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/wizardhat_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hats/wizardhat_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hikingboot.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hikingboot.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hikingboot.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hikingboot_desc_be.ogg</Path>
@@ -2158,6 +2255,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hikingboot_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hikingboot_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/hikingboot_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/jacket.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/jacket.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/jacket.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/jacket_desc_be.ogg</Path>
@@ -2167,6 +2265,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/jacket_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/jacket_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/jacket_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/red_handbag.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/red_handbag.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/red_handbag.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/red_handbag_desc_be.ogg</Path>
@@ -2176,6 +2275,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/red_handbag_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/red_handbag_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/red_handbag_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/red_highheel.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/red_highheel.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/red_highheel.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/red_highheel_desc_be.ogg</Path>
@@ -2186,6 +2286,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/red_highheel_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/red_highheel_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/sunglasses_01.dat</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/sunglasses_01.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/sunglasses_01.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/sunglasses_01.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/sunglasses_01_desc_be.ogg</Path>
@@ -2197,6 +2298,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/sunglasses_01_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/sunglasses_01_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/sunglasses_02.dat</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/sunglasses_02.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/sunglasses_02.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/sunglasses_02.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/sunglasses_02_desc_be.ogg</Path>
@@ -2208,6 +2310,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/sunglasses_02_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/sunglasses_02_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/t-shirt_01.dat</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/t-shirt_01.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/t-shirt_01.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/t-shirt_01.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/t-shirt_01_desc_be.ogg</Path>
@@ -2308,6 +2411,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/t_tshirt_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/t_tshirt_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/t_tshirt_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/top_skirt.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/top_skirt.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/top_skirt.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/top_skirt_desc_be.ogg</Path>
@@ -2317,6 +2421,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/top_skirt_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/top_skirt_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/top_skirt_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/white_pants.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/white_pants.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/white_pants.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/white_pants_desc_be.ogg</Path>
@@ -2326,20 +2431,24 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/white_pants_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/white_pants_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/clothes/white_pants_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/bread.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/bread.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/bread.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/bread_desc_be.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/bread_desc_bg.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/bread_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/bread_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/bread_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/bread_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/bread_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/cheese.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/cheese.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/cheese.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/cheese_desc_bg.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/cheese_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/cheese_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/cheese_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/cheese_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/cheese_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/cheese_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/cartoon/birthday_cake.dat</Path>
@@ -2353,6 +2462,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/cartoon/birthday_cake_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/cartoon/birthday_cake_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/cartoon/birthday_cake_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/cartoon/birthday_cake_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/cartoon/birthday_cake_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/cartoon/birthday_cake_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/cartoon/pink_cake.dat</Path>
@@ -2366,8 +2476,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/cartoon/pink_cake_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/cartoon/pink_cake_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/cartoon/pink_cake_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/cartoon/pink_cake_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/cartoon/pink_cake_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/cartoon/pink_cake_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/smallcake.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/smallcake.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/smallcake.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/smallcake_desc_be.ogg</Path>
@@ -2376,6 +2488,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/smallcake_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/smallcake_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/smallcake_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/smallcake_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/smallcake_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/dessert/smallcake_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Apricot_whole.png</Path>
@@ -2386,6 +2499,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Apricot_whole_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Apricot_whole_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Apricot_whole_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Apricot_whole_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Apricot_whole_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Apricot_whole_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Cherry_Stella.png</Path>
@@ -2396,6 +2510,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Cherry_Stella_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Cherry_Stella_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Cherry_Stella_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Cherry_Stella_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Cherry_Stella_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Cherry_Stella_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Strawberry2.png</Path>
@@ -2406,6 +2521,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Strawberry2_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Strawberry2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Strawberry2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Strawberry2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Strawberry2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/Strawberry2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_fuji.png</Path>
@@ -2417,6 +2533,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_fuji_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_fuji_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_fuji_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_fuji_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_fuji_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_fuji_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_granny_smith.png</Path>
@@ -2428,6 +2545,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_granny_smith_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_granny_smith_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_granny_smith_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_granny_smith_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_granny_smith_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_granny_smith_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_green.png</Path>
@@ -2439,6 +2557,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_green_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_green_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_green_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_green_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_green_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_green_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_red.ogg</Path>
@@ -2451,6 +2570,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_red_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_red_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_red_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_red_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_red_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_red_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_sierra_beauty.png</Path>
@@ -2462,6 +2582,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_sierra_beauty_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_sierra_beauty_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_sierra_beauty_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_sierra_beauty_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_sierra_beauty_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apple_sierra_beauty_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apricot.png</Path>
@@ -2473,6 +2594,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apricot_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apricot_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apricot_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apricot_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apricot_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apricot_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/apricot_whole_desc_el.ogg</Path>
@@ -2485,6 +2607,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/avocado_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/avocado_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/avocado_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/avocado_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/avocado_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/avocado_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/banana.png</Path>
@@ -2496,6 +2619,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/banana_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/banana_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/banana_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/banana_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/banana_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/banana_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple.dat</Path>
@@ -2505,6 +2629,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_core.dat</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_core.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_core.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_core_01.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_core_01.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_core_01.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_core_01_desc_be.ogg</Path>
@@ -2513,6 +2638,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_core_01_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_core_01_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_core_01_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_core_01_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_core_01_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_core_01_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_core_desc_be.ogg</Path>
@@ -2522,6 +2648,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_core_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_core_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_core_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_core_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_core_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_core_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_desc_be.ogg</Path>
@@ -2531,6 +2658,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/apple_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/banana.dat</Path>
@@ -2544,6 +2672,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/banana_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/banana_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/banana_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/banana_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/banana_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/banana_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/blueberry.dat</Path>
@@ -2556,18 +2685,21 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/blueberry_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/blueberry_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/blueberry_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/blueberry_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/blueberry_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/blueberry_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries.dat</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries2_desc_bg.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries2_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries_desc_bg.ogg</Path>
@@ -2576,6 +2708,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/cherries_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/grapes.dat</Path>
@@ -2589,6 +2722,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/grapes_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/grapes_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/grapes_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/grapes_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/grapes_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/grapes_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/lemon.dat</Path>
@@ -2602,6 +2736,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/lemon_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/lemon_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/lemon_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/lemon_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/lemon_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/lemon_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/lemon_slice.dat</Path>
@@ -2615,6 +2750,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/lemon_slice_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/lemon_slice_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/lemon_slice_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/lemon_slice_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/lemon_slice_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/lemon_slice_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/orange.dat</Path>
@@ -2628,6 +2764,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/orange_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/orange_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/orange_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/orange_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/orange_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/orange_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/peach.dat</Path>
@@ -2641,6 +2778,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/peach_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/peach_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/peach_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/peach_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/peach_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/peach_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/pear.dat</Path>
@@ -2654,6 +2792,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/pear_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/pear_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/pear_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/pear_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/pear_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/pear_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/pineapple.dat</Path>
@@ -2667,6 +2806,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/pineapple_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/pineapple_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/pineapple_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/pineapple_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/pineapple_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/pineapple_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/prune.dat</Path>
@@ -2680,6 +2820,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/prune_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/prune_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/prune_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/prune_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/prune_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/prune_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/raspberry.dat</Path>
@@ -2693,6 +2834,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/raspberry_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/raspberry_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/raspberry_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/raspberry_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/raspberry_desc_pt_BR.wav</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/raspberry_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/raspberry_desc_ru.ogg</Path>
@@ -2707,8 +2849,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/strawberry_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/strawberry_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/strawberry_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/strawberry_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/strawberry_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/strawberry_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/watermelon.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/watermelon.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/watermelon.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/watermelon_desc_be.ogg</Path>
@@ -2718,6 +2862,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/watermelon_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/watermelon_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/watermelon_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/watermelon_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/watermelon_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cartoon/watermelon_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cherimoya.png</Path>
@@ -2728,6 +2873,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cherimoya_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cherimoya_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cherimoya_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cherimoya_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cherimoya_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cherimoya_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/cherinoya_desc_el.ogg</Path>
@@ -2742,6 +2888,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/grapes_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/grapes_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/grapes_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/grapes_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/grapes_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/grapes_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/kiwi.png</Path>
@@ -2753,6 +2900,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/kiwi_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/kiwi_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/kiwi_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/kiwi_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/kiwi_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/kiwi_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/lemon.png</Path>
@@ -2764,6 +2912,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/lemon_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/lemon_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/lemon_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/lemon_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/lemon_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/lemon_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/mandarine.png</Path>
@@ -2775,6 +2924,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/mandarine_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/mandarine_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/mandarine_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/mandarine_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/mandarine_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/mandarine_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/mango.png</Path>
@@ -2786,6 +2936,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/mango_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/mango_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/mango_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/mango_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/mango_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/mango_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/orange.png</Path>
@@ -2797,6 +2948,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/orange_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/orange_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/orange_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/orange_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/orange_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/orange_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/orange_seville.png</Path>
@@ -2808,6 +2960,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/orange_seville_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/orange_seville_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/orange_seville_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/orange_seville_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/orange_seville_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/orange_seville_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pear.png</Path>
@@ -2819,6 +2972,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pear_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pear_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pear_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pear_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pear_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pear_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pineapple.png</Path>
@@ -2830,6 +2984,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pineapple_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pineapple_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pineapple_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pineapple_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pineapple_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pineapple_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pomegranate.png</Path>
@@ -2841,6 +2996,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pomegranate_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pomegranate_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pomegranate_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pomegranate_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pomegranate_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/pomegranate_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/raspberry.png</Path>
@@ -2852,6 +3008,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/raspberry_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/raspberry_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/raspberry_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/raspberry_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/raspberry_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/raspberry_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/sliced_lime.png</Path>
@@ -2863,6 +3020,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/sliced_lime_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/sliced_lime_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/sliced_lime_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/sliced_lime_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/sliced_lime_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/sliced_lime_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/sliced_orange.png</Path>
@@ -2874,6 +3032,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/sliced_orange_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/sliced_orange_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/sliced_orange_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/sliced_orange_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/sliced_orange_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/sliced_orange_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/strawberry.png</Path>
@@ -2886,8 +3045,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/strawberry_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/strawberry_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/strawberry_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/strawberry_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/strawberry_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/fruit/strawberry_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/loaf_of_bread.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/loaf_of_bread.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/loaf_of_bread.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/loaf_of_bread_desc_be.ogg</Path>
@@ -2895,6 +3056,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/loaf_of_bread_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/loaf_of_bread_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/loaf_of_bread_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/loaf_of_bread_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/loaf_of_bread_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/loaf_of_bread_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/almond.png</Path>
@@ -2906,6 +3068,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/almond_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/almond_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/almond_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/almond_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/almond_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/almond_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/pecan.png</Path>
@@ -2917,6 +3080,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/pecan_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/pecan_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/pecan_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/pecan_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/pecan_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/pecan_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/walnut.png</Path>
@@ -2928,6 +3092,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/walnut_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/walnut_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/walnut_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/walnut_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/walnut_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/walnut_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/walnut_shelled.png</Path>
@@ -2939,10 +3104,12 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/walnut_shelled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/walnut_shelled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/walnut_shelled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/walnut_shelled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/walnut_shelled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/nuts/walnut_shelled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/pizza.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/pizza.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/pizza_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/spices/ginger.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/spices/ginger.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/spices/ginger_desc_be.ogg</Path>
@@ -2951,6 +3118,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/spices/ginger_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/spices/ginger_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/spices/ginger_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/spices/ginger_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/spices/ginger_desc_pt_BR.wav</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/spices/ginger_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/spices/ginger_desc_ru.ogg</Path>
@@ -2963,6 +3131,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/broccoli_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/broccoli_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/broccoli_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/broccoli_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/broccoli_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/broccoli_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/carrot.png</Path>
@@ -2974,6 +3143,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/carrot_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/carrot_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/carrot_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/carrot_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/carrot_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/carrot_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/chilepepper.png</Path>
@@ -2985,6 +3155,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/chilepepper_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/chilepepper_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/chilepepper_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/chilepepper_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/chilepepper_desc_pt_BR.wav</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/chilepepper_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/chilepepper_desc_ru.ogg</Path>
@@ -2996,6 +3167,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/corn_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/corn_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/corn_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/corn_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/corn_desc_pt_BR.wav</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/corn_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/corn_desc_ru.ogg</Path>
@@ -3008,6 +3180,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/eggplant_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/eggplant_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/eggplant_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/eggplant_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/eggplant_desc_pt_BR.wav</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/eggplant_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/eggplant_desc_ru.ogg</Path>
@@ -3020,6 +3193,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/garlic_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/garlic_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/garlic_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/garlic_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/garlic_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/garlic_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/garlics.png</Path>
@@ -3031,6 +3205,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/garlics_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/garlics_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/garlics_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/garlics_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/garlics_desc_pt_BR.wav</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/garlics_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/garlics_desc_ru.ogg</Path>
@@ -3043,6 +3218,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/lettuce_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/lettuce_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/lettuce_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/lettuce_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/lettuce_desc_pt_BR.wav</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/lettuce_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/lettuce_desc_ru.ogg</Path>
@@ -3055,6 +3231,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/mushroom_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/mushroom_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/mushroom_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/mushroom_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/mushroom_desc_pt_BR.wav</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/mushroom_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/mushroom_desc_ru.ogg</Path>
@@ -3067,6 +3244,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/onion_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/onion_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/onion_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/onion_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/onion_desc_pt_BR.wav</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/onion_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/onion_desc_ru.ogg</Path>
@@ -3079,6 +3257,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pattypan_squash_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pattypan_squash_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pattypan_squash_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pattypan_squash_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pattypan_squash_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pattypan_squash_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pepper.png</Path>
@@ -3090,6 +3269,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pepper_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pepper_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pepper_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pepper_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pepper_desc_pt_BR.wav</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pepper_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pepper_desc_ru.ogg</Path>
@@ -3102,6 +3282,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/potato_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/potato_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/potato_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/potato_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/potato_desc_pt_BR.wav</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/potato_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/potato_desc_ru.ogg</Path>
@@ -3114,6 +3295,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pumpkin_small_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pumpkin_small_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pumpkin_small_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pumpkin_small_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pumpkin_small_desc_pt_BR.wav</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pumpkin_small_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/pumpkin_small_desc_ru.ogg</Path>
@@ -3126,6 +3308,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/redlettuce_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/redlettuce_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/redlettuce_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/redlettuce_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/redlettuce_desc_pt_BR.wav</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/redlettuce_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/redlettuce_desc_ru.ogg</Path>
@@ -3138,6 +3321,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/tomato_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/tomato_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/tomato_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/tomato_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/tomato_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/tomato_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/yam.png</Path>
@@ -3149,6 +3333,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/yam_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/yam_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/yam_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/yam_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/yam_desc_pt_BR.wav</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/yam_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/yam_desc_ru.ogg</Path>
@@ -3161,6 +3346,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/yellowpepper_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/yellowpepper_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/yellowpepper_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/yellowpepper_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/yellowpepper_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/food/vegetables/yellowpepper_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/binoculars.dat</Path>
@@ -3172,6 +3358,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/binoculars_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/binoculars_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/binoculars_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/binoculars_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/binoculars_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/binoculars_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/camera_35mm.ogg</Path>
@@ -3183,8 +3370,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/camera_35mm_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/camera_35mm_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/camera_35mm_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/camera_35mm_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/camera_35mm_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/camera_35mm_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/kite.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/kite.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/kite.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/kite_desc_be.ogg</Path>
@@ -3192,8 +3381,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/kite_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/kite_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/kite_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/kite_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/kite_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/kite_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/knitting.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/knitting.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/knitting.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/knitting_desc_be.ogg</Path>
@@ -3201,6 +3392,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/knitting_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/knitting_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/knitting_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/knitting_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/knitting_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/knitting_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/brass/trumpet.dat</Path>
@@ -3212,6 +3404,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/brass/trumpet_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/brass/trumpet_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/brass/trumpet_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/brass/trumpet_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/brass/trumpet_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/brass/trumpet_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/cymbal_crash.dat</Path>
@@ -3224,6 +3417,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/cymbal_crash_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/cymbal_crash_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/cymbal_crash_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/cymbal_crash_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/cymbal_crash_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/cymbal_crash_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/drum_tomtom_floor.dat</Path>
@@ -3236,6 +3430,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/drum_tomtom_floor_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/drum_tomtom_floor_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/drum_tomtom_floor_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/drum_tomtom_floor_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/drum_tomtom_floor_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/drum_tomtom_floor_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/drumkit.dat</Path>
@@ -3248,6 +3443,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/drumkit_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/drumkit_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/drumkit_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/drumkit_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/drumkit_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/percussion/drumkit_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/cello.dat</Path>
@@ -3260,6 +3456,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/cello_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/cello_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/cello_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/cello_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/cello_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/cello_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar2.png</Path>
@@ -3269,6 +3466,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar2_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_classical.dat</Path>
@@ -3280,6 +3478,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_classical_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_classical_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_classical_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_classical_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_classical_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_classical_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric.dat</Path>
@@ -3288,6 +3487,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_bass.dat</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_bass.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_bass.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_bass2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_bass2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_bass2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_bass2_desc_be.ogg</Path>
@@ -3295,6 +3495,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_bass2_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_bass2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_bass2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_bass2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_bass2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_bass2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_bass_desc_be.ogg</Path>
@@ -3302,6 +3503,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_bass_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_bass_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_bass_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_bass_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_bass_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_bass_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_desc_be.ogg</Path>
@@ -3310,12 +3512,14 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/guitar_electric_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin.dat</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin2_desc_be.ogg</Path>
@@ -3323,6 +3527,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin2_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin_desc_be.ogg</Path>
@@ -3331,9 +3536,9 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/string/violin_desc_ru.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/wind/bassoon.dat</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/wind/bassoon.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/wind/bassoon.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/wind/bassoon.txt</Path>
@@ -3343,6 +3548,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/wind/bassoon_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/wind/bassoon_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/wind/bassoon_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/wind/bassoon_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/wind/bassoon_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/hobbies/music/wind/bassoon_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/Lightbulb.png</Path>
@@ -3352,9 +3558,11 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/Lightbulb_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/Lightbulb_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/Lightbulb_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/Lightbulb_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/Lightbulb_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/Lightbulb_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/Washing-machine.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/Washing-machine.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/Washing-machine.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/Washing-machine.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/Washing-machine_desc_be.ogg</Path>
@@ -3362,8 +3570,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/Washing-machine_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/Washing-machine_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/Washing-machine_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/Washing-machine_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/Washing-machine_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/Washing-machine_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/Pencil.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/Pencil.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/Pencil.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/Pencil_desc_be.ogg</Path>
@@ -3371,8 +3581,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/Pencil_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/Pencil_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/Pencil_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/Pencil_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/Pencil_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/Pencil_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/ballpointpen.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/ballpointpen.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/ballpointpen.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/ballpointpen_desc_be.ogg</Path>
@@ -3380,8 +3592,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/ballpointpen_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/ballpointpen_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/ballpointpen_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/ballpointpen_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/ballpointpen_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/ballpointpen_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/biro.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/biro.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/biro.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/biro_desc_be.ogg</Path>
@@ -3389,6 +3603,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/biro_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/biro_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/biro_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/biro_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/biro_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/biro_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/highlighter.dat</Path>
@@ -3400,9 +3615,11 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/highlighter_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/highlighter_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/highlighter_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/highlighter_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/highlighter_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/highlighter_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/painttube.dat</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/painttube.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/painttube.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/painttube.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/painttube_desc_be.ogg</Path>
@@ -3410,6 +3627,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/painttube_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/painttube_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/painttube_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/painttube_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/painttube_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/painttube_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/pen_dryerase.dat</Path>
@@ -3421,8 +3639,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/pen_dryerase_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/pen_dryerase_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/pen_dryerase_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/pen_dryerase_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/pen_dryerase_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/pen_dryerase_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/pencil2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/pencil2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/pencil2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/pencil2_desc_be.ogg</Path>
@@ -3430,6 +3650,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/pencil2_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/pencil2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/pencil2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/pencil2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/pencil2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/pencil2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/scissors_small_closed.ogg</Path>
@@ -3441,6 +3662,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/scissors_small_closed_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/scissors_small_closed_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/scissors_small_closed_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/scissors_small_closed_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/scissors_small_closed_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/scissors_small_closed_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/scissors_small_open.ogg</Path>
@@ -3452,8 +3674,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/scissors_small_open_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/scissors_small_open_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/scissors_small_open_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/scissors_small_open_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/scissors_small_open_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/arttools/scissors_small_open_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/clothes_iron.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/clothes_iron.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/clothes_iron.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/clothes_iron_desc_be.ogg</Path>
@@ -3461,6 +3685,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/clothes_iron_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/clothes_iron_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/clothes_iron_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/clothes_iron_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/clothes_iron_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/clothes_iron_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/cylinder.png</Path>
@@ -3469,10 +3694,12 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/cylinder_desc_bg.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/cylinder_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/cylinder_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/cylinder_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/cylinder_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/cylinder_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/bottle.dat</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/bottle.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/bottle.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/bottle.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/bottle.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/bottle_desc_be.ogg</Path>
@@ -3480,9 +3707,11 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/bottle_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/bottle_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/bottle_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/bottle_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/bottle_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/bottle_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/fork.dat</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/fork.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/fork.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/fork.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/fork_desc_be.ogg</Path>
@@ -3490,6 +3719,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/fork_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/fork_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/fork_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/fork_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/fork_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/fork_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/pasta_pot.dat</Path>
@@ -3501,6 +3731,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/pasta_pot_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/pasta_pot_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/pasta_pot_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/pasta_pot_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/pasta_pot_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/pasta_pot_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/pressure_cooker.dat</Path>
@@ -3512,9 +3743,11 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/pressure_cooker_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/pressure_cooker_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/pressure_cooker_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/pressure_cooker_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/pressure_cooker_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/pressure_cooker_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/spoon.dat</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/spoon.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/spoon.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/spoon.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/spoon_desc_be.ogg</Path>
@@ -3522,8 +3755,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/spoon_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/spoon_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/spoon_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/spoon_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/spoon_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/cartoon/spoon_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/coffeecup.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/coffeecup.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/coffeecup.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/coffeecup_desc_be.ogg</Path>
@@ -3531,8 +3766,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/coffeecup_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/coffeecup_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/coffeecup_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/coffeecup_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/coffeecup_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/coffeecup_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/expresso.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/expresso.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/expresso.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/expresso_desc_be.ogg</Path>
@@ -3540,8 +3777,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/expresso_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/expresso_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/expresso_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/expresso_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/expresso_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/expresso_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/fork.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/fork.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/fork.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/fork_desc_be.ogg</Path>
@@ -3549,6 +3788,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/fork_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/fork_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/fork_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/fork_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/fork_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/fork_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/glass.dat</Path>
@@ -3561,8 +3801,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/glass_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/glass_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/glass_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/glass_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/glass_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/glass_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/knife.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/knife.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/knife.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/knife_desc_be.ogg</Path>
@@ -3570,6 +3812,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/knife_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/knife_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/knife_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/knife_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/knife_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/knife_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/mug.dat</Path>
@@ -3581,6 +3824,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/mug_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/mug_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/mug_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/mug_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/mug_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/mug_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/pitcher_small.dat</Path>
@@ -3592,8 +3836,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/pitcher_small_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/pitcher_small_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/pitcher_small_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/pitcher_small_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/pitcher_small_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/pitcher_small_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/spoon.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/spoon.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/spoon.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/spoon_desc_be.ogg</Path>
@@ -3601,6 +3847,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/spoon_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/spoon_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/spoon_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/spoon_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/spoon_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/spoon_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/teapot.dat</Path>
@@ -3612,6 +3859,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/teapot_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/teapot_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/teapot_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/teapot_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/teapot_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/teapot_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/utensils/nutcracker.png</Path>
@@ -3622,6 +3870,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/utensils/nutcracker_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/utensils/nutcracker_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/utensils/nutcracker_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/utensils/nutcracker_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/utensils/nutcracker_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/utensils/nutcracker_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/utensils/pepper_grinder.dat</Path>
@@ -3633,8 +3882,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/utensils/pepper_grinder_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/utensils/pepper_grinder_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/utensils/pepper_grinder_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/utensils/pepper_grinder_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/utensils/pepper_grinder_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/dishes/utensils/pepper_grinder_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/DSLR_Camera.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/DSLR_Camera.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/DSLR_Camera.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/DSLR_Camera_desc_be.ogg</Path>
@@ -3642,8 +3893,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/DSLR_Camera_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/DSLR_Camera_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/DSLR_Camera_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/DSLR_Camera_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/DSLR_Camera_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/DSLR_Camera_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/calculator.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/calculator.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/calculator.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/calculator_desc_be.ogg</Path>
@@ -3651,8 +3904,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/calculator_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/calculator_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/calculator_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/calculator_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/calculator_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/calculator_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/camera.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/camera.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/camera.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/camera_desc_be.ogg</Path>
@@ -3660,8 +3915,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/camera_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/camera_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/camera_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/camera_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/camera_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/camera_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/compact_disc.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/compact_disc.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/compact_disc.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/compact_disc_desc_be.ogg</Path>
@@ -3669,8 +3926,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/compact_disc_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/compact_disc_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/compact_disc_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/compact_disc_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/compact_disc_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/compact_disc_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/digitalcamera.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/digitalcamera.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/digitalcamera.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/digitalcamera_desc_be.ogg</Path>
@@ -3678,8 +3937,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/digitalcamera_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/digitalcamera_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/digitalcamera_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/digitalcamera_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/digitalcamera_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/digitalcamera_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/inkjet_printer.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/inkjet_printer.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/inkjet_printer.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/inkjet_printer_desc_be.ogg</Path>
@@ -3687,8 +3948,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/inkjet_printer_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/inkjet_printer_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/inkjet_printer_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/inkjet_printer_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/inkjet_printer_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/inkjet_printer_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/laptop.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/laptop.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/laptop.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/laptop_desc_be.ogg</Path>
@@ -3696,8 +3959,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/laptop_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/laptop_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/laptop_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/laptop_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/laptop_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/laptop_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/laser_printer.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/laser_printer.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/laser_printer.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/laser_printer_desc_be.ogg</Path>
@@ -3705,8 +3970,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/laser_printer_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/laser_printer_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/laser_printer_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/laser_printer_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/laser_printer_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/laser_printer_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/mobile.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/mobile.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/mobile.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/mobile_desc_be.ogg</Path>
@@ -3714,8 +3981,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/mobile_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/mobile_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/mobile_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/mobile_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/mobile_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/mobile_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/monitor.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/monitor.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/monitor.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/monitor_desc_be.ogg</Path>
@@ -3723,8 +3992,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/monitor_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/monitor_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/monitor_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/monitor_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/monitor_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/monitor_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/mouse.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/mouse.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/mouse.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/mouse_desc_be.ogg</Path>
@@ -3732,8 +4003,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/mouse_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/mouse_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/mouse_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/mouse_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/mouse_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/mouse_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/phone.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/phone.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/phone.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/phone_desc_be.ogg</Path>
@@ -3741,8 +4014,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/phone_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/phone_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/phone_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/phone_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/phone_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/electronics/phone_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/fridge.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/fridge.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/fridge.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/fridge_desc_be.ogg</Path>
@@ -3750,6 +4025,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/fridge_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/fridge_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/fridge_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/fridge_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/fridge_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/fridge_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/garbagecan.dat</Path>
@@ -3761,8 +4037,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/garbagecan_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/garbagecan_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/garbagecan_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/garbagecan_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/garbagecan_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/garbagecan_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/globe.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/globe.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/globe.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/globe_desc_be.ogg</Path>
@@ -3770,6 +4048,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/globe_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/globe_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/globe_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/globe_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/globe_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/globe_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/home_compost_bin.dat</Path>
@@ -3781,6 +4060,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/home_compost_bin_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/home_compost_bin_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/home_compost_bin_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/home_compost_bin_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/home_compost_bin_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/home_compost_bin_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/kettle.dat</Path>
@@ -3793,6 +4073,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/kettle_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/kettle_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/kettle_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/kettle_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/kettle_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/kettle_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/key.png</Path>
@@ -3803,9 +4084,11 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/key_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/key_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/key_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/key_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/key_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/key_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/lightbulb_desc_el.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/microwave.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/microwave.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/microwave.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/microwave_desc_be.ogg</Path>
@@ -3813,8 +4096,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/microwave_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/microwave_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/microwave_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/microwave_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/microwave_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/microwave_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/padlock_closed.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/padlock_closed.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/padlock_closed.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/padlock_closed_desc_be.ogg</Path>
@@ -3822,8 +4107,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/padlock_closed_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/padlock_closed_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/padlock_closed_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/padlock_closed_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/padlock_closed_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/padlock_closed_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/padlock_open.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/padlock_open.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/padlock_open.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/padlock_open_desc_be.ogg</Path>
@@ -3831,22 +4118,27 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/padlock_open_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/padlock_open_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/padlock_open_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/padlock_open_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/padlock_open_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/padlock_open_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/recyclingbox.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/recyclingbox.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/recyclingbox.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/recyclingbox2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/recyclingbox2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/recyclingbox2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/recyclingbox2_desc_be.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/recyclingbox2_desc_bg.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/recyclingbox2_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/recyclingbox2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/recyclingbox2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/recyclingbox2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/recyclingbox2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/recyclingbox_desc_be.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/recyclingbox_desc_bg.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/recyclingbox_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/recyclingbox_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/recyclingbox_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/recyclingbox_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/recyclingbox_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/rubberduck.dat</Path>
@@ -3859,14 +4151,17 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/rubberduck_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/rubberduck_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/rubberduck_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/rubberduck_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/rubberduck_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/rubberduck_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/tealight.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tealight.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tealight.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tealight_desc_be.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tealight_desc_bg.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tealight_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tealight_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/tealight_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tealight_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tealight_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/toilet.ogg</Path>
@@ -3878,6 +4173,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/toilet_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/toilet_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/toilet_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/toilet_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/toilet_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/toilet_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/cementmixer.png</Path>
@@ -3886,11 +4182,13 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/cementmixer_desc_bg.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/cementmixer_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/cementmixer_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/cementmixer_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/cementmixer_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/cementmixer_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/hammer.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/hammer.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/hammer.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/hammer2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/hammer2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/hammer2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/hammer2_desc_be.ogg</Path>
@@ -3898,6 +4196,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/hammer2_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/hammer2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/hammer2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/hammer2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/hammer2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/hammer2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/hammer_desc_be.ogg</Path>
@@ -3906,6 +4205,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/hammer_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/hammer_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/hammer_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/hammer_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/hammer_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/hammer_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/mallet_metal.ogg</Path>
@@ -3917,6 +4217,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/mallet_metal_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/mallet_metal_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/mallet_metal_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/mallet_metal_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/mallet_metal_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/mallet_metal_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/measuring_tape.png</Path>
@@ -3927,6 +4228,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/measuring_tape_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/measuring_tape_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/measuring_tape_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/measuring_tape_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/measuring_tape_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/measuring_tape_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/measuring_tape_mirror.png</Path>
@@ -3938,6 +4240,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/paintbrush_large_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/paintbrush_large_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/paintbrush_large_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/paintbrush_large_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/paintbrush_large_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/paintbrush_large_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/plyers.png</Path>
@@ -3948,6 +4251,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/plyers_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/plyers_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/plyers_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/plyers_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/plyers_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/plyers_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/saw.ogg</Path>
@@ -3959,8 +4263,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/saw_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/saw_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/saw_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/saw_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/saw_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/saw_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/screwdriver.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/screwdriver.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/screwdriver.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/screwdriver_desc_be.ogg</Path>
@@ -3968,6 +4274,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/screwdriver_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/screwdriver_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/screwdriver_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/screwdriver_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/screwdriver_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/screwdriver_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/spade.png</Path>
@@ -3976,6 +4283,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/spade_desc_bg.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/spade_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/spade_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/spade_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/spade_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/spade_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/toolbox.dat</Path>
@@ -3987,6 +4295,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/toolbox_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/toolbox_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/toolbox_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/toolbox_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/toolbox_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/toolbox_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench.png</Path>
@@ -3999,6 +4308,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench_adjustable_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench_adjustable_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench_adjustable_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench_adjustable_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench_adjustable_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench_adjustable_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench_desc_be.ogg</Path>
@@ -4007,6 +4317,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench_plumbers.png</Path>
@@ -4017,8 +4328,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench_plumbers_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench_plumbers_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench_plumbers_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench_plumbers_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench_plumbers_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/tools/wrench_plumbers_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/trash_can.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/trash_can.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/trash_can.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/trash_can_desc_be.ogg</Path>
@@ -4026,8 +4339,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/trash_can_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/trash_can_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/trash_can_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/trash_can_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/trash_can_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/trash_can_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/umbrella.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/umbrella.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/umbrella.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/umbrella_desc_be.ogg</Path>
@@ -4035,10 +4350,12 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/umbrella_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/umbrella_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/umbrella_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/umbrella_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/umbrella_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/umbrella_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/vacuum_cleaner.dat</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/vacuum_cleaner.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/vacuum_cleaner.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/vacuum_cleaner.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/vacuum_cleaner.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/vacuum_cleaner_desc_be.ogg</Path>
@@ -4046,6 +4363,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/vacuum_cleaner_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/vacuum_cleaner_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/vacuum_cleaner_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/vacuum_cleaner_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/vacuum_cleaner_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/vacuum_cleaner_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/wheelie_bin.dat</Path>
@@ -4057,6 +4375,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/wheelie_bin_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/wheelie_bin_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/wheelie_bin_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/household/wheelie_bin_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/wheelie_bin_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/household/wheelie_bin_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/bandage_adhesive.png</Path>
@@ -4066,8 +4385,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/bandage_adhesive_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/bandage_adhesive_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/bandage_adhesive_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/medical/bandage_adhesive_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/bandage_adhesive_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/bandage_adhesive_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/medical/digitalthermometer.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/digitalthermometer.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/digitalthermometer.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/digitalthermometer_desc_be.ogg</Path>
@@ -4075,6 +4396,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/digitalthermometer_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/digitalthermometer_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/digitalthermometer_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/medical/digitalthermometer_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/digitalthermometer_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/digitalthermometer_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/mercurythermometer.png</Path>
@@ -4084,6 +4406,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/mercurythermometer_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/mercurythermometer_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/mercurythermometer_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/medical/mercurythermometer_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/mercurythermometer_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/mercurythermometer_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/stethoscope.png</Path>
@@ -4094,6 +4417,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/stethoscope_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/stethoscope_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/stethoscope_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/medical/stethoscope_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/stethoscope_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/stethoscope_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/syringe.png</Path>
@@ -4104,10 +4428,13 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/syringe_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/syringe_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/syringe_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/medical/syringe_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/syringe_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/syringe_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/tooth.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/medical/tooth.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/medical/tooth_desc_nn.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/military/ammunition/bullet.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/military/ammunition/bullet.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/military/ammunition/bullet.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/military/ammunition/bullet_desc_be.ogg</Path>
@@ -4146,6 +4473,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/military/fireman240a_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/military/fireman240a_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/military/fireman240a_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/military/longsword.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/military/longsword.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/military/longsword.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/military/longsword_desc_be.ogg</Path>
@@ -4197,6 +4525,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/military/vehicles/infantry-stryker_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/military/vehicles/infantry-stryker_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/military/vehicles/infantry-stryker_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/military/vehicles/mustang.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/military/vehicles/mustang.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/military/vehicles/mustang.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/military/vehicles/mustang_desc_be.ogg</Path>
@@ -4255,6 +4584,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/naturalforces/lightningbolt_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye2_drawing.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye2_drawing.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye2_drawing.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye2_drawing_desc_be.ogg</Path>
@@ -4262,8 +4592,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye2_drawing_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye2_drawing_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye2_drawing_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye2_drawing_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye2_drawing_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye2_drawing_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_blue_left.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_blue_left.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_blue_left.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_blue_left_desc_be.ogg</Path>
@@ -4271,8 +4603,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_blue_left_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_blue_left_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_blue_left_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_blue_left_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_blue_left_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_blue_left_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_brown_left.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_brown_left.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_brown_left.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_brown_left_desc_be.ogg</Path>
@@ -4280,8 +4614,11 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_brown_left_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_brown_left_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_brown_left_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_brown_left_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_brown_left_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_brown_left_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_desc_nn.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_green_left.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_green_left.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_green_left.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_green_left_desc_be.ogg</Path>
@@ -4289,8 +4626,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_green_left_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_green_left_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_green_left_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_green_left_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_green_left_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_green_left_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_yellow.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_yellow.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_yellow.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_yellow_desc_be.ogg</Path>
@@ -4298,18 +4637,23 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_yellow_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_yellow_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_yellow_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_yellow_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_yellow_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/eye_yellow_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/girlface.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/girlface.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/girlface.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/girlface_desc_be.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/girlface_desc_bg.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/girlface_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/girlface_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/girlface_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/girlface_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/girlface_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/hair_manga.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/hair_manga.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/hair_manga.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/hair_manga_2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/hair_manga_2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/hair_manga_2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/hair_manga_2_desc_be.ogg</Path>
@@ -4317,14 +4661,17 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/hair_manga_2_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/hair_manga_2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/hair_manga_2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/hair_manga_2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/hair_manga_2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/hair_manga_2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/hair_manga_desc_bg.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/hair_manga_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/hair_manga_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/hair_manga_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/hair_manga_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/hair_manga_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/hair_manga_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/head_female.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/head_female.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/head_female.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/head_female_desc_be.ogg</Path>
@@ -4332,8 +4679,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/head_female_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/head_female_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/head_female_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/head_female_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/head_female_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/head_female_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/manga_eye_left.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/manga_eye_left.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/manga_eye_left.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/manga_eye_left_desc_be.ogg</Path>
@@ -4341,17 +4690,21 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/manga_eye_left_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/manga_eye_left_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/manga_eye_left_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/manga_eye_left_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/manga_eye_left_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/manga_eye_left_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/manga_eye_right.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/manga_eye_right.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/manga_eye_right.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/manga_eye_right_desc_bg.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/manga_eye_right_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/manga_eye_right_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/manga_eye_right_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/manga_eye_right_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/manga_eye_right_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/manga_eye_right_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/moustache.dat</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/moustache.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/moustache.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/moustache.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/moustache_desc_be.ogg</Path>
@@ -4359,12 +4712,15 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/moustache_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/moustache_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/moustache_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/moustache_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/moustache_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/moustache_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig.dat</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig2.dat</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig2_desc_be.ogg</Path>
@@ -4372,9 +4728,11 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig2_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig3.dat</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig3.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig3.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig3.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig3_desc_be.ogg</Path>
@@ -4382,6 +4740,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig3_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig3_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig3_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig3_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig3_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig3_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig_desc_be.ogg</Path>
@@ -4389,8 +4748,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/body_parts/wig_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/girl_in_wheelchair.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/girl_in_wheelchair.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/girl_in_wheelchair.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/girl_in_wheelchair_desc_be.ogg</Path>
@@ -4398,18 +4759,23 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/girl_in_wheelchair_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/girl_in_wheelchair_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/girl_in_wheelchair_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/girl_in_wheelchair_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/girl_in_wheelchair_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/girl_in_wheelchair_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/man_in_suit.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/man_in_suit.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/man_in_suit.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/man_in_suit_desc_be.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/man_in_suit_desc_bg.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/man_in_suit_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/man_in_suit_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/man_in_suit_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/man_in_suit_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/man_in_suit_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/mermaid.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/mermaid.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/mermaid_desc_nn.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/scarecrow.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/scarecrow.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/scarecrow.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/scarecrow_desc_be.ogg</Path>
@@ -4418,10 +4784,13 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/scarecrow_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/scarecrow_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/scarecrow_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/scarecrow_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/scarecrow_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/scarecrow_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/snowman.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/snowman.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/snowman_desc_nn.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_chemist.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_chemist.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_chemist.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_chemist_desc_be.ogg</Path>
@@ -4430,8 +4799,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_chemist_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_chemist_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_chemist_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_chemist_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_chemist_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_chemist_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_dancing.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_dancing.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_dancing.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_dancing_desc_be.ogg</Path>
@@ -4440,8 +4811,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_dancing_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_dancing_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_dancing_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_dancing_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_dancing_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_dancing_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_doctor.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_doctor.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_doctor.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_doctor_desc_be.ogg</Path>
@@ -4450,8 +4823,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_doctor_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_doctor_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_doctor_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_doctor_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_doctor_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_doctor_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_nurse.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_nurse.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_nurse.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_nurse_desc_be.ogg</Path>
@@ -4460,9 +4835,11 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_nurse_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_nurse_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_nurse_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_nurse_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_nurse_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_nurse_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer2_desc_el.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_1.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_1.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_1.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_1_desc_be.ogg</Path>
@@ -4470,8 +4847,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_1_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_1_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_1_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_1_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_1_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_1_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_2_desc_be.ogg</Path>
@@ -4479,6 +4858,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_2_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/cartoon/woman_police_officer_desc_el.ogg</Path>
@@ -4510,6 +4890,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/toys/grannysmith_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/toys/grannysmith_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/toys/grannysmith_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/people/toys/grannysmith_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/toys/grannysmith_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/people/toys/grannysmith_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/plants/eggplant.dat</Path>
@@ -4820,6 +5201,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/plants/thyme_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/plants/thyme_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/plants/thyme_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/plants/toadstool.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/plants/toadstool.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/plants/toadstool.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/plants/toadstool_desc_be.ogg</Path>
@@ -4840,7 +5222,6 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/plants/trees/birch_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/plants/trees/birch_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/plants/trees/birch_desc_ru.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/plants/trees/holly_leaves.dat</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/plants/trees/holly_leaves.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/plants/trees/holly_leaves.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/plants/trees/holly_leaves_desc_be.ogg</Path>
@@ -4903,6 +5284,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/plants/trees/tree336_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/plants/trees/tree336_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/balloon.dat</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/balloon.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/balloon.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/balloon.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/balloon_desc_be.ogg</Path>
@@ -4910,6 +5292,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/balloon_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/balloon_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/balloon_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/balloon_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/balloon_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/balloon_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/candle.dat</Path>
@@ -4921,6 +5304,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/candle_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/candle_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/candle_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/candle_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/candle_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/candle_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Candy_cane_photo_1.dat</Path>
@@ -4931,6 +5315,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Candy_cane_photo_1_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Candy_cane_photo_1_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Candy_cane_photo_1_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Candy_cane_photo_1_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Candy_cane_photo_1_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Candy_cane_photo_1_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Candy_cane_photo_2.dat</Path>
@@ -4941,6 +5326,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Candy_cane_photo_2_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Candy_cane_photo_2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Candy_cane_photo_2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Candy_cane_photo_2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Candy_cane_photo_2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Candy_cane_photo_2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Christmas_Tree_photo.dat</Path>
@@ -4951,6 +5337,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Christmas_Tree_photo_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Christmas_Tree_photo_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Christmas_Tree_photo_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Christmas_Tree_photo_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Christmas_Tree_photo_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Christmas_Tree_photo_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Christmas_pudding.dat</Path>
@@ -4961,6 +5348,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Christmas_pudding_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Christmas_pudding_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Christmas_pudding_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Christmas_pudding_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Christmas_pudding_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Christmas_pudding_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/German_Christmas_toy.dat</Path>
@@ -4971,6 +5359,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/German_Christmas_toy_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/German_Christmas_toy_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/German_Christmas_toy_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/German_Christmas_toy_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/German_Christmas_toy_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/German_Christmas_toy_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Mince_Pie.dat</Path>
@@ -4981,6 +5370,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Mince_Pie_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Mince_Pie_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Mince_Pie_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Mince_Pie_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Mince_Pie_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Mince_Pie_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Roast_turkey.dat</Path>
@@ -4990,10 +5380,12 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Roast_turkey_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Roast_turkey_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Roast_turkey_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Roast_turkey_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Roast_turkey_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Roast_turkey_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Santa.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Santa.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/Santa_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/bow.dat</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/bow.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/bow.txt</Path>
@@ -5003,6 +5395,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/bow_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/bow_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/bow_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/bow_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/bow_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/bow_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/candy_cane.dat</Path>
@@ -5015,10 +5408,12 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/candy_cane_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/candy_cane_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/candy_cane_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/candy_cane_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/candy_cane_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/candy_cane_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/christmas_pudding_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/christmas_tree_desc_el.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/elfhat.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/elfhat.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/elfhat.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/elfhat_desc_be.ogg</Path>
@@ -5026,15 +5421,12 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/elfhat_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/elfhat_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/elfhat_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/elfhat_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/elfhat_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/elfhat_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/german_christmas_tool_desc_el.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift.dat</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift.txt</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift2.dat</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift2_desc_be.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift2_desc_bg.ogg</Path>
@@ -5042,6 +5434,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift2_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift_desc_be.ogg</Path>
@@ -5050,6 +5443,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/gift_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/hard_candy.dat</Path>
@@ -5062,6 +5456,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/hard_candy_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/hard_candy_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/hard_candy_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/hard_candy_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/hard_candy_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/hard_candy_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/lamp.dat</Path>
@@ -5072,54 +5467,16 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/lamp_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/lamp_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/lamp_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/lamp_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/lamp_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/lamp_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/mince_pie_desc_el.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_chocolate.svg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_chocolate.txt</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_chocolate_desc_be.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_chocolate_desc_bg.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_chocolate_desc_ca.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_chocolate_desc_es.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_chocolate_desc_fr.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_chocolate_desc_ro.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_chocolate_desc_ru.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_gold.svg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_gold.txt</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_gold_desc_be.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_gold_desc_bg.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_gold_desc_ca.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_gold_desc_es.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_gold_desc_fr.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_gold_desc_ro.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_gold_desc_ru.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_green.svg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_green.txt</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_green_desc_be.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_green_desc_bg.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_green_desc_ca.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_green_desc_es.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_green_desc_fr.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_green_desc_ro.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_green_desc_ru.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_purple.svg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_purple.txt</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_purple_desc_be.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_purple_desc_bg.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_purple_desc_ca.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_purple_desc_es.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_purple_desc_fr.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_purple_desc_ro.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_purple_desc_ru.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_red.svg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_red.txt</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_red_desc_be.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_red_desc_bg.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_red_desc_ca.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_red_desc_es.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_red_desc_fr.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_red_desc_ro.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_red_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present.dat</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present.png</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present.svg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/present_desc_nn.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/rudolf_reindeer.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/rudolf_reindeer.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/rudolf_reindeer.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/rudolf_reindeer_desc_be.ogg</Path>
@@ -5127,11 +5484,13 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/rudolf_reindeer_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/rudolf_reindeer_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/rudolf_reindeer_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/rudolf_reindeer_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/rudolf_reindeer_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/rudolf_reindeer_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/santahat.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/santahat.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/santahat.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/santahat2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/santahat2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/santahat2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/santahat2_desc_be.ogg</Path>
@@ -5139,6 +5498,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/santahat2_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/santahat2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/santahat2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/santahat2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/santahat2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/santahat2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/santahat_desc_be.ogg</Path>
@@ -5147,6 +5507,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/santahat_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/santahat_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/santahat_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/santahat_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/santahat_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/santahat_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/star.dat</Path>
@@ -5158,6 +5519,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/star_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/star_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/star_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/star_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/star_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/star_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/stocking.png</Path>
@@ -5168,6 +5530,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/stocking_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/stocking_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/stocking_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/stocking_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/stocking_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/stocking_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/tree.dat</Path>
@@ -5179,6 +5542,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/tree_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/tree_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/tree_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/tree_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/tree_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/tree_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/xmas_tp_bulb.dat</Path>
@@ -5190,6 +5554,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/xmas_tp_bulb_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/xmas_tp_bulb_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/xmas_tp_bulb_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/xmas_tp_bulb_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/xmas_tp_bulb_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/xmas_tp_bulb_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/xmaswreath.dat</Path>
@@ -5201,8 +5566,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/xmaswreath_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/xmaswreath_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/xmaswreath_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/xmaswreath_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/xmaswreath_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/christmas/xmaswreath_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/clover.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/clover.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/clover.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/clover_desc_be.ogg</Path>
@@ -5210,6 +5577,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/clover_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/clover_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/clover_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/clover_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/clover_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/clover_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bluebird.dat</Path>
@@ -5221,6 +5589,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bluebird_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bluebird_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bluebird_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bluebird_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bluebird_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bluebird_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny-egg.dat</Path>
@@ -5232,6 +5601,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny-egg_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny-egg_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny-egg_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny-egg_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny-egg_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny-egg_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny-head.dat</Path>
@@ -5243,6 +5613,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny-head_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny-head_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny-head_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny-head_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny-head_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny-head_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny.dat</Path>
@@ -5254,6 +5625,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/bunny_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/butterfly.dat</Path>
@@ -5265,6 +5637,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/butterfly_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/butterfly_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/butterfly_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/butterfly_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/butterfly_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/butterfly_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick-hatched.dat</Path>
@@ -5276,6 +5649,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick-hatched_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick-hatched_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick-hatched_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick-hatched_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick-hatched_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick-hatched_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick-in-egg.dat</Path>
@@ -5287,6 +5661,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick-in-egg_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick-in-egg_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick-in-egg_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick-in-egg_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick-in-egg_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick-in-egg_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick.dat</Path>
@@ -5298,6 +5673,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/chick_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/daffodil.dat</Path>
@@ -5309,6 +5685,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/daffodil_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/daffodil_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/daffodil_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/daffodil_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/daffodil_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/daffodil_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/wrapped_chocolate_easter_egg.dat</Path>
@@ -5323,6 +5700,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/wrapped_chocolate_easter_egg_2_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/wrapped_chocolate_easter_egg_2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/wrapped_chocolate_easter_egg_2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/wrapped_chocolate_easter_egg_2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/wrapped_chocolate_easter_egg_2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/wrapped_chocolate_easter_egg_2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/wrapped_chocolate_easter_egg_desc_be.ogg</Path>
@@ -5331,6 +5709,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/wrapped_chocolate_easter_egg_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/wrapped_chocolate_easter_egg_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/wrapped_chocolate_easter_egg_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/wrapped_chocolate_easter_egg_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/wrapped_chocolate_easter_egg_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/easter/wrapped_chocolate_easter_egg_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/bat_left.ogg</Path>
@@ -5342,6 +5721,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/bat_left_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/bat_left_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/bat_left_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/bat_left_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/bat_left_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/bat_left_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/blackcat.dat</Path>
@@ -5354,6 +5734,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/blackcat_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/blackcat_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/blackcat_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/blackcat_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/blackcat_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/blackcat_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/ghost.dat</Path>
@@ -5366,6 +5747,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/ghost_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/ghost_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/ghost_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/ghost_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/ghost_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/ghost_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-a.png</Path>
@@ -5376,6 +5758,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-a_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-a_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-a_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-a_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-a_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-a_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-b.png</Path>
@@ -5386,6 +5769,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-b_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-b_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-b_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-b_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-b_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-b_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-c.png</Path>
@@ -5396,6 +5780,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-c_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-c_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-c_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-c_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-c_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-c_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-d.dat</Path>
@@ -5407,6 +5792,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-d_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-d_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-d_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-d_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-d_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-d_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-e.png</Path>
@@ -5417,6 +5803,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-e_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-e_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-e_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-e_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-e_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-e_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-f.png</Path>
@@ -5427,6 +5814,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-f_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-f_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-f_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-f_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-f_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-f_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-g.png</Path>
@@ -5437,6 +5825,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-g_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-g_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-g_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-g_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-g_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-g_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-h.png</Path>
@@ -5447,6 +5836,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-h_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-h_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-h_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-h_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-h_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-h_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-i.png</Path>
@@ -5457,6 +5847,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-i_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-i_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-i_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-i_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-i_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-i_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-j.png</Path>
@@ -5467,6 +5858,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-j_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-j_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-j_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-j_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-j_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/grave-j_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/jackolantern_mean.dat</Path>
@@ -5479,6 +5871,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/jackolantern_mean_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/jackolantern_mean_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/jackolantern_mean_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/jackolantern_mean_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/jackolantern_mean_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/jackolantern_mean_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/skull.png</Path>
@@ -5489,6 +5882,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/skull_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/skull_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/skull_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/skull_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/skull_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/skull_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/spider.ogg</Path>
@@ -5500,6 +5894,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/spider_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/spider_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/spider_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/spider_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/spider_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/halloween/spider_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-gimmel.dat</Path>
@@ -5512,6 +5907,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-gimmel_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-gimmel_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-gimmel_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-gimmel_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-gimmel_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-gimmel_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-gimmel_mirror.png</Path>
@@ -5525,6 +5921,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-hay_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-hay_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-hay_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-hay_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-hay_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-hay_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-hay_mirror.png</Path>
@@ -5538,6 +5935,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-nun_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-nun_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-nun_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-nun_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-nun_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-nun_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-nun_mirror.png</Path>
@@ -5550,6 +5948,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-shin_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-shin_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-shin_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-shin_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-shin_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-shin_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl-shin_mirror.png</Path>
@@ -5562,6 +5961,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/dreydl_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/holiday_candle.dat</Path>
@@ -5573,6 +5973,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/holiday_candle_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/holiday_candle_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/holiday_candle_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/holiday_candle_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/holiday_candle_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/holiday_candle_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/menorah.dat</Path>
@@ -5584,8 +5985,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/menorah_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/menorah_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/menorah_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/menorah_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/menorah_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/hanukkah/menorah_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/leafrake.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/leafrake.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/leafrake.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/leafrake_desc_be.ogg</Path>
@@ -5593,6 +5996,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/leafrake_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/leafrake_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/leafrake_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/leafrake_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/leafrake_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/leafrake_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/confetti.dat</Path>
@@ -5604,6 +6008,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/confetti_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/confetti_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/confetti_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/confetti_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/confetti_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/confetti_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/fireworks.dat</Path>
@@ -5619,6 +6024,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/fireworks2_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/fireworks2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/fireworks2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/fireworks2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/fireworks2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/fireworks2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/fireworks_desc_be.ogg</Path>
@@ -5627,6 +6033,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/fireworks_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/fireworks_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/fireworks_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/fireworks_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/fireworks_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/fireworks_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-hat.png</Path>
@@ -5637,6 +6044,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-hat_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-hat_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-hat_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-hat_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-hat_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-hat_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-horn-in.dat</Path>
@@ -5648,6 +6056,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-horn-in_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-horn-in_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-horn-in_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-horn-in_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-horn-in_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-horn-in_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-horn-out.dat</Path>
@@ -5659,8 +6068,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-horn-out_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-horn-out_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-horn-out_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-horn-out_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-horn-out_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/newyears/party-horn-out_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/shamrock.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/shamrock.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/shamrock.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/shamrock_desc_be.ogg</Path>
@@ -5668,8 +6079,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/shamrock_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/shamrock_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/shamrock_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/shamrock_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/shamrock_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/shamrock_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/sledge.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/sledge.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/sledge.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/sledge_desc_be.ogg</Path>
@@ -5677,8 +6090,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/sledge_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/sledge_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/sledge_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/sledge_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/sledge_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/sledge_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowflake.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowflake.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowflake.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowflake_desc_be.ogg</Path>
@@ -5686,10 +6101,13 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowflake_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowflake_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowflake_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowflake_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowflake_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowflake_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowman.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowman.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowman.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowman2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowman2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowman2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowman2_desc_be.ogg</Path>
@@ -5697,6 +6115,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowman2_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowman2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowman2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowman2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowman2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowman2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowman_desc_be.ogg</Path>
@@ -5704,6 +6123,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowman_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowman_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowman_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowman_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowman_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/seasonal/winter/snowman_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/apollo_lander.ogg</Path>
@@ -5715,6 +6135,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/apollo_lander_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/apollo_lander_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/apollo_lander_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/apollo_lander_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/apollo_lander_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/apollo_lander_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_3qt.png</Path>
@@ -5726,6 +6147,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_3qt_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_3qt_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_3qt_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_3qt_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_3qt_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_3qt_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_crescent.png</Path>
@@ -5737,6 +6159,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_crescent_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_crescent_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_crescent_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_crescent_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_crescent_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_crescent_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_full.png</Path>
@@ -5747,6 +6170,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_full_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_full_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_full_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_full_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_full_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/moon/moon_full_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/0_sun.png</Path>
@@ -5757,6 +6181,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/0_sun_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/0_sun_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/0_sun_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/0_sun_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/0_sun_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/0_sun_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/1_mercury.png</Path>
@@ -5768,6 +6193,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/1_mercury_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/1_mercury_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/1_mercury_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/1_mercury_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/1_mercury_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/1_mercury_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/2_venus.png</Path>
@@ -5778,6 +6204,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/2_venus_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/2_venus_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/2_venus_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/2_venus_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/2_venus_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/2_venus_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/3_earth.png</Path>
@@ -5788,6 +6215,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/3_earth_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/3_earth_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/3_earth_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/3_earth_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/3_earth_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/3_earth_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/4_mars.png</Path>
@@ -5799,6 +6227,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/4_mars_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/4_mars_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/4_mars_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/4_mars_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/4_mars_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/4_mars_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/5_jupiter.png</Path>
@@ -5810,6 +6239,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/5_jupiter_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/5_jupiter_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/5_jupiter_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/5_jupiter_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/5_jupiter_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/5_jupiter_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/6_saturn.png</Path>
@@ -5820,6 +6250,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/6_saturn_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/6_saturn_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/6_saturn_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/6_saturn_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/6_saturn_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/6_saturn_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/7_uranus.png</Path>
@@ -5830,6 +6261,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/7_uranus_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/7_uranus_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/7_uranus_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/7_uranus_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/7_uranus_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/7_uranus_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/8_neptune.png</Path>
@@ -5841,6 +6273,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/8_neptune_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/8_neptune_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/8_neptune_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/8_neptune_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/8_neptune_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/8_neptune_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/9_pluto.png</Path>
@@ -5852,20 +6285,33 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/9_pluto_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/9_pluto_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/9_pluto_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/9_pluto_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/9_pluto_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/planets/9_pluto_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/rocket1.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/rocket1.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/rocket1.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/rocket1_desc_nn.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/rocket2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/rocket2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/rocket2.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/rocket2_desc_nn.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/rocket3.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/rocket3.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/rocket3.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/rocket3_desc_nn.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/rocket4.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/rocket4.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/rocket4.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/rocket4_desc_nn.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/rocket5.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/rocket5.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/rocket5.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/rocket5_desc_nn.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/satellite.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/satellite.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/satellite.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/satellite_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/spacewalk.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/spacewalk.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/spacewalk_desc_be.ogg</Path>
@@ -5875,8 +6321,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/spacewalk_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/spacewalk_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/spacewalk_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/spacewalk_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/spacewalk_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/spacewalk_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/toyrocket.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/toyrocket.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/toyrocket.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/toyrocket_desc_be.ogg</Path>
@@ -5885,6 +6333,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/toyrocket_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/toyrocket_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/toyrocket_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/toyrocket_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/toyrocket_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/toyrocket_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/voyager2.png</Path>
@@ -5895,6 +6344,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/voyager2_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/voyager2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/voyager2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/space/voyager2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/voyager2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/space/voyager2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/australian_rules_football.dat</Path>
@@ -5906,6 +6356,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/australian_rules_football_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/australian_rules_football_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/australian_rules_football_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/sports/australian_rules_football_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/australian_rules_football_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/australian_rules_football_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/basketball.dat</Path>
@@ -5917,6 +6368,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/basketball_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/basketball_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/basketball_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/sports/basketball_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/basketball_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/basketball_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/football_helmet_front.dat</Path>
@@ -5927,6 +6379,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/football_helmet_front_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/football_helmet_front_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/football_helmet_front_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/football_helmet_front_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/football_helmet_front_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/football_helmet_front_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/football_helmet_side.dat</Path>
@@ -5937,6 +6390,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/football_helmet_side_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/football_helmet_side_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/football_helmet_side_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/football_helmet_side_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/football_helmet_side_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/football_helmet_side_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/volleyball.png</Path>
@@ -5945,6 +6399,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/volleyball_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/volleyball_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/volleyball_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/volleyball_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/volleyball_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cartoon/volleyball_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cricketball.dat</Path>
@@ -5956,6 +6411,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cricketball_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cricketball_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cricketball_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cricketball_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cricketball_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/cricketball_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/football.png</Path>
@@ -5966,6 +6422,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/football_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/football_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/football_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/sports/football_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/football_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/football_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/rugby_goal_posts.dat</Path>
@@ -5976,6 +6433,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/rugby_goal_posts_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/rugby_goal_posts_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/rugby_goal_posts_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/sports/rugby_goal_posts_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/rugby_goal_posts_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/rugby_goal_posts_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/soccer.png</Path>
@@ -5986,14 +6444,17 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/soccer_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/soccer_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/soccer_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/sports/soccer_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/soccer_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/soccer_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/sports/stopwatch.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/stopwatch.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/stopwatch.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/stopwatch_desc_be.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/stopwatch_desc_bg.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/stopwatch_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/stopwatch_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/sports/stopwatch_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/stopwatch_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/stopwatch_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/tennis_ball.dat</Path>
@@ -6005,6 +6466,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/tennis_ball_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/tennis_ball_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/tennis_ball_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/sports/tennis_ball_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/tennis_ball_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/tennis_ball_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/tennis_racket.dat</Path>
@@ -6016,6 +6478,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/tennis_racket_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/tennis_racket_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/tennis_racket_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/sports/tennis_racket_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/tennis_racket_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/tennis_racket_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/trophy_cup.dat</Path>
@@ -6027,6 +6490,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/trophy_cup_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/trophy_cup_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/trophy_cup_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/sports/trophy_cup_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/trophy_cup_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/sports/trophy_cup_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/asl/asl_a.dat</Path>
@@ -6387,6 +6851,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/a_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/a_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/a_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/a_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/a_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/a_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/a_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/a_filled_en_GB.ogg</Path>
@@ -6398,6 +6864,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/b_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/b_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/b_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/b_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/b_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/b_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/b_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/b_filled_en_GB.ogg</Path>
@@ -6409,6 +6877,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/c_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/c_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/c_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/c_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/c_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/c_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/c_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/c_filled_en_GB.ogg</Path>
@@ -6420,6 +6890,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/d_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/d_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/d_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/d_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/d_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/d_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/d_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/d_filled_en_GB.ogg</Path>
@@ -6431,6 +6903,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/e_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/e_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/e_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/e_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/e_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/e_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/e_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/e_filled_en_GB.ogg</Path>
@@ -6442,6 +6916,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/f_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/f_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/f_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/f_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/f_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/f_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/f_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/f_filled_en_GB.ogg</Path>
@@ -6453,6 +6929,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/g_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/g_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/g_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/g_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/g_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/g_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/g_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/g_filled_en_GB.ogg</Path>
@@ -6464,6 +6942,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/h_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/h_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/h_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/h_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/h_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/h_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/h_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/h_filled_en_GB.ogg</Path>
@@ -6475,6 +6955,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/i_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/i_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/i_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/i_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/i_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/i_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/i_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/i_filled_en_GB.ogg</Path>
@@ -6486,6 +6968,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/j_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/j_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/j_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/j_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/j_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/j_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/j_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/j_filled_en_GB.ogg</Path>
@@ -6497,6 +6981,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/k_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/k_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/k_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/k_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/k_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/k_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/k_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/k_filled_en_GB.ogg</Path>
@@ -6508,6 +6994,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/l_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/l_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/l_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/l_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/l_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/l_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/l_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/l_filled_en_GB.ogg</Path>
@@ -6519,6 +7007,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/m_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/m_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/m_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/m_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/m_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/m_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/m_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/m_filled_en_GB.ogg</Path>
@@ -6530,6 +7020,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/n_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/n_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/n_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/n_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/n_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/n_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/n_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/n_filled_en_GB.ogg</Path>
@@ -6541,6 +7033,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/o_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/o_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/o_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/o_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/o_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/o_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/o_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/o_filled_en_GB.ogg</Path>
@@ -6552,6 +7046,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/p_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/p_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/p_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/p_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/p_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/p_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/p_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/p_filled_en_GB.ogg</Path>
@@ -6563,6 +7059,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/q_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/q_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/q_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/q_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/q_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/q_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/q_filled_en_GB.ogg</Path>
@@ -6574,6 +7071,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/r_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/r_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/r_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/r_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/r_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/r_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/r_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/r_filled_en_GB.ogg</Path>
@@ -6585,6 +7084,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/s_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/s_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/s_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/s_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/s_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/s_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/s_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/s_filled_en_GB.ogg</Path>
@@ -6596,6 +7097,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/t_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/t_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/t_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/t_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/t_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/t_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/t_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/t_filled_en_GB.ogg</Path>
@@ -6607,6 +7110,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/u_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/u_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/u_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/u_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/u_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/u_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/u_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/u_filled_en_GB.ogg</Path>
@@ -6618,6 +7123,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/v_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/v_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/v_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/v_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/v_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/v_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/v_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/v_filled_en_GB.ogg</Path>
@@ -6629,6 +7136,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/w_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/w_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/w_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/w_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/w_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/w_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/w_filled_en_GB.ogg</Path>
@@ -6640,6 +7148,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/x_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/x_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/x_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/x_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/x_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/x_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/x_filled_en_GB.ogg</Path>
@@ -6651,6 +7160,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/y_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/y_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/y_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/y_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/y_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/y_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/y_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/y_filled_en_GB.ogg</Path>
@@ -6662,6 +7173,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/z_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/z_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/z_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/z_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/z_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/z_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/lowercase/z_filled_en_GB.ogg</Path>
@@ -6673,6 +7185,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/A_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/A_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/A_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/A_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/A_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/A_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/A_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/A_filled_en_GB.ogg</Path>
@@ -6684,6 +7198,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/B_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/B_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/B_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/B_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/B_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/B_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/B_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/B_filled_en_GB.ogg</Path>
@@ -6695,6 +7211,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/C_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/C_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/C_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/C_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/C_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/C_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/C_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/C_filled_en_GB.ogg</Path>
@@ -6706,6 +7224,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/D_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/D_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/D_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/D_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/D_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/D_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/D_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/D_filled_en_GB.ogg</Path>
@@ -6717,6 +7237,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/E_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/E_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/E_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/E_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/E_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/E_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/E_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/E_filled_en_GB.ogg</Path>
@@ -6728,6 +7250,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/F_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/F_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/F_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/F_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/F_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/F_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/F_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/F_filled_en_GB.ogg</Path>
@@ -6739,6 +7263,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/G_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/G_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/G_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/G_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/G_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/G_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/G_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/G_filled_en_GB.ogg</Path>
@@ -6750,6 +7276,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/H_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/H_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/H_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/H_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/H_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/H_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/H_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/H_filled_en_GB.ogg</Path>
@@ -6761,6 +7289,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/I_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/I_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/I_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/I_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/I_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/I_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/I_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/I_filled_en_GB.ogg</Path>
@@ -6772,6 +7302,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/J_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/J_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/J_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/J_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/J_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/J_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/J_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/J_filled_en_GB.ogg</Path>
@@ -6783,6 +7315,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/K_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/K_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/K_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/K_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/K_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/K_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/K_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/K_filled_en_GB.ogg</Path>
@@ -6794,6 +7328,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/L_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/L_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/L_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/L_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/L_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/L_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/L_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/L_filled_en_GB.ogg</Path>
@@ -6805,6 +7341,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/M_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/M_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/M_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/M_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/M_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/M_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/M_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/M_filled_en_GB.ogg</Path>
@@ -6816,6 +7354,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/N_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/N_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/N_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/N_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/N_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/N_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/N_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/N_filled_en_GB.ogg</Path>
@@ -6827,6 +7367,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/O_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/O_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/O_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/O_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/O_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/O_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/O_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/O_filled_en_GB.ogg</Path>
@@ -6838,6 +7380,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/P_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/P_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/P_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/P_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/P_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/P_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/P_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/P_filled_en_GB.ogg</Path>
@@ -6849,6 +7393,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Q_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Q_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Q_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Q_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Q_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Q_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Q_filled_en_GB.ogg</Path>
@@ -6860,6 +7405,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/R_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/R_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/R_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/R_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/R_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/R_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/R_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/R_filled_en_GB.ogg</Path>
@@ -6871,6 +7418,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/S_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/S_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/S_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/S_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/S_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/S_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/S_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/S_filled_en_GB.ogg</Path>
@@ -6882,6 +7431,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/T_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/T_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/T_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/T_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/T_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/T_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/T_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/T_filled_en_GB.ogg</Path>
@@ -6893,6 +7444,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/U_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/U_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/U_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/U_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/U_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/U_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/U_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/U_filled_en_GB.ogg</Path>
@@ -6904,6 +7457,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/V_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/V_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/V_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/V_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/V_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/V_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/V_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/V_filled_en_GB.ogg</Path>
@@ -6915,6 +7470,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/W_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/W_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/W_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/W_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/W_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/W_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/W_filled_en_GB.ogg</Path>
@@ -6926,6 +7482,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/X_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/X_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/X_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/X_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/X_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/X_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/X_filled_en_GB.ogg</Path>
@@ -6937,6 +7494,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Y_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Y_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Y_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Y_filled_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Y_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Y_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Y_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Y_filled_en_GB.ogg</Path>
@@ -6948,6 +7507,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Z_filled_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Z_filled_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Z_filled_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Z_filled_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Z_filled_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Z_filled_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/filled/uppercase/Z_filled_en_GB.ogg</Path>
@@ -6959,6 +7519,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/a_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/a_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/a_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/a_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/a_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/a_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/a_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/a_outline_en_GB.ogg</Path>
@@ -6970,6 +7532,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/b_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/b_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/b_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/b_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/b_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/b_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/b_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/b_outline_en_GB.ogg</Path>
@@ -6981,6 +7545,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/c_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/c_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/c_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/c_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/c_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/c_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/c_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/c_outline_en_GB.ogg</Path>
@@ -6992,6 +7558,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/d_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/d_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/d_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/d_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/d_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/d_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/d_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/d_outline_en_GB.ogg</Path>
@@ -7003,6 +7571,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/e_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/e_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/e_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/e_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/e_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/e_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/e_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/e_outline_en_GB.ogg</Path>
@@ -7014,6 +7584,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/f_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/f_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/f_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/f_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/f_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/f_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/f_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/f_outline_en_GB.ogg</Path>
@@ -7025,6 +7597,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/g_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/g_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/g_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/g_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/g_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/g_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/g_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/g_outline_en_GB.ogg</Path>
@@ -7036,6 +7610,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/h_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/h_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/h_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/h_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/h_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/h_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/h_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/h_outline_en_GB.ogg</Path>
@@ -7047,6 +7623,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/i_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/i_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/i_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/i_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/i_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/i_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/i_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/i_outline_en_GB.ogg</Path>
@@ -7058,6 +7636,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/j_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/j_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/j_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/j_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/j_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/j_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/j_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/j_outline_en_GB.ogg</Path>
@@ -7069,6 +7649,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/k_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/k_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/k_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/k_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/k_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/k_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/k_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/k_outline_en_GB.ogg</Path>
@@ -7080,6 +7662,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/l_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/l_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/l_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/l_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/l_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/l_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/l_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/l_outline_en_GB.ogg</Path>
@@ -7091,6 +7675,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/m_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/m_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/m_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/m_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/m_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/m_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/m_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/m_outline_en_GB.ogg</Path>
@@ -7102,6 +7688,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/n_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/n_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/n_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/n_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/n_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/n_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/n_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/n_outline_en_GB.ogg</Path>
@@ -7113,6 +7701,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/o_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/o_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/o_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/o_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/o_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/o_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/o_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/o_outline_en_GB.ogg</Path>
@@ -7124,6 +7714,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/p_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/p_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/p_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/p_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/p_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/p_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/p_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/p_outline_en_GB.ogg</Path>
@@ -7135,6 +7727,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/q_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/q_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/q_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/q_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/q_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/q_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/q_outline_en_GB.ogg</Path>
@@ -7146,6 +7739,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/r_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/r_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/r_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/r_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/r_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/r_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/r_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/r_outline_en_GB.ogg</Path>
@@ -7157,6 +7752,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/s_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/s_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/s_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/s_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/s_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/s_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/s_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/s_outline_en_GB.ogg</Path>
@@ -7168,6 +7765,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/t_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/t_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/t_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/t_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/t_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/t_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/t_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/t_outline_en_GB.ogg</Path>
@@ -7179,6 +7778,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/u_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/u_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/u_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/u_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/u_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/u_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/u_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/u_outline_en_GB.ogg</Path>
@@ -7190,6 +7791,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/v_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/v_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/v_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/v_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/v_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/v_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/v_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/v_outline_en_GB.ogg</Path>
@@ -7201,6 +7804,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/w_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/w_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/w_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/w_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/w_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/w_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/w_outline_en_GB.ogg</Path>
@@ -7212,6 +7816,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/x_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/x_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/x_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/x_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/x_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/x_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/x_outline_en_GB.ogg</Path>
@@ -7223,6 +7828,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/y_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/y_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/y_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/y_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/y_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/y_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/y_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/y_outline_en_GB.ogg</Path>
@@ -7234,6 +7841,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/z_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/z_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/z_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/z_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/z_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/z_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/lowercase/z_outline_en_GB.ogg</Path>
@@ -7245,6 +7853,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/A_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/A_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/A_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/A_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/A_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/A_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/A_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/A_outline_en_GB.ogg</Path>
@@ -7256,6 +7866,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/B_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/B_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/B_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/B_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/B_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/B_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/B_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/B_outline_en_GB.ogg</Path>
@@ -7267,6 +7879,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/C_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/C_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/C_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/C_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/C_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/C_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/C_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/C_outline_en_GB.ogg</Path>
@@ -7278,6 +7892,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/D_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/D_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/D_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/D_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/D_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/D_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/D_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/D_outline_en_GB.ogg</Path>
@@ -7289,6 +7905,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/E_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/E_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/E_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/E_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/E_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/E_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/E_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/E_outline_en_GB.ogg</Path>
@@ -7300,6 +7918,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/F_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/F_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/F_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/F_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/F_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/F_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/F_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/F_outline_en_GB.ogg</Path>
@@ -7311,6 +7931,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/G_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/G_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/G_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/G_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/G_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/G_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/G_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/G_outline_en_GB.ogg</Path>
@@ -7322,6 +7944,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/H_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/H_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/H_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/H_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/H_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/H_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/H_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/H_outline_en_GB.ogg</Path>
@@ -7333,6 +7957,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/I_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/I_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/I_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/I_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/I_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/I_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/I_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/I_outline_en_GB.ogg</Path>
@@ -7344,6 +7970,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/J_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/J_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/J_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/J_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/J_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/J_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/J_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/J_outline_en_GB.ogg</Path>
@@ -7355,6 +7983,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/K_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/K_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/K_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/K_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/K_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/K_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/K_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/K_outline_en_GB.ogg</Path>
@@ -7366,6 +7996,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/L_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/L_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/L_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/L_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/L_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/L_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/L_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/L_outline_en_GB.ogg</Path>
@@ -7377,6 +8009,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/M_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/M_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/M_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/M_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/M_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/M_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/M_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/M_outline_en_GB.ogg</Path>
@@ -7388,6 +8022,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/N_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/N_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/N_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/N_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/N_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/N_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/N_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/N_outline_en_GB.ogg</Path>
@@ -7399,6 +8035,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/O_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/O_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/O_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/O_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/O_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/O_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/O_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/O_outline_en_GB.ogg</Path>
@@ -7410,6 +8048,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/P_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/P_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/P_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/P_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/P_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/P_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/P_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/P_outline_en_GB.ogg</Path>
@@ -7421,6 +8061,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Q_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Q_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Q_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Q_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Q_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Q_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Q_outline_en_GB.ogg</Path>
@@ -7432,6 +8073,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/R_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/R_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/R_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/R_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/R_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/R_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/R_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/R_outline_en_GB.ogg</Path>
@@ -7443,6 +8086,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/S_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/S_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/S_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/S_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/S_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/S_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/S_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/S_outline_en_GB.ogg</Path>
@@ -7454,6 +8099,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/T_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/T_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/T_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/T_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/T_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/T_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/T_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/T_outline_en_GB.ogg</Path>
@@ -7465,6 +8112,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/U_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/U_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/U_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/U_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/U_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/U_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/U_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/U_outline_en_GB.ogg</Path>
@@ -7476,6 +8125,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/V_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/V_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/V_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/V_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/V_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/V_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/V_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/V_outline_en_GB.ogg</Path>
@@ -7487,6 +8138,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/W_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/W_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/W_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/W_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/W_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/W_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/W_outline_en_GB.ogg</Path>
@@ -7498,6 +8150,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/X_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/X_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/X_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/X_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/X_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/X_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/X_outline_en_GB.ogg</Path>
@@ -7509,6 +8162,8 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Y_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Y_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Y_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Y_outline_desc_lt.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Y_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Y_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Y_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Y_outline_en_GB.ogg</Path>
@@ -7520,6 +8175,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Z_outline_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Z_outline_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Z_outline_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Z_outline_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Z_outline_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Z_outline_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/alphabets/english/outlined/uppercase/Z_outline_en_GB.ogg</Path>
@@ -7829,6 +8485,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/chess/w_6_pawn_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/chess/w_6_pawn_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/chess/w_6_pawn_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/clock.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/clock.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/clock.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/clock_desc_be.ogg</Path>
@@ -8611,6 +9268,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/clef0_treble_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/clef0_treble_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/clef0_treble_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/clef0_treble_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/clef0_treble_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/clef0_treble_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/clef1_bass.dat</Path>
@@ -8621,6 +9279,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/clef1_bass_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/clef1_bass_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/clef1_bass_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/clef1_bass_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/clef1_bass_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/clef1_bass_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/key_flat.dat</Path>
@@ -8632,6 +9291,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/key_flat_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/key_flat_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/key_flat_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/key_flat_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/key_flat_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/key_flat_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/key_sharp.dat</Path>
@@ -8642,6 +9302,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/key_sharp_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/key_sharp_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/key_sharp_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/key_sharp_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/key_sharp_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/key_sharp_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_012_a.dat</Path>
@@ -8653,6 +9314,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_012_a_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_012_a_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_012_a_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_012_a_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_012_a_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_012_a_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_012_b.dat</Path>
@@ -8663,6 +9325,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_012_b_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_012_b_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_012_b_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_012_b_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_012_b_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_012_b_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_025_a.dat</Path>
@@ -8674,6 +9337,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_025_a_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_025_a_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_025_a_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_025_a_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_025_a_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_025_a_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_025_b.dat</Path>
@@ -8684,6 +9348,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_025_b_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_025_b_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_025_b_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_025_b_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_025_b_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_025_b_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_050_a.dat</Path>
@@ -8695,6 +9360,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_050_a_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_050_a_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_050_a_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_050_a_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_050_a_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_050_a_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_050_b.dat</Path>
@@ -8705,6 +9371,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_050_b_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_050_b_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_050_b_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_050_b_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_050_b_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_050_b_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_100.dat</Path>
@@ -8715,6 +9382,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_100_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_100_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_100_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_100_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_100_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/note_100_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/rest_025.dat</Path>
@@ -8725,6 +9393,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/rest_025_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/rest_025_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/rest_025_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/rest_025_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/rest_025_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/music/rest_025_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/recycle.dat</Path>
@@ -8745,10 +9414,12 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/hand_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/hand_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/hand_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/hand_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/hand_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/hand_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart.dat</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart.png</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_desc_be.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_desc_bg.ogg</Path>
@@ -8756,35 +9427,9 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_desc_ru.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_gold.svg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_gold.txt</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_gold_desc_be.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_gold_desc_bg.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_gold_desc_ca.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_gold_desc_es.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_gold_desc_fr.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_gold_desc_ro.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_gold_desc_ru.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_pink.svg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_pink.txt</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_pink_desc_be.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_pink_desc_bg.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_pink_desc_ca.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_pink_desc_es.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_pink_desc_fr.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_pink_desc_ro.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_pink_desc_ru.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_red.svg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_red.txt</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_red_desc_be.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_red_desc_bg.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_red_desc_ca.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_red_desc_es.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_red_desc_fr.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_red_desc_ro.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/heart_red_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/pawprint.dat</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/pawprint.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/pawprint.txt</Path>
@@ -8794,6 +9439,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/pawprint_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/pawprint_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/pawprint_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/pawprint_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/pawprint_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/pawprint_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/scream_balloon.dat</Path>
@@ -8806,6 +9452,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/scream_balloon_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/scream_balloon_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/scream_balloon_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/scream_balloon_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/scream_balloon_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/scream_balloon_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/speech_balloon.dat</Path>
@@ -8818,6 +9465,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/speech_balloon_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/speech_balloon_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/speech_balloon_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/speech_balloon_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/speech_balloon_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/speech_balloon_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/star.dat</Path>
@@ -8829,6 +9477,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/star_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/star_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/star_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/star_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/star_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/star_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/thought_balloon.dat</Path>
@@ -8841,6 +9490,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/thought_balloon_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/thought_balloon_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/thought_balloon_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/thought_balloon_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/thought_balloon_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/symbols/shapes/thought_balloon_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/docks.png</Path>
@@ -8853,6 +9503,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/docks_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/docks_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/docks_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/docks_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/docks_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/docks_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/fountain.png</Path>
@@ -8864,6 +9515,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/fountain_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/fountain_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/fountain_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/fountain_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/fountain_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/fountain_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/gate.png</Path>
@@ -8876,6 +9528,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/gate_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/gate_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/gate_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/gate_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/gate_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/gate_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/mine.png</Path>
@@ -8888,6 +9541,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/mine_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/mine_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/mine_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/mine_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/mine_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/mine_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/ruins.png</Path>
@@ -8900,6 +9554,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/ruins_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/ruins_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/ruins_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/ruins_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/ruins_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/ruins_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/shipwreck.png</Path>
@@ -8911,6 +9566,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/shipwreck_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/shipwreck_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/shipwreck_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/shipwreck_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/shipwreck_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/shipwreck_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/watch_tower.png</Path>
@@ -8923,6 +9579,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/watch_tower_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/watch_tower_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/watch_tower_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/watch_tower_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/watch_tower_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/watch_tower_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/wishing_well.png</Path>
@@ -8935,6 +9592,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/wishing_well_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/wishing_well_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/wishing_well_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/wishing_well_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/wishing_well_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/cartoon/wishing_well_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/blue-and-yellowflag.png</Path>
@@ -8946,6 +9604,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/blue-and-yellowflag_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/blue-and-yellowflag_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/blue-and-yellowflag_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/blue-and-yellowflag_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/blue-and-yellowflag_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/blue-and-yellowflag_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/checkeredflag.ogg</Path>
@@ -8958,6 +9617,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/checkeredflag_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/checkeredflag_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/checkeredflag_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/checkeredflag_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/checkeredflag_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/checkeredflag_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/greenflag.png</Path>
@@ -8969,6 +9629,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/greenflag_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/greenflag_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/greenflag_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/greenflag_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/greenflag_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/greenflag_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/redflag.png</Path>
@@ -8980,6 +9641,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/redflag_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/redflag_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/redflag_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/redflag_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/redflag_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/redflag_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/whiteflag.png</Path>
@@ -8991,6 +9653,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/whiteflag_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/whiteflag_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/whiteflag_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/whiteflag_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/whiteflag_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/whiteflag_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/yellowflag.png</Path>
@@ -9002,6 +9665,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/yellowflag_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/yellowflag_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/yellowflag_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/yellowflag_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/yellowflag_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/flags/yellowflag_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/blacksmith.png</Path>
@@ -9013,6 +9677,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/blacksmith_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/blacksmith_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/blacksmith_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/blacksmith_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/blacksmith_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/blacksmith_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cathedral.png</Path>
@@ -9025,6 +9690,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cathedral_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cathedral_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cathedral_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cathedral_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cathedral_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cathedral_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cave_entrance.png</Path>
@@ -9037,6 +9703,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cave_entrance_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cave_entrance_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cave_entrance_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cave_entrance_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cave_entrance_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cave_entrance_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/circus.png</Path>
@@ -9049,6 +9716,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/circus_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/circus_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/circus_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/circus_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/circus_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/circus_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/city.png</Path>
@@ -9061,6 +9729,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/city_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/city_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/city_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/city_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/city_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/city_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cityhouse.dat</Path>
@@ -9073,6 +9742,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cityhouse_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cityhouse_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cityhouse_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cityhouse_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cityhouse_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/cityhouse_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fairytale_castle.dat</Path>
@@ -9086,6 +9756,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fairytale_castle_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fairytale_castle_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fairytale_castle_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fairytale_castle_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fairytale_castle_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fairytale_castle_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/farm.png</Path>
@@ -9098,6 +9769,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/farm_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/farm_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/farm_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/farm_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/farm_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/farm_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fishery.png</Path>
@@ -9110,6 +9782,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fishery_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fishery_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fishery_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fishery_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fishery_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fishery_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fort.png</Path>
@@ -9122,6 +9795,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fort_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fort_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fort_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fort_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fort_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fort_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fortress.png</Path>
@@ -9134,6 +9808,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fortress_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fortress_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fortress_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fortress_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fortress_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/fortress_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/hunter.png</Path>
@@ -9145,6 +9820,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/hunter_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/hunter_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/hunter_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/hunter_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/hunter_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/hunter_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/igloo.dat</Path>
@@ -9158,6 +9834,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/igloo_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/igloo_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/igloo_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/igloo_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/igloo_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/igloo_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/inn.png</Path>
@@ -9170,6 +9847,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/inn_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/inn_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/inn_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/inn_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/inn_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/inn_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/jailhouse.png</Path>
@@ -9182,8 +9860,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/jailhouse_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/jailhouse_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/jailhouse_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/jailhouse_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/jailhouse_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/jailhouse_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/lighthouse.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/lighthouse.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/lighthouse.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/lighthouse_desc_be.ogg</Path>
@@ -9192,6 +9872,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/lighthouse_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/lighthouse_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/lighthouse_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/lighthouse_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/lighthouse_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/lighthouse_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/medieval_tent.png</Path>
@@ -9204,6 +9885,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/medieval_tent_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/medieval_tent_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/medieval_tent_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/medieval_tent_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/medieval_tent_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/medieval_tent_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/monastery.png</Path>
@@ -9216,6 +9898,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/monastery_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/monastery_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/monastery_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/monastery_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/monastery_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/monastery_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/pinkhome.dat</Path>
@@ -9229,6 +9912,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/pinkhome_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/pinkhome_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/pinkhome_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/pinkhome_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/pinkhome_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/pinkhome_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/stable_desc_el.ogg</Path>
@@ -9241,6 +9925,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/stables_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/stables_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/stables_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/stables_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/stables_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/stables_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/swisshome.dat</Path>
@@ -9254,6 +9939,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/swisshome_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/swisshome_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/swisshome_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/swisshome_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/swisshome_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/swisshome_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tavern.png</Path>
@@ -9266,6 +9952,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tavern_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tavern_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tavern_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tavern_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tavern_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tavern_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tent.dat</Path>
@@ -9279,6 +9966,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tent_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tent_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tent_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tent_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tent_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tent_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tepee.dat</Path>
@@ -9292,6 +9980,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tepee_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tepee_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tepee_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tepee_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tepee_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tepee_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_flag_red.png</Path>
@@ -9304,6 +9993,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_flag_red_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_flag_red_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_flag_red_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_flag_red_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_flag_red_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_flag_red_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_round.png</Path>
@@ -9316,6 +10006,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_round_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_round_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_round_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_round_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_round_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_round_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_round_flag.png</Path>
@@ -9328,6 +10019,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_round_flag_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_round_flag_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_round_flag_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_round_flag_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_round_flag_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_round_flag_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_square.png</Path>
@@ -9340,6 +10032,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_square_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_square_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_square_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_square_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_square_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/tower_square_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/townhall.png</Path>
@@ -9351,6 +10044,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/townhall_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/townhall_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/townhall_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/townhall_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/townhall_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/townhall_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/university.png</Path>
@@ -9363,6 +10057,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/university_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/university_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/university_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/university_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/university_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/university_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/warehouse.png</Path>
@@ -9375,6 +10070,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/warehouse_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/warehouse_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/warehouse_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/warehouse_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/warehouse_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/warehouse_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/windmill.png</Path>
@@ -9387,6 +10083,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/windmill_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/windmill_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/windmill_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/windmill_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/windmill_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/windmill_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/wooden_cottage.dat</Path>
@@ -9399,10 +10096,12 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/wooden_cottage_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/wooden_cottage_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/wooden_cottage_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/wooden_cottage_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/wooden_cottage_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/houses/cartoon/wooden_cottage_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/eiffel_tower.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/eiffel_tower.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/eiffel_tower_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/graveyard.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/graveyard.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/graveyard.txt</Path>
@@ -9413,6 +10112,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/graveyard_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/graveyard_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/graveyard_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/graveyard_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/graveyard_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/graveyard_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/magic_stones.png</Path>
@@ -9425,6 +10125,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/magic_stones_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/magic_stones_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/magic_stones_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/magic_stones_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/magic_stones_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/magic_stones_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/obelisk.png</Path>
@@ -9437,6 +10138,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/obelisk_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/obelisk_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/obelisk_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/obelisk_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/obelisk_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/obelisk_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/pyramid.png</Path>
@@ -9449,6 +10151,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/pyramid_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/pyramid_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/pyramid_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/pyramid_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/pyramid_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/pyramid_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/statue.png</Path>
@@ -9461,6 +10164,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/statue_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/statue_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/statue_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/statue_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/statue_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/statue_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/sword_in_the_stone.png</Path>
@@ -9472,6 +10176,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/sword_in_the_stone_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/sword_in_the_stone_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/sword_in_the_stone_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/sword_in_the_stone_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/sword_in_the_stone_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/sword_in_the_stone_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/sword_stone_desc_el.ogg</Path>
@@ -9485,6 +10190,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/totem_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/totem_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/totem_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/totem_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/totem_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/cartoon/totem_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/inukshuk-outline.dat</Path>
@@ -9504,7 +10210,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/inukshuk-photo_desc_be.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/inukshuk-photo_desc_bg.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/inukshuk-photo_desc_ca.ogg</Path>
-            <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/inukshuk-photo_desc_da.ogg.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/inukshuk-photo_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/inukshuk-photo_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/inukshuk-photo_desc_fr.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/monuments/inukshuk-photo_desc_ro.ogg</Path>
@@ -9518,8 +10224,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/arrow_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/arrow_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/arrow_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/arrow_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/arrow_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/arrow_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/blankroadsign.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/blankroadsign.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/blankroadsign.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/blankroadsign_desc_be.ogg</Path>
@@ -9528,6 +10236,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/blankroadsign_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/blankroadsign_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/blankroadsign_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/blankroadsign_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/blankroadsign_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/blankroadsign_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/crossroads.dat</Path>
@@ -9539,6 +10248,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/crossroads_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/crossroads_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/crossroads_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/crossroads_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/crossroads_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/crossroads_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/dead_end_sign.dat</Path>
@@ -9551,6 +10261,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/dead_end_sign_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/dead_end_sign_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/dead_end_sign_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/dead_end_sign_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/dead_end_sign_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/dead_end_sign_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/give_way_sign.dat</Path>
@@ -9562,6 +10273,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/give_way_sign_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/give_way_sign_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/give_way_sign_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/give_way_sign_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/give_way_sign_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/give_way_sign_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/hospital.dat</Path>
@@ -9573,6 +10285,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/hospital_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/hospital_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/hospital_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/hospital_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/hospital_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/hospital_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/no_entry_sign.dat</Path>
@@ -9585,6 +10298,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/no_entry_sign_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/no_entry_sign_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/no_entry_sign_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/no_entry_sign_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/no_entry_sign_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/no_entry_sign_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/no_uturn.dat</Path>
@@ -9597,6 +10311,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/no_uturn_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/no_uturn_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/no_uturn_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/no_uturn_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/no_uturn_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/no_uturn_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/railroad_crossing.dat</Path>
@@ -9609,6 +10324,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/railroad_crossing_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/railroad_crossing_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/railroad_crossing_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/railroad_crossing_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/railroad_crossing_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/railroad_crossing_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/roundabout.dat</Path>
@@ -9620,6 +10336,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/roundabout_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/roundabout_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/roundabout_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/roundabout_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/roundabout_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/roundabout_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/school_sign.dat</Path>
@@ -9631,6 +10348,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/school_sign_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/school_sign_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/school_sign_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/school_sign_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/school_sign_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/school_sign_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stop.png</Path>
@@ -9642,6 +10360,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stop_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stop_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stop_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stop_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stop_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stop_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_01_red.dat</Path>
@@ -9653,6 +10372,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_01_red_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_01_red_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_01_red_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_01_red_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_01_red_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_01_red_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_02_yellow.dat</Path>
@@ -9664,6 +10384,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_02_yellow_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_02_yellow_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_02_yellow_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_02_yellow_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_02_yellow_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_02_yellow_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_03_green.dat</Path>
@@ -9675,6 +10396,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_03_green_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_03_green_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_03_green_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_03_green_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_03_green_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/stoplight_03_green_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/t-junction.dat</Path>
@@ -9686,6 +10408,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/t-junction_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/t-junction_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/t-junction_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/t-junction_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/t-junction_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/t-junction_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/toilets.dat</Path>
@@ -9697,6 +10420,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/toilets_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/toilets_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/toilets_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/toilets_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/toilets_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/toilets_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/traffic_cone.dat</Path>
@@ -9709,6 +10433,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/traffic_cone_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/traffic_cone_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/traffic_cone_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/traffic_cone_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/traffic_cone_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/traffic_cone_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/xing_ped.dat</Path>
@@ -9722,6 +10447,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/xing_ped_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/xing_ped_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/xing_ped_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/xing_ped_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/xing_ped_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/xing_ped_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/xing_school.dat</Path>
@@ -9734,6 +10460,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/xing_school_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/xing_school_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/xing_school_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/xing_school_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/xing_school_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/xing_school_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/xing_school_mirror.png</Path>
@@ -9745,6 +10472,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/yield_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/yield_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/yield_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/yield_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/yield_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/roadsigns/yield_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/uk_post_box.dat</Path>
@@ -9757,6 +10485,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/uk_post_box_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/uk_post_box_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/uk_post_box_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/uk_post_box_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/uk_post_box_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/uk_post_box_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/usps_mailbox.dat</Path>
@@ -9769,6 +10498,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/usps_mailbox_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/usps_mailbox_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/usps_mailbox_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/town/usps_mailbox_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/usps_mailbox_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/town/usps_mailbox_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/7spoke256.dat</Path>
@@ -9781,6 +10511,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/7spoke256_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/7spoke256_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/7spoke256_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/7spoke256_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/7spoke256_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/7spoke256_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/beetle.dat</Path>
@@ -9793,6 +10524,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/beetle_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/beetle_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/beetle_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/beetle_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/beetle_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/beetle_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sedan.dat</Path>
@@ -9805,8 +10537,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sedan_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sedan_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sedan_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sedan_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sedan_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sedan_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar2.dat</Path>
@@ -9818,8 +10552,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar2_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar2_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar3.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar3.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar3.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar3_desc_be.ogg</Path>
@@ -9828,6 +10564,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar3_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar3_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar3_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar3_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar3_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar3_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar_desc_be.ogg</Path>
@@ -9837,6 +10574,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/sportscar_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/truck.dat</Path>
@@ -9849,8 +10587,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/truck_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/truck_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/truck_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/truck_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/truck_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/auto/truck_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/bikewheel.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/bikewheel.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/bikewheel.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/bikewheel_desc_be.ogg</Path>
@@ -9859,8 +10599,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/bikewheel_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/bikewheel_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/bikewheel_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/bikewheel_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/bikewheel_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/bikewheel_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/blue_truck.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/blue_truck.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/blue_truck.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/blue_truck_desc_be.ogg</Path>
@@ -9869,8 +10611,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/blue_truck_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/blue_truck_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/blue_truck_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/blue_truck_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/blue_truck_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/blue_truck_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/bulldozer.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/bulldozer.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/bulldozer.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/bulldozer_desc_be.ogg</Path>
@@ -9879,6 +10623,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/bulldozer_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/bulldozer_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/bulldozer_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/bulldozer_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/bulldozer_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/bulldozer_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/cementMixer.dat</Path>
@@ -9891,10 +10636,13 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/cementMixer_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/cementMixer_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/cementMixer_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/cementMixer_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/cementMixer_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/cementMixer_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/forklift.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/forklift.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/forklift.txt</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/forklift2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/forklift2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/forklift2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/forklift2_desc_be.ogg</Path>
@@ -9903,6 +10651,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/forklift2_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/forklift2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/forklift2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/forklift2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/forklift2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/forklift2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/forklift_desc_be.ogg</Path>
@@ -9911,6 +10660,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/forklift_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/forklift_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/forklift_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/forklift_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/forklift_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/forklift_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/terex.png</Path>
@@ -9922,6 +10672,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/terex_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/terex_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/terex_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/terex_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/terex_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/terex_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/towTruck.dat</Path>
@@ -9934,6 +10685,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/towTruck_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/towTruck_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/towTruck_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/towTruck_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/towTruck_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/cartoon/towTruck_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/dumper.dat</Path>
@@ -9946,9 +10698,11 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/dumper_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/dumper_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/dumper_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/dumper_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/dumper_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/dumper_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/construction/dumper_mirror.png</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/bluebike.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/bluebike.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/bluebike.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/bluebike_desc_be.ogg</Path>
@@ -9957,8 +10711,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/bluebike_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/bluebike_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/bluebike_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/bluebike_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/bluebike_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/bluebike_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/motorbike.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/motorbike.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/motorbike.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/motorbike_desc_be.ogg</Path>
@@ -9967,6 +10723,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/motorbike_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/motorbike_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/motorbike_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/motorbike_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/motorbike_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/motorbike_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/pink_tricycle.dat</Path>
@@ -9979,6 +10736,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/pink_tricycle_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/pink_tricycle_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/pink_tricycle_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/pink_tricycle_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/pink_tricycle_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/cycle/pink_tricycle_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/cartoon/fire_engine.png</Path>
@@ -9989,6 +10747,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/cartoon/fire_engine_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/cartoon/fire_engine_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/cartoon/fire_engine_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/cartoon/fire_engine_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/cartoon/fire_engine_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/cartoon/fire_engine_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/cartoon/fireengine_desc_da.ogg</Path>
@@ -10003,6 +10762,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/firetruck_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/firetruck_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/firetruck_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/firetruck_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/firetruck_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/firetruck_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/sedan_police.dat</Path>
@@ -10015,9 +10775,11 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/sedan_police_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/sedan_police_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/sedan_police_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/sedan_police_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/sedan_police_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/sedan_police_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/emergency/sedan_police_mirror.png</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/farming/cartoon/tractor.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/farming/cartoon/tractor.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/farming/cartoon/tractor.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/farming/cartoon/tractor_desc_be.ogg</Path>
@@ -10026,6 +10788,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/farming/cartoon/tractor_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/farming/cartoon/tractor_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/farming/cartoon/tractor_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/farming/cartoon/tractor_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/farming/cartoon/tractor_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/farming/cartoon/tractor_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/farming/cartoon/tux_tractor.png</Path>
@@ -10036,6 +10799,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/farming/cartoon/tux_tractor_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/farming/cartoon/tux_tractor_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/farming/cartoon/tux_tractor_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/farming/cartoon/tux_tractor_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/farming/cartoon/tux_tractor_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/farming/cartoon/tux_tractor_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/balloon360.dat</Path>
@@ -10048,6 +10812,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/balloon360_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/balloon360_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/balloon360_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/balloon360_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/balloon360_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/balloon360_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/cartoon/eddieCopter.dat</Path>
@@ -10060,6 +10825,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/cartoon/eddieCopter_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/cartoon/eddieCopter_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/cartoon/eddieCopter_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/cartoon/eddieCopter_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/cartoon/eddieCopter_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/cartoon/eddieCopter_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/747.png</Path>
@@ -10071,6 +10837,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/747_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/747_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/747_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/747_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/747_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/747_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/cartoon/plane.dat</Path>
@@ -10082,8 +10849,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/cartoon/plane_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/cartoon/plane_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/cartoon/plane_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/cartoon/plane_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/cartoon/plane_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/cartoon/plane_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/plane.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/plane.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/plane.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/plane_desc_be.ogg</Path>
@@ -10092,6 +10861,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/plane_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/plane_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/plane_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/plane_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/plane_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/flight/planes/plane_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/garbagetruck.png</Path>
@@ -10102,8 +10872,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/garbagetruck_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/garbagetruck_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/garbagetruck_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/garbagetruck_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/garbagetruck_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/garbagetruck_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_bus.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_bus.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_bus.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_bus_desc_be.ogg</Path>
@@ -10112,8 +10884,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_bus_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_bus_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_bus_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_bus_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_bus_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_bus_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_fireengine.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_fireengine.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_fireengine.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_fireengine_desc_be.ogg</Path>
@@ -10122,8 +10896,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_fireengine_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_fireengine_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_fireengine_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_fireengine_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_fireengine_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_fireengine_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry1.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry1.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry1.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry1_desc_be.ogg</Path>
@@ -10132,8 +10908,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry1_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry1_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry1_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry1_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry1_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry1_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry2_desc_be.ogg</Path>
@@ -10142,8 +10920,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry2_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry2_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry3.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry3.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry3.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry3_desc_be.ogg</Path>
@@ -10152,8 +10932,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry3_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry3_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry3_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry3_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry3_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry3_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry4.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry4.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry4.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry4_desc_be.ogg</Path>
@@ -10162,6 +10944,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry4_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry4_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry4_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry4_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry4_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/iso_lorry4_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/boxcar.png</Path>
@@ -10173,6 +10956,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/boxcar_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/boxcar_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/boxcar_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/boxcar_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/boxcar_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/boxcar_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/caboose.png</Path>
@@ -10183,6 +10967,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/caboose_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/caboose_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/caboose_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/caboose_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/caboose_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/caboose_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/carriage.png</Path>
@@ -10194,6 +10979,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/carriage_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/carriage_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/carriage_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/carriage_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/carriage_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/carriage_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/tanker.png</Path>
@@ -10204,6 +10990,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/tanker_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/tanker_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/tanker_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/tanker_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/tanker_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/tanker_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/tender.png</Path>
@@ -10214,6 +11001,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/tender_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/tender_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/tender_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/tender_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/tender_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/tender_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/tender_mirror.png</Path>
@@ -10226,6 +11014,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/toy_train_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/toy_train_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/toy_train_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/toy_train_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/toy_train_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/toy_train_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/trainSign.png</Path>
@@ -10237,8 +11026,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/trainSign_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/trainSign_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/trainSign_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/trainSign_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/trainSign_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/cartoon/trainSign_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/white_train.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/white_train.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/white_train.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/white_train_desc_be.ogg</Path>
@@ -10247,6 +11038,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/white_train_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/white_train_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/white_train_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/white_train_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/white_train_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/locomotive/white_train_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/cartoon/double_decker_bus.dat</Path>
@@ -10259,8 +11051,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/cartoon/double_decker_bus_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/cartoon/double_decker_bus_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/cartoon/double_decker_bus_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/cartoon/double_decker_bus_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/cartoon/double_decker_bus_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/cartoon/double_decker_bus_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/cartoon/schoolbus.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/cartoon/schoolbus.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/cartoon/schoolbus.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/cartoon/schoolbus_desc_be.ogg</Path>
@@ -10269,6 +11063,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/cartoon/schoolbus_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/cartoon/schoolbus_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/cartoon/schoolbus_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/cartoon/schoolbus_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/cartoon/schoolbus_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/cartoon/schoolbus_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/green_korean_bus.dat</Path>
@@ -10281,8 +11076,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/green_korean_bus_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/green_korean_bus_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/green_korean_bus_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/green_korean_bus_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/green_korean_bus_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/masstransit/green_korean_bus_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/race/f1_car.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/race/f1_car.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/race/f1_car.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/race/f1_car_desc_be.ogg</Path>
@@ -10291,6 +11088,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/race/f1_car_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/race/f1_car_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/race/f1_car_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/race/f1_car_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/race/f1_car_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/race/f1_car_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/race/indycar.dat</Path>
@@ -10303,6 +11101,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/race/indycar_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/race/indycar_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/race/indycar_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/race/indycar_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/race/indycar_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/race/indycar_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/cartoon/bathyscape.dat</Path>
@@ -10315,6 +11114,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/cartoon/bathyscape_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/cartoon/bathyscape_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/cartoon/bathyscape_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/cartoon/bathyscape_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/cartoon/bathyscape_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/cartoon/bathyscape_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/cartoon/tugboat.dat</Path>
@@ -10327,6 +11127,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/cartoon/tugboat_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/cartoon/tugboat_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/cartoon/tugboat_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/cartoon/tugboat_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/cartoon/tugboat_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/cartoon/tugboat_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/cartoon/tugboat_mirror.png</Path>
@@ -10340,8 +11141,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/chineseJunk_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/chineseJunk_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/chineseJunk_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/chineseJunk_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/chineseJunk_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/chineseJunk_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/sail_boat1.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/sail_boat1.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/sail_boat1.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/sail_boat1_desc_be.ogg</Path>
@@ -10350,8 +11153,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/sail_boat1_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/sail_boat1_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/sail_boat1_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/sail_boat1_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/sail_boat1_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/sail_boat1_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/sail_boat2.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/sail_boat2.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/sail_boat2.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/sail_boat2_desc_be.ogg</Path>
@@ -10360,6 +11165,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/sail_boat2_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/sail_boat2_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/sail_boat2_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/sail_boat2_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/sail_boat2_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/sail_boat2_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/walnutBoat.dat</Path>
@@ -10372,8 +11178,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/walnutBoat_desc_el.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/walnutBoat_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/walnutBoat_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/walnutBoat_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/walnutBoat_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/ship/walnutBoat_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/toy_truck.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/toy_truck.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/toy_truck.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/toy_truck_desc_be.ogg</Path>
@@ -10382,8 +11190,10 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/toy_truck_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/toy_truck_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/toy_truck_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/toy_truck_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/toy_truck_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/toy_truck_desc_ru.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/tyre_with_rim.png</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/tyre_with_rim.svg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/tyre_with_rim.txt</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/tyre_with_rim_desc_be.ogg</Path>
@@ -10392,6 +11202,7 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/tyre_with_rim_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/tyre_with_rim_desc_es.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/tyre_with_rim_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/tyre_with_rim_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/tyre_with_rim_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/tyre_with_rim_desc_ru.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/wheel_tractor.png</Path>
@@ -10401,17 +11212,18 @@
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/wheel_tractor_desc_ca.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/wheel_tractor_desc_da.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/wheel_tractor_desc_fr.ogg</Path>
+            <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/wheel_tractor_desc_nn.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/wheel_tractor_desc_ro.ogg</Path>
             <Path fileType="data">/usr/share/tuxpaint/stamps/vehicles/wheel_tractor_desc_ru.ogg</Path>
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2018-12-12</Date>
-            <Version>2018.08.01</Version>
+        <Update release="3">
+            <Date>2024-06-22</Date>
+            <Version>2024.01.29</Version>
             <Comment>Packaging update</Comment>
-            <Name>Bryan T. Meyers</Name>
-            <Email>bmeyers@datadrake.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://sourceforge.net/p/tuxpaint/tuxpaint-stamps/ci/master/tree/docs/CHANGES.txt).

**Summary**
- Started Tux Paint and checked it loaded the stamps.

**Checklist**

- [X] Package was built and tested against unstable
