### PR TITLE
lime3ds: Update to 2117.1

### DIFF
--- a/packages/l/lime3ds/abi_used_libs
+++ b/packages/l/lime3ds/abi_used_libs
@@ -10,6 +10,7 @@ libSDL2-2.0.so.0
 libSPIRV-Tools-opt.so
 libSPIRV-Tools.so
 libSoundTouch.so.1
+libatomic.so.1
 libboost_iostreams.so.1.83.0
 libboost_serialization.so.1.83.0
 libc.so.6

--- a/packages/l/lime3ds/abi_used_symbols
+++ b/packages/l/lime3ds/abi_used_symbols
@@ -244,6 +244,7 @@ libQt6Core.so.6:_ZN6QTimerC1EP7QObject
 libQt6Core.so.6:_ZN6QTimerD1Ev
 libQt6Core.so.6:_ZN7QLocale16languageToStringENS_8LanguageE
 libQt6Core.so.6:_ZN7QLocale17territoryToStringENS_7CountryE
+libQt6Core.so.6:_ZN7QLocale6systemEv
 libQt6Core.so.6:_ZN7QLocaleC1Ev
 libQt6Core.so.6:_ZN7QLocaleC2E11QStringView
 libQt6Core.so.6:_ZN7QLocaleD1Ev
@@ -651,7 +652,6 @@ libQt6Gui.so.6:_ZN5QFont12setStyleHintENS_9StyleHintENS_13StyleStrategyE
 libQt6Gui.so.6:_ZN5QFont13setFixedPitchEb
 libQt6Gui.so.6:_ZN5QFontC1ERK7QStringiib
 libQt6Gui.so.6:_ZN5QFontC1ERKS_
-libQt6Gui.so.6:_ZN5QFontC1Ev
 libQt6Gui.so.6:_ZN5QFontD1Ev
 libQt6Gui.so.6:_ZN5QIcon12setThemeNameERK7QString
 libQt6Gui.so.6:_ZN5QIcon16themeSearchPathsEv
@@ -693,7 +693,6 @@ libQt6Gui.so.6:_ZN7QAction11setShortcutERK12QKeySequence
 libQt6Gui.so.6:_ZN7QAction12setCheckableEb
 libQt6Gui.so.6:_ZN7QAction13setAutoRepeatEb
 libQt6Gui.so.6:_ZN7QAction16staticMetaObjectE
-libQt6Gui.so.6:_ZN7QAction18setShortcutContextEN2Qt15ShortcutContextE
 libQt6Gui.so.6:_ZN7QAction7hoveredEv
 libQt6Gui.so.6:_ZN7QAction7setDataERK8QVariant
 libQt6Gui.so.6:_ZN7QAction7setTextERK7QString
@@ -875,7 +874,6 @@ libQt6Widgets.so.6:_ZN11QFileDialog16getOpenFileNamesEP7QWidgetRK7QStringS4_S4_P
 libQt6Widgets.so.6:_ZN11QFileDialog20getExistingDirectoryEP7QWidgetRK7QStringS4_6QFlagsINS_6OptionEE
 libQt6Widgets.so.6:_ZN11QFormLayout17setLabelAlignmentE6QFlagsIN2Qt13AlignmentFlagEE
 libQt6Widgets.so.6:_ZN11QFormLayout6addRowERK7QStringP7QWidget
-libQt6Widgets.so.6:_ZN11QFormLayout7setItemEiNS_8ItemRoleEP11QLayoutItem
 libQt6Widgets.so.6:_ZN11QFormLayout9setWidgetEiNS_8ItemRoleEP7QWidget
 libQt6Widgets.so.6:_ZN11QFormLayoutC1EP7QWidget
 libQt6Widgets.so.6:_ZN11QGridLayout16setColumnStretchEii
@@ -939,8 +937,6 @@ libQt6Widgets.so.6:_ZN11QTreeWidget9sortItemsEiN2Qt9SortOrderE
 libQt6Widgets.so.6:_ZN11QTreeWidgetC1EP7QWidget
 libQt6Widgets.so.6:_ZN11QVBoxLayoutC1EP7QWidget
 libQt6Widgets.so.6:_ZN11QVBoxLayoutC1Ev
