### PR TITLE
appstream-data: Update to v46

### DIFF
--- a/packages/a/appstream-data/package.yml
+++ b/packages/a/appstream-data/package.yml
@@ -1,8 +1,8 @@
 name       : appstream-data
-version    : '45'
-release    : 47
+version    : '46'
+release    : 48
 source     :
-    - https://github.com/getsolus/solus-appstream-data/archive/refs/tags/v45.tar.gz : 1ad19acf4fd6d57382112bd5fbd046d4c16f32e210246f555628b45776711167
+    - https://github.com/getsolus/solus-appstream-data/archive/refs/tags/v46.tar.gz : ecfaa03aa0dc8eb36ba25ef6803d9944673b6461262e6d53ee75fcf88a57b394
 homepage   : https://www.freedesktop.org/wiki/Distributions/AppStream/
 license    :
     - CC-BY-SA-3.0

--- a/packages/a/appstream-data/pspec_x86_64.xml
+++ b/packages/a/appstream-data/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>appstream-data</Name>
         <Homepage>https://www.freedesktop.org/wiki/Distributions/AppStream/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Hans Kelson</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>CC-BY-SA-3.0</License>
         <License>CC-BY-SA-4.0</License>
@@ -59,7 +59,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.bitwarden.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.borgbase.Vorta.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.cubicsdr.cubicsdr.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.dosbox.DOSBox.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.etlegacy.ETLegacy.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.gexperts.Tilix.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.github.Flacon.png</Path>
@@ -89,6 +88,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.github.wwmm.pulseeffects.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.github.xournalpp.xournalpp.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.gitlab.cunidev.Gestures.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.gitlab.dogtail.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.heroicgameslauncher.hgl.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.kvibes.MediaElch.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.leinardi.gx52.png</Path>
@@ -98,6 +98,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.obsproject.Studio.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.ozmartians.VidCutter.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.play0ad.zeroad.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.protonvpn.www.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.rastersoft.devedeng.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.rawtherapee.RawTherapee.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.sayonara-player.Sayonara.png</Path>
@@ -108,11 +109,11 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.tv_lite.tv_lite.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.ulduzsoft.Birdtray.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.ultimaker.cura.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.uploadedlobster.peek.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.valvesoftware.Steam.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.viewizard.AstroMenace.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.yubico.yubikey_manager.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.yacreader.YACReader.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/conky-manager2.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/cool-retro-term.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/de.haeckerfelix.Shortwave.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/de.volle_kraft_voraus.kraft.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/deluge.png</Path>
@@ -128,9 +129,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/eu.usdx.UltraStarDeluxe.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/eu.vcmi.VCMI.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/fi.skyjake.Lagrange.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/firefox.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/firewall-config.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/focuswriter.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/fr.free.brouits.qspeakers.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/fr.free.mdoyen.HomeBank.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/fr.handbrake.ghb.png</Path>
@@ -145,22 +144,19 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/gmusicbrowser.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/gparted.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/gpxsee.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/grafx2.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/gsmartcontrol.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/hplip.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/hugin.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/im.dino.Dino.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/im.nheko.Nheko.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/info.bibletime.BibleTime.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/info.cemu.Cemu.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/info.mumble.Mumble.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/info.smplayer.SMPlayer.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.crow_translate.CrowTranslate.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.dbeaver.DBeaverCommunity.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.Hexchat.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.NhekoReborn.Nheko.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.OpenToonz.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.TransmissionRemoteGtk.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.ajour.ajour.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.antimicrox.antimicrox.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.aristocratos.btop.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.astroidmail.astroid.png</Path>
@@ -173,7 +169,9 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.chatty.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.ckb_next.ckb.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.colinpitrat.caprice32.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.costales.gufw.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.davatorium.rofi.rofi.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.diodon_dev.diodon.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.dosbox-staging.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.ebuc99.pacman.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.endless_sky.endless_sky.png</Path>
@@ -198,10 +196,12 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.thetumultuousunicornofdarkness.cpu-x.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.tmewett.brogue.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.lmms.LMMS.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.mgba.mGBA.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.mpv.mpv.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.otsaloma.gaupol.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.otsaloma.nfoview.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.sourceforge.cvassistant.cvassistant.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.sourceforge.deadbeef.deadbeef.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.sourceforge.doublecmd.double_commander.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.sourceforge.pentobi.png</Path>
@@ -213,7 +213,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/libreoffice-impress.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/libreoffice-writer.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/lugaru.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/lyx.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/mailnag.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/manaplus.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/mate-disk-usage-analyzer.png</Path>
@@ -276,12 +275,12 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.calf_studio_gear.calf.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.cataclysmdda.CataclysmDDA.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.cinelerra.gg.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.citra_emu.citra.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.claws_mail.Claws-Mail.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.codelite.codelite.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.corectrl.CoreCtrl.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.cryptomator.Cryptomator.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.darktable.darktable.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.dreamchess.dreamchess.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.entangle_photo.Manager.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.filezilla-project.FileZilla.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.flameshot.Flameshot.png</Path>
@@ -292,7 +291,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.freecadweb.FreeCAD.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.freeciv.gtk3.mp.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.freeciv.gtk3.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.freeciv.mp.gtk3.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.freeciv.server.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.freedesktop.Piper.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.freedesktop.ibus.engine.m17n.png</Path>
@@ -324,8 +322,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnome.Evolution.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnome.Extensions.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnome.FileRoller.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnome.FontManager.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnome.FontViewer.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnome.Four-in-a-row.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnome.GHex.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnome.Geary.png</Path>
@@ -382,7 +378,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnome.pan.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnome.seahorse.Application.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnome.tweaks.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnome.wiki.dia.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnu.emacs.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnu.gnubg.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnu.xboard.png</Path>
@@ -468,7 +463,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.ktorrent.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kwalletmanager5.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kwave.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kwrite.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.lokalize.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.marble.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.marknote.png</Path>
@@ -518,7 +512,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.openstreetmap.josm.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.openttd.OpenTTD.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.openxcom.openxcom.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.parlatype.Parlatype.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.pipewire.Helvum.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.pitivi.Pitivi.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.ppsspp.PPSSPP.png</Path>
@@ -567,7 +560,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.wireshark.Wireshark.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.workrave.workrave.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.x.Warpinator.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.xbmc.kodi.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.xfce.Catfish.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.xfce.PanelProfiles.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.xfce.Parole.png</Path>
@@ -577,6 +569,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.xfce.screenshooter.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.xfce.xfburn.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.xfce.xfdashboard.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.yamagi.YamagiQ2.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.zealdocs.zeal.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.zim_wiki.Zim.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.zotero.Zotero.png</Path>
@@ -628,6 +621,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/xiphos.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/xreader.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/xviewer.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/xyz.parlatype.Parlatype.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/xyz.z3ntu.razergenie.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/yelp.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/Element.png</Path>
@@ -668,7 +662,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.borgbase.Vorta.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.cubicsdr.cubicsdr.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.dev47apps.droidcam.DroidCam.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.dosbox.DOSBox.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.etlegacy.ETLegacy.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.gexperts.Tilix.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.github.Flacon.png</Path>
@@ -701,6 +694,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.github.wwmm.pulseeffects.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.github.xournalpp.xournalpp.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.gitlab.cunidev.Gestures.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.gitlab.dogtail.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.heroicgameslauncher.hgl.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.httrack.httrack_website_copier.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.kvibes.MediaElch.png</Path>
@@ -711,6 +705,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.obsproject.Studio.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.ozmartians.VidCutter.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.play0ad.zeroad.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.protonvpn.www.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.rastersoft.devedeng.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.rawtherapee.RawTherapee.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.sayonara-player.Sayonara.png</Path>
@@ -721,12 +716,12 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.tv_lite.tv_lite.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.ulduzsoft.Birdtray.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.ultimaker.cura.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.uploadedlobster.peek.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.valvesoftware.Steam.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.viewizard.AstroMenace.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.wordpress.firejail.firetools.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.yubico.yubikey_manager.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.yacreader.YACReader.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/conky-manager2.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/cool-retro-term.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/de.haeckerfelix.Shortwave.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/de.tu_chemnitz._user.ding.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/de.urwpp.C059.png</Path>
@@ -757,9 +752,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/eu.vcmi.VCMI.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/fi.skyjake.Lagrange.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/fira.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/firefox.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/firewall-config.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/focuswriter.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/font-clear-sans-ttf.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/font-droid-ttf.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/font-firacode-nerd.png</Path>
@@ -786,7 +779,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/gmusicbrowser.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/gparted.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/gpxsee.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/grafx2.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/gsmartcontrol.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/gtick.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/guake.png</Path>
@@ -795,18 +787,16 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/hedgewars.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/hplip.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/hugin.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/im.dino.Dino.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/im.nheko.Nheko.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/info.bibletime.BibleTime.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/info.cemu.Cemu.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/info.mumble.Mumble.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/info.smplayer.SMPlayer.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.crow_translate.CrowTranslate.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.dbeaver.DBeaverCommunity.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.Hexchat.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.NhekoReborn.Nheko.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.OpenToonz.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.TransmissionRemoteGtk.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.ajour.ajour.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.antimicrox.antimicrox.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.aristocratos.btop.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.astroidmail.astroid.png</Path>
@@ -819,8 +809,10 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.chatty.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.ckb_next.ckb.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.colinpitrat.caprice32.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.costales.gufw.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.davatorium.rofi.rofi.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.dh4.mupen64plus_qt.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.diodon_dev.diodon.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.dosbox-staging.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.ebuc99.pacman.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.endless_sky.endless_sky.png</Path>
@@ -849,10 +841,12 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.transgui.transgui.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.winff.winff.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.wxmaxima_developers.wxMaxima.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.lmms.LMMS.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.mgba.mGBA.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.mpv.mpv.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.otsaloma.gaupol.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.otsaloma.nfoview.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.sourceforge.cvassistant.cvassistant.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.sourceforge.deadbeef.deadbeef.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.sourceforge.doublecmd.double_commander.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.sourceforge.pentobi.png</Path>
@@ -869,7 +863,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/libreoffice-impress.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/libreoffice-writer.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/lugaru.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/lyx.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/mailnag.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/manaplus.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/mate-disk-usage-analyzer.png</Path>
@@ -948,12 +941,13 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.calf_studio_gear.calf.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.cataclysmdda.CataclysmDDA.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.cinelerra.gg.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.citra_emu.citra.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.claws_mail.Claws-Mail.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.codelite.codelite.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.corectrl.CoreCtrl.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.cryptomator.Cryptomator.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.darktable.darktable.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.dhewm3.Dhewm3.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.dreamchess.dreamchess.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.entangle_photo.Manager.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.filezilla-project.FileZilla.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.flameshot.Flameshot.png</Path>
@@ -964,7 +958,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.freecadweb.FreeCAD.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.freeciv.gtk3.mp.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.freeciv.gtk3.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.freeciv.mp.gtk3.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.freeciv.server.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.freedesktop.Piper.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.freedesktop.ibus.engine.m17n.png</Path>
@@ -996,8 +989,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnome.Evolution.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnome.Extensions.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnome.FileRoller.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnome.FontManager.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnome.FontViewer.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnome.Four-in-a-row.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnome.GHex.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnome.Geary.png</Path>
@@ -1055,7 +1046,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnome.pan.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnome.seahorse.Application.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnome.tweaks.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnome.wiki.dia.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnu.dfarc.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnu.emacs.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnu.gnubg.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnu.xboard.png</Path>
@@ -1146,7 +1137,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.ktorrent.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kwalletmanager5.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kwave.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kwrite.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.lokalize.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.marble.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.marknote.png</Path>
@@ -1199,7 +1189,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.openttd.OpenTTD.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.openxcom.openxcom.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.paraview.paraview.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.parlatype.Parlatype.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.pipewire.Helvum.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.pitivi.Pitivi.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.ppsspp.PPSSPP.png</Path>
@@ -1248,7 +1237,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.wireshark.Wireshark.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.workrave.workrave.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.x.Warpinator.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.xbmc.kodi.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.xfce.Catfish.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.xfce.PanelProfiles.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.xfce.Parole.png</Path>
@@ -1258,6 +1246,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.xfce.screenshooter.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.xfce.xfburn.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.xfce.xfdashboard.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.yamagi.YamagiQ2.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.zealdocs.zeal.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.zim_wiki.Zim.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.zotero.Zotero.png</Path>
@@ -1319,6 +1308,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/xpra.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/xreader.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/xviewer.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/xyz.parlatype.Parlatype.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/xyz.z3ntu.razergenie.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/yelp.png</Path>
             <Path fileType="data">/usr/share/app-info/xml</Path>
@@ -1327,12 +1317,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="47">
-            <Date>2024-07-27</Date>
-            <Version>45</Version>
+        <Update release="48">
+            <Date>2024-08-17</Date>
+            <Version>46</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Hans Kelson</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Update Appstream Metainfo to v46

**Test Plan**

Build appstream-data from this PR. See that software centers like Discover still work.

**Checklist**

- [x] Package was built and tested against unstable
