### PR TITLE
noto-sans-ttf: Update to 24.8.1

### DIFF
--- a/packages/n/noto-sans-ttf/package.yml
+++ b/packages/n/noto-sans-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : noto-sans-ttf
-version    : 24.7.1
-release    : 30
+version    : 24.8.1
+release    : 31
 source     :
-    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-24.7.1.tar.gz : 934ec561b5c623b460aea837f7bad243073165b1ed6766b61c44d623997b88e0
+    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-24.8.1.tar.gz : 84d292fc934ad6a9f20705fdfa5764b81b456b0e733f98b6f44388fb8c8eb44a
     - https://github.com/googlefonts/noto-emoji/archive/refs/tags/v2.042.tar.gz : b56bd2fa4029d0f057b66b742ac59af243dbc91067fed3eb4929dac762440fc9
 homepage   : https://fonts.google.com/noto
 extract    : no

--- a/packages/n/noto-sans-ttf/pspec_x86_64.xml
+++ b/packages/n/noto-sans-ttf/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>noto-sans-ttf</Name>
         <Homepage>https://fonts.google.com/noto</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>OFL-1.1</License>
         <PartOf>desktop.font</PartOf>
@@ -1538,12 +1538,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="30">
-            <Date>2024-07-05</Date>
-            <Version>24.7.1</Version>
+        <Update release="31">
+            <Date>2024-08-03</Date>
+            <Version>24.8.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Full commit log available [here](https://github.com/notofonts/notofonts.github.io/compare/noto-monthly-release-24.7.1...noto-monthly-release-24.8.1)

**Test Plan**
- Checked everything looked alright in my DE where Noto Sans is set as system font
- Wrote some text with Noto Sans and Noto Serif in LibreOffice Writer 

**Checklist**

- [x] Package was built and tested against unstable
