### PR TITLE
perl-io-utf8-strict: Update to 0.010

### DIFF
--- a/packages/p/perl-io-utf8-strict/abi_used_symbols
+++ b/packages/p/perl-io-utf8-strict/abi_used_symbols
@@ -5,6 +5,7 @@ UNKNOWN:PerlIOBase_eof
 UNKNOWN:PerlIOBase_error
 UNKNOWN:PerlIOBase_fileno
 UNKNOWN:PerlIOBase_setlinebuf
+UNKNOWN:PerlIOBase_unread
 UNKNOWN:PerlIOBuf_bufsiz
 UNKNOWN:PerlIOBuf_close
 UNKNOWN:PerlIOBuf_dup
@@ -19,7 +20,6 @@ UNKNOWN:PerlIOBuf_read
 UNKNOWN:PerlIOBuf_seek
 UNKNOWN:PerlIOBuf_set_ptrcnt
 UNKNOWN:PerlIOBuf_tell
-UNKNOWN:PerlIOBuf_unread
 UNKNOWN:PerlIOBuf_write
 UNKNOWN:PerlIO_define_layer
 UNKNOWN:PerlIO_fast_gets

--- a/packages/p/perl-io-utf8-strict/monitoring.yml
+++ b/packages/p/perl-io-utf8-strict/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 3231
+  rss: ~
+# No known CPE, checked 2024-08-09
+security:
+  cpe: ~

--- a/packages/p/perl-io-utf8-strict/package.yml
+++ b/packages/p/perl-io-utf8-strict/package.yml
@@ -1,8 +1,9 @@
 name       : perl-io-utf8-strict
-version    : 0.007
-release    : 6
+version    : '0.010'
+release    : 7
 source     :
-    - https://cpan.metacpan.org/authors/id/L/LE/LEONT/PerlIO-utf8_strict-0.007.tar.gz : 83a33f2fe046cb3ad6afc80790635a423e2c7c6854afacc6998cd46951cc81cb
+    - https://cpan.metacpan.org/authors/id/L/LE/LEONT/PerlIO-utf8_strict-0.010.tar.gz : bcd2848b72df290b5e984fae8b1a6ca96f6d072003cf222389a8c9e8e1c570cd
+homepage   : https://metacpan.org/pod/PerlIO::utf8_strict
 license    : Artistic-1.0-Perl
 component  : programming.perl
 summary    : PerlIO::utf8_strict - Fast and correct UTF-8 IO
@@ -18,3 +19,4 @@ install    : |
     %perl_install
 check      : |
     %perl_build test
+patterns   : /*

--- a/packages/p/perl-io-utf8-strict/pspec_x86_64.xml
+++ b/packages/p/perl-io-utf8-strict/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>perl-io-utf8-strict</Name>
+        <Homepage>https://metacpan.org/pod/PerlIO::utf8_strict</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>Artistic-1.0-Perl</License>
         <PartOf>programming.perl</PartOf>
         <Summary xml:lang="en">PerlIO::utf8_strict - Fast and correct UTF-8 IO</Summary>
         <Description xml:lang="en">PerlIO::utf8_strict - Fast and correct UTF-8 IO
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>perl-io-utf8-strict</Name>
@@ -26,12 +27,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2023-07-26</Date>
-            <Version>0.007</Version>
+        <Update release="7">
+            <Date>2024-08-09</Date>
+            <Version>0.010</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Full changelog can be read [here](https://fastapi.metacpan.org/source/LEONT/PerlIO-utf8_strict-0.010/Changes)

**Test Plan**

<!-- Short description of how the package was tested -->
Rebuild and run `biber`

**Checklist**

- [x] Package was built and tested against unstable
