### PR TITLE
physfs: Update to 3.2.0

### DIFF
--- a/packages/p/physfs/abi_symbols
+++ b/packages/p/physfs/abi_symbols
@@ -62,6 +62,7 @@ libphysfs.so.1:PHYSFS_seek
 libphysfs.so.1:PHYSFS_setAllocator
 libphysfs.so.1:PHYSFS_setBuffer
 libphysfs.so.1:PHYSFS_setErrorCode
+libphysfs.so.1:PHYSFS_setRoot
 libphysfs.so.1:PHYSFS_setSaneConfig
 libphysfs.so.1:PHYSFS_setWriteDir
 libphysfs.so.1:PHYSFS_stat

--- a/packages/p/physfs/package.yml
+++ b/packages/p/physfs/package.yml
@@ -1,8 +1,9 @@
 name       : physfs
-version    : 3.0.2
-release    : 6
+version    : 3.2.0
+release    : 7
 source     :
-    - https://icculus.org/physfs/downloads/physfs-3.0.2.tar.bz2 : 304df76206d633df5360e738b138c94e82ccf086e50ba84f456d3f8432f9f863
+    - https://github.com/icculus/physfs/archive/refs/tags/release-3.2.0.tar.gz : 1991500eaeb8d5325e3a8361847ff3bf8e03ec89252b7915e1f25b3f8ab5d560
+homepage   : https://icculus.org/physfs/
 license    : Zlib
 component  : programming.library
 summary    : PhysicsFS; a portable, flexible file i/o abstraction

--- a/packages/p/physfs/pspec_x86_64.xml
+++ b/packages/p/physfs/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>physfs</Name>
+        <Homepage>https://icculus.org/physfs/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>Zlib</License>
         <PartOf>programming.library</PartOf>
         <Summary xml:lang="en">PhysicsFS; a portable, flexible file i/o abstraction</Summary>
         <Description xml:lang="en">PhysicsFS is a library to provide abstract access to various archives. It is intended for use in video games, and the design was somewhat inspired by Quake 3&apos;s file subsystem. The programmer defines a &quot;write directory&quot; on the physical filesystem. No file writing done through the PhysicsFS API can leave that write directory, for security. For example, an embedded scripting language cannot write outside of this path if it uses PhysFS for all of its I/O, which means that untrusted scripts can run more safely. Symbolic links can be disabled as well, for added safety. For file reading, the programmer lists directories and archives that form a &quot;search path&quot;. Once the search path is defined, it becomes a single, transparent hierarchical filesystem. This makes for easy access to ZIP files in the same way as you access a file directly on the disk, and it makes it easy to ship a new archive that will override a previous archive on a per-file basis. Finally, PhysicsFS gives you platform-abstracted means to determine if CD-ROMs are available, the user&apos;s home directory, where in the real filesystem your program is running, etc.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>physfs</Name>
@@ -20,8 +21,8 @@
         <PartOf>programming.library</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/test_physfs</Path>
-            <Path fileType="library">/usr/lib/libphysfs.so.1</Path>
-            <Path fileType="library">/usr/lib/libphysfs.so.3.0.2</Path>
+            <Path fileType="library">/usr/lib64/libphysfs.so.1</Path>
+            <Path fileType="library">/usr/lib64/libphysfs.so.3.2.0</Path>
         </Files>
     </Package>
     <Package>
@@ -31,22 +32,24 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="6">physfs</Dependency>
+            <Dependency release="7">physfs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/physfs.h</Path>
-            <Path fileType="library">/usr/lib/libphysfs.a</Path>
-            <Path fileType="library">/usr/lib/libphysfs.so</Path>
-            <Path fileType="data">/usr/lib/pkgconfig/physfs.pc</Path>
+            <Path fileType="library">/usr/lib64/cmake/PhysFS/PhysFSConfig-relwithdebinfo.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/PhysFS/PhysFSConfig.cmake</Path>
+            <Path fileType="library">/usr/lib64/libphysfs.a</Path>
+            <Path fileType="library">/usr/lib64/libphysfs.so</Path>
+            <Path fileType="data">/usr/lib64/pkgconfig/physfs.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2022-03-24</Date>
-            <Version>3.0.2</Version>
+        <Update release="7">
+            <Date>2024-09-21</Date>
+            <Version>3.2.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/icculus/physfs/releases/tag/release-3.2.0).

**Test Plan**
- Installed Neverball which is dependent on this and played a game.

**Checklist**

- [X] Package was built and tested against unstable
