### PR TITLE
pueue: Update to 3.4.1, switch to cargo macros

### DIFF
--- a/packages/p/pueue/abi_used_symbols
+++ b/packages/p/pueue/abi_used_symbols
@@ -1,4 +1,3 @@
-libc.so.6:__environ
 libc.so.6:__errno_location
 libc.so.6:__libc_start_main
 libc.so.6:__register_atfork
@@ -37,6 +36,7 @@ libc.so.6:fstat64
 libc.so.6:fstatat64
 libc.so.6:gai_strerror
 libc.so.6:getaddrinfo
+libc.so.6:getauxval
 libc.so.6:getcwd
 libc.so.6:getenv
 libc.so.6:geteuid
@@ -53,11 +53,9 @@ libc.so.6:localtime_r
 libc.so.6:lseek64
 libc.so.6:lstat64
 libc.so.6:malloc
-libc.so.6:memchr
 libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
-libc.so.6:memrchr
 libc.so.6:memset
 libc.so.6:mkdir
 libc.so.6:mmap64
@@ -111,7 +109,6 @@ libc.so.6:sendmsg
 libc.so.6:setgid
 libc.so.6:setgroups
 libc.so.6:setpgid
-libc.so.6:setsid
 libc.so.6:setsockopt
 libc.so.6:setuid
 libc.so.6:shutdown

--- a/packages/p/pueue/package.yml
+++ b/packages/p/pueue/package.yml
@@ -1,8 +1,8 @@
 name       : pueue
-version    : 3.4.0
-release    : 9
+version    : 3.4.1
+release    : 10
 source     :
-    - https://github.com/Nukesor/pueue/archive/refs/tags/v3.4.0.tar.gz : 8468ff4d515d976607fc549c5eb994fa4f7d2ccdf47523561e34d778aa8d083e
+    - https://github.com/Nukesor/pueue/archive/refs/tags/v3.4.1.tar.gz : 868710de128db49e0a0c4ddee127dfc0e19b20cbdfd4a9d53d5ed792c5538244
 license    : MIT
 component  : system.utils
 homepage   : https://github.com/nukesor/pueue
@@ -13,10 +13,9 @@ builddeps  :
     - rust
 networking : yes
 setup      : |
-    cargo fetch --locked
+    %cargo_fetch
 build      : |
-    cargo build --frozen --release
-
+    %cargo_build 
     # Generate completions
     mkdir -p utils/completions/
     ./target/release/pueue completions bash utils/completions/
@@ -24,8 +23,8 @@ build      : |
     ./target/release/pueue completions zsh utils/completions/
 install    : |
     # Binaries
-    install -Dm00755 target/release/pueue $installdir/usr/bin/pueue
-    install -Dm00755 target/release/pueued $installdir/usr/bin/pueued
+    %cargo_install pueue
+    %cargo_install pueued
 
     # Systemd service
     install -Dm00644 utils/pueued.service $installdir/%libdir%/systemd/user/pueued.service
@@ -35,4 +34,4 @@ install    : |
     install -Dm00644 utils/completions/_pueue $installdir/usr/share/zsh/site-functions/_pueue
     install -Dm00644 utils/completions/pueue.fish $installdir/usr/share/fish/vendor_completions.d/pueue.fish
 check      : |
-    cargo test --frozen
+    %cargo_test

--- a/packages/p/pueue/pspec_x86_64.xml
+++ b/packages/p/pueue/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pueue</Name>
         <Homepage>https://github.com/nukesor/pueue</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -29,12 +29,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2024-04-25</Date>
-            <Version>3.4.0</Version>
+        <Update release="10">
+            <Date>2024-09-03</Date>
+            <Version>3.4.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Changelog [here](https://github.com/Nukesor/pueue/releases/tag/v3.4.1)

**Packaging**

- Switch to cargo macros
- Part of https://github.com/getsolus/packages/issues/3111

**Test Plan**

- Start pueue and queue a command

**Checklist**

- [x] Package was built and tested against unstable
