### PR TITLE
Add python-pypdf to fix nemo-media-columns

### DIFF
--- a/packages/n/nemo-extensions/package.yml
+++ b/packages/n/nemo-extensions/package.yml
@@ -1,6 +1,6 @@
 name       : nemo-extensions
 version    : 6.2.0
-release    : 8
+release    : 9
 source     :
     - https://github.com/linuxmint/nemo-extensions/archive/refs/tags/6.2.0.tar.gz : b1c7e3d269ed05f472c80c16cf3f12827cbb48cb05406b276be14060225dbbc3
 homepage   : https://github.com/linuxmint/nemo-extensions
@@ -80,7 +80,7 @@ rundeps    :
         - nemo-extensions
         - mutagen
         - pymediainfo
-        - python-pypdf2
+        - python-pypdf
         - python-pillow
         - python-stopit
     - ^nemo-pastebin :

--- a/packages/n/nemo-extensions/pspec_x86_64.xml
+++ b/packages/n/nemo-extensions/pspec_x86_64.xml
@@ -28,7 +28,7 @@
         <Description xml:lang="en">View audio tag information from the file manager&apos;s properties tab.</Description>
         <PartOf>desktop.gtk</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="8">nemo-extensions</Dependency>
+            <Dependency releaseFrom="9">nemo-extensions</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib/python3.11/site-packages/nemo_audio_tab-6.2.0-py3.11.egg-info/PKG-INFO</Path>
@@ -45,7 +45,7 @@
         <Description xml:lang="en">Simple context menu file comparison extension for Nemo, inspired by the discontinued &apos;diff-ext&apos; extension.</Description>
         <PartOf>desktop.gtk</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="8">nemo-extensions</Dependency>
+            <Dependency releaseFrom="9">nemo-extensions</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/nemo-compare-preferences</Path>
@@ -64,7 +64,7 @@
         <Description xml:lang="en">Nemo Dropbox is an extension that integrates the Dropbox web service with Nemo.</Description>
         <PartOf>desktop.gtk</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="8">nemo-extensions</Dependency>
+            <Dependency releaseFrom="9">nemo-extensions</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/nemo/extensions-3.0/libnemo-dropbox.so</Path>
@@ -84,7 +84,7 @@
         <Description xml:lang="en">Change a folder or file emblem in Nemo.</Description>
         <PartOf>desktop.gtk</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="8">nemo-extensions</Dependency>
+            <Dependency releaseFrom="9">nemo-extensions</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib/python3.11/site-packages/nemo_emblems-6.2.0-py3.11.egg-info/PKG-INFO</Path>
@@ -120,7 +120,7 @@
         <Description xml:lang="en">A Nemo extension to display music/EXIF and PDF metadata info in the Nemo List View</Description>
         <PartOf>desktop.gtk</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="8">nemo-extensions</Dependency>
+            <Dependency releaseFrom="9">nemo-extensions</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/nemo-media-columns-prefs</Path>
@@ -138,7 +138,7 @@
         <Description xml:lang="en">Nemo extension written in Python, which allows users to upload text-only files to a pastebin service just by right-clicking on them.</Description>
         <PartOf>desktop.gtk</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="8">nemo-extensions</Dependency>
+            <Dependency releaseFrom="9">nemo-extensions</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/nemo-pastebin-configurator</Path>
@@ -209,7 +209,7 @@
         <Description xml:lang="en">Nemo Terminal is an embedded terminal for Nemo. It embeds a terminal pane into Nemo that is accessible by hotkey (default F4) and automatically follows the currently active directory in Nemo.</Description>
         <PartOf>desktop.gtk</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="8">nemo-extensions</Dependency>
+            <Dependency releaseFrom="9">nemo-extensions</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/nemo-terminal-prefs</Path>
@@ -229,15 +229,15 @@
         <Description xml:lang="en">These are unstable bindings for the Nemo extension library.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="8">nemo-extensions</Dependency>
+            <Dependency release="9">nemo-extensions</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/lib64/pkgconfig/nemo-python.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2024-06-25</Date>
+        <Update release="9">
+            <Date>2024-07-06</Date>
             <Version>6.2.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>

--- a/packages/py/python-pypdf/monitoring.yml
+++ b/packages/py/python-pypdf/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 7703
+  rss: https://github.com/py-pdf/pypdf/tags.atom
+security:
+  cpe:
+    - vendor: pypdf_project
+      product: pypdf

--- a/packages/py/python-pypdf/package.yml
+++ b/packages/py/python-pypdf/package.yml
@@ -1,0 +1,21 @@
+name       : python-pypdf
+version    : 4.2.0
+release    : 1
+source     :
+    - https://github.com/py-pdf/pypdf/archive/refs/tags/4.2.0.tar.gz : 4096459bdb19df0231360617f2266d8068a40b9eb202bbea9c54274a320f0c55
+homepage   : https://pypdf.readthedocs.io
+license    : BSD-3-Clause
+component  : programming.python
+summary    : A pure-python PDF library capable of splitting, merging, cropping, and transforming the pages of PDF files
+description: |
+    A pure-python PDF library capable of splitting, merging, cropping, and transforming the pages of PDF files.
+builddeps  :
+    - python-build
+    - python-flit
+    - python-installer
+    - python-packaging
+    - python-wheel
+build      : |
+    %python3_setup
+install    : |
+    %python3_install

