### PR TITLE
chocolate-doom: Split into separate sub-packages

### DIFF
--- a/packages/c/chocolate-doom/package.yml
+++ b/packages/c/chocolate-doom/package.yml
@@ -1,19 +1,59 @@
 name       : chocolate-doom
 version    : 3.0.1
-release    : 8
+release    : 9
 source     :
     - https://github.com/chocolate-doom/chocolate-doom/archive/chocolate-doom-3.0.1.tar.gz : a54383beef6a52babc5b00d58fcf53a454f012ced7b1936ba359b13f1f10ac66
 homepage   : https://www.chocolate-doom.org/
 license    : GPL-2.0-or-later
 component  : games.action
-summary    : Chocolate Doom is a Doom source port that is conservative and historically accurate.
-description: |
-    Chocolate Doom is a Doom source port that is conservative and historically accurate.
+summary    :
+    - Chocolate Doom is a Doom source port that is conservative and historically accurate.
+    - heretic: Chocolate Heretic is a conservative, historically-accurate Heretic source port.
+    - hexen: Chocolate Hexen is a conservative, historically-accurate Hexen source port.
+    - server: Chocolate Doom Server is a standalone server application that let's you play the chocolate-doom games as multiplayer without client install.
+    - strife: Chocolate Strife is a conservative, historically-accurate recreation of the Strife engine.
+description:
+    - Chocolate Doom is a Doom source port that is conservative and historically accurate.
+    - heretic: Chocolate Heretic is a conservative, historically-accurate Heretic source port.
+    - hexen: Chocolate Hexen is a conservative, historically-accurate Hexen source port.
+    - server: Chocolate Doom Server is a standalone server application that let's you play the chocolate-doom games as multiplayer without client install.
+    - strife: Chocolate Strife is a conservative, historically-accurate recreation of the Strife engine.
 builddeps  :
     - pkgconfig(SDL2_mixer)
     - pkgconfig(SDL2_net)
     - pkgconfig(libpng)
     - pkgconfig(samplerate)
+patterns   :
+    - heretic:
+        - /usr/bin/chocolate-heretic*
+        - /usr/share/appdata/chocolate-heretic*
+        - /usr/share/applications/chocolate-heretic*
+        - /usr/share/bash-completion/completions/chocolate-heretic*
+        - /usr/share/doc/chocolate-heretic*
+        - /usr/share/icons/chocolate-heretic*
+        - /usr/share/man/man5/chocolate-heretic*
+        - /usr/share/man/man6/chocolate-heretic*
+    - hexen:
+        - /usr/bin/chocolate-hexen*
+        - /usr/share/appdata/chocolate-hexen*
+        - /usr/share/applications/chocolate-hexen*
+        - /usr/share/bash-completion/completions/chocolate-hexen*
+        - /usr/share/doc/chocolate-hexen*
+        - /usr/share/icons/chocolate-hexen*
+        - /usr/share/man/man5/chocolate-hexen*
+        - /usr/share/man/man6/chocolate-hexen*
+    - server:
+        - /usr/bin/chocolate-server*
+        - /usr/share/man/man6/chocolate-server*
+    - strife:
+        - /usr/bin/chocolate-strife*
+        - /usr/share/appdata/chocolate-strife*
+        - /usr/share/applications/chocolate-strife*
+        - /usr/share/bash-completion/completions/chocolate-strife*
+        - /usr/share/doc/chocolate-strife*
+        - /usr/share/icons/chocolate-strife*
+        - /usr/share/man/man5/chocolate-strife*
+        - /usr/share/man/man6/chocolate-strife*
 setup      : |
     %patch -p1 -i $pkgfiles/remove_redundant_definition.patch
     %reconfigure
@@ -21,3 +61,61 @@ build      : |
     %make
 install    : |
     %make_install
