### PR TITLE
ufw: Fix permissions

### DIFF
--- a/packages/u/ufw/package.yml
+++ b/packages/u/ufw/package.yml
@@ -1,6 +1,6 @@
 name       : ufw
 version    : 0.36.2
-release    : 15
+release    : 16
 source     :
     - https://launchpad.net/ufw/0.36/0.36.2/+download/ufw-0.36.2.tar.gz : 2a57a99eecef6b44db3537ed2520b30bae3759f8465456e22e404cd643838bf5
 homepage   : https://launchpad.net/ufw
@@ -22,7 +22,7 @@ install    : |
     chmod -R 00644 $installdir/etc/ufw/* \
                    $installdir/etc/default/ufw \
                    $installdir/%libdir%/ufw/*
-    chmod 00744 $installdir/usr/sbin/ufw $installdir/%libdir%/ufw/ufw-init
+    chmod 00755 $installdir/usr/sbin/ufw $installdir/%libdir%/ufw/ufw-init
 
     install -Dm00644 shell-completion/bash $installdir/usr/share/bash-completion/completions/ufw
     install -Dm00644 $pkgfiles/ufw.service $installdir/%libdir%/systemd/system/ufw.service

--- a/packages/u/ufw/pspec_x86_64.xml
+++ b/packages/u/ufw/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ufw</Name>
         <Homepage>https://launchpad.net/ufw</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>GPL-3.0-only</License>
@@ -120,12 +120,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2024-02-17</Date>
+        <Update release="16">
+            <Date>2024-09-03</Date>
             <Version>0.36.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Fix apparent packaging error.

Resolves getsolus/packages#3738

**Test Plan**

- Make sure users can not enable / disable ufw or modify firewall rules without sudo.
- Sanity check other distributions permissions for ufw.
- Confirm bash completions now work with ufw.

**Checklist**

- [x] Package was built and tested against unstable
