### PR TITLE
picard: Update to 2.12.1

### DIFF
--- a/packages/p/picard/package.yml
+++ b/packages/p/picard/package.yml
@@ -1,8 +1,8 @@
 name       : picard
-version    : '2.11'
-release    : 31
+version    : 2.12.1
+release    : 32
 source     :
-    - https://github.com/metabrainz/picard/archive/refs/tags/release-2.11.tar.gz : 8e47cdd38af821a16beb0a404f72871468903c491d9d6d220d9d790bff737b98
+    - https://github.com/metabrainz/picard/releases/download/release-2.12.1/picard-2.12.1.tar.gz : 93a62309bdd2fde49152c15e52f4a009bebdb5dc68346154fe6caf12f5099b52
 homepage   : https://picard.musicbrainz.org/
 license    : GPL-2.0-or-later
 component  : multimedia.audio

--- a/packages/p/picard/pspec_x86_64.xml
+++ b/packages/p/picard/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>picard</Name>
         <Homepage>https://picard.musicbrainz.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>multimedia.audio</PartOf>
@@ -25,11 +25,11 @@ Additionally, there are several plugins available that extend Picard&apos;s feat
         <PartOf>multimedia.audio</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/picard</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/picard-2.11-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/picard-2.11-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/picard-2.11-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/picard-2.11-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/picard-2.11-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/picard-2.12.1-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/picard-2.12.1-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/picard-2.12.1-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/picard-2.12.1-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/picard-2.12.1-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/picard/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/picard/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/picard/__pycache__/album.cpython-311.pyc</Path>
@@ -421,7 +421,6 @@ Additionally, there are several plugins available that extend Picard&apos;s feat
             <Path fileType="library">/usr/lib/python3.11/site-packages/picard/util/__pycache__/imagelist.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/picard/util/__pycache__/lrucache.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/picard/util/__pycache__/mbserver.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/picard/util/__pycache__/natsort.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/picard/util/__pycache__/periodictouch.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/picard/util/__pycache__/pipe.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/picard/util/__pycache__/preservedtags.cpython-311.pyc</Path>
@@ -450,7 +449,6 @@ Additionally, there are several plugins available that extend Picard&apos;s feat
             <Path fileType="library">/usr/lib/python3.11/site-packages/picard/util/imagelist.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/picard/util/lrucache.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/picard/util/mbserver.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/picard/util/natsort.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/picard/util/periodictouch.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/picard/util/pipe.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/picard/util/preservedtags.py</Path>
@@ -682,12 +680,12 @@ Additionally, there are several plugins available that extend Picard&apos;s feat
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2024-02-16</Date>
-            <Version>2.11</Version>
+        <Update release="32">
+            <Date>2024-08-16</Date>
+            <Version>2.12.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Update MusicBrainz Picard to the latest release.

Bugfixes:

- PICARD-2914 - macOS: Crash when opening options with Spanish UI
- PICARD-2939 - Crash when loading release with genre filters resulting in empty genre list
- PICARD-2940 - Possible bug with locking in Metadata.__iter__
- PICARD-2946 - Fix display length value in AppStream metadata

Release notes [here](https://github.com/metabrainz/picard/releases/tag/release-2.12.1)

Full changelog [here](https://github.com/metabrainz/picard/compare/release-2.11...release-2.12.1)

**Test Plan**

Launch picard and add Music folder. Let it identify and correct music metadata, then update files when complete.

**Checklist**

- [x] Package was built and tested against unstable
