### PR TITLE
bottom: Update to 0.9.7

### DIFF
--- a/packages/b/bottom/abi_used_symbols
+++ b/packages/b/bottom/abi_used_symbols
@@ -10,6 +10,7 @@ libc.so.6:chdir
 libc.so.6:clock_gettime
 libc.so.6:close
 libc.so.6:closedir
+libc.so.6:dirfd
 libc.so.6:dl_iterate_phdr
 libc.so.6:dlclose
 libc.so.6:dlerror

--- a/packages/b/bottom/monitoring.yml
+++ b/packages/b/bottom/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 141487
+  rss: https://github.com/ClementTsang/bottom/tags.atom
+# No known CPE, checked 2024-07-26
+security:
+  cpe: ~

--- a/packages/b/bottom/package.yml
+++ b/packages/b/bottom/package.yml
@@ -1,10 +1,10 @@
 name       : bottom
-version    : 0.9.6
-release    : 22
+version    : 0.9.7
+release    : 23
 source     :
-    - https://github.com/ClementTsang/bottom/archive/refs/tags/0.9.6.tar.gz : 202130e0d7c362d0d0cf211f6a13e31be3a02f13f998f88571e59a7735d60667
-    - https://github.com/ClementTsang/bottom/releases/download/0.9.6/completion.tar.gz : 74a525a17f56e3553bc179ab803d2568a9fe4b5599586f017edcf1d43913daa5
-    - https://github.com/ClementTsang/bottom/releases/download/0.9.6/manpage.tar.gz : a22799302ae15ac0b6ed037f35b6f857e264d78e06446b638bc5464846dd5046
+    - https://github.com/ClementTsang/bottom/archive/refs/tags/0.9.7.tar.gz : 29c3f75323ae0245576ea23268bb0956757352bf3b16d05f511357655b9cc71e
+    - https://github.com/ClementTsang/bottom/releases/download/0.9.7/completion.tar.gz : 721b3921157cbc3f31f20f0aaaea468a235b3d0fa8f876cbf9d3867578db8203
+    - https://github.com/ClementTsang/bottom/releases/download/0.9.7/manpage.tar.gz : e828123c48bfaec804db06dd211c7e4bb2c9899100c9a68522607832789a3ddb
 homepage   : https://clementtsang.github.io/bottom
 license    : MIT
 component  : system.utils

--- a/packages/b/bottom/pspec_x86_64.xml
+++ b/packages/b/bottom/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>bottom</Name>
         <Homepage>https://clementtsang.github.io/bottom</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -28,12 +28,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2024-07-04</Date>
-            <Version>0.9.6</Version>
+        <Update release="23">
+            <Date>2024-07-26</Date>
+            <Version>0.9.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fix building with Rust 1.80.0

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `btm` and see that all graphs worked as expected.

**Checklist**

- [x] Package was built and tested against unstable
