### PR TITLE
lz4: Update to 1.10.0

### DIFF
--- a/packages/l/lz4/package.yml
+++ b/packages/l/lz4/package.yml
@@ -1,8 +1,9 @@
 name       : lz4
-version    : 1.9.4
-release    : 17
+version    : 1.10.0
+release    : 18
 source     :
-    - https://github.com/lz4/lz4/archive/v1.9.4.tar.gz : 0b0e3aa07c8c063ddf40b082bdf7e37a1562bda40a0ff5272957f3e987e0e54b
+    - https://github.com/lz4/lz4/archive/refs/tags/v1.10.0.tar.gz : 537512904744b35e232912055ccf8ec66d768639ff3abe5788d90d792ec5f48b
+homepage   : http://www.lz4.org/
 license    :
     - BSD-2-Clause
     - GPL-2.0-or-later

--- a/packages/l/lz4/pspec_x86_64.xml
+++ b/packages/l/lz4/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>lz4</Name>
+        <Homepage>http://www.lz4.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Clifford Red</Name>
+            <Email>a108384@gmail.com</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <License>GPL-2.0-or-later</License>
@@ -11,7 +12,7 @@
         <Summary xml:lang="en">LZ4 commmand line tools</Summary>
         <Description xml:lang="en">LZ4 is a very fast lossless compression algorithm, providing compression speed at 400 MB/s per core, scalable with multi-cores CPU. It also features an extremely fast decoder, with speed in multiple GB/s per core, typically reaching RAM speed limits on multi-core systems.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>lz4</Name>
@@ -25,7 +26,7 @@
             <Path fileType="executable">/usr/bin/lz4cat</Path>
             <Path fileType="executable">/usr/bin/unlz4</Path>
             <Path fileType="library">/usr/lib64/liblz4.so.1</Path>
-            <Path fileType="library">/usr/lib64/liblz4.so.1.9.4</Path>
+            <Path fileType="library">/usr/lib64/liblz4.so.1.10.0</Path>
             <Path fileType="man">/usr/share/man/man1/lz4.1</Path>
             <Path fileType="man">/usr/share/man/man1/lz4c.1</Path>
             <Path fileType="man">/usr/share/man/man1/lz4cat.1</Path>
@@ -39,10 +40,11 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="17">lz4</Dependency>
+            <Dependency release="18">lz4</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/lz4.h</Path>
+            <Path fileType="header">/usr/include/lz4file.h</Path>
             <Path fileType="header">/usr/include/lz4frame.h</Path>
             <Path fileType="header">/usr/include/lz4frame_static.h</Path>
             <Path fileType="header">/usr/include/lz4hc.h</Path>
@@ -52,12 +54,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2022-08-20</Date>
-            <Version>1.9.4</Version>
+        <Update release="18">
+            <Date>2024-07-28</Date>
+            <Version>1.10.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Clifford Red</Name>
+            <Email>a108384@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- update lz4 from 1.9.4 to 1.10.0
- add homepage to package.yml
- Full lz4 [(changelog](https://github.com/lz4/lz4/releases/tag/v1.10.0))

**Test Plan**

Build and install lz4.  Compress various files and file types.  Extract / decompress those files back to their original state.
Confirm homepage is in package.yml file.
The build procedure for lz4 includes many internal tests - all are successful.

**Checklist**

- [X] Package was built and tested against unstable