-libQt6Widgets.so.6:_ZN11QWizardPage8setTitleERK7QString
-libQt6Widgets.so.6:_ZN11QWizardPageC1EP7QWidget
 libQt6Widgets.so.6:_ZN12QApplication11focusWidgetEv
 libQt6Widgets.so.6:_ZN12QApplication12focusChangedEP7QWidgetS1_
 libQt6Widgets.so.6:_ZN12QApplication13setStyleSheetERK7QString
@@ -951,8 +947,6 @@ libQt6Widgets.so.6:_ZN12QApplication4execEv
 libQt6Widgets.so.6:_ZN12QApplication5alertEP7QWidgeti
 libQt6Widgets.so.6:_ZN12QApplicationC1ERiPPci
 libQt6Widgets.so.6:_ZN12QApplicationD1Ev
-libQt6Widgets.so.6:_ZN12QButtonGroup9addButtonEP15QAbstractButtoni
-libQt6Widgets.so.6:_ZN12QButtonGroupC1EP7QObject
 libQt6Widgets.so.6:_ZN12QColorDialog8getColorERK6QColorP7QWidgetRK7QString6QFlagsINS_17ColorDialogOptionEE
 libQt6Widgets.so.6:_ZN12QInputDialog7getTextEP7QWidgetRK7QStringS4_N9QLineEdit8EchoModeES4_Pb6QFlagsIN2Qt10WindowTypeEES8_INS9_15InputMethodHintEE
 libQt6Widgets.so.6:_ZN12QProgressBar10setMaximumEi
@@ -1248,23 +1242,6 @@ libQt6Widgets.so.6:_ZN7QWidget9showEventEP10QShowEvent
 libQt6Widgets.so.6:_ZN7QWidgetC1EPS_6QFlagsIN2Qt10WindowTypeEE
 libQt6Widgets.so.6:_ZN7QWidgetC2EPS_6QFlagsIN2Qt10WindowTypeEE
 libQt6Widgets.so.6:_ZN7QWidgetD2Ev
-libQt6Widgets.so.6:_ZN7QWizard10paintEventEP11QPaintEvent
-libQt6Widgets.so.6:_ZN7QWizard10setOptionsE6QFlagsINS_12WizardOptionEE
-libQt6Widgets.so.6:_ZN7QWizard10setVisibleEb
-libQt6Widgets.so.6:_ZN7QWizard11cleanupPageEi
-libQt6Widgets.so.6:_ZN7QWizard11qt_metacallEN11QMetaObject4CallEiPPv
-libQt6Widgets.so.6:_ZN7QWizard11qt_metacastEPKc
-libQt6Widgets.so.6:_ZN7QWizard11resizeEventEP12QResizeEvent
-libQt6Widgets.so.6:_ZN7QWizard14initializePageEi
-libQt6Widgets.so.6:_ZN7QWizard16staticMetaObjectE
-libQt6Widgets.so.6:_ZN7QWizard19validateCurrentPageEv
-libQt6Widgets.so.6:_ZN7QWizard4backEv
-libQt6Widgets.so.6:_ZN7QWizard4doneEi
-libQt6Widgets.so.6:_ZN7QWizard4nextEv
-libQt6Widgets.so.6:_ZN7QWizard5eventEP6QEvent
-libQt6Widgets.so.6:_ZN7QWizard7setPageEiP11QWizardPage
-libQt6Widgets.so.6:_ZN7QWizardC2EP7QWidget6QFlagsIN2Qt10WindowTypeEE
-libQt6Widgets.so.6:_ZN7QWizardD2Ev
 libQt6Widgets.so.6:_ZN8QMenuBar16staticMetaObjectE
 libQt6Widgets.so.6:_ZN8QMenuBar7hoveredEP7QAction
 libQt6Widgets.so.6:_ZN8QMenuBarC1EP7QWidget
