### PR TITLE
neovide: Update to 0.13.3

### DIFF
--- a/packages/n/neovide/package.yml
+++ b/packages/n/neovide/package.yml
@@ -1,8 +1,8 @@
 name       : neovide
-version    : 0.13.2
-release    : 3
+version    : 0.13.3
+release    : 4
 source     :
-    - https://github.com/neovide/neovide/archive/refs/tags/0.13.2.tar.gz : 3ae09d94ad6bbae9fdba306523b28071508c5e8eb205bc8fa9f32e7323fffdb6
+    - https://github.com/neovide/neovide/archive/refs/tags/0.13.3.tar.gz : 21c8eaa53cf3290d2b1405c8cb2cde5f39bc14ef597b328e76f1789b0ef3539a
 homepage   : https://neovide.dev/
 license    :
     - MIT

--- a/packages/n/neovide/pspec_x86_64.xml
+++ b/packages/n/neovide/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>neovide</Name>
         <Homepage>https://neovide.dev/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Wouter Horlings</Name>
+            <Email>wouter@horlin.gs</Email>
         </Packager>
         <License>MIT</License>
         <License>CC-BY-4.0</License>
@@ -36,12 +36,12 @@ To checkout all the cool features, installation instructions, configuration sett
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-07-15</Date>
-            <Version>0.13.2</Version>
+        <Update release="4">
+            <Date>2024-07-17</Date>
+            <Version>0.13.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Wouter Horlings</Name>
+            <Email>wouter@horlin.gs</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Buxfix:

- Use predifined font weights only if user does not specify one

Full release notes:

- [0.13.3](https://github.com/neovide/neovide/releases/tag/0.13.3)

**Test Plan**

- Edited and saved a file

**Checklist**

- [x] Package was built and tested against unstable
