### PR TITLE
starship: Update to 1.20.0

### DIFF
--- a/packages/s/starship/abi_used_libs
+++ b/packages/s/starship/abi_used_libs
@@ -1,4 +1,3 @@
-ld-linux-x86-64.so.2
 libc.so.6
 libgcc_s.so.1
 libm.so.6

--- a/packages/s/starship/abi_used_symbols
+++ b/packages/s/starship/abi_used_symbols
@@ -1,5 +1,3 @@
-ld-linux-x86-64.so.2:__tls_get_addr
-libc.so.6:__environ
 libc.so.6:__errno_location
 libc.so.6:__libc_start_main
 libc.so.6:__register_atfork
@@ -37,7 +35,6 @@ libc.so.6:getegid
 libc.so.6:getenv
 libc.so.6:geteuid
 libc.so.6:getgroups
-libc.so.6:gethostname
 libc.so.6:getpeername
 libc.so.6:getpid
 libc.so.6:getpwnam

--- a/packages/s/starship/package.yml
+++ b/packages/s/starship/package.yml
@@ -1,8 +1,8 @@
 name       : starship
-version    : 1.19.0
-release    : 17
+version    : 1.20.0
+release    : 18
 source     :
-    - https://github.com/starship/starship/archive/refs/tags/v1.19.0.tar.gz : cf789791b5c11d6d7a00628590696627bb8f980e3d7c7a0200026787b08aba37
+    - https://github.com/starship/starship/archive/refs/tags/v1.20.0.tar.gz : ea73a5463d30c5d5dfd473b11a27f2f25942635121dc3fc89297eeb22755ce8f
 homepage   : https://starship.rs/
 license    : ISC
 component  : system.utils
@@ -17,9 +17,13 @@ description: |
     Easy: quick to install – start using it in minutes.
 builddeps  :
     - rust
+checkdeps  :
+    - git
 setup      : |
     %cargo_fetch
 build      : |
     %cargo_build
 install    : |
     %cargo_install
+check      : |
+    %cargo_test -- --skip "modules::username::tests::show_always_false"

--- a/packages/s/starship/pspec_x86_64.xml
+++ b/packages/s/starship/pspec_x86_64.xml
@@ -34,9 +34,9 @@ Easy: quick to install &#x2013; start using it in minutes.
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2024-05-16</Date>
-            <Version>1.19.0</Version>
+        <Update release="18">
+            <Date>2024-07-26</Date>
+            <Version>1.20.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- color: add prev_fg and prev_bg as color specifiers based on the previous foreground/background colors respectively
- color: add prevfg,prevbg as color specifiers based on the previous foreground/background colors respectively
- gcloud: Disabled gcloud module when active config hasn't been set
- purescript: add support for spago-next configuration files
- custom: escape characters in command output by default
- direnv: replace nonexistent "orange" color with "bright-yellow"
- dotnet: Remove duplicate v in dotnet version
- k8s: don't trigger if scan config is set but env vars are not
- preset: fix typo in Open Policy Agent module format string
- k8s: Improve performance of kubeconfig module

**Security**
- CVE-2024-41815

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new terminal session, navigate to the Solus packages repo, and navigate to a Rust project, and see that the modules update as expected.

**Checklist**

- [x] Package was built and tested against unstable
