### PR TITLE
juliaup: Update to 1.17.2

### DIFF
--- a/packages/j/juliaup/MAINTAINERS.md
+++ b/packages/j/juliaup/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Gavin Aagaard
+  - Matrix: @aagaardgw:matrix.org
+  - Email: aagaardgw@outlook.com

--- a/packages/j/juliaup/abi_used_symbols
+++ b/packages/j/juliaup/abi_used_symbols
@@ -1,4 +1,3 @@
-libc.so.6:__environ
 libc.so.6:__errno_location
 libc.so.6:__libc_start_main
 libc.so.6:__res_init
@@ -15,6 +14,7 @@ libc.so.6:clock_gettime
 libc.so.6:close
 libc.so.6:closedir
 libc.so.6:connect
+libc.so.6:dirfd
 libc.so.6:dl_iterate_phdr
 libc.so.6:dlsym
 libc.so.6:dup2
@@ -40,9 +40,11 @@ libc.so.6:ftruncate64
 libc.so.6:futimes
 libc.so.6:gai_strerror
 libc.so.6:getaddrinfo
+libc.so.6:getauxval
 libc.so.6:getcwd
 libc.so.6:getenv
 libc.so.6:getpeername
+libc.so.6:getpid
 libc.so.6:getpwuid_r
 libc.so.6:getsockname
 libc.so.6:getsockopt
@@ -53,15 +55,12 @@ libc.so.6:isatty
 libc.so.6:lchown
 libc.so.6:linkat
 libc.so.6:lseek64
-libc.so.6:lsetxattr
 libc.so.6:lstat64
 libc.so.6:lutimes
 libc.so.6:malloc
-libc.so.6:memchr
 libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
-libc.so.6:memrchr
 libc.so.6:memset
 libc.so.6:mkdir
 libc.so.6:mmap64
@@ -100,7 +99,6 @@ libc.so.6:pthread_mutex_unlock
 libc.so.6:pthread_self
 libc.so.6:pthread_setname_np
 libc.so.6:pthread_setspecific
-libc.so.6:raise
 libc.so.6:read
 libc.so.6:readdir64
 libc.so.6:readlink
@@ -108,8 +106,11 @@ libc.so.6:readv
 libc.so.6:realloc
 libc.so.6:realpath
 libc.so.6:recv
+libc.so.6:recvmsg
+libc.so.6:rename
 libc.so.6:sched_yield
 libc.so.6:send
+libc.so.6:sendmsg
 libc.so.6:setgid
 libc.so.6:setgroups
 libc.so.6:setpgid
@@ -122,6 +123,7 @@ libc.so.6:sigaltstack
 libc.so.6:sigemptyset
 libc.so.6:signal
 libc.so.6:socket
+libc.so.6:socketpair
 libc.so.6:stat64
 libc.so.6:strlen
 libc.so.6:symlink
@@ -130,6 +132,7 @@ libc.so.6:sysconf
 libc.so.6:unlink
 libc.so.6:unlinkat
 libc.so.6:utimensat
+libc.so.6:waitid
 libc.so.6:waitpid
 libc.so.6:write
 libc.so.6:writev

--- a/packages/j/juliaup/package.yml
+++ b/packages/j/juliaup/package.yml
@@ -1,12 +1,12 @@
 name       : juliaup
-version    : 1.11.22
-release    : 1
+version    : 1.17.2
+release    : 2
 source     :
-    - https://github.com/JuliaLang/juliaup/archive/refs/tags/v1.11.22.tar.gz : 8a0b4540262a8bea9e61a4f287ced32ec4ad2ac4cb528a1b473eea6f139256df
+    - https://github.com/JuliaLang/juliaup/archive/refs/tags/v1.17.2.tar.gz : d0860697e70b5cf8c5ee8a529da82413317d996f3f1a34ff6a6fef3a4564bbd5
 homepage   : https://github.com/JuliaLang/juliaup
 license    : MIT
 component  : programming.tools
-summary    : Julia installer and version multiplexer 
+summary    : Julia installer and version multiplexer
 description: |
     A cross-platform installer for the Julia programming language.
 replaces   : julia
@@ -14,13 +14,9 @@ networking : yes
 builddeps  :
     - rust
 setup      : |
-    # It seems like the `built` crate is having trouble fetching system
-    # information inside solbuild's container environment
-    sed -i 's|built::write_built_file().expect("Failed to acquire build-time information");||' build.rs
-    sed -i 's|include!(concat!(env!("OUT_DIR"), "/built.rs"))|pub const PKG_VERSION: \&str = "%version%"|' src/lib.rs
-    cargo fetch --locked
+    %cargo_fetch
 build      : |
-    cargo build --frozen %JOBS% --release --bin juliaup --bin julialauncher --features binjulialauncher
+    %cargo_build --bin juliaup --bin julialauncher --features binjulialauncher
 install    : |
-    install -Dm00755 target/release/{juliaup,julialauncher} -t $installdir/usr/bin
+    %cargo_install
     ln -s /usr/bin/julialauncher $installdir/usr/bin/julia

--- a/packages/j/juliaup/pspec_x86_64.xml
+++ b/packages/j/juliaup/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>juliaup</Name>
         <Homepage>https://github.com/JuliaLang/juliaup</Homepage>
         <Packager>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>Gavin Aagaard</Name>
+            <Email>aagaardgw@outlook.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.tools</PartOf>
         <Summary xml:lang="en">Julia installer and version multiplexer</Summary>
         <Description xml:lang="en">A cross-platform installer for the Julia programming language.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>juliaup</Name>
@@ -21,7 +21,6 @@
         <PartOf>programming.tools</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/julia</Path>
-            <Path fileType="executable">/usr/bin/julialauncher</Path>
             <Path fileType="executable">/usr/bin/juliaup</Path>
         </Files>
         <Replaces>
@@ -29,12 +28,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2023-09-23</Date>
-            <Version>1.11.22</Version>
+        <Update release="2">
+            <Date>2024-08-20</Date>
+            <Version>1.17.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>Gavin Aagaard</Name>
+            <Email>aagaardgw@outlook.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Updated juliaup to 1.17.2 and resolves getsolus/packages#3111 by updating to the new cargo macros supported by ypkg

Release notes can be found [here](https://github.com/JuliaLang/juliaup/releases/tag/v1.17.2)

**Summary**

<!-- Info on what this pull request updates/changes/etc -->

**Test Plan**

<!-- Short description of how the package was tested -->
Installed and tested commands with juliaup using bash
**Checklist**

- [X] Package was built and tested against unstable
