### PR TITLE
common/Scripts/worklog.py: Fix missing whitespace

### DIFF
--- a/common/Scripts/worklog.py
+++ b/common/Scripts/worklog.py
@@ -247,7 +247,7 @@ class Build(Listable):
 
     @property
     def _comment(self) -> Optional[str]:
-        return self.comment.replace('\n','; ') if self.comment else None
+        return self.comment.replace('\n', '; ') if self.comment else None
 
     @property
     def status_color(self) -> str:


### PR DESCRIPTION
**Summary**
This is a simple fix for a linter error which was causing failures in unrelated PRs.

**Test Plan**
1. Test out `worklog.py`. See that it works perfectly.
2. Run `flake8` against `worklog.py`. See that it fails.
3. Check out this PR.
4. Run `flake8` against `worklog.py` again. See that it passes. 
5. Try `worklog.py` again and see that it functions in the same way.

**Checklist**

- [x] Package was built and tested against unstable
