### PR TITLE
eza: Update to 0.19.4

### DIFF
--- a/packages/e/eza/package.yml
+++ b/packages/e/eza/package.yml
@@ -1,8 +1,8 @@
 name       : eza
-version    : 0.19.2
-release    : 30
+version    : 0.19.4
+release    : 31
 source     :
-    - https://github.com/eza-community/eza/archive/refs/tags/v0.19.2.tar.gz : db4897ef7f58d0802620180e0b13bb35563e03c9de66624206b35dcad21007f8
+    - https://github.com/eza-community/eza/archive/refs/tags/v0.19.4.tar.gz : c0094b3ee230702d4dd983045e38ea2bd96375c16381c0206c88fae82fb551a4
 homepage   : https://github.com/eza-community/eza
 license    : MIT
 component  : system.utils

--- a/packages/e/eza/pspec_x86_64.xml
+++ b/packages/e/eza/pspec_x86_64.xml
@@ -33,9 +33,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="30">
-            <Date>2024-09-10</Date>
-            <Version>0.19.2</Version>
+        <Update release="31">
+            <Date>2024-09-25</Date>
+            <Version>0.19.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Remove `non_alpha` from percent encoding to fix hyprlinks
- Convert empty space to `%20` when render hyperlinks

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

List files and directories inside a directory.

**Checklist**

- [x] Package was built and tested against unstable
