### PR TITLE
libvips: Update to 8.15.3

### DIFF
--- a/packages/l/libvips/abi_used_symbols
+++ b/packages/l/libvips/abi_used_symbols
@@ -518,6 +518,7 @@ libgobject-2.0.so.0:g_value_set_int
 libgobject-2.0.so.0:g_value_set_int64
 libgobject-2.0.so.0:g_value_set_object
 libgobject-2.0.so.0:g_value_set_pointer
+libgobject-2.0.so.0:g_value_set_static_string
 libgobject-2.0.so.0:g_value_set_string
 libgobject-2.0.so.0:g_value_set_uint64
 libgobject-2.0.so.0:g_value_transform
@@ -575,6 +576,7 @@ libheif.so.1:heif_image_release
 libheif.so.1:heif_image_set_raw_color_profile
 libheif.so.1:heif_init
 libheif.so.1:heif_main_brand
+libheif.so.1:heif_nclx_color_profile_alloc
 libhwy.so.1:_ZN3hwy15GetChosenTargetEv
 libhwy.so.1:_ZN3hwy16SupportedTargetsEv
 libhwy.so.1:_ZN3hwy26SetSupportedTargetsForTestEl
@@ -589,7 +591,6 @@ libjpeg.so.8:jpeg_read_header
 libjpeg.so.8:jpeg_read_scanlines
 libjpeg.so.8:jpeg_resync_to_restart
 libjpeg.so.8:jpeg_save_markers
-libjpeg.so.8:jpeg_set_colorspace
 libjpeg.so.8:jpeg_set_defaults
 libjpeg.so.8:jpeg_set_quality
 libjpeg.so.8:jpeg_simple_progression
@@ -718,6 +719,7 @@ libpng16.so.16:png_set_IHDR
 libpng16.so.16:png_set_chunk_cache_max
 libpng16.so.16:png_set_chunk_malloc_max
 libpng16.so.16:png_set_compression_level
+libpng16.so.16:png_set_crc_action
 libpng16.so.16:png_set_eXIf_1
 libpng16.so.16:png_set_expand_gray_1_2_4_to_8
 libpng16.so.16:png_set_filter

--- a/packages/l/libvips/package.yml
+++ b/packages/l/libvips/package.yml
@@ -1,8 +1,8 @@
 name       : libvips
-version    : 8.15.2
-release    : 46
+version    : 8.15.3
+release    : 47
 source     :
-    - https://github.com/libvips/libvips/archive/refs/tags/v8.15.2.tar.gz : 8c3ece7be367636fd676573a8ff22170c07e95e81fd94f2d1eb9966800522e1f
+    - https://github.com/libvips/libvips/archive/refs/tags/v8.15.3.tar.gz : c23a820443241c35e62f1f1f0a1f6c199b37e07d98e3268a7fa9db43309fd67d
 homepage   : https://www.libvips.org/
 license    : LGPL-2.1-or-later
 component  : multimedia.library

--- a/packages/l/libvips/pspec_x86_64.xml
+++ b/packages/l/libvips/pspec_x86_64.xml
@@ -27,9 +27,9 @@
             <Path fileType="executable">/usr/bin/vipsthumbnail</Path>
             <Path fileType="library">/usr/lib64/girepository-1.0/Vips-8.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libvips-cpp.so.42</Path>
-            <Path fileType="library">/usr/lib64/libvips-cpp.so.42.17.2</Path>
+            <Path fileType="library">/usr/lib64/libvips-cpp.so.42.17.3</Path>
             <Path fileType="library">/usr/lib64/libvips.so.42</Path>
-            <Path fileType="library">/usr/lib64/libvips.so.42.17.2</Path>
+            <Path fileType="library">/usr/lib64/libvips.so.42.17.3</Path>
             <Path fileType="library">/usr/lib64/vips-modules-8.15/vips-heif.so</Path>
             <Path fileType="library">/usr/lib64/vips-modules-8.15/vips-jxl.so</Path>
             <Path fileType="library">/usr/lib64/vips-modules-8.15/vips-magick.so</Path>
@@ -51,7 +51,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="46">libvips</Dependency>
+            <Dependency release="47">libvips</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/vips/VConnection8.h</Path>
@@ -196,9 +196,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="46">
-            <Date>2024-06-09</Date>
-            <Version>8.15.2</Version>
+        <Update release="47">
+            <Date>2024-08-12</Date>
+            <Version>8.15.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- fix dzsave of >8-bit images to JPEG
- jpegsave: fix chrominance subsampling mode with jpegli
- pngload: disable ADLER32/CRC checking in non-fail mode
- improve target_clones support check
- fix pipe read limit
- conva: fix a crash with {u,}{short,int} images
- fix vips_image_get_string
- heifsave: fix lossless mode
- composite: fix dest-atop blend mode
- fix vips_source_map for zero-length sources

**Test Plan**

Edited a few images using `vips`

**Checklist**

- [x] Package was built and tested against unstable
