### PR TITLE
micro: Bump to add .desktop and .metainfo.xml

### DIFF
--- a/packages/m/micro/package.yml
+++ b/packages/m/micro/package.yml
@@ -1,6 +1,6 @@
 name       : micro
 version    : 2.0.14
-release    : 30
+release    : 31
 source     :
     - git|https://github.com/zyedidia/micro.git : v2.0.14
 license    : MIT
@@ -20,6 +20,8 @@ build      : |
 install    : |
     install -Dm00755 $workdir/micro $installdir/usr/bin/micro
     install -Dm00644 $workdir/assets/packaging/micro.1 $installdir/usr/share/man/man1/micro.1
+    install -Dm00644 $workdir/assets/packaging/micro.desktop -t $installdir/usr/share/applications
+    install -Dm00644 $workdir/data/io.github.zyedidia.micro.metainfo.xml -t $installdir/usr/share/metainfo
 
     # Set EDITOR and VISUAL defaults should nano be removed.
 

--- a/packages/m/micro/pspec_x86_64.xml
+++ b/packages/m/micro/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>micro</Name>
         <Homepage>https://micro-editor.github.io</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>editor</PartOf>
@@ -21,18 +21,20 @@
         <PartOf>editor</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/micro</Path>
+            <Path fileType="data">/usr/share/applications/micro.desktop</Path>
             <Path fileType="data">/usr/share/defaults/etc/profile.d/80-micro-is-default-EDITOR-and-VISUAL.fish</Path>
             <Path fileType="data">/usr/share/defaults/etc/profile.d/80-micro-is-default-EDITOR-and-VISUAL.sh</Path>
             <Path fileType="man">/usr/share/man/man1/micro.1</Path>
+            <Path fileType="data">/usr/share/metainfo/io.github.zyedidia.micro.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="30">
-            <Date>2024-08-28</Date>
+        <Update release="31">
+            <Date>2024-09-16</Date>
             <Version>2.0.14</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add the .desktop file that ships with micro. This allows micro to open supported file types from GUI e.g. file browsers. 
Also add the metainfo.xml shipped with micro.

**Test Plan**

Open nautilus (or your preferred file browser) and navigate to a folder containing a .typ file. Right click -> Open With -> select micro. Make sure the file opens in micro. Check that micro appears in the application menu.

**Checklist**

- [x] Package was built and tested against unstable
