### PR TITLE
python-wheel: Drop python 2 support

### DIFF
--- a/packages/py/python-wheel/package.yml
+++ b/packages/py/python-wheel/package.yml
@@ -1,6 +1,6 @@
 name       : python-wheel
 version    : 0.37.1
-release    : 19
+release    : 20
 source     :
     - https://github.com/pypa/wheel/archive/refs/tags/0.37.1.tar.gz : a82516a039e521100ecdef137f9e44249bf6903f9aff7d368e84ac31d60597f5
 homepage   : https://github.com/pypa/wheel
@@ -13,18 +13,16 @@ builddeps  :
     - pkgconfig(python3)
     - python-jsonschema
     - python-keyring
-    - python-pytest
-    - python-setuptools
     - pyxdg
+checkdeps  :
+    - python-pytest
 setup      : |
     # Don't require pytest-cov for tests
     sed -i 's/--cov//' setup.cfg
     sed -i 's/--cov-config=setup.cfg//' setup.cfg
 build      : |
-    %python_setup
     %python3_setup
 install    : |
-    %python_install
     %python3_install
 check      : |
     %python3_test py.test3

--- a/packages/py/python-wheel/pspec_x86_64.xml
+++ b/packages/py/python-wheel/pspec_x86_64.xml
@@ -9,57 +9,18 @@
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
         <Summary xml:lang="en">A built-package format for Python</Summary>
-        <Description xml:lang="en">A wheel is a ZIP-format archive with a specially formatted filename and the .whl extension. It is designed to contain all the files for a PEP 376 compatible install in a way that is very close to the on-disk format. Many packages will be properly installed with only the “Unpack” step (simply extracting the file onto sys.path), and the unpacked archive preserves enough information to “Spread” (copy data and scripts to their final locations) at any later time.
+        <Description xml:lang="en">A wheel is a ZIP-format archive with a specially formatted filename and the .whl extension. It is designed to contain all the files for a PEP 376 compatible install in a way that is very close to the on-disk format. Many packages will be properly installed with only the &#x201c;Unpack&#x201d; step (simply extracting the file onto sys.path), and the unpacked archive preserves enough information to &#x201c;Spread&#x201d; (copy data and scripts to their final locations) at any later time.
 </Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>python-wheel</Name>
         <Summary xml:lang="en">A built-package format for Python</Summary>
-        <Description xml:lang="en">A wheel is a ZIP-format archive with a specially formatted filename and the .whl extension. It is designed to contain all the files for a PEP 376 compatible install in a way that is very close to the on-disk format. Many packages will be properly installed with only the “Unpack” step (simply extracting the file onto sys.path), and the unpacked archive preserves enough information to “Spread” (copy data and scripts to their final locations) at any later time.
+        <Description xml:lang="en">A wheel is a ZIP-format archive with a specially formatted filename and the .whl extension. It is designed to contain all the files for a PEP 376 compatible install in a way that is very close to the on-disk format. Many packages will be properly installed with only the &#x201c;Unpack&#x201d; step (simply extracting the file onto sys.path), and the unpacked archive preserves enough information to &#x201c;Spread&#x201d; (copy data and scripts to their final locations) at any later time.
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/wheel</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel-0.37.1-py2.7.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel-0.37.1-py2.7.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel-0.37.1-py2.7.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel-0.37.1-py2.7.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel-0.37.1-py2.7.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel-0.37.1-py2.7.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel-0.37.1-py2.7.egg-info/top_level.txt</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/__init__.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/__main__.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/__main__.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/bdist_wheel.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/bdist_wheel.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/cli/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/cli/__init__.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/cli/convert.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/cli/convert.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/cli/pack.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/cli/pack.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/cli/unpack.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/cli/unpack.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/macosx_libfile.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/macosx_libfile.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/metadata.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/metadata.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/pkginfo.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/pkginfo.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/util.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/util.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/vendored/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/vendored/__init__.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/vendored/packaging/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/vendored/packaging/__init__.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/vendored/packaging/_typing.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/vendored/packaging/_typing.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/vendored/packaging/tags.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/vendored/packaging/tags.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/wheelfile.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/wheel/wheelfile.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel-0.37.1-py3.11.egg-info/PKG-INFO</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel-0.37.1-py3.11.egg-info/SOURCES.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel-0.37.1-py3.11.egg-info/dependency_links.txt</Path>
@@ -102,8 +63,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2024-02-27</Date>
+        <Update release="20">
+            <Date>2024-07-02</Date>
             <Version>0.37.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Joey Riches</Name>


### PR DESCRIPTION
**Summary**
- ruamel-yaml was the last pkg to require this

**Test Plan**

n/a

**Checklist**

- [x] Package was built and tested against unstable
