### PR TITLE
deluge: remove unneeded dependency

### DIFF
--- a/packages/d/deluge/package.yml
+++ b/packages/d/deluge/package.yml
@@ -1,6 +1,6 @@
 name       : deluge
 version    : 2.1.1
-release    : 24
+release    : 25
 source     :
     - https://ftp.osuosl.org/pub/deluge/source/2.1/deluge-2.1.1.tar.xz : 768dd319802e42437ab3794ebe75b497142e08ed5b0fb2503bad62cef442dff7
 homepage   : https://deluge-torrent.org/
@@ -10,19 +10,18 @@ summary    : A full-featured BitTorrent client
 description: |
     Deluge is a full-featured BitTorrent client written in Python and GTK.
 builddeps  :
-    - python-wheel
     - intltool
+    - python-wheel
 rundeps    :
     - libayatana-appindicator
     - librsvg
     - libtorrent-rasterbar
     - python-chardet
     - python-distro
-    - python-geoip
     - python-gobject
     - python-openssl
-    - python-rencode
     - python-pillow
+    - python-rencode
     - python-setproctitle
     - python-six
     - python-twisted

--- a/packages/d/deluge/pspec_x86_64.xml
+++ b/packages/d/deluge/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>deluge</Name>
         <Homepage>https://deluge-torrent.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.download</PartOf>
@@ -744,12 +744,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2024-02-15</Date>
+        <Update release="25">
+            <Date>2024-07-03</Date>
             <Version>2.1.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Removed python-geoip as run dependency
- Part of https://github.com/getsolus/packages/issues/3027

**Test Plan**
- Installed downloaded a torrent and checked peers, installed python-geoip and saw no difference.

**Checklist**

- [X] Package was built and tested against unstable
