### PR TITLE
perl-extutils-installpaths: Update to 0.013

### DIFF
--- a/packages/p/perl-extutils-installpaths/monitoring.yml
+++ b/packages/p/perl-extutils-installpaths/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 11849
+  rss: ~
+# No known CPE, checked 2024-08-07
+security:
+  cpe: ~

--- a/packages/p/perl-extutils-installpaths/package.yml
+++ b/packages/p/perl-extutils-installpaths/package.yml
@@ -1,8 +1,9 @@
 name       : perl-extutils-installpaths
-version    : '0.012'
-release    : 9
+version    : '0.013'
+release    : 10
 source     :
-    - https://cpan.metacpan.org/authors/id/L/LE/LEONT/ExtUtils-InstallPaths-0.012.tar.gz : 84735e3037bab1fdffa3c2508567ad412a785c91599db3c12593a50a1dd434ed
+    - https://cpan.metacpan.org/authors/id/L/LE/LEONT/ExtUtils-InstallPaths-0.013.tar.gz : 65969d3ad8a3a2ea8ef5b4213ed5c2c83961bb5bd12f7ad35128f6bd5b684aa0
+homepage   : https://metacpan.org/pod/ExtUtils::InstallPaths
 license    : Artistic-2.0
 component  : programming.perl
 summary    : Build.PL install path logic made easy
@@ -18,3 +19,4 @@ install    : |
     %perl_install
 check      : |
     %perl_build test
+patterns   : /*

--- a/packages/p/perl-extutils-installpaths/pspec_x86_64.xml
+++ b/packages/p/perl-extutils-installpaths/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>perl-extutils-installpaths</Name>
+        <Homepage>https://metacpan.org/pod/ExtUtils::InstallPaths</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>Artistic-2.0</License>
         <PartOf>programming.perl</PartOf>
         <Summary xml:lang="en">Build.PL install path logic made easy</Summary>
         <Description xml:lang="en">Build.PL install path logic made easy
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>perl-extutils-installpaths</Name>
@@ -25,12 +26,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2023-07-25</Date>
-            <Version>0.012</Version>
+        <Update release="10">
+            <Date>2024-08-07</Date>
+            <Version>0.013</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Try to install any installable paths

**Test Plan**

<!-- Short description of how the package was tested -->
Rebuild  `perl-extutils-config`, `perl-module-build-tiny` and `perl-readonly`

**Checklist**

- [x] Package was built and tested against unstable
