### PR TITLE
solbuild: Drop fakeroot use, use eopkg.bin

### DIFF
--- a/packages/s/solbuild/package.yml
+++ b/packages/s/solbuild/package.yml
@@ -1,8 +1,8 @@
 name       : solbuild
 version    : 1.7.0
-release    : 55
+release    : 56
 source     :
-    - git|https://github.com/getsolus/solbuild.git : 39c0bf58b0c72ca6a626ae383e9e5fe73cd7976b
+    - https://github.com/getsolus/solbuild/archive/refs/tags/v1.7.0.tar.gz : b4541992e119d2fe37c5fec6ead4f2872e648bdd3767e013775503019cccdde7
 homepage   : https://github.com/getsolus/solbuild
 license    : Apache-2.0
 component  :

--- a/packages/s/solbuild/package.yml
+++ b/packages/s/solbuild/package.yml
@@ -1,8 +1,8 @@
 name       : solbuild
-version    : 1.6.3
-release    : 54
+version    : 1.7.0
+release    : 55
 source     :
-    - https://github.com/getsolus/solbuild/archive/refs/tags/v1.6.3.tar.gz : 51fd8fde341847b3a8aeb37fce257600ff5185a83371bc5cee14cc3d38a4b38d
+    - git|https://github.com/getsolus/solbuild.git : 39c0bf58b0c72ca6a626ae383e9e5fe73cd7976b
 homepage   : https://github.com/getsolus/solbuild
 license    : Apache-2.0
 component  :

--- a/packages/s/solbuild/pspec_x86_64.xml
+++ b/packages/s/solbuild/pspec_x86_64.xml
@@ -38,7 +38,7 @@
 </Description>
         <PartOf>programming.tools</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="55">solbuild</Dependency>
+            <Dependency releaseFrom="56">solbuild</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/solbuild/local-unstable-x86_64.profile</Path>
@@ -51,15 +51,15 @@
 </Description>
         <PartOf>programming.tools</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="55">solbuild</Dependency>
+            <Dependency releaseFrom="56">solbuild</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/solbuild/99_unstable.conf</Path>
         </Files>
     </Package>
     <History>
-        <Update release="55">
-            <Date>2024-10-16</Date>
+        <Update release="56">
+            <Date>2024-10-23</Date>
             <Version>1.7.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Rune Morling</Name>

--- a/packages/s/solbuild/pspec_x86_64.xml
+++ b/packages/s/solbuild/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>solbuild</Name>
         <Homepage>https://github.com/getsolus/solbuild</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.tools</PartOf>
@@ -38,7 +38,7 @@
 </Description>
         <PartOf>programming.tools</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="54">solbuild</Dependency>
+            <Dependency releaseFrom="55">solbuild</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/solbuild/local-unstable-x86_64.profile</Path>
@@ -51,19 +51,19 @@
 </Description>
         <PartOf>programming.tools</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="54">solbuild</Dependency>
+            <Dependency releaseFrom="55">solbuild</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/solbuild/99_unstable.conf</Path>
         </Files>
     </Package>
     <History>
-        <Update release="54">
-            <Date>2024-06-16</Date>
-            <Version>1.6.3</Version>
+        <Update release="55">
+            <Date>2024-10-16</Date>
+            <Version>1.7.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Adds the new solbuild with no-fakeroot functionality.

Important note: Landing this PR to -unstable needs to be followed up by updating the solbuild image, otherwise we will get some really annoying failures related to libglib-json moving certain files to a -devel subpackage IIUC.

Depends on https://github.com/getsolus/packages/pull/4063 and should be landed after it.

**Test Plan**

- Complete the Test Plan for https://github.com/getsolus/packages/pull/4063 first
- Check out the branch associated with the present PR
- Build solbuild with `go-task localcp` and install it
- Run `solbuild version` and check that it shows 1.7.0
- Check out the branch from https://github.com/getsolus/packages/pull/4063 again
- Demonstrate to yourself that the two PRs taken together are self-hosting:
  - Re-build pisi, eopkg, ypkg from the 4063 branch w/ `go-task localcp` and re-install each of them after each build completes
  - Switch back to the present solbuild branch, and rebuild solbuild with `go-task localcp` and re-install it after the build completes 
  - It is important that you do _not_ clean the Local repo cache before doing this!
  - Once again, pay attention to the `FilesDB (version:` output. It should shift from being version 3 to version 4 from `eopkg` and onwards, which is a sign that the new solbuild is now asking `ypkg-install-deps` to use `eopkg.bin` to install deps (it was hardcoded to `eopkg -> eopkg.py2` in ypkg before).
- Build a bunch of packages of your choice (using `go-task local` or `go-task localcp`) to test the new tooling versions.
  - Again, pay special attention to the `FilesDB (version:` output in the build logs.
  - If you do, you will realise that the FilesDB is getting rebuilt during each build. This is because the solbuild backing image has not yet been generated with the new version of `eopkg.bin`. Once the #4063 PR and the present PR has been landed, we can then update the solbuild images to also use eopkg.bin and `FilesDB (version: 4)`.

**Checklist**

- [x] Package was built and tested against unstable
