### PR TITLE
github-cli: Update to 2.56.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.55.0
-release    : 53
+version    : 2.56.0
+release    : 54
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.55.0.tar.gz : f467cfdaedd372a5c20bb0daad017a0b3f75fa25179f1e4dcdc1d01ed59e62a5
+    - https://github.com/cli/cli/archive/refs/tags/v2.56.0.tar.gz : ed19f01df36e336472c434edfadf01a2cbe4bf07394724b064a80c8fd6a0dc1e
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -219,9 +219,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="53">
-            <Date>2024-08-22</Date>
-            <Version>2.55.0</Version>
+        <Update release="54">
+            <Date>2024-09-10</Date>
+            <Version>2.56.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/cli/cli/releases/tag/v2.56.0).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this PR.

**Checklist**

- [x] Package was built and tested against unstable
