### PR TITLE
zsh: fix - do not source bash files and fix build

### DIFF
--- a/packages/z/zsh/files/006-52383-Avoid-incompatible-pointer-types-in-terminfo-g.patch
+++ b/packages/z/zsh/files/006-52383-Avoid-incompatible-pointer-types-in-terminfo-g.patch
@@ -1,0 +1,46 @@
+From 4c89849c98172c951a9def3690e8647dae76308f Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Fri, 8 Dec 2023 21:58:07 +0100
+Subject: [PATCH] 52383: Avoid incompatible pointer types in terminfo global
+ variable checks
+
+---
+ configure.ac | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -1766,27 +1766,27 @@ if test x$zsh_cv_path_term_header != xno
+   fi
+ 
+   AC_MSG_CHECKING(if boolcodes is available)
+-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = boolcodes; puts(*test);]])],[AC_DEFINE(HAVE_BOOLCODES) boolcodes=yes],[boolcodes=no])
++  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = (char **)boolcodes; puts(*test);]])],[AC_DEFINE(HAVE_BOOLCODES) boolcodes=yes],[boolcodes=no])
+   AC_MSG_RESULT($boolcodes)
+ 
+   AC_MSG_CHECKING(if numcodes is available)
+-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = numcodes; puts(*test);]])],[AC_DEFINE(HAVE_NUMCODES) numcodes=yes],[numcodes=no])
++  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = (char **)numcodes; puts(*test);]])],[AC_DEFINE(HAVE_NUMCODES) numcodes=yes],[numcodes=no])
+   AC_MSG_RESULT($numcodes)
+ 
+   AC_MSG_CHECKING(if strcodes is available)
+-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = strcodes; puts(*test);]])],[AC_DEFINE(HAVE_STRCODES) strcodes=yes],[strcodes=no])
++  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = (char **)strcodes; puts(*test);]])],[AC_DEFINE(HAVE_STRCODES) strcodes=yes],[strcodes=no])
+   AC_MSG_RESULT($strcodes)
+ 
+   AC_MSG_CHECKING(if boolnames is available)
+-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = boolnames; puts(*test);]])],[AC_DEFINE(HAVE_BOOLNAMES) boolnames=yes],[boolnames=no])
++  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = (char **)boolnames; puts(*test);]])],[AC_DEFINE(HAVE_BOOLNAMES) boolnames=yes],[boolnames=no])
+   AC_MSG_RESULT($boolnames)
+ 
+   AC_MSG_CHECKING(if numnames is available)
+-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = numnames; puts(*test);]])],[AC_DEFINE(HAVE_NUMNAMES) numnames=yes],[numnames=no])
++  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = (char **)numnames; puts(*test);]])],[AC_DEFINE(HAVE_NUMNAMES) numnames=yes],[numnames=no])
+   AC_MSG_RESULT($numnames)
+ 
+   AC_MSG_CHECKING(if strnames is available)
+-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = strnames; puts(*test);]])],[AC_DEFINE(HAVE_STRNAMES) strnames=yes],[strnames=no])
++  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = (char **)strnames; puts(*test);]])],[AC_DEFINE(HAVE_STRNAMES) strnames=yes],[strnames=no])
+   AC_MSG_RESULT($strnames)
+ 
+   dnl There are apparently defective terminal library headers on some

