### PR TITLE
claws-mail: update to 4.3.0

### DIFF
--- a/packages/c/claws-mail/abi_symbols
+++ b/packages/c/claws-mail/abi_symbols
@@ -450,6 +450,7 @@ claws-mail:alertpanel_with_widget
 claws-mail:app_will_exit
 claws-mail:append_file
 claws-mail:argv0
+claws-mail:attach_image
 claws-mail:attrib_adding
 claws-mail:attrib_saving
 claws-mail:attrkeyvalue_create
@@ -619,7 +620,6 @@ claws-mail:debug_srcname
 claws-mail:decode_uri
 claws-mail:decode_uri_with_plus
 claws-mail:description_window_create
-claws-mail:dirent_is_regular_file
 claws-mail:display_header_prop_free
 claws-mail:display_header_prop_get_str
 claws-mail:display_header_prop_read_str
@@ -1500,6 +1500,7 @@ claws-mail:mainwindow_delete_duplicated_all
 claws-mail:mainwindow_enter_folder
 claws-mail:mainwindow_exit_folder
 claws-mail:mainwindow_get_mainwindow
+claws-mail:mainwindow_import_mbox
 claws-mail:mainwindow_is_obscured
 claws-mail:mainwindow_jump_to
 claws-mail:mainwindow_learn
@@ -2344,7 +2345,6 @@ claws-mail:str_write_to_file
 claws-mail:strchr_with_skip_quote
 claws-mail:strcrchomp
 claws-mail:strcrlftrunc
-claws-mail:string_match_precompile
 claws-mail:string_remove_match
 claws-mail:string_table_free
 claws-mail:string_table_free_string

--- a/packages/c/claws-mail/abi_used_symbols
+++ b/packages/c/claws-mail/abi_used_symbols
@@ -118,7 +118,6 @@ libc.so.6:fgets_unlocked
 libc.so.6:fileno
 libc.so.6:flock
 libc.so.6:flockfile
-libc.so.6:fmemopen
 libc.so.6:fopen
 libc.so.6:fork
 libc.so.6:fputc
@@ -468,6 +467,7 @@ libexpat.so.1:XML_SetUnknownEncodingHandler
 libexpat.so.1:XML_SetUserData
 libgdk-3.so.0:gdk_app_launch_context_new
 libgdk-3.so.0:gdk_app_launch_context_set_screen
+libgdk-3.so.0:gdk_atom_intern
 libgdk-3.so.0:gdk_atom_intern_static_string
 libgdk-3.so.0:gdk_atom_name
 libgdk-3.so.0:gdk_cairo_create
@@ -833,8 +833,8 @@ libglib-2.0.so.0:g_node_prepend
 libglib-2.0.so.0:g_node_reverse_children
 libglib-2.0.so.0:g_node_traverse
 libglib-2.0.so.0:g_node_unlink
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_path_get_basename
 libglib-2.0.so.0:g_path_get_dirname
 libglib-2.0.so.0:g_path_is_absolute
@@ -1270,6 +1270,7 @@ libgtk-3.so.0:gtk_check_menu_item_set_inconsistent
 libgtk-3.so.0:gtk_clipboard_get
 libgtk-3.so.0:gtk_clipboard_set_image
 libgtk-3.so.0:gtk_clipboard_set_text
+libgtk-3.so.0:gtk_clipboard_wait_for_contents
 libgtk-3.so.0:gtk_clipboard_wait_for_text
 libgtk-3.so.0:gtk_color_button_new_with_rgba
 libgtk-3.so.0:gtk_color_button_set_title
@@ -1573,11 +1574,13 @@ libgtk-3.so.0:gtk_scrolled_window_set_policy
 libgtk-3.so.0:gtk_scrolled_window_set_propagate_natural_height
 libgtk-3.so.0:gtk_scrolled_window_set_shadow_type
 libgtk-3.so.0:gtk_scrolled_window_set_vadjustment
+libgtk-3.so.0:gtk_selection_data_free
 libgtk-3.so.0:gtk_selection_data_get_data
 libgtk-3.so.0:gtk_selection_data_get_data_type
 libgtk-3.so.0:gtk_selection_data_get_format
 libgtk-3.so.0:gtk_selection_data_get_length
 libgtk-3.so.0:gtk_selection_data_get_target
+libgtk-3.so.0:gtk_selection_data_get_targets
 libgtk-3.so.0:gtk_selection_data_set
 libgtk-3.so.0:gtk_selection_mode_get_type
 libgtk-3.so.0:gtk_separator_menu_item_new
@@ -1821,7 +1824,6 @@ libgtk-3.so.0:gtk_tree_view_set_enable_search
 libgtk-3.so.0:gtk_tree_view_set_enable_tree_lines
 libgtk-3.so.0:gtk_tree_view_set_headers_visible
 libgtk-3.so.0:gtk_tree_view_set_reorderable
-libgtk-3.so.0:gtk_tree_view_set_rules_hint
 libgtk-3.so.0:gtk_tree_view_set_search_column
 libgtk-3.so.0:gtk_tree_view_set_search_equal_func
 libgtk-3.so.0:gtk_true
@@ -2268,8 +2270,8 @@ libpython3.11.so.1.0:_Py_Dealloc
 libpython3.11.so.1.0:_Py_FalseStruct
 libpython3.11.so.1.0:_Py_NoneStruct
 libpython3.11.so.1.0:_Py_TrueStruct
