### PR TITLE
gpxsee: Update to 13.23

### DIFF
--- a/packages/g/gpxsee/abi_used_symbols
+++ b/packages/g/gpxsee/abi_used_symbols
@@ -1584,9 +1584,7 @@ libstdc++.so.6:_ZTISt9bad_alloc
 libstdc++.so.6:_ZTVN10__cxxabiv117__class_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv120__si_class_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv121__vmi_class_type_infoE
-libstdc++.so.6:_ZdaPv
 libstdc++.so.6:_ZdlPv
-libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
 libstdc++.so.6:_ZnwmRKSt9nothrow_t
 libstdc++.so.6:__cxa_begin_catch

--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.22'
-release    : 41
+version    : '13.23'
+release    : 42
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.22.tar.gz : 34eccacac18b8a3c5145eff9f256f76fafcc3d9d5070191a673b27ea5a0aadda
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.23.tar.gz : 676f8423b3ee56f37134ea52909b78e3cd1b05e73e287dc9e1863275d842fe17
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -172,9 +172,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="41">
-            <Date>2024-06-16</Date>
-            <Version>13.22</Version>
+        <Update release="42">
+            <Date>2024-07-28</Date>
+            <Version>13.23</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Improved ENC maps rendering.
- Various minor fixes.

**Test Plan**
- zoom in and out a map

**Checklist**
- [X] Package was built and tested against unstable
