### PR TITLE
acpica-unix: Update to 20240827

### DIFF
--- a/packages/a/acpica-unix/abi_used_symbols
+++ b/packages/a/acpica-unix/abi_used_symbols
@@ -3,7 +3,9 @@ libc.so.6:__ctype_tolower_loc
 libc.so.6:__ctype_toupper_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoul
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__printf_chk
@@ -85,12 +87,9 @@ libc.so.6:strnlen
 libc.so.6:strrchr
 libc.so.6:strstr
 libc.so.6:strtok
-libc.so.6:strtol
-libc.so.6:strtoul
 libc.so.6:sysconf
 libc.so.6:tcgetattr
 libc.so.6:tcsetattr
 libc.so.6:time
 libc.so.6:ungetc
 libc.so.6:usleep
-libc.so.6:wcslen

--- a/packages/a/acpica-unix/package.yml
+++ b/packages/a/acpica-unix/package.yml
@@ -1,8 +1,8 @@
 name       : acpica-unix
-version    : '20230628'
-release    : 8
+version    : '20240827'
+release    : 9
 source     :
-    - https://github.com/acpica/acpica/archive/refs/tags/R06_28_23.tar.gz : 2248799b7ca08a7711ac87d31924354ed49047507607d033bd327ba861ec4d31
+    - https://github.com/acpica/acpica/archive/refs/tags/version-20240827.tar.gz : fe5b043d83521d489246c8e8f9a32aed24f9dfddf3e676453fe5d3bd0316a740
 license    : GPL-2.0-or-later
 homepage   : https://www.intel.com/content/www/us/en/developer/topic-technology/open/acpica/overview.html
 component  : programming.tools

--- a/packages/a/acpica-unix/pspec_x86_64.xml
+++ b/packages/a/acpica-unix/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>acpica-unix</Name>
         <Homepage>https://www.intel.com/content/www/us/en/developer/topic-technology/open/acpica/overview.html</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>programming.tools</PartOf>
         <Summary xml:lang="en">ACPI Source Code Compiler &amp; Disassembler</Summary>
         <Description xml:lang="en">ACPICA defines and implements a group of software components that together create an implementation of the ACPI specification for both 32-bit and 64-bit platforms.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>acpica-unix</Name>
@@ -31,12 +31,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2023-07-21</Date>
-            <Version>20230628</Version>
+        <Update release="9">
+            <Date>2024-08-31</Date>
+            <Version>20240827</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Changelog available [here](https://github.com/acpica/acpica/blob/master/documents/changes.txt)

**Test Plan**

- Hex-dump a random executable


**Checklist**

- [x] Package was built and tested against unstable
