### PR TITLE
gpxsee: Update to 13.25

### DIFF
--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.24'
-release    : 43
+version    : '13.25'
+release    : 44
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.24.tar.gz : f15d503d0c5efcf42f6d4e6d4c924de9ad672722365adc6573ff1f9d755a71c2
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.25.tar.gz : aa79e3068393cc0f52b76d4899922a3b3df868061eaca1292b98099a4785dd31
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -172,9 +172,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="43">
-            <Date>2024-09-09</Date>
-            <Version>13.24</Version>
+        <Update release="44">
+            <Date>2024-09-20</Date>
+            <Version>13.25</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- [changelog](https://build.opensuse.org/projects/home:tumic:GPXSee/packages/gpxsee/files/gpxsee.changes)

**Test Plan**
- zoom in and out

**Checklist**
- [X] Package was built and tested against unstable
