### PR TITLE
bash: Tweak default history options

### DIFF
--- a/packages/b/bash/files/profile/50-history.sh
+++ b/packages/b/bash/files/profile/50-history.sh
@@ -1,6 +1,12 @@
 # Begin /usr/share/defaults/etc/profile.d/50-history.sh
 
-export HISTSIZE=1000
+# Append to history file on exit instead of overwrite (parallel terminals)
+shopt -s histappend
+
+export HISTSIZE=1500
 export HISTIGNORE="&:[bf]g:exit"
+# ignoredups: Do not add to history the same line executed consecutively
+# erasedups: All previous saved entries of line will be removed on write
+export HISTCONTROL=ignoredups:erasedups
 
 # End /usr/share/defaults/etc/profile.d/50-history.sh

--- a/packages/b/bash/package.yml
+++ b/packages/b/bash/package.yml
@@ -1,6 +1,6 @@
 name       : bash
 version    : 5.2.32
-release    : 81
+release    : 82
 source     :
     - https://ftp.gnu.org/gnu/bash/bash-5.2.21.tar.gz : c8e31bdc59b69aaffc5b36509905ba3e5cbb12747091d27b4b977f078560d5b8
 license    :

--- a/packages/b/bash/pspec_x86_64.xml
+++ b/packages/b/bash/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>bash</Name>
         <Homepage>https://www.gnu.org/software/bash</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -133,7 +133,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="81">bash</Dependency>
+            <Dependency release="82">bash</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/bash/alias.h</Path>
@@ -199,12 +199,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="81">
-            <Date>2024-08-01</Date>
+        <Update release="82">
+            <Date>2024-09-11</Date>
             <Version>5.2.32</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Enable hist append by default: Append to history instead of overwriting with multiple terminals.
- Enable ignoreddups: the same line executed consecutively will not be written to the history.
- Enable erasedups: when saving to the history if previous saved entries of the line exist, they be be removed.

**Test Plan**

Verify options work as expected

**Checklist**

- [x] Package was built and tested against unstable
