### PR TITLE
Switch mdns resolver

### DIFF
--- a/packages/a/avahi/package.yml
+++ b/packages/a/avahi/package.yml
@@ -1,6 +1,6 @@
 name       : avahi
 version    : '0.8'
-release    : 27
+release    : 28
 source     :
     # - https://github.com/avahi/avahi/archive/refs/tags/v0.8.tar.gz : c15e750ef7c6df595fb5f2ce10cac0fee2353649600e6919ad08ae8871e4945f
     # Use git source until v0.9 releases:
@@ -53,13 +53,6 @@ install    : |
 
         install -D -m 00644 $pkgfiles/avahi.sysusers $installdir%libdir%/sysusers.d/avahi.conf
         install -D -m 00644 $pkgfiles/avahi.tmpfiles $installdir%libdir%/tmpfiles.d/avahi.conf
-
-        # Pre-enable
-        install -D -d -m 00755 $installdir/%libdir%/systemd/system/sockets.target.wants
-        install -D -d -m 00755 $installdir/%libdir%/systemd/system/multi-user.target.wants
-        ln -sv ../avahi-daemon.socket -t $installdir/%libdir%/systemd/system/sockets.target.wants
-        ln -sv avahi-daemon.service $installdir/%libdir%/systemd/system/dbus-org.freedesktop.Avahi.service
-        ln -sv ../avahi-daemon.service $installdir/%libdir%/systemd/system/multi-user.target.wants/avahi-daemon.service
     else
         rm -rfv $installdir/%libdir%/systemd
     fi

--- a/packages/a/avahi/pspec_x86_64.xml
+++ b/packages/a/avahi/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>avahi</Name>
         <Homepage>https://www.avahi.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>desktop.core</PartOf>
@@ -52,9 +52,6 @@
             <Path fileType="library">/usr/lib64/systemd/system/avahi-daemon.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/avahi-daemon.socket</Path>
             <Path fileType="library">/usr/lib64/systemd/system/avahi-dnsconfd.service</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/dbus-org.freedesktop.Avahi.service</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/multi-user.target.wants/avahi-daemon.service</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/sockets.target.wants/avahi-daemon.socket</Path>
             <Path fileType="library">/usr/lib64/sysusers.d/avahi.conf</Path>
             <Path fileType="library">/usr/lib64/tmpfiles.d/avahi.conf</Path>
             <Path fileType="executable">/usr/sbin/avahi-autoipd</Path>
@@ -157,7 +154,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="27">avahi</Dependency>
+            <Dependency release="28">avahi</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/girepository-1.0/Avahi-0.6.typelib</Path>
@@ -189,8 +186,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="27">avahi-devel</Dependency>
-            <Dependency release="27">avahi-32bit</Dependency>
+            <Dependency release="28">avahi-devel</Dependency>
+            <Dependency release="28">avahi-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/lib32/pkgconfig/avahi-client.pc</Path>
@@ -207,7 +204,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="27">avahi</Dependency>
+            <Dependency release="28">avahi</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/avahi-client/client.h</Path>
@@ -252,12 +249,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2024-07-20</Date>
+        <Update release="28">
+            <Date>2024-09-08</Date>
             <Version>0.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/s/samba/files/smb-device-info.dnssd
+++ b/packages/s/samba/files/smb-device-info.dnssd
@@ -1,0 +1,4 @@
+[Service]
+Name=%H
+Type=_device-info._tcp
+TxtText=model=RackMac

--- a/packages/s/samba/files/smb.dnssd
+++ b/packages/s/samba/files/smb.dnssd
@@ -1,0 +1,4 @@
+[Service]
+Name=%H
+Type=_smb._tcp
+Port=445

--- a/packages/s/samba/package.yml
+++ b/packages/s/samba/package.yml
@@ -1,6 +1,6 @@
 name       : samba
 version    : 4.19.6
-release    : 106
+release    : 107
 source     :
     - https://download.samba.org/pub/samba/stable/samba-4.19.6.tar.gz : 653b52095554dbc223c63b96af5cdf9e98c3e048549c5f56143d3b33dce1cef1
 homepage   : https://samba.org
@@ -93,6 +93,8 @@ install    : |
     install -D -m00644 $pkgfiles/avahi.smb.service $installdir/usr/share/defaults/samba/avahi.smb.service
     install -d -m00755 $installdir/etc/avahi/services
     ln -sv /usr/share/defaults/samba/avahi.smb.service $installdir/etc/avahi/services/smb.service
