### PR TITLE
eopkg/pisi: Order baselayout first, don't reorder eopkg

### DIFF
--- a/packages/e/eopkg/package.yml
+++ b/packages/e/eopkg/package.yml
@@ -1,8 +1,8 @@
 name       : eopkg
-version    : 4.1.1
-release    : 8
+version    : 4.1.2
+release    : 9
 source     :
-    - git|https://github.com/getsolus/eopkg : 1f1fc60acccbe9ac30adf114072ecfc3086ed8a1
+    - git|https://github.com/getsolus/eopkg : 515f101c5076d50b032169de4c366cc392d554cc
     - git|https://github.com/getsolus/PackageKit.git : 48fccbbc6cf48d578588b0cbfb253ce97a4dde1a
 homepage   : https://github.com/getsolus/eopkg
 license    : GPL-2.0-or-later
@@ -15,6 +15,10 @@ description:
     - python-eopkg : The Solus package manager (pure python3 eopkg.py3 version)
 strip      : no
 debug      : no
+# Sadly necessary for now to deal with rel8 having the bad "reorder eopkg code"
+# AND depending on an updated, versioned glibc version.
+# FIXME: Remove `autodep: no` for the eopkg package in the epoch bumped repo
+autodep    : no
 builddeps  :
     - pkgconfig(packagekit-glib2)
     - pkgconfig(python3)
@@ -31,6 +35,7 @@ builddeps  :
     - python-xattr
     - python-zstandard
 rundeps    :
+    - glibc
     - ^python-eopkg :
         - iksemel
         - python-ordered-set

--- a/packages/e/eopkg/pspec_x86_64.xml
+++ b/packages/e/eopkg/pspec_x86_64.xml
@@ -33,12 +33,12 @@
             <Path fileType="executable">/usr/bin/eopkg.py3</Path>
             <Path fileType="executable">/usr/bin/lseopkg.py3</Path>
             <Path fileType="executable">/usr/bin/uneopkg.py3</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.1.dist-info/AUTHORS</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.1.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.2.dist-info/AUTHORS</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.2.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.2.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/__pycache__/__init__.cpython-311.pyc</Path>
@@ -440,9 +440,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2024-06-28</Date>
-            <Version>4.1.1</Version>
+        <Update release="9">
+            <Date>2024-06-30</Date>
+            <Version>4.1.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Rune Morling</Name>
             <Email>ermo@serpentos.com</Email>

