### PR TITLE
fzf: update to 0.54.0

### DIFF
--- a/packages/f/fzf/package.yml
+++ b/packages/f/fzf/package.yml
@@ -1,8 +1,8 @@
 name       : fzf
-version    : 0.52.1
-release    : 28
+version    : 0.54.0
+release    : 29
 source     :
-    - git|https://github.com/junegunn/fzf : 6432f00f0d026c61f683c83ded4d2e15317e927e
+    - git|https://github.com/junegunn/fzf : 9e92b6f11e0f59272de410f56493893334071e6e
 homepage   : https://github.com/junegunn/fzf
 license    : MIT
 component  : system.utils

--- a/packages/f/fzf/pspec_x86_64.xml
+++ b/packages/f/fzf/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>fzf</Name>
         <Homepage>https://github.com/junegunn/fzf</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -34,12 +34,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2024-05-15</Date>
-            <Version>0.52.1</Version>
+        <Update release="29">
+            <Date>2024-07-18</Date>
+            <Version>0.54.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/junegunn/fzf/releases/tag/v0.54.0).

**Test Plan**
- Installed did some fuzzy finding and checked the version.

**Checklist**

-  [X] Package was built and tested against unstable
