### PR TITLE
apparmor: Fix service path error and switch to launchpad tarball

### DIFF
--- a/packages/a/apparmor/files/0001-Update-paths-in-service-file.patch
+++ b/packages/a/apparmor/files/0001-Update-paths-in-service-file.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Thomas Staudinger <Staudi.Kaos@gmail.com>
+Date: Fri, 28 Jun 2024 11:44:02 +0200
+Subject: [PATCH] Update paths in service file
+
+Signed-off-by: Thomas Staudinger <Staudi.Kaos@gmail.com>
+---
+ parser/apparmor.service | 12 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/parser/apparmor.service b/parser/apparmor.service
+index 15b9f74..752eda1 100644
+--- a/parser/apparmor.service
++++ b/parser/apparmor.service
+@@ -9,8 +9,8 @@ ConditionSecurity=apparmor
+ 
+ [Service]
+ Type=oneshot
+-ExecStart=/lib/apparmor/apparmor.systemd reload
+-ExecReload=/lib/apparmor/apparmor.systemd reload
++ExecStart=/usr/lib64/apparmor/apparmor.systemd reload
++ExecReload=/usr/lib64/apparmor/apparmor.systemd reload
+ 
+ # systemd maps 'restart' to 'stop; start' which means removing AppArmor confinement
+ # from running processes (and not being able to re-apply it later).

--- a/packages/a/apparmor/package.yml
+++ b/packages/a/apparmor/package.yml
@@ -1,9 +1,8 @@
 name       : apparmor
 version    : 3.1.7
-release    : 30
+release    : 31
 source     :
-    # TODO replace this with the launchpad tar and switch back to configure when they upload it
-    - https://gitlab.com/apparmor/apparmor/-/archive/v3.1.7/apparmor-v3.1.7.tar.gz : 64494bd99fa6547a9cbdb4fc6bc732451a02dd19e6eb70eab977b239632151eb
+    - https://launchpad.net/apparmor/3.1/3.1.7/+download/apparmor-3.1.7.tar.gz : c6c161d6dbd99c2f10758ff347cbc6848223c7381f311de62522f22b0a16de64
 license    :
     - GPL-2.0-only
     - LGPL-2.1-or-later
@@ -19,17 +18,18 @@ builddeps  :
     - pyflakes     # Tests
     - swig
 rundeps    :
-    - python3
     - python-notify2
+    - python3
 networking : yes
 environment: |
     export PYTHON=/usr/bin/python3
     export PYTHON_VERSIONS=python3
 setup      : |
     %patch -p1 -i $pkgfiles/0001-Add-stateless-directory-to-default-apparmor-profile.patch
+    %patch -p1 -i $pkgfiles/0001-Update-paths-in-service-file.patch
     # You can't build this with --disable-static since the libraries here need to statically compile it
     cd libraries/libapparmor
-    %reconfigure --with-python
+    %configure --with-python
 build      : |
     %make -C libraries/libapparmor
     %make -C binutils

--- a/packages/a/apparmor/pspec_x86_64.xml
+++ b/packages/a/apparmor/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>apparmor</Name>
         <Homepage>https://gitlab.com/apparmor/apparmor</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <License>LGPL-2.1-or-later</License>
@@ -586,7 +586,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="30">apparmor</Dependency>
+            <Dependency release="31">apparmor</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/aalogparse/aalogparse.h</Path>
@@ -602,12 +602,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="30">
-            <Date>2024-06-27</Date>
+        <Update release="31">
+            <Date>2024-06-28</Date>
             <Version>3.1.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

After the recent preparation work for the usr-merge script the apparmor service caused errors during boot due to the path `/lib/apparmor/apparmor.systemd` no longer existing. This patches the path in the service file to use the new lib64 path

Also switch to the launchpad tarball and use `%configure` again as mentioned in the TODO

**Test Plan**

Rebooted and confirmed there were no more AppArmor errors in journal and `dmesg`

**Checklist**

- [x] Package was built and tested against unstable
