### PR TITLE
github-cli: Update to 2.55.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.54.0
-release    : 52
+version    : 2.55.0
+release    : 53
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.54.0.tar.gz : eedac958431876cebe243925dc354b0c21915d1bc84c5678a8073f0ec91d6a4c
+    - https://github.com/cli/cli/archive/refs/tags/v2.55.0.tar.gz : f467cfdaedd372a5c20bb0daad017a0b3f75fa25179f1e4dcdc1d01ed59e62a5
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -219,9 +219,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="52">
-            <Date>2024-08-04</Date>
-            <Version>2.54.0</Version>
+        <Update release="53">
+            <Date>2024-08-22</Date>
+            <Version>2.55.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Update `gh variable get` to use repo host
- Improve Unix compliance in `gh repo set-default`
- Document that `gh run download` downloads the latest artifact by default
- Improve `gh release create --notes-from-tag` behavior with multiline tag annotation
- Add `pr create --editor`
- Improve documentation for pr checks and exit codes
- Fix behavior for `gh issue develop -b does-not-exist-on-remote`
- Update `--project <number>` flags in `gh search` to `owner/number`

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
