### PR TITLE
github-cli: Update to 2.57.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.56.0
-release    : 54
+version    : 2.57.0
+release    : 55
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.56.0.tar.gz : ed19f01df36e336472c434edfadf01a2cbe4bf07394724b064a80c8fd6a0dc1e
+    - https://github.com/cli/cli/archive/refs/tags/v2.57.0.tar.gz : 6433bca534da722a980126541fe28d278f4b3518a6f7a7ef4a23949a3968e8b9
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -219,9 +219,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="54">
-            <Date>2024-09-10</Date>
-            <Version>2.56.0</Version>
+        <Update release="55">
+            <Date>2024-09-25</Date>
+            <Version>2.57.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Added tenancy aware attestation commands
- Added `--active flag` to the `gh auth status` command
- `gh attestation verify` test for custom OIDC issuers
- Update `gh attestation verify` bundle parsing and validation errors
- Suppress `attestation verify` output when no TTY present
- Use api subdomains for tenant hosts

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and make this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
