### PR TITLE
perl-extutils-helpers: Update to 0.027

### DIFF
--- a/packages/p/perl-extutils-helpers/monitoring.yml
+++ b/packages/p/perl-extutils-helpers/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 11848
+  rss: ~
+# No known CPE, checked 2024-08-07
+security:
+  cpe: ~

--- a/packages/p/perl-extutils-helpers/package.yml
+++ b/packages/p/perl-extutils-helpers/package.yml
@@ -1,8 +1,9 @@
 name       : perl-extutils-helpers
-version    : 0.026
-release    : 8
+version    : '0.027'
+release    : 9
 source     :
-    - http://search.cpan.org/CPAN/authors/id/L/LE/LEONT/ExtUtils-Helpers-0.026.tar.gz : de901b6790a4557cf4ec908149e035783b125bf115eb9640feb1bc1c24c33416
+    - http://search.cpan.org/CPAN/authors/id/L/LE/LEONT/ExtUtils-Helpers-0.027.tar.gz : 9d592131dc5845a86dc28be9143f764e73cb62db06fedf50a895be1324b6cec5
+homepage   : https://metacpan.org/pod/ExtUtils::Helpers
 license    : Artistic-2.0
 component  : programming.perl
 summary    : Various portability utilities for module builders
@@ -14,3 +15,4 @@ build      : |
     %perl_build
 install    : |
     %perl_install
+patterns   : /*

--- a/packages/p/perl-extutils-helpers/pspec_x86_64.xml
+++ b/packages/p/perl-extutils-helpers/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>perl-extutils-helpers</Name>
+        <Homepage>https://metacpan.org/pod/ExtUtils::Helpers</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>Artistic-2.0</License>
         <PartOf>programming.perl</PartOf>
         <Summary xml:lang="en">Various portability utilities for module builders</Summary>
         <Description xml:lang="en">Various portability utilities for module builders
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>perl-extutils-helpers</Name>
@@ -31,12 +32,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2023-07-24</Date>
-            <Version>0.026</Version>
+        <Update release="9">
+            <Date>2024-08-07</Date>
+            <Version>0.027</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Revert "Make split_like_shell always unixy"

**Test Plan**

<!-- Short description of how the package was tested -->
Rebuild `perl-module-build-tiny` and `perl-readonly`

**Checklist**

- [x] Package was built and tested against unstable
