### PR TITLE
wireplumber: Include patches to fix crashes in device linking system

### DIFF
--- a/packages/w/wireplumber/files/fix-linking.patch
+++ b/packages/w/wireplumber/files/fix-linking.patch
@@ -1,0 +1,384 @@
+From fe42d931da0a24d2618783bf49de33df487190e9 Mon Sep 17 00:00:00 2001
+From: George Kiagiadakis <george.kiagiadakis@collabora.com>
+Date: Thu, 27 Jun 2024 17:10:04 +0300
+Subject: [PATCH 1/4] linking-utils: fallback to role priority 0 if none is
+ defined
+
+See #682
+---
+ src/scripts/lib/linking-utils.lua | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/scripts/lib/linking-utils.lua b/src/scripts/lib/linking-utils.lua
+index 4a91461e..b4640514 100644
+--- a/src/scripts/lib/linking-utils.lua
++++ b/src/scripts/lib/linking-utils.lua
+@@ -27,7 +27,7 @@ function lutils.clear_flags (self, si_id)
+ end
+ 
+ function getprio (link)
+-  return tonumber (link.properties ["policy.role-based.priority"])
++  return tonumber (link.properties ["policy.role-based.priority"]) or 0
+ end
+ 
+ function getplugged (link)
+-- 
+2.45.1
+
+
+From 96dc04538210da6df121b064af8bd5e1c78e9d0a Mon Sep 17 00:00:00 2001
+From: Julian Bouzas <julian.bouzas@collabora.com>
+Date: Thu, 27 Jun 2024 10:14:48 -0400
+Subject: [PATCH 2/4] l/find-best-target: Allow regular filters to be best
+ targets
+
+Similar to 4868b3c3 and fa671216, we always want to treat regular filters as
+normal stream/device nodes.
+---
+ src/config/wireplumber.conf              | 1 +
+ src/scripts/linking/find-best-target.lua | 7 +++++--
+ 2 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/config/wireplumber.conf b/src/config/wireplumber.conf
+index e02ffb88..ad830941 100644
+--- a/src/config/wireplumber.conf
++++ b/src/config/wireplumber.conf
+@@ -579,6 +579,7 @@ wireplumber.components = [
+   {
+     name = linking/find-best-target.lua, type = script/lua
+     provides = hooks.linking.target.find-best
++    requires = [ metadata.filters ]
+   }
+   {
+     name = linking/get-filter-from-target.lua, type = script/lua
+diff --git a/src/scripts/linking/find-best-target.lua b/src/scripts/linking/find-best-target.lua
+index b73839e7..cab8ea61 100644
+--- a/src/scripts/linking/find-best-target.lua
++++ b/src/scripts/linking/find-best-target.lua
+@@ -8,6 +8,7 @@
+ 
+ lutils = require ("linking-utils")
+ cutils = require ("common-utils")
++futils = require ("filter-utils")
+ log = Log.open_topic ("s-linking")
+ 
+ SimpleEventHook {
+@@ -52,8 +53,10 @@ SimpleEventHook {
+         tostring (target_props ["node.name"]),
+         tostring (target_node_id)))
+ 
+-      if si_target_link_group ~= nil then
+-        Log.debug ("... ignoring filter as best target")
++      -- Skip smart filters as best target
++      if si_target_link_group ~= nil and
++          futils.is_filter_smart (target_direction, si_target_link_group) then
++        Log.debug ("... ignoring smart filter as best target")
+         goto skip_linkable
+       end
+ 
+-- 
+2.45.1
+
+
+From abc299c1d3fb24844430475c1ab37a8b1ac5e6bd Mon Sep 17 00:00:00 2001
+From: George Kiagiadakis <george.kiagiadakis@collabora.com>
+Date: Thu, 27 Jun 2024 19:11:00 +0300
+Subject: [PATCH 3/4] linking: redefine script dependencies
+
+This way of definining dependencies ensures that if we remove one
+of the find-* hooks from the config, the rest of them will continue
+to work in the expected order. Previously, removing one of them
+would break the entire chain.
+---
+ src/scripts/linking/find-best-target.lua       | 6 +++++-
+ src/scripts/linking/find-default-target.lua    | 5 ++++-
+ src/scripts/linking/find-defined-target.lua    | 1 +
+ src/scripts/linking/find-filter-target.lua     | 1 +
+ src/scripts/linking/find-media-role-target.lua | 4 +++-
+ src/scripts/linking/get-filter-from-target.lua | 7 ++++++-
+ src/scripts/linking/prepare-link.lua           | 1 -
+ 7 files changed, 20 insertions(+), 5 deletions(-)
+
+diff --git a/src/scripts/linking/find-best-target.lua b/src/scripts/linking/find-best-target.lua
+index cab8ea61..adaa63ca 100644
+--- a/src/scripts/linking/find-best-target.lua
++++ b/src/scripts/linking/find-best-target.lua
+@@ -13,7 +13,11 @@ log = Log.open_topic ("s-linking")
+ 
+ SimpleEventHook {
+   name = "linking/find-best-target",
+-  after = "linking/find-default-target",
++  after = { "linking/find-defined-target",
++            "linking/find-filter-target",
++            "linking/find-media-role-target",
++            "linking/find-default-target" },
++  before = "linking/prepare-link",
+   interests = {
+     EventInterest {
+       Constraint { "event.type", "=", "select-target" },
+diff --git a/src/scripts/linking/find-default-target.lua b/src/scripts/linking/find-default-target.lua
+index eba3fc31..f3c455fa 100644
+--- a/src/scripts/linking/find-default-target.lua
++++ b/src/scripts/linking/find-default-target.lua
+@@ -11,7 +11,10 @@ log = Log.open_topic ("s-linking")
+ 
+ SimpleEventHook {
+   name = "linking/find-default-target",
+-  after = "linking/find-media-role-target",
++  after = { "linking/find-defined-target",
++            "linking/find-filter-target",
++            "linking/find-media-role-target" },
++  before = "linking/prepare-link",
+   interests = {
+     EventInterest {
+       Constraint { "event.type", "=", "select-target" },
+diff --git a/src/scripts/linking/find-defined-target.lua b/src/scripts/linking/find-defined-target.lua
+index f027cf5b..f19124f9 100644
+--- a/src/scripts/linking/find-defined-target.lua
++++ b/src/scripts/linking/find-defined-target.lua
+@@ -15,6 +15,7 @@ log = Log.open_topic ("s-linking")
+ 
+ SimpleEventHook {
+   name = "linking/find-defined-target",
++  before = "linking/prepare-link",
+   interests = {
+     EventInterest {
+       Constraint { "event.type", "=", "select-target" },
+diff --git a/src/scripts/linking/find-filter-target.lua b/src/scripts/linking/find-filter-target.lua
+index 550370c4..02d5c2b3 100644
+--- a/src/scripts/linking/find-filter-target.lua
++++ b/src/scripts/linking/find-filter-target.lua
+@@ -34,6 +34,7 @@ end
+ SimpleEventHook {
+   name = "linking/find-filter-target",
+   after = "linking/find-defined-target",
++  before = "linking/prepare-link",
+   interests = {
+     EventInterest {
+       Constraint { "event.type", "=", "select-target" },
+diff --git a/src/scripts/linking/find-media-role-target.lua b/src/scripts/linking/find-media-role-target.lua
+index bdd6b023..d654b0c2 100644
+--- a/src/scripts/linking/find-media-role-target.lua
++++ b/src/scripts/linking/find-media-role-target.lua
+@@ -12,7 +12,9 @@ log = Log.open_topic("s-linking")
+ 
+ SimpleEventHook {
+   name = "linking/find-media-role-target",
+-  after = "linking/find-filter-target",
++  after = { "linking/find-defined-target",
++            "linking/find-filter-target" },
++  before = "linking/prepare-link",
+   interests = {
+     EventInterest {
+       Constraint { "event.type", "=", "select-target" },
+diff --git a/src/scripts/linking/get-filter-from-target.lua b/src/scripts/linking/get-filter-from-target.lua
+index 15d092d7..58ac7c1b 100644
+--- a/src/scripts/linking/get-filter-from-target.lua
++++ b/src/scripts/linking/get-filter-from-target.lua
+@@ -13,7 +13,12 @@ log = Log.open_topic ("s-linking")
+ 
+ SimpleEventHook {
+   name = "linking/get-filter-from-target",
+-  after = "linking/find-best-target",
++  after = { "linking/find-defined-target",
++            "linking/find-filter-target",
++            "linking/find-media-role-target",
++            "linking/find-default-target",
++            "linking/find-best-target" },
++  before = "linking/prepare-link",
+   interests = {
+     EventInterest {
+       Constraint { "event.type", "=", "select-target" },
+diff --git a/src/scripts/linking/prepare-link.lua b/src/scripts/linking/prepare-link.lua
+index 6a6ccbe1..69da939c 100644
+--- a/src/scripts/linking/prepare-link.lua
++++ b/src/scripts/linking/prepare-link.lua
+@@ -14,7 +14,6 @@ log = Log.open_topic ("s-linking")
+ 
+ SimpleEventHook {
+   name = "linking/prepare-link",
+-  after = "linking/get-filter-from-target",
+   interests = {
+     EventInterest {
+       Constraint { "event.type", "=", "select-target" },
+-- 
+2.45.1
+
+
+From 01a7339625c4c6088be94eed45845e0fe22bea77 Mon Sep 17 00:00:00 2001
+From: George Kiagiadakis <george.kiagiadakis@collabora.com>
+Date: Fri, 28 Jun 2024 10:06:58 +0300
+Subject: [PATCH 4/4] linking: explicitly mark targets that should be managed
+ by the role-based policy
+
+The previous assumption that any target with "device.intended-roles"
+should be managed by the role-based policy is wrong, as for example
+Bluetooth SCO nodes always have "device.intended-roles = Communication"
+and some ALSA devices managed by ACP also do. This is meant to be used
+as a hint for the desktop policy (it's been there in PulseAudio as well)
+and does not necessarily mean that a role-priority-based policy should
+be applied on all links to those devices.
+
+Instead, use a new property to explicitly mark all the targets that
+are meant to be managed by the role-based policy and respect that in
+all places where we check for a potential role-based policy link.
+
+Fixes: #682
+---
+ .../media-role-nodes.conf                        |  5 +++++
+ src/scripts/lib/linking-utils.lua                | 13 ++++++++++++-
+ src/scripts/linking/get-filter-from-target.lua   |  4 ++--
+ src/scripts/linking/link-target.lua              | 16 +++++-----------
+ src/scripts/linking/rescan-media-role-links.lua  |  4 ++--
+ src/scripts/linking/rescan.lua                   |  2 +-
+ 6 files changed, 27 insertions(+), 17 deletions(-)
+
+diff --git a/src/config/wireplumber.conf.d.examples/media-role-nodes.conf b/src/config/wireplumber.conf.d.examples/media-role-nodes.conf
+index 9b0c392f..13ff96f0 100644
+--- a/src/config/wireplumber.conf.d.examples/media-role-nodes.conf
++++ b/src/config/wireplumber.conf.d.examples/media-role-nodes.conf
+@@ -36,6 +36,11 @@ wireplumber.components.rules = [
+       merge = {
+         arguments = {
+           capture.props = {
++            # Explicitly mark all these sinks as valid role-based policy
++            # targets, meaning that any links between streams and these sinks
++            # will be managed by the role-based policy
++            policy.role-based.target = true
++
+             audio.position = [ FL, FR ]
+             media.class = Audio/Sink
+           }
+diff --git a/src/scripts/lib/linking-utils.lua b/src/scripts/lib/linking-utils.lua
+index b4640514..cfc924c2 100644
+--- a/src/scripts/lib/linking-utils.lua
++++ b/src/scripts/lib/linking-utils.lua
+@@ -63,7 +63,7 @@ function lutils.clearPriorityMediaRoleLink (link)
+   for l in cutils.get_object_manager ("session-item"):iterate {
+     type = "SiLink",
+     Constraint { "item.factory.name", "=", "si-standard-link", type = "pw-global" },
+-    Constraint { "is.media.role.link", "=", true },
++    Constraint { "is.role.policy.link", "=", true },
+     Constraint { "target.media.class", "=", lmc },
+   } do
+     local props = l.properties
+@@ -122,6 +122,17 @@ function setPriorityMediaRoleLink (lmc, link)
+   end
+ end
+ 
++function lutils.is_role_policy_target (si_props, target_props)
++  -- role-based policy links are those that link to targets with
++  -- policy.role-based.target = true, unless the stream is a monitor
++  -- (usually pavucontrol) or the stream is linking to the monitor ports
++  -- of a sink (both are "input")
++  return Core.test_feature ("hooks.linking.role-based.rescan")
++      and cutils.parseBool (target_props["policy.role-based.target"])
++      and not cutils.parseBool (si_props ["stream.monitor"])
++      and si_props["item.node.direction"] ~= target_props["item.node.direction"]
++end
++
+ function lutils.unwrap_select_target_event (self, event)
+   local source = event:get_source ()
+   local si = event:get_subject ()
+diff --git a/src/scripts/linking/get-filter-from-target.lua b/src/scripts/linking/get-filter-from-target.lua
+index 58ac7c1b..f216ec14 100644
+--- a/src/scripts/linking/get-filter-from-target.lua
++++ b/src/scripts/linking/get-filter-from-target.lua
+@@ -28,8 +28,8 @@ SimpleEventHook {
+     local source, om, si, si_props, si_flags, target =
+         lutils:unwrap_select_target_event (event)
+ 
+-    -- bypass the hook if the target was not found or if the target is media role node
+-    if target == nil or target.properties["device.intended-roles"] then
++    -- bypass the hook if the target was not found or if it is a role-based policy target
++    if target == nil or lutils.is_role_policy_target (si_props, target.properties) then
+       return
+     end
+ 
+diff --git a/src/scripts/linking/link-target.lua b/src/scripts/linking/link-target.lua
+index f9bb2e83..683bf784 100644
+--- a/src/scripts/linking/link-target.lua
++++ b/src/scripts/linking/link-target.lua
+@@ -63,13 +63,7 @@ AsyncEventHook {
+           out_item = target
+         end
+ 
+-        -- role links are those that link to targets with intended-roles
+-        -- unless the stream is a monitor (usually pavucontrol) or the stream
+-        -- is linking to the monitor ports of a sink (both are "input")
+-        local is_media_role_link = Core.test_feature ("hooks.linking.role-based.rescan")
+-            and target_props["device.intended-roles"] ~= nil
+-            and not cutils.parseBool (si_props ["stream.monitor"])
+-            and si_props["item.node.direction"] ~= target_props["item.node.direction"]
++        local is_role_policy_link = lutils.is_role_policy_target (si_props, target_props)
+ 
+         log:info (si,
+           string.format ("link %s <-> %s passthrough:%s, exclusive:%s, media role link:%s",
+@@ -77,7 +71,7 @@ AsyncEventHook {
+             tostring (target_props ["node.name"]),
+             tostring (passthrough),
+             tostring (exclusive),
+-            tostring (is_media_role_link)))
++            tostring (is_role_policy_link)))
+ 
+         -- create and configure link
+         si_link = SessionItem ("si-standard-link")
+@@ -93,7 +87,7 @@ AsyncEventHook {
+           ["policy.role-based.priority"] = target_props["policy.role-based.priority"],
+           ["policy.role-based.action.same-priority"] = target_props["policy.role-based.action.same-priority"],
+           ["policy.role-based.action.lower-priority"] = target_props["policy.role-based.action.lower-priority"],
+-          ["is.media.role.link"] = is_media_role_link,
++          ["is.role.policy.link"] = is_role_policy_link,
+           ["main.item.id"] = si.id,
+           ["target.item.id"] = target.id,
+         } then
+@@ -129,9 +123,9 @@ AsyncEventHook {
+         log:debug (si_link, "registered link between "
+             .. tostring (si) .. " and " .. tostring (target))
+ 
+-        -- only activate non media role links because their activation is
++        -- only activate non role-based policy links because their activation is
+         -- handled by rescan-media-role-links.lua
+-        if not is_media_role_link then
++        if not is_role_policy_link then
+           si_link:activate (Feature.SessionItem.ACTIVE, function (l, e)
+             if e then
+               transition:return_error (tostring (l) .. " link failed: "
+diff --git a/src/scripts/linking/rescan-media-role-links.lua b/src/scripts/linking/rescan-media-role-links.lua
+index 358e40dc..34ef4e0c 100644
+--- a/src/scripts/linking/rescan-media-role-links.lua
++++ b/src/scripts/linking/rescan-media-role-links.lua
+@@ -85,7 +85,7 @@ AsyncEventHook {
+       -- on media client link added and removed
+       Constraint { "event.type", "c", "session-item-added", "session-item-removed" },
+       Constraint { "event.session-item.interface", "=", "link" },
+-      Constraint { "is.media.role.link", "=", true },
++      Constraint { "is.role.policy.link", "=", true },
+     },
+     EventInterest {
+       -- on default metadata suspend.playback changed
+@@ -140,7 +140,7 @@ AsyncEventHook {
+ 
+         for link in om:iterate {
+           type = "SiLink",
+-          Constraint { "is.media.role.link", "=", true },
++          Constraint { "is.role.policy.link", "=", true },
+           Constraint { "target.media.class", "=", mc },
+         } do
+           -- deactivate all links if suspend playback metadata is present
+diff --git a/src/scripts/linking/rescan.lua b/src/scripts/linking/rescan.lua
+index b4c44e1b..a49ad29e 100644
+--- a/src/scripts/linking/rescan.lua
++++ b/src/scripts/linking/rescan.lua
+@@ -82,7 +82,7 @@ function unhandleLinkable (si, om)
+         out_flags.peer_id = nil
+       end
+ 
+-      if cutils.parseBool (silink.properties["is.media.role.link"]) then
++      if cutils.parseBool (silink.properties["is.role.policy.link"]) then
+         lutils.clearPriorityMediaRoleLink(silink)
+       end
+ 
+-- 
+2.45.1
+

--- a/packages/w/wireplumber/package.yml
+++ b/packages/w/wireplumber/package.yml
@@ -1,6 +1,6 @@
 name       : wireplumber
 version    : 0.5.4
-release    : 31
+release    : 32
 source     :
     - https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/0.5.4/wireplumber-0.5.4.tar.gz : 83a75ab7dc88fbce976378fc2303418f8c66a8562120f4f598391ae263d7fc9e
 license    : MIT
@@ -15,6 +15,7 @@ builddeps  :
     - doxygen
     - python-lxml
 setup      : |
+    %patch -p1 -i $pkgfiles/fix-linking.patch
     %meson_configure -Dsystem-lua=true -Delogind=disabled
 build      : |
     %ninja_build

--- a/packages/w/wireplumber/pspec_x86_64.xml
+++ b/packages/w/wireplumber/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>wireplumber</Name>
         <Homepage>https://pipewire.pages.freedesktop.org/wireplumber/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>multimedia.library</PartOf>
@@ -179,7 +179,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="31">wireplumber</Dependency>
+            <Dependency release="32">wireplumber</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wireplumber-0.5/wp/base-dirs.h</Path>
@@ -227,12 +227,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2024-06-26</Date>
+        <Update release="32">
+            <Date>2024-06-28</Date>
             <Version>0.5.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
…devices

**Summary**

Version 0.5.4 introduced an issue causing `wireplumber` to crash during certain Bluetooth device operations, for example profile switching.

This backports the patches to the linking system that fix those crashes.

**Test Plan**

Switched audio profiles, launched games, played audio in browser, and confirmed `wireplumber` didn't crash

**Checklist**

- [x] Package was built and tested against unstable
