### PR TITLE
python-pikepdf: Update to v9

### DIFF
--- a/packages/py/pybind11/monitoring.yml
+++ b/packages/py/pybind11/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 13384
+  rss: https://github.com/pybind/pybind11/tags.atom
+# No known CPE, checked 2024-09-06
+security:
+  cpe: ~

--- a/packages/py/pybind11/package.yml
+++ b/packages/py/pybind11/package.yml
@@ -1,8 +1,8 @@
 name       : pybind11
-version    : 2.11.1
-release    : 9
+version    : 2.13.5
+release    : 10
 source     :
-    - https://github.com/pybind/pybind11/archive/refs/tags/v2.11.1.tar.gz : d475978da0cdc2d43b73f30910786759d593a9d8ee05b1b6846d1eb16c6d2e0c
+    - https://github.com/pybind/pybind11/archive/refs/tags/v2.13.5.tar.gz : b1e209c42b3a9ed74da3e0b25a4f4cd478d89d5efbb48f04b277df427faf6252
 homepage   : https://github.com/pybind/pybind11
 license    : BSD-3-Clause
 component  : programming.python
@@ -13,11 +13,12 @@ patterns   :
     - /usr/include
     - /usr/share
 builddeps  :
-    - pkgconfig(eigen3)  # check
     - pkgconfig(python3)
     - libboost-devel
-    - python-pytest      # check
-    - scipy              # check
+checkdeps  :
+    - pkgconfig(eigen3)
+    - python-pytest
+    - scipy
 setup      : |
     mkdir -p build && pushd build
     %cmake ..

--- a/packages/py/pybind11/pspec_x86_64.xml
+++ b/packages/py/pybind11/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pybind11</Name>
         <Homepage>https://github.com/pybind/pybind11</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Algent Albrahimi</Name>
+            <Email>algent@protonmail.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -34,6 +34,7 @@
             <Path fileType="header">/usr/include/pybind11/detail/internals.h</Path>
             <Path fileType="header">/usr/include/pybind11/detail/type_caster_base.h</Path>
             <Path fileType="header">/usr/include/pybind11/detail/typeid.h</Path>
+            <Path fileType="header">/usr/include/pybind11/detail/value_and_holder.h</Path>
             <Path fileType="header">/usr/include/pybind11/eigen.h</Path>
             <Path fileType="header">/usr/include/pybind11/eigen/common.h</Path>
             <Path fileType="header">/usr/include/pybind11/eigen/matrix.h</Path>
@@ -42,6 +43,7 @@
             <Path fileType="header">/usr/include/pybind11/eval.h</Path>
             <Path fileType="header">/usr/include/pybind11/functional.h</Path>
             <Path fileType="header">/usr/include/pybind11/gil.h</Path>
+            <Path fileType="header">/usr/include/pybind11/gil_safe_call_once.h</Path>
             <Path fileType="header">/usr/include/pybind11/iostream.h</Path>
             <Path fileType="header">/usr/include/pybind11/numpy.h</Path>
             <Path fileType="header">/usr/include/pybind11/operators.h</Path>
@@ -52,13 +54,14 @@
             <Path fileType="header">/usr/include/pybind11/stl/filesystem.h</Path>
             <Path fileType="header">/usr/include/pybind11/stl_bind.h</Path>
             <Path fileType="header">/usr/include/pybind11/type_caster_pyobject_ptr.h</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11-2.11.1-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11-2.11.1-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11-2.11.1-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11-2.11.1-py3.11.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11-2.11.1-py3.11.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11-2.11.1-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11-2.11.1-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="header">/usr/include/pybind11/typing.h</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11-2.13.5-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11-2.13.5-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11-2.13.5-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11-2.13.5-py3.11.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11-2.13.5-py3.11.egg-info/not-zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11-2.13.5-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11-2.13.5-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/__pycache__/__init__.cpython-311.pyc</Path>
