### PR TITLE
wine: Update to 9.12

### DIFF
--- a/packages/w/wine/abi_symbols
+++ b/packages/w/wine/abi_symbols
@@ -725,6 +725,7 @@ win32u.so:window_surface_init
 win32u.so:window_surface_lock
 win32u.so:window_surface_release
 win32u.so:window_surface_set_clip
+win32u.so:window_surface_set_layered
 win32u.so:window_surface_unlock
 wine64:_IO_stdin_used
 wine64:__bss_start

--- a/packages/w/wine/abi_symbols32
+++ b/packages/w/wine/abi_symbols32
@@ -718,6 +718,7 @@ win32u.so:window_surface_init
 win32u.so:window_surface_lock
 win32u.so:window_surface_release
 win32u.so:window_surface_set_clip
+win32u.so:window_surface_set_layered
 win32u.so:window_surface_unlock
 wine:_IO_stdin_used
 wine:__bss_start

--- a/packages/w/wine/abi_used_symbols
+++ b/packages/w/wine/abi_used_symbols
@@ -1029,6 +1029,7 @@ libpulse.so.0:pa_context_errno
 libpulse.so.0:pa_context_get_protocol_version
 libpulse.so.0:pa_context_get_server
 libpulse.so.0:pa_context_get_server_protocol_version
+libpulse.so.0:pa_context_get_sink_info_by_name
 libpulse.so.0:pa_context_get_sink_info_list
 libpulse.so.0:pa_context_get_source_info_list
 libpulse.so.0:pa_context_get_state

--- a/packages/w/wine/abi_used_symbols32
+++ b/packages/w/wine/abi_used_symbols32
@@ -966,6 +966,7 @@ libpulse.so.0:pa_context_errno
 libpulse.so.0:pa_context_get_protocol_version
 libpulse.so.0:pa_context_get_server
 libpulse.so.0:pa_context_get_server_protocol_version
+libpulse.so.0:pa_context_get_sink_info_by_name
 libpulse.so.0:pa_context_get_sink_info_list
 libpulse.so.0:pa_context_get_source_info_list
 libpulse.so.0:pa_context_get_state

--- a/packages/w/wine/package.yml
+++ b/packages/w/wine/package.yml
@@ -1,8 +1,8 @@
 name       : wine
-version    : '9.11'
-release    : 177
+version    : '9.12'
+release    : 178
 source     :
-    - https://dl.winehq.org/wine/source/9.x/wine-9.11.tar.xz : dfa00c264ea71169d02a849a833e48cae761fb08422a00df8644ebd67bf87240
+    - https://dl.winehq.org/wine/source/9.x/wine-9.12.tar.xz : 09145ae720b2f9f18187970ba0640bbf3ced5ae8dc78af1d7d57f5077ec26af6
 license    : LGPL-2.1-or-later
 component  : virt
 homepage   : https://www.winehq.org/

--- a/packages/w/wine/pspec_x86_64.xml
+++ b/packages/w/wine/pspec_x86_64.xml
@@ -109,6 +109,7 @@
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/avicap32.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/avifil32.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/avrt.dll</Path>
+            <Path fileType="library">/usr/lib64/wine/x86_64-windows/bcp47langs.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/bcrypt.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/bcryptprimitives.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/bluetoothapis.dll</Path>
@@ -518,6 +519,7 @@
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/presentationfontcache.exe</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/printui.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/prntvpt.dll</Path>
+            <Path fileType="library">/usr/lib64/wine/x86_64-windows/profapi.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/progman.exe</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/propsys.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/psapi.dll</Path>
@@ -545,6 +547,7 @@
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/riched20.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/riched32.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/robocopy.exe</Path>
+            <Path fileType="library">/usr/lib64/wine/x86_64-windows/rometadata.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/rpcrt4.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/rpcss.exe</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/rsabase.dll</Path>
@@ -981,7 +984,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="177">wine</Dependency>
+            <Dependency release="178">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/wine</Path>
@@ -1047,6 +1050,7 @@
             <Path fileType="library">/usr/lib32/wine/i386-windows/avifil32.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/avifile.dll16</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/avrt.dll</Path>
