### PR TITLE
vgrep: Update to 2.8.0

### DIFF
--- a/packages/v/vgrep/package.yml
+++ b/packages/v/vgrep/package.yml
@@ -1,8 +1,8 @@
 name       : vgrep
-version    : 2.7.0
-release    : 6
+version    : 2.8.0
+release    : 7
 source     :
-    - https://github.com/vrothberg/vgrep/archive/refs/tags/v2.7.0.tar.gz : 0fb2ca6df8cdbb57bc50589e626e456f8a62b2d8d545b93425070844fcff26ea
+    - https://github.com/vrothberg/vgrep/archive/refs/tags/v2.8.0.tar.gz : 325b28bd5e8da316e319361f2dd8e3cc74fcd55724fc8ad4b2a73c21b2903bd8
 homepage   : https://github.com/vrothberg/vgrep/
 license    : GPL-3.0-only
 component  : system.utils

--- a/packages/v/vgrep/pspec_x86_64.xml
+++ b/packages/v/vgrep/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>vgrep</Name>
         <Homepage>https://github.com/vrothberg/vgrep/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <PartOf>system.utils</PartOf>
@@ -25,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2024-05-18</Date>
-            <Version>2.7.0</Version>
+        <Update release="7">
+            <Date>2024-08-21</Date>
+            <Version>2.8.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- handle *grep errors
- add GitHub workflows
- build(deps): bump golang.org/x/term from 0.19.0 to 0.20.0
- update golangci-lint to v1.57.2
- build(deps): bump golang.org/x/term from 0.18.0 to 0.19.0
- build(deps): bump golang.org/x/term from 0.17.0 to 0.18.0
- update copyright date to 2024
- bump go.mod to 1.21
- update github.com/rivo/uniseg
- build(deps): bump golang.org/x/term from 0.16.0 to 0.17.0
- bump golangci-lint to 1.55.2
- build(deps): bump golang.org/x/term from 0.15.0 to 0.16.0
- build(deps): bump golang.org/x/term from 0.14.0 to 0.15.0
- build(deps): bump golang.org/x/term from 0.13.0 to 0.14.0

**Test Plan**
- Ran example commands from github.

**Checklist**

- [X] Package was built and tested against unstable
