### PR TITLE
split mate desktop

### DIFF
--- a/packages/a/atril/abi_used_symbols
+++ b/packages/a/atril/abi_used_symbols
@@ -613,7 +613,9 @@ libglib-2.0.so.0:g_node_nth_child
 libglib-2.0.so.0:g_node_unlink
 libglib-2.0.so.0:g_once_impl
 libglib-2.0.so.0:g_once_init_enter
+libglib-2.0.so.0:g_once_init_enter_pointer
 libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_group
 libglib-2.0.so.0:g_option_context_add_main_entries
 libglib-2.0.so.0:g_option_context_free

--- a/packages/a/atril/package.yml
+++ b/packages/a/atril/package.yml
@@ -1,6 +1,6 @@
 name       : atril
 version    : 1.28.0
-release    : 44
+release    : 45
 source     :
     - https://github.com/mate-desktop/atril/releases/download/v1.28.0/atril-1.28.0.tar.xz : ced4725f6e9b71c4ea63676bfc3cc3be09d29dba08aa7a7ab97964e0b4355162
 homepage   : https://mate-desktop.org/

--- a/packages/a/atril/pspec_x86_64.xml
+++ b/packages/a/atril/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>atril</Name>
         <Homepage>https://mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.mate</PartOf>
@@ -5902,7 +5902,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="44">atril</Dependency>
+            <Dependency release="45">atril</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/atril/1.5.0/atril-document.h</Path>
@@ -6089,12 +6089,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="44">
-            <Date>2024-03-07</Date>
+        <Update release="45">
+            <Date>2024-08-27</Date>
             <Version>1.28.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/c/caja-extensions/abi_used_symbols
+++ b/packages/c/caja-extensions/abi_used_symbols
@@ -170,8 +170,8 @@ libglib-2.0.so.0:g_malloc0
 libglib-2.0.so.0:g_malloc_n
 libglib-2.0.so.0:g_markup_printf_escaped
 libglib-2.0.so.0:g_once_impl
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_group
 libglib-2.0.so.0:g_option_context_add_main_entries
 libglib-2.0.so.0:g_option_context_new

--- a/packages/c/caja-extensions/package.yml
+++ b/packages/c/caja-extensions/package.yml
@@ -1,6 +1,6 @@
 name       : caja-extensions
 version    : 1.28.0
-release    : 22
+release    : 23
 source     :
     - https://github.com/mate-desktop/caja-extensions/releases/download/v1.28.0/caja-extensions-1.28.0.tar.xz : d2986c5e0740835fe271cfbd5823eeeaf03291af1763203f4700abb8109e3175
 homepage   : https://www.mate-desktop.org/

--- a/packages/c/caja-extensions/pspec_x86_64.xml
+++ b/packages/c/caja-extensions/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>caja-extensions</Name>
         <Homepage>https://www.mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.mate</PartOf>
@@ -182,7 +182,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="22">caja-extensions</Dependency>
+            <Dependency release="23">caja-extensions</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/caja-sendto/caja-sendto-plugin.h</Path>
@@ -213,12 +213,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2024-03-07</Date>
+        <Update release="23">
+            <Date>2024-08-28</Date>
             <Version>1.28.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/c/caja/abi_used_symbols
+++ b/packages/c/caja/abi_used_symbols
@@ -842,7 +842,9 @@ libglib-2.0.so.0:g_mutex_init
 libglib-2.0.so.0:g_mutex_lock
 libglib-2.0.so.0:g_mutex_unlock
 libglib-2.0.so.0:g_once_init_enter
+libglib-2.0.so.0:g_once_init_enter_pointer
 libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_group
 libglib-2.0.so.0:g_option_context_add_main_entries
 libglib-2.0.so.0:g_option_context_free

--- a/packages/c/caja/package.yml
+++ b/packages/c/caja/package.yml
@@ -1,6 +1,6 @@
 name       : caja
 version    : 1.28.0
-release    : 42
+release    : 43
 source     :
     - https://github.com/mate-desktop/caja/releases/download/v1.28.0/caja-1.28.0.tar.xz : 1e3014ce1455817ec2ef74d09efdfb6835d8a372ed9a16efb5919ef7b821957a
 homepage   : https://www.mate-desktop.org/

