### PR TITLE
wine: Add gnutls dependency to enable SSL

### DIFF
--- a/packages/w/wine/abi_libs
+++ b/packages/w/wine/abi_libs
@@ -1,4 +1,5 @@
 avicap32.so
+bcrypt.so
 crypt32.so
 ctapi32.so
 dnsapi.so
@@ -15,6 +16,7 @@ odbc32.so
 opencl.so
 opengl32.so
 qcap.so
+secur32.so
 win32u.so
 wine64
 winealsa.so

--- a/packages/w/wine/abi_libs32
+++ b/packages/w/wine/abi_libs32
@@ -1,4 +1,5 @@
 avicap32.so
+bcrypt.so
 crypt32.so
 ctapi32.so
 dnsapi.so
@@ -15,6 +16,7 @@ odbc32.so
 opencl.so
 opengl32.so
 qcap.so
+secur32.so
 win32u.so
 wine
 winealsa.so

--- a/packages/w/wine/abi_symbols
+++ b/packages/w/wine/abi_symbols
@@ -1,5 +1,7 @@
 avicap32.so:__wine_unix_call_funcs
 avicap32.so:__wine_unix_call_wow64_funcs
+bcrypt.so:__wine_unix_call_funcs
+bcrypt.so:__wine_unix_call_wow64_funcs
 crypt32.so:__wine_unix_call_funcs
 crypt32.so:__wine_unix_call_wow64_funcs
 ctapi32.so:__wine_unix_call_funcs
@@ -307,6 +309,8 @@ opengl32.so:__wine_unix_call_funcs
 opengl32.so:__wine_unix_call_wow64_funcs
 qcap.so:__wine_unix_call_funcs
 qcap.so:__wine_unix_call_wow64_funcs
+secur32.so:__wine_unix_call_funcs
+secur32.so:__wine_unix_call_wow64_funcs
 win32u.so:CopyImage
 win32u.so:DrawTextW
 win32u.so:GetStockObject

--- a/packages/w/wine/abi_symbols32
+++ b/packages/w/wine/abi_symbols32
@@ -1,4 +1,5 @@
 avicap32.so:__wine_unix_call_funcs
+bcrypt.so:__wine_unix_call_funcs
 crypt32.so:__wine_unix_call_funcs
 ctapi32.so:__wine_unix_call_funcs
 dnsapi.so:__wine_unix_call_funcs
@@ -300,6 +301,7 @@ odbc32.so:__wine_unix_call_funcs
 opencl.so:__wine_unix_call_funcs
 opengl32.so:__wine_unix_call_funcs
 qcap.so:__wine_unix_call_funcs
+secur32.so:__wine_unix_call_funcs
 win32u.so:CopyImage
 win32u.so:DrawTextW
 win32u.so:GetStockObject

--- a/packages/w/wine/package.yml
+++ b/packages/w/wine/package.yml
@@ -1,6 +1,6 @@
 name       : wine
 version    : '9.12'
-release    : 178
+release    : 179
 source     :
     - https://dl.winehq.org/wine/source/9.x/wine-9.12.tar.xz : 09145ae720b2f9f18187970ba0640bbf3ced5ae8dc78af1d7d57f5077ec26af6
 license    : LGPL-2.1-or-later
@@ -16,6 +16,7 @@ builddeps  :
     - pkgconfig32(d3d)
     - pkgconfig32(dbus-1)
     - pkgconfig32(glu)
+    - pkgconfig32(gnutls)
     - pkgconfig32(gstreamer-plugins-base-1.0)
     - pkgconfig32(gtk+-3.0)
     - pkgconfig32(ice)

--- a/packages/w/wine/pspec_x86_64.xml
+++ b/packages/w/wine/pspec_x86_64.xml
@@ -984,7 +984,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="178">wine</Dependency>
+            <Dependency release="179">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/wine</Path>
@@ -1818,7 +1818,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="178">wine</Dependency>
+            <Dependency release="179">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wine/debug.h</Path>
@@ -3133,8 +3133,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="178">
-            <Date>2024-06-29</Date>
+        <Update release="179">
+            <Date>2024-07-09</Date>
             <Version>9.12</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>


### PR DESCRIPTION
**Summary**

This fixes issues with SSL connections in wine iexplore and other apps

**Test Plan**

Confirmed `wine iexplore google.com` actually loaded the page

**Checklist**

- [x] Package was built and tested against unstable
