### PR TITLE
mbedtls: Update to 2.28.9

### DIFF
--- a/packages/m/mbedtls/files/0001-Fix-calloc-argument-order.patch
+++ b/packages/m/mbedtls/files/0001-Fix-calloc-argument-order.patch
@@ -1,0 +1,50 @@
+From a25edabaa0b645676b52d066a648908b58fa342d Mon Sep 17 00:00:00 2001
+From: Thomas Staudinger <Staudi.Kaos@gmail.com>
+Date: Fri, 30 Aug 2024 21:33:04 +0200
+Subject: [PATCH] Fix calloc argument order
+
+Signed-off-by: Thomas Staudinger <Staudi.Kaos@gmail.com>
+---
+ tests/include/test/macros.h | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/tests/include/test/macros.h b/tests/include/test/macros.h
+index 894fc6727..56cc6680f 100644
+--- a/tests/include/test/macros.h
++++ b/tests/include/test/macros.h
+@@ -135,8 +135,8 @@
+     do {                                                    \
+         TEST_ASSERT((pointer) == NULL);                     \
+         if ((item_count) != 0) {                            \
+-            (pointer) = mbedtls_calloc(sizeof(*(pointer)),  \
+-                                       (item_count));       \
++            (pointer) = mbedtls_calloc((item_count),        \
++                                        sizeof(*(pointer)));\
+             TEST_ASSERT((pointer) != NULL);                 \
+         }                                                   \
+     } while (0)
+@@ -165,8 +165,8 @@
+ #define TEST_CALLOC_NONNULL(pointer, item_count)            \
+     do {                                                    \
+         TEST_ASSERT((pointer) == NULL);                     \
+-        (pointer) = mbedtls_calloc(sizeof(*(pointer)),      \
+-                                   (item_count));           \
++        (pointer) = mbedtls_calloc((item_count),            \
++                                    sizeof(*(pointer)));    \
+         if (((pointer) == NULL) && ((item_count) == 0)) {   \
+             (pointer) = mbedtls_calloc(1, 1);               \
+         }                                                   \
+@@ -185,8 +185,8 @@
+     do {                                                    \
+         TEST_ASSERT((pointer) == NULL);                     \
+         if ((item_count) != 0) {                            \
+-            (pointer) = mbedtls_calloc(sizeof(*(pointer)),  \
+-                                       (item_count));       \
++            (pointer) = mbedtls_calloc((item_count),        \
++                                        sizeof(*(pointer)));\
+             TEST_ASSUME((pointer) != NULL);                 \
+         }                                                   \
+     } while (0)
+-- 
+2.46.0
+

--- a/packages/m/mbedtls/package.yml
+++ b/packages/m/mbedtls/package.yml
@@ -1,8 +1,8 @@
 name       : mbedtls
-version    : 2.28.8
-release    : 14
+version    : 2.28.9
+release    : 15
 source     :
-    - https://github.com/Mbed-TLS/mbedtls/archive/mbedtls-2.28.8.tar.gz : 98b91415d86311b9c08f383906f58332429605895b53bb598d61b0bc29128a1d
+    - https://github.com/Mbed-TLS/mbedtls/archive/mbedtls-2.28.9.tar.gz : 53231b898f908dde38879bf27a29ddf670dee252dec37681f2c1f83588c0c40e
 homepage   : https://www.trustedfirmware.org/projects/mbed-tls/
 license    :
     - GPL-2.0-or-later
@@ -14,6 +14,8 @@ description: |
 setup      : |
     # Don't include third-party headers
     %patch -Rp1 -i $pkgfiles/revert-unconditional-third-party.patch
+    # Fix build with GCC 14
+    %patch -p1 -i $pkgfiles/0001-Fix-calloc-argument-order.patch
 
     %cmake -DENABLE_PROGRAMS=OFF \
            -DENABLE_ZLIB_SUPPORT=ON \

--- a/packages/m/mbedtls/pspec_x86_64.xml
+++ b/packages/m/mbedtls/pspec_x86_64.xml
@@ -21,12 +21,12 @@
 </Description>
         <PartOf>programming.library</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib64/libmbedcrypto.so.2.28.8</Path>
+            <Path fileType="library">/usr/lib64/libmbedcrypto.so.2.28.9</Path>
             <Path fileType="library">/usr/lib64/libmbedcrypto.so.7</Path>
             <Path fileType="library">/usr/lib64/libmbedtls.so.14</Path>
-            <Path fileType="library">/usr/lib64/libmbedtls.so.2.28.8</Path>
+            <Path fileType="library">/usr/lib64/libmbedtls.so.2.28.9</Path>
             <Path fileType="library">/usr/lib64/libmbedx509.so.1</Path>
-            <Path fileType="library">/usr/lib64/libmbedx509.so.2.28.8</Path>
+            <Path fileType="library">/usr/lib64/libmbedx509.so.2.28.9</Path>
         </Files>
     </Package>
     <Package>
@@ -36,7 +36,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="14">mbedtls</Dependency>
+            <Dependency release="15">mbedtls</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/mbedtls/aes.h</Path>
@@ -144,9 +144,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2024-06-09</Date>
-            <Version>2.28.8</Version>
+        <Update release="15">
+            <Date>2024-08-30</Date>
+            <Version>2.28.9</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- CTR_DRBG prioritized over HMAC_DRBG as the PSA DRBG
- Fix the build in some configurations when check_config.h is not included
- Fix issue of redefinition warning messages for _GNU_SOURCE in entropy_poll.c and sha_256.c
- Fix error handling when creating a key in a dynamic secure element
- Fix a memory leak that could occur when failing to process an RSA key through some PSA functions due to low memory conditions
- Document and enforce the limitation of mbedtls_psa_register_se_key() to persistent keys

Full release notes available [here](https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-2.28.9)

**Security**
Includes fixes for:
- CVE-2024-45157

**Test Plan**

Rebuilt and used `dolphin-emu` with this version

**Checklist**

- [x] Package was built and tested against unstable
