### PR TITLE
pisi: Update to v3.12.2, tweak reordering code

### DIFF
--- a/packages/p/pisi/files/baselayout-first-no-eopkg-reordering.patch
+++ b/packages/p/pisi/files/baselayout-first-no-eopkg-reordering.patch
@@ -12,10 +12,18 @@ index 23ea996..f02c90e 100644
  __all__ = [ 'api', 'configfile', 'db']
  
 diff --git a/pisi/operations/helper.py b/pisi/operations/helper.py
-index c311dbc..b459c60 100644
+index c311dbc..c5e5c4b 100644
 --- a/pisi/operations/helper.py
 +++ b/pisi/operations/helper.py
-@@ -42,6 +42,19 @@ def reorder_base_packages(order):
+@@ -37,11 +37,26 @@ def reorder_base_packages(order):
+         else:
+             nonbase_order.append(pkg)
+     install_order = systembase_order + nonbase_order
+-    ctx.ui.warning(_("Reordering install order so system.base packages come first."))
++    # this is a cheat; the code runs regardless currently
++    if not ctx.config.values.general.ignore_safety and not ctx.get_option('ignore_safety'):
++        ctx.ui.warning(_("Reordering install order so system.base packages come first."))
+     if len(install_order) > 1 and ctx.config.get_option("debug"):
          ctx.ui.info(_("install_order: %s" % install_order))
      return install_order
  
@@ -29,7 +37,7 @@ index c311dbc..b459c60 100644
 +       packages in it to be un-removable.
 +    """
 +    if len(order) > 1 and ctx.config.get_option("debug"):
-+        ctx.ui.info(_("install_order including system.base deps: %s" % order))
++        ctx.ui.info(_("install_order including any system.base deps: %s" % order))
 +    return order
 +
  def check_conflicts(order, packagedb):

--- a/packages/p/pisi/pspec.xml
+++ b/packages/p/pisi/pspec.xml
@@ -71,7 +71,19 @@
     </Package>
 
     <History>
-        <Update release="113">
+        <Update release="114">
+            <Date>04-07-2024</Date>
+            <Version>3.12.2</Version>
+            <Comment>Update to v3.12.2, tweak reordering code
+**Summary**
+The install order reordering code now puts baselayout first and doesn't attempt to reorder eopkg.
+
+In addition, a cosmetic tweak was added which doesn't show the "reordering system.base packages" warning when `--ignore-safety` is specified.
+</Comment>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
+        </Update>
+            <Update release="113">
             <Date>29-06-2024</Date>
             <Version>3.12.2</Version>
             <Comment>Update to v3.12.2, tweak reordering code


### PR DESCRIPTION
**Summary**
The install order reordering code now puts baselayout first and doesn't attempt to reorder eopkg.

In addition, a cosmetic tweak was added which doesn't show the "reordering system.base packages" warning when `--ignore-safety` is specified.

**Test Plan**

Run `eopkg.py2 it --reinstall eopkg` with and without `--ignore-safety` flag and check that the warning output differs.

**Checklist**

- [x] Package was built and tested against unstable
