### PR TITLE
clr-boot-manager: Update freestanding initrd dir

### DIFF
--- a/packages/c/clr-boot-manager/package.yml
+++ b/packages/c/clr-boot-manager/package.yml
@@ -1,6 +1,6 @@
 name       : clr-boot-manager
 version    : 3.5.0
-release    : 36
+release    : 37
 source     :
     - https://github.com/getsolus/clr-boot-manager/releases/download/solus-3.5.0/clr-boot-manager-3.5.0.tar.xz : 5749a728b56a313991729457c1a123974341397408038ae7163c176531177bac
 homepage   : https://www.clearlinux.org
@@ -26,6 +26,7 @@ setup      : |
                      -Dwith-kernel-modules-dir=/usr/lib64/modules \
                      -Dwith-kernel-namespace=com.solus-project \
                      -Dwith-kernel-vendor-conf-dir=/usr/lib64/kernel \
+                     -Dwith-initrd-dir=/usr/lib64/kernel/initrd.d \
                      -Dwith-bootloader=shim-systemd-boot \
                      -Dwith-uefi-entry-label="Solus Linux Bootloader"
 build      : |

--- a/packages/c/clr-boot-manager/pspec_x86_64.xml
+++ b/packages/c/clr-boot-manager/pspec_x86_64.xml
@@ -38,8 +38,8 @@ Most importantly, clr-boot-manager provides a simple mechanism to provide kernel
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2024-07-13</Date>
+        <Update release="37">
+            <Date>2024-07-15</Date>
             <Version>3.5.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Silke Hofstra</Name>

--- a/packages/n/nvidia-beta-driver/package.yml
+++ b/packages/n/nvidia-beta-driver/package.yml
@@ -1,6 +1,6 @@
 name       : nvidia-beta-driver
 version    : 555.58.02
-release    : 279
+release    : 280
 source     :
     - https://us.download.nvidia.com/XFree86/Linux-x86_64/555.58.02/NVIDIA-Linux-x86_64-555.58.02.run : c5cb6de133d194e27aaf94b9e21e56e8f4faff7672d91e0048d14fbbc4d21ca3
 extract    : no
@@ -265,7 +265,7 @@ install    : |
     mkdir -p init-firmware/nvidia-firmware && pushd init-firmware
     cp -ra $installdir/usr/lib64/firmware/nvidia/ nvidia-firmware/
     find . | cpio --create --format='newc' | zstd -19 > $workdir/initrd-firmware
-    install -D -m 00644 $workdir/initrd-firmware $installdir/usr/lib64/kernel/initrd-com.solus-project.nvidia-firmware
+    install -D -m 00644 $workdir/initrd-firmware $installdir/usr/lib64/kernel/initrd.d/com.solus-project.nvidia-firmware
 
     # Compress modules with zstd. TODO fix this so that we're able to capture the debug symbols (needs ypkg changes)
     find "$installdir" -name '*.ko' -exec strip --strip-unneeded {} \; -exec zstd -19 {} \; -exec rm -v {} \;

--- a/packages/n/nvidia-beta-driver/pspec_x86_64.xml
+++ b/packages/n/nvidia-beta-driver/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nvidia-beta-driver</Name>
         <Homepage>https://nvidia.com</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>EULA</License>
         <PartOf>kernel.drivers</PartOf>
@@ -24,7 +24,7 @@ NVIDIA Short-lived Binary Driver
 </Description>
         <PartOf>kernel.drivers</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="279">nvidia-beta-driver-common</Dependency>
+            <Dependency releaseFrom="280">nvidia-beta-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.6.37-248.lts/kernel/drivers/video/nvidia-drm.ko.zst</Path>
@@ -54,7 +54,7 @@ NVIDIA Short-lived Binary Driver
 </Description>
         <PartOf>xorg.driver</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="279">nvidia-beta-driver-common</Dependency>
