### PR TITLE
broot: update to 1.39.0

### DIFF
--- a/packages/b/broot/abi_used_symbols
+++ b/packages/b/broot/abi_used_symbols
@@ -1,7 +1,6 @@
 libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_tolower_loc
 libc.so.6:__ctype_toupper_loc
-libc.so.6:__environ
 libc.so.6:__errno_location
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
@@ -34,23 +33,20 @@ libc.so.6:epoll_ctl
 libc.so.6:epoll_wait
 libc.so.6:execvp
 libc.so.6:exit
-libc.so.6:fclose
 libc.so.6:fcntl
-libc.so.6:fdopendir
-libc.so.6:fopen
 libc.so.6:fork
 libc.so.6:free
 libc.so.6:fstat
 libc.so.6:fstat64
 libc.so.6:fstatat64
 libc.so.6:fsync
+libc.so.6:getauxval
 libc.so.6:getcwd
 libc.so.6:getenv
 libc.so.6:geteuid
 libc.so.6:getgid
 libc.so.6:getgrgid_r
 libc.so.6:getloadavg
-libc.so.6:getmntent
 libc.so.6:getpeername
 libc.so.6:getpgid
 libc.so.6:getpid
@@ -74,7 +70,6 @@ libc.so.6:memchr
 libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
-libc.so.6:memrchr
 libc.so.6:memset
 libc.so.6:mkdir
 libc.so.6:mmap
@@ -84,7 +79,6 @@ libc.so.6:munmap
 libc.so.6:nanosleep
 libc.so.6:open
 libc.so.6:open64
-libc.so.6:openat64
 libc.so.6:opendir
 libc.so.6:pipe2
 libc.so.6:poll
@@ -171,7 +165,6 @@ libc.so.6:tcgetattr
 libc.so.6:tcsetattr
 libc.so.6:time
 libc.so.6:unlink
-libc.so.6:unlinkat
 libc.so.6:utimes
 libc.so.6:waitid
 libc.so.6:waitpid

--- a/packages/b/broot/package.yml
+++ b/packages/b/broot/package.yml
@@ -1,8 +1,8 @@
 name       : broot
-version    : 1.36.1
-release    : 22
+version    : 1.39.0
+release    : 23
 source     :
-    - https://github.com/Canop/broot/archive/refs/tags/v1.36.1.tar.gz : b52e60a86e3ca38931cf8ed0ccbd4138f12b733c2459ea3088c267a98b8a555b
+    - https://github.com/Canop/broot/archive/refs/tags/v1.39.0.tar.gz : d1d2ccc11543ff4ea645d57a5e78639542a6f510b585a78c31ddb3a24399bf61
 homepage   : https://dystroy.org/broot/
 license    : MIT
 component  : system.utils
@@ -12,10 +12,12 @@ description: |
 networking : yes
 builddeps  :
     - rust
+setup      : |
+    %cargo_fetch
 build      : |
-    cargo build --release
+    %cargo_build
 install    : |
-    install -Dm00755 target/release/broot $installdir/usr/bin/broot
+    %cargo_install
 
     # install manpage
     sed -i "s/#date//" man/page

--- a/packages/b/broot/pspec_x86_64.xml
+++ b/packages/b/broot/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>broot</Name>
         <Homepage>https://dystroy.org/broot/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -26,12 +26,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2024-04-14</Date>
-            <Version>1.36.1</Version>
+        <Update release="23">
+            <Date>2024-07-03</Date>
+            <Version>1.39.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- :open_trash shows the content of the trash. Other new internals & verbs: :delete_trashed_file, :restore_trashed_file, :purge_trash
- it's now possible to remove a default keybinding by defining a verb with no execution

**Test Plan**
- Ran it and opened a file. 

**Checklist**

- [X] Package was built and tested against unstable

**Packaging notes**
- Switched to new cargo macros.
