### PR TITLE
flatpak: Enable flathub by default

### DIFF
--- a/packages/f/flatpak/files/flatpak-enable-flathub.service
+++ b/packages/f/flatpak/files/flatpak-enable-flathub.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Add flathub flatpak repositories
+ConditionPathExists=!/var/lib/flatpak/.flathub-initialized
+Before=flatpak-system-helper.service
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/flatpak remote-add --system --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+ExecStartPost=/usr/bin/touch /var/lib/flatpak/.flathub-initialized
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/f/flatpak/package.yml
+++ b/packages/f/flatpak/package.yml
@@ -1,6 +1,6 @@
 name       : flatpak
 version    : 1.14.8
-release    : 77
+release    : 78
 source     :
     - https://github.com/flatpak/flatpak/releases/download/1.14.8/flatpak-1.14.8.tar.xz : 1016b7327f7af87896f95465f7e5813750d3b7049a3740a1a4ddcb5fa8c5348e
 homepage   : https://flatpak.org/
@@ -50,3 +50,8 @@ install    : |
     # Add auto-update systemd services
     install -Dm00644 -t $installdir/%libdir%/systemd/system $pkgfiles/system/flatpak-update.{service,timer}
     install -Dm00644 -t $installdir/%libdir%/systemd/user $pkgfiles/user/flatpak-update.{service,timer}
+
+    # Enable flathub
+    install -dm00644 $installdir/%libdir%/systemd/system/multi-user.target.wants
+    install -Dm00644 -t $installdir/%libdir%/systemd/system $pkgfiles/flatpak-enable-flathub.service
+    ln -sv ../flatpak-enable-flathub.service $installdir/%libdir%/systemd/system/multi-user.target.wants/flatpak-enable-flathub.service

--- a/packages/f/flatpak/pspec_x86_64.xml
+++ b/packages/f/flatpak/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>flatpak</Name>
         <Homepage>https://flatpak.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>desktop</PartOf>
@@ -40,8 +40,10 @@
             <Path fileType="library">/usr/lib64/girepository-1.0/Flatpak-1.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libflatpak.so.0</Path>
             <Path fileType="library">/usr/lib64/libflatpak.so.0.11408.0</Path>
+            <Path fileType="library">/usr/lib64/systemd/system/flatpak-enable-flathub.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/flatpak-update.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/flatpak-update.timer</Path>
+            <Path fileType="library">/usr/lib64/systemd/system/multi-user.target.wants/flatpak-enable-flathub.service</Path>
             <Path fileType="library">/usr/lib64/systemd/user/flatpak-update.service</Path>
             <Path fileType="library">/usr/lib64/systemd/user/flatpak-update.timer</Path>
             <Path fileType="library">/usr/lib64/sysusers.d/flatpak.conf</Path>
@@ -148,7 +150,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="77">flatpak</Dependency>
+            <Dependency release="78">flatpak</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/flatpak/flatpak-bundle-ref.h</Path>
@@ -216,12 +218,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="77">
-            <Date>2024-04-30</Date>
+        <Update release="78">
+            <Date>2024-07-28</Date>
             <Version>1.14.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Enable flathub by default

**Test Plan**

- Install, reboot
- `flatpak remotes`
- Verify flathub is added

**Checklist**

- [x] Package was built and tested against unstable
