### PR TITLE
egl-wayland: Update to 1.1.16

### DIFF
--- a/packages/e/egl-wayland/package.yml
+++ b/packages/e/egl-wayland/package.yml
@@ -1,8 +1,8 @@
 name       : egl-wayland
-version    : 1.1.15
-release    : 23
+version    : 1.1.16
+release    : 24
 source     :
-    - https://github.com/NVIDIA/egl-wayland/archive/refs/tags/1.1.15.tar.gz : 24281c3b5409900ceb2472f781d19c079f11f4bba78771c518a71afb47ead793
+    - https://github.com/NVIDIA/egl-wayland/archive/refs/tags/1.1.16.tar.gz : d3302002987128dac159ec5dde7a53831ccb905288daad62d1d18bafa0388858
 homepage   : https://github.com/NVIDIA/egl-wayland
 license    : MIT
 component  : programming.library

--- a/packages/e/egl-wayland/pspec_x86_64.xml
+++ b/packages/e/egl-wayland/pspec_x86_64.xml
@@ -21,7 +21,7 @@
         <PartOf>programming.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libnvidia-egl-wayland.so.1</Path>
-            <Path fileType="library">/usr/lib64/libnvidia-egl-wayland.so.1.1.15</Path>
+            <Path fileType="library">/usr/lib64/libnvidia-egl-wayland.so.1.1.16</Path>
             <Path fileType="data">/usr/share/egl/egl_external_platform.d/10_nvidia_wayland.json</Path>
         </Files>
     </Package>
@@ -32,7 +32,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="23">egl-wayland</Dependency>
+            <Dependency release="24">egl-wayland</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libnvidia-egl-wayland.so</Path>
@@ -44,9 +44,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2024-08-12</Date>
-            <Version>1.1.15</Version>
+        <Update release="24">
+            <Date>2024-08-22</Date>
+            <Version>1.1.16</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fix a crash due to an assertion firing during surface destruction, which affected Qt6 webengine
- Add an explicit dependency on the EGL headers

**Test Plan**
- Test akregator and confirm it no longer segfaults
 (still seems to crash intermittently without `__NV_DISABLE_EXPLICIT_SYNC` though)

**Checklist**

- [x] Package was built and tested against unstable
