### PR TITLE
python-google-auth-httplib2: add homepage

### DIFF
--- a/packages/py/python-google-auth-httplib2/package.yml
+++ b/packages/py/python-google-auth-httplib2/package.yml
@@ -1,8 +1,9 @@
 name       : python-google-auth-httplib2
 version    : 0.1.0
-release    : 6
+release    : 7
 source     :
     - https://github.com/googleapis/google-auth-library-python-httplib2/archive/refs/tags/v0.1.0.tar.gz : 495ab3ded76145eb5568e26cf5f84a8cec6e769d4b39547cd228fc84d0417fac
+homepage   : https://github.com/googleapis/google-auth-library-python-httplib2
 license    : Apache-2.0
 component  : programming.python
 summary    : Provides an httplib2 transport for google-auth

--- a/packages/py/python-google-auth-httplib2/pspec_x86_64.xml
+++ b/packages/py/python-google-auth-httplib2/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>python-google-auth-httplib2</Name>
+        <Homepage>https://github.com/googleapis/google-auth-library-python-httplib2</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Deyan Dimitrov</Name>
+            <Email>dikelito@tutamail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -29,12 +30,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2024-02-14</Date>
+        <Update release="7">
+            <Date>2024-08-01</Date>
             <Version>0.1.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Deyan Dimitrov</Name>
+            <Email>dikelito@tutamail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Adds homepage to `python-google-auth-httplib2`

**Test Plan**

Checked homepage was added

**Checklist**

- [x] Package was built and tested against unstable