@@ -1361,7 +1338,6 @@ libQt6Widgets.so.6:_ZNK11QMainWindow9statusBarEv
 libQt6Widgets.so.6:_ZNK11QMessageBox13clickedButtonEv
 libQt6Widgets.so.6:_ZNK11QTreeWidget10headerItemEv
 libQt6Widgets.so.6:_ZNK11QTreeWidget17invisibleRootItemEv
-libQt6Widgets.so.6:_ZNK12QButtonGroup9checkedIdEv
 libQt6Widgets.so.6:_ZNK12QTableWidget10currentRowEv
 libQt6Widgets.so.6:_ZNK12QTableWidget11columnCountEv
 libQt6Widgets.so.6:_ZNK12QTableWidget13currentColumnEv
@@ -1428,10 +1404,6 @@ libQt6Widgets.so.6:_ZNK7QWidget6screenEv
 libQt6Widgets.so.6:_ZNK7QWidget7actionsEv
 libQt6Widgets.so.6:_ZNK7QWidget7devTypeEv
 libQt6Widgets.so.6:_ZNK7QWidget8sizeHintEv
-libQt6Widgets.so.6:_ZNK7QWizard6buttonENS_12WizardButtonE
-libQt6Widgets.so.6:_ZNK7QWizard6nextIdEv
-libQt6Widgets.so.6:_ZNK7QWizard8sizeHintEv
-libQt6Widgets.so.6:_ZNK7QWizard9currentIdEv
 libQt6Widgets.so.6:_ZNK8QSpinBox5valueEv
 libQt6Widgets.so.6:_ZNK9QCheckBox10checkStateEv
 libQt6Widgets.so.6:_ZNK9QComboBox11currentDataEi
@@ -1458,7 +1430,6 @@ libQt6Widgets.so.6:_ZTI6QFrame
 libQt6Widgets.so.6:_ZTI6QLabel
 libQt6Widgets.so.6:_ZTI7QDialog
 libQt6Widgets.so.6:_ZTI7QWidget
-libQt6Widgets.so.6:_ZTI7QWizard
 libQt6Widgets.so.6:_ZTV11QSpacerItem
 libQt6Widgets.so.6:_ZThn16_NK7QWidget10redirectedEP6QPoint
 libQt6Widgets.so.6:_ZThn16_NK7QWidget11initPainterEP8QPainter
@@ -1584,6 +1555,7 @@ libSoundTouch.so.1:_ZN10soundtouch10SoundTouch5flushEv
 libSoundTouch.so.1:_ZN10soundtouch10SoundTouch8setPitchEd
 libSoundTouch.so.1:_ZN10soundtouch10SoundTouch8setTempoEd
 libSoundTouch.so.1:_ZN10soundtouch10SoundTouchC1Ev
+libatomic.so.1:__atomic_is_lock_free
 libboost_iostreams.so.1.83.0:_ZN5boost9iostreams15file_descriptor4readEPcl
 libboost_iostreams.so.1.83.0:_ZN5boost9iostreams15file_descriptor4seekElSt12_Ios_Seekdir
 libboost_iostreams.so.1.83.0:_ZN5boost9iostreams15file_descriptor5closeEv
@@ -1699,7 +1671,6 @@ libc.so.6:fileno
 libc.so.6:fopen
 libc.so.6:fopen64
 libc.so.6:fprintf
-libc.so.6:fputc
 libc.so.6:fputs
 libc.so.6:fread
 libc.so.6:free
@@ -2038,7 +2009,7 @@ libstdc++.so.6:_ZNSt13runtime_errorD2Ev
 libstdc++.so.6:_ZNSt14basic_ifstreamIcSt11char_traitsIcEEC1EPKcSt13_Ios_Openmode
 libstdc++.so.6:_ZNSt14basic_ifstreamIcSt11char_traitsIcEEC1ERKNSt7__cxx1112basic_stringIcS1_SaIcEEESt13_Ios_Openmode
 libstdc++.so.6:_ZNSt14basic_ifstreamIcSt11char_traitsIcEEC1Ev