+
+    # Remove duplicate man pages
+    rm -v $installdir/usr/share/man/man5/default.cfg.5
+    rm -v $installdir/usr/share/man/man5/heretic.cfg.5
+    rm -v $installdir/usr/share/man/man5/hexen.cfg.5
+    rm -v $installdir/usr/share/man/man5/strife.cfg.5
+
+    # Copy icons for seperate packages
+    cp -v $installdir/usr/share/icons/chocolate-doom.png $installdir/usr/share/icons/chocolate-heretic.png
+    cp -v $installdir/usr/share/icons/chocolate-doom.png $installdir/usr/share/icons/chocolate-hexen.png
+    cp -v $installdir/usr/share/icons/chocolate-doom.png $installdir/usr/share/icons/chocolate-strife.png
+
+    cp -v $installdir/usr/share/icons/chocolate-setup.png $installdir/usr/share/icons/chocolate-heretic-setup.png
+    cp -v $installdir/usr/share/icons/chocolate-setup.png $installdir/usr/share/icons/chocolate-hexen-setup.png
+    cp -v $installdir/usr/share/icons/chocolate-setup.png $installdir/usr/share/icons/chocolate-strife-setup.png
+
+    # Copy setup desktop file
+    cp -v $installdir/usr/share/applications/chocolate-setup.desktop $installdir/usr/share/applications/chocolate-heretic-setup.desktop
+    cp -v $installdir/usr/share/applications/chocolate-setup.desktop $installdir/usr/share/applications/chocolate-hexen-setup.desktop
+    cp -v $installdir/usr/share/applications/chocolate-setup.desktop $installdir/usr/share/applications/chocolate-strife-setup.desktop
+
+    # Fix icons in desktop files
+    sed -i 's/Icon=chocolate-doom/Icon=chocolate-heretic/g' $installdir/usr/share/applications/chocolate-heretic.desktop
+    sed -i 's/Icon=chocolate-doom/Icon=chocolate-hexen/g' $installdir/usr/share/applications/chocolate-hexen.desktop
+    sed -i 's/Icon=chocolate-doom/Icon=chocolate-strife/g' $installdir/usr/share/applications/chocolate-strife.desktop
+
+    sed -i 's/Icon=chocolate-setup/Icon=chocolate-heretic-setup/g' $installdir/usr/share/applications/chocolate-heretic-setup.desktop
+    sed -i 's/Icon=chocolate-setup/Icon=chocolate-hexen-setup/g' $installdir/usr/share/applications/chocolate-hexen-setup.desktop
+    sed -i 's/Icon=chocolate-setup/Icon=chocolate-strife-setup/g' $installdir/usr/share/applications/chocolate-strife-setup.desktop
+
+    # Fix exec in desktop files
+    sed -i 's/Exec=chocolate-setup/Exec=chocolate-doom-setup/g' $installdir/usr/share/applications/chocolate-setup.desktop
+    sed -i 's/Exec=chocolate-setup/Exec=chocolate-heretic-setup/g' $installdir/usr/share/applications/chocolate-heretic-setup.desktop
+    sed -i 's/Exec=chocolate-setup/Exec=chocolate-hexen-setup/g' $installdir/usr/share/applications/chocolate-hexen-setup.desktop
+    sed -i 's/Exec=chocolate-setup/Exec=chocolate-strife-setup/g' $installdir/usr/share/applications/chocolate-strife-setup.desktop
+
+    # Fix Name in desktop files
+    sed -i 's/Name=Chocolate Setup/Name=Chocolate Doom Setup/g' $installdir/usr/share/applications/chocolate-setup.desktop
+    sed -i 's/Name=Chocolate Setup/Name=Chocolate Heretic Setup/g' $installdir/usr/share/applications/chocolate-heretic-setup.desktop
+    sed -i 's/Name=Chocolate Setup/Name=Chocolate Hexen Setup/g' $installdir/usr/share/applications/chocolate-hexen-setup.desktop
+    sed -i 's/Name=Chocolate Setup/Name=Chocolate Strife Setup/g' $installdir/usr/share/applications/chocolate-strife-setup.desktop
+
+    # Fix keywords in desktop files
+    sed -i '8d' $installdir/usr/share/applications/chocolate-setup.desktop
+    sed -i '8d' $installdir/usr/share/applications/chocolate-heretic-setup.desktop
+    sed -i '8d' $installdir/usr/share/applications/chocolate-hexen-setup.desktop
+    sed -i '8d' $installdir/usr/share/applications/chocolate-strife-setup.desktop
+    sed -i '8d' $installdir/usr/share/applications/chocolate-heretic.desktop
+    sed -i '8d' $installdir/usr/share/applications/chocolate-hexen.desktop
+    sed -i '8d' $installdir/usr/share/applications/chocolate-strife.desktop
+
+    echo "Keywords=first;person;shooter;doom;vanilla;" >> $installdir/usr/share/applications/chocolate-setup.desktop
+    echo "Keywords=first;person;shooter;doom;heretic;vanilla;" >> $installdir/usr/share/applications/chocolate-heretic-setup.desktop
+    echo "Keywords=first;person;shooter;doom;hexen;vanilla;" >> $installdir/usr/share/applications/chocolate-hexen-setup.desktop
+    echo "Keywords=first;person;shooter;doom;strife;vanilla;" >> $installdir/usr/share/applications/chocolate-strife-setup.desktop
+    echo "Keywords=first;person;shooter;doom;heretic;vanilla;" >> $installdir/usr/share/applications/chocolate-heretic.desktop
+    echo "Keywords=first;person;shooter;doom;hexen;vanilla;" >> $installdir/usr/share/applications/chocolate-hexen.desktop
+    echo "Keywords=first;person;shooter;doom;strife;vanilla;" >> $installdir/usr/share/applications/chocolate-strife.desktop

