### PR TITLE
python-pkginfo: Add homepage

### DIFF
--- a/packages/py/python-pkginfo/package.yml
+++ b/packages/py/python-pkginfo/package.yml
@@ -1,8 +1,9 @@
 name       : python-pkginfo
 version    : 1.9.6
-release    : 3
+release    : 4
 source     :
     - https://pypi.io/packages/source/p/pkginfo/pkginfo-1.9.6.tar.gz : 8fd5896e8718a4372f0ea9cc9d96f6417c9b986e23a4d116dda26b62cc29d046
+homepage   : https://code.launchpad.net/~tseaver/pkginfo/trunk
 license    : MIT
 component  : programming.python
 summary    : Query metadatdata from sdists / bdists / installed packages.

--- a/packages/py/python-pkginfo/pspec_x86_64.xml
+++ b/packages/py/python-pkginfo/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>python-pkginfo</Name>
+        <Homepage>https://code.launchpad.net/~tseaver/pkginfo/trunk</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Deyan Dimitrov</Name>
+            <Email>dikelito@tutamail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -81,12 +82,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-02-14</Date>
+        <Update release="4">
+            <Date>2024-08-08</Date>
             <Version>1.9.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Deyan Dimitrov</Name>
+            <Email>dikelito@tutamail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Adds `homepage` key to `package.yml`

**Test Plan**

- Checked homepage was added

**Checklist**

- [x] Package was built and tested against unstable
