### PR TITLE
unsnap: Add at 2023.03.11

### DIFF
--- a/packages/u/unsnap/files/0001-Check-for-package-managers-not-distros.patch
+++ b/packages/u/unsnap/files/0001-Check-for-package-managers-not-distros.patch
@@ -1,0 +1,153 @@
+From b2e621c98bcb045396c6d40dd5c3e827044e522b Mon Sep 17 00:00:00 2001
+From: Lucas Burlingham <lucas@lucasburlingham.me>
+Date: Wed, 6 Apr 2022 07:39:45 -0400
+Subject: [PATCH 01/11] Check for package managers, not distros
+
+Rework unsnap to work based on package managers instead of distros.
+Supported package managers are apt, pacman, zypper, dnf, yum and eopkg.
+
+Co-authored-by: Silke Hofstra <silke@slxh.eu>
+---
+ unsnap | 80 +++++++++++++++++++++++++++++++++++++++++++++-------------
+ 1 file changed, 62 insertions(+), 18 deletions(-)
+
+diff --git a/unsnap b/unsnap
+index d15cdce..c7f2db3 100755
+--- a/unsnap
++++ b/unsnap
+@@ -30,7 +30,7 @@ function setup_environment() {
+     SHEBANG="#!/usr/bin/env bash"
+     RECOMMENDREBOOT="no"
+     REBOOTTEXT="WARNING: Please logout/in or reboot, to ensure applications appear in your desktop menu"
+-    DISTRO="unknown"
++    PACKAGEMGR="unknown"
+ }
+ 
+ function create_logdir() {
+@@ -99,17 +99,46 @@ function generate_flatpak_install_script() {
+     # to run script using sudo or root.
+     echo "INFO: Generating flatpak installer script in $INSTALLFLATPACKSCRIPT" | tee -a "$LOGFILE"
+     echo "$SHEBANG" > "$INSTALLFLATPACKSCRIPT"
+-    case $DISTRO in
+-        debian|ubuntu|linuxmint|pop|elementary|zorin)
++    echo "# Documentation: https://flatpak.org/setup/" >> "$INSTALLFLATPACKSCRIPT"
++    case $PACKAGEMGR in
++        apt)
+         cat <<EOT >> "$INSTALLFLATPACKSCRIPT"
+-# Documentation: https://flatpak.org/setup/
+ sudo apt update
+ sudo apt install -y flatpak
+ # sudo apt install gnome-software-plugin-flatpak
++EOT
++            ;;
++        pacman)
++        cat <<EOT >> "$INSTALLFLATPACKSCRIPT"
++sudo pacman -Syu
++sudo pacman -S flatpak
++EOT
++            ;;
++        zypper)
++        cat <<EOT >> "$INSTALLFLATPACKSCRIPT"
++sudo zypper refresh
++sudo zypper install flatpak
++EOT
++            ;;
++        dnf)
++        cat <<EOT >> "$INSTALLFLATPACKSCRIPT"
++sudo dnf update
++sudo dnf install flatpak
++EOT
++            ;;
++        yum)
++        cat <<EOT >> "$INSTALLFLATPACKSCRIPT"
++sudo yum update
++sudo yum install flatpak
++EOT
++            ;;
++        eopkg)
++        cat <<EOT >> "$INSTALLFLATPACKSCRIPT"
++sudo eopkg install flatpak
+ EOT
+             ;;
+         *)
+-            echo "ERROR: Unable to generate flatpak install script. Unimplemented distro." | tee -a "$LOGFILE"
++            echo "ERROR: Unable to generate flatpak install script. Unimplemented Package Manager." | tee -a "$LOGFILE"
+             exit 5
+     esac
+     RECOMMENDREBOOT="yes"
+@@ -186,12 +215,27 @@ function generate_remove_snapd_script() {
+     echo "INFO: Generating snapd removal script in $REMOVESNAPDSCRIPT" | tee -a "$LOGFILE"
+     echo "$SHEBANG" > "$REMOVESNAPDSCRIPT" 
+     echo "echo Removing snapd" >> "$REMOVESNAPDSCRIPT" 
+-    case $DISTRO in
+-        debian|ubuntu|linuxmint|pop|elementary|zorin)
++    case $PACKAGEMGR in
++        apt)
+             echo "sudo apt remove snapd" >> "$REMOVESNAPDSCRIPT"
+             ;;
++        pacman)
++            echo "sudo pacman -Rsn snapd" >> "$REMOVESNAPDSCRIPT"
++            ;;
++        zypper)
++            echo "sudo zypper remove snapd" >> "$REMOVESNAPDSCRIPT"
++            ;;
++        dnf)
++            echo "sudo dnf remove snapd" >> "$REMOVESNAPDSCRIPT"
++            ;;
++        yum)
++            echo "sudo yum remove snapd" >> "$REMOVESNAPDSCRIPT"
++            ;;
++        eopkg)
++            echo "sudo eopkg remove snapd" >> "$REMOVESNAPDSCRIPT"
++            ;;
+         *)
+-            echo "ERROR: Unable to generate snapd removal script. Unimplemented distro." | tee -a "$LOGFILE"
++            echo "ERROR: Unable to generate snapd removal script. Unimplemented package manager." | tee -a "$LOGFILE"
+     esac
+     chmod +x "$REMOVESNAPDSCRIPT"
+ }
+@@ -241,21 +285,20 @@ function check_for_flathub() {
+     fi
+ }
+ 
+-function determine_distro() {
+-    # Figure out what distro we're running on so we can use appropriate commands
++function determine_packagemanager() {
++    # Figure out what package manager is base to the current system on so we can use appropriate commands
+     # later for installing / removing snapd and installing flatpak
+-    # TODO: Add more distros
+-    CANDIDATE=$(grep -w ID /etc/os-release | awk -F "=" '{ print $2} ')
+-    case $CANDIDATE in
+-        debian|ubuntu|linuxmint|pop|elementary|zorin)
+-            DISTRO="$CANDIDATE"
++    PACKAGEMGR=$(command -v {apt,pacman,zypper,dnf,eopkg} | sed "s/.*\///")
++    case $PACKAGEMGR in
++        apt|pacman|zypper|dnf|yum|eopkg)
++            PACKAGEMGR="$PACKAGEMGR"
+             ;;
+         *)
+-            echo "ERROR: Running on unknown distro, '$CANDIDATE' aborting" | tee -a "$LOGFILE"
++            echo "ERROR: Could not determine appropriate package manager, '$PACKAGEMGR' aborting" | tee -a "$LOGFILE"
+             exit 2
+             ;;
+     esac
+-    echo "INFO: Detected $DISTRO" | tee -a "$LOGFILE"
++    echo "INFO: Detected $PACKAGEMGR as package manager" | tee -a "$LOGFILE"
+ }
+ 
+ function get_installed_snaps() {
+@@ -346,9 +389,10 @@ else
+     display_warnings
+     create_logdir
+ fi
+-determine_distro
++
+ check_for_snap # this should be universal, so we can check for the binary earlier for check_snap
+ check_for_flatpak # this should be universal check maybe, so it can be checked in "check_flatpak"
++determine_packagemanager
+ get_installed_snaps
+ generate_backup_script
+ generate_packages_install_script
+-- 
+2.45.2
+

--- a/packages/u/unsnap/files/0002-Add-color-to-output.patch
+++ b/packages/u/unsnap/files/0002-Add-color-to-output.patch
@@ -1,0 +1,320 @@
+From 2fa024e2d2592fb87f6070557c95ad68711a6537 Mon Sep 17 00:00:00 2001
+From: Lucas Burlingham <lucas@lucasburlingham.me>
+Date: Wed, 6 Apr 2022 07:40:21 -0400
+Subject: [PATCH 02/11] Add color to output
+
+---
+ unsnap | 115 +++++++++++++++++++++++++++++++--------------------------
+ 1 file changed, 63 insertions(+), 52 deletions(-)
+
+diff --git a/unsnap b/unsnap
+index c7f2db3..18ade18 100755
+--- a/unsnap
++++ b/unsnap
+@@ -3,8 +3,19 @@
+ # unsnap - a tool to migrate away from snaps
+ # shellcheck disable=SC2129
+ 
++# Define some ANSI colors
++RED='\033[0;31m'
++GREEN='\033[0;32m'
++YELLOW='\033[0;33m'
++BLUE='\033[0;34m'
++PURPLE='\033[0;35m'
++CYAN='\033[0;36m'
++WHITE='\033[0;37m'
++NC='\033[0m' # No Color
++
++
+ function display_warnings() {
+-    echo "WARNING! Care has been taken to ensure this script is safe."
++    echo -e "${YELLOW}WARNING:${NC} Care has been taken to ensure this script is safe."
+     echo "The generated scripts will remove applications and data."
+     echo "Please ensure you have backups in case you need to recover data."
+     echo "Also note significant disk space may be required to migrate,"
+@@ -29,7 +40,7 @@ function setup_environment() {
+     REMOVESNAPDSCRIPT="$LOGDIR/99-remove-snapd"
+     SHEBANG="#!/usr/bin/env bash"
+     RECOMMENDREBOOT="no"
+-    REBOOTTEXT="WARNING: Please logout/in or reboot, to ensure applications appear in your desktop menu"
++    REBOOTTEXT="${YELLOW}WARNING:${NC} Please logout/in or reboot, to ensure applications appear in your desktop menu"
+     PACKAGEMGR="unknown"
+ }
+ 
+@@ -78,16 +89,16 @@ function check_for_snap() {
+     # Check for the existence of a an executable snap binary.
+     # If snap doesn't exist or work, likelyhood is no snaps are installed either
+     # so we exit out.
+-    echo "INFO: Checking for snap binary"  | tee -a "$LOGFILE"
++    echo -e "${GREEN}INFO:${NC} Checking for snap binary"  | tee -a "$LOGFILE"
+     if [ -x "$(command -v snap)" ]; then
+-        echo "INFO: snap found" | tee -a "$LOGFILE"
++        echo -e "${GREEN}INFO:${NC} snap found" | tee -a "$LOGFILE"
+     else
+-        echo "ERROR: snapd doesn't appear to be installed, exiting." | tee -a "$LOGFILE"
++        echo -e "${RED}ERROR:${NC} snapd doesn't appear to be installed, exiting." | tee -a "$LOGFILE"
+         exit 1
+     fi
+-    echo "INFO: Check for any snaps installed" | tee -a "$LOGFILE"
++    echo -e "${GREEN}INFO:${NC} Check for any snaps installed" | tee -a "$LOGFILE"
+     if [ "$(snap list | wc -l)" == "0" ]; then 
+-        echo "ERROR: No snaps installed, nothing to do here!" | tee -a "$LOGFILE"
++        echo -e "${RED}ERROR:${NC} No snaps installed, nothing to do here!" | tee -a "$LOGFILE"
+         exit 6
+     fi
+ }
+@@ -97,7 +108,7 @@ function generate_flatpak_install_script() {
+     # As flatpak binary may not be installed (especially on Ubuntu and some derivatives)
+     # TODO: We assume use of sudo here, which we really shouldn't, but instead tell user
+     # to run script using sudo or root.
+-    echo "INFO: Generating flatpak installer script in $INSTALLFLATPACKSCRIPT" | tee -a "$LOGFILE"
++    echo -e "${GREEN}INFO:${NC} Generating flatpak installer script in $INSTALLFLATPACKSCRIPT" | tee -a "$LOGFILE"
+     echo "$SHEBANG" > "$INSTALLFLATPACKSCRIPT"
+     echo "# Documentation: https://flatpak.org/setup/" >> "$INSTALLFLATPACKSCRIPT"
+     case $PACKAGEMGR in
+@@ -138,7 +149,7 @@ sudo eopkg install flatpak
+ EOT
+             ;;
+         *)
+-            echo "ERROR: Unable to generate flatpak install script. Unimplemented Package Manager." | tee -a "$LOGFILE"
++            echo -e "${RED}ERROR:${NC} Unable to generate flatpak install script. Unimplemented Package Manager." | tee -a "$LOGFILE"
+             exit 5
+     esac
+     RECOMMENDREBOOT="yes"
+@@ -150,7 +161,7 @@ function generate_packages_install_script() {
+     # Generate shell script to install each flatpak in turn
+     # TODO: Should also wrap each install to detect if it fails, and stop to cope
+     # with error situations like disk full.
+-    echo "INFO: Generating flatpaks installer script in $INSTALLPACKAGESSCRIPT" | tee -a "$LOGFILE"
++    echo -e "${GREEN}INFO:${NC} Generating flatpaks installer script in $INSTALLPACKAGESSCRIPT" | tee -a "$LOGFILE"
+     echo "$SHEBANG" > "$INSTALLPACKAGESSCRIPT"
+     echo -n "for f in " >> "$INSTALLPACKAGESSCRIPT"
+     while IFS="" read -r p || [ -n "$p" ]
+@@ -158,7 +169,7 @@ function generate_packages_install_script() {
+         snap=$p
+         flatpak=$(grep "^$p" "$APPLIST" | awk -F ',' '{ print $2}')
+         if [ "$flatpak" == "" ]; then
+-            echo "WARNING: No equivalent flatpak for $snap found" | tee -a "$LOGFILE"
++            echo -e "${YELLOW}WARNING:${NC} No equivalent flatpak for $snap found" | tee -a "$LOGFILE"
+             echo "$snap" >> "$MISSINGFLATPAK"
+         else
+             echo -n "$flatpak " >> "$INSTALLPACKAGESSCRIPT"
+@@ -176,7 +187,7 @@ function generate_flathub_enablement_script() {
+     # the user hasn't already enabled it as (currently) all the applications we 
+     # install are from flathub - but this could change in the future.
+     # flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+-    echo "INFO: Generating flathub enablement script in $ENABLEFLATHUBSRIPT" | tee -a "$LOGFILE"
++    echo -e "${GREEN}INFO:${NC} Generating flathub enablement script in $ENABLEFLATHUBSRIPT" | tee -a "$LOGFILE"
+     echo "$SHEBANG" > "$ENABLEFLATHUBSRIPT" 
+     echo "sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo" >> "$ENABLEFLATHUBSRIPT"
+     chmod +x "$ENABLEFLATHUBSRIPT"
+@@ -184,7 +195,7 @@ function generate_flathub_enablement_script() {
+ 
+ function generate_remove_snaps_script() {
+     # Generate a shell script to remove each snap in turn.
+-    echo "INFO: Generating snap removal script in $REMOVESNAPSSCRIPT" | tee -a "$LOGFILE"
++    echo -e "${GREEN}INFO:${NC} Generating snap removal script in $REMOVESNAPSSCRIPT" | tee -a "$LOGFILE"
+     echo "$SHEBANG" > "$REMOVESNAPSSCRIPT" 
+     echo -n "for s in " >> "$REMOVESNAPSSCRIPT"
+     # Iterate through the filtered list of snaps (that is snaps which aren't excluded from matching)
+@@ -193,7 +204,7 @@ function generate_remove_snaps_script() {
+         snap=$(echo "$p" | awk -F ',' '{ print $1}')
+         # Check to make sure the snap isn't on the missing list.
+         if grep "$snap" "$MISSINGFLATPAK"; then
+-            echo "WARNING: $snap snap has no equivalent, not candidate for removing" | tee -a "$LOGFILE"
++            echo -e "${YELLOW}WARNING:${NC} $snap snap has no equivalent, not candidate for removing" | tee -a "$LOGFILE"
+         else
+             echo -n "$snap " >> "$REMOVESNAPSSCRIPT"
+         fi
+@@ -212,7 +223,7 @@ function generate_remove_snapd_script() {
+     # Note that currently we assume sudo, but for some distros, that won't work
+     # so we might be better off removing all references to sudo, and inform the user
+     # to run the script as "root user or sudo as appropriate".
+-    echo "INFO: Generating snapd removal script in $REMOVESNAPDSCRIPT" | tee -a "$LOGFILE"
++    echo -e "${GREEN}INFO:${NC} Generating snapd removal script in $REMOVESNAPDSCRIPT" | tee -a "$LOGFILE"
+     echo "$SHEBANG" > "$REMOVESNAPDSCRIPT" 
+     echo "echo Removing snapd" >> "$REMOVESNAPDSCRIPT" 
+     case $PACKAGEMGR in
+@@ -235,7 +246,7 @@ function generate_remove_snapd_script() {
+             echo "sudo eopkg remove snapd" >> "$REMOVESNAPDSCRIPT"
+             ;;
+         *)
+-            echo "ERROR: Unable to generate snapd removal script. Unimplemented package manager." | tee -a "$LOGFILE"
++            echo -e "${RED}ERROR:${NC} Unable to generate snapd removal script. Unimplemented package manager." | tee -a "$LOGFILE"
+     esac
+     chmod +x "$REMOVESNAPDSCRIPT"
+ }
+@@ -246,7 +257,7 @@ function generate_backup_script() {
+     # might run the 'remove snapd' script, which will nuke all their snaps, not just migrated
+     # ones.
+     # Not all snaps store data in their own directory - classic snaps being a good culprit
+-    echo "INFO: Generating snap backup script in $BACKUPSCRIPT"  | tee -a "$LOGFILE"
++    echo -e "${GREEN}INFO:${NC} Generating snap backup script in $BACKUPSCRIPT"  | tee -a "$LOGFILE"
+     echo "$SHEBANG" > "$BACKUPSCRIPT" 
+     echo "# Documentation: https://snapcraft.io/docs/snapshots" >> "$BACKUPSCRIPT"
+     echo -n "sudo snap save " >> "$BACKUPSCRIPT"
+@@ -262,12 +273,12 @@ function generate_backup_script() {
+ function check_for_flatpak() {
+     # Check if the flatpak binary exists, and if it doesn't call 
+     # function to generate a script to install flatpak
+-    echo "INFO: Checking for flatpak binary" | tee -a "$LOGFILE"
++    echo -e "${GREEN}INFO:${NC} Checking for flatpak binary" | tee -a "$LOGFILE"
+     if [ -x "$(command -v flatpak)" ]; then
+-        echo "INFO: flatpak found no need to generate flatpak install script" | tee -a "$LOGFILE"
++        echo -e "${GREEN}INFO:${NC} flatpak found no need to generate flatpak install script" | tee -a "$LOGFILE"
+         check_for_flathub
+     else
+-        echo "INFO: flatpak doesn't appear to be installed, adding installer script and enabling flathub" | tee -a "$LOGFILE"
++        echo -e "${GREEN}INFO:${NC} flatpak doesn't appear to be installed, adding installer script and enabling flathub" | tee -a "$LOGFILE"
+         generate_flatpak_install_script
+         generate_flathub_enablement_script
+     fi
+@@ -276,11 +287,11 @@ function check_for_flatpak() {
+ function check_for_flathub() {
+     # Check if flathub is a configured remote and if not, call function to 
+     # generate a script which enables it.
+-    echo "INFO: Checking for flathub remote" | tee -a "$LOGFILE"
++    echo -e "${GREEN}INFO:${NC} Checking for flathub remote" | tee -a "$LOGFILE"
+     if flatpak remotes | grep flathub > /dev/null; then
+-        echo "INFO: flathub already enabled" |  tee -a "$LOGFILE"
++        echo -e "${GREEN}INFO:${NC} flathub already enabled" |  tee -a "$LOGFILE"
+     else
+-        echo "INFO: flathub doesn't appear to be enabled" |  tee -a "$LOGFILE"
++        echo -e "${GREEN}INFO:${NC} flathub doesn't appear to be enabled" |  tee -a "$LOGFILE"
+         generate_flathub_enablement_script
+     fi
+ }
+@@ -294,20 +305,20 @@ function determine_packagemanager() {
+             PACKAGEMGR="$PACKAGEMGR"
+             ;;
+         *)
+-            echo "ERROR: Could not determine appropriate package manager, '$PACKAGEMGR' aborting" | tee -a "$LOGFILE"
++            echo -e "${RED}ERROR:${NC} Could not determine appropriate package manager, '$PACKAGEMGR' aborting" | tee -a "$LOGFILE"
+             exit 2
+             ;;
+     esac
+-    echo "INFO: Detected $PACKAGEMGR as package manager" | tee -a "$LOGFILE"
++    echo -e "${GREEN}INFO:${NC} Detected $PACKAGEMGR as package manager" | tee -a "$LOGFILE"
+ }
+ 
+ function get_installed_snaps() {
+     # Get list of currently installed snaps on this machine
+     # Then filter out excluded snaps, for which we know there is no
+     # equivalent in flathub (such as platform / theme snaps)
+-    echo "INFO! Getting list of installed snaps to $INSTALLEDSNAPLIST" | tee -a "$LOGFILE"
++    echo -e "${GREEN}INFO:${NC} Getting list of installed snaps to $INSTALLEDSNAPLIST" | tee -a "$LOGFILE"
+     snap list | tail -n +2 | awk -F " " '{ print $1 }' > "$INSTALLEDSNAPLIST"
+-    echo "INFO! Trimming list of installed snaps to $FILTEREDSNAPLIST" | tee -a "$LOGFILE"
++    echo -e "${GREEN}INFO:${NC} Trimming list of installed snaps to $FILTEREDSNAPLIST" | tee -a "$LOGFILE"
+     grep -v -f "$EXCLUDEDSNAPLIST" "$INSTALLEDSNAPLIST" > "$FILTEREDSNAPLIST"
+ }
+ 
+@@ -318,72 +329,72 @@ function cleanup() {
+ 
+ function run_scripts() {
+     # Run the actual scripts one by one, stopping on error
+-    echo "INFO: Running backup" | tee -a "$LOGFILE"
++    echo -e "${GREEN}INFO:${NC} Running backup" | tee -a "$LOGFILE"
+     if "$BACKUPSCRIPT"; then
+-        echo "INFO: Backup finished" | tee -a "$LOGFILE"
++        echo -e "${GREEN}INFO:${NC} Backup finished" | tee -a "$LOGFILE"
+     else
+-        echo "ERROR: Backup failed" | tee -a "$LOGFILE"
++        echo -e "${RED}ERROR:${NC} Backup failed" | tee -a "$LOGFILE"
+         exit 10
+     fi
+     if test -f "$INSTALLFLATPACKSCRIPT"; then
+-        echo "INFO: Installing flatpak" | tee -a "$LOGFILE"
++        echo -e "${GREEN}INFO:${NC} Installing flatpak" | tee -a "$LOGFILE"
+         if "$INSTALLFLATPACKSCRIPT"; then
+-            echo "INFO: Installing flatpak finished" | tee -a "$LOGFILE"
++            echo -e "${GREEN}INFO:${NC} Installing flatpak finished" | tee -a "$LOGFILE"
+         else
+-            echo "ERROR: Install flatpak failed" | tee -a "$LOGFILE"
++            echo -e "${RED}ERROR:${NC} Install flatpak failed" | tee -a "$LOGFILE"
+             exit 11
+         fi
+     else
+-        echo "INFO: Skipping installing flatpak, already installed" | tee -a "$LOGFILE"
++        echo -e "${GREEN}INFO:${NC} Skipping installing flatpak, already installed" | tee -a "$LOGFILE"
+     fi
+     if test -f "$ENABLEFLATHUBSRIPT"; then
+-        echo "INFO: Enabling flathub" | tee -a "$LOGFILE"
++        echo -e "${GREEN}INFO:${NC} Enabling flathub" | tee -a "$LOGFILE"
+         if "$ENABLEFLATHUBSRIPT"; then
+-            echo "INFO: Flathub enabled" | tee -a "$LOGFILE"
++            echo -e "${GREEN}INFO:${NC} Flathub enabled" | tee -a "$LOGFILE"
+         else
+-            echo "ERROR: Enabling flathub failed" | tee -a "$LOGFILE"
++            echo -e "${RED}ERROR:${NC} Enabling flathub failed" | tee -a "$LOGFILE"
+             exit 12
+         fi
+     else
+-        echo "INFO: Skipping enabling flathub, already enabled" | tee -a "$LOGFILE"
++        echo -e "${GREEN}INFO:${NC} Skipping enabling flathub, already enabled" | tee -a "$LOGFILE"
+     fi
+-    echo "INFO: Installing flatpak packages" | tee -a "$LOGFILE"
++    echo -e "${GREEN}INFO:${NC} Installing flatpak packages" | tee -a "$LOGFILE"
+     if "$INSTALLPACKAGESSCRIPT"; then
+-        echo "INFO: flatpaks installed" | tee -a "$LOGFILE"
+-        echo "INFO: These flatpaks are now installed:" | tee -a "$LOGFILE"
++        echo -e "${GREEN}INFO:${NC} flatpaks installed" | tee -a "$LOGFILE"
++        echo -e "${GREEN}INFO:${NC} These flatpaks are now installed:" | tee -a "$LOGFILE"
+         flatpak list | tee -a "$LOGFILE"
+     else
+-        echo "ERROR: Failed to install flatpaks" | tee -a "$LOGFILE"
++        echo -e "${RED}ERROR:${NC} Failed to install flatpaks" | tee -a "$LOGFILE"
+         exit 13
+     fi
+-    echo "INFO: Removing snaps" | tee -a "$LOGFILE"
++    echo -e "${GREEN}INFO:${NC} Removing snaps" | tee -a "$LOGFILE"
+     if "$REMOVESNAPSSCRIPT"; then
+-        echo "INFO: Snaps removed" | tee -a "$LOGFILE"
+-        echo "WARNING: These snaps are still installed:" | tee -a "$LOGFILE"
++        echo -e "${GREEN}INFO:${NC} Snaps removed" | tee -a "$LOGFILE"
++        echo -e "${YELLOW}WARNING:${NC} These snaps are still installed:" | tee -a "$LOGFILE"
+         snap list | tee -a "$LOGFILE"
+     else
+-        echo "ERROR: Failed to remove snaps" | tee -a "$LOGFILE"
++        echo -e "${RED}ERROR:${NC} Failed to remove snaps" | tee -a "$LOGFILE"
+         exit 14
+     fi
+-    # echo "INFO: Removing snapd daemon" | tee -a "$LOGFILE"
++    # echo -e "${GREEN}INFO:${NC} Removing snapd daemon" | tee -a "$LOGFILE"
+     # if "$REMOVESNAPDSCRIPT"; then
+-    #     echo "INFO: snapd removed" | tee -a "$LOGFILE"
++    #     echo -e "${GREEN}INFO:${NC} snapd removed" | tee -a "$LOGFILE"
+     # else
+-    #     echo "ERROR: Failed to remove snapd" | tee -a "$LOGFILE"
++    #     echo -e "${RED}ERROR:${NC} Failed to remove snapd" | tee -a "$LOGFILE"
+     #     exit 15
+     # fi
+ }
+ 
+ function recommend_reboot() {
+     if [ "$RECOMMENDREBOOT" == "yes" ]; then
+-        echo "$REBOOTTEXT" | tee -a "$LOGFILE"
++        echo -e "$REBOOTTEXT" | tee -a "$LOGFILE"
+     fi
+ }
+ 
+ setup_environment
+ if [ "$1" == "check" ]; then
+     create_logdir
+-    echo "INFO: Check requested" | tee -a "$LOGFILE"
++    echo -e "${GREEN}INFO:${NC} Check requested" | tee -a "$LOGFILE"
+     check_applist
+ else
+     display_warnings
+@@ -400,7 +411,7 @@ generate_remove_snaps_script
+ generate_remove_snapd_script
+ cleanup
+ if [ "$1" == "auto" ]; then
+-    echo "INFO: Auto requested" | tee -a "$LOGFILE"
++    echo -e "${GREEN}INFO:${NC} Auto requested" | tee -a "$LOGFILE"
+     run_scripts
+     recommend_reboot
+ fi
+-- 
+2.45.2
+

--- a/packages/u/unsnap/files/0003-Remove-mentions-of-supporting-specific-distros.patch
+++ b/packages/u/unsnap/files/0003-Remove-mentions-of-supporting-specific-distros.patch
@@ -1,0 +1,25 @@
+From 57cfc26feab804fdbe84ca0017455b63ba1cff9b Mon Sep 17 00:00:00 2001
+From: Lucas Burlingham <lucas@lucasburlingham.me>
+Date: Wed, 6 Apr 2022 09:58:32 -0400
+Subject: [PATCH 03/11] Remove mentions of supporting specific distros
+
+---
+ README.md | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/README.md b/README.md
+index 958816b..7ae6245 100644
+--- a/README.md
++++ b/README.md
+@@ -92,8 +92,6 @@ The purpose of [excluded_snaps.txt](excluded_snaps.txt) is **not** to list packa
+ 
+ I knocked this prototype up over the weekend, but it's far from complete. Here're some features that aren't yet complete. Contributions welcome!
+ 
+-* Support distributions other than Ubuntu
+-  * According to [snapcraft core18 store page](https://snapcraft.io/core18) (which I have no reason to disbelieve), the following distros are most popular in terms of snaps installed: Manjaro, Linux Mint, Zorin, Debian, Fedora, Pop_OS!, KDE Neon, Raspbian, Centos, elementary OS.
+ * Update `applist.csv` to be a more complete list of migratable applications
+   * Consider [submitting](https://github.com/popey/unsnap/issues/new?assignees=&labels=&template=missing-flatpak-report.md&title=) the `missingflatpak.txt` report from running `unsnap` here
+ * Update `excluded_snaps.txt` to contain further examples of non-migratable applications
+-- 
+2.45.2
+

--- a/packages/u/unsnap/files/0004-Remove-snapd-when-there-are-no-missing-snaps.patch
+++ b/packages/u/unsnap/files/0004-Remove-snapd-when-there-are-no-missing-snaps.patch
@@ -1,0 +1,43 @@
+From 66bb99ebed411902a50c4d648651a95d676c866b Mon Sep 17 00:00:00 2001
+From: Silke Hofstra <silke@slxh.eu>
+Date: Wed, 3 Jul 2024 15:20:16 +0200
+Subject: [PATCH 04/11] Remove snapd when there are no missing snaps
+
+---
+ unsnap | 20 +++++++++++++-------
+ 1 file changed, 13 insertions(+), 7 deletions(-)
+
+diff --git a/unsnap b/unsnap
+index 18ade18..c1d666a 100755
+--- a/unsnap
++++ b/unsnap
+@@ -376,13 +376,19 @@ function run_scripts() {
+         echo -e "${RED}ERROR:${NC} Failed to remove snaps" | tee -a "$LOGFILE"
+         exit 14
+     fi
+-    # echo -e "${GREEN}INFO:${NC} Removing snapd daemon" | tee -a "$LOGFILE"
+-    # if "$REMOVESNAPDSCRIPT"; then
+-    #     echo -e "${GREEN}INFO:${NC} snapd removed" | tee -a "$LOGFILE"
+-    # else
+-    #     echo -e "${RED}ERROR:${NC} Failed to remove snapd" | tee -a "$LOGFILE"
+-    #     exit 15
+-    # fi
++
++    if [ -e "$MISSINGFLATPAK" ]; then
++        echo -e "${YELLOW}WARNING:${NC} the following snaps have no known alternative, will not remove snapd"
++        cat "$MISSINGFLATPAK"
++    else
++        echo -e "${GREEN}INFO:${NC} Removing snapd daemon" | tee -a "$LOGFILE"
++        if "$REMOVESNAPDSCRIPT"; then
++            echo -e "${GREEN}INFO:${NC} snapd removed" | tee -a "$LOGFILE"
++        else
++            echo -e "${RED}ERROR:${NC} Failed to remove snapd" | tee -a "$LOGFILE"
++            exit 15
++        fi
++    fi
+ }
+ 
+ function recommend_reboot() {
+-- 
+2.45.2
+

--- a/packages/u/unsnap/files/0005-Add-gnome-42-2204-to-excluded-snaps.patch
+++ b/packages/u/unsnap/files/0005-Add-gnome-42-2204-to-excluded-snaps.patch
@@ -1,0 +1,24 @@
+From 89aec1e6fac61eea8f1d4efbbe12759f77521464 Mon Sep 17 00:00:00 2001
+From: Silke Hofstra <silke@slxh.eu>
+Date: Wed, 3 Jul 2024 15:20:27 +0200
+Subject: [PATCH 05/11] Add gnome-42-2204 to excluded snaps
+
+---
+ excluded_snaps.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/excluded_snaps.txt b/excluded_snaps.txt
+index 7add089..c8f7fa4 100644
+--- a/excluded_snaps.txt
++++ b/excluded_snaps.txt
+@@ -7,6 +7,7 @@ core22
+ gnome-3-28-1804
+ gnome-3-34-1804
+ gnome-3-38-2004
++gnome-42-2204
+ godot-runtime
+ gtk-common-themes
+ gtk2-common-themes
+-- 
+2.45.2
+

--- a/packages/u/unsnap/files/0006-Load-lists-from-usr-share-unsnap.patch
+++ b/packages/u/unsnap/files/0006-Load-lists-from-usr-share-unsnap.patch
@@ -1,0 +1,27 @@
+From 97457d80e491dc28ab6f0a797f55c035645f3e66 Mon Sep 17 00:00:00 2001
+From: Silke Hofstra <silke@slxh.eu>
+Date: Wed, 3 Jul 2024 16:30:12 +0200
+Subject: [PATCH 06/11] Load lists from /usr/share/unsnap
+
+---
+ unsnap | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/unsnap b/unsnap
+index c1d666a..c776ca1 100755
+--- a/unsnap
++++ b/unsnap
+@@ -30,8 +30,8 @@ function setup_environment() {
+     INSTALLEDSNAPLIST="$LOGDIR/allsnaps.txt"
+     FILTEREDSNAPLIST="$LOGDIR/filteredsnaps.txt"
+     MISSINGFLATPAK="$LOGDIR/missingflatpak.txt"
+-    APPLIST="./applist.csv"
+-    EXCLUDEDSNAPLIST="./excluded_snaps.txt"
++    APPLIST="/usr/share/unsnap/applist.csv"
++    EXCLUDEDSNAPLIST="/usr/share/unsnap/excluded_snaps.txt"
+     BACKUPSCRIPT="$LOGDIR/00-backup"
+     INSTALLFLATPACKSCRIPT="$LOGDIR/01-install-flatpak"
+     ENABLEFLATHUBSRIPT="$LOGDIR/02-enable-flathub"
+-- 
+2.45.2
+

--- a/packages/u/unsnap/files/0007-Fix-grep-errors-when-MISSINGFLATPAK-is-empty.patch
+++ b/packages/u/unsnap/files/0007-Fix-grep-errors-when-MISSINGFLATPAK-is-empty.patch
@@ -1,0 +1,25 @@
+From b6a1072c5e039bbd7f8f88af9acbd4bba6560957 Mon Sep 17 00:00:00 2001
+From: Silke Hofstra <silke@slxh.eu>
+Date: Wed, 3 Jul 2024 17:36:41 +0200
+Subject: [PATCH 07/11] Fix grep errors when MISSINGFLATPAK is empty
+
+---
+ unsnap | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/unsnap b/unsnap
+index c776ca1..b1431f6 100755
+--- a/unsnap
++++ b/unsnap
+@@ -203,7 +203,7 @@ function generate_remove_snaps_script() {
+     do
+         snap=$(echo "$p" | awk -F ',' '{ print $1}')
+         # Check to make sure the snap isn't on the missing list.
+-        if grep "$snap" "$MISSINGFLATPAK"; then
++        if [ -e "$MISSINGFLATPAK" ] && grep -q "$snap" "$MISSINGFLATPAK"; then
+             echo -e "${YELLOW}WARNING:${NC} $snap snap has no equivalent, not candidate for removing" | tee -a "$LOGFILE"
+         else
+             echo -n "$snap " >> "$REMOVESNAPSSCRIPT"
+-- 
+2.45.2
+

--- a/packages/u/unsnap/files/0008-Disable-systemd-units-on-snapd-removal.patch
+++ b/packages/u/unsnap/files/0008-Disable-systemd-units-on-snapd-removal.patch
@@ -1,0 +1,40 @@
+From 3350f4d3bc1abdd6fd6dc03e96094eb6d0c4c641 Mon Sep 17 00:00:00 2001
+From: Silke Hofstra <silke@slxh.eu>
+Date: Wed, 3 Jul 2024 17:36:56 +0200
+Subject: [PATCH 08/11] Disable systemd units on snapd removal
+
+---
+ unsnap | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/unsnap b/unsnap
+index b1431f6..4315d3d 100755
+--- a/unsnap
++++ b/unsnap
+@@ -224,7 +224,8 @@ function generate_remove_snapd_script() {
+     # so we might be better off removing all references to sudo, and inform the user
+     # to run the script as "root user or sudo as appropriate".
+     echo -e "${GREEN}INFO:${NC} Generating snapd removal script in $REMOVESNAPDSCRIPT" | tee -a "$LOGFILE"
+-    echo "$SHEBANG" > "$REMOVESNAPDSCRIPT" 
++    echo "$SHEBANG" > "$REMOVESNAPDSCRIPT"
++
+     echo "echo Removing snapd" >> "$REMOVESNAPDSCRIPT" 
+     case $PACKAGEMGR in
+         apt)
+@@ -248,6 +249,13 @@ function generate_remove_snapd_script() {
+         *)
+             echo -e "${RED}ERROR:${NC} Unable to generate snapd removal script. Unimplemented package manager." | tee -a "$LOGFILE"
+     esac
++
++    echo "echo Disabling all systemd units" >> "$REMOVESNAPDSCRIPT"
++    for unit in snapd.{socket,service} snapd.apparmor.service /etc/systemd/system/snap-*.mount
++    do
++        echo "sudo systemctl disable --now $(basename "${unit//\\/\\\\}")" >> "$REMOVESNAPDSCRIPT"
++    done
++
+     chmod +x "$REMOVESNAPDSCRIPT"
+ }
+ 
+-- 
+2.45.2
+

--- a/packages/u/unsnap/files/0009-Log-to-var-log.patch
+++ b/packages/u/unsnap/files/0009-Log-to-var-log.patch
@@ -1,0 +1,34 @@
+From 57a529d4c24bd23c25be14c8f2de3c6245ab2389 Mon Sep 17 00:00:00 2001
+From: Silke Hofstra <silke@slxh.eu>
+Date: Wed, 3 Jul 2024 18:06:41 +0200
+Subject: [PATCH 09/11] Log to /var/log
+
+---
+ unsnap | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/unsnap b/unsnap
+index 4315d3d..6ad515a 100755
+--- a/unsnap
++++ b/unsnap
+@@ -25,7 +25,7 @@ function display_warnings() {
+ 
+ function setup_environment() {
+     DATETIMESTAMP=$(date +%Y-%m-%d.%H.%M.%S)
+-    LOGDIR="./log-$DATETIMESTAMP"
++    LOGDIR="/var/log/unsnap/$DATETIMESTAMP"
+     LOGFILE="$LOGDIR/unsnap.log"
+     INSTALLEDSNAPLIST="$LOGDIR/allsnaps.txt"
+     FILTEREDSNAPLIST="$LOGDIR/filteredsnaps.txt"
+@@ -45,7 +45,7 @@ function setup_environment() {
+ }
+ 
+ function create_logdir() {
+-    mkdir "$LOGDIR"
++    mkdir -p "$LOGDIR"
+ }
+ 
+ function audit_snap() {
+-- 
+2.45.2
+

--- a/packages/u/unsnap/files/0010-Add-unwrapped-snap-to-PATH.patch
+++ b/packages/u/unsnap/files/0010-Add-unwrapped-snap-to-PATH.patch
@@ -1,0 +1,25 @@
+From ddf6882e2e2b26d28861ef20dcc8dcff6d97bbd8 Mon Sep 17 00:00:00 2001
+From: Silke Hofstra <silke@slxh.eu>
+Date: Wed, 10 Jul 2024 16:24:54 +0200
+Subject: [PATCH 10/11] Add unwrapped snap to PATH
+
+---
+ unsnap | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/unsnap b/unsnap
+index 6ad515a..d4a4d6b 100755
+--- a/unsnap
++++ b/unsnap
+@@ -13,6 +13,8 @@ CYAN='\033[0;36m'
+ WHITE='\033[0;37m'
+ NC='\033[0m' # No Color
+ 
++# Add unwrapped snap to PATH.
++export PATH="/usr/lib64/snapd:${PATH}"
+ 
+ function display_warnings() {
+     echo -e "${YELLOW}WARNING:${NC} Care has been taken to ensure this script is safe."
+-- 
+2.45.2
+

--- a/packages/u/unsnap/files/0011-Extend-usage-info-when-running-without-arguments.patch
+++ b/packages/u/unsnap/files/0011-Extend-usage-info-when-running-without-arguments.patch
@@ -1,0 +1,28 @@
+From e522db6b2d425e661ff7b4fb88aa7cc4e212995a Mon Sep 17 00:00:00 2001
+From: Silke Hofstra <silke@slxh.eu>
+Date: Thu, 11 Jul 2024 21:33:56 +0200
+Subject: [PATCH 11/11] Extend usage info when running without arguments
+
+---
+ unsnap | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/unsnap b/unsnap
+index d4a4d6b..330e12e 100755
+--- a/unsnap
++++ b/unsnap
+@@ -413,6 +413,11 @@ if [ "$1" == "check" ]; then
+     echo -e "${GREEN}INFO:${NC} Check requested" | tee -a "$LOGFILE"
+     check_applist
+ else
++    if [ $# -eq 0 ]; then
++        echo -e "${GREEN}INFO:${NC} running \`unsnap\` without arguments generates removal scripts in $LOGDIR"
++        echo -e "Run \`unsnap auto\` to automatically execute those scripts afterwards."
++        echo -e "See https://help.getsol.us/docs/user/software/third-party/snap for more information.\n"
++    fi
+     display_warnings
+     create_logdir
+ fi
+-- 
+2.45.2
+

--- a/packages/u/unsnap/files/series
+++ b/packages/u/unsnap/files/series
@@ -1,0 +1,11 @@
+0001-Check-for-package-managers-not-distros.patch
+0002-Add-color-to-output.patch
+0003-Remove-mentions-of-supporting-specific-distros.patch
+0004-Remove-snapd-when-there-are-no-missing-snaps.patch
+0005-Add-gnome-42-2204-to-excluded-snaps.patch
+0006-Load-lists-from-usr-share-unsnap.patch
+0007-Fix-grep-errors-when-MISSINGFLATPAK-is-empty.patch
+0008-Disable-systemd-units-on-snapd-removal.patch
+0009-Log-to-var-log.patch
+0010-Add-unwrapped-snap-to-PATH.patch
+0011-Extend-usage-info-when-running-without-arguments.patch

--- a/packages/u/unsnap/package.yml
+++ b/packages/u/unsnap/package.yml
@@ -1,0 +1,16 @@
+name       : unsnap
+version    : 2023.03.11
+release    : 1
+source     :
+    - git|https://github.com/popey/unsnap.git : d86736cdeedfb423f17b05846385bf0f785b7723
+homepage   : https://github.com/popey/unsnap
+license    : MIT
+component  : desktop
+summary    : Quickly migrate from using snap packages to flatpaks
+description: |
+    Quickly and easily migrate from using snap for applications to flatpak.
+setup      : |
+    %apply_patches
+install    : |
+    install -Dm0755 -t $installdir/usr/bin/ unsnap
+    install -Dm0644 -t $installdir/usr/share/unsnap/ applist.csv excluded_snaps.txt

--- a/packages/u/unsnap/pspec_x86_64.xml
+++ b/packages/u/unsnap/pspec_x86_64.xml
@@ -1,0 +1,37 @@
+<PISI>
+    <Source>
+        <Name>unsnap</Name>
+        <Homepage>https://github.com/popey/unsnap</Homepage>
+        <Packager>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
+        </Packager>
+        <License>MIT</License>
+        <PartOf>desktop</PartOf>
+        <Summary xml:lang="en">Quickly migrate from using snap packages to flatpaks</Summary>
+        <Description xml:lang="en">Quickly and easily migrate from using snap for applications to flatpak.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>unsnap</Name>
+        <Summary xml:lang="en">Quickly migrate from using snap packages to flatpaks</Summary>
+        <Description xml:lang="en">Quickly and easily migrate from using snap for applications to flatpak.
+</Description>
+        <PartOf>desktop</PartOf>
+        <Files>
+            <Path fileType="executable">/usr/bin/unsnap</Path>
+            <Path fileType="data">/usr/share/unsnap/applist.csv</Path>
+            <Path fileType="data">/usr/share/unsnap/excluded_snaps.txt</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2024-07-10</Date>
+            <Version>2023.03.11</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**

Initial inclusion of `unsnap` at the last upstream commit. It includes a patchset that adds support for `eopkg`.

Resolves #323

**Test Plan**

Run `sudo unsnap auto` to automatically migrate snaps to flatpak.

**Checklist**

- [x] Package was built and tested against unstable
