### PR TITLE
weechat: Update to 4.3.5

### DIFF
--- a/packages/w/weechat/abi_symbols
+++ b/packages/w/weechat/abi_symbols
@@ -2668,6 +2668,7 @@ python.so:weechat_python_info_eval_cb
 python.so:weechat_python_infolist_cb
 python.so:weechat_python_infolist_constants
 python.so:weechat_python_infolist_functions
+python.so:weechat_python_init_before_autoload
 python.so:weechat_python_load
 python.so:weechat_python_load_cb
 python.so:weechat_python_output_flush

--- a/packages/w/weechat/abi_used_symbols
+++ b/packages/w/weechat/abi_used_symbols
@@ -550,6 +550,7 @@ libruby.so.3.2:ruby_cleanup
 libruby.so.3.2:ruby_init
 libruby.so.3.2:ruby_init_loadpath
 libruby.so.3.2:ruby_init_stack
+libruby.so.3.2:ruby_options
 libruby.so.3.2:ruby_script
 libruby.so.3.2:ruby_snprintf
 libruby.so.3.2:ruby_version

--- a/packages/w/weechat/package.yml
+++ b/packages/w/weechat/package.yml
@@ -1,8 +1,8 @@
 name       : weechat
-version    : 4.3.2
-release    : 83
+version    : 4.3.5
+release    : 84
 source     :
-    - https://github.com/weechat/weechat/archive/refs/tags/v4.3.2.tar.gz : f3311a523d4b19c1ebed15dab7a2913bd0edabf69be345fe2095ff4e64506537
+    - https://github.com/weechat/weechat/archive/refs/tags/v4.3.5.tar.gz : 6e2acfe3472b61ec43a57058c596793464b38a5f17961259470e8a7d0f31a758
 homepage   : https://weechat.org
 license    : GPL-3.0-or-later
 summary    : WeeChat is a fast, light and extensible chat client.

--- a/packages/w/weechat/pspec_x86_64.xml
+++ b/packages/w/weechat/pspec_x86_64.xml
@@ -72,7 +72,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="83">weechat</Dependency>
+            <Dependency release="84">weechat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/weechat/weechat-plugin.h</Path>
@@ -80,9 +80,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="83">
-            <Date>2024-06-06</Date>
-            <Version>4.3.2</Version>
+        <Update release="84">
+            <Date>2024-07-18</Date>
+            <Version>4.3.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- ruby: fix crash in plugin initialization
- python: fix crash on quit with Python 3.12 (Solus is on Python 3.11)
- core: fix crash when deleting a bar that has no items
- ruby: fix builtin functions not available
- relay/api: fix "body_type" returned when lines or nicks of a buffer are requested
- core, plugins: return "0x0" instead of "(nil)" for pointers formatted in strings

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Connect to Libera Chat, join a room, send and receive messages.

**Checklist**

- [x] Package was built and tested against unstable