--- a/packages/z/zsh/files/010-gcc14.patch
+++ b/packages/z/zsh/files/010-gcc14.patch
@@ -1,0 +1,11 @@
+--- a/Src/Modules/pcre.c
++++ b/Src/Modules/pcre.c
+@@ -152,7 +152,7 @@ zpcre_get_substrings(pcre2_code *pat, ch
+ 	int nelem = captured_count - 1;
+ 	/* Set to the offsets of the complete match */
+ 	if (want_offset_pair) {
+-	    sprintf(offset_all, "%ld %ld", ovec[0], ovec[1]);
++	    sprintf(offset_all, "%zd %zd", ovec[0], ovec[1]);
+ 	    setsparam("ZPCRE_OP", ztrdup(offset_all));
+ 	}
+ 	/*

--- a/packages/z/zsh/files/series
+++ b/packages/z/zsh/files/series
@@ -4,10 +4,12 @@
 0004-50662-unset-LC_-for-all-the-tests.patch
 0005-51207-fix-for-read-d-when-the-delimiter-is-a-byte-0x.patch
 0006-51214-handle-read-d-and-a-delimiter-that-can-t-be-de.patch
+006-52383-Avoid-incompatible-pointer-types-in-terminfo-g.patch
 0007-51483-Enable-assignment-and-expansion-of-parameters-.patch
 0008-51484-Extend-named-reference-handling-for-special-pa.patch
 0009-51723-migrate-pcre-module-to-pcre2.patch
 0010-51728-assign-pcre-named-capture-groups-to-a-hash.patch
+010-gcc14.patch
 0011-51738-support-pcre-s-alternative-DFA-matching-algori.patch
 0012-51877-do-not-build-pcre-module-if-pcre2-config-is-no.patch
 0013-51889-fix-module-loading-problem-with-full-RELRO.patch

--- a/packages/z/zsh/files/zprofile
+++ b/packages/z/zsh/files/zprofile
@@ -2,6 +2,50 @@ if [ -f /etc/zprofile ]; then
     source /etc/zprofile
 elif [ -f /etc/zsh/zprofile ]; then
     source /etc/zsh/zprofile
-else
-    emulate sh -c 'source /etc/profile'
 fi
+
+# Source paths that may not be included by systemctl
+if [ -f /usr/share/defaults/etc/profile.d/10-path.sh ]; then
+    emulate sh -c 'source /usr/share/defaults/etc/profile.d/10-path.sh'
+fi
+
+# Source paths not included by systemctl necessary for XDG_DATA_DIRS
+
+if [ -f 10-xdg.sh ]; then
+    emulate sh -c 'source 10-xdg.sh'
+fi
+
+# Source paths not included by systemctl necessary for flatpaks to be found in the app menu and run
+
+if [ -f /usr/share/defaults/etc/profile.d/70-flatpak.sh ]; then
+    emulate sh -c 'source /usr/share/defaults/etc/profile.d/70-flatpak.sh'
+fi
+
+# Source paths not included by systemctl necessary for snaps to be found in the app menu and run
+
+if [ -f /usr/share/defaults/etc/profile.d/70-snapd.sh ]; then
+    emulate sh -c 'source /usr/share/defaults/etc/profile.d/70-snapd.sh'
+fi
+
+# Source gtk modules variable for menus
+
+if [ -f /usr/share/defaults/etc/profile.d/appmenu-gtk2-module.sh ]; then
+    emulate sh -c 'source /usr/share/defaults/etc/profile.d/appmenu-gtk2-module.sh'
+fi
+
+# Paths for gawk
+
+if [ -f /usr/share/defaults/etc/profile.d/gawk.sh ]; then
+    emulate sh -c 'source /usr/share/defaults/etc/profile.d/gawk.sh'
+fi
+
+# Environment for vte, zsh compatible
+
+if [ -f /usr/share/defaults/etc/profile.d/vte.sh ]; then
+    source /usr/share/defaults/etc/profile.d/vte.sh
+fi
+
+# Do not source /etc/profile as Arch does
+# This will source all other bash scripts in /etc/profile.d, some of which may not load properly.
+# Some may also conflict with zsh frameworks or have other unintended consequences
+# Additionally, Solus sources ~/.bashrc.d from /etc/profile which is not obvious to the user or expected in zsh

--- a/packages/z/zsh/package.yml
+++ b/packages/z/zsh/package.yml
@@ -1,6 +1,6 @@
 name       : zsh
 version    : '5.9'
-release    : 32
+release    : 33
 source     :
     - https://sourceforge.net/projects/zsh/files/zsh/5.9/zsh-5.9.tar.xz : 9b8d1ecedd5b5e81fbf1918e876752a7dd948e05c1a0dba10ab863842d45acd5
 homepage   : https://www.zsh.org/

--- a/packages/z/zsh/pspec_x86_64.xml
+++ b/packages/z/zsh/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>zsh</Name>
         <Homepage>https://www.zsh.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -1397,12 +1397,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2024-05-11</Date>
+        <Update release="33">
+            <Date>2024-08-05</Date>
             <Version>5.9</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Remove sourcing of /etc/profile for zsh
Fix errors from sourcing bash scripts that are incompatible with zsh

Add patches to correct make error

**Test Plan**

After reboot
- Log into TTY, verify there are no errors, ran htop
- Launch Konsole, verify there are no errors. Verify I can call commands from `solus-monorepo-helpers.zsh`
- Verified `onefetch` and `mpv`, which rely on zsh functions, work as expected
- Verify `which snap` returns the binary location for snap
- Verify `/var/lib/snapd/desktop` is in $XDG_DATA_DIRS once and only once
- Installed the Spotify snap via command line. Verify it is shown in the app menu and that it launches.
- Verify flatpaks are seen in the app menu and can be launched from there.
- Verified $XDG_DATA_DIRS was correct
```
/home/$user/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share/:/usr/share/:/var/lib/snapd/desktop/:/var/lib/snapd/desktop
```

**Checklist**

- [x] Package was built and tested against unstable
