### PR TITLE
libytnef: update to 2.1.2

### DIFF
--- a/packages/l/libytnef/abi_used_symbols
+++ b/packages/l/libytnef/abi_used_symbols
@@ -1,7 +1,6 @@
 libc.so.6:__ctype_b_loc
 libc.so.6:__fprintf_chk
 libc.so.6:__libc_start_main
-libc.so.6:__memcpy_chk
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail

--- a/packages/l/libytnef/package.yml
+++ b/packages/l/libytnef/package.yml
@@ -1,8 +1,9 @@
 name       : libytnef
-version    : "2.0"
-release    : 1
+version    : '2.1.2'
+release    : 2
 source     :
-    - https://github.com/Yeraze/ytnef/archive/refs/tags/v2.0.tar.gz : bb12f34572de89e4825fce98d2d235d93cd34b2c41fed0074ebfa89af9e724a9
+    - https://github.com/Yeraze/ytnef/archive/refs/tags/v2.1.2.tar.gz : 340f03f495884611209e9c0bc943fad06ce920e8c79655aa228d5ca7418dc360
+homepage   : https://github.com/Yeraze/ytnef
 license    : GPL-2.0-or-later
 component  : desktop.library
 summary    : TNEF Stream Reader library

--- a/packages/l/libytnef/pspec_x86_64.xml
+++ b/packages/l/libytnef/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>libytnef</Name>
+        <Homepage>https://github.com/Yeraze/ytnef</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Clifford Red</Name>
+            <Email>a108384@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.library</PartOf>
         <Summary xml:lang="en">TNEF Stream Reader library</Summary>
         <Description xml:lang="en">TNEF Stream Reader library (decodes winmail.dat)
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>libytnef</Name>
@@ -33,7 +34,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="1">libytnef</Dependency>
+            <Dependency release="2">libytnef</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/mapi.h</Path>
@@ -47,12 +48,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2022-03-07</Date>
-            <Version>2.0</Version>
+        <Update release="2">
+            <Date>2024-08-05</Date>
+            <Version>2.1.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Clifford Red</Name>
+            <Email>a108384@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Add homepage to package.yml
- Update from version 2.0 to 2.1.2 
  - changelog [2.1.2](https://github.com/Yeraze/ytnef/releases/tag/v2.1.2) 
  - changelog [2.1.1](https://github.com/Yeraze/ytnef/releases/tag/v2.1.1) 
  - changelog [2.1.0](https://github.com/Yeraze/ytnef/releases/tag/v2.1)


**Test Plan**
- [x] Build and install new package
- [x] Verify homepage link
- [x] Successfully execute test script from repository to extract data from sample winmail.dat file

**Checklist**

- [X] Package was built and tested against unstable
