### PR TITLE
flask-cors: Update to 4.0.2

### DIFF
--- a/packages/f/flask-cors/package.yml
+++ b/packages/f/flask-cors/package.yml
@@ -1,8 +1,8 @@
 name       : flask-cors
-version    : 4.0.1
-release    : 10
+version    : 4.0.2
+release    : 11
 source     :
-    - https://github.com/corydolphin/flask-cors/archive/refs/tags/4.0.1.tar.gz : 2f1016334ac5e1234feb9e1408cabd9bfd1038d2128e94a9e28539542d846344
+    - https://github.com/corydolphin/flask-cors/archive/refs/tags/4.0.2.tar.gz : f252679632d1a6c6f5c628d271bdbf3def30fea07c86aea6b7227dda07b83795
 license    : MIT
 homepage   : https://flask-cors.corydolphin.com/
 component  : programming.python

--- a/packages/f/flask-cors/pspec_x86_64.xml
+++ b/packages/f/flask-cors/pspec_x86_64.xml
@@ -20,12 +20,12 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/Flask_Cors-4.0.1-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/Flask_Cors-4.0.1-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/Flask_Cors-4.0.1-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/Flask_Cors-4.0.1-py3.11.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/Flask_Cors-4.0.1-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/Flask_Cors-4.0.1-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/Flask_Cors-4.0.2-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/Flask_Cors-4.0.2-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/Flask_Cors-4.0.2-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/Flask_Cors-4.0.2-py3.11.egg-info/not-zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/Flask_Cors-4.0.2-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/Flask_Cors-4.0.2-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/flask_cors/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/flask_cors/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/flask_cors/__pycache__/core.cpython-311.pyc</Path>
@@ -39,9 +39,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2024-06-09</Date>
-            <Version>4.0.1</Version>
+        <Update release="11">
+            <Date>2024-08-30</Date>
+            <Version>4.0.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Backwards Compatible Fix for CVE-2024-6221
- Add unit tests for Private-Network

**Security**
Includes fixes for:
- CVE-2024-6221

**Test Plan**

Executed some example from the project's README

**Checklist**

- [x] Package was built and tested against unstable