+    # systemd resolved autodiscovery configuration
+    install -Dm0644 -t $installdir/usr/lib/systemd/dnssd $pkgfiles/*.dnssd
     # cups
     install -d -m00755 $installdir/%libdir%/cups/backend
     ln -sv /usr/bin/smbspool $installdir/%libdir%/cups/backend/smb

--- a/packages/s/samba/pspec_x86_64.xml
+++ b/packages/s/samba/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>samba</Name>
         <Homepage>https://samba.org</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop.core</PartOf>
@@ -62,6 +62,8 @@ For more information, see the Solus Help Center [Samba file sharing guide](https
             <Path fileType="executable">/usr/bin/smbtree</Path>
             <Path fileType="executable">/usr/bin/testparm</Path>
             <Path fileType="executable">/usr/bin/wbinfo</Path>
+            <Path fileType="library">/usr/lib/systemd/dnssd/smb-device-info.dnssd</Path>
+            <Path fileType="library">/usr/lib/systemd/dnssd/smb.dnssd</Path>
             <Path fileType="library">/usr/lib/systemd/system/nmb.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/smb.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/winbind.service</Path>
@@ -395,7 +397,7 @@ For more information, see the Solus Help Center [Samba file sharing guide](https
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="106">samba</Dependency>
+            <Dependency release="107">samba</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/samba-4.0/charset.h</Path>
@@ -515,12 +517,12 @@ For more information, see the Solus Help Center [Samba file sharing guide](https
         </Files>
     </Package>
     <History>
-        <Update release="106">
-            <Date>2024-07-06</Date>
+        <Update release="107">
+            <Date>2024-09-08</Date>
             <Version>4.19.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/s/systemd/package.yml
+++ b/packages/s/systemd/package.yml
@@ -1,6 +1,6 @@
 name       : systemd
 version    : '254.17'
-release    : 164
+release    : 165
 source     :
     - https://github.com/systemd/systemd-stable/archive/refs/tags/v254.17.tar.gz : a3ffb90b6d79214014b7469eac51b07e12dd765e6c3b524a915503815c32e6cb
 license    :
@@ -90,7 +90,7 @@ setup      : |
                      -Ddefault-hierarchy="unified" \
                      -Ddefault-kill-user-processes=false \
                      -Ddefault-llmnr=resolve \
-                     -Ddefault-mdns=no \
+                     -Ddefault-mdns=yes \
                      -Ddefault-timeout-sec=30 \
                      -Ddefault-user-timeout-sec=30 \
                      -Ddns-over-tls='openssl' \

--- a/packages/s/systemd/pspec_x86_64.xml
+++ b/packages/s/systemd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>systemd</Name>
         <Homepage>https://www.github.com/systemd/systemd</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <License>GPL-2.0-or-later</License>
@@ -140,7 +140,6 @@
             <Path fileType="library">/usr/lib/systemd/boot/efi/linuxx64.efi.stub</Path>
             <Path fileType="library">/usr/lib/systemd/boot/efi/systemd-bootia32.efi</Path>
             <Path fileType="library">/usr/lib/systemd/boot/efi/systemd-bootx64.efi</Path>
-            <Path fileType="library">/usr/lib/systemd/boot/solus-mok.cer</Path>
             <Path fileType="library">/usr/lib/systemd/catalog/systemd.be.catalog</Path>
             <Path fileType="library">/usr/lib/systemd/catalog/systemd.be@latin.catalog</Path>
             <Path fileType="library">/usr/lib/systemd/catalog/systemd.bg.catalog</Path>
@@ -1145,7 +1144,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="164">systemd</Dependency>
+            <Dependency release="165">systemd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnss_myhostname.so.2</Path>
@@ -1169,8 +1168,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="164">systemd-32bit</Dependency>
-            <Dependency release="164">systemd-devel</Dependency>
+            <Dependency release="165">systemd-32bit</Dependency>
+            <Dependency release="165">systemd-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/lib32/pkgconfig/libsystemd.pc</Path>
@@ -1184,7 +1183,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="164">systemd</Dependency>
+            <Dependency release="165">systemd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libudev.h</Path>
@@ -1986,12 +1985,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="164">
-            <Date>2024-08-19</Date>
+        <Update release="165">
+            <Date>2024-09-08</Date>
             <Version>254.17</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

This PR switches to using `systemd-resolved` as the default resolver, replacing `avahi-daemon`.

Resolves #2443

**Test Plan**

1. Install packages from this PR
2. Reboot or stop/start the correct services:
   ```
   sudo systemctl stop avahi-daemon.{socket,service}
   sudo systemctl restart systemd-resolved
   ```
3. Resolve local hosts in the network:
   ```
   resolvectl query --cache=no -p mdns <host>.local
3. Resolve device info from a different machine:
   ```
   resolvectl query --cache=no -p mdns --type=TXT <host>._device-info._tcp.local
   <host>._device-info._tcp.local IN TXT "model=RackMac"
   ```

**Checklist**

- [x] Package was built and tested against unstable
