### PR TITLE
a52dec: Fix license, pkgconfig and add monitoring.yml

### DIFF
--- a/packages/a/a52dec/monitoring.yml
+++ b/packages/a/a52dec/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 13972
+  rss: https://git.adelielinux.org/community/a52dec/-/tags?format=atom
+# No known CPE, checked 2024-08-12
+security:
+  cpe: ~

--- a/packages/a/a52dec/package.yml
+++ b/packages/a/a52dec/package.yml
@@ -1,10 +1,10 @@
 name       : a52dec
 version    : 0.8.0
-release    : 5
+release    : 6
 source     :
     - https://git.adelielinux.org/community/a52dec/-/archive/v0.8.0/a52dec-v0.8.0.tar.bz2 : d4f26685d32a8c85f86a5cb800554160fb85400298a0a27151c3d1e63a170943
 homepage   : https://git.adelielinux.org/community/a52dec/
-license    : GPL-2.0-only
+license    : GPL-2.0-or-later
 component  :
     - multimedia.audio
     - ^liba52dec : multimedia.codecs
@@ -17,6 +17,8 @@ description:
     - a52dec CLI tools
     - ^liba52dec : Library for decoding ATSC A/52 (also known as AC-3) streams
     - ^liba52dec-devel : Development files for liba52dec
+replaces   :
+    - ^liba52dec-devel : a52dec-devel
 setup      : |
     %reconfigure --disable-static --enable-shared
 build      : |
@@ -29,3 +31,4 @@ patterns   :
     - ^liba52dec-devel :
         - /usr/include
         - /usr/lib64/lib*.so
+        - /usr/lib64/pkgconfig/*

--- a/packages/a/a52dec/pspec_x86_64.xml
+++ b/packages/a/a52dec/pspec_x86_64.xml
@@ -3,10 +3,10 @@
         <Name>a52dec</Name>
         <Homepage>https://git.adelielinux.org/community/a52dec/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
-        <License>GPL-2.0-only</License>
+        <License>GPL-2.0-or-later</License>
         <PartOf>multimedia.audio</PartOf>
         <Summary xml:lang="en">a52dec CLI tools</Summary>
         <Description xml:lang="en">a52dec CLI tools</Description>
@@ -18,7 +18,7 @@
         <Description xml:lang="en">a52dec CLI tools</Description>
         <PartOf>multimedia.audio</PartOf>
         <RuntimeDependencies>
-            <Dependency release="5">liba52dec</Dependency>
+            <Dependency release="6">liba52dec</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/a52dec</Path>
@@ -43,7 +43,7 @@
         <Description xml:lang="en">Development files for liba52dec</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="5">liba52dec</Dependency>
+            <Dependency release="6">liba52dec</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/a52dec/a52.h</Path>
@@ -51,27 +51,19 @@
             <Path fileType="header">/usr/include/a52dec/audio_out.h</Path>
             <Path fileType="header">/usr/include/a52dec/mm_accel.h</Path>
             <Path fileType="library">/usr/lib64/liba52.so</Path>
-        </Files>
-    </Package>
-    <Package>
-        <Name>a52dec-devel</Name>
-        <Summary xml:lang="en">Development files for a52dec</Summary>
-        <Description xml:lang="en">a52dec CLI tools</Description>
-        <PartOf>programming.devel</PartOf>
-        <RuntimeDependencies>
-            <Dependency release="5">a52dec</Dependency>
-        </RuntimeDependencies>
-        <Files>
             <Path fileType="data">/usr/lib64/pkgconfig/liba52.pc</Path>
         </Files>
+        <Replaces>
+            <Package>a52dec-devel</Package>
+        </Replaces>
     </Package>
     <History>
-        <Update release="5">
+        <Update release="6">
             <Date>2024-08-12</Date>
             <Version>0.8.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2510,5 +2510,6 @@
 		<Package>gcc-devel</Package>
 		<Package>replaysorcery</Package>
 		<Package>replaysorcery-dbginfo</Package>
+		<Package>a52dec-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3341,5 +3341,8 @@
 		<!-- Unmaintained -->
 		<Package>replaysorcery</Package>
 		<Package>replaysorcery-dbginfo</Package>
+
+		<!-- Merged into liba52dec-devel package again -->
+		<Package>a52dec-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
**Summary**

This is a small fixup for the previous commit to put everything in its proper place

Also the license wasn't quite correct according to the license headers

**Test Plan**

Confirmed correct license name and pkgconfig location, and that `liba52dec-devel` package properly replaces `a52dec-devel`

**Checklist**

- [x] Package was built and tested against unstable
