### PR TITLE
weechat: Update to 4.4.0

### DIFF
--- a/packages/w/weechat/abi_symbols
+++ b/packages/w/weechat/abi_symbols
@@ -757,6 +757,7 @@ guile.so:weechat_guile_api_infolist_string
 guile.so:weechat_guile_api_infolist_time
 guile.so:weechat_guile_api_key_bind
 guile.so:weechat_guile_api_key_unbind
+guile.so:weechat_guile_api_line_search_by_id
 guile.so:weechat_guile_api_list_add
 guile.so:weechat_guile_api_list_casesearch
 guile.so:weechat_guile_api_list_casesearch_pos
@@ -1198,6 +1199,7 @@ irc.so:irc_config_look_item_nick_modes
 irc.so:irc_config_look_item_nick_prefix
 irc.so:irc_config_look_join_auto_add_chantype
 irc.so:irc_config_look_list_buffer
+irc.so:irc_config_look_list_buffer_format_export
 irc.so:irc_config_look_list_buffer_scroll_horizontal
 irc.so:irc_config_look_list_buffer_sort
 irc.so:irc_config_look_list_buffer_topic_strip_colors
@@ -1375,6 +1377,7 @@ irc.so:irc_list_compare_cb
 irc.so:irc_list_create_buffer
 irc.so:irc_list_display_line
 irc.so:irc_list_end
+irc.so:irc_list_export
 irc.so:irc_list_filter_channels
 irc.so:irc_list_filter_hashtable_extra_vars
 irc.so:irc_list_filter_hashtable_options
@@ -1734,6 +1737,7 @@ irc.so:irc_server_get_tags_to_send
 irc.so:irc_server_gnutls_callback
 irc.so:irc_server_has_channels
 irc.so:irc_server_hdata_server_cb
+irc.so:irc_server_ipv6_string
 irc.so:irc_server_login
 irc.so:irc_server_msgq_add_buffer
 irc.so:irc_server_msgq_add_msg
@@ -2270,6 +2274,7 @@ perl.so:XS_weechat_api_infolist_string
 perl.so:XS_weechat_api_infolist_time
 perl.so:XS_weechat_api_key_bind
 perl.so:XS_weechat_api_key_unbind
+perl.so:XS_weechat_api_line_search_by_id
 perl.so:XS_weechat_api_list_add
 perl.so:XS_weechat_api_list_casesearch
 perl.so:XS_weechat_api_list_casesearch_pos
@@ -2777,7 +2782,7 @@ relay.so:relay_client_send_outqueue
 relay.so:relay_client_send_signal
 relay.so:relay_client_set_desc
 relay.so:relay_client_set_status
-relay.so:relay_client_timer_cb
+relay.so:relay_client_timer
 relay.so:relay_client_timer_send_cb
 relay.so:relay_client_valid
 relay.so:relay_clients
@@ -2792,6 +2797,8 @@ relay.so:relay_completion_init
 relay.so:relay_completion_protocol_name_cb
 relay.so:relay_completion_relays_cb
 relay.so:relay_completion_remotes_cb
+relay.so:relay_config_api_remote_autoreconnect_delay_growing
+relay.so:relay_config_api_remote_autoreconnect_delay_max
 relay.so:relay_config_api_remote_get_lines
 relay.so:relay_config_auto_open_buffer
 relay.so:relay_config_change_auto_open_buffer_cb
@@ -2859,6 +2866,7 @@ relay.so:relay_config_network_tls_priorities
 relay.so:relay_config_network_totp_secret
 relay.so:relay_config_network_totp_window
 relay.so:relay_config_network_websocket_allowed_origins
+relay.so:relay_config_network_websocket_permessage_deflate
 relay.so:relay_config_read
 relay.so:relay_config_refresh_cb
 relay.so:relay_config_regex_allowed_ips
@@ -2919,6 +2927,8 @@ relay.so:relay_http_send
 relay.so:relay_http_send_error_json
 relay.so:relay_http_send_json
 relay.so:relay_http_url_decode
+relay.so:relay_info_info_relay_api_version_cb
+relay.so:relay_info_info_relay_api_version_number_cb
 relay.so:relay_info_info_relay_client_count_cb
 relay.so:relay_info_infolist_relay_cb
 relay.so:relay_info_init
@@ -2988,11 +2998,13 @@ relay.so:relay_remote_add_to_infolist
 relay.so:relay_remote_alloc
 relay.so:relay_remote_auto_connect
 relay.so:relay_remote_auto_connect_timer_cb
+relay.so:relay_remote_buffer_input
+relay.so:relay_remote_build_string_tags
 relay.so:relay_remote_connect
 relay.so:relay_remote_disconnect
 relay.so:relay_remote_disconnect_all
 relay.so:relay_remote_event_apply_props
-relay.so:relay_remote_event_buffer_input_cb
+relay.so:relay_remote_event_buffer_input
 relay.so:relay_remote_event_cb_buffer
 relay.so:relay_remote_event_cb_buffer_cleared
 relay.so:relay_remote_event_cb_buffer_closed
@@ -3000,20 +3012,25 @@ relay.so:relay_remote_event_cb_input
 relay.so:relay_remote_event_cb_line
 relay.so:relay_remote_event_cb_nick
 relay.so:relay_remote_event_cb_nick_group
+relay.so:relay_remote_event_cb_quit
+relay.so:relay_remote_event_cb_upgrade
 relay.so:relay_remote_event_cb_version
 relay.so:relay_remote_event_check_local_var
+relay.so:relay_remote_event_clear_buffers
 relay.so:relay_remote_event_get_buffer_id
 relay.so:relay_remote_event_handle_nick
 relay.so:relay_remote_event_handle_nick_group
