### PR TITLE
distrobox: Add at v1.7.2.1

### DIFF
--- a/packages/d/distrobox/MAINTAINERS.md
+++ b/packages/d/distrobox/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Robert Gonzalez
+  - Email: uni.dos12@outlook.com
+

--- a/packages/d/distrobox/package.yml
+++ b/packages/d/distrobox/package.yml
@@ -1,0 +1,16 @@
+name       : distrobox
+version    : 1.7.2.1
+release    : 1
+source     :
+    - https://github.com/89luca89/distrobox/archive/refs/tags/1.7.2.1.tar.gz : ff2cca0c6334fff6ed577d23f68a6746ad4009f42d8a45eef5ca3850c895a4bb
+homepage   : https://distrobox.it/
+license    : GPL-3.0-only
+component  : virt
+summary    : Use any Linux distribution inside your terminal
+description: |
+    Use any Linux distribution inside your terminal. Enable both backward and forward compatibility with software and freedom to use whatever distribution you're more comfortable with
+rundeps    : 
+    - podman
+install    : |
+    ./install -P $installdir/usr
+

--- a/packages/d/distrobox/pspec_x86_64.xml
+++ b/packages/d/distrobox/pspec_x86_64.xml
@@ -1,0 +1,96 @@
+<PISI>
+    <Source>
+        <Name>distrobox</Name>
+        <Homepage>https://distrobox.it/</Homepage>
+        <Packager>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
+        </Packager>
+        <License>GPL-3.0-only</License>
+        <PartOf>virt</PartOf>
+        <Summary xml:lang="en">Use any Linux distribution inside your terminal</Summary>
+        <Description xml:lang="en">Use any Linux distribution inside your terminal. Enable both backward and forward compatibility with software and freedom to use whatever distribution you&apos;re more comfortable with
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>distrobox</Name>
+        <Summary xml:lang="en">Use any Linux distribution inside your terminal</Summary>
+        <Description xml:lang="en">Use any Linux distribution inside your terminal. Enable both backward and forward compatibility with software and freedom to use whatever distribution you&apos;re more comfortable with
+</Description>
+        <PartOf>virt</PartOf>
+        <Files>
+            <Path fileType="executable">/usr/bin/distrobox</Path>
+            <Path fileType="executable">/usr/bin/distrobox-assemble</Path>
+            <Path fileType="executable">/usr/bin/distrobox-create</Path>
+            <Path fileType="executable">/usr/bin/distrobox-enter</Path>
+            <Path fileType="executable">/usr/bin/distrobox-ephemeral</Path>
+            <Path fileType="executable">/usr/bin/distrobox-export</Path>
+            <Path fileType="executable">/usr/bin/distrobox-generate-entry</Path>
+            <Path fileType="executable">/usr/bin/distrobox-host-exec</Path>
+            <Path fileType="executable">/usr/bin/distrobox-init</Path>
+            <Path fileType="executable">/usr/bin/distrobox-list</Path>
+            <Path fileType="executable">/usr/bin/distrobox-rm</Path>
+            <Path fileType="executable">/usr/bin/distrobox-stop</Path>
+            <Path fileType="executable">/usr/bin/distrobox-upgrade</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/distrobox</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/distrobox-assemble</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/distrobox-create</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/distrobox-enter</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/distrobox-ephemeral</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/distrobox-generate-entry</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/distrobox-list</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/distrobox-rm</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/distrobox-stop</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/distrobox-upgrade</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/terminal-distrobox-icon.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16/apps/terminal-distrobox-icon.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22/apps/terminal-distrobox-icon.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24/apps/terminal-distrobox-icon.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/terminal-distrobox-icon.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/terminal-distrobox-icon.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36/apps/terminal-distrobox-icon.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/terminal-distrobox-icon.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/terminal-distrobox-icon.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72/apps/terminal-distrobox-icon.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96/apps/terminal-distrobox-icon.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/terminal-distrobox-icon.svg</Path>
+            <Path fileType="man">/usr/share/man/man1/distrobox-assemble.1</Path>
+            <Path fileType="man">/usr/share/man/man1/distrobox-compatibility.1</Path>
+            <Path fileType="man">/usr/share/man/man1/distrobox-create.1</Path>
+            <Path fileType="man">/usr/share/man/man1/distrobox-enter.1</Path>
+            <Path fileType="man">/usr/share/man/man1/distrobox-ephemeral.1</Path>
+            <Path fileType="man">/usr/share/man/man1/distrobox-export.1</Path>
+            <Path fileType="man">/usr/share/man/man1/distrobox-generate-entry.1</Path>
+            <Path fileType="man">/usr/share/man/man1/distrobox-host-exec.1</Path>
+            <Path fileType="man">/usr/share/man/man1/distrobox-init.1</Path>
+            <Path fileType="man">/usr/share/man/man1/distrobox-list.1</Path>
+            <Path fileType="man">/usr/share/man/man1/distrobox-rm.1</Path>
+            <Path fileType="man">/usr/share/man/man1/distrobox-stop.1</Path>
+            <Path fileType="man">/usr/share/man/man1/distrobox-upgrade.1</Path>
+            <Path fileType="man">/usr/share/man/man1/distrobox.1</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_distrobox</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_distrobox-assemble</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_distrobox-create</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_distrobox-enter</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_distrobox-ephemeral</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_distrobox-export</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_distrobox-generate-entry</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_distrobox-host-exec</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_distrobox-init</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_distrobox-list</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_distrobox-rm</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_distrobox-stop</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_distrobox-upgrade</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2024-06-25</Date>
+            <Version>1.7.2.1</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**

Add the distrobox package, which allows users to create containers for other Linux distros.

**Test Plan**

Create a box and run software not available in the Solus repos.

**Checklist**

- [x] Package was built and tested against unstable

Resolves https://github.com/getsolus/packages/issues/2811

Users might need to create subuid and subgid files. 

