### PR TITLE
obs-cmd: Update to 0.17.8

### DIFF
--- a/packages/o/obs-cmd/abi_used_symbols
+++ b/packages/o/obs-cmd/abi_used_symbols
@@ -40,6 +40,7 @@ libc.so.6:mprotect
 libc.so.6:munmap
 libc.so.6:open
 libc.so.6:open64
+libc.so.6:pause
 libc.so.6:poll
 libc.so.6:posix_memalign
 libc.so.6:pthread_attr_destroy
@@ -50,7 +51,6 @@ libc.so.6:pthread_attr_setstacksize
 libc.so.6:pthread_create
 libc.so.6:pthread_detach
 libc.so.6:pthread_getattr_np
-libc.so.6:pthread_getspecific
 libc.so.6:pthread_join
 libc.so.6:pthread_key_create
 libc.so.6:pthread_key_delete

--- a/packages/o/obs-cmd/files/fix-version.patch
+++ b/packages/o/obs-cmd/files/fix-version.patch
@@ -1,13 +1,12 @@
-diff --git a/Cargo.lock b/Cargo.lock
-index 9225cfa..aaa85a8 100644
---- a/Cargo.lock
-+++ b/Cargo.lock
-@@ -586,7 +586,7 @@ dependencies = [
- 
- [[package]]
+diff --git a/Cargo.toml b/Cargo.toml
+index bcb4b83..375a4c6 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -1,6 +1,6 @@
+ [package]
  name = "obs-cmd"
--version = "0.1.1"
-+version = "0.17.7"
- dependencies = [
-  "clap",
-  "obws",
+-version = "0.17.7"
++version = "0.17.8"
+ edition = "2021"
+ description = "A minimal command to control obs via obs-websocket"
+ authors = ["Luigi Maselli <luigi@grigio.org>"]

--- a/packages/o/obs-cmd/package.yml
+++ b/packages/o/obs-cmd/package.yml
@@ -1,8 +1,8 @@
 name       : obs-cmd
-version    : 0.17.7
-release    : 1
+version    : 0.17.8
+release    : 2
 source     :
-    - https://github.com/grigio/obs-cmd/archive/refs/tags/v0.17.7.tar.gz : 5d3021ba066ac83cea383f4380a98f2bffd2412d10471d7281a2aa09d8a4616e
+    - https://github.com/grigio/obs-cmd/archive/refs/tags/v0.17.8.tar.gz : cc0cf8897ddaf13d72cfacfc7af54cd4ba7987bb0619aff31911f919d75bf6ec
 homepage   : https://github.com/grigio/obs-cmd
 license    : MIT
 component  : system.utils

--- a/packages/o/obs-cmd/pspec_x86_64.xml
+++ b/packages/o/obs-cmd/pspec_x86_64.xml
@@ -24,9 +24,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-09-03</Date>
-            <Version>0.17.7</Version>
+        <Update release="2">
+            <Date>2024-09-16</Date>
+            <Version>0.17.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Ian M. Jones</Name>
             <Email>ian@ianmjones.com</Email>


### PR DESCRIPTION
**Summary**

Enhancements:

- Add streaming status command

Full release notes:

- [0.17.8](https://github.com/grigio/obs-cmd/releases/tag/v0.17.8)

**Test Plan**

* Built.
* Ran few manual commands.
* Ran few scripted commands (via deckmaster).

**Checklist**

- [x] Package was built and tested against unstable
