### PR TITLE
picocom: Update to 2024.07

### DIFF
--- a/packages/p/picocom/abi_used_symbols
+++ b/packages/p/picocom/abi_used_symbols
@@ -1,5 +1,6 @@
-libc.so.6:__assert_fail
 libc.so.6:__ctype_b_loc
+libc.so.6:__ctype_tolower_loc
+libc.so.6:__ctype_toupper_loc
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
@@ -12,8 +13,10 @@ libc.so.6:__stack_chk_fail
 libc.so.6:__vsnprintf_chk
 libc.so.6:__xpg_basename
 libc.so.6:calloc
+libc.so.6:cfgetispeed
 libc.so.6:cfgetospeed
 libc.so.6:cfmakeraw
+libc.so.6:cfsetispeed
 libc.so.6:cfsetospeed
 libc.so.6:close
 libc.so.6:closedir
@@ -40,11 +43,13 @@ libc.so.6:malloc
 libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset
+libc.so.6:nanosleep
 libc.so.6:open
 libc.so.6:opendir
 libc.so.6:optarg
 libc.so.6:opterr
 libc.so.6:optind
+libc.so.6:optopt
 libc.so.6:putchar
 libc.so.6:puts
 libc.so.6:read
@@ -62,6 +67,7 @@ libc.so.6:stderr
 libc.so.6:stdin
 libc.so.6:stdout
 libc.so.6:strcasecmp
+libc.so.6:strcat
 libc.so.6:strchr
 libc.so.6:strcmp
 libc.so.6:strdup
@@ -79,6 +85,5 @@ libc.so.6:tcgetattr
 libc.so.6:tcsendbreak
 libc.so.6:tcsetattr
 libc.so.6:ttyname
-libc.so.6:usleep
 libc.so.6:waitpid
 libc.so.6:write

--- a/packages/p/picocom/package.yml
+++ b/packages/p/picocom/package.yml
@@ -1,15 +1,19 @@
 name       : picocom
-version    : '3.1'
-release    : 3
+version    : '2024.07'
+release    : 4
 source     :
-    - https://github.com/npat-efault/picocom/archive/3.1.tar.gz : e6761ca932ffc6d09bd6b11ff018bdaf70b287ce518b3282d29e0270e88420bb
+    - https://gitlab.com/wsakernel/picocom/-/archive/2024-07/picocom-2024-07.tar.bz2 : af2b89bc974060bfb2c5683bd9d905312075d4227456ddafbcb0b280b5451a7f
+homepage   : https://gitlab.com/wsakernel/picocom
 license    : GPL-2.0-or-later
 component  : system.utils
 summary    : Dumb-terminal emulator for serial connections
 description: |
     Dumb terminal emulator for serial simple, manual, modem configuration, testing, and debugging tool. It has also served (quite well) as a low-tech serial communications program to allow access to all types of devices that provide serial consoles. It could also prove useful in many other similar tasks.
+builddeps  : 
+    - go-md2man
 build      : |
     %make
+    make doc
 install    : |
     install -Dm00755 picocom $installdir/usr/bin/picocom
     install -Dm00644 picocom.1 $installdir/usr/share/man/man1/picocom.1

--- a/packages/p/picocom/pspec_x86_64.xml
+++ b/packages/p/picocom/pspec_x86_64.xml
@@ -1,16 +1,17 @@
 <PISI>
     <Source>
         <Name>picocom</Name>
+        <Homepage>https://gitlab.com/wsakernel/picocom</Homepage>
         <Packager>
-            <Name>Joshua Strobl</Name>
-            <Email>joshua@getsol.us</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">Dumb-terminal emulator for serial connections</Summary>
         <Description xml:lang="en">Dumb terminal emulator for serial simple, manual, modem configuration, testing, and debugging tool. It has also served (quite well) as a low-tech serial communications program to allow access to all types of devices that provide serial consoles. It could also prove useful in many other similar tasks.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>picocom</Name>
@@ -24,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2021-06-27</Date>
-            <Version>3.1</Version>
+        <Update release="4">
+            <Date>2024-09-26</Date>
+            <Version>2024.07</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joshua Strobl</Name>
-            <Email>joshua@getsol.us</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://gitlab.com/wsakernel/picocom/-/releases/2024-07).
- Resolves https://github.com/getsolus/packages/issues/3875

**Test Plan**
- Installed, checked help. Read the manual.

**Checklist**

- [X] Package was built and tested against unstable
