### PR TITLE
python-txtorcon: update to 23.11.0

### DIFF
--- a/packages/py/python-txtorcon/package.yml
+++ b/packages/py/python-txtorcon/package.yml
@@ -1,21 +1,21 @@
 name       : python-txtorcon
-version    : 21.1.0
-release    : 7
+version    : 23.11.0
+release    : 8
 source     :
-    - https://github.com/meejah/txtorcon/archive/refs/tags/v21.1.0.tar.gz : 61ef40e110a2b52255a6033293d02647dedb63ed9311ce572571c777b2302750
+    - https://github.com/meejah/txtorcon/archive/refs/tags/v23.11.0.tar.gz : b8283bec83ab2de45949e154abeeb9216acd93cd60323002f340e2b783406688
+homepage   : https://github.com/meejah/txtorcon
 license    : MIT
 component  : programming.python
 summary    : A Twisted-based Python asynchronous controller library for Tor
 description: |
     A Twisted-based Python asynchronous controller library for Tor
-builddeps  :
-    - lsof # check
-    - python-mock # check
-    - python-pytest # check
-    - python-twisted # check
-    - python-zope.interface # check
+checkdeps  :
+    - lsof
+    - python-mock
+    - python-pytest
+    - python-twisted
+    - python-zope.interface
 rundeps    :
-    - python-geoip
     - python-twisted
 setup      : |
     %python3_setup

--- a/packages/py/python-txtorcon/pspec_x86_64.xml
+++ b/packages/py/python-txtorcon/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>python-txtorcon</Name>
+        <Homepage>https://github.com/meejah/txtorcon</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -21,11 +22,11 @@
         <Files>
             <Path fileType="library">/usr/lib/python3.11/site-packages/twisted/plugins/__pycache__/txtorcon_endpoint_parser.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/twisted/plugins/txtorcon_endpoint_parser.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/txtorcon-21.1.0-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/txtorcon-21.1.0-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/txtorcon-21.1.0-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/txtorcon-21.1.0-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/txtorcon-21.1.0-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/txtorcon-23.11.0-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/txtorcon-23.11.0-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/txtorcon-23.11.0-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/txtorcon-23.11.0-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/txtorcon-23.11.0-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/txtorcon/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/txtorcon/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/txtorcon/__pycache__/_metadata.cpython-311.pyc</Path>
@@ -136,12 +137,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2024-02-15</Date>
-            <Version>21.1.0</Version>
+        <Update release="8">
+            <Date>2024-07-04</Date>
+            <Version>23.11.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
 * Fix test-failures on Python 3.12
 * Particular GETINFO hanging (ultra-long lines over 16KiB caused problems in the protocol)
 * Use built-in `mock` only
 * Remove `incremental`

**Test Plan**
- Started magic-wormhole who is dependent on this and sent a file.

**Checklist**

- [X] Package was built and tested against unstable

**Packaging notes**
- Removed python-geoip as run dependency
- Part of https://github.com/getsolus/packages/issues/3027
