### PR TITLE
light: Change upstreams

### DIFF
--- a/packages/l/light/abi_used_symbols
+++ b/packages/l/light/abi_used_symbols
@@ -1,7 +1,7 @@
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_fscanf
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_fscanf
+libc.so.6:__isoc23_sscanf
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk

--- a/packages/l/light/monitoring.yml
+++ b/packages/l/light/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 16142
+  rss: null # Upstream is an archived mirror, feed is DOA
+# No known CPE, checked 2024-09-16
+security:
+  cpe: ~

--- a/packages/l/light/package.yml
+++ b/packages/l/light/package.yml
@@ -1,9 +1,10 @@
 name       : light
 version    : 1.2.2
-release    : 5
+release    : 6
 source     :
-    - https://github.com/haikarainen/light/archive/v1.2.2.tar.gz : 62e889ee9be80fe808a972ef4981acc39e83a20f9a84a66a82cd1f623c868d9c
-license    : GPL-3.0
+    - git|https://gitlab.com/dpeukert/light.git : 2a54078cbe3814105ee4f565f451b1b5947fbde0
+homepage   : https://gitlab.com/dpeukert/light
+license    : GPL-3.0-or-later
 component  : system.utils
 summary    : GNU/Linux application to control backlights
 description: |

--- a/packages/l/light/pspec_x86_64.xml
+++ b/packages/l/light/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>light</Name>
+        <Homepage>https://gitlab.com/dpeukert/light</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-3.0</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">GNU/Linux application to control backlights</Summary>
         <Description xml:lang="en">GNU/Linux application to control backlights
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>light</Name>
@@ -25,12 +26,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2021-06-25</Date>
+        <Update release="6">
+            <Date>2024-09-16</Date>
             <Version>1.2.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Original GitHub repository is gone, switch to this GitLab archived mirror, used by other distros.

Resolves https://github.com/getsolus/packages/issues/3845

**Test Plan**

- List available backlight controllers

**Checklist**

- [x] Package was built and tested against unstable