--- a/packages/c/caja/pspec_x86_64.xml
+++ b/packages/c/caja/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>caja</Name>
         <Homepage>https://www.mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.0-or-later</License>
@@ -240,7 +240,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="42">caja</Dependency>
+            <Dependency release="43">caja</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/caja/libcaja-extension/caja-column-provider.h</Path>
@@ -295,12 +295,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="42">
-            <Date>2024-03-07</Date>
+        <Update release="43">
+            <Date>2024-08-27</Date>
             <Version>1.28.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/e/eom/abi_used_symbols
+++ b/packages/e/eom/abi_used_symbols
@@ -375,8 +375,8 @@ libglib-2.0.so.0:g_node_new
 libglib-2.0.so.0:g_node_nth_child
 libglib-2.0.so.0:g_node_unlink
 libglib-2.0.so.0:g_once_impl
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_group
 libglib-2.0.so.0:g_option_context_add_main_entries
 libglib-2.0.so.0:g_option_context_free

--- a/packages/e/eom/package.yml
+++ b/packages/e/eom/package.yml
@@ -1,6 +1,6 @@
 name       : eom
 version    : 1.28.0
-release    : 34
+release    : 35
 source     :
     - https://github.com/mate-desktop/eom/releases/download/v1.28.0/eom-1.28.0.tar.xz : 9a01cab2995a1a8c7258c865eae5f182ed4730c44672afdc3a07e423edd53abc
 homepage   : https://mate-desktop.org/

--- a/packages/e/eom/pspec_x86_64.xml
+++ b/packages/e/eom/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>eom</Name>
         <Homepage>https://mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.mate</PartOf>
@@ -635,7 +635,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="34">eom</Dependency>
+            <Dependency release="35">eom</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/eom-2.20/eom/eom-application-activatable.h</Path>
@@ -731,12 +731,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="34">
-            <Date>2024-03-07</Date>
+        <Update release="35">
+            <Date>2024-08-27</Date>
             <Version>1.28.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/m/marco/abi_used_symbols
+++ b/packages/m/marco/abi_used_symbols
@@ -491,8 +491,8 @@ libglib-2.0.so.0:g_markup_printf_escaped
 libglib-2.0.so.0:g_match_info_fetch
 libglib-2.0.so.0:g_match_info_free
 libglib-2.0.so.0:g_memdup2
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_main_entries
 libglib-2.0.so.0:g_option_context_free
 libglib-2.0.so.0:g_option_context_new

--- a/packages/m/marco/package.yml
+++ b/packages/m/marco/package.yml
@@ -1,6 +1,6 @@
 name       : marco
 version    : 1.28.1
-release    : 29
+release    : 30
 source     :
     - https://github.com/mate-desktop/marco/releases/download/v1.28.1/marco-1.28.1.tar.xz : 2496e5e40ee980cd6849493ac3e0f8fd0dec8b81c674da8d9ba19a577f0ac2e1
 homepage   : https://mate-desktop.org/

--- a/packages/m/marco/pspec_x86_64.xml
+++ b/packages/m/marco/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>marco</Name>
         <Homepage>https://mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.mate</PartOf>
@@ -242,7 +242,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="29">marco</Dependency>
+            <Dependency release="30">marco</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/marco-1/marco-private/boxes.h</Path>
@@ -257,12 +257,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="29">
-            <Date>2024-03-07</Date>
+        <Update release="30">
+            <Date>2024-08-27</Date>
             <Version>1.28.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/m/mate-applets/abi_used_symbols
+++ b/packages/m/mate-applets/abi_used_symbols
@@ -329,8 +329,8 @@ libglib-2.0.so.0:g_malloc0_n
 libglib-2.0.so.0:g_malloc_n
 libglib-2.0.so.0:g_markup_printf_escaped
 libglib-2.0.so.0:g_mkdir_with_parents
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_group
 libglib-2.0.so.0:g_option_context_add_main_entries
 libglib-2.0.so.0:g_option_context_free

--- a/packages/m/mate-applets/package.yml
+++ b/packages/m/mate-applets/package.yml
@@ -1,6 +1,6 @@
 name       : mate-applets
 version    : 1.28.0
