### PR TITLE
hyphen-de: Update to 2022.09.23

### DIFF
--- a/packages/h/hyphen-de/package.yml
+++ b/packages/h/hyphen-de/package.yml
@@ -1,9 +1,10 @@
 name       : hyphen-de
-version    : 2007.02.17
-release    : 1
+version    : 2022.09.23
+release    : 2
 source     :
-    - http://download.services.openoffice.org/contrib/dictionaries/hyph_de_DE.zip : 731a87fb5ed128341b4178b1dee11819fd5e7392e4ac0526c318d9ab28cf61c9
-license    : LGPL-2.0-or-later
+    - git|https://anongit.freedesktop.org/git/libreoffice/dictionaries.git : 9e27d044d98e65f89af8c86df722a77be827bdc8
+homepage   : https://wiki.documentfoundation.org/Development/Dictionaries
+license    : LGPL-2.1-or-later
 component  : office
 summary    : German hyphenation rules
 description: |
@@ -11,11 +12,16 @@ description: |
 rundeps    :
     - hyphen
 install    : |
-    install -Dm00644 hyph_de_DE.dic $installdir/usr/share/hyphen/hyph_de_DE.dic
+    install -dm00755 $installdir/usr/share/hyphen
+    cp -p de/hyph_de_??.* $installdir/usr/share/hyphen
 
     pushd $installdir/usr/share/hyphen/
-        de_DE_aliases="de_AT de_BE de_CH de_LI de_LU"
-        for lang in ${de_DE_aliases}; do
-            ln -s hyph_de_DE.dic hyph_${lang}.dic
+        de_DE_aliases="de_BE de_LU"
+        for lang in $de_DE_aliases; do
+            ln -s hyph_de_DE.dic hyph_$lang.dic
+        done
+        de_CH_aliases="de_LI"
+        for lang in $de_CH_aliases; do
+            ln -s hyph_de_CH.dic hyph_$lang.dic
         done
     popd

--- a/packages/h/hyphen-de/pspec_x86_64.xml
+++ b/packages/h/hyphen-de/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>hyphen-de</Name>
+        <Homepage>https://wiki.documentfoundation.org/Development/Dictionaries</Homepage>
         <Packager>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
-        <License>LGPL-2.0-or-later</License>
+        <License>LGPL-2.1-or-later</License>
         <PartOf>office</PartOf>
         <Summary xml:lang="en">German hyphenation rules</Summary>
         <Description xml:lang="en">German hyphenation rules.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>hyphen-de</Name>
@@ -28,12 +29,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2021-03-02</Date>
-            <Version>2007.02.17</Version>
+        <Update release="2">
+            <Date>2024-07-18</Date>
+            <Version>2022.09.23</Version>
             <Comment>Packaging update</Comment>
-            <Name>Pierre-Yves</Name>
-            <Email>pyu@riseup.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- No upstream changelog
- Switch to git source, no tarball available
- Add homepage` key to `package.yml` (Part of getsolus/packages#411)
- Resolves getsolus/packages#2640

**Test Plan**

<!-- Short description of how the package was tested -->
Need german speaker to actually test it

**Checklist**

- [x] Package was built and tested against unstable
