### PR TITLE
libheif: Update to 1.18.1

### DIFF
--- a/packages/l/libheif/abi_symbols
+++ b/packages/l/libheif/abi_symbols
@@ -207,6 +207,7 @@ libheif.so.1:heif_init
 libheif.so.1:heif_item_add_property_user_description
 libheif.so.1:heif_item_add_raw_property
 libheif.so.1:heif_item_get_properties_of_type
+libheif.so.1:heif_item_get_property_raw_data
 libheif.so.1:heif_item_get_property_raw_size
 libheif.so.1:heif_item_get_property_transform_crop_borders
 libheif.so.1:heif_item_get_property_transform_mirror

--- a/packages/l/libheif/abi_used_symbols
+++ b/packages/l/libheif/abi_used_symbols
@@ -193,7 +193,6 @@ libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE5rfindEcm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6substrEmm
 libstdc++.so.6:_ZNKSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE3strEv
 libstdc++.so.6:_ZNKSt8__detail20_Prime_rehash_policy14_M_need_rehashEmmm
-libstdc++.so.6:_ZNSdC2Ev
 libstdc++.so.6:_ZNSdD2Ev
 libstdc++.so.6:_ZNSi4readEPcl
 libstdc++.so.6:_ZNSi5seekgElSt12_Ios_Seekdir

--- a/packages/l/libheif/package.yml
+++ b/packages/l/libheif/package.yml
@@ -1,8 +1,8 @@
 name       : libheif
-version    : 1.18.0
-release    : 40
+version    : 1.18.1
+release    : 41
 source     :
-    - https://github.com/strukturag/libheif/releases/download/v1.18.0/libheif-1.18.0.tar.gz : 3f25f516d84401d7c22a24ef313ae478781b95f235c250b06152701c401055c3
+    - https://github.com/strukturag/libheif/releases/download/v1.18.1/libheif-1.18.1.tar.gz : 8702564b0f288707ea72b260b3bf4ba9bf7abfa7dac01353def3a86acd6bbb76
 license    : LGPL-3.0-or-later
 homepage   : https://github.com/strukturag/libheif
 component  : multimedia.codecs

--- a/packages/l/libheif/pspec_x86_64.xml
+++ b/packages/l/libheif/pspec_x86_64.xml
@@ -29,7 +29,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
             <Path fileType="library">/usr/lib64/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-heif.so</Path>
             <Path fileType="library">/usr/lib64/libheif</Path>
             <Path fileType="library">/usr/lib64/libheif.so.1</Path>
-            <Path fileType="library">/usr/lib64/libheif.so.1.18.0</Path>
+            <Path fileType="library">/usr/lib64/libheif.so.1.18.1</Path>
             <Path fileType="man">/usr/share/man/man1/heif-dec.1</Path>
             <Path fileType="man">/usr/share/man/man1/heif-enc.1</Path>
             <Path fileType="man">/usr/share/man/man1/heif-info.1</Path>
@@ -45,7 +45,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="40">libheif</Dependency>
+            <Dependency release="41">libheif</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libheif/heif.h</Path>
@@ -63,9 +63,9 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
         </Files>
     </Package>
     <History>
-        <Update release="40">
-            <Date>2024-07-11</Date>
-            <Version>1.18.0</Version>
+        <Update release="41">
+            <Date>2024-07-25</Date>
+            <Version>1.18.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

This releases fixes the syntax of the `vvcC` box and a few build issues

**Test Plan**

Encoded, decoded and viewed a couple of HEIF images

**Checklist**

- [x] Package was built and tested against unstable
