### PR TITLE
doflicky: Fix license

### DIFF
--- a/packages/d/doflicky/package.yml
+++ b/packages/d/doflicky/package.yml
@@ -1,10 +1,10 @@
 name       : doflicky
 version    : '6'
-release    : 21
+release    : 22
 source     :
     - git|https://github.com/getsolus/doflicky.git : 5c4a0dbb83cdef50e5e7f1e4bfbe3ef16485821b
 homepage   : https://github.com/getsolus/doflicky
-license    : GPL-2.0-only
+license    : GPL-2.0-or-later
 component  : system.utils
 summary    : Solus Driver Management
 description: |

--- a/packages/d/doflicky/pspec_x86_64.xml
+++ b/packages/d/doflicky/pspec_x86_64.xml
@@ -3,10 +3,10 @@
         <Name>doflicky</Name>
         <Homepage>https://github.com/getsolus/doflicky</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
-        <License>GPL-2.0-only</License>
+        <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">Solus Driver Management</Summary>
         <Description xml:lang="en">A tool to provide automated driver detection and management
@@ -47,12 +47,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2024-03-22</Date>
+        <Update release="22">
+            <Date>2024-08-12</Date>
             <Version>6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

It's actually `GPL-2.0-or-later` according to the license headers

See e.g. https://github.com/Staudey/doflicky/blob/master/doflicky-ui#L6-L11

**Test Plan**

Confirmed the correct license was shown in Software Center

**Checklist**

- [x] Package was built and tested against unstable
