### PR TITLE
python-absl-py: Update to 2.1.0

### DIFF
--- a/packages/py/python-absl-py/package.yml
+++ b/packages/py/python-absl-py/package.yml
@@ -1,8 +1,9 @@
 name       : python-absl-py
-version    : 0.15.0
-release    : 9
+version    : 2.1.0
+release    : 10
 source     :
-    - https://github.com/abseil/abseil-py/archive/refs/tags/pypi-v0.15.0.tar.gz : 0be59b82d65dfa1f995365dcfea2cc57989297b065fda696ef13f30fcc6c8e5b
+    - https://github.com/abseil/abseil-py/archive/v2.1.0.tar.gz : 8a3d0830e4eb4f66c4fa907c06edf6ce1c719ced811a12e26d9d3162f8471758
+homepage   : https://github.com/abseil/abseil-py
 license    : Apache-2.0
 component  : programming.python
 summary    : Abseil Python Common Libraries
@@ -13,8 +14,6 @@ builddeps  :
 rundeps    :
     - python-six
 build      : |
-    %python_setup
     %python3_setup
 install    : |
-    %python_install
     %python3_install

--- a/packages/py/python-absl-py/pspec_x86_64.xml
+++ b/packages/py/python-absl-py/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>python-absl-py</Name>
+        <Homepage>https://github.com/abseil/abseil-py</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Deyan Dimitrov</Name>
+            <Email>dikelito@tutamail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -19,77 +20,12 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/__init__.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/_collections_abc.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/_collections_abc.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/_enum_module.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/_enum_module.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/app.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/app.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/command_name.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/command_name.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/flags/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/flags/__init__.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/flags/_argument_parser.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/flags/_argument_parser.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/flags/_defines.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/flags/_defines.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/flags/_exceptions.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/flags/_exceptions.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/flags/_flag.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/flags/_flag.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/flags/_flagvalues.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/flags/_flagvalues.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/flags/_helpers.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/flags/_helpers.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/flags/_validators.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/flags/_validators.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/flags/_validators_classes.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/flags/_validators_classes.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/flags/argparse_flags.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/flags/argparse_flags.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/logging/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/logging/__init__.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/logging/converter.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/logging/converter.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/testing/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/testing/__init__.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/testing/_bazelize_command.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/testing/_bazelize_command.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/testing/_parameterized_async.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/testing/_pretty_print_reporter.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/testing/_pretty_print_reporter.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/testing/absltest.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/testing/absltest.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/testing/flagsaver.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/testing/flagsaver.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/testing/parameterized.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/testing/parameterized.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/testing/xml_reporter.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/testing/xml_reporter.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/third_party/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/third_party/__init__.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/third_party/unittest3_backport/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/third_party/unittest3_backport/__init__.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/third_party/unittest3_backport/case.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/third_party/unittest3_backport/case.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/third_party/unittest3_backport/result.py</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl/third_party/unittest3_backport/result.pyc</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl_py-0.15.0-py2.7.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl_py-0.15.0-py2.7.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl_py-0.15.0-py2.7.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl_py-0.15.0-py2.7.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python2.7/site-packages/absl_py-0.15.0-py2.7.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/__pycache__/__init__.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/absl/__pycache__/_collections_abc.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/absl/__pycache__/_enum_module.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/__pycache__/app.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/__pycache__/command_name.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/absl/_collections_abc.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/absl/_enum_module.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/app.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/absl/app.pyi</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/command_name.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/flags/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/flags/__pycache__/__init__.cpython-311.pyc</Path>
@@ -112,47 +48,37 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/flags/_validators_classes.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/flags/argparse_flags.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/logging/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/absl/logging/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/logging/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/logging/__pycache__/converter.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/logging/converter.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/testing/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/testing/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/testing/__pycache__/_bazelize_command.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/absl/testing/__pycache__/_parameterized_async.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/testing/__pycache__/_pretty_print_reporter.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/testing/__pycache__/absltest.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/testing/__pycache__/flagsaver.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/testing/__pycache__/parameterized.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/testing/__pycache__/xml_reporter.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/testing/_bazelize_command.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/absl/testing/_parameterized_async.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/testing/_pretty_print_reporter.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/testing/absltest.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/testing/flagsaver.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/testing/parameterized.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/absl/testing/xml_reporter.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/absl/third_party/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/absl/third_party/__pycache__/__init__.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/absl/third_party/unittest3_backport/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/absl/third_party/unittest3_backport/__pycache__/__init__.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/absl/third_party/unittest3_backport/__pycache__/case.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/absl/third_party/unittest3_backport/__pycache__/result.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/absl/third_party/unittest3_backport/case.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/absl/third_party/unittest3_backport/result.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/absl_py-0.15.0-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/absl_py-0.15.0-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/absl_py-0.15.0-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/absl_py-0.15.0-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/absl_py-0.15.0-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/absl_py-2.1.0-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/absl_py-2.1.0-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/absl_py-2.1.0-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/absl_py-2.1.0-py3.11.egg-info/top_level.txt</Path>
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2024-02-14</Date>
-            <Version>0.15.0</Version>
+        <Update release="10">
+            <Date>2024-07-28</Date>
+            <Version>2.1.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Deyan Dimitrov</Name>
+            <Email>dikelito@tutamail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Updates `python-absl-py` to 2.1.0 and adds homepage url
- Full changelog [here](https://github.com/abseil/abseil-py/releases/tag/v2.1.0)

**Test Plan**

- Run [sample app](https://github.com/abseil/abseil-py/blob/main/smoke_tests/sample_app.py) from the package repo and verified it works
- Checked homepage was added
- Built `python-tensorboard` against the new version

**Checklist**

- [x] Package was built and tested against unstable
