### PR TITLE
mu: Update to 1.12.6

### DIFF
--- a/packages/m/mu/abi_used_symbols
+++ b/packages/m/mu/abi_used_symbols
@@ -130,10 +130,10 @@ libglib-2.0.so.0:g_key_file_unref
 libglib-2.0.so.0:g_locale_from_utf8
 libglib-2.0.so.0:g_log
 libglib-2.0.so.0:g_log_set_writer_func
-libglib-2.0.so.0:g_log_structured_standard
 libglib-2.0.so.0:g_log_writer_format_fields
 libglib-2.0.so.0:g_log_writer_journald
 libglib-2.0.so.0:g_log_writer_standard_streams
+libglib-2.0.so.0:g_log_writer_syslog
 libglib-2.0.so.0:g_malloc
 libglib-2.0.so.0:g_markup_escape_text
 libglib-2.0.so.0:g_match_info_fetch
@@ -477,6 +477,7 @@ libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
 libstdc++.so.6:__cxa_allocate_exception
 libstdc++.so.6:__cxa_begin_catch
+libstdc++.so.6:__cxa_call_terminate
 libstdc++.so.6:__cxa_end_catch
 libstdc++.so.6:__cxa_free_exception
 libstdc++.so.6:__cxa_guard_abort

--- a/packages/m/mu/package.yml
+++ b/packages/m/mu/package.yml
@@ -1,8 +1,8 @@
 name       : mu
-version    : 1.12.5
-release    : 26
+version    : 1.12.6
+release    : 27
 source     :
-    - https://github.com/djcb/mu/releases/download/v1.12.5/mu-1.12.5.tar.xz : 770b92e3072adae8777bd4e985c8b027c66ce0b7ef7cbb8eab4497b92ba68acb
+    - https://github.com/djcb/mu/releases/download/v1.12.6/mu-1.12.6.tar.xz : f8a539b687c999678fd7cd37cc4ab15ee5e87801027d982ba195b3a9cb53b761
 license    : GPL-3.0-only
 homepage   : https://www.djcbsoftware.nl/code/mu/
 component  : editor

--- a/packages/m/mu/pspec_x86_64.xml
+++ b/packages/m/mu/pspec_x86_64.xml
@@ -106,9 +106,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2024-05-04</Date>
-            <Version>1.12.5</Version>
+        <Update release="27">
+            <Date>2024-07-28</Date>
+            <Version>1.12.6</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- improved documentation
- fix mu4e-compose-pre-hook
- fix bookmark support
- [changelog](https://github.com/djcb/mu/releases/tag/v1.12.6)

**Test Plan**
- search for and view message

**Checklist**
- [X] Package was built and tested against unstable
