### PR TITLE
fb2converter: Update to 1.75.2

### DIFF
--- a/packages/f/fb2converter/package.yml
+++ b/packages/f/fb2converter/package.yml
@@ -1,8 +1,8 @@
 name       : fb2converter
-version    : 1.75.1
-release    : 24
+version    : 1.75.2
+release    : 25
 source     :
-    - git|https://github.com/rupor-github/fb2converter.git : v1.75.1
+    - git|https://github.com/rupor-github/fb2converter.git : v1.75.2
 homepage   : https://github.com/rupor-github/fb2converter
 license    : GPL-3.0-only
 component  : office.viewers

--- a/packages/f/fb2converter/pspec_x86_64.xml
+++ b/packages/f/fb2converter/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>fb2converter</Name>
         <Homepage>https://github.com/rupor-github/fb2converter</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Nazar Stasiv</Name>
+            <Email>nazar@autistici.org</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <PartOf>office.viewers</PartOf>
@@ -26,12 +26,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2024-03-09</Date>
-            <Version>1.75.1</Version>
+        <Update release="25">
+            <Date>2024-07-21</Date>
+            <Version>1.75.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Nazar Stasiv</Name>
+            <Email>nazar@autistici.org</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- [changelog](https://github.com/rupor-github/fb2converter/compare/v1.75.1...v1.75.2)

**Test Plan**
- fb2c convert --to epub file.fb2

**Checklist**
- [X] Package was built and tested against unstable
