### PR TITLE
Add an ignore list to the appstream checker script

### DIFF
--- a/common/Scripts/appstream_ignored_packages.txt
+++ b/common/Scripts/appstream_ignored_packages.txt
@@ -1,3 +1,89 @@
 # Add packages to be ignored by the appstream checker here.
 # Comments in this file must be on a separate line and start with a # character.
 # Blank lines are meaningless to the parser, and can be used to separate categories of packages.
+
+# Plasma Internals
+polkit-kde-agent
+plasma-thunderbolt
+powerdevil
+akonadi-import-wizard
+sddm-kcm
+colord-kde
+flatpak-kcm
+kaccounts-integration
+kf6-kded
+klayout
+kf6-kguiaddons
+kf6-knewstuff
+kded
+kdepim-runtime
+knewstuff
+kio
+kf6-kio
+kwin
+kf6-kwallet
+kio-extras
+kmail-account-wizard
+drkonqi
+plasma-browser-integration
+
+# If you need it, it's already installed
+calamares
+lightdm-settings
+lightdm-gtk-greeter-settings
+libgtk-3
+libkcddb
+linux-steam-integration
+pinentry
+qt5-tools
+qt6-tools
+hwloc
+snapd
+solus-mate-transition-tool
+stoken
+xdg-desktop-portal-gtk
+xdg-desktop-portal-xapp
+xdg-desktop-portal-kde
+xdg-desktop-portal-gnome
+xorg-xwayland
+v4l-utils
+evolution-data-server
+doflicky
+ibus
+
+# XFCE Internals
+libxfce4ui
+xfwm4
+xfce4-settings
+xfdesktop
+xfce4-session
+xfce4-notifyd
+xfce4-screensaver
+xfce4-panel
+xfce4-settings
+
+
+# GNOME Internals
+libgnomekbd
+gnome-online-accounts-gtk
+gnome-online-accounts
+gnome-remote-desktop
+gnome-browser-connector
+gnome-bluetooth
+
+# Budgie Internals
+gnome-bluetooth-1
+budgie-desktop
+budgie-screensaver
+budgie-desktop-view
+
+# MATE Internals
+mate-screensaver
+mate-media
+mate-control-center
+mate-desktop
+mate-user-guide
+mate-notification-daemon
+mate-panel
+mate-session-manager
+mate-power-manager

--- a/common/Scripts/appstream_ignored_packages.txt
+++ b/common/Scripts/appstream_ignored_packages.txt
@@ -1,0 +1,3 @@
+# Add packages to be ignored by the appstream checker here.
+# Comments in this file must be on a separate line and start with a # character.
+# Blank lines are meaningless to the parser, and can be used to separate categories of packages.


### PR DESCRIPTION
**Summary**

This PR gives the appstream progress checker the ability to ignore a list of packages, which is provided by common/Scripts/appstream_ignored_packages.txt. It also contains a starting point for that list of ignored packages.

**Test Plan**

1. Run `go-task check-appstream-progress` within the repo.
2. Make note of how many packages are reported as needing appstream data.
3. Check out this PR.
4. Run `go-task check-appstream-progress` again.
5. Note the abrupt decrease in packages reported as needing appstream data.
