### PR TITLE
font-iosevka-ttf: Update to 30.3.1

### DIFF
--- a/packages/f/font-iosevka-ttf/package.yml
+++ b/packages/f/font-iosevka-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : font-iosevka-ttf
-version    : 30.3.0
-release    : 67
+version    : 30.3.1
+release    : 68
 source     :
-    - https://github.com/be5invis/Iosevka/releases/download/v30.3.0/PkgTTF-Iosevka-30.3.0.zip : d833557a33df730a47cbdd55f0cc95ff13cfa4e58a6c3ddbf0db76bb15e5c27b
+    - https://github.com/be5invis/Iosevka/releases/download/v30.3.1/PkgTTF-Iosevka-30.3.1.zip : fbf67a31c080ec55452d45afd55ce6e938532b59e2ea56036243fb38a039309b
 homepage   : https://typeof.net/Iosevka
 license    : OFL-1.1
 component  : desktop.font

--- a/packages/f/font-iosevka-ttf/pspec_x86_64.xml
+++ b/packages/f/font-iosevka-ttf/pspec_x86_64.xml
@@ -78,9 +78,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="67">
-            <Date>2024-06-22</Date>
-            <Version>30.3.0</Version>
+        <Update release="68">
+            <Date>2024-07-06</Date>
+            <Version>30.3.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
* Add Capital Eszet (`VXAC`) variants with top-left corner.
* Add square-dotted variant for brailles
* Fix leaning mark anchors for `U+0195`, `U+019E`, `U+01A6`, and `U+0220`.
* Optimize glyph shape for `U+01A6`, `U+A68A`, and `U+A68B`.
* Make `ss20` use `seven`.`curly-serifless` by default.
* Adjust balancing of r with corner hooks
* Fix side bearings of Latin-1 Macron (`U+00AF`) under Quasi-Proportional.
* Make `U+050F`, `U+A68B`, `U+FB03`, and `U+FB04` slightly wider under Quasi-Proportional.

**Test Plan**
- render text

**Checklist**
- [X] Package was built and tested against unstable
