### PR TITLE
sof-firmware: update to 2.10

### DIFF
--- a/packages/s/sof-firmware/package.yml
+++ b/packages/s/sof-firmware/package.yml
@@ -1,9 +1,9 @@
 name       : sof-firmware
 homepage   : https://github.com/thesofproject/sof-bin
-version    : '2.9'
-release    : 21
+version    : '2.10'
+release    : 22
 source     :
-    - https://github.com/thesofproject/sof-bin/releases/download/v2024.03/sof-bin-2024.03.tar.gz : 4fd932f7bbc1517b06fa7911e6d566814d5dc4fec5608bdb44e7c4fe4929fbf6
+    - https://github.com/thesofproject/sof-bin/releases/download/v2024.06/sof-bin-2024.06.tar.gz : 581ca3285bb56837a8954953f629ebddce644152b673ecd4bbfae1504306d7d6
 license    :
     - BSD-3-Clause
     - ISC

--- a/packages/s/sof-firmware/pspec_x86_64.xml
+++ b/packages/s/sof-firmware/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>sof-firmware</Name>
         <Homepage>https://github.com/thesofproject/sof-bin</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>ISC</License>
@@ -35,21 +35,38 @@
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-idisp.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-imx8mp-wm8960.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt1318-l12-rt714-l0.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt711-4ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt711-l0-rt1316-l23-rt714-l1.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt712-l2-rt1712-l3.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt722-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0-cs35l56-l12.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0-cs35l56-l23.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-es83x6-ssp1-hdmi-ssp02.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-hdmi-ssp02.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-max98357a-rt5682-google-aec.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-max98357a-rt5682-ssp2-ssp0-2ch-pdm1-google-aec.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-max98357a-rt5682-ssp2-ssp0-2ch-pdm1.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-max98357a-rt5682-ssp2-ssp0-google-aec.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-max98357a-rt5682-ssp2-ssp0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-max98357a-rt5682.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt1019-rt5682.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt1318-l12-rt714-l0.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt5650-dts-google-aec.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt5650-dts.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt5650.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt711-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt711-l0-rt1316-l23-rt714-l1.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt711-l0-rt1316-l3-2ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt711-l0-rt1316-l3-4ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt711-l0-rt1316-l3.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt712-l0-rt1712-l3.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt712-l0.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt712-vb-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt713-l0-rt1316-l12-rt1713-l3.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt713-l0-rt1316-l12.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt713-l0-rt1318-l1-rt1713-l3.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt713-l0-rt1318-l12-rt1713-l3.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt722-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-sdw-cs42l42-l0-max98363-l2.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-tgl-cs42l43-l3-cs35l56-l01.tplg</Path>
@@ -67,6 +84,14 @@
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4/adl/community/sof-adl.ri</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4/adl/intel-signed/sof-adl.ri</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4/adl/sof-adl.ri</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4/arl-s/community/sof-arl-s.ri</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4/arl-s/intel-signed/sof-arl-s.ri</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4/arl-s/sof-arl-s.ri</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4/arl/community/sof-arl.ri</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4/ehl/community/sof-ehl.ri</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4/lnl/community/sof-lnl.ri</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4/lnl/intel-signed/sof-lnl.ri</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4/lnl/sof-lnl.ri</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4/mtl/community/sof-mtl.ri</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4/mtl/intel-signed/sof-mtl.ri</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4/mtl/sof-mtl.ri</Path>
@@ -452,21 +477,38 @@
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-idisp.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-imx8mp-wm8960.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt1318-l12-rt714-l0.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt711-4ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt711-l0-rt1316-l23-rt714-l1.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt712-l2-rt1712-l3.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt722-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0-cs35l56-l12.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0-cs35l56-l23.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-es83x6-ssp1-hdmi-ssp02.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-hdmi-ssp02.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-max98357a-rt5682-google-aec.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-max98357a-rt5682-ssp2-ssp0-2ch-pdm1-google-aec.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-max98357a-rt5682-ssp2-ssp0-2ch-pdm1.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-max98357a-rt5682-ssp2-ssp0-google-aec.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-max98357a-rt5682-ssp2-ssp0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-max98357a-rt5682.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt1019-rt5682.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt1318-l12-rt714-l0.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt5650-dts-google-aec.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt5650-dts.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt5650.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt711-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt711-l0-rt1316-l23-rt714-l1.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt711-l0-rt1316-l3-2ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt711-l0-rt1316-l3-4ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt711-l0-rt1316-l3.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt712-l0-rt1712-l3.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt712-l0.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt712-vb-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt713-l0-rt1316-l12-rt1713-l3.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt713-l0-rt1316-l12.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt713-l0-rt1318-l1-rt1713-l3.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt713-l0-rt1318-l12-rt1713-l3.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt722-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-sdw-cs42l42-l0-max98363-l2.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-tgl-cs42l43-l3-cs35l56-l01.tplg</Path>
@@ -484,6 +526,14 @@
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/adl/community/sof-adl.ri</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/adl/intel-signed/sof-adl.ri</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/adl/sof-adl.ri</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/arl-s/community/sof-arl-s.ri</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/arl-s/intel-signed/sof-arl-s.ri</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/arl-s/sof-arl-s.ri</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/arl/community/sof-arl.ri</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/ehl/community/sof-ehl.ri</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/lnl/community/sof-lnl.ri</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/lnl/intel-signed/sof-lnl.ri</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/lnl/sof-lnl.ri</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/mtl/community/sof-mtl.ri</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/mtl/intel-signed/sof-mtl.ri</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/mtl/sof-mtl.ri</Path>
@@ -859,12 +909,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2024-06-29</Date>
-            <Version>2.9</Version>
+        <Update release="22">
+            <Date>2024-07-26</Date>
+            <Version>2.10</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

For v2.10 series, the following new topology files have been added since v2.9:

v2.10.x/sof-ipc4-tplg-v2.10
├── sof-lnl-rt1318-l12-rt714-l0.tplg
├── sof-lnl-rt711-4ch.tplg
├── sof-lnl-rt711-l0-rt1316-l23-rt714-l1.tplg
├── sof-lnl-rt712-l2-rt1712-l3.tplg
├── sof-lnl-rt722-l0.tplg
├── sof-mtl-max98357a-rt5682-google-aec.tplg
├── sof-mtl-max98357a-rt5682-ssp2-ssp0-2ch-pdm1-google-aec.tplg ├── sof-mtl-max98357a-rt5682-ssp2-ssp0-google-aec.tplg ├── sof-mtl-rt5650-dts-google-aec.tplg
├── sof-mtl-rt5650.tplg
├── sof-mtl-rt711-l0-rt1316-l3-2ch.tplg
├── sof-mtl-rt711-l0-rt1316-l3-4ch.tplg
├── sof-mtl-rt711-l0-rt1316-l3.tplg
├── sof-mtl-rt712-l0.tplg
├── sof-mtl-rt712-vb-l0.tplg
├── sof-mtl-rt713-l0-rt1318-l12-rt1713-l3.tplg
├── sof-mtl-rt713-l0-rt1318-l1-rt1713-l3.tplg

Full release notes [here](https://github.com/thesofproject/sof-bin/releases)

**Test Plan**

Verified firmware files were installed to correct paths.
Restarted pipewire.
    systemctl --user restart pipewire.service
Listened to music and triggered system sounds to verify that sound still works.

**Checklist**

- [x] Package was built and tested against unstable