### PR TITLE
fb2converter: Update to 1.75.4

### DIFF
--- a/packages/f/fb2converter/package.yml
+++ b/packages/f/fb2converter/package.yml
@@ -1,8 +1,8 @@
 name       : fb2converter
-version    : 1.75.3
-release    : 26
+version    : 1.75.4
+release    : 27
 source     :
-    - git|https://github.com/rupor-github/fb2converter.git : v1.75.2
+    - git|https://github.com/rupor-github/fb2converter.git : v1.75.4
 homepage   : https://github.com/rupor-github/fb2converter
 license    : GPL-3.0-only
 component  : office.viewers

--- a/packages/f/fb2converter/pspec_x86_64.xml
+++ b/packages/f/fb2converter/pspec_x86_64.xml
@@ -26,9 +26,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2024-07-27</Date>
-            <Version>1.75.3</Version>
+        <Update release="27">
+            <Date>2024-08-24</Date>
+            <Version>1.75.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- [changelog](https://github.com/rupor-github/fb2converter/compare/v1.75.2...v1.75.4)

**Test Plan**
- fb2c convert --to epub in.fb2

**Checklist**
- [X] Package was built and tested against unstable
