### PR TITLE
snapd: Add confinement warning

### DIFF
--- a/packages/s/snapd/files/wrapper.sh
+++ b/packages/s/snapd/files/wrapper.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+YELLOW='\033[0;33m'
+NC='\033[0m'
+URL="https://help.getsol.us/docs/user/software/third-party/snap"
+SNAP="/usr/lib64/snapd/snap"
+CONFIG="/var/lib/snapd/solus"
+CONFINEMENT="$("${SNAP}" debug confinement 2>/dev/null)"
+
+if [[ -e "${CONFIG}" ]]
+then
+  # shellcheck disable=SC1090
+  . "${CONFIG}"
+fi
+
+if [[ "$#" -ge 1 ]] && [[ "$1" == "hide-confinement-warning" ]]
+then
+  echo "This will disable warnings when snap is running without strict confinement."
+  read -rp "Are you sure you want to do this [yN]? " choice
+  if [[ "${choice}" = "y" ]]
+  then
+    echo "DISABLE_CONFINEMENT_WARNING=y" >> "${CONFIG}"
+    echo "Confinement warnings disabled."
+  fi
+
+  exit 0
+fi
+
+if [[ "${CONFINEMENT}" != "strict" ]] && [[ "${DISABLE_CONFINEMENT_WARNING:-n}" != "y" ]]
+  then
+  if [[ -n "${BAMF_DESKTOP_FILE_HINT+x}" ]] && [[ -n "${GIO_LAUNCHED_DESKTOP_FILE+x}" ]]
+  then
+      notify-send \
+          --app-name Snap \
+          --urgency normal \
+          --icon dialog-warning \
+          "Snap has ${CONFINEMENT} confinement" \
+          "See ${URL} for details."
+  else
+      echo -e "${YELLOW}WARNING:${NC} snap is running with ${CONFINEMENT} confinement." \
+        "See ${URL} for details"
+  fi
+fi
+
+exec -a "$0" "${SNAP}" "$@"

--- a/packages/s/snapd/package.yml
+++ b/packages/s/snapd/package.yml
@@ -1,7 +1,7 @@
 name       : snapd
 version    : 2.63
 homepage   : https://snapcraft.io/
-release    : 81
+release    : 82
 source     :
     - https://github.com/snapcore/snapd/releases/download/2.63/snapd_2.63.vendor.tar.xz : 2f0083d2c4e087c29f48cd1abb8a92eb2e63cf04cd433256c86fac05d0b28cab
 license    : GPL-3.0-only
@@ -66,7 +66,8 @@ install    : |
 
     # Golang binaries
     for snap_bin in ${bincommands[@]} ; do
-        install -m00755 bin/$snap_bin $installdir/usr/bin/.
+        install -m00755 $pkgfiles/wrapper.sh $installdir/usr/bin/$snap_bin
+        install -m00755 bin/$snap_bin $installdir/%libdir%/$package/.
     done
     for snap_lib in ${dcommands[@]} ; do
         install -m00755 bin/$snap_lib $installdir/%libdir%/$package/.

--- a/packages/s/snapd/pspec_x86_64.xml
+++ b/packages/s/snapd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>snapd</Name>
         <Homepage>https://snapcraft.io/</Homepage>
         <Packager>
-            <Name>Zygmunt Krynicki</Name>
-            <Email>me@zygoon.pl</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <PartOf>desktop</PartOf>
@@ -31,6 +31,7 @@
             <Path fileType="library">/usr/lib64/snapd/complete.sh</Path>
             <Path fileType="library">/usr/lib64/snapd/etelpmoc.sh</Path>
             <Path fileType="library">/usr/lib64/snapd/info</Path>
+            <Path fileType="library">/usr/lib64/snapd/snap</Path>
             <Path fileType="library">/usr/lib64/snapd/snap-confine</Path>
             <Path fileType="library">/usr/lib64/snapd/snap-device-helper</Path>
             <Path fileType="library">/usr/lib64/snapd/snap-discard-ns</Path>
@@ -76,12 +77,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="81">
-            <Date>2024-05-27</Date>
+        <Update release="82">
+            <Date>2024-07-10</Date>
             <Version>2.63</Version>
             <Comment>Packaging update</Comment>
-            <Name>Zygmunt Krynicki</Name>
-            <Email>me@zygoon.pl</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add a warning when starting snap applications. The warning is shown on the CLI when invoking `snap` there, and as a notification when starting a GUI application.

**Test Plan**

Run a `snap` command on the CLI:

![afbeelding](https://github.com/getsolus/packages/assets/5798032/01569f77-ade7-48d3-b4b2-b4646471d70d)

Run a GUI application:

![afbeelding](https://github.com/getsolus/packages/assets/5798032/c58e8eee-41e3-4a3b-9fba-b0a08884a369)

**Checklist**

- [x] Package was built and tested against unstable
