### PR TITLE
Drop python-packaging from system.base by splitting glib2 better

### DIFF
--- a/packages/g/glib2/package.yml
+++ b/packages/g/glib2/package.yml
@@ -1,6 +1,6 @@
 name       : glib2
 version    : 2.80.4
-release    : 109
+release    : 110
 source     :
     - https://download.gnome.org/sources/glib/2.80/glib-2.80.4.tar.xz : 24e029c5dfc9b44e4573697adf33078a9827c48938555004b3b9096fa4ea034f
 homepage   : https://wiki.gnome.org/Projects/GLib
@@ -21,7 +21,8 @@ builddeps  :
     - pkgconfig32(zlib)
     - python-packaging
 rundeps    :
-    - python-packaging
+    - devel :
+      - python-packaging
 setup      : |
     %apply_patches
     export CFLAGS+=" -g3"
@@ -44,3 +45,21 @@ install    : |
     %ninja_install
     # Allow emul32 to work correctly.
     install -Dm00644 $pkgfiles/glibconfig.h $installdir/usr/include/glib-2.0/glibconfig.h
+patterns   :
+    - devel :
+        - /usr/bin/gdbus-codegen
+        - /usr/bin/glib-mkenums
+        - /usr/bin/glib-genmarshal
+        - /usr/bin/gresource
+        - /usr/bin/gtester
+        - /usr/bin/gtester-report
+        - /usr/share/gdb/
+        - /usr/share/glib-2.0/gdb/
+        - /usr/share/glib-2.0/codegen/
+        - /usr/share/bash-completion/completions/gresource
+        - /usr/share/man/man1/gdbus-codegen.1
+        - /usr/share/man/man1/glib-mkenums.1
+        - /usr/share/man/man1/glib-genmarshal.1
+        - /usr/share/man/man1/gresource.1
+        - /usr/share/man/man1/gtester.1
+        - /usr/share/man/man1/gtester-report.1

--- a/packages/g/glib2/pspec_x86_64.xml
+++ b/packages/g/glib2/pspec_x86_64.xml
@@ -22,7 +22,6 @@
         <Files>
             <Path fileType="executable">/usr/bin/gapplication</Path>
             <Path fileType="executable">/usr/bin/gdbus</Path>
-            <Path fileType="executable">/usr/bin/gdbus-codegen</Path>
             <Path fileType="executable">/usr/bin/gi-compile-repository</Path>
             <Path fileType="executable">/usr/bin/gi-decompile-typelib</Path>
             <Path fileType="executable">/usr/bin/gi-inspect-typelib</Path>
@@ -30,14 +29,9 @@
             <Path fileType="executable">/usr/bin/gio-querymodules</Path>
             <Path fileType="executable">/usr/bin/glib-compile-resources</Path>
             <Path fileType="executable">/usr/bin/glib-compile-schemas</Path>
-            <Path fileType="executable">/usr/bin/glib-genmarshal</Path>
             <Path fileType="executable">/usr/bin/glib-gettextize</Path>
-            <Path fileType="executable">/usr/bin/glib-mkenums</Path>
             <Path fileType="executable">/usr/bin/gobject-query</Path>
-            <Path fileType="executable">/usr/bin/gresource</Path>
             <Path fileType="executable">/usr/bin/gsettings</Path>
-            <Path fileType="executable">/usr/bin/gtester</Path>
-            <Path fileType="executable">/usr/bin/gtester-report</Path>
             <Path fileType="library">/usr/lib64/gio/modules</Path>
             <Path fileType="library">/usr/lib64/girepository-1.0/GIRepository-3.0.typelib</Path>
             <Path fileType="library">/usr/lib64/girepository-1.0/GLib-2.0.typelib</Path>
@@ -63,12 +57,7 @@
             <Path fileType="data">/usr/share/bash-completion/completions/gapplication</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/gdbus</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/gio</Path>
