### PR TITLE
rawtherapee: Backport patch for libjpeg-turbo

### DIFF
--- a/packages/r/rawtherapee/abi_used_symbols
+++ b/packages/r/rawtherapee/abi_used_symbols
@@ -1,8 +1,11 @@
+UNKNOWN:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_disposeEv
 UNKNOWN:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructEmc
 UNKNOWN:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4swapERS4_
 UNKNOWN:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7reserveEm
+UNKNOWN:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE8_M_eraseEmm
 UNKNOWN:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_assignERKS4_
 UNKNOWN:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_mutateEmmPKcm
+UNKNOWN:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE10_M_disposeEv
 UNKNOWN:_ZTIN3Atk11ImplementorE
 UNKNOWN:_ZTIN3Gio11ActionGroupE
 UNKNOWN:_ZTIN3Gio11ApplicationE
@@ -1532,7 +1535,6 @@ libjpeg.so.8:jpeg_set_quality
 libjpeg.so.8:jpeg_start_compress
 libjpeg.so.8:jpeg_start_decompress
 libjpeg.so.8:jpeg_std_error
-libjpeg.so.8:jpeg_std_message_table
 libjpeg.so.8:jpeg_stdio_dest
 libjpeg.so.8:jpeg_write_m_byte
 libjpeg.so.8:jpeg_write_m_header
@@ -1759,18 +1761,14 @@ libstdc++.so.6:_ZNSt6localeC1ERKS_
 libstdc++.so.6:_ZNSt6localeC1Ev
 libstdc++.so.6:_ZNSt6localeD1Ev
 libstdc++.so.6:_ZNSt6localeaSERKS_
-libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_disposeEv
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE14_M_replace_auxEmmmc
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6appendEPKcm
-libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE8_M_eraseEmm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_appendEPKcm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createERmm
-libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1EOS4_
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1EPKcRKS3_
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEaSEOS4_
-libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE10_M_disposeEv
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE10_M_replaceEmmPKwm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE9_M_assignERKS4_
 libstdc++.so.6:_ZNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE7_M_syncEPcmm
@@ -1816,7 +1814,6 @@ libstdc++.so.6:_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
 libstdc++.so.6:_ZSt7getlineIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EE
 libstdc++.so.6:_ZSt7getlineIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EES4_
 libstdc++.so.6:_ZSt7nothrow
-libstdc++.so.6:_ZSt9terminatev
 libstdc++.so.6:_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
 libstdc++.so.6:_ZStrsIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EE
 libstdc++.so.6:_ZTINSt6locale5facetE
@@ -1858,6 +1855,7 @@ libstdc++.so.6:_Znwm
 libstdc++.so.6:_ZnwmRKSt9nothrow_t
 libstdc++.so.6:__cxa_allocate_exception
 libstdc++.so.6:__cxa_begin_catch
+libstdc++.so.6:__cxa_call_terminate
 libstdc++.so.6:__cxa_call_unexpected
 libstdc++.so.6:__cxa_end_catch
 libstdc++.so.6:__cxa_free_exception

