### PR TITLE
python-wheel: Update to 0.43.0

### DIFF
--- a/packages/py/python-wheel/monitoring.yml
+++ b/packages/py/python-wheel/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 11428
+  rss: https://github.com/pypa/wheel/tags.atom
+security:
+  cpe:
+    - vendor: wheel_project
+      product: wheel

--- a/packages/py/python-wheel/package.yml
+++ b/packages/py/python-wheel/package.yml
@@ -1,8 +1,8 @@
 name       : python-wheel
-version    : 0.37.1
-release    : 20
+version    : 0.43.0
+release    : 21
 source     :
-    - https://github.com/pypa/wheel/archive/refs/tags/0.37.1.tar.gz : a82516a039e521100ecdef137f9e44249bf6903f9aff7d368e84ac31d60597f5
+    - https://github.com/pypa/wheel/archive/refs/tags/0.43.0.tar.gz : 23060d7cc8afafc2930554624b4bae7d58031830672048622c926675ab91e3b0
 homepage   : https://github.com/pypa/wheel
 license    : MIT
 component  : programming.python
@@ -11,18 +11,16 @@ description: |
     A wheel is a ZIP-format archive with a specially formatted filename and the .whl extension. It is designed to contain all the files for a PEP 376 compatible install in a way that is very close to the on-disk format. Many packages will be properly installed with only the “Unpack” step (simply extracting the file onto sys.path), and the unpacked archive preserves enough information to “Spread” (copy data and scripts to their final locations) at any later time.
 builddeps  :
     - pkgconfig(python3)
-    - python-jsonschema
-    - python-keyring
-    - pyxdg
+    - python-build
+    - python-flit-core
+    - python-installer
 checkdeps  :
     - python-pytest
-setup      : |
-    # Don't require pytest-cov for tests
-    sed -i 's/--cov//' setup.cfg
-    sed -i 's/--cov-config=setup.cfg//' setup.cfg
+rundeps    :
+    - pyxdg   # optional
 build      : |
     %python3_setup
 install    : |
     %python3_install
 check      : |
-    %python3_test py.test3
+    %python3_test py.test -v

--- a/packages/py/python-wheel/pspec_x86_64.xml
+++ b/packages/py/python-wheel/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-wheel</Name>
         <Homepage>https://github.com/pypa/wheel</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Algent Albrahimi</Name>
+            <Email>algent@protonmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -21,54 +21,102 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/wheel</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel-0.37.1-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel-0.37.1-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel-0.37.1-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel-0.37.1-py3.11.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel-0.37.1-py3.11.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel-0.37.1-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel-0.37.1-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel-0.43.0.dist-info/LICENSE.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel-0.43.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel-0.43.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel-0.43.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel-0.43.0.dist-info/entry_points.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/__main__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/__pycache__/__main__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/__pycache__/__main__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/__pycache__/_setuptools_logging.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/__pycache__/_setuptools_logging.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/__pycache__/bdist_wheel.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/__pycache__/bdist_wheel.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/__pycache__/macosx_libfile.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/__pycache__/macosx_libfile.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/__pycache__/metadata.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/__pycache__/metadata.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/__pycache__/pkginfo.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/__pycache__/util.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/__pycache__/util.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/__pycache__/wheelfile.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/__pycache__/wheelfile.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/_setuptools_logging.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/bdist_wheel.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/cli/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/cli/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/cli/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/cli/__pycache__/convert.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/cli/__pycache__/convert.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/cli/__pycache__/pack.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/cli/__pycache__/pack.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/cli/__pycache__/tags.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/cli/__pycache__/tags.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/cli/__pycache__/unpack.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/cli/__pycache__/unpack.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/cli/convert.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/cli/pack.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/cli/tags.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/cli/unpack.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/macosx_libfile.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/metadata.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/pkginfo.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/util.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/__init__.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/_typing.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/_elffile.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/_elffile.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/_manylinux.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/_manylinux.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/_musllinux.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/_musllinux.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/_parser.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/_parser.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/_structures.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/_structures.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/_tokenizer.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/_tokenizer.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/markers.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/markers.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/requirements.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/requirements.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/specifiers.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/specifiers.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/tags.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/tags.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/_typing.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/utils.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/utils.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/version.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/__pycache__/version.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/_elffile.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/_manylinux.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/_musllinux.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/_parser.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/_structures.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/_tokenizer.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/markers.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/requirements.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/specifiers.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/tags.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/utils.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/packaging/version.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/vendored/vendor.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/wheel/wheelfile.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2024-07-02</Date>
-            <Version>0.37.1</Version>
+        <Update release="21">
+            <Date>2024-07-06</Date>
+            <Version>0.43.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Algent Albrahimi</Name>
+            <Email>algent@protonmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Full changelog [here](https://github.com/pypa/wheel/blob/0.43.0/docs/news.rst)
- Add `monitoring.yml`

**Security Fixes**
- CVE-2022-40898

**Test Plan**
- Install all revdepc and check for  errors with `pip3 check`.
- Run a few scripts in `thonny`

**Checklist**
- [x] Package was built and tested against unstable