@@ -81,6 +84,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/include/pybind11/detail/internals.h</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/include/pybind11/detail/type_caster_base.h</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/include/pybind11/detail/typeid.h</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/include/pybind11/detail/value_and_holder.h</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/include/pybind11/eigen.h</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/include/pybind11/eigen/common.h</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/include/pybind11/eigen/matrix.h</Path>
@@ -89,6 +93,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/include/pybind11/eval.h</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/include/pybind11/functional.h</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/include/pybind11/gil.h</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/include/pybind11/gil_safe_call_once.h</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/include/pybind11/iostream.h</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/include/pybind11/numpy.h</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/include/pybind11/operators.h</Path>
@@ -99,12 +104,14 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/include/pybind11/stl/filesystem.h</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/include/pybind11/stl_bind.h</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/include/pybind11/type_caster_pyobject_ptr.h</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/include/pybind11/typing.h</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/py.typed</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/setup_helpers.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/share/cmake/pybind11/FindPythonLibsNew.cmake</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/share/cmake/pybind11/pybind11Common.cmake</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/share/cmake/pybind11/pybind11Config.cmake</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/share/cmake/pybind11/pybind11ConfigVersion.cmake</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/share/cmake/pybind11/pybind11GuessPythonExtSuffix.cmake</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/share/cmake/pybind11/pybind11NewTools.cmake</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/share/cmake/pybind11/pybind11Targets.cmake</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pybind11/share/cmake/pybind11/pybind11Tools.cmake</Path>
@@ -113,6 +120,7 @@
             <Path fileType="data">/usr/share/cmake/pybind11/pybind11Common.cmake</Path>
             <Path fileType="data">/usr/share/cmake/pybind11/pybind11Config.cmake</Path>
             <Path fileType="data">/usr/share/cmake/pybind11/pybind11ConfigVersion.cmake</Path>
+            <Path fileType="data">/usr/share/cmake/pybind11/pybind11GuessPythonExtSuffix.cmake</Path>
             <Path fileType="data">/usr/share/cmake/pybind11/pybind11NewTools.cmake</Path>
             <Path fileType="data">/usr/share/cmake/pybind11/pybind11Targets.cmake</Path>
             <Path fileType="data">/usr/share/cmake/pybind11/pybind11Tools.cmake</Path>
@@ -120,12 +128,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2024-02-14</Date>
-            <Version>2.11.1</Version>
+        <Update release="10">
+            <Date>2024-09-06</Date>
+            <Version>2.13.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Algent Albrahimi</Name>
+            <Email>algent@protonmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/py/python-pikepdf/abi_used_libs
+++ b/packages/py/python-pikepdf/abi_used_libs
@@ -1,4 +1,5 @@
 UNKNOWN
+ld-linux-x86-64.so.2
 libc.so.6
 libgcc_s.so.1
 libm.so.6

--- a/packages/py/python-pikepdf/abi_used_symbols
+++ b/packages/py/python-pikepdf/abi_used_symbols
@@ -19,6 +19,7 @@ UNKNOWN:PyCapsule_New
 UNKNOWN:PyCapsule_SetContext
 UNKNOWN:PyCapsule_SetPointer
 UNKNOWN:PyCapsule_Type
+UNKNOWN:PyCode_GetVarnames
 UNKNOWN:PyDict_Contains
 UNKNOWN:PyDict_Copy
 UNKNOWN:PyDict_DelItemString
@@ -48,6 +49,7 @@ UNKNOWN:PyExc_AttributeError
 UNKNOWN:PyExc_BufferError
 UNKNOWN:PyExc_DeprecationWarning
 UNKNOWN:PyExc_Exception
+UNKNOWN:PyExc_FutureWarning
 UNKNOWN:PyExc_ImportError
 UNKNOWN:PyExc_IndexError
 UNKNOWN:PyExc_KeyError
@@ -70,6 +72,7 @@ UNKNOWN:PyFloat_Type
 UNKNOWN:PyFrame_GetBack
 UNKNOWN:PyFrame_GetCode
 UNKNOWN:PyFrame_GetLineNumber
+UNKNOWN:PyGILState_Check
 UNKNOWN:PyGILState_Ensure
 UNKNOWN:PyGILState_GetThisThreadState
 UNKNOWN:PyGILState_Release
@@ -179,10 +182,14 @@ UNKNOWN:_Py_FalseStruct
 UNKNOWN:_Py_NoneStruct
 UNKNOWN:_Py_NotImplementedStruct
 UNKNOWN:_Py_TrueStruct
+ld-linux-x86-64.so.2:__tls_get_addr
+libc.so.6:__assert_fail
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
+libc.so.6:__fprintf_chk
 libc.so.6:__libc_single_threaded
 libc.so.6:__stack_chk_fail
+libc.so.6:fflush
 libc.so.6:free
 libc.so.6:isupper
 libc.so.6:memchr
