### PR TITLE
libwpe: Update to 1.16.0

### DIFF
--- a/packages/l/libwpe/abi_symbols
+++ b/packages/l/libwpe/abi_symbols
@@ -77,6 +77,7 @@ libwpe-1.0.so.1:wpe_view_backend_dispatch_frame_displayed
 libwpe-1.0.so.1:wpe_view_backend_dispatch_get_accessible
 libwpe-1.0.so.1:wpe_view_backend_dispatch_keyboard_event
 libwpe-1.0.so.1:wpe_view_backend_dispatch_pointer_event
+libwpe-1.0.so.1:wpe_view_backend_dispatch_pointer_lock_event
 libwpe-1.0.so.1:wpe_view_backend_dispatch_request_enter_fullscreen
 libwpe-1.0.so.1:wpe_view_backend_dispatch_request_exit_fullscreen
 libwpe-1.0.so.1:wpe_view_backend_dispatch_set_device_scale_factor
@@ -88,8 +89,11 @@ libwpe-1.0.so.1:wpe_view_backend_get_target_refresh_rate
 libwpe-1.0.so.1:wpe_view_backend_initialize
 libwpe-1.0.so.1:wpe_view_backend_platform_set_fullscreen
 libwpe-1.0.so.1:wpe_view_backend_remove_activity_state
+libwpe-1.0.so.1:wpe_view_backend_request_pointer_lock
+libwpe-1.0.so.1:wpe_view_backend_request_pointer_unlock
 libwpe-1.0.so.1:wpe_view_backend_set_backend_client
 libwpe-1.0.so.1:wpe_view_backend_set_fullscreen_client
 libwpe-1.0.so.1:wpe_view_backend_set_fullscreen_handler
 libwpe-1.0.so.1:wpe_view_backend_set_input_client
+libwpe-1.0.so.1:wpe_view_backend_set_pointer_lock_handler
 libwpe-1.0.so.1:wpe_view_backend_set_target_refresh_rate

--- a/packages/l/libwpe/monitoring.yml
+++ b/packages/l/libwpe/monitoring.yml
@@ -1,0 +1,5 @@
+releases:
+  id: 17789
+  rss: https://github.com/WebPlatformForEmbedded/libwpe/tags.atom
+security:
+  cpe: ~

--- a/packages/l/libwpe/package.yml
+++ b/packages/l/libwpe/package.yml
@@ -1,17 +1,17 @@
 name       : libwpe
-version    : 1.14.1
-release    : 10
+version    : 1.16.0
+release    : 11
 source     :
-    - https://github.com/WebPlatformForEmbedded/libwpe/releases/download/1.14.1/libwpe-1.14.1.tar.xz : b1d0cdcf0f8dbb494e65b0f7913e357106da9a0d57f4fbb7b9d1238a6dbe9ade
+    - https://github.com/WebPlatformForEmbedded/libwpe/releases/download/1.16.0/libwpe-1.16.0.tar.xz : c7f3a3c6b3d006790d486dc7cceda2b6d2e329de07f33bc47dfc53f00f334b2a
+homepage   : https://github.com/WebPlatformForEmbedded/libwpe
 license    : BSD-2-Clause
 component  : programming.library
 summary    : General-purpose library specifically developed for the WPE-flavored port of WebKit.
 description: |
     General-purpose library specifically developed for the WPE-flavored port of WebKit.
 builddeps  :
-    - pkgconfig(gbm)
-    - pkgconfig(x11)
-    - pkgconfig(xkbcommon)
+   - pkgconfig(gbm)
+   - pkgconfig(xkbcommon)
 setup      : |
     %cmake_ninja
 build      : |

--- a/packages/l/libwpe/pspec_x86_64.xml
+++ b/packages/l/libwpe/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>libwpe</Name>
+        <Homepage>https://github.com/WebPlatformForEmbedded/libwpe</Homepage>
         <Packager>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>programming.library</PartOf>
         <Summary xml:lang="en">General-purpose library specifically developed for the WPE-flavored port of WebKit.</Summary>
         <Description xml:lang="en">General-purpose library specifically developed for the WPE-flavored port of WebKit.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>libwpe</Name>
@@ -20,7 +21,7 @@
         <PartOf>programming.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libwpe-1.0.so.1</Path>
-            <Path fileType="library">/usr/lib64/libwpe-1.0.so.1.8.1</Path>
+            <Path fileType="library">/usr/lib64/libwpe-1.0.so.1.9.3</Path>
         </Files>
     </Package>
     <Package>
@@ -30,7 +31,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">libwpe</Dependency>
+            <Dependency release="11">libwpe</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wpe-1.0/wpe/export.h</Path>
@@ -54,12 +55,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2023-07-17</Date>
-            <Version>1.14.1</Version>
+        <Update release="11">
+            <Date>2024-07-28</Date>
+            <Version>1.16.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- added homepage
- remove dependency on x11
- full changelog [here](https://github.com/WebPlatformForEmbedded/libwpe/blob/1.16.0/NEWS)

**Checklist**

- [x] Package was built and tested against unstable
