### PR TITLE
engrampa: Update to 1.28.2

### DIFF
--- a/packages/e/engrampa/abi_used_symbols
+++ b/packages/e/engrampa/abi_used_symbols
@@ -37,7 +37,6 @@ libc.so.6:localtime
 libc.so.6:lseek
 libc.so.6:memcpy
 libc.so.6:memmove
-libc.so.6:memset
 libc.so.6:mkdtemp
 libc.so.6:mktime
 libc.so.6:open
@@ -358,7 +357,9 @@ libglib-2.0.so.0:g_mkdir_with_parents
 libglib-2.0.so.0:g_mutex_lock
 libglib-2.0.so.0:g_mutex_unlock
 libglib-2.0.so.0:g_once_init_enter
+libglib-2.0.so.0:g_once_init_enter_pointer
 libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_group
 libglib-2.0.so.0:g_option_context_add_main_entries
 libglib-2.0.so.0:g_option_context_free

--- a/packages/e/engrampa/package.yml
+++ b/packages/e/engrampa/package.yml
@@ -1,8 +1,8 @@
 name       : engrampa
-version    : 1.28.1
-release    : 27
+version    : 1.28.2
+release    : 28
 source     :
-    - https://github.com/mate-desktop/engrampa/releases/download/v1.28.1/engrampa-1.28.1.tar.xz : 9c5c4c9bcf8b08eeaa8f275538d24b4c955089d58aec0331e89c02b84d85386a
+    - https://github.com/mate-desktop/engrampa/releases/download/v1.28.2/engrampa-1.28.2.tar.xz : 1e9977c23745bf8843a37f315171d9af97814a0971aeac3d774f017650ac09ef
 homepage   : https://www.mate-desktop.org/
 license    : GPL-2.0-or-later
 component  : desktop.mate

--- a/packages/e/engrampa/pspec_x86_64.xml
+++ b/packages/e/engrampa/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>engrampa</Name>
         <Homepage>https://www.mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.mate</PartOf>
@@ -850,12 +850,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2024-03-07</Date>
-            <Version>1.28.1</Version>
+        <Update release="28">
+            <Date>2024-08-17</Date>
+            <Version>1.28.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Fix extract of encrypted archives
- Fix volume split button in "Compress" window
- src/file-utils.c: Fix "error: implicit declaration of function ‘strcasecmp’..."
- fr-process.c: Setting error status
- Resolves https://github.com/getsolus/packages/issues/3595

**Test Plan**
- Installed checked version.

**Checklist**

- [X] Package was built and tested against unstable