-            <Path fileType="data">/usr/share/bash-completion/completions/gresource</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/gsettings</Path>
-            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib32/libglib-2.0.so.0.8000.4-gdb.py</Path>
-            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib32/libgobject-2.0.so.0.8000.4-gdb.py</Path>
-            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib64/libglib-2.0.so.0.8000.4-gdb.py</Path>
-            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib64/libgobject-2.0.so.0.8000.4-gdb.py</Path>
             <Path fileType="data">/usr/share/gettext/its/gschema.its</Path>
             <Path fileType="data">/usr/share/gettext/its/gschema.loc</Path>
             <Path fileType="data">/usr/share/gir-1.0/GIRepository-3.0.gir</Path>
@@ -78,19 +67,7 @@
             <Path fileType="data">/usr/share/gir-1.0/GObject-2.0.gir</Path>
             <Path fileType="data">/usr/share/gir-1.0/Gio-2.0.gir</Path>
             <Path fileType="data">/usr/share/gir-1.0/GioUnix-2.0.gir</Path>
-            <Path fileType="data">/usr/share/glib-2.0/codegen/__init__.py</Path>
-            <Path fileType="data">/usr/share/glib-2.0/codegen/codegen.py</Path>
-            <Path fileType="data">/usr/share/glib-2.0/codegen/codegen_docbook.py</Path>
-            <Path fileType="data">/usr/share/glib-2.0/codegen/codegen_main.py</Path>
-            <Path fileType="data">/usr/share/glib-2.0/codegen/codegen_md.py</Path>
-            <Path fileType="data">/usr/share/glib-2.0/codegen/codegen_rst.py</Path>
-            <Path fileType="data">/usr/share/glib-2.0/codegen/config.py</Path>
-            <Path fileType="data">/usr/share/glib-2.0/codegen/dbustypes.py</Path>
-            <Path fileType="data">/usr/share/glib-2.0/codegen/parser.py</Path>
-            <Path fileType="data">/usr/share/glib-2.0/codegen/utils.py</Path>
             <Path fileType="data">/usr/share/glib-2.0/dtds/gresource.dtd</Path>
-            <Path fileType="data">/usr/share/glib-2.0/gdb/glib_gdb.py</Path>
-            <Path fileType="data">/usr/share/glib-2.0/gdb/gobject_gdb.py</Path>
             <Path fileType="data">/usr/share/glib-2.0/gettext/po/Makefile.in.in</Path>
             <Path fileType="data">/usr/share/glib-2.0/schemas/gschema.dtd</Path>
             <Path fileType="data">/usr/share/glib-2.0/valgrind/glib.supp</Path>
@@ -204,7 +181,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="109">glib2</Dependency>
+            <Dependency release="110">glib2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/gio/modules</Path>
@@ -231,8 +208,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="109">glib2-devel</Dependency>
-            <Dependency release="109">glib2-32bit</Dependency>
+            <Dependency release="110">glib2-devel</Dependency>
+            <Dependency release="110">glib2-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libgio-2.0.so</Path>
@@ -259,9 +236,15 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="109">glib2</Dependency>
+            <Dependency release="110">glib2</Dependency>
         </RuntimeDependencies>
         <Files>
+            <Path fileType="executable">/usr/bin/gdbus-codegen</Path>
+            <Path fileType="executable">/usr/bin/glib-genmarshal</Path>
+            <Path fileType="executable">/usr/bin/glib-mkenums</Path>
+            <Path fileType="executable">/usr/bin/gresource</Path>
+            <Path fileType="executable">/usr/bin/gtester</Path>
+            <Path fileType="executable">/usr/bin/gtester-report</Path>
             <Path fileType="header">/usr/include/gio-unix-2.0/gio/gdesktopappinfo.h</Path>
             <Path fileType="header">/usr/include/gio-unix-2.0/gio/gfiledescriptorbased.h</Path>
             <Path fileType="header">/usr/include/gio-unix-2.0/gio/gunixfdmessage.h</Path>
@@ -586,11 +569,28 @@
             <Path fileType="data">/usr/share/aclocal/glib-2.0.m4</Path>
             <Path fileType="data">/usr/share/aclocal/glib-gettext.m4</Path>
             <Path fileType="data">/usr/share/aclocal/gsettings.m4</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/gresource</Path>
