### PR TITLE
noto-sans-ttf: Update to 24.9.1

### DIFF
--- a/packages/n/noto-sans-ttf/package.yml
+++ b/packages/n/noto-sans-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : noto-sans-ttf
-version    : 24.8.1
-release    : 31
+version    : 24.9.1
+release    : 32
 source     :
-    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-24.8.1.tar.gz : 84d292fc934ad6a9f20705fdfa5764b81b456b0e733f98b6f44388fb8c8eb44a
+    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-24.9.1.tar.gz : 73fc256356e4ed66c54aa300a71c390695603547e127f27cd6eefdeb942726b0
     - https://github.com/googlefonts/noto-emoji/archive/refs/tags/v2.042.tar.gz : b56bd2fa4029d0f057b66b742ac59af243dbc91067fed3eb4929dac762440fc9
 homepage   : https://fonts.google.com/noto
 extract    : no

--- a/packages/n/noto-sans-ttf/pspec_x86_64.xml
+++ b/packages/n/noto-sans-ttf/pspec_x86_64.xml
@@ -1538,9 +1538,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2024-08-03</Date>
-            <Version>24.8.1</Version>
+        <Update release="32">
+            <Date>2024-09-01</Date>
+            <Version>24.9.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Full commit log available [here](https://github.com/notofonts/notofonts.github.io/compare/noto-monthly-release-24.8.1...noto-monthly-release-24.9.1)

**Test Plan**
- Confirmed my system UI looks correct with Noto system fonts
- Wrote some text with Noto Sans/Serif in LibreOffice

**Checklist**

- [x] Package was built and tested against unstable