+            <Dependency releaseFrom="280">nvidia-beta-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libEGL_nvidia.so</Path>
@@ -148,7 +148,7 @@ NVIDIA Short-lived Binary Driver
             <Path fileType="library">/usr/lib64/firmware/nvidia/555.58.02/gsp_tu10x.bin</Path>
             <Path fileType="library">/usr/lib64/gbm/nvidia-drm_gbm.so</Path>
             <Path fileType="library">/usr/lib64/kernel/cmdline.d/40_nvidia.conf</Path>
-            <Path fileType="library">/usr/lib64/kernel/initrd-com.solus-project.nvidia-firmware</Path>
+            <Path fileType="library">/usr/lib64/kernel/initrd.d/com.solus-project.nvidia-firmware</Path>
             <Path fileType="library">/usr/lib64/libEGL_nvidia.so</Path>
             <Path fileType="library">/usr/lib64/libEGL_nvidia.so.0</Path>
             <Path fileType="library">/usr/lib64/libEGL_nvidia.so.555.58.02</Path>
@@ -280,7 +280,7 @@ NVIDIA Short-lived Binary Driver
 </Description>
         <PartOf>kernel.drivers</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="279">nvidia-beta-driver-common</Dependency>
+            <Dependency releaseFrom="280">nvidia-beta-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.9.8-294.current/kernel/drivers/video/nvidia-drm.ko.zst</Path>
@@ -302,12 +302,12 @@ NVIDIA Short-lived Binary Driver
         </Conflicts>
     </Package>
     <History>
-        <Update release="279">
-            <Date>2024-07-06</Date>
+        <Update release="280">
+            <Date>2024-07-07</Date>
             <Version>555.58.02</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/n/nvidia-developer-driver/package.yml
+++ b/packages/n/nvidia-developer-driver/package.yml
@@ -1,6 +1,6 @@
 name       : nvidia-developer-driver
 version    : 550.40.65
-release    : 296
+release    : 297
 source     :
     - https://developer.nvidia.com/downloads/vulkan-beta-5504065-linux : 76ef3a187301c73524acffa70f33287417711f77754ee78b3c7e4a79848d2985
 extract    : no
@@ -275,10 +275,11 @@ install    : |
     install -D -m 00644 $workdir/initrd-lts $installdir/usr/lib64/kernel/initrd-com.solus-project.lts.$lts_string.nvidia
 
     # Generate single initrd (to be shared between current and lts) with the GSP firmware
-    mkdir -p init-firmware/nvidia-firmware && pushd init-firmware
-    cp -ra $installdir/usr/lib64/firmware/nvidia/ nvidia-firmware/
-    find . | cpio --create --format='newc' | zstd -19 > $workdir/initrd-firmware
-    install -D -m 00644 $workdir/initrd-firmware $installdir/usr/lib64/kernel/initrd-com.solus-project.nvidia-firmware
+    # Enable after it has been found to work correctly in the beta driver.
+    # mkdir -p init-firmware/nvidia-firmware && pushd init-firmware
+    # cp -ra $installdir/usr/lib64/firmware/nvidia/ nvidia-firmware/
+    # find . | cpio --create --format='newc' | zstd -19 > $workdir/initrd-firmware
+    # install -D -m 00644 $workdir/initrd-firmware $installdir/usr/lib64/kernel/initrd.d/com.solus-project.nvidia-firmware
 
     # Compress modules with zstd. TODO fix this so that we're able to capture the debug symbols (needs ypkg changes)
     find "$installdir" -name '*.ko' -exec strip --strip-unneeded {} \; -exec zstd -19 {} \; -exec rm -v {} \;

--- a/packages/n/nvidia-developer-driver/pspec_x86_64.xml
+++ b/packages/n/nvidia-developer-driver/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nvidia-developer-driver</Name>
         <Homepage>https://developer.nvidia.com/vulkan-driver</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>EULA</License>
         <PartOf>kernel.drivers</PartOf>
