### PR TITLE
usysconf-epoch: Increase the usr-merge chance to 100%

### DIFF
--- a/packages/u/usysconf-epoch/files/usr-merge.sh
+++ b/packages/u/usysconf-epoch/files/usr-merge.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # This configures the probability that a system is usr merged
 # It should be a value from 0 to 256, with 0 being 0% chance, and 256 being 100% chance.
-USR_MERGE_CHANCE="${USR_MERGE_CHANCE:=0}"
+USR_MERGE_CHANCE="${USR_MERGE_CHANCE:=256}"
 
 # This is where orphaned files and flag markers will be set
 STATE_DIR="${STATE_DIR:=/var/solus/usr-merge}"

--- a/packages/u/usysconf-epoch/package.yml
+++ b/packages/u/usysconf-epoch/package.yml
@@ -1,6 +1,6 @@
 name       : usysconf-epoch
 version    : 0.0.1
-release    : 11
+release    : 12
 source     :
     # We need something for a source
     - https://getsol.us/sources/hotspot.txt : a12b7cb43c9d9134b5bb1b35e9096b66775d9e92e7611d1cc92b02edd6782a87

--- a/packages/u/usysconf-epoch/pspec_x86_64.xml
+++ b/packages/u/usysconf-epoch/pspec_x86_64.xml
@@ -26,8 +26,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2024-09-11</Date>
+        <Update release="12">
+            <Date>2024-09-13</Date>
             <Version>0.0.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Silke Hofstra</Name>


### PR DESCRIPTION
**Summary**

Update the chance that a system is usr-merged to 100%.

Depending on how the week goes we will either reduce it to 10% or keep it as is before sync to stable.

**Test Plan**

Run on a system:

```
$ sudo /usr/lib/usysconf/usr-merge.sh
# see usr merge run
```

~~(output will differ for machines with a machine ID ending in 00-1A, see `hostnamectl`)~~

**Checklist**

- [x] Package was built and tested against unstable