+            <Path fileType="library">/usr/lib32/wine/i386-windows/bcp47langs.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/bcrypt.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/bcryptprimitives.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/bluetoothapis.dll</Path>
@@ -1484,6 +1488,7 @@
             <Path fileType="library">/usr/lib32/wine/i386-windows/presentationfontcache.exe</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/printui.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/prntvpt.dll</Path>
+            <Path fileType="library">/usr/lib32/wine/i386-windows/profapi.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/progman.exe</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/propsys.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/psapi.dll</Path>
@@ -1512,6 +1517,7 @@
             <Path fileType="library">/usr/lib32/wine/i386-windows/riched20.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/riched32.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/robocopy.exe</Path>
+            <Path fileType="library">/usr/lib32/wine/i386-windows/rometadata.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/rpcrt4.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/rpcss.exe</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/rsabase.dll</Path>
@@ -1812,7 +1818,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="177">wine</Dependency>
+            <Dependency release="178">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wine/debug.h</Path>
@@ -2663,6 +2669,7 @@
             <Path fileType="header">/usr/include/wine/windows/rmxftmpl.x</Path>
             <Path fileType="header">/usr/include/wine/windows/roapi.h</Path>
             <Path fileType="header">/usr/include/wine/windows/roerrorapi.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/rometadata.h</Path>
             <Path fileType="header">/usr/include/wine/windows/rometadataresolution.h</Path>
             <Path fileType="header">/usr/include/wine/windows/roparameterizediid.h</Path>
             <Path fileType="header">/usr/include/wine/windows/roparameterizediid.idl</Path>
@@ -2870,6 +2877,10 @@
             <Path fileType="header">/usr/include/wine/windows/windef.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windns.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windot11.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.applicationmodel.activation.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.applicationmodel.activation.idl</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.applicationmodel.background.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.applicationmodel.background.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.applicationmodel.core.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.applicationmodel.core.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.applicationmodel.h</Path>
@@ -2882,6 +2893,8 @@
             <Path fileType="header">/usr/include/wine/windows/windows.devices.geolocation.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.devices.haptics.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.devices.haptics.idl</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.devices.input.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.devices.input.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.devices.power.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.devices.power.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.devices.radios.h</Path>
@@ -2916,8 +2929,10 @@
             <Path fileType="header">/usr/include/wine/windows/windows.graphics.directx.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.graphics.effects.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.graphics.effects.idl</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.graphics.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.graphics.holographic.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.graphics.holographic.idl</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.graphics.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.graphics.imaging.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.graphics.imaging.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.h</Path>
@@ -2989,6 +3004,8 @@
             <Path fileType="header">/usr/include/wine/windows/windows.ui.core.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.ui.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.ui.idl</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.ui.input.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.ui.input.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.ui.viewmanagement.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.ui.viewmanagement.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.ui.xaml.hosting.desktopwindowxamlsource.h</Path>
@@ -3116,9 +3133,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="177">
-            <Date>2024-06-15</Date>
-            <Version>9.11</Version>
+        <Update release="178">
+            <Date>2024-06-29</Date>
+            <Version>9.12</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Highlighted changes:
- Initial support for user32 data structures in shared memory
- Mono engine updated to version 9.2.0
- Rewrite of the CMD.EXE engine
- Fixed handling of async I/O status in new WoW64 mode
- Various bug fixes

Full release notes available [here](https://gitlab.winehq.org/wine/wine/-/releases/wine-9.12)

**Test Plan**
- Used `winemine`, `winecfg`, `wineconsole`, `winefile`
- Played Age of Empires I Trial

**Checklist**

- [x] Package was built and tested against unstable