@@ -190,6 +197,8 @@ libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset
+libc.so.6:pthread_once
+libc.so.6:stderr
 libc.so.6:strchr
 libc.so.6:strcmp
 libc.so.6:strdup
@@ -290,7 +299,6 @@ libqpdf.so.29:_ZN16QPDFObjectHandle16newUnicodeStringERKNSt7__cxx1112basic_strin
 libqpdf.so.29:_ZN16QPDFObjectHandle17parsePageContentsEPNS_15ParserCallbacksE
 libqpdf.so.29:_ZN16QPDFObjectHandle17replaceStreamDataERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS_S9_
 libqpdf.so.29:_ZN16QPDFObjectHandle18parseContentStreamES_PNS_15ParserCallbacksE
-libqpdf.so.29:_ZN16QPDFObjectHandle19getArrayAsRectangleEv
 libqpdf.so.29:_ZN16QPDFObjectHandle19getInlineImageValueB5cxx11Ev
 libqpdf.so.29:_ZN16QPDFObjectHandle5parseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES7_
 libqpdf.so.29:_ZN16QPDFObjectHandle6aitemsEv
@@ -523,11 +531,16 @@ libqpdf.so.29:_ZlsRSoRK10QPDFObjGen
 libstdc++.so.6:_ZNKSt13runtime_error4whatEv
 libstdc++.so.6:_ZNKSt5ctypeIcE13_M_widen_initEv
 libstdc++.so.6:_ZNKSt6locale2id5_M_idEv
+libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE13find_first_ofEPKcm
+libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE16find_last_not_ofEPKcmm
+libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE17find_first_not_ofEPKcmm
+libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEPKcm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEcm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE5rfindEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE3strEv
 libstdc++.so.6:_ZNKSt8__detail20_Prime_rehash_policy14_M_need_rehashEmmm
+libstdc++.so.6:_ZNSdD2Ev
 libstdc++.so.6:_ZNSi10_M_extractIlEERSiRT_
 libstdc++.so.6:_ZNSo3putEc
 libstdc++.so.6:_ZNSo5writeEPKcl
@@ -570,7 +583,6 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constru
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE14_M_replace_auxEmmmc
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6appendEPKc
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6appendEPKcm
-libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6insertEmPKc
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7replaceEmmPKcm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7reserveEm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE8_M_eraseEmm
@@ -580,6 +592,7 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createER
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_mutateEmmPKcm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9push_backEc
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1EOS4_
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1ERKS4_
 libstdc++.so.6:_ZNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE7_M_syncEPcmm
 libstdc++.so.6:_ZNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEC1Ev
@@ -594,6 +607,8 @@ libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE5imbueERKSt6locale
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE5rdbufEPSt15basic_streambufIcS1_E
 libstdc++.so.6:_ZNSt9exceptionD2Ev
 libstdc++.so.6:_ZSt11_Hash_bytesPKvmm
+libstdc++.so.6:_ZSt11__once_call
+libstdc++.so.6:_ZSt15__once_callable
 libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
 libstdc++.so.6:_ZSt16__throw_bad_castv
 libstdc++.so.6:_ZSt17__throw_bad_allocv
@@ -605,6 +620,7 @@ libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt19__throw_regex_errorNSt15regex_constants10error_typeE
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
+libstdc++.so.6:_ZSt20__throw_system_errori
 libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
 libstdc++.so.6:_ZSt25__throw_bad_function_callv
@@ -614,9 +630,10 @@ libstdc++.so.6:_ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_
 libstdc++.so.6:_ZSt4cerr
 libstdc++.so.6:_ZSt4cout
 libstdc++.so.6:_ZSt7getlineIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EES4_
-libstdc++.so.6:_ZSt9terminatev
+libstdc++.so.6:_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
 libstdc++.so.6:_ZTIN10__cxxabiv115__forced_unwindE
 libstdc++.so.6:_ZTINSt6locale5facetE
+libstdc++.so.6:_ZTIPKc
 libstdc++.so.6:_ZTISt11logic_error
 libstdc++.so.6:_ZTISt11range_error
 libstdc++.so.6:_ZTISt11regex_error
@@ -631,6 +648,13 @@ libstdc++.so.6:_ZTISt16nested_exception
 libstdc++.so.6:_ZTISt5ctypeIcE
 libstdc++.so.6:_ZTISt9bad_alloc
 libstdc++.so.6:_ZTISt9exception
