### PR TITLE
github-cli: Update to 2.54.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.53.0
-release    : 51
+version    : 2.54.0
+release    : 52
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.53.0.tar.gz : 5e47d567216b1f63a4939e634f9067c9b60b0852625edf8ad10e1b9be5033cff
+    - https://github.com/cli/cli/archive/refs/tags/v2.54.0.tar.gz : eedac958431876cebe243925dc354b0c21915d1bc84c5678a8073f0ec91d6a4c
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -219,9 +219,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="51">
-            <Date>2024-07-18</Date>
-            <Version>2.53.0</Version>
+        <Update release="52">
+            <Date>2024-08-04</Date>
+            <Version>2.54.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Remove redundant whitespace
- Update documentation for `gh api PATCH`
- Clarify usage of template flags for PR and issue creation
- Expose json databaseId field for release commands
- Expose `fullDatabaseId` for PR json export
- Handle `--bare` clone targets
- Slightly clarify when CLI exits with code 4
- Exit with 1 on authentication issues
- Add `--remove-milestone` option to `issue edit` and `pr edit`

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and open this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
