### PR TITLE
tree: Update to 2.1.3

### DIFF
--- a/packages/t/tree/abi_used_symbols
+++ b/packages/t/tree/abi_used_symbols
@@ -2,6 +2,8 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_get_mb_cur_max
 libc.so.6:__ctype_tolower_loc
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoul
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__realpath_chk
@@ -56,7 +58,5 @@ libc.so.6:strncmp
 libc.so.6:strncpy
 libc.so.6:strstr
 libc.so.6:strtok
-libc.so.6:strtol
-libc.so.6:strtoul
 libc.so.6:strverscmp
 libc.so.6:time

--- a/packages/t/tree/package.yml
+++ b/packages/t/tree/package.yml
@@ -1,8 +1,8 @@
 name       : tree
-version    : 2.1.1
-release    : 8
+version    : 2.1.3
+release    : 9
 source     :
-    - https://gitlab.com/OldManProgrammer/unix-tree/-/archive/2.1.1/unix-tree-2.1.1.tar.gz : bcd2a0327ad40592a9c43e09a4d2ef834e6f17aa9a59012a5fb1007950b5eced
+    - https://gitlab.com/OldManProgrammer/unix-tree/-/archive/2.1.3/unix-tree-2.1.3.tar.gz : f554a1b62233b96fa8eaa2d85e91bc62cad80ee441fd591380f16cdfbe3e8868
 homepage   : https://gitlab.com/OldManProgrammer/unix-tree
 license    : GPL-2.0-or-later
 component  : system.utils

--- a/packages/t/tree/pspec_x86_64.xml
+++ b/packages/t/tree/pspec_x86_64.xml
@@ -11,7 +11,7 @@
         <Summary xml:lang="en">list contents of directories in a tree-like format.</Summary>
         <Description xml:lang="en">Tree is a recursive directory listing command that produces a depth indented listing of files, which is colorized ala dircolors if the LS_COLORS environment variable is set and output is to tty
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>tree</Name>
@@ -25,9 +25,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2023-06-27</Date>
-            <Version>2.1.1</Version>
+        <Update release="9">
+            <Date>2024-07-10</Date>
+            <Version>2.1.3</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- 2.1.3
  - Fix regression in `search()` function that broke `--fromfile`
  - Allow the `-L` option to accept its parameter immediately (with no space)
- 2.1.2
  - Fix issue where `--gitignore` does not think a pattern with a singular terminal '/'
  - Don't emit the error 'recursive, not followed' if when using `-L`, the depth would prevent descending anyway
  - Don't prematurely sort files/directories with `--from*file`

**Test Plan**

- See that `tree` makes a tree

**Checklist**

- [x] Package was built and tested against unstable
