### PR TITLE
bottom: Update to 0.10.2

### DIFF
--- a/packages/b/bottom/package.yml
+++ b/packages/b/bottom/package.yml
@@ -1,10 +1,10 @@
 name       : bottom
-version    : 0.10.1
-release    : 24
+version    : 0.10.2
+release    : 25
 source     :
-    - https://github.com/ClementTsang/bottom/archive/refs/tags/0.10.1.tar.gz : c0e507cc3a5246e65521e91391410efc605840abe3b40194c5769265051fa1cc
-    - https://github.com/ClementTsang/bottom/releases/download/0.10.1/completion.tar.gz : 87a722518bbed7012214ff77425aa69b582c8ab1d50817f427b1c920da420710
-    - https://github.com/ClementTsang/bottom/releases/download/0.10.1/manpage.tar.gz : a320f028f728fbdbdea1d309840544a1da15243f158477a537bb8eeab05259f7
+    - https://github.com/ClementTsang/bottom/archive/refs/tags/0.10.2.tar.gz : 1db45fe9bc1fabb62d67bf8a1ea50c96e78ff4d2a5e25bf8ae8880e3ad5af80a
+    - https://github.com/ClementTsang/bottom/releases/download/0.10.2/completion.tar.gz : 899be2ef2d1cd8406f11536d1828b568161fdabafbf0a7172a58bd3b636fcda0
+    - https://github.com/ClementTsang/bottom/releases/download/0.10.2/manpage.tar.gz : d9f99261e51f29f81b4e3bcf439f43c41e3a7ccf07ba55754c8aeda0fa6edf5f
 homepage   : https://clementtsang.github.io/bottom
 license    : MIT
 component  : system.utils

--- a/packages/b/bottom/pspec_x86_64.xml
+++ b/packages/b/bottom/pspec_x86_64.xml
@@ -28,9 +28,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2024-08-04</Date>
-            <Version>0.10.1</Version>
+        <Update release="25">
+            <Date>2024-08-10</Date>
+            <Version>0.10.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Add option to move the AVG CPU bar to another row in basic mode
- Fix the `--default_cpu_entry` argument not being checked

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `btm` and see that the charts are displaying as expected.

**Checklist**

- [x] Package was built and tested against unstable
