### PR TITLE
libva-vdpau-driver: Update to 0.7.4 bump

### DIFF
--- a/packages/l/libva-vdpau-driver/abi_symbols
+++ b/packages/l/libva-vdpau-driver/abi_symbols
@@ -5,4 +5,3 @@ vdpau_drv_video.so:map_iter_
 vdpau_drv_video.so:map_next_
 vdpau_drv_video.so:map_remove_
 vdpau_drv_video.so:map_set_
-vdpau_drv_video.so:vdpau_CreateSurfaceFromV4L2Buf

--- a/packages/l/libva-vdpau-driver/abi_symbols32
+++ b/packages/l/libva-vdpau-driver/abi_symbols32
@@ -5,4 +5,3 @@ vdpau_drv_video.so:map_iter_
 vdpau_drv_video.so:map_next_
 vdpau_drv_video.so:map_remove_
 vdpau_drv_video.so:map_set_
-vdpau_drv_video.so:vdpau_CreateSurfaceFromV4L2Buf

--- a/packages/l/libva-vdpau-driver/package.yml
+++ b/packages/l/libva-vdpau-driver/package.yml
@@ -1,8 +1,9 @@
 name       : libva-vdpau-driver
 version    : 0.7.4
-release    : 15
+release    : 16
 source     :
-    - git|https://github.com/xuanruiqi/vdpau-va-driver-vp9.git : 509d3b21a1084b4f492b50cced8835f4cd591c4a
+    - git|https://github.com/xuanruiqi/vdpau-va-driver-vp9.git : 3fb149e1dee806952f0362e10933c2fc4d87e34f
+homepage   : https://github.com/xuanruiqi/vdpau-va-driver-vp9
 license    : GPL-2.0-or-later
 component  : xorg.display
 summary    : libva vdpau driver (UNSUPPORTED)

--- a/packages/l/libva-vdpau-driver/pspec_x86_64.xml
+++ b/packages/l/libva-vdpau-driver/pspec_x86_64.xml
@@ -1,9 +1,10 @@
 <PISI>
     <Source>
         <Name>libva-vdpau-driver</Name>
+        <Homepage>https://github.com/xuanruiqi/vdpau-va-driver-vp9</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>xorg.display</PartOf>
@@ -34,7 +35,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="15">libva-vdpau-driver</Dependency>
+            <Dependency release="16">libva-vdpau-driver</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/dri/nvidia_drv_video.so</Path>
@@ -43,12 +44,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2024-06-25</Date>
+        <Update release="16">
+            <Date>2024-08-10</Date>
             <Version>0.7.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Added homepage
- Following most recent commit

**Test Plan**

Ensure homepage key was added to pspec

**Checklist**

- [x] Package was built and tested against unstable
