### PR TITLE
eza: Update to 0.19.0

### DIFF
--- a/packages/e/eza/package.yml
+++ b/packages/e/eza/package.yml
@@ -1,8 +1,8 @@
 name       : eza
-version    : 0.18.24
-release    : 28
+version    : 0.19.0
+release    : 29
 source     :
-    - https://github.com/eza-community/eza/archive/refs/tags/v0.18.24.tar.gz : bdcf83f73f6d5088f6dc17c119d0d288fed4acd122466404772be5ef278887de
+    - https://github.com/eza-community/eza/archive/refs/tags/v0.19.0.tar.gz : 440fff093c23635d7c1a9955d42489a2f5c5839a0e85a03e39daeca39e9dbf84
 homepage   : https://github.com/eza-community/eza
 license    : MIT
 component  : system.utils

--- a/packages/e/eza/pspec_x86_64.xml
+++ b/packages/e/eza/pspec_x86_64.xml
@@ -33,9 +33,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2024-08-04</Date>
-            <Version>0.18.24</Version>
+        <Update release="29">
+            <Date>2024-08-10</Date>
+            <Version>0.19.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- **[breaking]** Implement `EZA_GRID_ROWS` grid details view minimum rows threshold

Before this change, the `EZA_GRID_ROWS` variable was ignored, despite documentation existing. Users relying on `EZA_GRID_ROW` not doing anything will find their output changed.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `eza` and `eza -l` in a directory.

**Checklist**

- [x] Package was built and tested against unstable