--- a/packages/p/pisi/files/baselayout-first-no-eopkg-reordering.patch
+++ b/packages/p/pisi/files/baselayout-first-no-eopkg-reordering.patch
@@ -1,0 +1,114 @@
+diff --git a/pisi/__init__.py b/pisi/__init__.py
+index 23ea996..f02c90e 100644
+--- a/pisi/__init__.py
++++ b/pisi/__init__.py
+@@ -29,7 +29,7 @@ except:
+     def translate(msg): return msg
+ 
+ 
+-__version__ = "3.12.1"
++__version__ = "3.12.2"
+ 
+ __all__ = [ 'api', 'configfile', 'db']
+ 
+diff --git a/pisi/operations/helper.py b/pisi/operations/helper.py
+index c311dbc..b459c60 100644
+--- a/pisi/operations/helper.py
++++ b/pisi/operations/helper.py
+@@ -42,6 +42,19 @@ def reorder_base_packages(order):
+         ctx.ui.info(_("install_order: %s" % install_order))
+     return install_order
+ 
++def reorder_base_packages_dummy(order):
++    """Dummy function that doesn't actually re-order system.base in front.
++
++       We now use OrderedSets, which keep the original topological sort,
++       so this shouldn't actually be necessary now.
++
++       This also implies that the only function of system.base is for the
++       packages in it to be un-removable.
++    """
++    if len(order) > 1 and ctx.config.get_option("debug"):
++        ctx.ui.info(_("install_order including system.base deps: %s" % order))
++    return order
++
+ def check_conflicts(order, packagedb):
+     """check if upgrading to the latest versions will cause havoc
+     done in a simple minded way without regard for dependencies of
+diff --git a/pisi/operations/install.py b/pisi/operations/install.py
+index b63d871..1753c9e 100644
+--- a/pisi/operations/install.py
++++ b/pisi/operations/install.py
+@@ -27,24 +27,14 @@ import pisi.ui as ui
+ import pisi.db
+ 
+ BASELAYOUT_PKG = 'baselayout'
+-EOPKG_PKG = 'eopkg'
+ 
+-def plan_deterministic_install_order(order):
+-    """Ensure that baselayout and eopkg are put at the end of any topological sort that includes them."""
++def reorder_baselayout(order):
++    """Ensure that baselayout is put at the end of any topological sort that includes it."""
+ 
+     # save cycles
+     if len(order) <= 1:
+         return order
+ 
+-    # when eopkg is in the order, move it to the end of the order (since the order gets reversed).
+-    # this is useful when file ownership between it and pisi changes.
+-    if EOPKG_PKG in order:
+-        order.remove(EOPKG_PKG)
+-        order.append(EOPKG_PKG)
+-        # An alternative is to _force_ eopkg to be upgraded/installed by itself, such that the next
+-        # operation is guaranteed to be using the new eopkg version. This option needs to stay on the table.
+-        #return [EOPKG_PKG]
+-
+     # always order baselayout _last_ (since the order gets reversed)
+     if BASELAYOUT_PKG in order:
+         order.remove(BASELAYOUT_PKG)
+@@ -274,7 +264,7 @@ def install_pkg_files(package_URIs, reinstall = False):
+         conflicts = operations.helper.check_conflicts(order, packagedb)
+         if conflicts:
+             operations.remove.remove_conflicting_packages(conflicts)
+-    order = plan_deterministic_install_order(order)
++    order = reorder_baselayout(order)
+     order.reverse()
+     ctx.ui.info(_('Installation order: ') + util.strlist(order) )
+ 
+@@ -342,9 +332,9 @@ def plan_install_pkg_names(A):
+     order = G_f.topological_sort()
+     if len(order) > 1 and ctx.config.get_option("debug"):
+         ctx.ui.info(_("topological_sort order: %s" % order))
+-    order = plan_deterministic_install_order(order)
++    order = reorder_baselayout(order)
+     if len(order) > 1 and ctx.config.get_option("debug"):
+-        ctx.ui.info(_("deterministic order: %s" % order))
++        ctx.ui.info(_("baselayout last: %s" % order))
+     order.reverse()
+     if len(order) > 1 and ctx.config.get_option("debug"):
+         ctx.ui.info(_("final order.reverse(): %s" % order))
+diff --git a/pisi/operations/upgrade.py b/pisi/operations/upgrade.py
+index a4a693c..30f68f8 100644
+--- a/pisi/operations/upgrade.py
++++ b/pisi/operations/upgrade.py
+@@ -335,7 +335,7 @@ def plan_upgrade(A, force_replaced=True, replaces=None):
+         G_f.write_graphviz(sys.stdout)
+ 
+     order = G_f.topological_sort()
+-    order = operations.install.plan_deterministic_install_order(order)
++    order = operations.install.reorder_baselayout(order)
+     order.reverse()
+     return G_f, order
+ 
+@@ -371,9 +371,9 @@ def upgrade_base(A = set()):
+             install_and_upgrade_order = set(install_order + upgrade_order)
+             if len(install_and_upgrade_order) > 1 and ctx.config.get_option("debug"):
+                 ctx.ui.info(_("installs and upgrades (unordered): %s" % install_and_upgrade_order))
+-            install_and_upgrade_order = operations.install.plan_deterministic_install_order(install_and_upgrade_order)
++            install_and_upgrade_order = operations.install.reorder_baselayout(install_and_upgrade_order)
+             if len(install_and_upgrade_order) > 1 and ctx.config.get_option("debug"):
+-                ctx.ui.info(_("installs and upgrades (deterministic order): %s" % install_and_upgrade_order))
++                ctx.ui.info(_("installs and upgrades (baselayout last): %s" % install_and_upgrade_order))
+             # return packages that must be added to any installation
+             return install_and_upgrade_order
+         else:

--- a/packages/p/pisi/pspec.xml
+++ b/packages/p/pisi/pspec.xml
@@ -23,6 +23,7 @@
         </BuildDependencies>
 
         <Patches>
+            <Patch level="1">baselayout-first-no-eopkg-reordering.patch</Patch>
         </Patches>
     </Source>
 
@@ -59,9 +60,8 @@
         </Provides>
         <RuntimeDependencies>
             <Dependency>db5</Dependency>
-            <!-- for documentation etc. once pisi / eopkg.py2 is the "lesser" twin (after epoch bump)
+            <!-- To ensure pisi is always installed after eopkg, and for documentation etc. once pisi / eopkg.py2 is the "lesser" twin (after epoch bump) -->
             <Dependency>eopkg</Dependency>
-            -->
             <Dependency>piksemel</Dependency>
             <Dependency>python</Dependency>
             <Dependency>python2-ordered-set</Dependency>
@@ -71,7 +71,17 @@
     </Package>
 
     <History>
-        <Update release="112">
+        <Update release="113">
+            <Date>29-06-2024</Date>
+            <Version>3.12.2</Version>
+            <Comment>Update to v3.12.2, tweak reordering code
+**Summary**
+The install order reordering code now puts baselayout first and doesn't attempt to reorder eopkg.
+</Comment>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
+        </Update>
+         <Update release="112">
             <Date>24-06-2024</Date>
             <Version>3.12.1</Version>
             <Comment>sync to v3.12.1, add dep on python2-ordered-set


### PR DESCRIPTION
**Summary**

This should fix issues with eopkg being uninstallable because glibc was not installed first.

**Test Plan**

- VM testing
  - Installed 4.5 ISO in VM
  - Updated to newest stable (eopkg4 r7)
  - Sideloaded pisi from this PR
  - Switched to unstable using sideloaded pisi
  - Upgraded to latest unstable using sideloaded pisi
- ISO testing
  - Successfully built an Xfce smoketest ISO with the new pisi/eopkg versions installed and in my local repo
- chroot builds
  - Successfully built multiple chroots with `eopkg.py3 it -c system.base -D <the outputdir>` and saw first baselayout then fairly close after (directly after or after iso-codes) saw glibc being installed, implying that the topological_sort order is now not being scrambled by set operations.

**Checklist**

- [x] Package was built and tested against unstable
