### PR TITLE
thunar: Update to 4.18.11

### DIFF
--- a/packages/t/thunar/abi_used_symbols
+++ b/packages/t/thunar/abi_used_symbols
@@ -559,7 +559,9 @@ libglib-2.0.so.0:g_node_new
 libglib-2.0.so.0:g_node_nth_child
 libglib-2.0.so.0:g_node_traverse
 libglib-2.0.so.0:g_once_init_enter
+libglib-2.0.so.0:g_once_init_enter_pointer
 libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_path_get_basename
 libglib-2.0.so.0:g_path_get_dirname
 libglib-2.0.so.0:g_path_is_absolute
@@ -1444,6 +1446,7 @@ libgtk-3.so.0:gtk_window_set_application
 libgtk-3.so.0:gtk_window_set_default_icon_name
 libgtk-3.so.0:gtk_window_set_default_size
 libgtk-3.so.0:gtk_window_set_destroy_with_parent
+libgtk-3.so.0:gtk_window_set_focus_on_map
 libgtk-3.so.0:gtk_window_set_icon_name
 libgtk-3.so.0:gtk_window_set_modal
 libgtk-3.so.0:gtk_window_set_resizable

--- a/packages/t/thunar/monitoring.yml
+++ b/packages/t/thunar/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 14669
+  rss: https://gitlab.xfce.org/xfce/thunar/-/tags?format=atom
+security:
+  cpe:
+    - vendor: xfce
+      product: thunar

--- a/packages/t/thunar/package.yml
+++ b/packages/t/thunar/package.yml
@@ -1,8 +1,8 @@
 name       : thunar
-version    : 4.18.10
-release    : 6
+version    : 4.18.11
+release    : 7
 source     :
-    - https://archive.xfce.org/src/xfce/thunar/4.18/thunar-4.18.10.tar.bz2 : e8308a1f139602d8c125f594bfcebb063b7dac1fbb6e14293bab4cdb3ecf1d08
+    - https://archive.xfce.org/src/xfce/thunar/4.18/thunar-4.18.11.tar.bz2 : 7d0bdae2076a568c137d403ab5600e06a7a4f7a02514d486da7b8414aa75d612
 homepage   : https://docs.xfce.org/xfce/thunar/start
 license    : GPL-2.0-or-later
 component  : desktop.xfce

--- a/packages/t/thunar/pspec_x86_64.xml
+++ b/packages/t/thunar/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>thunar</Name>
         <Homepage>https://docs.xfce.org/xfce/thunar/start</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.xfce</PartOf>
@@ -126,7 +126,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="6">thunar</Dependency>
+            <Dependency release="7">thunar</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/thunarx-3/thunarx/thunarx-config.h</Path>
@@ -307,12 +307,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2024-02-13</Date>
-            <Version>4.18.10</Version>
+        <Update release="7">
+            <Date>2024-07-30</Date>
+            <Version>4.18.11</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Use parent windows for undo/redo dialog
- Fix for `misc_open_new_windows_in_split_view`
- Don't add directories to `recent:///`
- Focus split view pane on DnD events
- Don't reload folder when `draw_frames` is set
- Allow submenu UCAs in toolbar
- Fix shortcuts for ucas in subfolders
- Don't show 'open location' on recent icon
- Fix for image preview visibility
- Prevent focus stealing of file transfer dialog
- Don't update `last-view` when searching
- Translation updates

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Open Thunar and browse to different directories.

**Checklist**

- [x] Package was built and tested against unstable