-libstdc++.so.6:_ZNSt14basic_ifstreamIcSt11char_traitsIcEED1Ev
+libstdc++.so.6:_ZNSt14basic_ifstreamIcSt11char_traitsIcEED2Ev
 libstdc++.so.6:_ZNSt14basic_ofstreamIcSt11char_traitsIcEEC1EPKcSt13_Ios_Openmode
 libstdc++.so.6:_ZNSt14basic_ofstreamIcSt11char_traitsIcEEC1ERKNSt7__cxx1112basic_stringIcS1_SaIcEEESt13_Ios_Openmode
 libstdc++.so.6:_ZNSt14basic_ofstreamIcSt11char_traitsIcEEC1Ev
@@ -2090,7 +2061,6 @@ libstdc++.so.6:_ZNSt6thread4joinEv
 libstdc++.so.6:_ZNSt6thread6_StateD2Ev
 libstdc++.so.6:_ZNSt6thread6detachEv
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructEmc
-libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE14_M_replace_auxEmmmc
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE8_M_eraseEmm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_appendEPKcm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createERmm
@@ -2210,6 +2180,7 @@ libstdc++.so.6:_ZTIv
 libstdc++.so.6:_ZTTNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEEE
 libstdc++.so.6:_ZTTNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEEE
 libstdc++.so.6:_ZTTNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEE
+libstdc++.so.6:_ZTTSt14basic_ifstreamIcSt11char_traitsIcEE
 libstdc++.so.6:_ZTVN10__cxxabiv116__enum_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv117__class_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv119__pointer_type_infoE

--- a/packages/l/lime3ds/package.yml
+++ b/packages/l/lime3ds/package.yml
@@ -1,8 +1,8 @@
 name       : lime3ds
-version    : 2116
-release    : 4
+version    : '2117.1'
+release    : 5
 source     :
-    - git|https://github.com/Lime3DS/Lime3DS.git : 90ebe220b200ba1d6b79a1d7fe3ef7f590c09453
+    - https://github.com/Lime3DS/Lime3DS/releases/download/2117.1/lime3ds-unified-source-2117.1.tar.xz : 76117e30355e44157cd6b6c7581a8f2fd10480e94e8c5ea67b649c350385ef69
 homepage   : https://lime3ds.github.io/
 license    : GPL-2.0-or-later
 component  : games.emulator
@@ -23,14 +23,13 @@ builddeps  :
     - cubeb-devel
     - glslang-devel
     - libboost-devel
-    - robin-map
+    # - robin-map FIXME: use our package rather than relying on what ships in lime3ds/externals/dynarmic/externals/robin-map
 clang      : yes
 optimize   :
     - speed
     - thin-lto
 setup      : |
     %cmake_ninja \
-        -DCMAKE_BUILD_TYPE=Release \
         -DENABLE_QT_UPDATER=OFF \
         -DUSE_DISCORD_PRESENCE=ON \
         -DUSE_SYSTEM_BOOST=ON \

--- a/packages/l/lime3ds/pspec_x86_64.xml
+++ b/packages/l/lime3ds/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>lime3ds</Name>
         <Homepage>https://lime3ds.github.io/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>games.emulator</PartOf>
@@ -33,12 +33,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-07-28</Date>
-            <Version>2116</Version>
+        <Update release="5">
+            <Date>2024-08-22</Date>
+            <Version>2117.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Bugfixes:
- Fix a known crash in 2 games caused by invalid cubemap face IDs
- Fix interface language sometimes being detected incorrectly
- All hotkeys now work correctly when using 2-window layout

Improvements:
- The "report compatibility" button now links to the Lime3DS compatibility repo
- Frame advancing is now possible while emulation is paused.

Release notes for 2117 [here](https://github.com/Lime3DS/Lime3DS/releases/tag/2117) (note that 2117.1 has no user-facing changes vs. 2117)
Full changelog [here](https://github.com/Lime3DS/Lime3DS/compare/2116...2117.1)

**Test Plan**

Launch a few titles and make sure things look and sound alright

**Checklist**

- [x] Package was built and tested against unstable
