### PR TITLE
conky: update to 1.21.4

### DIFF
--- a/packages/c/conky/package.yml
+++ b/packages/c/conky/package.yml
@@ -1,8 +1,8 @@
 name       : conky
-version    : 1.21.3
-release    : 46
+version    : 1.21.4
+release    : 47
 source     :
-    - https://github.com/brndnmtthws/conky/archive/refs/tags/v1.21.3.tar.gz : 8de17f704abff4290cd76e513e43d28fba6475ba8da5fdbbf4902eda5890ad9a
+    - https://github.com/brndnmtthws/conky/archive/refs/tags/v1.21.4.tar.gz : 567607122272f4d7d9c2665319b5c17c1aab1f953d388fbfcf4b22c5acab4480
 homepage   : https://github.com/brndnmtthws/conky
 license    :
     - BSD-3-Clause

--- a/packages/c/conky/pspec_x86_64.xml
+++ b/packages/c/conky/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>conky</Name>
         <Homepage>https://github.com/brndnmtthws/conky</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>GPL-3.0-or-later</License>
@@ -28,19 +28,19 @@
             <Path fileType="library">/usr/lib/conky/libimlib2.so</Path>
             <Path fileType="library">/usr/lib/conky/librsvg.so</Path>
             <Path fileType="data">/usr/share/applications/conky.desktop</Path>
-            <Path fileType="doc">/usr/share/doc/conky-1.21.3/conky.conf</Path>
-            <Path fileType="doc">/usr/share/doc/conky-1.21.3/conky_no_x11.conf</Path>
-            <Path fileType="doc">/usr/share/doc/conky-1.21.3/convert.lua</Path>
+            <Path fileType="doc">/usr/share/doc/conky-1.21.4/conky.conf</Path>
+            <Path fileType="doc">/usr/share/doc/conky-1.21.4/conky_no_x11.conf</Path>
+            <Path fileType="doc">/usr/share/doc/conky-1.21.4/convert.lua</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/conky-logomark-violet.svg</Path>
         </Files>
     </Package>
     <History>
-        <Update release="46">
-            <Date>2024-06-15</Date>
-            <Version>1.21.3</Version>
+        <Update release="47">
+            <Date>2024-07-15</Date>
+            <Version>1.21.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/brndnmtthws/conky/releases/tag/v1.21.4).

**Test Plan**
- Checked it started.

**Checklist**

- [X] Package was built and tested against unstable
