### PR TITLE
obs-vkcapture: Update to 1.5.1

### DIFF
--- a/packages/o/obs-vkcapture/package.yml
+++ b/packages/o/obs-vkcapture/package.yml
@@ -1,8 +1,8 @@
 name       : obs-vkcapture
-version    : 1.5.0
-release    : 9
+version    : 1.5.1
+release    : 10
 source     :
-    - https://github.com/nowrep/obs-vkcapture/archive/refs/tags/v1.5.0.tar.gz : 338c407f2a795a12d16010416cadb7c402638dee54d9615343dccf8d104753f0
+    - https://github.com/nowrep/obs-vkcapture/archive/refs/tags/v1.5.1.tar.gz : 141edd95489d59e9af2597406d3200509a43bb6b012717a24c7afb163baa7f7f
 license    : GPL-2.0-or-later
 homepage   : https://github.com/nowrep/obs-vkcapture
 component  : multimedia.video

--- a/packages/o/obs-vkcapture/pspec_x86_64.xml
+++ b/packages/o/obs-vkcapture/pspec_x86_64.xml
@@ -48,7 +48,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="9">obs-vkcapture</Dependency>
+            <Dependency release="10">obs-vkcapture</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libVkLayer_obs_vkcapture.so</Path>
@@ -56,9 +56,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2024-04-27</Date>
-            <Version>1.5.0</Version>
+        <Update release="10">
+            <Date>2024-08-22</Date>
+            <Version>1.5.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fixed build issues with latest OBS

**Test Plan**

Recorded footage from a Vulkan game

**Checklist**

- [x] Package was built and tested against unstable
