### PR TITLE
 qutebrowser: update to 3.2.1 

### DIFF
--- a/packages/q/qutebrowser/package.yml
+++ b/packages/q/qutebrowser/package.yml
@@ -1,8 +1,8 @@
 name       : qutebrowser
-version    : 3.2.0
-release    : 45
+version    : 3.2.1
+release    : 46
 source     :
-    - https://github.com/qutebrowser/qutebrowser/archive/refs/tags/v3.2.0.tar.gz : 6558bc55bdd7d7a5cefbb9166eea14cd7eaa53ba3e97f6814eb3ebaa548f68e2
+    - https://github.com/qutebrowser/qutebrowser/archive/refs/tags/v3.2.1.tar.gz : c062782d35b49d085f9b44cedeb85dc7af83c11a23884e634c84bbd3865f7186
 homepage   : https://qutebrowser.org
 license    : GPL-3.0-or-later
 component  : network.web.browser

--- a/packages/q/qutebrowser/pspec_x86_64.xml
+++ b/packages/q/qutebrowser/pspec_x86_64.xml
@@ -21,13 +21,13 @@
         <PartOf>network.web.browser</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/qutebrowser</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.0-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.0-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.0-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.0-py3.11.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.0-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.0-py3.11.egg-info/top_level.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.0-py3.11.egg-info/zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.1-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.1-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.1-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.1-py3.11.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.1-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.1-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.1-py3.11.egg-info/zip-safe</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
@@ -758,9 +758,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="45">
-            <Date>2024-06-03</Date>
-            <Version>3.2.0</Version>
+        <Update release="46">
+            <Date>2024-06-25</Date>
+            <Version>3.2.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
 - When the selected Qt wrapper is unavailable, qutebrowser now again shows a GUI error message instead of only an exception in the terminal.

**Test Plan**
- Surfed the web.

**Checklist**

- [X] Package was built and tested against unstable
