### PR TITLE
antidote: update to 1.9.7

### DIFF
--- a/packages/a/antidote/package.yml
+++ b/packages/a/antidote/package.yml
@@ -1,8 +1,8 @@
 name       : antidote
-version    : 1.9.6
-release    : 2
+version    : 1.9.7
+release    : 3
 source     :
-    - https://github.com/mattmc3/antidote/archive/refs/tags/v1.9.6.tar.gz : 17b76964b2faebb750c0291effc452aaab09a13db16c5fa8971db8454e24f918
+    - https://github.com/mattmc3/antidote/archive/refs/tags/v1.9.7.tar.gz : 67245a39d9719251e295cbeae7b050c99eccff5b978badd1e4b61e90575a6fac
 homepage   : https://getantidote.github.io/
 license    : MIT
 component  : system.utils

--- a/packages/a/antidote/pspec_x86_64.xml
+++ b/packages/a/antidote/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>antidote</Name>
         <Homepage>https://getantidote.github.io/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -27,12 +27,14 @@
             <Path fileType="data">/usr/share/antidote/functions/__antidote_bundle_type</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_bundle_zcompile</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_collect_input</Path>
+            <Path fileType="data">/usr/share/antidote/functions/__antidote_del</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_filter_defers</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_get_cachedir</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_indent</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_initfiles</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_load_prep</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_parse_bundles</Path>
+            <Path fileType="data">/usr/share/antidote/functions/__antidote_print_path</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_setup</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_tourl</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_usage</Path>
@@ -57,12 +59,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-05-30</Date>
-            <Version>1.9.6</Version>
+        <Update release="3">
+            <Date>2024-07-19</Date>
+            <Version>1.9.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/mattmc3/antidote/releases/tag/v1.9.7).

**Test Plan**
- Checked plugins.

**Checklist**

- [X] Package was built and tested against unstable
