### PR TITLE
python-pyrate-limiter: Update to 3.6.2

### DIFF
--- a/packages/py/python-pyrate-limiter/package.yml
+++ b/packages/py/python-pyrate-limiter/package.yml
@@ -1,8 +1,8 @@
 name       : python-pyrate-limiter
-version    : 3.6.1
-release    : 4
+version    : 3.6.2
+release    : 5
 source     :
-    - https://files.pythonhosted.org/packages/source/p/pyrate-limiter/pyrate_limiter-3.6.1.tar.gz : 78bdaaf31d76ffb3f6e9b9d26d676a52824492b9f4578d48530d1fa657ac6d8f
+    - https://files.pythonhosted.org/packages/source/p/pyrate-limiter/pyrate_limiter-3.6.2.tar.gz : c0042ad0f1855971de48457e3aa00f970d1a7a1462d217c5f55b30592736e116
 license    : MIT
 homepage   : https://pyratelimiter.readthedocs.io/
 component  : programming.python

--- a/packages/py/python-pyrate-limiter/pspec_x86_64.xml
+++ b/packages/py/python-pyrate-limiter/pspec_x86_64.xml
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter-3.6.1.dist-info/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter-3.6.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter-3.6.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter-3.6.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter-3.6.2.dist-info/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter-3.6.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter-3.6.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter-3.6.2.dist-info/WHEEL</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter/__pycache__/__init__.cpython-311.pyc</Path>
@@ -70,9 +70,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-06-11</Date>
-            <Version>3.6.1</Version>
+        <Update release="5">
+            <Date>2024-08-11</Date>
+            <Version>3.6.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Address issue with SQLite backend
- Fix small bug in binary-search algo
- Update document on sync/async support

**Test Plan**
- Tested some examples from the project's README
- Confirmed `python-moddb` still works correctly

**Checklist**

- [x] Package was built and tested against unstable
