### PR TITLE
frog-protocols: Add at 0.01

### DIFF
--- a/packages/f/frog-protocols/MAINTAINERS.md
+++ b/packages/f/frog-protocols/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Evan Maddock
+  - Matrix: @ebonjaeger:matrix.org
+  - Email: maddock.evan@vivaldi.net

--- a/packages/f/frog-protocols/monitoring.yml
+++ b/packages/f/frog-protocols/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 374559
+  rss: https://github.com/misyltoad/frog-protocols/tags.atom
+# No known CPE, checked 2024-09-23
+security:
+  cpe: ~

--- a/packages/f/frog-protocols/package.yml
+++ b/packages/f/frog-protocols/package.yml
@@ -1,0 +1,17 @@
+name       : frog-protocols
+version    : 0.01
+release    : 1
+source     :
+    - https://github.com/misyltoad/frog-protocols/archive/refs/tags/0.01.tar.gz : 875940795480ade6c16375fa07d8550e7ed2841937d86cc762f77a2cec6bfac9
+homepage   : https://github.com/misyltoad/frog-protocols
+license    : MIT
+component  : desktop.wayland
+summary    : Frog Protocols for Wayland
+description: |
+    Frog Protocols are a set of Wayland protocols that are much more iterative.
+setup      : |
+    %meson_configure
+build      : |
+    %ninja_build
+install    : |
+    %ninja_install

--- a/packages/f/frog-protocols/pspec_x86_64.xml
+++ b/packages/f/frog-protocols/pspec_x86_64.xml
@@ -1,0 +1,49 @@
+<PISI>
+    <Source>
+        <Name>frog-protocols</Name>
+        <Homepage>https://github.com/misyltoad/frog-protocols</Homepage>
+        <Packager>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
+        </Packager>
+        <License>MIT</License>
+        <PartOf>desktop.wayland</PartOf>
+        <Summary xml:lang="en">Frog Protocols for Wayland</Summary>
+        <Description xml:lang="en">Frog Protocols are a set of Wayland protocols that are much more iterative.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>frog-protocols</Name>
+        <Summary xml:lang="en">Frog Protocols for Wayland</Summary>
+        <Description xml:lang="en">Frog Protocols are a set of Wayland protocols that are much more iterative.
+</Description>
+        <PartOf>desktop.wayland</PartOf>
+        <Files>
+            <Path fileType="data">/usr/share/frog-protocols/frog-color-management-v1.xml</Path>
+            <Path fileType="data">/usr/share/frog-protocols/frog-fifo-v1.xml</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>frog-protocols-devel</Name>
+        <Summary xml:lang="en">Development files for frog-protocols</Summary>
+        <Description xml:lang="en">Frog Protocols are a set of Wayland protocols that are much more iterative.
+</Description>
+        <PartOf>programming.devel</PartOf>
+        <RuntimeDependencies>
+            <Dependency release="1">frog-protocols</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="data">/usr/share/pkgconfig/frog-protocols.pc</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2024-09-23</Date>
+            <Version>0.01</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**
- Initial inclusion of `frog-protocols`

Fixes https://github.com/getsolus/packages/issues/3898

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

n/a (Package only contains XML definitions of the protocols)

**Checklist**

- [x] Package was built and tested against unstable
