### PR TITLE
perl-image-exiftool: Update to 12.76

### DIFF
--- a/packages/p/perl-image-exiftool/package.yml
+++ b/packages/p/perl-image-exiftool/package.yml
@@ -1,8 +1,8 @@
 name       : perl-image-exiftool
-version    : '12.70'
-release    : 23
+version    : '12.76'
+release    : 24
 source     :
-    - https://cpan.metacpan.org/authors/id/E/EX/EXIFTOOL/Image-ExifTool-12.70.tar.gz : 4cb2522445cc3e3f3bd13904c6aeaeada5fc5a5e2498d7abad2957dcb42caffe
+    - https://cpan.metacpan.org/authors/id/E/EX/EXIFTOOL/Image-ExifTool-12.76.tar.gz : 5d3430ec57aa031f7ca43170f7ed6338a66bda99ab95b9e071f1ee27555f515f
 homepage   : https://exiftool.org/
 license    : Artistic-1.0-Perl
 component  : multimedia.library

--- a/packages/p/perl-image-exiftool/pspec_x86_64.xml
+++ b/packages/p/perl-image-exiftool/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>perl-image-exiftool</Name>
         <Homepage>https://exiftool.org/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>Artistic-1.0-Perl</License>
         <PartOf>multimedia.library</PartOf>
@@ -26,6 +26,7 @@
             <Path fileType="library">/usr/lib64/perl5/vendor_perl/5.38/Image/ExifTool.pm</Path>
             <Path fileType="library">/usr/lib64/perl5/vendor_perl/5.38/Image/ExifTool.pod</Path>
             <Path fileType="library">/usr/lib64/perl5/vendor_perl/5.38/Image/ExifTool/7Z.pm</Path>
+            <Path fileType="library">/usr/lib64/perl5/vendor_perl/5.38/Image/ExifTool/AAC.pm</Path>
             <Path fileType="library">/usr/lib64/perl5/vendor_perl/5.38/Image/ExifTool/AES.pm</Path>
             <Path fileType="library">/usr/lib64/perl5/vendor_perl/5.38/Image/ExifTool/AFCP.pm</Path>
             <Path fileType="library">/usr/lib64/perl5/vendor_perl/5.38/Image/ExifTool/AIFF.pm</Path>
@@ -263,12 +264,13 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="23">perl-image-exiftool</Dependency>
+            <Dependency release="24">perl-image-exiftool</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="man">/usr/share/man/man3/File::RandomAccess.3</Path>
             <Path fileType="man">/usr/share/man/man3/Image::ExifTool.3</Path>
             <Path fileType="man">/usr/share/man/man3/Image::ExifTool::7Z.3</Path>
+            <Path fileType="man">/usr/share/man/man3/Image::ExifTool::AAC.3</Path>
             <Path fileType="man">/usr/share/man/man3/Image::ExifTool::AES.3</Path>
             <Path fileType="man">/usr/share/man/man3/Image::ExifTool::AFCP.3</Path>
             <Path fileType="man">/usr/share/man/man3/Image::ExifTool::AIFF.3</Path>
@@ -464,12 +466,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2024-01-15</Date>
-            <Version>12.70</Version>
+        <Update release="24">
+            <Date>2024-08-22</Date>
+            <Version>12.76</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

 - Properly implement patch of 12.45 to avoid duplicating raw data when writing Sony ARW images where the raw data is double-referenced as both strips and tiles
 - Improved handling of bad offsets in HtmlDump output
 - Resolves https://github.com/getsolus/packages/issues/3647

**Test Plan**
- Checked in Digikam that this new version was loaded.

**Checklist**

- [X] Package was built and tested against unstable

**Packaging notes**
- Did not update to the requested version as that is not a production release. 12.76 is the latest for production.