-release    : 34
+release    : 35
 source     :
     - https://github.com/mate-desktop/mate-applets/releases/download/v1.28.0/mate-applets-1.28.0.tar.xz : 1b6bef6bd5d326fb9dc828ff910e4b1b9294b4660c311dc1c90310fd9c356686
 license    :

--- a/packages/m/mate-applets/pspec_x86_64.xml
+++ b/packages/m/mate-applets/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mate-applets</Name>
         <Homepage>https://mate-desktop.org</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>GFDL-1.1-or-later</License>
@@ -11264,12 +11264,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="34">
-            <Date>2024-03-07</Date>
+        <Update release="35">
+            <Date>2024-08-28</Date>
             <Version>1.28.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/m/mate-control-center/abi_used_symbols
+++ b/packages/m/mate-control-center/abi_used_symbols
@@ -552,8 +552,8 @@ libglib-2.0.so.0:g_mutex_clear
 libglib-2.0.so.0:g_mutex_init
 libglib-2.0.so.0:g_mutex_lock
 libglib-2.0.so.0:g_mutex_unlock
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_group
 libglib-2.0.so.0:g_option_context_add_main_entries
 libglib-2.0.so.0:g_option_context_free

--- a/packages/m/mate-control-center/package.yml
+++ b/packages/m/mate-control-center/package.yml
@@ -1,6 +1,6 @@
 name       : mate-control-center
 version    : 1.28.0
-release    : 37
+release    : 38
 source     :
     - https://github.com/mate-desktop/mate-control-center/releases/download/v1.28.0/mate-control-center-1.28.0.tar.xz : ebf2c704fd5248dc2f9836ff29028869ef29d5054907cc615734b6383a7914bc
 homepage   : https://mate-desktop.org/
@@ -15,8 +15,8 @@ builddeps  :
     - pkgconfig(libcanberra-gtk3)
     - pkgconfig(libgtop-2.0)
     - pkgconfig(libmarco-private)
-    - pkgconfig(libmatekbd)
     - pkgconfig(libmate-menu)
+    - pkgconfig(libmatekbd)
     - pkgconfig(librsvg-2.0)
     - pkgconfig(mate-desktop-2.0)
     - pkgconfig(mate-settings-daemon)

--- a/packages/m/mate-control-center/pspec_x86_64.xml
+++ b/packages/m/mate-control-center/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mate-control-center</Name>
         <Homepage>https://mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.mate</PartOf>
@@ -2066,7 +2066,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="37">mate-control-center</Dependency>
+            <Dependency release="38">mate-control-center</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/lib64/pkgconfig/mate-default-applications.pc</Path>
@@ -2074,12 +2074,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="37">
-            <Date>2024-03-07</Date>
+        <Update release="38">
+            <Date>2024-08-28</Date>
             <Version>1.28.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/m/mate-desktop/abi_used_symbols
+++ b/packages/m/mate-desktop/abi_used_symbols
@@ -347,8 +347,8 @@ libglib-2.0.so.0:g_mutex_init
 libglib-2.0.so.0:g_mutex_lock
 libglib-2.0.so.0:g_mutex_unlock
 libglib-2.0.so.0:g_once_impl
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_group
 libglib-2.0.so.0:g_option_context_add_main_entries
 libglib-2.0.so.0:g_option_context_free

--- a/packages/m/mate-desktop/package.yml
+++ b/packages/m/mate-desktop/package.yml
@@ -1,6 +1,6 @@
 name       : mate-desktop
 version    : 1.28.2
-release    : 34
+release    : 35
 source     :
     - https://github.com/mate-desktop/mate-desktop/releases/download/v1.28.2/mate-desktop-1.28.2.tar.xz : 32bb4b792014b391c1e1b8ae9c18a82b4d447650984b4cba7d28e95564964aa2
 license    :
@@ -9,9 +9,12 @@ license    :
     - GFDL-1.1-or-later
 component  : desktop.mate
 homepage   : https://mate-desktop.org/
