### PR TITLE
Update python-vdf and protontricks for new Steam vdf format

### DIFF
--- a/packages/p/protontricks/files/vdf-29-support.patch
+++ b/packages/p/protontricks/files/vdf-29-support.patch
@@ -1,0 +1,101 @@
+From f7b1fa33b0438dbd72f7222703f8442e40edc510 Mon Sep 17 00:00:00 2001
+From: Janne Pulkkinen <janne.pulkkinen@protonmail.com>
+Date: Thu, 1 Aug 2024 19:48:41 +0300
+Subject: [PATCH] Support appinfo.vdf V29
+
+Steam beta introduced a new version of appinfo.vdf with a space-saving
+optimization. Field keys are stored in a separate table at the end of
+the file, with the actual VDF segments having to be parsed using the
+table to map the indices to actual field names.
+
+`vdf` library does not support serializing appinfo.vdf using this
+format, at least yet, so just use appinfo.vdf V28 in tests for the time
+being. This might need to be fixed in the future once appinfo.vdf V28 is
+phased out.
+
+Fixes #304
+---
+ src/protontricks/steam.py | 56 +++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 56 insertions(+)
+
+diff --git a/src/protontricks/steam.py b/src/protontricks/steam.py
+index db47cd1..bcae17e 100644
+--- a/src/protontricks/steam.py
++++ b/src/protontricks/steam.py
+@@ -471,6 +471,7 @@ def find_legacy_steam_runtime_path(steam_root):
+ 
+ APPINFO_STRUCT_HEADER = "<4sL"
+ APPINFO_V28_STRUCT_SECTION = "<LLLLQ20sL20s"
++APPINFO_V29_STRUCT_SECTION = "<LLLLQ20sL20s"
+ 
+ 
+ def iter_appinfo_sections(path):
+@@ -506,6 +507,59 @@ def _iter_v28_appinfo(data, start):
+             if i == len(data) - 4:
+                 return
+ 
++    def _iter_v29_appinfo(data, start):
++        """
++        Parse and iterate appinfo.vdf version 29.
++        """
++        i = start
++
++        # The header contains the offset to the key table
++        key_table_offset = struct.unpack("<q", data[i:i+8])[0]
++        key_table = []
++
++        key_count = struct.unpack(
++            "<i", data[key_table_offset:key_table_offset+4]
++        )[0]
++
++        table_i = key_table_offset + 4
++        for _ in range(0, key_count):
++            key = bytearray()
++            while True:
++                key.append(data[table_i])
++                table_i += 1
++
++                if key[-1] == 0:
++                    key_table.append(
++                        key[0:-1].decode("utf-8", errors="replace")
++                    )
++                    break
++
++        i += 8
++
++        section_size = struct.calcsize(APPINFO_V29_STRUCT_SECTION)
++        while True:
++            # We don't need any of the fields besides 'entry_size',
++            # which is used to determine the length of the variable-length VDF
++            # field.
++            # Still, here they are for posterity's sake.
++            (appid, entry_size, infostate, last_updated, access_token,
++             sha_hash, change_number, vdf_sha_hash) = struct.unpack(
++                APPINFO_V29_STRUCT_SECTION, data[i:i+section_size])
++            vdf_section_size = entry_size - (section_size - 8)
++
++            i += section_size
++
++            vdf_d = vdf.binary_loads(
++                data[i:i+vdf_section_size], key_table=key_table
++            )
++            vdf_d = lower_dict(vdf_d)
++            yield vdf_d
++
++            i += vdf_section_size
++
++            if i == key_table_offset - 4:
++                return
++
+     logger.debug("Loading appinfo.vdf in %s", path)
+ 
+     # appinfo.vdf is not actually a (binary) VDF file, but a binary file
+@@ -527,6 +581,8 @@ def _iter_v28_appinfo(data, start):
+ 
+     if magic == b'(DV\x07':
+         yield from _iter_v28_appinfo(data, i)
++    elif magic == b')DV\x07':
++        yield from _iter_v29_appinfo(data, i)
+     else:
+         raise SyntaxError(
+             "Invalid file magic number. The appinfo.vdf version might not be "

--- a/packages/p/protontricks/package.yml
+++ b/packages/p/protontricks/package.yml
@@ -1,6 +1,6 @@
 name       : protontricks
 version    : 1.11.1
-release    : 25
+release    : 26
 source     :
     - https://files.pythonhosted.org/packages/source/p/protontricks/protontricks-1.11.1.tar.gz : aa4141a0d63d27540946318346280b657a3a7523f98f82aee86f2301fe1e2014
 homepage   : https://github.com/Matoking/protontricks
@@ -10,17 +10,19 @@ summary    : A simple wrapper that does winetricks things for Proton enabled gam
 description: |
     A simple wrapper that does winetricks things for Proton enabled games
 builddeps  :
-    - python-pillow
     - python-setuptools-scm
-    - python-vdf
 checkdeps  :
+    - python-pillow
     - python-pytest
+    - python-vdf
     - python-wheel
 rundeps    :
     - python-pillow
     - python-vdf
     - winetricks
     - yad
+setup      : |
+    %patch -p1 -i $pkgfiles/vdf-29-support.patch
 build      : |
     %python3_setup
 install    : |

--- a/packages/p/protontricks/pspec_x86_64.xml
+++ b/packages/p/protontricks/pspec_x86_64.xml
@@ -67,8 +67,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="25">
-            <Date>2024-06-11</Date>
+        <Update release="26">
+            <Date>2024-08-01</Date>
             <Version>1.11.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>

--- a/packages/py/python-vdf/files/new-format-compat.patch
+++ b/packages/py/python-vdf/files/new-format-compat.patch
@@ -1,0 +1,104 @@
+From 981cad270c2558aeb8eccaf42cfcf9fabbbed199 Mon Sep 17 00:00:00 2001
+From: Janne Pulkkinen <janne.pulkkinen@protonmail.com>
+Date: Mon, 1 Jul 2024 00:48:20 +0300
+Subject: [PATCH] Add deserialize support for binary VDF w/ table
+
+The new Steam beta introduced a new `appinfo.vdf` version. This
+appinfo.vdf V29 introduces a new binary VDF format which does not
+include field keys in binary VDF segments as-is. Instead, each key is
+represented by a 32-bit integer which needs to be mapped to an actual
+string using a table stored at the end of the `appinfo.vdf` file.
+
+This also means the binary VDF segments in this case are no longer
+self-contained. The developer can parse and provide the table
+themselves or instead use the `ValvePython/steam` library which
+contains a function to parse `appinfo.vdf` files.
+
+Also see SteamDatabase/SteamAppInfo@56b1fec7f5ce6be961c3e44cf9baf117e363ad91
+
+Refs ValvePython/steam#462
+---
+ tests/test_binary_vdf.py |  6 ++++++
+ vdf/__init__.py          | 26 ++++++++++++++++++++++----
+ 2 files changed, 28 insertions(+), 4 deletions(-)
+
+diff --git a/tests/test_binary_vdf.py b/tests/test_binary_vdf.py
+index 0424c28..4a7445d 100644
+--- a/tests/test_binary_vdf.py
++++ b/tests/test_binary_vdf.py
+@@ -166,6 +166,12 @@ def test_raise_on_remaining_with_file(self):
+             vdf.binary_load(buf, raise_on_remaining=True)
+         self.assertEqual(buf.read(), b'aaaa')
+ 
++    def test_key_table(self):
++        test = b'\x01\x00\x00\x00\x00value\x00\x01\x02\x00\x00\x00value3\x00\x08'
++        key_table = ['key', 'key2', 'key3', 'key4']
++
++        self.assertEqual({'key': 'value', 'key3': 'value3'}, vdf.binary_loads(test, key_table=key_table))
++
+     def test_vbkv_loads_empty(self):
+         with self.assertRaises(ValueError):
+             vdf.vbkv_loads(b'')
+diff --git a/vdf/__init__.py b/vdf/__init__.py
+index 6b47213..e79136b 100644
+--- a/vdf/__init__.py
++++ b/vdf/__init__.py
+@@ -295,7 +295,7 @@ class COLOR(BASE_INT):
+ BIN_INT64       = b'\x0A'
+ BIN_END_ALT     = b'\x0B'
+ 
+-def binary_loads(b, mapper=dict, merge_duplicate_keys=True, alt_format=False, raise_on_remaining=True):
++def binary_loads(b, mapper=dict, merge_duplicate_keys=True, alt_format=False, key_table=None, raise_on_remaining=True):
+     """
+     Deserialize ``b`` (``bytes`` containing a VDF in "binary form")
+     to a Python object.
+@@ -307,13 +307,18 @@ def binary_loads(b, mapper=dict, merge_duplicate_keys=True, alt_format=False, ra
+     ``merge_duplicate_keys`` when ``True`` will merge multiple KeyValue lists with the
+     same key into one instead of overwriting. You can se this to ``False`` if you are
+     using ``VDFDict`` and need to preserve the duplicates.
++
++    ``key_table`` will be used to translate keys in binary VDF objects
++    which do not encode strings directly but instead store them in an out-of-band
++    table. Newer `appinfo.vdf` format stores this table the end of the file,
++    and it is needed to deserialize the binary VDF objects in that file.
+     """
+     if not isinstance(b, bytes):
+         raise TypeError("Expected s to be bytes, got %s" % type(b))
+ 
+-    return binary_load(BytesIO(b), mapper, merge_duplicate_keys, alt_format, raise_on_remaining)
++    return binary_load(BytesIO(b), mapper, merge_duplicate_keys, alt_format, key_table, raise_on_remaining)
+ 
+-def binary_load(fp, mapper=dict, merge_duplicate_keys=True, alt_format=False, raise_on_remaining=False):
++def binary_load(fp, mapper=dict, merge_duplicate_keys=True, alt_format=False, key_table=None, raise_on_remaining=False):
+     """
+     Deserialize ``fp`` (a ``.read()``-supporting file-like object containing
+     binary VDF) to a Python object.
+@@ -325,6 +330,11 @@ def binary_load(fp, mapper=dict, merge_duplicate_keys=True, alt_format=False, ra
+     ``merge_duplicate_keys`` when ``True`` will merge multiple KeyValue lists with the
+     same key into one instead of overwriting. You can se this to ``False`` if you are
+     using ``VDFDict`` and need to preserve the duplicates.
++
++    ``key_table`` will be used to translate keys in binary VDF objects
++    which do not encode strings directly but instead store them in an out-of-band
++    table. Newer `appinfo.vdf` format stores this table the end of the file,
++    and it is needed to deserialize the binary VDF objects in that file.
+     """
+     if not hasattr(fp, 'read') or not hasattr(fp, 'tell') or not hasattr(fp, 'seek'):
+         raise TypeError("Expected fp to be a file-like object with tell()/seek() and read() returning bytes")
+@@ -382,7 +392,15 @@ def read_string(fp, wide=False):
+                 continue
+             break
+ 
+-        key = read_string(fp)
++        if key_table:
++            # If 'key_table' was provided, each key is an int32 value that
++            # needs to be mapped to an actual field name using a key table.
++            # Newer appinfo.vdf (V29+) stores this table at the end of the file.
++            index = int32.unpack(fp.read(int32.size))[0]
++
++            key = key_table[index]
++        else:
++            key = read_string(fp)
+ 
+         if t == BIN_NONE:
+             if merge_duplicate_keys and key in stack[-1]:

--- a/packages/py/python-vdf/package.yml
+++ b/packages/py/python-vdf/package.yml
@@ -1,6 +1,6 @@
 name       : python-vdf
 version    : '3.4'
-release    : 5
+release    : 6
 source     :
     - https://github.com/ValvePython/vdf/archive/refs/tags/v3.4.tar.gz : c9fb42b6de9daf475cd229377d0c32d6e87c0f21e874a35e0e679eb201723a67
 homepage   : https://github.com/ValvePython/vdf
@@ -9,6 +9,8 @@ component  : programming.python
 summary    : Python module for working with Valve's text and binary KeyValue format
 description: |
     Python module for (de)serialization to and from VDF that works just like json
+setup      : |
+    %patch -p1 -i $pkgfiles/new-format-compat.patch
 build      : |
     %python3_setup
 install    : |

--- a/packages/py/python-vdf/pspec_x86_64.xml
+++ b/packages/py/python-vdf/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-vdf</Name>
         <Homepage>https://github.com/ValvePython/vdf</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -32,12 +32,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2024-02-15</Date>
+        <Update release="6">
+            <Date>2024-07-24</Date>
             <Version>3.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

This updates `python-vdf` and `protontricks` so they are compatible with the new vdf format in the current Steam beta

**Test Plan**

Used `protontricks` to install components into a game's proton prefix.

**Checklist**

- [x] Package was built and tested against unstable
