### PR TITLE
fb2converter: Update to 1.75.3

### DIFF
--- a/packages/f/fb2converter/package.yml
+++ b/packages/f/fb2converter/package.yml
@@ -1,6 +1,6 @@
 name       : fb2converter
-version    : 1.75.2
-release    : 25
+version    : 1.75.3
+release    : 26
 source     :
     - git|https://github.com/rupor-github/fb2converter.git : v1.75.2
 homepage   : https://github.com/rupor-github/fb2converter

--- a/packages/f/fb2converter/pspec_x86_64.xml
+++ b/packages/f/fb2converter/pspec_x86_64.xml
@@ -26,9 +26,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="25">
-            <Date>2024-07-21</Date>
-            <Version>1.75.2</Version>
+        <Update release="26">
+            <Date>2024-07-27</Date>
+            <Version>1.75.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Handle "hanging" images within floating notes.
- [changelog](https://github.com/rupor-github/fb2converter/compare/v1.75.2...v1.75.3)

**Test Plan**
- fb2c convert --to epub in.fb2

**Checklist**
- [X] Package was built and tested against unstable