-summary    : Core library for MATE Desktop applications
-description: |
-    mate-desktop contains the libmate-desktop library, the mate-about program as well as some desktop-wide documents.
+summary    :
+    - Core library for MATE Desktop applications
+    - libs : Shared libraries for libmate-desktop
+description:
+    - Contains the libmate-desktop library, the mate-about program, as well as some desktop-wide documents.
+    - libs : Shared libraries for libmate-desktop
 builddeps  :
     - pkgconfig(dconf)
     - pkgconfig(gtk+-3.0)
@@ -20,6 +23,8 @@ builddeps  :
     - pkgconfig(libstartup-notification-1.0)
     - pkgconfig(x11)
     - mate-common
+rundeps    :
+    - mate-desktop-libs
 setup      : |
     %patch -p1 -i $pkgfiles/0001-Use-xapp-portal.patch
     %configure --disable-static \
@@ -29,3 +34,8 @@ build      : |
     %make
 install    : |
     %make_install
+patterns   :
+    - libs :
+        - /usr/lib64/girepository-1.0/MateDesktop-2.0.typelib
+        - /usr/lib64/libmate-desktop-2.so.*
+        - /usr/share/glib-2.0/schemas/org.mate.*.gschema.xml

--- a/packages/m/mate-desktop/pspec_x86_64.xml
+++ b/packages/m/mate-desktop/pspec_x86_64.xml
@@ -3,51 +3,31 @@
         <Name>mate-desktop</Name>
         <Homepage>https://mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.0-or-later</License>
         <License>GFDL-1.1-or-later</License>
         <PartOf>desktop.mate</PartOf>
         <Summary xml:lang="en">Core library for MATE Desktop applications</Summary>
-        <Description xml:lang="en">mate-desktop contains the libmate-desktop library, the mate-about program as well as some desktop-wide documents.
-</Description>
+        <Description xml:lang="en">Contains the libmate-desktop library, the mate-about program, as well as some desktop-wide documents.</Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>mate-desktop</Name>
         <Summary xml:lang="en">Core library for MATE Desktop applications</Summary>
-        <Description xml:lang="en">mate-desktop contains the libmate-desktop library, the mate-about program as well as some desktop-wide documents.
-</Description>
+        <Description xml:lang="en">Contains the libmate-desktop library, the mate-about program, as well as some desktop-wide documents.</Description>
         <PartOf>desktop.mate</PartOf>
+        <RuntimeDependencies>
+            <Dependency release="35">mate-desktop-libs</Dependency>
+        </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/mate-about</Path>
             <Path fileType="executable">/usr/bin/mate-color-select</Path>
-            <Path fileType="library">/usr/lib64/girepository-1.0/MateDesktop-2.0.typelib</Path>
-            <Path fileType="library">/usr/lib64/libmate-desktop-2.so.17</Path>
-            <Path fileType="library">/usr/lib64/libmate-desktop-2.so.17.1.4</Path>
             <Path fileType="data">/usr/share/applications/mate-about.desktop</Path>
             <Path fileType="data">/usr/share/applications/mate-color-select.desktop</Path>
             <Path fileType="data">/usr/share/gir-1.0/MateDesktop-2.0.gir</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.accessibility-keyboard.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.accessibility-startup.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.applications-at-mobility.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.applications-at-visual.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.applications-browser.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.applications-calculator.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.applications-messenger.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.applications-office.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.applications-terminal.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.background.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.debug.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.file-views.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.interface.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.lockdown.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.sound.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.thumbnail-cache.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.thumbnailers.gschema.xml</Path>
-            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.typing-break.gschema.xml</Path>
             <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/mate-desktop.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/16x16/apps/mate-desktop.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/22x22/apps/mate-desktop.png</Path>
@@ -184,11 +164,11 @@
     <Package>
         <Name>mate-desktop-devel</Name>
         <Summary xml:lang="en">Development files for mate-desktop</Summary>
-        <Description xml:lang="en">mate-desktop contains the libmate-desktop library, the mate-about program as well as some desktop-wide documents.
-</Description>
+        <Description xml:lang="en">Contains the libmate-desktop library, the mate-about program, as well as some desktop-wide documents.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="34">mate-desktop</Dependency>
+            <Dependency release="35">mate-desktop</Dependency>
+            <Dependency release="35">mate-desktop-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/mate-desktop-2.0/libmate-desktop/mate-bg-crossfade.h</Path>
@@ -214,8 +194,7 @@
     <Package>
         <Name>mate-desktop-docs</Name>
         <Summary xml:lang="en">Documentation for mate-desktop</Summary>
