### PR TITLE
tailscale: Update to 1.72.0

### DIFF
--- a/packages/t/tailscale/package.yml
+++ b/packages/t/tailscale/package.yml
@@ -1,8 +1,8 @@
 name       : tailscale
-version    : 1.70.0
-release    : 22
+version    : 1.72.0
+release    : 23
 source     :
-    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.70.0.tar.gz : 8429728708f9694534489daa0a30af58be67f25742597940e7613793275c738f
+    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.72.0.tar.gz : 4f80f4572c6e9c150c1082acffab8c511264e04d56e9865bfb5a66f799e19b37
 homepage   : https://tailscale.com
 license    : BSD-3-Clause
 component  : network.clients

--- a/packages/t/tailscale/pspec_x86_64.xml
+++ b/packages/t/tailscale/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2024-07-21</Date>
-            <Version>1.70.0</Version>
+        <Update release="23">
+            <Date>2024-08-20</Date>
+            <Version>1.72.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Captive portal detection is now supported.
- The tailscale cert command now contains the --min-validity flag
- The tailscale lock command now supports passing keys as files
- A warning is now raised if unable to forward DNS queries
- Mitigate low throughput over high latency networks
- [changelog](https://tailscale.com/changelog#2024-08-19)

**Test Plan**
- tailscale netcheck

**Checklist**
- [X] Package was built and tested against unstable
