### PR TITLE
dcfldd: Change source, Update to 1.9.1

### DIFF
--- a/packages/d/dcfldd/abi_used_symbols
+++ b/packages/d/dcfldd/abi_used_symbols
@@ -1,3 +1,4 @@
+libc.so.6:__asprintf_chk
 libc.so.6:__assert_fail
 libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_tolower_loc
@@ -12,7 +13,6 @@ libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__vfprintf_chk
 libc.so.6:_exit
-libc.so.6:asprintf
 libc.so.6:close
 libc.so.6:difftime
 libc.so.6:dup2
@@ -43,7 +43,9 @@ libc.so.6:memset
 libc.so.6:open64
 libc.so.6:opterr
 libc.so.6:optind
+libc.so.6:pclose
 libc.so.6:pipe
+libc.so.6:popen
 libc.so.6:putc
 libc.so.6:puts
 libc.so.6:read

--- a/packages/d/dcfldd/monitoring.yml
+++ b/packages/d/dcfldd/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 5455
+  rss: https://github.com/resurrecting-open-source-projects/dcfldd/releases.atom
+# No known CPE, checked 2024-09-05
+security:
+  cpe: ~

--- a/packages/d/dcfldd/package.yml
+++ b/packages/d/dcfldd/package.yml
@@ -1,16 +1,16 @@
 name       : dcfldd
-version    : 1.3.4.1
-release    : 7
+version    : 1.9.1
+release    : 8
 source     :
-    - https://sourceforge.net/projects/dcfldd/files/dcfldd/1.3.4-1/dcfldd-1.3.4-1.tar.gz : f5143a184da56fd5ac729d6d8cbcf9f5da8e1cf4604aa9fb97c59553b7e6d5f8
-homepage   : http://dcfldd.sourceforge.net
-license    : GPL-2.0
+    - https://github.com/resurrecting-open-source-projects/dcfldd/archive/refs/tags/v1.9.1.tar.gz : efb9406b7186cbe6c3edf8ff438ff37c915b21dad026bd27ee4f4cc5a6644bd8
+homepage   : https://github.com/resurrecting-open-source-projects/dcfldd
+license    : GPL-2.0-or-later
 component  : system.utils
 summary    : dcfldd - enhanced version of dd or forensics and security
 description: |
     dd copies a file with a changeable I/O block size, while optionally performing conversions on it
 setup      : |
-    %configure
+    %reconfigure
 build      : |
     %make
 install    : |

--- a/packages/d/dcfldd/pspec_x86_64.xml
+++ b/packages/d/dcfldd/pspec_x86_64.xml
@@ -1,17 +1,17 @@
 <PISI>
     <Source>
         <Name>dcfldd</Name>
-        <Homepage>http://dcfldd.sourceforge.net</Homepage>
+        <Homepage>https://github.com/resurrecting-open-source-projects/dcfldd</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
-        <License>GPL-2.0</License>
+        <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">dcfldd - enhanced version of dd or forensics and security</Summary>
         <Description xml:lang="en">dd copies a file with a changeable I/O block size, while optionally performing conversions on it
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>dcfldd</Name>
@@ -25,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2021-06-24</Date>
-            <Version>1.3.4.1</Version>
+        <Update release="8">
+            <Date>2024-09-05</Date>
+            <Version>1.9.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Contributors to the old SourceForge source are inactive, other distros have moved to this fork
- Post-fork changelog available [here](https://github.com/resurrecting-open-source-projects/dcfldd/blob/master/ChangeLog)

**Test Plan**

- Copy a small partition, generate hash

**Checklist**

- [x] Package was built and tested against unstable