--- a/packages/c/chocolate-doom/pspec_x86_64.xml
+++ b/packages/c/chocolate-doom/pspec_x86_64.xml
@@ -3,46 +3,28 @@
         <Name>chocolate-doom</Name>
         <Homepage>https://www.chocolate-doom.org/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Maik W&#xf6;hl</Name>
+            <Email>maik.woehl@outlook.de</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>games.action</PartOf>
         <Summary xml:lang="en">Chocolate Doom is a Doom source port that is conservative and historically accurate.</Summary>
-        <Description xml:lang="en">Chocolate Doom is a Doom source port that is conservative and historically accurate.
-</Description>
+        <Description xml:lang="en">Chocolate Doom is a Doom source port that is conservative and historically accurate.</Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>chocolate-doom</Name>
         <Summary xml:lang="en">Chocolate Doom is a Doom source port that is conservative and historically accurate.</Summary>
-        <Description xml:lang="en">Chocolate Doom is a Doom source port that is conservative and historically accurate.
-</Description>
+        <Description xml:lang="en">Chocolate Doom is a Doom source port that is conservative and historically accurate.</Description>
         <PartOf>games.action</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/chocolate-doom</Path>
             <Path fileType="executable">/usr/bin/chocolate-doom-setup</Path>
-            <Path fileType="executable">/usr/bin/chocolate-heretic</Path>
-            <Path fileType="executable">/usr/bin/chocolate-heretic-setup</Path>
-            <Path fileType="executable">/usr/bin/chocolate-hexen</Path>
-            <Path fileType="executable">/usr/bin/chocolate-hexen-setup</Path>
-            <Path fileType="executable">/usr/bin/chocolate-server</Path>
-            <Path fileType="executable">/usr/bin/chocolate-strife</Path>
-            <Path fileType="executable">/usr/bin/chocolate-strife-setup</Path>
             <Path fileType="data">/usr/share/appdata/chocolate-doom.appdata.xml</Path>
-            <Path fileType="data">/usr/share/appdata/chocolate-heretic.appdata.xml</Path>
-            <Path fileType="data">/usr/share/appdata/chocolate-hexen.appdata.xml</Path>
-            <Path fileType="data">/usr/share/appdata/chocolate-strife.appdata.xml</Path>
             <Path fileType="data">/usr/share/applications/chocolate-doom.desktop</Path>
-            <Path fileType="data">/usr/share/applications/chocolate-heretic.desktop</Path>
-            <Path fileType="data">/usr/share/applications/chocolate-hexen.desktop</Path>
             <Path fileType="data">/usr/share/applications/chocolate-setup.desktop</Path>
-            <Path fileType="data">/usr/share/applications/chocolate-strife.desktop</Path>
             <Path fileType="data">/usr/share/applications/screensavers/chocolate-doom-screensaver.desktop</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/chocolate-doom</Path>
-            <Path fileType="data">/usr/share/bash-completion/completions/chocolate-heretic</Path>
-            <Path fileType="data">/usr/share/bash-completion/completions/chocolate-hexen</Path>
-            <Path fileType="data">/usr/share/bash-completion/completions/chocolate-strife</Path>
             <Path fileType="doc">/usr/share/doc/chocolate-doom/CMDLINE.doom</Path>
             <Path fileType="doc">/usr/share/doc/chocolate-doom/ChangeLog</Path>
             <Path fileType="doc">/usr/share/doc/chocolate-doom/INSTALL.doom</Path>
@@ -51,6 +33,25 @@
             <Path fileType="doc">/usr/share/doc/chocolate-doom/PHILOSOPHY.md</Path>
             <Path fileType="doc">/usr/share/doc/chocolate-doom/README.Music.md</Path>
             <Path fileType="doc">/usr/share/doc/chocolate-doom/README.md</Path>