-        <Description xml:lang="en">mate-desktop contains the libmate-desktop library, the mate-about program as well as some desktop-wide documents.
-</Description>
+        <Description xml:lang="en">Contains the libmate-desktop library, the mate-about program, as well as some desktop-wide documents.</Description>
         <PartOf>programming.docs</PartOf>
         <Files>
             <Path fileType="doc">/usr/share/gtk-doc/html/mate-desktop/MateBG.html</Path>
@@ -250,13 +229,41 @@
             <Path fileType="doc">/usr/share/gtk-doc/html/mate-desktop/up.png</Path>
         </Files>
     </Package>
+    <Package>
+        <Name>mate-desktop-libs</Name>
+        <Summary xml:lang="en">Shared libraries for libmate-desktop</Summary>
+        <Description xml:lang="en">Shared libraries for libmate-desktop</Description>
+        <Files>
+            <Path fileType="library">/usr/lib64/girepository-1.0/MateDesktop-2.0.typelib</Path>
+            <Path fileType="library">/usr/lib64/libmate-desktop-2.so.17</Path>
+            <Path fileType="library">/usr/lib64/libmate-desktop-2.so.17.1.4</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.accessibility-keyboard.gschema.xml</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.accessibility-startup.gschema.xml</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.applications-at-mobility.gschema.xml</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.applications-at-visual.gschema.xml</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.applications-browser.gschema.xml</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.applications-calculator.gschema.xml</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.applications-messenger.gschema.xml</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.applications-office.gschema.xml</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.applications-terminal.gschema.xml</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.background.gschema.xml</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.debug.gschema.xml</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.file-views.gschema.xml</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.interface.gschema.xml</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.lockdown.gschema.xml</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.sound.gschema.xml</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.thumbnail-cache.gschema.xml</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.thumbnailers.gschema.xml</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.mate.typing-break.gschema.xml</Path>
+        </Files>
+    </Package>
     <History>
-        <Update release="34">
-            <Date>2024-03-25</Date>
+        <Update release="35">
+            <Date>2024-08-27</Date>
             <Version>1.28.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/m/mate-media/abi_used_symbols
+++ b/packages/m/mate-media/abi_used_symbols
@@ -117,8 +117,8 @@ libglib-2.0.so.0:g_list_free
 libglib-2.0.so.0:g_log
 libglib-2.0.so.0:g_malloc
 libglib-2.0.so.0:g_mkdir_with_parents
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_group
 libglib-2.0.so.0:g_option_context_free
 libglib-2.0.so.0:g_option_context_new

--- a/packages/m/mate-media/package.yml
+++ b/packages/m/mate-media/package.yml
@@ -1,6 +1,6 @@
 name       : mate-media
 version    : 1.28.1
-release    : 27
+release    : 28
 source     :
     - https://github.com/mate-desktop/mate-media/releases/download/v1.28.1/mate-media-1.28.1.tar.xz : bcdc102e22f63f55e63166d5c708e91c113570e6a30a874345a88609e83a9912
 homepage   : https://mate-desktop.org/

--- a/packages/m/mate-media/pspec_x86_64.xml
+++ b/packages/m/mate-media/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mate-media</Name>
         <Homepage>https://mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>GFDL-1.1-or-later</License>
@@ -211,12 +211,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2024-03-07</Date>
+        <Update release="28">
+            <Date>2024-08-28</Date>
             <Version>1.28.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/m/mate-notification-daemon/abi_used_symbols
+++ b/packages/m/mate-notification-daemon/abi_used_symbols
@@ -172,8 +172,8 @@ libglib-2.0.so.0:g_markup_escape_text
 libglib-2.0.so.0:g_memdup2
 libglib-2.0.so.0:g_mutex_clear
 libglib-2.0.so.0:g_mutex_init
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_group
 libglib-2.0.so.0:g_option_context_add_main_entries
 libglib-2.0.so.0:g_option_context_free

