### PR TITLE
update desktop brandings for xapps

### DIFF
--- a/packages/b/budgie-desktop-branding/package.yml
+++ b/packages/b/budgie-desktop-branding/package.yml
@@ -1,8 +1,8 @@
 name       : budgie-desktop-branding
 version    : '22.1'
-release    : 74
+release    : 75
 source     :
-    - git|https://github.com/getsolus/budgie-desktop-branding.git : c9bda52f1073b087e1ce62e2423bb0df04e29f72
+    - git|https://github.com/getsolus/budgie-desktop-branding.git : 664ee2d5c90ea7ae08f495cb1cf6a680caeb3bb2
 homepage   : https://github.com/getsolus/budgie-desktop-branding
 license    : GPL-2.0-only
 summary    :

--- a/packages/b/budgie-desktop-branding/pspec_x86_64.xml
+++ b/packages/b/budgie-desktop-branding/pspec_x86_64.xml
@@ -36,7 +36,7 @@
         <Description xml:lang="en">Budgie LiveCD-specific Configuration</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="74">budgie-desktop-branding</Dependency>
+            <Dependency releaseFrom="75">budgie-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/glib-2.0/schemas/50_budgie_settings.gschema.override</Path>
@@ -44,8 +44,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="74">
-            <Date>2024-05-21</Date>
+        <Update release="75">
+            <Date>2024-06-25</Date>
             <Version>22.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>

--- a/packages/x/xfce4-desktop-branding/package.yml
+++ b/packages/x/xfce4-desktop-branding/package.yml
@@ -1,8 +1,8 @@
 name       : xfce4-desktop-branding
 version    : 1.0.0
-release    : 10
+release    : 11
 source     :
-    - git|https://github.com/getsolus/xfce4-desktop-branding.git : 1224e4248ac05f7254f467de82a67e6914ce9a3e
+    - git|https://github.com/getsolus/xfce4-desktop-branding.git : 2ca9eb73d342d58df4c179d3c4a74d9207416f91
 homepage   : https://github.com/getsolus/xfce4-desktop-branding
 license    : GPL-2.0-only
 component  :

--- a/packages/x/xfce4-desktop-branding/pspec_x86_64.xml
+++ b/packages/x/xfce4-desktop-branding/pspec_x86_64.xml
@@ -34,15 +34,15 @@
         <Description xml:lang="en">Defaults for the XFCE4 Desktop.</Description>
         <PartOf>desktop.xfce</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="10">xfce4-desktop-branding</Dependency>
+            <Dependency releaseFrom="11">xfce4-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/lightdm/lightdm.conf.d/xfce_config.conf</Path>
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2024-05-21</Date>
+        <Update release="11">
+            <Date>2024-06-25</Date>
             <Version>1.0.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**

- **xfce4-desktop-branding: Sync with git**
- **budgie-desktop-branding: Sync with git**

Fixes https://github.com/getsolus/xfce4-desktop-branding/issues/9

**Test Plan**

Update the packages and see that the mimeapps.list files changed.

**Checklist**

- [x] Package was built and tested against unstable
