### PR TITLE
scrcpy: Update to 2.7

### DIFF
--- a/packages/s/scrcpy/abi_used_symbols
+++ b/packages/s/scrcpy/abi_used_symbols
@@ -22,6 +22,11 @@ libSDL2-2.0.so.0:SDL_GL_BindTexture
 libSDL2-2.0.so.0:SDL_GL_GetDrawableSize
 libSDL2-2.0.so.0:SDL_GL_GetProcAddress
 libSDL2-2.0.so.0:SDL_GL_UnbindTexture
+libSDL2-2.0.so.0:SDL_GameControllerClose
+libSDL2-2.0.so.0:SDL_GameControllerFromInstanceID
+libSDL2-2.0.so.0:SDL_GameControllerGetJoystick
+libSDL2-2.0.so.0:SDL_GameControllerName
+libSDL2-2.0.so.0:SDL_GameControllerOpen
 libSDL2-2.0.so.0:SDL_GetClipboardText
 libSDL2-2.0.so.0:SDL_GetDisplayUsableBounds
 libSDL2-2.0.so.0:SDL_GetError
@@ -34,6 +39,8 @@ libSDL2-2.0.so.0:SDL_GetWindowPosition
 libSDL2-2.0.so.0:SDL_GetWindowSize
 libSDL2-2.0.so.0:SDL_HideWindow
 libSDL2-2.0.so.0:SDL_Init
+libSDL2-2.0.so.0:SDL_IsGameController
+libSDL2-2.0.so.0:SDL_JoystickInstanceID
 libSDL2-2.0.so.0:SDL_LockAudioDevice
 libSDL2-2.0.so.0:SDL_LockMutex
 libSDL2-2.0.so.0:SDL_LogDebug
@@ -45,8 +52,10 @@ libSDL2-2.0.so.0:SDL_LogSetOutputFunction
 libSDL2-2.0.so.0:SDL_LogSetPriority
 libSDL2-2.0.so.0:SDL_LogVerbose
 libSDL2-2.0.so.0:SDL_LogWarn
+libSDL2-2.0.so.0:SDL_NumJoysticks
 libSDL2-2.0.so.0:SDL_OpenAudioDevice
 libSDL2-2.0.so.0:SDL_PauseAudioDevice
+libSDL2-2.0.so.0:SDL_PollEvent
 libSDL2-2.0.so.0:SDL_PushEvent
 libSDL2-2.0.so.0:SDL_Quit
 libSDL2-2.0.so.0:SDL_RenderClear
@@ -56,6 +65,7 @@ libSDL2-2.0.so.0:SDL_RenderPresent
 libSDL2-2.0.so.0:SDL_RenderSetLogicalSize
 libSDL2-2.0.so.0:SDL_RestoreWindow
 libSDL2-2.0.so.0:SDL_SetClipboardText
+libSDL2-2.0.so.0:SDL_SetEventFilter
 libSDL2-2.0.so.0:SDL_SetHint
 libSDL2-2.0.so.0:SDL_SetPaletteColors
 libSDL2-2.0.so.0:SDL_SetRelativeMouseMode
@@ -66,6 +76,7 @@ libSDL2-2.0.so.0:SDL_SetWindowPosition
 libSDL2-2.0.so.0:SDL_SetWindowSize
 libSDL2-2.0.so.0:SDL_SetYUVConversionMode
 libSDL2-2.0.so.0:SDL_ShowWindow
+libSDL2-2.0.so.0:SDL_ThreadID
 libSDL2-2.0.so.0:SDL_UnlockAudioDevice
 libSDL2-2.0.so.0:SDL_UnlockMutex
 libSDL2-2.0.so.0:SDL_UpdateYUVTexture
@@ -190,6 +201,7 @@ libc.so.6:strcspn
 libc.so.6:strdup
 libc.so.6:strlen
 libc.so.6:strncmp
+libc.so.6:strpbrk
 libc.so.6:strrchr
 libc.so.6:strspn
 libc.so.6:strtok_r

--- a/packages/s/scrcpy/package.yml
+++ b/packages/s/scrcpy/package.yml
@@ -1,9 +1,9 @@
 name       : scrcpy
-version    : 2.6.1
-release    : 27
+version    : '2.7'
+release    : 28
 source     :
-    - https://github.com/Genymobile/scrcpy/archive/v2.6.1.tar.gz : 4948474f1494fdff852a0a7fa823a0b3c25d3ea0384acdaf46c322e34b13e449
-    - https://github.com/Genymobile/scrcpy/releases/download/v2.6.1/scrcpy-server-v2.6.1 : ca7ab50b2e25a0e5af7599c30383e365983fa5b808e65ce2e1c1bba5bfe8dc3b
+    - https://github.com/Genymobile/scrcpy/archive/v2.7.tar.gz : 3ceea215f6eccb59535f68a16db6db2b05a8a1c91bdcb4a6e222d3093a9daf8c
+    - https://github.com/Genymobile/scrcpy/releases/download/v2.7/scrcpy-server-v2.7 : a23c5659f36c260f105c022d27bcb3eafffa26070e7baa9eda66d01377a1adba
 homepage   : https://github.com/Genymobile/scrcpy
 license    : Apache-2.0
 component  : network.util

--- a/packages/s/scrcpy/pspec_x86_64.xml
+++ b/packages/s/scrcpy/pspec_x86_64.xml
@@ -31,9 +31,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2024-08-29</Date>
-            <Version>2.6.1</Version>
+        <Update release="28">
+            <Date>2024-09-16</Date>
+            <Version>2.7</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Highlighed changes:
- Add gamepad support
- Fix workarounds for ONYX devices
- Accept float values for --max-fps
- Various technical fixes

Full release notes available [here](https://github.com/Genymobile/scrcpy/releases/tag/v2.7)

**Test Plan**

Mirrored my phone's screen and controlled a game with my gamepad

**Checklist**

- [x] Package was built and tested against unstable
