### PR TITLE
bash: Build new PATH the smart way

### DIFF
--- a/packages/b/bash/files/profile/10-path.sh
+++ b/packages/b/bash/files/profile/10-path.sh
@@ -1,20 +1,64 @@
 # Begin /usr/share/defaults/etc/profile.d/10-path.sh
 
-export PATH="/usr/sbin:/usr/bin"
-if [ -d "/usr/local/sbin" ]; then
-  export PATH="$PATH:/usr/local/sbin"
+PREFIX_PATH=
+POSTFIX_PATH=
+
+# PATH exists, only append missing stuff to it
+if [[ -n "${PATH}" ]]; then
+
+  echo "DEBUG: Starting \$PATH: ${PATH}"
+
+  for d in "/usr/sbin" "/usr/bin" "/usr/local/sbin" "/usr/local/bin"; do
+    # respect user path ordering if the element is already in $PATH
+    if [[ "${PATH}" =~ "${d}" ]]; then
+      :
+      echo "DEBUG: Skipping ${d} as it is already in \$PATH"
+    else
+      POSTFIX_PATH="${POSTFIX_PATH}:${d}"
+      echo "DEBUG: Added ${d} to \$POSTFIX_PATH, \$POSTFIX_PATH is now: ${POSTFIX_PATH}"
+    fi
+  done
+
+  for d in "${HOME}/.local/bin" "${HOME}/bin"; do
+    # respect user path ordering if the element is already in $PATH
+    if [[ "${PATH}" =~ "${d}" ]]; then
+      :
+      echo "DEBUG: Skipping ${d} as it is already in \$PATH"
+    else
+      PREFIX_PATH="${d}:${PREFIX_PATH}"
+      echo "DEBUG: Added ${d} to \$PREFIX_PATH, \$PREFIX_PATH is now: ${PREFIX_PATH}"
+    fi
+  done
+
+  # this should adequately respect existing path definitions
+  PATH="${PREFIX_PATH}${PATH}${POSTFIX_PATH}"
+
+else
+# PATH does NOT exist, build it from scratch.
+
+  echo "DEBUG: \$PATH is empty, building a default \$PATH ..."
+
+  DEFAULT_PATH="/usr/sbin:/usr/bin"
+  if [[ -d "/usr/local/sbin" ]]; then
+    DEFAULT_PATH="${DEFAULT_PATH}:/usr/local/sbin"
+  fi
+
+  if [[ -d "/usr/local/bin" ]]; then
+    DEFAULT_PATH="${DEFAULT_PATH}:/usr/local/bin"
+  fi
+
+  if [[ -d "$HOME/bin" ]]; then
+    DEFAULT_PATH="${HOME}/bin:${DEFAULT_PATH}"
+  fi
+
+  if [[ -d "$HOME/.local/bin" ]]; then
+    DEFAULT_PATH="${HOME}/.local/bin:${DEFAULT_PATH}"
+  fi
+
+  PATH="${DEFAULT_PATH}"
 fi
 
-if [ -d "/usr/local/bin" ]; then
-  export PATH="$PATH:/usr/local/bin"
-fi
-
-if [ -d "$HOME/bin" ]; then
-  export PATH="$HOME/bin:$PATH"
-fi
-
-if [ -d "$HOME/.local/bin" ]; then
-  export PATH="$HOME/.local/bin:$PATH"
-fi
+export PATH="${PATH}"
+echo "DEBUG: \$PATH is now: ${PATH}"
 
 # End /usr/share/defaults/etc/profile.d/10-path.sh

--- a/packages/b/bash/package.yml
+++ b/packages/b/bash/package.yml
@@ -1,6 +1,6 @@
 name       : bash
 version    : 5.2.26
-release    : 80
+release    : 81
 source     :
     - https://ftp.gnu.org/gnu/bash/bash-5.2.21.tar.gz : c8e31bdc59b69aaffc5b36509905ba3e5cbb12747091d27b4b977f078560d5b8
 license    :

--- a/packages/b/bash/pspec_x86_64.xml
+++ b/packages/b/bash/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>bash</Name>
         <Homepage>https://www.gnu.org/software/bash</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -133,7 +133,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="80">bash</Dependency>
+            <Dependency release="81">bash</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/bash/alias.h</Path>
@@ -199,12 +199,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="80">
+        <Update release="81">
             <Date>2024-06-25</Date>
             <Version>5.2.26</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
The goal with this PR is to ensure that any existing user-set PATH is respected to the widest extent possible. Any elements of the default PATH which have not already been added, will be added to the new PATH in (what I hope to be) a sane way.

In the case of no user-set PATH, prepare a sane default PATH.

I have left the debug statements in for now to provide visibility to the various test cases. Naturally, these debug statements will need to disappear before the commit is merged to main.

**Test Plan**

Open a new virtual terminal with the new 10-path.sh file in place in /usr/share/defaults/etc/profile.d/

**Checklist**

- [x] Package was built and tested against unstable
