### PR TITLE
zim-tools: Update to 3.4.2

### DIFF
--- a/packages/z/zim-tools/package.yml
+++ b/packages/z/zim-tools/package.yml
@@ -1,8 +1,8 @@
 name       : zim-tools
-version    : 3.4.1
-release    : 15
+version    : 3.4.2
+release    : 16
 source     :
-    - https://github.com/openzim/zim-tools/archive/refs/tags/3.4.1.tar.gz : 0ee5a761c73dee4ec63263ba4b45cbedab77aff00bdeb765ae8250243b873928
+    - https://github.com/openzim/zim-tools/archive/refs/tags/3.4.2.tar.gz : 628c84a9c164bea01504183f0f0dddf19d66a62ce8bdb19747f9bde8a2d90cf3
     - git|https://github.com/kainjow/Mustache : v4.1
 homepage   : https://github.com/openzim/zim-tools/
 license    : GPL-3.0-only

--- a/packages/z/zim-tools/pspec_x86_64.xml
+++ b/packages/z/zim-tools/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>zim-tools</Name>
         <Homepage>https://github.com/openzim/zim-tools/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Nazar Stasiv</Name>
+            <Email>nazar@autistici.org</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <PartOf>office.viewers</PartOf>
@@ -32,12 +32,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2024-07-06</Date>
-            <Version>3.4.1</Version>
+        <Update release="16">
+            <Date>2024-07-14</Date>
+            <Version>3.4.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Nazar Stasiv</Name>
+            <Email>nazar@autistici.org</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- zimwriterfs: Support short option `-a` (tags)
- zimwriterfs: "Name", "Title" and "LongDescription" are mandatory metadata
- zimcheck: Do not run check on content if zim integrity test is failing
- zimrecreate: Do not try to add twice metadata (and fix return code)

**Test Plan**
- zimcheck file.zim

**Checklist**
- [X] Package was built and tested against unstable
