### PR TITLE
eza: Update to 0.18.22

### DIFF
--- a/packages/e/eza/package.yml
+++ b/packages/e/eza/package.yml
@@ -1,8 +1,8 @@
 name       : eza
-version    : 0.18.21
-release    : 26
+version    : 0.18.22
+release    : 27
 source     :
-    - https://github.com/eza-community/eza/archive/refs/tags/v0.18.21.tar.gz : 53cee12706be2b5bedcf40b97e077a18b254f0f53f1aee52d1d74136466045bc
+    - https://github.com/eza-community/eza/archive/refs/tags/v0.18.22.tar.gz : 552fe9997ed4fc6e11dafebffc2aa249ab3fb465a05c614181c7b62e8a0df698
 homepage   : https://github.com/eza-community/eza
 license    : MIT
 component  : system.utils

--- a/packages/e/eza/pspec_x86_64.xml
+++ b/packages/e/eza/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>eza</Name>
         <Homepage>https://github.com/eza-community/eza</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -33,12 +33,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2024-07-04</Date>
-            <Version>0.18.21</Version>
+        <Update release="27">
+            <Date>2024-07-18</Date>
+            <Version>0.18.22</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Use NaiveDateTime::from_timestamp_opt instead of panicky From impl

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

List files in a directory.

**Checklist**

- [x] Package was built and tested against unstable
