### PR TITLE
nano-syntax-highlighting: add at 2022.11.02

### DIFF
--- a/packages/n/nano-syntax-highlighting/files/0001-Fix-git-commit-colours-for-dark-terminals.patch
+++ b/packages/n/nano-syntax-highlighting/files/0001-Fix-git-commit-colours-for-dark-terminals.patch
@@ -1,0 +1,70 @@
+From 5ac5d27b33b4a37af3413aadeb83b88eb6ca5f1e Mon Sep 17 00:00:00 2001
+From: Thomas Staudinger <Staudi.Kaos@gmail.com>
+Date: Sun, 7 Aug 2022 03:12:15 +0200
+Subject: [PATCH] Fix git(commit) colours for dark terminals
+
+---
+ git.nanorc | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/git.nanorc b/git.nanorc
+index 0aaf475..711ee5f 100644
+--- a/git.nanorc
++++ b/git.nanorc
+@@ -4,7 +4,7 @@ color brightcyan "\<(true|false)\>"
+ color cyan "^[[:space:]]*[^=]*="
+ color brightmagenta "^[[:space:]]*\[.*\]$"
+ color yellow ""(\\.|[^"])*"|'(\\.|[^'])*'"
+-color brightblack "(^|[[:space:]])#([^{].*)?$"
++color brightblue "(^|[[:space:]])#([^{].*)?$"
+ color ,green "[[:space:]]+$"
+ color ,red "	+"
+ 
+@@ -22,7 +22,7 @@ syntax "git-commit" "COMMIT_EDITMSG|TAG_EDITMSG"
+ color yellow ".*"
+ 
+ # Comments
+-color brightblack "^#.*"
++color brightblue "^#.*"
+ 
+ # Files changes
+ color white       "#[[:space:]](deleted|modified|new file|renamed):[[:space:]].*"
+@@ -36,14 +36,14 @@ color black "^#	[^/?*:;{}\\]+\.[^/?*:;{}\\]+$"
+ 
+ color brightmagenta "^#[[:space:]]Changes.*[:]"
+ color brightred "^#[[:space:]]Your branch and '[^']+"
+-color brightblack "^#[[:space:]]Your branch and '"
++color brightblue "^#[[:space:]]Your branch and '"
+ color brightwhite "^#[[:space:]]On branch [^ ]+"
+-color brightblack "^#[[:space:]]On branch"
++color brightblue "^#[[:space:]]On branch"
+ 
+ # Recolor hash symbols
+ 
+ # Recolor hash symbols
+-color brightblack "#"
++color brightblue "#"
+ 
+ # Trailing spaces (+LINT is not ok, git uses tabs)
+ color ,green "[[:space:]]+$"
+@@ -56,7 +56,7 @@ syntax "git-rebase-todo" "git-rebase-todo"
+ color yellow ".*"
+ 
+ # Comments
+-color brightblack "^#.*"
++color brightblue "^#.*"
+ 
+ # Rebase commands
+ color green       "^(e|edit) [0-9a-f]{7,40}"
+@@ -73,7 +73,7 @@ color yellow      "^(x|exec) [^ ]+ [0-9a-f]{7,40}"
+ color yellow      "^#  (x, exec)"
+ 
+ # Recolor hash symbols
+-color brightblack "#"
++color brightblue "#"
+ 
+ # Commit IDs
+ color brightblue "[0-9a-f]{7,40}"
+-- 
+2.35.4
+

--- a/packages/n/nano-syntax-highlighting/package.yml
+++ b/packages/n/nano-syntax-highlighting/package.yml
@@ -1,0 +1,20 @@
+name       : nano-syntax-highlighting
+version    : 2022.11.02
+release    : 1
+source     :
+    - https://github.com/galenguyer/nano-syntax-highlighting/archive/refs/tags/2022.11.02.tar.gz : 296c5f56408fc609d4b774ba23b80136233f50af083f05ccbd67218025d46858
+homepage   : https://github.com/galenguyer/nano-syntax-highlighting
+license    : GPL-3.0-or-later
+component  : system.devel
+summary    : Improved Nano Syntax Highlighting Files.
+description: |
+    Package with language-specific nanorc files that have improved definitions of syntax highlighting
+replaces   :
+    - nanorc
+setup      : |
+    %patch -p1 -i $pkgfiles/0001-Fix-git-commit-colours-for-dark-terminals.patch
+install    : |
+    install -dDm755 $installdir/usr/share/nanorc
+    find $workdir -name "*.nanorc" | xargs install -Dm644 -t $installdir/usr/share/nanorc
+conflicts : 
+    - nanorc