+            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib32/libglib-2.0.so.0.8000.4-gdb.py</Path>
+            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib32/libgobject-2.0.so.0.8000.4-gdb.py</Path>
+            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib64/libglib-2.0.so.0.8000.4-gdb.py</Path>
+            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib64/libgobject-2.0.so.0.8000.4-gdb.py</Path>
+            <Path fileType="data">/usr/share/glib-2.0/codegen/__init__.py</Path>
+            <Path fileType="data">/usr/share/glib-2.0/codegen/codegen.py</Path>
+            <Path fileType="data">/usr/share/glib-2.0/codegen/codegen_docbook.py</Path>
+            <Path fileType="data">/usr/share/glib-2.0/codegen/codegen_main.py</Path>
+            <Path fileType="data">/usr/share/glib-2.0/codegen/codegen_md.py</Path>
+            <Path fileType="data">/usr/share/glib-2.0/codegen/codegen_rst.py</Path>
+            <Path fileType="data">/usr/share/glib-2.0/codegen/config.py</Path>
+            <Path fileType="data">/usr/share/glib-2.0/codegen/dbustypes.py</Path>
+            <Path fileType="data">/usr/share/glib-2.0/codegen/parser.py</Path>
+            <Path fileType="data">/usr/share/glib-2.0/codegen/utils.py</Path>
+            <Path fileType="data">/usr/share/glib-2.0/gdb/glib_gdb.py</Path>
+            <Path fileType="data">/usr/share/glib-2.0/gdb/gobject_gdb.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="109">
-            <Date>2024-07-10</Date>
+        <Update release="110">
+            <Date>2024-07-11</Date>
             <Version>2.80.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Joey Riches</Name>

--- a/packages/py/python-packaging/package.yml
+++ b/packages/py/python-packaging/package.yml
@@ -1,11 +1,11 @@
 name       : python-packaging
 version    : '24.1'
-release    : 21
+release    : 22
 source     :
     - https://pypi.debian.net/packaging/packaging-24.1.tar.gz : 026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002
 homepage   : https://packaging.pypa.io/
 license    : Apache-2.0
-component  : system.base
+component  : programming.python
 summary    : Core utilities for Python packages
 description: |
     Reusable core utilities for various Python Packaging interoperability specifications. This library provides utilities that implement the interoperability specifications which have clearly one correct behaviour (eg: PEP 440) or benefit greatly from having a single shared implementation (eg: PEP 425).

--- a/packages/py/python-packaging/pspec_x86_64.xml
+++ b/packages/py/python-packaging/pspec_x86_64.xml
@@ -3,11 +3,11 @@
         <Name>python-packaging</Name>
         <Homepage>https://packaging.pypa.io/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
-        <PartOf>system.base</PartOf>
+        <PartOf>programming.python</PartOf>
         <Summary xml:lang="en">Core utilities for Python packages</Summary>
         <Description xml:lang="en">Reusable core utilities for various Python Packaging interoperability specifications. This library provides utilities that implement the interoperability specifications which have clearly one correct behaviour (eg: PEP 440) or benefit greatly from having a single shared implementation (eg: PEP 425).
 </Description>
@@ -18,7 +18,7 @@
         <Summary xml:lang="en">Core utilities for Python packages</Summary>
         <Description xml:lang="en">Reusable core utilities for various Python Packaging interoperability specifications. This library provides utilities that implement the interoperability specifications which have clearly one correct behaviour (eg: PEP 440) or benefit greatly from having a single shared implementation (eg: PEP 425).
 </Description>
-        <PartOf>system.base</PartOf>
+        <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="library">/usr/lib/python3.11/site-packages/packaging-24.1.dist-info/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/packaging-24.1.dist-info/LICENSE.APACHE</Path>
@@ -72,12 +72,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2024-07-22</Date>
+        <Update release="22">
+            <Date>2024-09-18</Date>
             <Version>24.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Move more development related bits to the glib2-devel subpackage in order to drop python-packaging from the system.base group

**Test Plan**

Used system as normal, ensured nothing gnomey blew up

**Checklist**

- [x] Package was built and tested against unstable
