### PR TITLE
bottom: Update to 0.10.1

### DIFF
--- a/packages/b/bottom/abi_used_symbols
+++ b/packages/b/bottom/abi_used_symbols
@@ -32,8 +32,6 @@ libc.so.6:fstat64
 libc.so.6:getauxval
 libc.so.6:getcwd
 libc.so.6:getenv
-libc.so.6:getgrgid_r
-libc.so.6:getgrouplist
 libc.so.6:getifaddrs
 libc.so.6:getpeername
 libc.so.6:getpid
@@ -133,10 +131,8 @@ libgcc_s.so.1:_Unwind_RaiseException
 libgcc_s.so.1:_Unwind_Resume
 libgcc_s.so.1:_Unwind_SetGR
 libgcc_s.so.1:_Unwind_SetIP
-libm.so.6:ceil
 libm.so.6:ceilf
 libm.so.6:floor
-libm.so.6:fmod
 libm.so.6:log10
 libm.so.6:log2
 libm.so.6:round

--- a/packages/b/bottom/package.yml
+++ b/packages/b/bottom/package.yml
@@ -1,10 +1,10 @@
 name       : bottom
-version    : 0.9.7
-release    : 23
+version    : 0.10.1
+release    : 24
 source     :
-    - https://github.com/ClementTsang/bottom/archive/refs/tags/0.9.7.tar.gz : 29c3f75323ae0245576ea23268bb0956757352bf3b16d05f511357655b9cc71e
-    - https://github.com/ClementTsang/bottom/releases/download/0.9.7/completion.tar.gz : 721b3921157cbc3f31f20f0aaaea468a235b3d0fa8f876cbf9d3867578db8203
-    - https://github.com/ClementTsang/bottom/releases/download/0.9.7/manpage.tar.gz : e828123c48bfaec804db06dd211c7e4bb2c9899100c9a68522607832789a3ddb
+    - https://github.com/ClementTsang/bottom/archive/refs/tags/0.10.1.tar.gz : c0e507cc3a5246e65521e91391410efc605840abe3b40194c5769265051fa1cc
+    - https://github.com/ClementTsang/bottom/releases/download/0.10.1/completion.tar.gz : 87a722518bbed7012214ff77425aa69b582c8ab1d50817f427b1c920da420710
+    - https://github.com/ClementTsang/bottom/releases/download/0.10.1/manpage.tar.gz : a320f028f728fbdbdea1d309840544a1da15243f158477a537bb8eeab05259f7
 homepage   : https://clementtsang.github.io/bottom
 license    : MIT
 component  : system.utils

--- a/packages/b/bottom/pspec_x86_64.xml
+++ b/packages/b/bottom/pspec_x86_64.xml
@@ -28,9 +28,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2024-07-26</Date>
-            <Version>0.9.7</Version>
+        <Update release="24">
+            <Date>2024-08-04</Date>
+            <Version>0.10.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/ClementTsang/bottom/blob/0.10.1/CHANGELOG.md#0101---2024-08-01).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `btm` and see that the graphs display as expected.

**Checklist**

- [x] Package was built and tested against unstable
