### PR TITLE
shotcut: Drop unneeded rundep

### DIFF
--- a/packages/s/shotcut/package.yml
+++ b/packages/s/shotcut/package.yml
@@ -1,6 +1,6 @@
 name       : shotcut
 version    : 24.06.26
-release    : 38
+release    : 39
 source     :
     - https://github.com/mltframework/shotcut/archive/refs/tags/v24.06.26.tar.gz : cd7a90228df954ad1e706940795abf9aff657c7686ce82092f009f9befec7e0b
 homepage   : https://www.shotcut.org/
@@ -23,7 +23,6 @@ builddeps  :
     - pkgconfig(x11)
 rundeps    :
     - frei0r
-    - qt5-quickcontrols
     - sdl2
     - swh-plugins
 clang      : yes

--- a/packages/s/shotcut/pspec_x86_64.xml
+++ b/packages/s/shotcut/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>shotcut</Name>
         <Homepage>https://www.shotcut.org/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>multimedia.video</PartOf>
@@ -945,12 +945,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="38">
-            <Date>2024-07-19</Date>
+        <Update release="39">
+            <Date>2024-09-11</Date>
             <Version>24.06.26</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

`qt5-quickcontrols` is an old rundep that should have been removed with the switch to qt6.

ref:
https://github.com/getsolus/packages/pull/3365#discussion_r1684682512

**Test Plan**

- shotcut runs

**Checklist**

- [x] Package was built and tested against unstable
