### PR TITLE
libxdg-basedir: Update to 1.2.3

### DIFF
--- a/packages/l/libxdg-basedir/abi_symbols
+++ b/packages/l/libxdg-basedir/abi_symbols
@@ -1,9 +1,3 @@
-libxdg-basedir.so.1:
-libxdg-basedir.so.1:__bss_start
-libxdg-basedir.so.1:_edata
-libxdg-basedir.so.1:_end
-libxdg-basedir.so.1:_fini
-libxdg-basedir.so.1:_init
 libxdg-basedir.so.1:xdgCacheHome
 libxdg-basedir.so.1:xdgConfigDirectories
 libxdg-basedir.so.1:xdgConfigFind

--- a/packages/l/libxdg-basedir/abi_used_symbols
+++ b/packages/l/libxdg-basedir/abi_used_symbols
@@ -1,5 +1,4 @@
 libc.so.6:__errno_location
-libc.so.6:__strdup
 libc.so.6:calloc
 libc.so.6:fclose
 libc.so.6:fopen
@@ -10,4 +9,5 @@ libc.so.6:memcpy
 libc.so.6:mkdir
 libc.so.6:realloc
 libc.so.6:strcat
+libc.so.6:strdup
 libc.so.6:strlen

--- a/packages/l/libxdg-basedir/monitoring.yml
+++ b/packages/l/libxdg-basedir/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 230210
+  rss: https://github.com/devnev/libxdg-basedir/tags.atom
+# No known CPE, checked 2024-08-13
+security:
+  cpe: ~

--- a/packages/l/libxdg-basedir/package.yml
+++ b/packages/l/libxdg-basedir/package.yml
@@ -1,10 +1,11 @@
 name       : libxdg-basedir
-version    : 1.2.0
-release    : 3
+version    : 1.2.3
+release    : 4
 source     :
-    - https://github.com/devnev/libxdg-basedir/archive/libxdg-basedir-1.2.0.tar.gz : 1c2b0032a539033313b5be2e48ddd0ae94c84faf21d93956d53562eef4614868
+    - https://github.com/devnev/libxdg-basedir/archive/refs/tags/libxdg-basedir-1.2.3.tar.gz : ff30c60161f7043df4dcc6e7cdea8e064e382aa06c73dcc3d1885c7d2c77451d
+homepage   : https://github.com/devnev/libxdg-basedir
 license    : MIT
-component  : programming
+component  : programming.library
 summary    : An implementation of the XDG Base Directory specifications.
 description: |
     An implementation of the XDG Base Directory specifications.

--- a/packages/l/libxdg-basedir/pspec_x86_64.xml
+++ b/packages/l/libxdg-basedir/pspec_x86_64.xml
@@ -1,25 +1,27 @@
 <PISI>
     <Source>
         <Name>libxdg-basedir</Name>
+        <Homepage>https://github.com/devnev/libxdg-basedir</Homepage>
         <Packager>
-            <Name>Bryan T. Meyers</Name>
-            <Email>bmeyers@datadrake.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
-        <PartOf>programming</PartOf>
+        <PartOf>programming.library</PartOf>
         <Summary xml:lang="en">An implementation of the XDG Base Directory specifications.</Summary>
         <Description xml:lang="en">An implementation of the XDG Base Directory specifications.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://solus-project.com/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>libxdg-basedir</Name>
         <Summary xml:lang="en">An implementation of the XDG Base Directory specifications.</Summary>
         <Description xml:lang="en">An implementation of the XDG Base Directory specifications.
 </Description>
-        <PartOf>programming</PartOf>
+        <PartOf>programming.library</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib64/lib*.so.*</Path>
+            <Path fileType="library">/usr/lib64/libxdg-basedir.so.1</Path>
+            <Path fileType="library">/usr/lib64/libxdg-basedir.so.1.2.0</Path>
         </Files>
     </Package>
     <Package>
@@ -29,21 +31,22 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="3">libxdg-basedir</Dependency>
+            <Dependency release="4">libxdg-basedir</Dependency>
         </RuntimeDependencies>
         <Files>
-            <Path fileType="header">/usr/include/</Path>
-            <Path fileType="library">/usr/lib64/lib*.so</Path>
-            <Path fileType="data">/usr/lib64/pkgconfig/*.pc</Path>
+            <Path fileType="header">/usr/include/basedir.h</Path>
+            <Path fileType="header">/usr/include/basedir_fs.h</Path>
+            <Path fileType="library">/usr/lib64/libxdg-basedir.so</Path>
+            <Path fileType="data">/usr/lib64/pkgconfig/libxdg-basedir.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2016-11-27</Date>
-            <Version>1.2.0</Version>
+        <Update release="4">
+            <Date>2024-08-13</Date>
+            <Version>1.2.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Bryan T. Meyers</Name>
-            <Email>bmeyers@datadrake.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Minor documentation fixes
- Fix xdgZeroMemory fallback
- Use strdup rather than malloc+strcpy
- Fix overflow bug
- Add homepage
- Add `monitoring.yml`

Part of https://github.com/getsolus/packages/issues/3554

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build `radiotray-ng` with this package.

**Checklist**

- [x] Package was built and tested against unstable
