### PR TITLE
python-maturin: Update to 1.7.2

### DIFF
--- a/packages/py/python-maturin/abi_used_symbols
+++ b/packages/py/python-maturin/abi_used_symbols
@@ -67,6 +67,7 @@ libc.so.6:open
 libc.so.6:open64
 libc.so.6:openat64
 libc.so.6:opendir
+libc.so.6:pause
 libc.so.6:pipe2
 libc.so.6:poll
 libc.so.6:posix_memalign
@@ -87,7 +88,6 @@ libc.so.6:pthread_attr_setstacksize
 libc.so.6:pthread_create
 libc.so.6:pthread_detach
 libc.so.6:pthread_getattr_np
-libc.so.6:pthread_getspecific
 libc.so.6:pthread_join
 libc.so.6:pthread_key_create
 libc.so.6:pthread_key_delete
@@ -161,7 +161,6 @@ libcrypto.so.3:EVP_PKEY_free
 libcrypto.so.3:OpenSSL_version_num
 libcrypto.so.3:PEM_read_bio_X509
 libcrypto.so.3:X509_STORE_add_cert
-libcrypto.so.3:X509_STORE_free
 libcrypto.so.3:X509_STORE_new
 libcrypto.so.3:X509_VERIFY_PARAM_set1_host
 libcrypto.so.3:X509_VERIFY_PARAM_set1_ip

--- a/packages/py/python-maturin/package.yml
+++ b/packages/py/python-maturin/package.yml
@@ -1,8 +1,8 @@
 name       : python-maturin
-version    : 1.7.1
-release    : 46
+version    : 1.7.2
+release    : 47
 source     :
-    - https://github.com/PyO3/maturin/archive/refs/tags/v1.7.1.tar.gz : 40259109a3d941237db3dff2f34c5e953904de86410e516c098f824d6160109b
+    - https://github.com/PyO3/maturin/archive/refs/tags/v1.7.2.tar.gz : 522e763a77830dd4251bafeb83f376a29e225a06fbe985ed14d98e3db0ecabd9
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-maturin/pspec_x86_64.xml
+++ b/packages/py/python-maturin/pspec_x86_64.xml
@@ -22,12 +22,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/maturin</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.1-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.1-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.1-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.1-py3.11.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.1-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.1-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.2-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.2-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.2-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.2-py3.11.egg-info/not-zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.2-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.2-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/__pycache__/__init__.cpython-311.pyc</Path>
@@ -35,9 +35,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="46">
-            <Date>2024-08-22</Date>
-            <Version>1.7.1</Version>
+        <Update release="47">
+            <Date>2024-09-25</Date>
+            <Version>1.7.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Cross building fixes
- Normalize `REPOSITORY_URL`
- UniFFI: supports bindings generated from multiple crates
- Enable `--all-features` when building source distribution
- Replace "." with "/" in module_name

**Test Plan**

Successfully built `python-orjson`

**Checklist**

- [x] Package was built and tested against unstable
