### PR TITLE
hplip: update to 3.24.4

### DIFF
--- a/packages/h/hplip/abi_used_symbols
+++ b/packages/h/hplip/abi_used_symbols
@@ -334,10 +334,10 @@ libstdc++.so.6:_ZNKSt5ctypeIcE13_M_widen_initEv
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE13find_first_ofEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEPKcm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEPKcmm
-libstdc++.so.6:_ZNSdC2Ev
 libstdc++.so.6:_ZNSdD2Ev
 libstdc++.so.6:_ZNSo3putEc
 libstdc++.so.6:_ZNSo5flushEv
+libstdc++.so.6:_ZNSoC2Ev
 libstdc++.so.6:_ZNSt12__basic_fileIcED1Ev
 libstdc++.so.6:_ZNSt13basic_filebufIcSt11char_traitsIcEE4openEPKcSt13_Ios_Openmode
 libstdc++.so.6:_ZNSt13basic_filebufIcSt11char_traitsIcEE5closeEv
@@ -358,8 +358,8 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_mutateEm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1EOS4_
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1ERKS4_
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev
-libstdc++.so.6:_ZNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE17_M_stringbuf_initESt13_Ios_Openmode
 libstdc++.so.6:_ZNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE7_M_syncEPcmm
+libstdc++.so.6:_ZNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEEC1ERKNS_12basic_stringIcS2_S3_EESt13_Ios_Openmode
 libstdc++.so.6:_ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt8ios_baseC2Ev
 libstdc++.so.6:_ZNSt8ios_baseD2Ev

--- a/packages/h/hplip/monitoring.yml
+++ b/packages/h/hplip/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 1327
+  rss: https://sourceforge.net/projects/hplip/rss?limit=200
+# No known CPE, checked 2024-07-14
+security:
+  cpe: ~

--- a/packages/h/hplip/package.yml
+++ b/packages/h/hplip/package.yml
@@ -1,8 +1,8 @@
 name       : hplip
-version    : 3.23.12
-release    : 62
+version    : 3.24.4
+release    : 63
 source     :
-    - https://sourceforge.net/projects/hplip/files/hplip/3.23.12/hplip-3.23.12.tar.gz : a76c2ac8deb31ddb5f0da31398d25ac57440928a0692dcb060a48daa718e69ed
+    - https://downloads.sourceforge.net/project/hplip/hplip/3.24.4/hplip-3.24.4.tar.gz : 5d7643831893a5e2addf9d42d581a5dbfe5aaf023626886b8762c5645da0f1fb
 homepage   : https://developers.hp.com/hp-linux-imaging-and-printing/gethplip
 license    :
     - GPL-2.0-or-later

--- a/packages/h/hplip/pspec_x86_64.xml
+++ b/packages/h/hplip/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>hplip</Name>
         <Homepage>https://developers.hp.com/hp-linux-imaging-and-printing/gethplip</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>MIT</License>
@@ -22,7 +22,7 @@
 </Description>
         <PartOf>desktop.core</PartOf>
         <RuntimeDependencies>
-            <Dependency release="62">hplip-drivers</Dependency>
+            <Dependency release="63">hplip-drivers</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="config">/etc/hp/hplip.conf</Path>
@@ -71,40 +71,40 @@
             <Path fileType="library">/usr/lib/systemd/system/hplip-printer@.service</Path>
             <Path fileType="data">/usr/share/applications/hp-uiscan.desktop</Path>
             <Path fileType="data">/usr/share/applications/hplip.desktop</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/COPYING</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/README_LIBJPG</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/commandline.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/copying.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/copyright</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/devicemanager.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/faxtrouble.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/gettinghelp.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/hpscan.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/images/favicon.ico</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/images/print.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/images/toolbox_actions.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/images/toolbox_fax.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/images/toolbox_print_control.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/images/toolbox_print_settings.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/images/toolbox_status.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/images/toolbox_supplies.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/images/xsane.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/index.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/mainttask.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/plugins.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/print.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/printing.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/printoptions.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/printtroubleshooting.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/scanning.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/scantrouble.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/sendfax.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/setup.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/styles/css.css</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/systray.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/troubleshooting.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/uninstalling.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.23.12/upgrading.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/COPYING</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/README_LIBJPG</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/commandline.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/copying.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/copyright</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/devicemanager.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/faxtrouble.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/gettinghelp.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/hpscan.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/images/favicon.ico</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/images/print.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/images/toolbox_actions.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/images/toolbox_fax.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/images/toolbox_print_control.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/images/toolbox_print_settings.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/images/toolbox_status.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/images/toolbox_supplies.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/images/xsane.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/index.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/mainttask.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/plugins.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/print.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/printing.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/printoptions.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/printtroubleshooting.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/scanning.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/scantrouble.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/sendfax.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/setup.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/styles/css.css</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/systray.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/troubleshooting.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/uninstalling.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.24.4/upgrading.html</Path>
             <Path fileType="data">/usr/share/hplip/__init__.py</Path>
             <Path fileType="data">/usr/share/hplip/align.py</Path>
             <Path fileType="data">/usr/share/hplip/base/CdmWifi.py</Path>
@@ -1721,6 +1721,10 @@
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_8010_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_8020_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_8040_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_8120_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_8120e_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_8130_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_8130e_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_8700.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_9010_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_9100_series-pcl3.ppd.gz</Path>
@@ -1768,6 +1772,10 @@
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_8020_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_8030_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_8100.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_8120_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_8120e_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_8130_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_8130e_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_8210-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_8500_a909a.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_8500_a909g.ppd.gz</Path>
@@ -1789,6 +1797,10 @@
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9110b_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9120b_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9130b_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9720_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9720e_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9730_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9730e_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_k5300.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_k5400.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_k550.ppd.gz</Path>
@@ -2042,12 +2054,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="62">
-            <Date>2024-05-04</Date>
-            <Version>3.23.12</Version>
+        <Update release="63">
+            <Date>2024-07-14</Date>
+            <Version>3.24.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
After installing or updating this package, run `hp-plugin` on command line before attempting to add a printer, print or scan.

**Summary**

Added support for new printers:
HP OfficeJet 8120 All-in-One series
HP OfficeJet Pro 8120 All-in-One series
HP OfficeJet 8130 All-in-One series
HP OfficeJet Pro 8130 All-in-One series
HP OfficeJet Pro 9720 Series
HP OfficeJet Pro 9730 Series

Solus:
- Added monitoring.yml

**Test Plan**

Verified
- plugin was installed successfully by `hp-plugin`
- previously installed HP Printer is still configurable in Print Settings
- hp-toolbox launches HP Device Manager successfully
- ability to remove and re-add printer / fax in hp-toolbox (Note: must first run hp-plugin)
- scanning works with Simple Scan
- printing works

**Checklist**

- [x] Package was built and tested against unstable