+libstdc++.so.6:_ZTIb
+libstdc++.so.6:_ZTId
+libstdc++.so.6:_ZTIi
+libstdc++.so.6:_ZTIj
+libstdc++.so.6:_ZTIl
+libstdc++.so.6:_ZTIm
+libstdc++.so.6:_ZTIx
 libstdc++.so.6:_ZTTNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEEE
 libstdc++.so.6:_ZTTNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEEE
 libstdc++.so.6:_ZTTNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEE
@@ -656,6 +680,7 @@ libstdc++.so.6:_Znwm
 libstdc++.so.6:_ZnwmSt11align_val_t
 libstdc++.so.6:__cxa_allocate_exception
 libstdc++.so.6:__cxa_begin_catch
+libstdc++.so.6:__cxa_call_terminate
 libstdc++.so.6:__cxa_demangle
 libstdc++.so.6:__cxa_end_catch
 libstdc++.so.6:__cxa_free_exception
@@ -666,3 +691,4 @@ libstdc++.so.6:__cxa_rethrow
 libstdc++.so.6:__cxa_throw
 libstdc++.so.6:__dynamic_cast
 libstdc++.so.6:__gxx_personality_v0
+libstdc++.so.6:__once_proxy

--- a/packages/py/python-pikepdf/package.yml
+++ b/packages/py/python-pikepdf/package.yml
@@ -1,8 +1,8 @@
 name       : python-pikepdf
-version    : 8.14.0
-release    : 32
+version    : 9.2.1
+release    : 33
 source     :
-    - https://github.com/pikepdf/pikepdf/archive/refs/tags/v8.14.0.tar.gz : 190e040e777df1d884b2e7a31131c00c5a37b6ebae617194f41a95c6f127e6fc
+    - https://github.com/pikepdf/pikepdf/archive/refs/tags/v9.2.1.tar.gz : 9289eae74886619c459c804e6ee0a90ca0dcf8b2aa7f1edf8b6bcdfd595e9c10
 homepage   : https://github.com/pikepdf/pikepdf
 license    : MPL-2.0
 component  : programming.python

--- a/packages/py/python-pikepdf/pspec_x86_64.xml
+++ b/packages/py/python-pikepdf/pspec_x86_64.xml
@@ -20,11 +20,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf-8.14.0-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf-8.14.0-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf-8.14.0-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf-8.14.0-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf-8.14.0-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf-9.2.1-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf-9.2.1-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf-9.2.1-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf-9.2.1-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf-9.2.1-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/__pycache__/_augments.cpython-311.pyc</Path>
@@ -32,7 +32,6 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/__pycache__/_exceptions.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/__pycache__/_io.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/__pycache__/_methods.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/__pycache__/_qpdf.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/__pycache__/_version.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/__pycache__/_xml.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/__pycache__/canvas.cpython-311.pyc</Path>
@@ -47,7 +46,6 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/_exceptions.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/_io.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/_methods.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/_qpdf.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/_version.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/_xml.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/canvas.py</Path>
@@ -59,14 +57,12 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/models/__pycache__/_transcoding.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/models/__pycache__/encryption.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/models/__pycache__/image.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/models/__pycache__/matrix.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/models/__pycache__/metadata.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/models/__pycache__/outlines.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/models/_content_stream.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/models/_transcoding.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/models/encryption.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/models/image.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/models/matrix.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/models/metadata.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/models/outlines.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pikepdf/objects.py</Path>
@@ -75,9 +71,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2024-03-26</Date>
-            <Version>8.14.0</Version>
+        <Update release="33">
+            <Date>2024-09-06</Date>
+            <Version>9.2.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Algent Albrahimi</Name>
             <Email>algent@protonmail.com</Email>


### PR DESCRIPTION
**Summary**
- pybind11 v2.13.5 [changelog](https://pybind11.readthedocs.io/en/stable/changelog.html#version-2-13-5-august-22-2024)
- python-pikepdf v9 [changelog](https://pikepdf.readthedocs.io/en/latest/releasenotes/version9.html#v9-2-1)
- python-pikepdf v8 [changelog](https://pikepdf.readthedocs.io/en/latest/releasenotes/version8.html#v8-15-1)

**Test Plan**
Run `pdfarranger` and modify some PDF Files.

**Checklist**

- [x] Package was built and tested against unstable