--- a/packages/m/mate-notification-daemon/package.yml
+++ b/packages/m/mate-notification-daemon/package.yml
@@ -1,6 +1,6 @@
 name       : mate-notification-daemon
 version    : 1.28.0
-release    : 18
+release    : 19
 source     :
     - https://github.com/mate-desktop/mate-notification-daemon/releases/download/v1.28.0/mate-notification-daemon-1.28.0.tar.xz : a4310348ead866cbcb9b4c463f4d265cc6a96a1a782a9411a08b23bd65dbb2e0
 homepage   : https://mate-desktop.org/

--- a/packages/m/mate-notification-daemon/pspec_x86_64.xml
+++ b/packages/m/mate-notification-daemon/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mate-notification-daemon</Name>
         <Homepage>https://mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.mate</PartOf>
@@ -154,12 +154,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2024-03-07</Date>
+        <Update release="19">
+            <Date>2024-08-28</Date>
             <Version>1.28.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/m/mate-panel/package.yml
+++ b/packages/m/mate-panel/package.yml
@@ -1,6 +1,6 @@
 name       : mate-panel
 version    : 1.28.2
-release    : 40
+release    : 41
 source     :
     - https://github.com/mate-desktop/mate-panel/releases/download/v1.28.2/mate-panel-1.28.2.tar.xz : 678a43e837aa2718494204fddf19bb906cf07e5d80fd2e1dde745f26d2adba33
 homepage   : https://mate-desktop.org/

--- a/packages/m/mate-panel/pspec_x86_64.xml
+++ b/packages/m/mate-panel/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mate-panel</Name>
         <Homepage>https://mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.0-or-later</License>
@@ -1108,7 +1108,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="40">mate-panel</Dependency>
+            <Dependency release="41">mate-panel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/mate-panel-4.0/libmate-panel-applet/mate-panel-applet-enums.h</Path>
@@ -1147,12 +1147,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="40">
-            <Date>2024-06-25</Date>
+        <Update release="41">
+            <Date>2024-08-27</Date>
             <Version>1.28.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/m/mate-power-manager/abi_used_symbols
+++ b/packages/m/mate-power-manager/abi_used_symbols
@@ -213,8 +213,8 @@ libglib-2.0.so.0:g_main_loop_unref
 libglib-2.0.so.0:g_malloc
 libglib-2.0.so.0:g_malloc0
 libglib-2.0.so.0:g_malloc0_n
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_group
 libglib-2.0.so.0:g_option_context_add_main_entries
 libglib-2.0.so.0:g_option_context_free

--- a/packages/m/mate-power-manager/package.yml
+++ b/packages/m/mate-power-manager/package.yml
@@ -1,6 +1,6 @@
 name       : mate-power-manager
 version    : 1.28.1
-release    : 24
+release    : 25
 source     :
     - https://github.com/mate-desktop/mate-power-manager/releases/download/v1.28.1/mate-power-manager-1.28.1.tar.xz : 8ebdcb74b607e868336ba9a8146cdef8f97bce535c2b0cb3bf650c58f71eee21
 homepage   : https://mate-desktop.org/

--- a/packages/m/mate-power-manager/pspec_x86_64.xml
+++ b/packages/m/mate-power-manager/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mate-power-manager</Name>
         <Homepage>https://mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.mate</PartOf>
@@ -2619,12 +2619,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2024-03-07</Date>
+        <Update release="25">
+            <Date>2024-08-28</Date>
             <Version>1.28.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/m/mate-screensaver/abi_used_symbols
+++ b/packages/m/mate-screensaver/abi_used_symbols
@@ -387,8 +387,8 @@ libglib-2.0.so.0:g_mkdir_with_parents
 libglib-2.0.so.0:g_mutex_init
 libglib-2.0.so.0:g_mutex_lock
 libglib-2.0.so.0:g_mutex_unlock
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_main_entries
 libglib-2.0.so.0:g_option_context_free
 libglib-2.0.so.0:g_option_context_new

--- a/packages/m/mate-screensaver/package.yml
+++ b/packages/m/mate-screensaver/package.yml
@@ -1,6 +1,6 @@
 name       : mate-screensaver
 version    : 1.28.0
