### PR TITLE
lightdm-gtk-greeter-settings:  Update to 1.2.3

### DIFF
--- a/packages/l/lightdm-gtk-greeter-settings/monitoring.yml
+++ b/packages/l/lightdm-gtk-greeter-settings/monitoring.yml
@@ -1,0 +1,5 @@
+releases:
+  id: 16718
+  rss: https://github.com/Xubuntu/lightdm-gtk-greeter-settings/releases.atom
+security:
+  cpe: ~

--- a/packages/l/lightdm-gtk-greeter-settings/package.yml
+++ b/packages/l/lightdm-gtk-greeter-settings/package.yml
@@ -1,8 +1,9 @@
 name       : lightdm-gtk-greeter-settings
-version    : 1.2.2
-release    : 8
+version    : 1.2.3
+release    : 9
 source     :
-    - https://github.com/Xubuntu/lightdm-gtk-greeter-settings/releases/download/lightdm-gtk-greeter-settings-1.2.2/lightdm-gtk-greeter-settings-1.2.2.tar.gz : 4364d8b25b23d2ef4856d19724fd6c67de9a2d3c1b3833f7a5441145fd39dcb7
+    - https://github.com/Xubuntu/lightdm-gtk-greeter-settings/releases/download/lightdm-gtk-greeter-settings-1.2.3/lightdm-gtk-greeter-settings-1.2.3.tar.gz : 77482a95cb7cc23d78d3c95810a965deddce62cb70349cd03c7a79fe000e740f
+homepage   : https://github.com/Xubuntu/lightdm-gtk-greeter-settings
 license    : GPL-3.0-or-later
 component  : system.utils
 summary    : Dialog for modifying the settings of lightdm-gtk-greeter

--- a/packages/l/lightdm-gtk-greeter-settings/pspec_x86_64.xml
+++ b/packages/l/lightdm-gtk-greeter-settings/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>lightdm-gtk-greeter-settings</Name>
+        <Homepage>https://github.com/Xubuntu/lightdm-gtk-greeter-settings</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -21,10 +22,10 @@
         <Files>
             <Path fileType="executable">/usr/bin/lightdm-gtk-greeter-settings</Path>
             <Path fileType="executable">/usr/bin/lightdm-gtk-greeter-settings-pkexec</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/lightdm_gtk_greeter_settings-1.2.2-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/lightdm_gtk_greeter_settings-1.2.2-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/lightdm_gtk_greeter_settings-1.2.2-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/lightdm_gtk_greeter_settings-1.2.2-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lightdm_gtk_greeter_settings-1.2.3-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lightdm_gtk_greeter_settings-1.2.3-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lightdm_gtk_greeter_settings-1.2.3-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lightdm_gtk_greeter_settings-1.2.3-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lightdm_gtk_greeter_settings/Config.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lightdm_gtk_greeter_settings/GtkGreeterSettingsWindow.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lightdm_gtk_greeter_settings/IconChooserDialog.py</Path>
@@ -54,7 +55,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lightdm_gtk_greeter_settings/installation_config.py</Path>
             <Path fileType="data">/usr/share/applications/lightdm-gtk-greeter-settings.desktop</Path>
             <Path fileType="doc">/usr/share/doc/lightdm-gtk-greeter-settings/NEWS</Path>
-            <Path fileType="doc">/usr/share/doc/lightdm-gtk-greeter-settings/README</Path>
+            <Path fileType="doc">/usr/share/doc/lightdm-gtk-greeter-settings/README.md</Path>
             <Path fileType="data">/usr/share/icons/hicolor/16x16/apps/lightdm-gtk-greeter-settings.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/24x24/apps/lightdm-gtk-greeter-settings.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/lightdm-gtk-greeter-settings.png</Path>
@@ -67,6 +68,7 @@
             <Path fileType="data">/usr/share/lightdm-gtk-greeter-settings/MultiheadSetupDialog.ui</Path>
             <Path fileType="data">/usr/share/lightdm-gtk-greeter-settings/gtk_greeter_settings.xml</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/be/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="localedata">/usr/share/locale/br/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
@@ -74,31 +76,41 @@
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="localedata">/usr/share/locale/el/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/et/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fi/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/he/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="localedata">/usr/share/locale/hr/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/hu/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="localedata">/usr/share/locale/kk/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ko/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lt/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="localedata">/usr/share/locale/nl/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/oc/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pl/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ru/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sl/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sr/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/tr/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/lightdm-gtk-greeter-settings.mo</Path>
             <Path fileType="data">/usr/share/polkit-1/actions/com.ubuntu.pkexec.lightdm-gtk-greeter-settings.policy</Path>
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2024-02-16</Date>
-            <Version>1.2.2</Version>
+        <Update release="9">
+            <Date>2024-07-18</Date>
+            <Version>1.2.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- [changelog](https://github.com/Xubuntu/lightdm-gtk-greeter-settings/releases/tag/lightdm-gtk-greeter-settings-1.2.3)
- add homepage

**Test Plan**

change settings in vm

**Checklist**

- [x] Package was built and tested against unstable