@@ -20,7 +20,7 @@
 </Description>
         <PartOf>kernel.drivers</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="296">nvidia-developer-driver-common</Dependency>
+            <Dependency releaseFrom="297">nvidia-developer-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.6.37-248.lts/kernel/drivers/video/nvidia-drm.ko.zst</Path>
@@ -48,7 +48,7 @@
 </Description>
         <PartOf>xorg.driver</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="296">nvidia-developer-driver-common</Dependency>
+            <Dependency releaseFrom="297">nvidia-developer-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libEGL_nvidia.so</Path>
@@ -141,7 +141,6 @@
             <Path fileType="library">/usr/lib64/firmware/nvidia/550.40.65/gsp_tu10x.bin</Path>
             <Path fileType="library">/usr/lib64/gbm/nvidia-drm_gbm.so</Path>
             <Path fileType="library">/usr/lib64/kernel/cmdline.d/40_nvidia.conf</Path>
-            <Path fileType="library">/usr/lib64/kernel/initrd-com.solus-project.nvidia-firmware</Path>
             <Path fileType="library">/usr/lib64/libEGL_nvidia.so</Path>
             <Path fileType="library">/usr/lib64/libEGL_nvidia.so.0</Path>
             <Path fileType="library">/usr/lib64/libEGL_nvidia.so.550.40.65</Path>
@@ -274,7 +273,7 @@
 </Description>
         <PartOf>kernel.drivers</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="296">nvidia-developer-driver-common</Dependency>
+            <Dependency releaseFrom="297">nvidia-developer-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.9.8-294.current/kernel/drivers/video/nvidia-drm.ko.zst</Path>
@@ -307,12 +306,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="296">
-            <Date>2024-07-06</Date>
+        <Update release="297">
+            <Date>2024-07-07</Date>
             <Version>550.40.65</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/n/nvidia-glx-driver/package.yml
+++ b/packages/n/nvidia-glx-driver/package.yml
@@ -2,7 +2,7 @@
 # nvidia-beta-driver should always be ahead of nvidia-glx-driver version-wise or at the same version, never behind.
 name       : nvidia-glx-driver
 version    : '550.100'
-release    : 533
+release    : 534
 source     :
     - https://us.download.nvidia.com/XFree86/Linux-x86_64/550.100/NVIDIA-Linux-x86_64-550.100.run : 8a6b5fb287bf11f5056734784bda64c1064a09c2aa79f6b225ec0fb56d23802d
 extract    : no
@@ -297,10 +297,11 @@ install    : |
     install -D -m 00644 $workdir/initrd-lts $installdir/usr/lib64/kernel/initrd-com.solus-project.lts.$lts_string.nvidia
 
     # Generate single initrd (to be shared between current and lts) with the GSP firmware
-    mkdir -p init-firmware/nvidia-firmware && pushd init-firmware
-    cp -ra $installdir/usr/lib64/firmware/nvidia/ nvidia-firmware/
-    find . | cpio --create --format='newc' | zstd -19 > $workdir/initrd-firmware
-    install -D -m 00644 $workdir/initrd-firmware $installdir/usr/lib64/kernel/initrd-com.solus-project.nvidia-firmware
+    # Enable after it has been found to work correctly in the beta driver.
+    # mkdir -p init-firmware/nvidia-firmware && pushd init-firmware
+    # cp -ra $installdir/usr/lib64/firmware/nvidia/ nvidia-firmware/
+    # find . | cpio --create --format='newc' | zstd -19 > $workdir/initrd-firmware
+    # install -D -m 00644 $workdir/initrd-firmware $installdir/usr/lib64/kernel/initrd.d/com.solus-project.nvidia-firmware
 
     # Compress modules with zstd. TODO fix this so that we're able to capture the debug symbols (needs ypkg changes)
     find "$installdir" -name '*.ko' -exec strip --strip-unneeded {} \; -exec zstd -19 {} \; -exec rm -v {} \;