-release    : 25
+release    : 26
 source     :
     - https://github.com/mate-desktop/mate-screensaver/releases/download/v1.28.0/mate-screensaver-1.28.0.tar.xz : 6a0f24a8f84a2f95e10114ab53e63fd4aca688a55fdc503ed650e0a410e3ea70
 license    :

--- a/packages/m/mate-screensaver/pspec_x86_64.xml
+++ b/packages/m/mate-screensaver/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mate-screensaver</Name>
         <Homepage>https://mate-desktop.org</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.0-or-later</License>
@@ -176,19 +176,19 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="25">mate-screensaver</Dependency>
+            <Dependency release="26">mate-screensaver</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/lib64/pkgconfig/mate-screensaver.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="25">
-            <Date>2024-03-07</Date>
+        <Update release="26">
+            <Date>2024-08-27</Date>
             <Version>1.28.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/m/mate-settings-daemon/abi_used_symbols
+++ b/packages/m/mate-settings-daemon/abi_used_symbols
@@ -469,8 +469,8 @@ libglib-2.0.so.0:g_markup_printf_escaped
 libglib-2.0.so.0:g_memdup2
 libglib-2.0.so.0:g_mutex_clear
 libglib-2.0.so.0:g_mutex_init
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_group
 libglib-2.0.so.0:g_option_context_add_main_entries
 libglib-2.0.so.0:g_option_context_free

--- a/packages/m/mate-settings-daemon/package.yml
+++ b/packages/m/mate-settings-daemon/package.yml
@@ -1,6 +1,6 @@
 name       : mate-settings-daemon
 version    : 1.28.0
-release    : 36
+release    : 37
 source     :
     - https://github.com/mate-desktop/mate-settings-daemon/releases/download/v1.28.0/mate-settings-daemon-1.28.0.tar.xz : 4ed7cdadaaa4c99efffc0282b8411703bb76e072c41c4b57989f8c5b40611a3a
 homepage   : https://mate-desktop.org/
@@ -12,11 +12,12 @@ summary    : MATE Settings Daemon
 description: |
     Settings Daemon for the MATE Desktop
 builddeps  :
+    - pkgconfig(dbus-glib-1)
     - pkgconfig(dconf)
     - pkgconfig(libcanberra-gtk3)
+    - pkgconfig(libmatekbd)
     - pkgconfig(libmatekbdui)
     - pkgconfig(libmatemixer)
-    - pkgconfig(libmatekbd)
     - pkgconfig(libnotify)
     - pkgconfig(libpulse)
     - pkgconfig(mate-desktop-2.0)

--- a/packages/m/mate-settings-daemon/pspec_x86_64.xml
+++ b/packages/m/mate-settings-daemon/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mate-settings-daemon</Name>
         <Homepage>https://mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -243,7 +243,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="36">mate-settings-daemon</Dependency>
+            <Dependency release="37">mate-settings-daemon</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/mate-settings-daemon/mate-settings-plugin.h</Path>
@@ -251,12 +251,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2024-03-07</Date>
+        <Update release="37">
+            <Date>2024-08-27</Date>
             <Version>1.28.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/m/mate-user-admin/package.yml
+++ b/packages/m/mate-user-admin/package.yml
@@ -1,6 +1,6 @@
 name       : mate-user-admin
 version    : 1.7.0
-release    : 9
+release    : 10
 source     :
     - https://github.com/zhuyaliang/user-admin/archive/refs/tags/v1.7.0.tar.gz : b4eb0783b382ed9405c76b765148d105dd113e20f66e61ad63d6fb7de7cafe1d
 homepage   : https://github.com/zhuyaliang/user-admin

--- a/packages/m/mate-user-admin/pspec_x86_64.xml
+++ b/packages/m/mate-user-admin/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mate-user-admin</Name>
         <Homepage>https://github.com/zhuyaliang/user-admin</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop.mate</PartOf>
@@ -160,12 +160,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2024-05-07</Date>
+        <Update release="10">
+            <Date>2024-08-27</Date>
             <Version>1.7.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/m/mate-utils/abi_used_symbols
