### PR TITLE
Taskfile: Make the clean-local target list .eopkgs

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -219,17 +219,23 @@ tasks:
   clean-local:
     desc: WARNING - Clean ALL eopkgs found in solbuild local repository /var/lib/solbuild/local
     aliases: [rmlocal, rml]
-    prompt: This will clean ALL eopkgs found in solbuild local repository /var/lib/solbuild/local. Continue?
     cmds:
-      - task: list-local
+      - task: list-local       # first show all found .eopkg files
+      - task: delete-local     # then prompt before deleting them
+      - task: build-localindex # ... and rebuild the index afterwards
+
+  delete-local:
+    desc: Ask before deleting all .eopkgs found in the local repo
+    dir: '{{ .TASKFILE_DIR }}'
+    prompt: This will delete ALL .eopkgs found in the solbuild local repository. Continue?
+    cmds:
       - sudo rm /var/lib/solbuild/local/*.eopkg
-      - task: build-localindex
 
   list-local:
     desc: List all .eopkgs in the local repo (/var/lib/solbuild/local/*.eopkg)
     aliases: [lslocal, lsl]
     cmds:
-      - ls -lh /var/lib/solbuild/local/
+      - ls -AFcghlot /var/lib/solbuild/local/
 
   clean-all:
     desc: List all .eopkgs found in the monorepo, ask before deleting them.


### PR DESCRIPTION
**Summary**
This should make `go-task clean-local` more ergonomic to use.

Note that `go-task list-local` now also lists files in descending date, which has the effect of showing you if you have added an .eopkg which is not yet in the index.

**Test Plan**

`go-task clean-local`

Example output:

```
ermo@solbox:~/repos/getsolus/monorepo [smarter-clean-local-task* +8 ~1 -0 !]
$ gt clean-local
task: [list-local] ls -AFcghlot /var/lib/solbuild/local/
total 8,1M
-rw-rwSr-- 1   40 Sep 23 13:33 eopkg-index.xml.sha1sum
-rw-rwSr-- 1 1,4K Sep 23 13:33 eopkg-index.xml.xz
-rw-rwSr-- 1   40 Sep 23 13:33 eopkg-index.xml.xz.sha1sum
-rw-rwSr-- 1  12K Sep 23 13:33 eopkg-index.xml
-rw-r--r-- 1  96K Sep 23 13:24 libjson-glib-32bit-1.8.0-27-1-x86_64.eopkg
-rw-r--r-- 1 1,7K Sep 23 13:24 libjson-glib-32bit-devel-1.8.0-27-1-x86_64.eopkg
-rw-r--r-- 1  43K Sep 23 13:24 libjson-glib-devel-1.8.0-27-1-x86_64.eopkg
-rw-r--r-- 1 171K Sep 23 13:24 libjson-glib-1.8.0-27-1-x86_64.eopkg
-rw-r--r-- 1 4,0M Sep 23 13:13 solbuild-1.7.0-55-1-x86_64.eopkg
-rw-r--r-- 1 2,0K Sep 23 13:13 solbuild-config-local-unstable-1.6.3-55-1-x86_64.eopkg
-rw-r--r-- 1 2,0K Sep 23 13:13 solbuild-config-local-unstable-1.7.0-55-1-x86_64.eopkg
-rw-r--r-- 1 1,5K Sep 23 13:13 solbuild-config-unstable-1.6.3-55-1-x86_64.eopkg
-rw-r--r-- 1 1,5K Sep 23 13:13 solbuild-config-unstable-1.7.0-55-1-x86_64.eopkg
-rw-r--r-- 1 3,8M Sep 23 13:13 solbuild-1.6.3-55-1-x86_64.eopkg
This will delete ALL .eopkgs found in the solbuild local repository. Continue? [y/N]:
```

**Checklist**

- [x] Package was built and tested against unstable
