### PR TITLE
deepfilternet: use new cargo macros

### DIFF
--- a/packages/d/deepfilternet/abi_used_symbols
+++ b/packages/d/deepfilternet/abi_used_symbols
@@ -88,15 +88,14 @@ libc.so.6:dl_iterate_phdr
 libc.so.6:dlsym
 libc.so.6:free
 libc.so.6:fstat64
+libc.so.6:getauxval
 libc.so.6:getcwd
 libc.so.6:getenv
 libc.so.6:lseek64
 libc.so.6:malloc
-libc.so.6:memchr
 libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
-libc.so.6:memrchr
 libc.so.6:memset
 libc.so.6:mmap
 libc.so.6:mmap64

--- a/packages/d/deepfilternet/package.yml
+++ b/packages/d/deepfilternet/package.yml
@@ -1,6 +1,6 @@
 name       : deepfilternet
 version    : 0.5.6
-release    : 2
+release    : 3
 source     :
     - https://github.com/Rikorose/DeepFilterNet/archive/refs/tags/v0.5.6.tar.gz : 0f9a219d06c404bc4200f228e7e224f108cbbca04d7227a6de7d2ce974c2f579
 homepage   : https://github.com/Rikorose/DeepFilterNet
@@ -17,9 +17,9 @@ builddeps  :
     - pkgconfig(python3)
     - rust
 setup      : |
-    cargo fetch --locked
+    %cargo_fetch
 build      : |
-    cargo build --frozen --release
+    %cargo_build
 install    : |
     install -Dm00644 -t $installdir/usr/lib64 target/release/liblibdf{,data}.so
     install -Dm00644 -t $installdir/usr/lib64/ladspa target/release/libdeep_filter_ladspa.so

--- a/packages/d/deepfilternet/pspec_x86_64.xml
+++ b/packages/d/deepfilternet/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>deepfilternet</Name>
         <Homepage>https://github.com/Rikorose/DeepFilterNet</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>multimedia.library</PartOf>
@@ -24,12 +24,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-02-15</Date>
+        <Update release="3">
+            <Date>2024-07-05</Date>
             <Version>0.5.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Use new cargo macros

**Test Plan**
- Checked it build

**Checklist**

- [X] Package was built and tested against unstable

**Packaging notes**
- Seemed to be only libraries so did not use %cargo_install