### PR TITLE
python-html2text: update to 2024.2.26

### DIFF
--- a/packages/py/python-html2text/package.yml
+++ b/packages/py/python-html2text/package.yml
@@ -1,8 +1,9 @@
 name       : python-html2text
-version    : 2020.1.16
-release    : 7
+version    : 2024.2.26
+release    : 8
 source     :
-    - https://pypi.io/packages/source/h/html2text/html2text-2020.1.16.tar.gz : e296318e16b059ddb97f7a8a1d6a5c1d7af4544049a01e261731d2d5cc277bbb
+    - https://github.com/Alir3z4/html2text/archive/2024.2.26.tar.gz : 3632dbbb3dafbf28bee3709df67ccc48d2dc9510c75903c38f860a36e397c386
+homepage   : https://alir3z4.github.io/html2text
 license    : GPL-3.0-only
 component  : programming.python
 summary    : Convert HTML to Markdown-formatted text

--- a/packages/py/python-html2text/pspec_x86_64.xml
+++ b/packages/py/python-html2text/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>python-html2text</Name>
+        <Homepage>https://alir3z4.github.io/html2text</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Deyan Dimitrov</Name>
+            <Email>dikelito@tutamail.com</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <PartOf>programming.python</PartOf>
@@ -20,36 +21,36 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/html2text</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/html2text-2020.1.16-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/html2text-2020.1.16-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/html2text-2020.1.16-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/html2text-2020.1.16-py3.11.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/html2text-2020.1.16-py3.11.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/html2text-2020.1.16-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/html2text-2024.2.26-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/html2text-2024.2.26-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/html2text-2024.2.26-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/html2text-2024.2.26-py3.11.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/html2text-2024.2.26-py3.11.egg-info/not-zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/html2text-2024.2.26-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/html2text/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/html2text/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/html2text/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/html2text/__pycache__/__main__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/html2text/__pycache__/_typing.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/html2text/__pycache__/cli.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/html2text/__pycache__/config.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/html2text/__pycache__/elements.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/html2text/__pycache__/typing.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/html2text/__pycache__/utils.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/html2text/_typing.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/html2text/cli.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/html2text/config.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/html2text/elements.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/html2text/py.typed</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/html2text/typing.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/html2text/utils.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2024-02-14</Date>
-            <Version>2020.1.16</Version>
+        <Update release="8">
+            <Date>2024-08-01</Date>
+            <Version>2024.2.26</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Deyan Dimitrov</Name>
+            <Email>dikelito@tutamail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Updates `python-html2text` to 2024.2.26 and adds homepage
- Full changelog [here](https://github.com/Alir3z4/html2text/blob/master/ChangeLog.rst#2024226)

**Test Plan**

- Run simple example from the readme file
- Checked homepage was added

**Checklist**

- [x] Package was built and tested against unstable
