### PR TITLE
libheif: Update to 1.18.2

### DIFF
--- a/packages/l/libheif/abi_used_symbols
+++ b/packages/l/libheif/abi_used_symbols
@@ -234,7 +234,6 @@ libstdc++.so.6:_ZNSt6thread4joinEv
 libstdc++.so.6:_ZNSt6thread6_StateD2Ev
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_disposeEv
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
-libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructEmc
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE13_S_copy_charsEPcPKcS7_
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6appendEPKc
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7reserveEm

--- a/packages/l/libheif/package.yml
+++ b/packages/l/libheif/package.yml
@@ -1,8 +1,8 @@
 name       : libheif
-version    : 1.18.1
-release    : 41
+version    : 1.18.2
+release    : 42
 source     :
-    - https://github.com/strukturag/libheif/releases/download/v1.18.1/libheif-1.18.1.tar.gz : 8702564b0f288707ea72b260b3bf4ba9bf7abfa7dac01353def3a86acd6bbb76
+    - https://github.com/strukturag/libheif/releases/download/v1.18.2/libheif-1.18.2.tar.gz : c4002a622bec9f519f29d84bfdc6024e33fd67953a5fb4dc2c2f11f67d5e45bf
 license    : LGPL-3.0-or-later
 homepage   : https://github.com/strukturag/libheif
 component  : multimedia.codecs

--- a/packages/l/libheif/pspec_x86_64.xml
+++ b/packages/l/libheif/pspec_x86_64.xml
@@ -22,6 +22,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
 </Description>
         <PartOf>multimedia.codecs</PartOf>
         <Files>
+            <Path fileType="executable">/usr/bin/heif-convert</Path>
             <Path fileType="executable">/usr/bin/heif-dec</Path>
             <Path fileType="executable">/usr/bin/heif-enc</Path>
             <Path fileType="executable">/usr/bin/heif-info</Path>
@@ -29,7 +30,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
             <Path fileType="library">/usr/lib64/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-heif.so</Path>
             <Path fileType="library">/usr/lib64/libheif</Path>
             <Path fileType="library">/usr/lib64/libheif.so.1</Path>
-            <Path fileType="library">/usr/lib64/libheif.so.1.18.1</Path>
+            <Path fileType="library">/usr/lib64/libheif.so.1.18.2</Path>
             <Path fileType="man">/usr/share/man/man1/heif-dec.1</Path>
             <Path fileType="man">/usr/share/man/man1/heif-enc.1</Path>
             <Path fileType="man">/usr/share/man/man1/heif-info.1</Path>
@@ -45,7 +46,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="41">libheif</Dependency>
+            <Dependency release="42">libheif</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libheif/heif.h</Path>
@@ -63,9 +64,9 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
         </Files>
     </Package>
     <History>
-        <Update release="41">
-            <Date>2024-07-25</Date>
-            <Version>1.18.1</Version>
+        <Update release="42">
+            <Date>2024-08-08</Date>
+            <Version>1.18.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fix regression that Exif orientation was not correctly reset when converting rotated HEIF (`heif-dec`)
- Swap Exif width/height when rotating image by 90 degrees
- Fix memory leak in OpenJPEG decoding plugin
- Pay attention to `DESTDIR` variable when installing `heif-convert` symlink

**Test Plan**
- Encode and decode a couple of heif images
- View heif images in my image viewer (`eog`)

**Checklist**

- [x] Package was built and tested against unstable
