### PR TITLE
rust-bindgen: use new cargo macros

### DIFF
--- a/packages/r/rust-bindgen/abi_used_symbols
+++ b/packages/r/rust-bindgen/abi_used_symbols
@@ -1,5 +1,4 @@
 ld-linux-x86-64.so.2:__tls_get_addr
-libc.so.6:__environ
 libc.so.6:__errno_location
 libc.so.6:__libc_start_main
 libc.so.6:__xpg_strerror_r
@@ -25,19 +24,17 @@ libc.so.6:fcntl
 libc.so.6:fork
 libc.so.6:free
 libc.so.6:fstat64
+libc.so.6:getauxval
 libc.so.6:getcwd
 libc.so.6:getenv
 libc.so.6:getpid
-libc.so.6:getuid
 libc.so.6:gnu_get_libc_version
 libc.so.6:ioctl
 libc.so.6:lseek64
 libc.so.6:malloc
-libc.so.6:memchr
 libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
-libc.so.6:memrchr
 libc.so.6:memset
 libc.so.6:mkdir
 libc.so.6:mmap64

--- a/packages/r/rust-bindgen/package.yml
+++ b/packages/r/rust-bindgen/package.yml
@@ -1,6 +1,6 @@
 name       : rust-bindgen
 version    : 0.69.4
-release    : 1
+release    : 2
 source     :
     - https://github.com/rust-lang/rust-bindgen/archive/refs/tags/v0.69.4.tar.gz : c02ce18b95c4e5021b95b8b461e5dbe6178edffc52a5f555cbca35b910559b5e
 license    : BSD-3-Clause
@@ -13,16 +13,16 @@ description: |
 builddeps  :
     - rust
 setup      : |
-    cargo fetch --locked --target x86_64-unknown-linux-gnu
+    %cargo_fetch
     mkdir -p completions
 build      : |
-    cargo build --frozen --release --all-targets
+    %cargo_build --all-targets
 
     ./target/release/bindgen --generate-shell-completions bash > "completions/bindgen"
     ./target/release/bindgen --generate-shell-completions fish > "completions/bindgen.fish"
     ./target/release/bindgen --generate-shell-completions zsh  > "completions/_bindgen"
 install    : |
-    install -Dm00755 target/release/bindgen $installdir/usr/bin/bindgen
+    %cargo_install bindgen
 
     install -Dm664 "completions/bindgen" -t "$installdir/usr/share/bash-completion/completions/"
     install -Dm664 "completions/bindgen.fish" -t "$installdir/usr/share/fish/vendor_completions.d/"

--- a/packages/r/rust-bindgen/pspec_x86_64.xml
+++ b/packages/r/rust-bindgen/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>rust-bindgen</Name>
         <Homepage>https://github.com/rust-lang/rust-bindgen</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming</PartOf>
@@ -27,12 +27,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-04-25</Date>
+        <Update release="2">
+            <Date>2024-07-14</Date>
             <Version>0.69.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Use new cargo macros

**Test Plan**
- Checked it build.

**Checklist**

- [X] Package was built and tested against unstable