+++ b/packages/m/mate-utils/abi_used_symbols
@@ -471,8 +471,8 @@ libglib-2.0.so.0:g_match_info_matches
 libglib-2.0.so.0:g_mkdir_with_parents
 libglib-2.0.so.0:g_mutex_lock
 libglib-2.0.so.0:g_mutex_unlock
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_group
 libglib-2.0.so.0:g_option_context_add_main_entries
 libglib-2.0.so.0:g_option_context_free

--- a/packages/m/mate-utils/package.yml
+++ b/packages/m/mate-utils/package.yml
@@ -1,6 +1,6 @@
 name       : mate-utils
 version    : 1.28.0
-release    : 27
+release    : 28
 source     :
     - https://github.com/mate-desktop/mate-utils/releases/download/v1.28.0/mate-utils-1.28.0.tar.xz : 58449d7a0d1d900ff03b78ca9f7e98c21e97f47fc26bee7ff1c61834f22f88d3
 homepage   : https://mate-desktop.org/

--- a/packages/m/mate-utils/pspec_x86_64.xml
+++ b/packages/m/mate-utils/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mate-utils</Name>
         <Homepage>https://mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GFDL-1.1-or-later</License>
         <License>GPL-2.0-or-later</License>
@@ -3300,7 +3300,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="27">mate-utils</Dependency>
+            <Dependency release="28">mate-utils</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/mate-dict/gdict/gdict-client-context.h</Path>
@@ -3361,12 +3361,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2024-03-07</Date>
+        <Update release="28">
+            <Date>2024-08-28</Date>
             <Version>1.28.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/p/pluma/abi_used_symbols
+++ b/packages/p/pluma/abi_used_symbols
@@ -438,8 +438,8 @@ libglib-2.0.so.0:g_match_info_next
 libglib-2.0.so.0:g_mkdir_with_parents
 libglib-2.0.so.0:g_mutex_lock
 libglib-2.0.so.0:g_mutex_unlock
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_group
 libglib-2.0.so.0:g_option_context_add_main_entries
 libglib-2.0.so.0:g_option_context_free

--- a/packages/p/pluma/package.yml
+++ b/packages/p/pluma/package.yml
@@ -1,6 +1,6 @@
 name       : pluma
 version    : 1.28.0
-release    : 33
+release    : 34
 source     :
     - https://github.com/mate-desktop/pluma/releases/download/v1.28.0/pluma-1.28.0.tar.xz : aa8adf9589345093a50e30b27ede4a78a2421d1727c27f465fc87c435965a1d4
 homepage   : https://mate-desktop.org/

--- a/packages/p/pluma/pspec_x86_64.xml
+++ b/packages/p/pluma/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pluma</Name>
         <Homepage>https://mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.mate</PartOf>
@@ -733,7 +733,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="33">pluma</Dependency>
+            <Dependency release="34">pluma</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/pluma/pluma-app-activatable.h</Path>
@@ -805,12 +805,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2024-03-07</Date>
+        <Update release="34">
+            <Date>2024-08-27</Date>
             <Version>1.28.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- **mate-desktop: Split libraries to separate package**
- **caja: Rebuild for mate-desktop**
- **eom: Rebuild for mate-desktop**
- **marco: Rebuild for mate-desktop**
- **mate-panel: Rebuild for mate-desktop**
- **mate-screensaver: Rebuild for mate-desktop**
- **mate-settings-daemon: Rebuild for mate-desktop**
- **mate-user-admin: Rebuild for mate-desktop**
- **pluma: Rebuild for mate-desktop**
- **atril: Rebuild for mate-desktop**
- **caja-extensions: Rebuild for mate-desktop**
- **mate-applets: Rebuild for mate-desktop**
- **mate-control-center: Rebuild for mate-desktop**
- **mate-media: Rebuild for mate-desktop**
- **mate-notification-daemon: Rebuild for mate-desktop**
- **mate-power-manager: Rebuild for mate-desktop**
- **mate-utils: Rebuild for mate-desktop**

Splits the `mate-package` between MATE Desktop specific bits, such as the About program, and the shared libraries. This enables packages like Engrampa to be installed without needlessly pulling in parts of MATE Desktop that it doesn't actually need.

**Test Plan**

Install Engrampa on Budgie Desktop and see that `mate-desktop` does not get installed.

**Checklist**

- [x] Package was built and tested against unstable