+            <Path fileType="data">/usr/share/icons/chocolate-doom.png</Path>
+            <Path fileType="data">/usr/share/icons/chocolate-setup.png</Path>
+            <Path fileType="man">/usr/share/man/man5/chocolate-doom.cfg.5</Path>
+            <Path fileType="man">/usr/share/man/man6/chocolate-doom-setup.6</Path>
+            <Path fileType="man">/usr/share/man/man6/chocolate-doom.6</Path>
+            <Path fileType="man">/usr/share/man/man6/chocolate-setup.6</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>chocolate-doom-heretic</Name>
+        <Summary xml:lang="en">Chocolate Heretic is a conservative, historically-accurate Heretic source port.</Summary>
+        <Description xml:lang="en">Chocolate Heretic is a conservative, historically-accurate Heretic source port.</Description>
+        <Files>
+            <Path fileType="executable">/usr/bin/chocolate-heretic</Path>
+            <Path fileType="executable">/usr/bin/chocolate-heretic-setup</Path>
+            <Path fileType="data">/usr/share/appdata/chocolate-heretic.appdata.xml</Path>
+            <Path fileType="data">/usr/share/applications/chocolate-heretic-setup.desktop</Path>
+            <Path fileType="data">/usr/share/applications/chocolate-heretic.desktop</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/chocolate-heretic</Path>
             <Path fileType="doc">/usr/share/doc/chocolate-heretic/CMDLINE.heretic</Path>
             <Path fileType="doc">/usr/share/doc/chocolate-heretic/ChangeLog</Path>
             <Path fileType="doc">/usr/share/doc/chocolate-heretic/INSTALL.heretic</Path>
@@ -58,6 +59,24 @@
             <Path fileType="doc">/usr/share/doc/chocolate-heretic/PHILOSOPHY.md</Path>
             <Path fileType="doc">/usr/share/doc/chocolate-heretic/README.Music.md</Path>
             <Path fileType="doc">/usr/share/doc/chocolate-heretic/README.md</Path>
+            <Path fileType="data">/usr/share/icons/chocolate-heretic-setup.png</Path>
+            <Path fileType="data">/usr/share/icons/chocolate-heretic.png</Path>
+            <Path fileType="man">/usr/share/man/man5/chocolate-heretic.cfg.5</Path>
+            <Path fileType="man">/usr/share/man/man6/chocolate-heretic-setup.6</Path>
+            <Path fileType="man">/usr/share/man/man6/chocolate-heretic.6</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>chocolate-doom-hexen</Name>
+        <Summary xml:lang="en">Chocolate Hexen is a conservative, historically-accurate Hexen source port.</Summary>
+        <Description xml:lang="en">Chocolate Hexen is a conservative, historically-accurate Hexen source port.</Description>
+        <Files>
+            <Path fileType="executable">/usr/bin/chocolate-hexen</Path>
+            <Path fileType="executable">/usr/bin/chocolate-hexen-setup</Path>
+            <Path fileType="data">/usr/share/appdata/chocolate-hexen.appdata.xml</Path>
+            <Path fileType="data">/usr/share/applications/chocolate-hexen-setup.desktop</Path>
+            <Path fileType="data">/usr/share/applications/chocolate-hexen.desktop</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/chocolate-hexen</Path>
             <Path fileType="doc">/usr/share/doc/chocolate-hexen/CMDLINE.hexen</Path>
             <Path fileType="doc">/usr/share/doc/chocolate-hexen/ChangeLog</Path>
             <Path fileType="doc">/usr/share/doc/chocolate-hexen/INSTALL.hexen</Path>
@@ -65,6 +84,33 @@
             <Path fileType="doc">/usr/share/doc/chocolate-hexen/PHILOSOPHY.md</Path>
             <Path fileType="doc">/usr/share/doc/chocolate-hexen/README.Music.md</Path>
             <Path fileType="doc">/usr/share/doc/chocolate-hexen/README.md</Path>