-librsvg-2.so.2:rsvg_handle_get_dimensions
+librsvg-2.so.2:rsvg_handle_get_intrinsic_size_in_pixels
 librsvg-2.so.2:rsvg_handle_new_from_file
-librsvg-2.so.2:rsvg_handle_render_cairo
+librsvg-2.so.2:rsvg_handle_render_document
 libz.so.1:deflate
 libz.so.1:deflateInit_

--- a/packages/c/claws-mail/files/org.claws_mail.Claws-Mail.appdata.xml
+++ b/packages/c/claws-mail/files/org.claws_mail.Claws-Mail.appdata.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2019 Danny van Heumen -->
+<component type="desktop-application">
+  <id>org.claws_mail.Claws-Mail</id>
+  <name>Claws-Mail</name>
+  <project_license>GPL-3.0-only</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <developer_name>The Claws Mail Team</developer_name>
+  <summary>Claws Mail is an email client (and news reader), based on GTK+</summary>
+  <url type="homepage">https://claws-mail.org/</url>
+
+  <description>
+    <p>Claws Mail is an email client (and news reader), based on GTK+, featuring:</p>
+    <ul>
+      <li>Quick response</li>
+      <li>Graceful, and sophisticated interface</li>
+      <li>Easy configuration, intuitive operation</li>
+      <li>Abundant features</li>
+      <li>Extensibility</li>
+      <li>Robustness and stability</li>
+    </ul>
+  </description>
+
+  <launchable type="desktop-id">claws-mail.desktop</launchable>
+
+  <screenshots>
+    <screenshot>
+      <image type="source">
+        https://raw.githubusercontent.com/flathub/org.claws_mail.Claws-Mail/379b411ceda0d0fb6f612c94eed008724df674eb/screenshots/claws-mail-main-window.png
+      </image>
+    </screenshot>
+    <screenshot>
+      <image type="source">
+        https://raw.githubusercontent.com/flathub/org.claws_mail.Claws-Mail/379b411ceda0d0fb6f612c94eed008724df674eb/screenshots/claws-mail-compose-window.png
+      </image>
+    </screenshot>
+    <screenshot>
+      <image type="source">
+        https://raw.githubusercontent.com/flathub/org.claws_mail.Claws-Mail/379b411ceda0d0fb6f612c94eed008724df674eb/screenshots/claws-mail-reading-mail.png
+      </image>
+    </screenshot>
+    <screenshot>
+      <image type="source">
+        https://raw.githubusercontent.com/flathub/org.claws_mail.Claws-Mail/379b411ceda0d0fb6f612c94eed008724df674eb/screenshots/claws-mail-current-features.png
+      </image>
+    </screenshot>
+    <screenshot>
+      <image type="source">
+        https://raw.githubusercontent.com/flathub/org.claws_mail.Claws-Mail/379b411ceda0d0fb6f612c94eed008724df674eb/screenshots/claws-mail-current-plugins.png
+      </image>
+    </screenshot>
+  </screenshots>
+
+</component>

--- a/packages/c/claws-mail/package.yml
+++ b/packages/c/claws-mail/package.yml
@@ -1,8 +1,8 @@
 name       : claws-mail
-version    : 4.2.0
-release    : 39
+version    : 4.3.0
+release    : 40
 source     :
-    - https://www.claws-mail.org/releases/claws-mail-4.2.0.tar.xz : 7c8ab1732d74197df06d61a6b7ebc7c580ecf6e92eb1ef6ae5b0107533f1af07
+    - https://www.claws-mail.org/releases/claws-mail-4.3.0.tar.xz : 95dc1d888eb916f028467fa0c3cbf45baff6678793b7bfb35fabba029d581ce1
 homepage   : https://claws-mail.org/
 license    : GPL-3.0-or-later
 component  : network.mail
@@ -46,3 +46,4 @@ build      : |
     %make
 install    : |
     %make_install
+    install -Dm00644 $pkgfiles/org.claws_mail.Claws-Mail.appdata.xml $installdir/usr/share/metainfo/org.claws_mail.Claws-Mail.appdata.xml

--- a/packages/c/claws-mail/pspec_x86_64.xml
+++ b/packages/c/claws-mail/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>claws-mail</Name>
         <Homepage>https://claws-mail.org/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.mail</PartOf>
@@ -76,10 +76,12 @@
             <Path fileType="localedata">/usr/share/locale/ro/LC_MESSAGES/claws-mail.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ru/LC_MESSAGES/claws-mail.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sk/LC_MESSAGES/claws-mail.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sq/LC_MESSAGES/claws-mail.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/claws-mail.mo</Path>
             <Path fileType="localedata">/usr/share/locale/tr/LC_MESSAGES/claws-mail.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/claws-mail.mo</Path>
             <Path fileType="man">/usr/share/man/man1/claws-mail.1</Path>
+            <Path fileType="data">/usr/share/metainfo/org.claws_mail.Claws-Mail.appdata.xml</Path>
         </Files>
     </Package>
     <Package>
@@ -89,7 +91,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="39">claws-mail</Dependency>
+            <Dependency release="40">claws-mail</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/claws-mail/account.h</Path>
@@ -325,12 +327,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="39">
-            <Date>2024-03-04</Date>
-            <Version>4.2.0</Version>
+        <Update release="40">
+            <Date>2024-07-17</Date>
+            <Version>4.3.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://www.claws-mail.org/news.php).

**Test Plan**
- Installed and setup an account.

**Checklist**

- [X] Package was built and tested against unstable

**Packaging notes**
- Appstream metadata added from flathub.
