### PR TITLE
phinger-cursors: Update to 2.1

### DIFF
--- a/packages/p/phinger-cursors/package.yml
+++ b/packages/p/phinger-cursors/package.yml
@@ -1,8 +1,8 @@
 name       : phinger-cursors
-version    : 2.0
-release    : 1
+version    : '2.1'
+release    : 2
 source     :
-    - https://github.com/phisch/phinger-cursors/releases/download/v2.0/phinger-cursors-variants.tar.bz2 : 035d811ad734fb00ea79218de256d47b91b73efe08b100784e4bd61e70d4e9b1
+    - https://github.com/phisch/phinger-cursors/releases/download/v2.1/phinger-cursors-variants.tar.bz2 : ddb7310c62bf8e0e2798a24f8a867e4af7b17a39757ba45c85e13f3988f646fc
 homepage   : https://github.com/phisch/phinger-cursors
 license    : CC-BY-SA-4.0
 component  : desktop.theme

--- a/packages/p/phinger-cursors/pspec_x86_64.xml
+++ b/packages/p/phinger-cursors/pspec_x86_64.xml
@@ -317,9 +317,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-05-27</Date>
-            <Version>2.0</Version>
+        <Update release="2">
+            <Date>2024-07-15</Date>
+            <Version>2.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Robert Gonzalez</Name>
             <Email>uni.dos12@outlook.com</Email>


### PR DESCRIPTION
**Summary**
[Release notes](https://github.com/phisch/phinger-cursors/releases/tag/v2.1)

**Test Plan**

Set cursor theme on xfce 

**Checklist**

- [x] Package was built and tested against unstable