+            <Path fileType="data">/usr/share/icons/chocolate-hexen-setup.png</Path>
+            <Path fileType="data">/usr/share/icons/chocolate-hexen.png</Path>
+            <Path fileType="man">/usr/share/man/man5/chocolate-hexen.cfg.5</Path>
+            <Path fileType="man">/usr/share/man/man6/chocolate-hexen-setup.6</Path>
+            <Path fileType="man">/usr/share/man/man6/chocolate-hexen.6</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>chocolate-doom-server</Name>
+        <Summary xml:lang="en">Chocolate Doom Server is a standalone server application that let&apos;s you play the chocolate-doom games as multiplayer without client install.</Summary>
+        <Description xml:lang="en">Chocolate Doom Server is a standalone server application that let&apos;s you play the chocolate-doom games as multiplayer without client install.</Description>
+        <Files>
+            <Path fileType="executable">/usr/bin/chocolate-server</Path>
+            <Path fileType="man">/usr/share/man/man6/chocolate-server.6</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>chocolate-doom-strife</Name>
+        <Summary xml:lang="en">Chocolate Strife is a conservative, historically-accurate recreation of the Strife engine.</Summary>
+        <Description xml:lang="en">Chocolate Strife is a conservative, historically-accurate recreation of the Strife engine.</Description>
+        <Files>
+            <Path fileType="executable">/usr/bin/chocolate-strife</Path>
+            <Path fileType="executable">/usr/bin/chocolate-strife-setup</Path>
+            <Path fileType="data">/usr/share/appdata/chocolate-strife.appdata.xml</Path>
+            <Path fileType="data">/usr/share/applications/chocolate-strife-setup.desktop</Path>
+            <Path fileType="data">/usr/share/applications/chocolate-strife.desktop</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/chocolate-strife</Path>
             <Path fileType="doc">/usr/share/doc/chocolate-strife/CMDLINE.strife</Path>
             <Path fileType="doc">/usr/share/doc/chocolate-strife/ChangeLog</Path>
             <Path fileType="doc">/usr/share/doc/chocolate-strife/INSTALL.strife</Path>
@@ -73,35 +119,20 @@
             <Path fileType="doc">/usr/share/doc/chocolate-strife/README.Music.md</Path>
             <Path fileType="doc">/usr/share/doc/chocolate-strife/README.Strife.md</Path>
             <Path fileType="doc">/usr/share/doc/chocolate-strife/README.md</Path>
-            <Path fileType="data">/usr/share/icons/chocolate-doom.png</Path>
-            <Path fileType="data">/usr/share/icons/chocolate-setup.png</Path>
-            <Path fileType="man">/usr/share/man/man5/chocolate-doom.cfg.5</Path>
-            <Path fileType="man">/usr/share/man/man5/chocolate-heretic.cfg.5</Path>
-            <Path fileType="man">/usr/share/man/man5/chocolate-hexen.cfg.5</Path>
+            <Path fileType="data">/usr/share/icons/chocolate-strife-setup.png</Path>
+            <Path fileType="data">/usr/share/icons/chocolate-strife.png</Path>
             <Path fileType="man">/usr/share/man/man5/chocolate-strife.cfg.5</Path>
-            <Path fileType="man">/usr/share/man/man5/default.cfg.5</Path>
-            <Path fileType="man">/usr/share/man/man5/heretic.cfg.5</Path>
-            <Path fileType="man">/usr/share/man/man5/hexen.cfg.5</Path>
-            <Path fileType="man">/usr/share/man/man5/strife.cfg.5</Path>
-            <Path fileType="man">/usr/share/man/man6/chocolate-doom-setup.6</Path>
-            <Path fileType="man">/usr/share/man/man6/chocolate-doom.6</Path>
-            <Path fileType="man">/usr/share/man/man6/chocolate-heretic-setup.6</Path>
-            <Path fileType="man">/usr/share/man/man6/chocolate-heretic.6</Path>
-            <Path fileType="man">/usr/share/man/man6/chocolate-hexen-setup.6</Path>
-            <Path fileType="man">/usr/share/man/man6/chocolate-hexen.6</Path>
-            <Path fileType="man">/usr/share/man/man6/chocolate-server.6</Path>
-            <Path fileType="man">/usr/share/man/man6/chocolate-setup.6</Path>
             <Path fileType="man">/usr/share/man/man6/chocolate-strife-setup.6</Path>
             <Path fileType="man">/usr/share/man/man6/chocolate-strife.6</Path>
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2024-01-03</Date>
+        <Update release="9">
+            <Date>2024-10-31</Date>
             <Version>3.0.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Maik W&#xf6;hl</Name>
+            <Email>maik.woehl@outlook.de</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Fixes getsolus/packages#78

**Test Plan**

Install packages and look whether they are showing up correctly in the menu.
Setup programs are starting, the game itself does not start because [you need *wad* files](https://www.chocolate-doom.org/wiki/index.php/FAQ#How_do_I_set_up_Chocolate_Doom_on_my_computer.3F) for that. 

**Checklist**

- [x] Package was built and tested against unstable