--- a/packages/r/rawtherapee/files/0001-jpeg-turbo.patch
+++ b/packages/r/rawtherapee/files/0001-jpeg-turbo.patch
@@ -1,0 +1,95 @@
+From efdc5bce3b9794847093baeb040937ab55eba86e Mon Sep 17 00:00:00 2001
+From: Richard E Barber <kd6kxr@gmail.com>
+Date: Sun, 19 May 2024 04:27:10 -0700
+Subject: [PATCH 1/2] Fix linking with jpeg-turbo
+
+patch via Termux PR
+https://github.com/termux-user-repository/tur/pull/1027
+---
+ rtengine/jdatasrc.cc | 28 ++--------------------------
+ 1 file changed, 2 insertions(+), 26 deletions(-)
+
+diff --git a/rtengine/jdatasrc.cc b/rtengine/jdatasrc.cc
+index fa13b9dd1..a0d12657f 100644
+--- a/rtengine/jdatasrc.cc
++++ b/rtengine/jdatasrc.cc
+@@ -247,20 +247,6 @@ my_error_exit (j_common_ptr cinfo)
+ #endif
+ }
+ 
+-
+-#ifdef _WIN32
+-#define JVERSION	"6b  27-Mar-1998"
+-#define JCOPYRIGHT_SHORT	"(C) 1998, Thomas G. Lane"
+-#define JMESSAGE(code,string)	string ,
+-
+-const char * const jpeg_std_message_table[] = {
+-#include "jerror.h"
+-  NULL
+-};
+-#else
+-extern const char * const jpeg_std_message_table[];
+-#endif
+-
+ /*
+  * Actual output of an error or trace message.
+  * Applications may override this method to send JPEG messages somewhere
+@@ -409,24 +395,14 @@ reset_error_mgr (j_common_ptr cinfo)
+ GLOBAL(struct jpeg_error_mgr *)
+ my_jpeg_std_error (struct jpeg_error_mgr * err)
+ {
++    err = jpeg_std_error(err);
+ 
++    /* override these functions */
+     err->error_exit = my_error_exit;
+     err->emit_message = emit_message;
+     err->output_message = output_message;
+     err->format_message = format_message;
+     err->reset_error_mgr = reset_error_mgr;
+ 
+-    err->trace_level = 0;     /* default = no tracing */
+-    err->num_warnings = 0;    /* no warnings emitted yet */
+-    err->msg_code = 0;        /* may be useful as a flag for "no error" */
+-
+-    /* Initialize message table pointers */
+-    err->jpeg_message_table = jpeg_std_message_table;
+-    err->last_jpeg_message = (int) JMSG_LASTMSGCODE - 1;
+-
+-    err->addon_message_table = nullptr;
+-    err->first_addon_message = 0; /* for safety */
+-    err->last_addon_message = 0;
+-
+     return err;
+ }
+-- 
+2.45.1
+
+
+From 7789a8574b454ebd874522a70930ae4b40726da4 Mon Sep 17 00:00:00 2001
+From: Richard E Barber <kd6kxr@gmail.com>
+Date: Sun, 19 May 2024 16:39:28 -0700
+Subject: [PATCH 2/2] removes redundant jpeg error message
+
+Co-authored-by: Lawrence37 <45837045+Lawrence37@users.noreply.github.com>
+---
+ rtengine/jdatasrc.cc | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/rtengine/jdatasrc.cc b/rtengine/jdatasrc.cc
+index a0d12657f..96b6f83b6 100644
+--- a/rtengine/jdatasrc.cc
++++ b/rtengine/jdatasrc.cc
+@@ -399,10 +399,6 @@ my_jpeg_std_error (struct jpeg_error_mgr * err)
+ 
+     /* override these functions */
+     err->error_exit = my_error_exit;
+-    err->emit_message = emit_message;
+-    err->output_message = output_message;
+-    err->format_message = format_message;
+-    err->reset_error_mgr = reset_error_mgr;
+ 
+     return err;
+ }
+-- 
+2.45.1
+

--- a/packages/r/rawtherapee/package.yml
+++ b/packages/r/rawtherapee/package.yml
@@ -1,6 +1,6 @@
 name       : rawtherapee
 version    : '5.10'
-release    : 21
+release    : 22
 source     :
     - https://rawtherapee.com/shared/source/rawtherapee-5.10.tar.xz : a799b53cd54dba4a211479e342ffc9c5db1c44d3d6c3a27d5cc13adf0debd2da
 homepage   : https://rawtherapee.com/
@@ -30,6 +30,8 @@ builddeps  :
 environment: |
      export CFLAGS="$CFLAGS -O3"
 setup      : |
+    %patch -p1 -i $pkgfiles/0001-jpeg-turbo.patch
+
     cat > rtgui/version.h << EOF
     #ifndef _VERSION_
     #define _VERSION_

--- a/packages/r/rawtherapee/pspec_x86_64.xml
+++ b/packages/r/rawtherapee/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>rawtherapee</Name>
         <Homepage>https://rawtherapee.com/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>multimedia.graphics</PartOf>
@@ -664,12 +664,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2024-02-19</Date>
+        <Update release="22">
+            <Date>2024-08-06</Date>
             <Version>5.10</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Backport patch for libjpeg-turbo

Fixes https://github.com/getsolus/packages/issues/3485

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Launch RawTherapee and see that it doesn't crash on start.

**Checklist**

- [x] Package was built and tested against unstable
