### PR TITLE
mate-panel: Update to 1.28.2

### DIFF
--- a/packages/m/mate-panel/package.yml
+++ b/packages/m/mate-panel/package.yml
@@ -1,8 +1,8 @@
 name       : mate-panel
-version    : 1.28.1
-release    : 39
+version    : 1.28.2
+release    : 40
 source     :
-    - https://github.com/mate-desktop/mate-panel/releases/download/v1.28.1/mate-panel-1.28.1.tar.xz : 5133c64f5969ae8eeebe6e8bba450dea792cb0be06d9ae1c36e8569d2f8524ba
+    - https://github.com/mate-desktop/mate-panel/releases/download/v1.28.2/mate-panel-1.28.2.tar.xz : 678a43e837aa2718494204fddf19bb906cf07e5d80fd2e1dde745f26d2adba33
 homepage   : https://mate-desktop.org/
 license    :
     - GPL-2.0-or-later

--- a/packages/m/mate-panel/pspec_x86_64.xml
+++ b/packages/m/mate-panel/pspec_x86_64.xml
@@ -1108,7 +1108,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="39">mate-panel</Dependency>
+            <Dependency release="40">mate-panel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/mate-panel-4.0/libmate-panel-applet/mate-panel-applet-enums.h</Path>
@@ -1147,9 +1147,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="39">
-            <Date>2024-04-23</Date>
-            <Version>1.28.1</Version>
+        <Update release="40">
+            <Date>2024-06-25</Date>
+            <Version>1.28.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- status-notifier: Plug large leak with icons from paths

Resolves #3095

**Test Plan**
- Re-arranged panel
- Added applets to panel
- Pinned apps to panel and launched them

**Checklist**

- [x] Package was built and tested against unstable
