### PR TITLE
eopkg: sync packagekit backend w/ git for eopkg.bin

### DIFF
--- a/packages/e/eopkg/package.yml
+++ b/packages/e/eopkg/package.yml
@@ -1,9 +1,9 @@
 name       : eopkg
 version    : 4.1.1
-release    : 7
+release    : 8
 source     :
     - git|https://github.com/getsolus/eopkg : 1f1fc60acccbe9ac30adf114072ecfc3086ed8a1
-    - git|https://github.com/getsolus/PackageKit.git : dcfcd941d2aa09a1378d738bc98afb4ca52d14df
+    - git|https://github.com/getsolus/PackageKit.git : 48fccbbc6cf48d578588b0cbfb253ce97a4dde1a
 homepage   : https://github.com/getsolus/eopkg
 license    : GPL-2.0-or-later
 component  : system.base

--- a/packages/e/eopkg/pspec_x86_64.xml
+++ b/packages/e/eopkg/pspec_x86_64.xml
@@ -440,8 +440,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2024-06-24</Date>
+        <Update release="8">
+            <Date>2024-06-28</Date>
             <Version>4.1.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Rune Morling</Name>


### PR DESCRIPTION
**Summary**

Error handling bugfixes in the PK eopkg backend

**Test Plan**

Successfully use KDE Discover to refresh the repo and install upgrades.

**Checklist**

- [x] Package was built and tested against unstable
