### PR TITLE
gpxsee: Update to 13.24

### DIFF
--- a/packages/g/gpxsee/abi_used_symbols
+++ b/packages/g/gpxsee/abi_used_symbols
@@ -168,6 +168,7 @@ libQt5Core.so.5:_ZN5QDate10fromStringERK7QStringS2_
 libQt5Core.so.5:_ZN5QDate11currentDateEv
 libQt5Core.so.5:_ZN5QDateC1Eiii
 libQt5Core.so.5:_ZN5QFile11setFileNameERK7QString
+libQt5Core.so.5:_ZN5QFile16staticMetaObjectE
 libQt5Core.so.5:_ZN5QFile4openE6QFlagsIN9QIODevice12OpenModeFlagEE
 libQt5Core.so.5:_ZN5QFile6removeEv
 libQt5Core.so.5:_ZN5QFile6renameERK7QString
@@ -433,6 +434,7 @@ libQt5Core.so.5:_ZNK5QRectorERKS_
 libQt5Core.so.5:_ZNK5QTime7addSecsEi
 libQt5Core.so.5:_ZNK5QTime7isValidEv
 libQt5Core.so.5:_ZNK5QTime8addMSecsEi
+libQt5Core.so.5:_ZNK5QTime8toStringERK7QString
 libQt5Core.so.5:_ZNK6QLineF10intersectsERKS_P7QPointF
 libQt5Core.so.5:_ZNK6QLineF10unitVectorEv
 libQt5Core.so.5:_ZNK6QLineF5angleEv
@@ -448,8 +450,6 @@ libQt5Core.so.5:_ZNK7QLocale17measurementSystemEv
 libQt5Core.so.5:_ZNK7QLocale6toDateERK7QStringS2_
 libQt5Core.so.5:_ZNK7QLocale6toTimeERK7QStringS2_
 libQt5Core.so.5:_ZNK7QLocale8toStringERK5QDateNS_10FormatTypeE
-libQt5Core.so.5:_ZNK7QLocale8toStringERK5QTimeNS_10FormatTypeE
-libQt5Core.so.5:_ZNK7QLocale8toStringERK9QDateTimeNS_10FormatTypeE
 libQt5Core.so.5:_ZNK7QLocale8toStringEdci
 libQt5Core.so.5:_ZNK7QLocale8toStringEx
 libQt5Core.so.5:_ZNK7QObject10objectNameEv

--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.23'
-release    : 42
+version    : '13.24'
+release    : 43
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.23.tar.gz : 676f8423b3ee56f37134ea52909b78e3cd1b05e73e287dc9e1863275d842fe17
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.24.tar.gz : f15d503d0c5efcf42f6d4e6d4c924de9ad672722365adc6573ff1f9d755a71c2
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -172,9 +172,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="42">
-            <Date>2024-07-28</Date>
-            <Version>13.23</Version>
+        <Update release="43">
+            <Date>2024-09-09</Date>
+            <Version>13.24</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- [changelog](https://build.opensuse.org/projects/home:tumic:GPXSee/packages/gpxsee/files/gpxsee.changes)

**Test Plan**
- render map

**Checklist**
- [X] Package was built and tested against unstable