--- a/packages/n/nano-syntax-highlighting/pspec_x86_64.xml
+++ b/packages/n/nano-syntax-highlighting/pspec_x86_64.xml
@@ -1,0 +1,165 @@
+<PISI>
+    <Source>
+        <Name>nano-syntax-highlighting</Name>
+        <Homepage>https://github.com/galenguyer/nano-syntax-highlighting</Homepage>
+        <Packager>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
+        </Packager>
+        <License>GPL-3.0-or-later</License>
+        <PartOf>system.devel</PartOf>
+        <Summary xml:lang="en">Improved Nano Syntax Highlighting Files.</Summary>
+        <Description xml:lang="en">Package with language-specific nanorc files that have improved definitions of syntax highlighting
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>nano-syntax-highlighting</Name>
+        <Summary xml:lang="en">Improved Nano Syntax Highlighting Files.</Summary>
+        <Description xml:lang="en">Package with language-specific nanorc files that have improved definitions of syntax highlighting
+</Description>
+        <PartOf>system.devel</PartOf>
+        <Files>
+            <Path fileType="data">/usr/share/nanorc/Dockerfile.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/Rnw.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/apacheconf.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/arduino.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/asciidoc.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/asm.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/awk.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/batch.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/beancount.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/c.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/clojure.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/cmake.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/coffeescript.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/colortest.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/conf.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/conky.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/creole.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/csh.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/csharp.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/css.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/csv.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/cython.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/dot.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/dotenv.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/elixir.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/email.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/erb.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/etc-hosts.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/fish.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/fortran.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/fsharp.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/gemini.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/genie.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/gentoo.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/git.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/gitcommit.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/glsl.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/go.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/gophermap.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/gradle.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/groff.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/haml.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/haskell.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/hcl.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/html.j2.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/html.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/i3.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/ical.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/ini.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/inputrc.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/jade.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/java.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/javascript.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/jrnl.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/js.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/json.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/julia.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/keymap.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/kickstart.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/kotlin.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/ledger.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/lisp.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/lua.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/m3u.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/makefile.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/man.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/markdown.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/moonscript.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/mpdconf.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/mutt.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/nanorc.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/nginx.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/nmap.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/ocaml.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/octave.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/patch.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/peg.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/perl.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/perl6.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/php.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/pkg-config.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/pkgbuild.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/po.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/pov.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/powershell.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/privoxy.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/prolog.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/properties.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/pug.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/puppet.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/python.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/reST.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/rego.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/rpmspec.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/ruby.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/rust.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/scala.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/sed.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/sh.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/sieve.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/sls.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/solidity.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/sparql.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/sql.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/subrip.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/svn.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/swift.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/systemd.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/tcl.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/tex.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/toml.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/ts.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/twig.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/vala.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/verilog.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/vi.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/x11basic.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/xml.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/xresources.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/yaml.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/yum.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/zeek.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/zig.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/zsh.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/zshrc.nanorc</Path>
+        </Files>
+        <Conflicts>
+            <Package>nanorc</Package>
+        </Conflicts>
+        <Replaces>
+            <Package>nanorc</Package>
+        </Replaces>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2024-06-30</Date>
+            <Version>2022.11.02</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
+        </Update>
+    </History>
+</PISI>

--- a/packages/n/nano/package.yml
+++ b/packages/n/nano/package.yml
@@ -1,6 +1,6 @@
 name       : nano
 version    : '8.1'
-release    : 196
+release    : 197
 source     :
     - https://www.nano-editor.org/dist/v8/nano-8.1.tar.xz : 93b3e3e9155ae389fe9ccf9cb7ab380eac29602835ba3077b22f64d0f0cbe8cb
 homepage   : https://www.nano-editor.org
@@ -11,9 +11,9 @@ description: |
     GNU nano is an easy-to-use text editor originally designed as a replacement for Pico, the ncurses-based editor from the non-free mailer package Pine (itself now available under the Apache License as Alpine).
 mancompress: yes
 builddeps  :
-    - nanorc
+    - nano-syntax-highlighting
 rundeps    :
-    - nanorc
+    - nano-syntax-highlighting
 setup      : |
     %patch -p1 -i $pkgfiles/0001-Use-a-stateless-configuration.patch
     %configure \

--- a/packages/n/nano/pspec_x86_64.xml
+++ b/packages/n/nano/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nano</Name>
         <Homepage>https://www.nano-editor.org</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.devel</PartOf>
@@ -117,12 +117,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="196">
-            <Date>2024-07-13</Date>
+        <Update release="197">
+            <Date>2024-07-17</Date>
             <Version>8.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/n/nanorc/package.yml
+++ b/packages/n/nanorc/package.yml
@@ -1,9 +1,9 @@
 name       : nanorc
 version    : 2020.10.10
-release    : 3
+release    : 4
 source     :
     - git|https://github.com/scopatz/nanorc.git : 1aa64a86cf4c750e4d4788ef1a19d7a71ab641dd
-homepage  : https://github.com/scopatz/nanorc
+homepage   : https://github.com/scopatz/nanorc
 license    : GPL-3.0-or-later
 component  : system.devel
 summary    : Improved Nano Syntax Highlighting Files
@@ -14,3 +14,5 @@ setup      : |
 install    : |
     install -dDm755 $installdir/usr/share/nanorc
     find $workdir -name "*.nanorc" | xargs install -Dm644 -t $installdir/usr/share/nanorc
+conflicts  :
+    - nano-syntax-highlighting

--- a/packages/n/nanorc/pspec_x86_64.xml
+++ b/packages/n/nanorc/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nanorc</Name>
         <Homepage>https://github.com/scopatz/nanorc</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.devel</PartOf>
@@ -140,14 +140,17 @@
             <Path fileType="data">/usr/share/nanorc/zsh.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/zshrc.nanorc</Path>
         </Files>
+        <Conflicts>
+            <Package>nano-syntax-highlighting</Package>
+        </Conflicts>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-05-18</Date>
+        <Update release="4">
+            <Date>2024-07-17</Date>
             <Version>2020.10.10</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Initial inclusion at version 2022.11.02
- Resolves https://github.com/getsolus/packages/issues/2615

**Test Plan**
- Checked some highlighting.

**Checklist**

- [X] Package was built and tested against unstable

**Packaging notes**
Nano depends on nanorc which conflicts with nano-syntax-highlighting. So this wont build without the conflicts tag. After this is pushed then nanorc can be deprecated at whole.