+relay.so:relay_remote_event_initial_sync_buffers
+relay.so:relay_remote_event_line_add
+relay.so:relay_remote_event_line_update
 relay.so:relay_remote_event_recv
 relay.so:relay_remote_event_remove_localvar_cb
 relay.so:relay_remote_event_search_buffer
+relay.so:relay_remote_event_search_line_by_id
 relay.so:relay_remote_event_sync_with_remote
 relay.so:relay_remote_find_pos
 relay.so:relay_remote_free
 relay.so:relay_remote_free_all
-relay.so:relay_remote_get_address
-relay.so:relay_remote_get_port
 relay.so:relay_remote_name_valid
 relay.so:relay_remote_network_check_auth
 relay.so:relay_remote_network_close_connection
@@ -3037,7 +3054,10 @@ relay.so:relay_remote_new_with_infolist
 relay.so:relay_remote_new_with_options
 relay.so:relay_remote_option_default
 relay.so:relay_remote_option_string
+relay.so:relay_remote_parse_url
 relay.so:relay_remote_print_log
+relay.so:relay_remote_reconnect
+relay.so:relay_remote_reconnect_schedule
 relay.so:relay_remote_rename
 relay.so:relay_remote_search
 relay.so:relay_remote_search_by_number
@@ -3046,6 +3066,7 @@ relay.so:relay_remote_send
 relay.so:relay_remote_send_signal
 relay.so:relay_remote_set_status
 relay.so:relay_remote_set_url
+relay.so:relay_remote_timer
 relay.so:relay_remote_url_valid
 relay.so:relay_remote_valid
 relay.so:relay_remotes
@@ -3071,6 +3092,7 @@ relay.so:relay_signal_upgrade_received
 relay.so:relay_status_name
 relay.so:relay_status_search
 relay.so:relay_status_string
+relay.so:relay_timer_cb
 relay.so:relay_upgrade_load
 relay.so:relay_upgrade_read_cb
 relay.so:relay_upgrade_save
@@ -3458,6 +3480,7 @@ script.so:script_download_enabled
 script.so:script_extension
 script.so:script_get_loaded_plugins
 script.so:script_get_scripts
+script.so:script_info_info_script_info_cb
 script.so:script_info_info_script_loaded_cb
 script.so:script_info_infolist_script_script_cb
 script.so:script_info_init
@@ -4021,6 +4044,7 @@ xfer.so:xfer_buffer_input_cb
 xfer.so:xfer_buffer_open
 xfer.so:xfer_buffer_refresh
 xfer.so:xfer_buffer_selected_line
+xfer.so:xfer_chat_apply_props
 xfer.so:xfer_chat_buffer_close_cb
 xfer.so:xfer_chat_buffer_input_cb
 xfer.so:xfer_chat_color_for_tags

--- a/packages/w/weechat/abi_used_symbols
+++ b/packages/w/weechat/abi_used_symbols
@@ -220,6 +220,7 @@ libcjson.so.1:cJSON_GetObjectItem
 libcjson.so.1:cJSON_GetStringValue
 libcjson.so.1:cJSON_IsArray
 libcjson.so.1:cJSON_IsBool
+libcjson.so.1:cJSON_IsNull
 libcjson.so.1:cJSON_IsNumber
 libcjson.so.1:cJSON_IsObject
 libcjson.so.1:cJSON_IsString

--- a/packages/w/weechat/package.yml
+++ b/packages/w/weechat/package.yml
@@ -1,8 +1,8 @@
 name       : weechat
-version    : 4.3.5
-release    : 84
+version    : 4.4.0
+release    : 85
 source     :
-    - https://github.com/weechat/weechat/archive/refs/tags/v4.3.5.tar.gz : 6e2acfe3472b61ec43a57058c596793464b38a5f17961259470e8a7d0f31a758
+    - https://github.com/weechat/weechat/archive/refs/tags/v4.4.0.tar.gz : 8c8abda3790dfe784c315d0256c80d99dc0e65bd6be701f9b3787f96b7576255
 homepage   : https://weechat.org
 license    : GPL-3.0-or-later
 summary    : WeeChat is a fast, light and extensible chat client.

--- a/packages/w/weechat/pspec_x86_64.xml
+++ b/packages/w/weechat/pspec_x86_64.xml
@@ -72,7 +72,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="84">weechat</Dependency>
+            <Dependency release="85">weechat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/weechat/weechat-plugin.h</Path>
@@ -80,9 +80,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="84">
-            <Date>2024-07-18</Date>
-            <Version>4.3.5</Version>
+        <Update release="85">
+            <Date>2024-08-17</Date>
+            <Version>4.4.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- **breaking:** relay/api: flatten JSON event object sent to clients, always set "body_type" and "body" (null if there is no body) in websocket frame, add body types buffers and lines (array), add field "request_id" in websocket frame (request and response)
- **breaking:** core, plugins: force "short_name" in buffers to non-empty value (name by default), remove buffer property "short_name_is_set"
- **breaking:** alias: display an error with `/alias add` or `/alias addcompletion` when the alias already exists, add options `addreplace` and `addreplacecompletion` in command `/alias`
- **breaking:** irc: rename parameter `-re` to `-raw` in command `/list`
- **breaking:** api: add constants for IPv6 and allow force of IPv6 in function hook_connect
- **breaking:** irc: convert server option `ipv6` from boolean to enum (disable, auto, force)
- **breaking:** core: convert proxy option `ipv6` from boolean to enum (disable, auto, force), set option to `auto` by default when creating a new proxy

Full changelog available [here](https://github.com/weechat/weechat/releases/tag/v4.4.0).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Connect to Libera Chat, join a room, send and receive messages.

**Checklist**

- [x] Package was built and tested against unstable
