### PR TITLE
blueman: Update to 2.4.2

### DIFF
--- a/packages/b/blueman/package.yml
+++ b/packages/b/blueman/package.yml
@@ -1,8 +1,8 @@
 name       : blueman
-version    : 2.4.1
-release    : 24
+version    : 2.4.2
+release    : 25
 source     :
-    - https://github.com/blueman-project/blueman/releases/download/2.4.1/blueman-2.4.1.tar.gz : 86a7bd3556f1aae671dddcfb35baa7fba4477a035e32ff0ad7b0c2455c978216
+    - https://github.com/blueman-project/blueman/releases/download/2.4.2/blueman-2.4.2.tar.gz : 2ce2750037c946b20abb7339a975c17ec5110988f3433f47b29d0851d335f175
 homepage   : https://github.com/blueman-project/blueman
 license    : GPL-3.0-or-later
 component  : desktop.mate

--- a/packages/b/blueman/pspec_x86_64.xml
+++ b/packages/b/blueman/pspec_x86_64.xml
@@ -522,6 +522,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/blueman.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/48x48/status/blueman-active.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/48x48/status/blueman-disabled.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48/status/blueman-tray.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/48x48/status/blueman.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/blueman.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/64x64/status/blueman-active.png</Path>
@@ -632,9 +633,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2024-05-09</Date>
-            <Version>2.4.1</Version>
+        <Update release="25">
+            <Date>2024-06-24</Date>
+            <Version>2.4.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Added an option to toggle the manager window with the tray icon
- Only a single battery notification
- Renamed recent connections header in applet menu
- Translation updates
- Fixed: Broken audio profile applet menu items
- Fixed: Missing manager window title
- Fixed: Teardown of DBus mock server in tests

**Test Plan**
- Connected and disconnected my headphones
- Switched Bluetooth audio profiles

**Checklist**

- [x] Package was built and tested against unstable
