### PR TITLE
typst: update to 0.11.1

### DIFF
--- a/packages/t/typst/abi_used_symbols
+++ b/packages/t/typst/abi_used_symbols
@@ -1,4 +1,3 @@
-libc.so.6:__environ
 libc.so.6:__errno_location
 libc.so.6:__libc_start_main
 libc.so.6:__res_init
@@ -38,6 +37,7 @@ libc.so.6:ftruncate64
 libc.so.6:futimes
 libc.so.6:gai_strerror
 libc.so.6:getaddrinfo
+libc.so.6:getauxval
 libc.so.6:getcwd
 libc.so.6:getenv
 libc.so.6:getpeername
@@ -58,11 +58,9 @@ libc.so.6:lseek64
 libc.so.6:lstat64
 libc.so.6:lutimes
 libc.so.6:malloc
-libc.so.6:memchr
 libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
-libc.so.6:memrchr
 libc.so.6:memset
 libc.so.6:mkdir
 libc.so.6:mmap

--- a/packages/t/typst/package.yml
+++ b/packages/t/typst/package.yml
@@ -1,8 +1,8 @@
 name       : typst
-version    : 0.11.0
-release    : 3
+version    : 0.11.1
+release    : 4
 source     :
-    - https://github.com/typst/typst/archive/refs/tags/v0.11.0.tar.gz : fd8debe21d5d22d4cd6c823494537f1356c9954cc2fe6c5db8c76c1b126112dd
+    - https://github.com/typst/typst/archive/refs/tags/v0.11.1.tar.gz : b1ba054e821073daafd90675c4822bcd8166f33fe2e3acba87ba1451a0d1fc56
 homepage   : https://typst.app
 license    : Apache-2.0
 component  : office
@@ -13,8 +13,8 @@ networking : yes
 builddeps  :
     - rust
 setup      : |
-    cargo fetch --locked
+    %cargo_fetch
 build      : |
-    cargo build --frozen %JOBS% --release -p typst-cli
+    %cargo_build -p typst-cli
 install    : |
-    install -Dm00755 target/release/typst -t $installdir/usr/bin
+    %cargo_install

--- a/packages/t/typst/pspec_x86_64.xml
+++ b/packages/t/typst/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>typst</Name>
         <Homepage>https://typst.app</Homepage>
         <Packager>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>office</PartOf>
@@ -24,12 +24,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-03-15</Date>
-            <Version>0.11.0</Version>
+        <Update release="4">
+            <Date>2024-07-15</Date>
+            <Version>0.11.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/typst/typst/releases/tag/v0.11.1).

**Test Plan**
- Created a pdf.

**Checklist**

- [X] Package was built and tested against unstable
