### PR TITLE
python-maturin: Update to 1.7.0

### DIFF
--- a/packages/py/python-maturin/abi_used_symbols
+++ b/packages/py/python-maturin/abi_used_symbols
@@ -20,6 +20,7 @@ libc.so.6:execvp
 libc.so.6:exit
 libc.so.6:fchmod
 libc.so.6:fcntl
+libc.so.6:fdatasync
 libc.so.6:fdopendir
 libc.so.6:fork
 libc.so.6:free
@@ -61,6 +62,7 @@ libc.so.6:posix_spawnattr_setpgroup
 libc.so.6:posix_spawnattr_setsigdefault
 libc.so.6:posix_spawnp
 libc.so.6:pthread_attr_destroy
+libc.so.6:pthread_attr_getguardsize
 libc.so.6:pthread_attr_getstack
 libc.so.6:pthread_getattr_np
 libc.so.6:pthread_getspecific

--- a/packages/py/python-maturin/package.yml
+++ b/packages/py/python-maturin/package.yml
@@ -1,8 +1,8 @@
 name       : python-maturin
-version    : 1.6.0
-release    : 43
+version    : 1.7.0
+release    : 44
 source     :
-    - https://github.com/PyO3/maturin/archive/refs/tags/v1.6.0.tar.gz : 10809d4df85532cb70d9f186117cac8b2d2fa9b03c8f2fb53a8dc8a531f5afeb
+    - https://github.com/PyO3/maturin/archive/refs/tags/v1.7.0.tar.gz : 27e26b05e9abc474c75402e4e8dd13f045f3dcbe08a8ea48b0eb12c3f96a9cc1
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-maturin/pspec_x86_64.xml
+++ b/packages/py/python-maturin/pspec_x86_64.xml
@@ -22,24 +22,22 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/maturin</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.6.0-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.6.0-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.6.0-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.6.0-py3.11.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.6.0-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.6.0-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.0-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.0-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.0-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.0-py3.11.egg-info/not-zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.0-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.0-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/__pycache__/__main__.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/__pycache__/import_hook.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/import_hook.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="43">
-            <Date>2024-06-05</Date>
-            <Version>1.6.0</Version>
+        <Update release="44">
+            <Date>2024-07-09</Date>
+            <Version>1.7.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Expose env variable to suppress build backend warning
- Canonicalize base executable path in PEP 517 build
- Initial iOS support
- Remove old import hook
- Bump MSRV to 1.74.0
- Override wheel tag with `_PYTHON_HOST_PLATFORM`
- Don't add duplicate files
- pep517: only use base python when `MATURIN_PEP517_USE_BASE_PYTHON` env var is set

**Test Plan**

Built `python-orjson` against this version

**Checklist**

- [x] Package was built and tested against unstable