--- a/packages/py/python-pypdf/pspec_x86_64.xml
+++ b/packages/py/python-pypdf/pspec_x86_64.xml
@@ -1,0 +1,189 @@
+<PISI>
+    <Source>
+        <Name>python-pypdf</Name>
+        <Homepage>https://pypdf.readthedocs.io</Homepage>
+        <Packager>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
+        </Packager>
+        <License>BSD-3-Clause</License>
+        <PartOf>programming.python</PartOf>
+        <Summary xml:lang="en">A pure-python PDF library capable of splitting, merging, cropping, and transforming the pages of PDF files</Summary>
+        <Description xml:lang="en">A pure-python PDF library capable of splitting, merging, cropping, and transforming the pages of PDF files.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>python-pypdf</Name>
+        <Summary xml:lang="en">A pure-python PDF library capable of splitting, merging, cropping, and transforming the pages of PDF files</Summary>
+        <Description xml:lang="en">A pure-python PDF library capable of splitting, merging, cropping, and transforming the pages of PDF files.
+</Description>
+        <PartOf>programming.python</PartOf>
+        <Files>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf-4.2.0.dist-info/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf-4.2.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf-4.2.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf-4.2.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_cmap.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_cmap.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_doc_common.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_doc_common.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_encryption.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_encryption.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_merger.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_merger.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_page.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_page.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_page_labels.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_page_labels.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_protocols.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_protocols.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_reader.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_reader.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_utils.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_utils.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_version.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_version.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_writer.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_writer.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_xobj_image_helpers.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/_xobj_image_helpers.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/constants.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/constants.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/errors.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/errors.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/filters.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/filters.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/pagerange.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/pagerange.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/papersizes.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/papersizes.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/types.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/types.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/xmp.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/__pycache__/xmp.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_cmap.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_codecs/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_codecs/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_codecs/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_codecs/__pycache__/adobe_glyphs.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_codecs/__pycache__/adobe_glyphs.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_codecs/__pycache__/pdfdoc.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_codecs/__pycache__/pdfdoc.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_codecs/__pycache__/std.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_codecs/__pycache__/std.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_codecs/__pycache__/symbol.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_codecs/__pycache__/symbol.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_codecs/__pycache__/zapfding.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_codecs/__pycache__/zapfding.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_codecs/adobe_glyphs.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_codecs/pdfdoc.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_codecs/std.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_codecs/symbol.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_codecs/zapfding.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_crypt_providers/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_crypt_providers/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_crypt_providers/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_crypt_providers/__pycache__/_base.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_crypt_providers/__pycache__/_base.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_crypt_providers/__pycache__/_cryptography.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_crypt_providers/__pycache__/_cryptography.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_crypt_providers/__pycache__/_fallback.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_crypt_providers/__pycache__/_fallback.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_crypt_providers/__pycache__/_pycryptodome.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_crypt_providers/__pycache__/_pycryptodome.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_crypt_providers/_base.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_crypt_providers/_cryptography.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_crypt_providers/_fallback.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_crypt_providers/_pycryptodome.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_doc_common.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_encryption.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_merger.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_page.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_page_labels.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_protocols.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_reader.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/_layout_mode/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/_layout_mode/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/_layout_mode/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/_layout_mode/__pycache__/_fixed_width_page.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/_layout_mode/__pycache__/_fixed_width_page.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/_layout_mode/__pycache__/_font.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/_layout_mode/__pycache__/_font.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/_layout_mode/__pycache__/_font_widths.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/_layout_mode/__pycache__/_font_widths.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/_layout_mode/__pycache__/_text_state_manager.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/_layout_mode/__pycache__/_text_state_manager.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/_layout_mode/__pycache__/_text_state_params.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/_layout_mode/__pycache__/_text_state_params.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/_layout_mode/_font.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/_layout_mode/_font_widths.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/_layout_mode/_text_state_manager.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_text_extraction/_layout_mode/_text_state_params.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_utils.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_version.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_writer.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/_xobj_image_helpers.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/annotations/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/annotations/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/annotations/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/annotations/__pycache__/_base.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/annotations/__pycache__/_base.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/annotations/__pycache__/_markup_annotations.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/annotations/__pycache__/_markup_annotations.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/annotations/__pycache__/_non_markup_annotations.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/annotations/__pycache__/_non_markup_annotations.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/annotations/_base.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/annotations/_markup_annotations.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/annotations/_non_markup_annotations.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/constants.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/errors.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/filters.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/__pycache__/_base.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/__pycache__/_base.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/__pycache__/_data_structures.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/__pycache__/_data_structures.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/__pycache__/_fit.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/__pycache__/_fit.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/__pycache__/_outline.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/__pycache__/_outline.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/__pycache__/_rectangle.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/__pycache__/_rectangle.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/__pycache__/_utils.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/__pycache__/_utils.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/__pycache__/_viewerpref.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/__pycache__/_viewerpref.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/_base.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/_data_structures.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/_fit.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/_outline.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/_rectangle.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/_utils.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/generic/_viewerpref.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/pagerange.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/papersizes.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/py.typed</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/types.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pypdf/xmp.py</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2024-07-06</Date>
+            <Version>4.2.0</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**

- **python-pypdf: Add at 4.2.0**
- **nemo-extensions: Fix nemo-media-columns extension**

This adds an updated version of `python-pypdf2` that underwent a significant refactor. One of the Nemo extensions has updated to this version of PyPDF, but the other application in the repository that uses it, Kraft, is still on the old version. Luckily, they appear to be co-installable.

**Test Plan**

Add and enable the `nemo-media-columns` extension in Nemo.

**Checklist**

- [x] Package was built and tested against unstable
