### PR TITLE
labwc: update to 0.7.4

### DIFF
--- a/packages/l/labwc/package.yml
+++ b/packages/l/labwc/package.yml
@@ -1,8 +1,8 @@
 name       : labwc
-version    : 0.7.3
-release    : 4
+version    : 0.7.4
+release    : 5
 source     :
-    - https://github.com/labwc/labwc/archive/refs/tags/0.7.3.tar.gz : 72352250b2a9758a24d5766030a7c3f62c658df7b94552f3701ea86e557d0f2a
+    - https://github.com/labwc/labwc/archive/refs/tags/0.7.4.tar.gz : 2afa1ef483863fc6217803a540b9afab6939d2324e9bb4dcf4a028281b731fb9
 homepage   : https://labwc.github.io/
 license    : GPL-2.0-or-later
 component  : desktop

--- a/packages/l/labwc/pspec_x86_64.xml
+++ b/packages/l/labwc/pspec_x86_64.xml
@@ -62,9 +62,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-07-13</Date>
-            <Version>0.7.3</Version>
+        <Update release="5">
+            <Date>2024-07-19</Date>
+            <Version>0.7.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Facundo Ciruzzi</Name>
             <Email>ciruzzifacundo@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Minor update, crash related to pipemenus

Full release note: [0.7.4](https://github.com/labwc/labwc/releases/tag/0.7.4)

**Test Plan**

It was updated, and it loads the previous configuration with zero issues

**Checklist**

- [x] Package was built and tested against unstable
