### PR TITLE
delta: Update to 0.18.2

### DIFF
--- a/packages/d/delta/abi_used_symbols
+++ b/packages/d/delta/abi_used_symbols
@@ -75,6 +75,7 @@ libc.so.6:munmap
 libc.so.6:open
 libc.so.6:open64
 libc.so.6:opendir
+libc.so.6:pause
 libc.so.6:pipe2
 libc.so.6:poll
 libc.so.6:posix_memalign

--- a/packages/d/delta/package.yml
+++ b/packages/d/delta/package.yml
@@ -1,8 +1,8 @@
 name       : delta
-version    : 0.18.1
-release    : 2
+version    : 0.18.2
+release    : 3
 source     :
-    - https://github.com/dandavison/delta/archive/refs/tags/0.18.1.tar.gz : ef558e0ee4c9a10046f2f8e2e59cf1bedbb18c2871306b772d3d9b8e3b242b9c
+    - https://github.com/dandavison/delta/archive/refs/tags/0.18.2.tar.gz : 64717c3b3335b44a252b8e99713e080cbf7944308b96252bc175317b10004f02
 homepage   : https://dandavison.github.io/delta/
 license    : MIT
 component  : programming.tools

--- a/packages/d/delta/pspec_x86_64.xml
+++ b/packages/d/delta/pspec_x86_64.xml
@@ -24,9 +24,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-08-25</Date>
-            <Version>0.18.1</Version>
+        <Update release="3">
+            <Date>2024-09-19</Date>
+            <Version>0.18.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Ivan Trepakov</Name>
             <Email>liontiger23@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changelog:

- [0.18.2](https://github.com/dandavison/delta/releases/tag/0.18.2)

**Test Plan**

All following scenarios should output neatly formatted and highlighted
diffs:

- Use `delta` as replacement for `diff`:
  ```console
  $ delta /usr/share/defaults/etc/profile /usr/share/defaults/etc/xprofile
  ```
- Use `delta` in git repository:
  ```console
  $ GIT_PAGER=delta git diff HEAD~1
  ```
- Use `delta` with side-by-side mode in git repository:
  ```console
  $ GIT_PAGER=delta DELTA_FEATURES='+side-by-side' git diff HEAD~1
  ```

**Checklist**

- [x] Package was built and tested against unstable
