### PR TITLE
onedrive-gui: Update to 1.1.0 and add monitoring.yml

### DIFF
--- a/packages/o/onedrive-gui/files/0001-make-project-buildable.patch
+++ b/packages/o/onedrive-gui/files/0001-make-project-buildable.patch
@@ -66,7 +66,7 @@ index 608aa39..5fd04d7 100644
 +    global app
      app = QApplication(sys.argv)
      app.setApplicationName("OneDriveGUI")
-     app.setWindowIcon(QIcon(DIR_PATH + "/resources/images/icons8-clouds-48.png"))
+     app.setWindowIcon(QIcon(DIR_PATH + "/resources/images/icons8-clouds-80-dark-edge.png"))
  
 +    global main_window
      main_window = MainWindow()

--- a/packages/o/onedrive-gui/files/0002-create-package-directory.patch
+++ b/packages/o/onedrive-gui/files/0002-create-package-directory.patch
@@ -30,10 +30,10 @@ diff --git a/src/OneDriveGUI.py b/src/onedrive_gui/OneDriveGUI.py
 similarity index 99%
 rename from src/OneDriveGUI.py
 rename to src/onedrive_gui/OneDriveGUI.py
-index 5fd04d7..60c0d0e 100644
+index 6c34672..edd7a64 100644
 --- a/src/OneDriveGUI.py
 +++ b/src/onedrive_gui/OneDriveGUI.py
-@@ -43,26 +43,26 @@ from urllib3 import HTTPSConnectionPool
+@@ -43,20 +43,20 @@ from urllib3 import HTTPSConnectionPool
  # TODO: Split into multiple files once all main features are implemented.
  
  # Imports for main window.
@@ -56,18 +56,11 @@ index 5fd04d7..60c0d0e 100644
 +from .ui.ui_gui_settings_window import Ui_gui_settings_window
  
  # Import for login windows.
- # Don't use WebEngine login window when running from AppImage.
- DIR_PATH = os.path.dirname(os.path.realpath(__file__))
- APPIMAGE = True if "tmp/.mount_one" in DIR_PATH.lower() else False
- if APPIMAGE:
--    from ui.ui_external_login import Ui_ExternalLoginWindow
-+    from .ui.ui_external_login import Ui_ExternalLoginWindow
- else:
--    from ui.ui_login import Ui_LoginWindow
-+    from .ui.ui_login import Ui_LoginWindow
+-from ui.ui_external_login import Ui_ExternalLoginWindow
++from .ui.ui_external_login import Ui_ExternalLoginWindow
  
- 
- PROFILES_FILE = os.path.expanduser("~/.config/onedrive-gui/profiles")
+ # try:
+ #     from ui.ui_login import Ui_LoginWindow
 diff --git a/src/onedrive_gui/__init__.py b/src/onedrive_gui/__init__.py
 new file mode 100644
 index 0000000..e69de29
@@ -259,3 +252,11 @@ diff --git a/src/ui/ui_profile_settings_window.py b/src/onedrive_gui/ui/ui_profi
 similarity index 100%
 rename from src/ui/ui_profile_settings_window.py
 rename to src/onedrive_gui/ui/ui_profile_settings_window.py
+diff --git a/src/ui/profile_settings_window_ui.py b/src/onedrive_gui/ui/profile_settings_window_ui.py
+similarity index 100%
+rename from src/ui/profile_settings_window_ui.py
+rename to src/onedrive_gui/ui/profile_settings_window_ui.py
+diff --git a/src/ui/mainwindow_ui.py b/src/onedrive_gui/ui/mainwindow_ui.py
+similarity index 100%
+rename from src/ui/mainwindow_ui.py
+rename to src/onedrive_gui/ui/mainwindow_ui.py

--- a/packages/o/onedrive-gui/monitoring.yml
+++ b/packages/o/onedrive-gui/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 374597
+  rss: https://github.com/bpozdena/OneDriveGUI/releases.atom
+# No known CPE, checked 2024-09-25
+security:
+  cpe: ~

--- a/packages/o/onedrive-gui/package.yml
+++ b/packages/o/onedrive-gui/package.yml
@@ -1,8 +1,8 @@
 name       : onedrive-gui
-version    : 1.0.3
-release    : 2
+version    : 1.1.0
+release    : 3
 source     :
-    - https://github.com/bpozdena/OneDriveGUI/archive/refs/tags/v1.0.3.tar.gz : 30511dd2b9c3c548e125564c08e2aaf50f0cfe348abded5733ea04dfa8eb93cf
+    - git|https://github.com/bpozdena/OneDriveGUI.git : 0dff5718ace7fd16649ab0959d232afbad9f94bc
 homepage   : https://github.com/bpozdena/OneDriveGUI
 license    : GPL-3.0-or-later
 component  : network.clients

--- a/packages/o/onedrive-gui/pspec_x86_64.xml
+++ b/packages/o/onedrive-gui/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>onedrive-gui</Name>
         <Homepage>https://github.com/bpozdena/OneDriveGUI</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.clients</PartOf>
@@ -54,6 +54,10 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/resources/images/storage.png</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/resources/images/user-account.png</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/resources/images/warning.png</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/ui/__pycache__/mainwindow_ui.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/ui/__pycache__/mainwindow_ui.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/ui/__pycache__/profile_settings_window_ui.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/ui/__pycache__/profile_settings_window_ui.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/ui/__pycache__/ui_create_new_profile.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/ui/__pycache__/ui_create_new_profile.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/ui/__pycache__/ui_external_login.cpython-311.opt-1.pyc</Path>
@@ -82,9 +86,11 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/ui/login.ui</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/ui/mainwindow.ui</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/ui/mainwindow.ui.autosave</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/ui/mainwindow_ui.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/ui/process_status_page.ui</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/ui/profile_settings_page.ui</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/ui/profile_settings_window.ui</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/ui/profile_settings_window_ui.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/ui/setup_wizard.ui</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/ui/test.ui</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/onedrive_gui/ui/ui_create_new_profile.py</Path>
@@ -102,12 +108,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-02-16</Date>
-            <Version>1.0.3</Version>
+        <Update release="3">
+            <Date>2024-09-25</Date>
+            <Version>1.1.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

**Important:** If you are using sync_business_shared_folders in config of OneDrive v2.4, you will need to manually remove it from the config file.

OneDrive Client for Linux v2.5.0 introduces significant changes and is not backwards compatible with v2.4.x. Please ensure that you do not use both v2.5.0 and v2.4.x clients with the same Microsoft OneDrive account simultaneously - whether on the same or different systems. If you upgrade to v2.5.0, all your clients must be updated to this version. However, you can revert to v2.4.x at any time if necessary, but do not run different versions at the same time on any system.

Changes:
- Provides compatibility with new features introduced in OneDrive client v2.5.0
- Added support for multi-threaded upload/download progress monitoring
- Removed GUI based configuration of Business Shared Folders
- Various bug fixes and small visual improvements

Packaging change: Switched to git build because 1.1.0 release tag has all kinds of issues

**Test Plan**

Logged in and synced my OneDrive

**Checklist**

- [x] Package was built and tested against unstable
