### PR TITLE
python-pyrate-limiter: Update to 3.7.0

### DIFF
--- a/packages/py/python-pyrate-limiter/package.yml
+++ b/packages/py/python-pyrate-limiter/package.yml
@@ -1,8 +1,8 @@
 name       : python-pyrate-limiter
-version    : 3.6.2
-release    : 5
+version    : 3.7.0
+release    : 6
 source     :
-    - https://files.pythonhosted.org/packages/source/p/pyrate-limiter/pyrate_limiter-3.6.2.tar.gz : c0042ad0f1855971de48457e3aa00f970d1a7a1462d217c5f55b30592736e116
+    - https://files.pythonhosted.org/packages/source/p/pyrate-limiter/pyrate_limiter-3.7.0.tar.gz : dc1e6d2c80b559f3333cb44bd822bd558f5a47946dc50cce4263a9c1c5fd8067
 license    : MIT
 homepage   : https://pyratelimiter.readthedocs.io/
 component  : programming.python

--- a/packages/py/python-pyrate-limiter/pspec_x86_64.xml
+++ b/packages/py/python-pyrate-limiter/pspec_x86_64.xml
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter-3.6.2.dist-info/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter-3.6.2.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter-3.6.2.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter-3.6.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter-3.7.0.dist-info/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter-3.7.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter-3.7.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter-3.7.0.dist-info/WHEEL</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter/__pycache__/__init__.cpython-311.pyc</Path>
@@ -44,9 +44,12 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter/abstracts/__pycache__/clock.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter/abstracts/__pycache__/rate.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter/abstracts/__pycache__/rate.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter/abstracts/__pycache__/wrappers.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter/abstracts/__pycache__/wrappers.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter/abstracts/bucket.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter/abstracts/clock.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter/abstracts/rate.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter/abstracts/wrappers.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter/buckets/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter/buckets/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pyrate_limiter/buckets/__pycache__/__init__.cpython-311.pyc</Path>
@@ -70,9 +73,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2024-08-11</Date>
-            <Version>3.6.2</Version>
+        <Update release="6">
+            <Date>2024-08-12</Date>
+            <Version>3.7.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Add method to remove bucket

**Test Plan**
- Ran some examples from the project README
- Confirmed `python-moddb` still works

**Checklist**

- [x] Package was built and tested against unstable