--- a/packages/n/nvidia-glx-driver/pspec_x86_64.xml
+++ b/packages/n/nvidia-glx-driver/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nvidia-glx-driver</Name>
         <Homepage>https://nvidia.com</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>EULA</License>
         <PartOf>kernel.drivers</PartOf>
@@ -18,7 +18,7 @@
         <Description xml:lang="en">NVIDIA Binary Driver (LTS Kernel)</Description>
         <PartOf>kernel.drivers</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="533">nvidia-glx-driver-common</Dependency>
+            <Dependency releaseFrom="534">nvidia-glx-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.6.37-248.lts/kernel/drivers/video/nvidia-drm.ko.zst</Path>
@@ -46,7 +46,7 @@
         <Description xml:lang="en">32-bit libraries for NVIDIA Binary Driver</Description>
         <PartOf>xorg.driver</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="533">nvidia-glx-driver-common</Dependency>
+            <Dependency releaseFrom="534">nvidia-glx-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libEGL_nvidia.so</Path>
@@ -138,7 +138,6 @@
             <Path fileType="library">/usr/lib64/firmware/nvidia/550.100/gsp_tu10x.bin</Path>
             <Path fileType="library">/usr/lib64/gbm/nvidia-drm_gbm.so</Path>
             <Path fileType="library">/usr/lib64/kernel/cmdline.d/40_nvidia.conf</Path>
-            <Path fileType="library">/usr/lib64/kernel/initrd-com.solus-project.nvidia-firmware</Path>
             <Path fileType="library">/usr/lib64/libEGL_nvidia.so</Path>
             <Path fileType="library">/usr/lib64/libEGL_nvidia.so.0</Path>
             <Path fileType="library">/usr/lib64/libEGL_nvidia.so.550.100</Path>
@@ -267,7 +266,7 @@
         <Description xml:lang="en">NVIDIA Binary Driver (Current Kernel)</Description>
         <PartOf>kernel.drivers</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="533">nvidia-glx-driver-common</Dependency>
+            <Dependency releaseFrom="534">nvidia-glx-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.9.8-294.current/kernel/drivers/video/nvidia-drm.ko.zst</Path>
@@ -300,12 +299,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="533">
-            <Date>2024-07-10</Date>
+        <Update release="534">
+            <Date>2024-07-15</Date>
             <Version>550.100</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Change the location from which freestanding initrd files are loaded to `/usr/lib64/kernel/initrd.d` and install the common initrd files shipped in the nvidia driver packages to that directory. See `man clr-boot-manager` for details on freestanding initrds.

**Test Plan**

Install nvidia package and verify that the initrd is installed:

```
# cat /boot/loader/entries/Solus-current-6.9.8-294.conf
title Solus 4.5 Resilience
linux /EFI/com.solus-project/kernel-com.solus-project.current.6.9.8-294
initrd /EFI/com.solus-project/initrd-com.solus-project.current.6.9.8-294
initrd /EFI/com.solus-project/initrd-com.solus-project.current.6.9.8-294.nvidia
initrd /EFI/com.solus-project/freestanding-com.solus-project.nvidia-firmware
options root=UUID=fad493c3-e3ca-4041-8f45-1a2a38b7e957 rd.luks.uuid=eb14b3d3-f2c2-453d-a396-dd97fcc769d2 rootflags=subvol=solus quiet rw nvidia-drm.modeset=1 nvidia.NVreg_PreserveVideoMemoryAllocations=1 nvi
dia.NVreg_TemporaryFilePath=/var/tmp console=tty0 console=ttyS0,115200n8 vconsole.keymap=en-latin9 rd.luks.options=tpm2-device=auto,discard amdgpu.pcie_gen2=0 systemd.unified_cgroup_hierarchy=1 systemd.show_
status=true  amd_pstate=active
```

**Checklist**

- [x] Package was built and tested against unstable
