### PR TITLE
curl: Backport patch to fix transmission crash

### DIFF
--- a/packages/c/curl/files/init-sigpipe.patch
+++ b/packages/c/curl/files/init-sigpipe.patch
@@ -1,0 +1,32 @@
+From 3eec5afbd0b6377eca893c392569b2faf094d970 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Mon, 5 Aug 2024 00:17:17 +0200
+Subject: [PATCH] sigpipe: init the struct so that first apply ignores
+
+Initializes 'no_signal' to TRUE, so that a call to sigpipe_apply() after
+init ignores the signal (unless CURLOPT_NOSIGNAL) is set.
+
+I have read the existing code multiple times now and I think it gets the
+initial state reversed this missing to ignore.
+
+Regression from 17e6f06ea37136c36d27
+
+Reported-by: Rasmus Thomsen
+Fixes #14344
+Closes #14390
+---
+ lib/sigpipe.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/sigpipe.h b/lib/sigpipe.h
+index b91a2f51333956..d78afd905d3414 100644
+--- a/lib/sigpipe.h
++++ b/lib/sigpipe.h
+@@ -39,6 +39,7 @@ struct sigpipe_ignore {
+ static void sigpipe_init(struct sigpipe_ignore *ig)
+ {
+   memset(ig, 0, sizeof(*ig));
++  ig->no_signal = TRUE;
+ }
+ 
+ /*

--- a/packages/c/curl/package.yml
+++ b/packages/c/curl/package.yml
@@ -1,6 +1,6 @@
 name       : curl
 version    : 8.9.1
-release    : 94
+release    : 95
 source     :
     - https://github.com/curl/curl/releases/download/curl-8_9_1/curl-8.9.1.tar.gz : 291124a007ee5111997825940b3876b3048f7d31e73e9caa681b80fe48b2dcd5
 extract    : no
@@ -60,6 +60,7 @@ setup      : |
     fi
 
     pushd main
+    %patch -p1 -i $pkgfiles/init-sigpipe.patch
     %configure $common \
                --enable-libcurl-option \
                --with-fish-functions-dir=/usr/share/fish/vendor_completions.d \

--- a/packages/c/curl/pspec_x86_64.xml
+++ b/packages/c/curl/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>curl</Name>
         <Homepage>https://curl.se</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.base</PartOf>
@@ -34,7 +34,7 @@
         <Description xml:lang="en">curl is a client to get files from servers using any of the supported protocols. The command is designed to work without user interaction or any kind of interactivity. curl offers a busload of useful tricks like proxy support, user authentication, ftp upload, HTTP post, file transfer resume and more.</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="94">curl</Dependency>
+            <Dependency release="95">curl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libcurl.so.4</Path>
@@ -47,8 +47,8 @@
         <Description xml:lang="en">curl is a client to get files from servers using any of the supported protocols. The command is designed to work without user interaction or any kind of interactivity. curl offers a busload of useful tricks like proxy support, user authentication, ftp upload, HTTP post, file transfer resume and more.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="94">curl-devel</Dependency>
-            <Dependency release="94">curl-32bit</Dependency>
+            <Dependency release="95">curl-devel</Dependency>
+            <Dependency release="95">curl-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libcurl.so</Path>
@@ -61,7 +61,7 @@
         <Description xml:lang="en">curl is a client to get files from servers using any of the supported protocols. The command is designed to work without user interaction or any kind of interactivity. curl offers a busload of useful tricks like proxy support, user authentication, ftp upload, HTTP post, file transfer resume and more.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="94">curl</Dependency>
+            <Dependency release="95">curl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/curl/curl.h</Path>
@@ -601,12 +601,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="94">
-            <Date>2024-08-01</Date>
+        <Update release="95">
+            <Date>2024-08-16</Date>
             <Version>8.9.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

`transmission` started crashing during download after curl update 8.9.1 due to [this curl issue](https://github.com/curl/curl/issues/14344)

This backports the patch fixing the crash.

**Test Plan**

Successfully downloaded a torrent that would previously crash consistently

**Checklist**

- [x] Package was built and tested against unstable
