### PR TITLE
xmlto: update to 0.0.29

### DIFF
--- a/packages/x/xmlto/abi_used_symbols
+++ b/packages/x/xmlto/abi_used_symbols
@@ -1,14 +1,15 @@
-libc.so.6:_IO_putc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
+libc.so.6:clearerr
 libc.so.6:exit
 libc.so.6:fileno
 libc.so.6:free
 libc.so.6:fwrite
 libc.so.6:malloc
 libc.so.6:memcmp
+libc.so.6:putc
 libc.so.6:puts
 libc.so.6:read
 libc.so.6:realloc

--- a/packages/x/xmlto/package.yml
+++ b/packages/x/xmlto/package.yml
@@ -1,17 +1,19 @@
 name       : xmlto
-version    : 0.0.28
-release    : 4
+version    : 0.0.29
+release    : 5
 source     :
-    - https://releases.pagure.org/xmlto/xmlto-0.0.28.tar.bz2 : 1130df3a7957eb9f6f0d29e4aa1c75732a7dfb6d639be013859b5c7ec5421276
+    - https://pagure.io/xmlto/archive/0.0.29/xmlto-0.0.29.tar.gz : 40504db68718385a4eaa9154a28f59e51e59d006d1aa14f5bc9d6fded1d6017a
+homepage   : https://pagure.io/xmlto
 license    : GPL-2.0-or-later
 component  : system.utils
 summary    : Convert XML to various formats
 builddeps  :
     - pkgconfig(libxslt)
+    - docbook-xml
 description: |
     xmlto converts XML files to various formats, and at the moment it supports conversion from docbook, xhtml1 and fo format to various output formats (awt, fo, htmlhelp, javahelp, mif, pdf, svg, xhtml, dvi, html, html-nochunks, man , pcl, ps, txt, xhtml-nochunks, epub).
 setup      : |
-    %configure
+    %reconfigure
 build      : |
     %make
 install    : |

--- a/packages/x/xmlto/pspec_x86_64.xml
+++ b/packages/x/xmlto/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>xmlto</Name>
+        <Homepage>https://pagure.io/xmlto</Homepage>
         <Packager>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">Convert XML to various formats</Summary>
         <Description xml:lang="en">xmlto converts XML files to various formats, and at the moment it supports conversion from docbook, xhtml1 and fo format to various output formats (awt, fo, htmlhelp, javahelp, mif, pdf, svg, xhtml, dvi, html, html-nochunks, man , pcl, ps, txt, xhtml-nochunks, epub).
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://solus-project.com/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>xmlto</Name>
@@ -61,12 +62,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2018-08-20</Date>
-            <Version>0.0.28</Version>
+        <Update release="5">
+            <Date>2024-06-30</Date>
+            <Version>0.0.29</Version>
             <Comment>Packaging update</Comment>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Rename variable BASH to XMLTO_BASH_PATH
- Regenerate xmlif to use new version of gcc
- Rename and format markdown files
- Skip validating xmlto man page during build

**Test Plan**
- Checked it installed.

**Checklist**

- [X] Package was built and tested against unstable

**Packaging notes**
- Changed to reconfigure macro as no makefile was found.
