### PR TITLE
scrcpy: Update to 2.6.1

### DIFF
--- a/packages/s/scrcpy/abi_used_symbols
+++ b/packages/s/scrcpy/abi_used_symbols
@@ -64,6 +64,7 @@ libSDL2-2.0.so.0:SDL_SetWindowFullscreen
 libSDL2-2.0.so.0:SDL_SetWindowIcon
 libSDL2-2.0.so.0:SDL_SetWindowPosition
 libSDL2-2.0.so.0:SDL_SetWindowSize
+libSDL2-2.0.so.0:SDL_SetYUVConversionMode
 libSDL2-2.0.so.0:SDL_ShowWindow
 libSDL2-2.0.so.0:SDL_UnlockAudioDevice
 libSDL2-2.0.so.0:SDL_UnlockMutex
@@ -80,7 +81,6 @@ libavcodec.so.60:av_packet_rescale_ts
 libavcodec.so.60:av_packet_side_data_new
 libavcodec.so.60:av_packet_unref
 libavcodec.so.60:avcodec_alloc_context3
-libavcodec.so.60:avcodec_close
 libavcodec.so.60:avcodec_find_decoder
 libavcodec.so.60:avcodec_find_encoder
 libavcodec.so.60:avcodec_free_context
@@ -161,6 +161,7 @@ libc.so.6:jrand48
 libc.so.6:kill
 libc.so.6:listen
 libc.so.6:malloc
+libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset

--- a/packages/s/scrcpy/package.yml
+++ b/packages/s/scrcpy/package.yml
@@ -1,9 +1,9 @@
 name       : scrcpy
-version    : 2.4
-release    : 26
+version    : 2.6.1
+release    : 27
 source     :
-    - https://github.com/Genymobile/scrcpy/archive/v2.4.tar.gz : 60596f6d4c11163083da3e6805666326873ed57f7defd8a20256b928a1d3503b
-    - https://github.com/Genymobile/scrcpy/releases/download/v2.4/scrcpy-server-v2.4 : 93c272b7438605c055e127f7444064ed78fa9ca49f81156777fd201e79ce7ba3
+    - https://github.com/Genymobile/scrcpy/archive/v2.6.1.tar.gz : 4948474f1494fdff852a0a7fa823a0b3c25d3ea0384acdaf46c322e34b13e449
+    - https://github.com/Genymobile/scrcpy/releases/download/v2.6.1/scrcpy-server-v2.6.1 : ca7ab50b2e25a0e5af7599c30383e365983fa5b808e65ce2e1c1bba5bfe8dc3b
 homepage   : https://github.com/Genymobile/scrcpy
 license    : Apache-2.0
 component  : network.util

--- a/packages/s/scrcpy/pspec_x86_64.xml
+++ b/packages/s/scrcpy/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>scrcpy</Name>
         <Homepage>https://github.com/Genymobile/scrcpy</Homepage>
         <Packager>
-            <Name>Mislav &#x10c;akari&#x107;</Name>
-            <Email>mcakaric@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>network.util</PartOf>
@@ -31,12 +31,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2024-05-22</Date>
-            <Version>2.4</Version>
+        <Update release="27">
+            <Date>2024-08-29</Date>
+            <Version>2.6.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Mislav &#x10c;akari&#x107;</Name>
-            <Email>mcakaric@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Highlighted changes:
- Control-only option
- Pause/unpause display
- Mouse hover
- Mouse bindings
- Audio mirroring
- Secondary mouse bindings

Full release notes:
- [2.5](https://github.com/Genymobile/scrcpy/releases/tag/v2.5)
- [2.6](https://github.com/Genymobile/scrcpy/releases/tag/v2.6)
- [2.6.1](https://github.com/Genymobile/scrcpy/releases/tag/v2.6.1)

**Test Plan**

Succesfully mirrored my phone's screen
(Note: can't currently test mouse control of device due to a Xiaomi bug)

**Checklist**

- [x] Package was built and tested against unstable
