### PR TITLE
repo-wide: Canonicalize Sourceforge download URLs

### DIFF
--- a/packages/a/aalib/package.yml
+++ b/packages/a/aalib/package.yml
@@ -2,7 +2,7 @@ name       : aalib
 version    : 1.4.0_5
 release    : 8
 source     :
-    - https://ufpr.dl.sourceforge.net/project/aa-project/aa-lib/1.4rc5/aalib-1.4rc5.tar.gz : fbddda9230cf6ee2a4f5706b4b11e2190ae45f5eda1f0409dc4f99b35e0a70ee
+    - https://sourceforge.net/projects/aa-project/files/aa-lib/1.4rc5/aalib-1.4rc5.tar.gz : fbddda9230cf6ee2a4f5706b4b11e2190ae45f5eda1f0409dc4f99b35e0a70ee
 homepage   : https://aa-project.sourceforge.net/aalib/
 license    : LGPL-2.0
 component  : multimedia.library

--- a/packages/a/acpi/package.yml
+++ b/packages/a/acpi/package.yml
@@ -2,7 +2,7 @@ name       : acpi
 version    : '1.7'
 release    : 3
 source     :
-    - https://jaist.dl.sourceforge.net/project/acpiclient/acpiclient/1.7/acpi-1.7.tar.gz : d7a504b61c716ae5b7e81a0c67a50a51f06c7326f197b66a4b823de076a35005
+    - https://sourceforge.net/projects/acpiclient/files/acpiclient/1.7/acpi-1.7.tar.gz : d7a504b61c716ae5b7e81a0c67a50a51f06c7326f197b66a4b823de076a35005
 homepage   : https://sourceforge.net/projects/acpiclient/
 license    : GPL-2.0
 component  : system.utils

--- a/packages/a/acsccid/package.yml
+++ b/packages/a/acsccid/package.yml
@@ -2,7 +2,7 @@ name       : acsccid
 version    : 1.1.10
 release    : 9
 source     :
-    - https://downloads.sourceforge.net/acsccid/acsccid-1.1.10.tar.bz2 : 5ee112febdcac6656629025f3a85923f155f6ca150b2d24fd716f9043265528e
+    - https://sourceforge.net/projects/acsccid/files/acsccid-1.1.10.tar.bz2 : 5ee112febdcac6656629025f3a85923f155f6ca150b2d24fd716f9043265528e
 homepage   : https://acsccid.sourceforge.io/
 license    : LGPL-2.1-or-later
 component  : security.library

--- a/packages/a/apcupsd/package.yml
+++ b/packages/a/apcupsd/package.yml
@@ -2,7 +2,7 @@ name       : apcupsd
 version    : 3.14.14
 release    : 4
 source     :
-    - https://downloads.sourceforge.net/project/apcupsd/apcupsd%20-%20Stable/3.14.14/apcupsd-3.14.14.tar.gz : db7748559b6b4c3784f9856561ef6ac6199ef7bd019b3edcd7e0a647bf8f9867
+    - https://sourceforge.net/projects/apcupsd/files/apcupsd%20-%20Stable/3.14.14/apcupsd-3.14.14.tar.gz : db7748559b6b4c3784f9856561ef6ac6199ef7bd019b3edcd7e0a647bf8f9867
 homepage   : http://www.apcupsd.org/
 license    : GPL-2.0-only
 component  : system.util

--- a/packages/a/asio/package.yml
+++ b/packages/a/asio/package.yml
@@ -2,7 +2,7 @@ name       : asio
 version    : 1.30.2
 release    : 4
 source     :
-    - https://downloads.sourceforge.net/project/asio/asio/1.30.2%20%28Stable%29/asio-1.30.2.tar.gz : 12e7bb4dada8bc1191de9d550a59ee658ce4e645ffc97c911c099ab4e8699d55
+    - https://sourceforge.net/projects/asio/files/asio/1.30.2%20%28Stable%29/asio-1.30.2.tar.gz : 12e7bb4dada8bc1191de9d550a59ee658ce4e645ffc97c911c099ab4e8699d55
 license    : BSL-1.0
 homepage   : http://think-async.com/Asio/
 component  : programming.library

--- a/packages/b/blobby2/package.yml
+++ b/packages/b/blobby2/package.yml
@@ -2,7 +2,7 @@ name       : blobby2
 version    : 1.1.1
 release    : 6
 source     :
-    - https://jaist.dl.sourceforge.net/project/blobby/Blobby%20Volley%202%20%28Linux%29/1.1.1/blobby2-linux-1.1.1.tar.gz : 357ee513e69d3b50f67fc063d4acb7959a5fe88977817f0aab14ccc70db214ba
+    - https://sourceforge.net/projects/blobby/files/Blobby%20Volley%202%20%28Linux%29/1.1.1/blobby2-linux-1.1.1.tar.gz : 357ee513e69d3b50f67fc063d4acb7959a5fe88977817f0aab14ccc70db214ba
 homepage   : https://blobbyvolley.de/
 license    : GPL-2.0-or-later
 component  : games.arcade

--- a/packages/c/cdrdao/package.yml
+++ b/packages/c/cdrdao/package.yml
@@ -2,7 +2,7 @@ name       : cdrdao
 version    : 1.2.5
 release    : 8
 source     :
-    - https://liquidtelecom.dl.sourceforge.net/project/cdrdao/rel_1_2_5/cdrdao-1.2.5.tar.bz2 : d19b67c853c5dba2406afaab6cd788e77f35eebe634cac4679528477c7be01b6
+    - https://sourceforge.net/projects/cdrdao/files/rel_1_2_5/cdrdao-1.2.5.tar.bz2 : d19b67c853c5dba2406afaab6cd788e77f35eebe634cac4679528477c7be01b6
 homepage   : https://cdrdao.sourceforge.net/
 license    : GPL-2.0-or-later
 component  : programming

--- a/packages/c/cntlm/package.yml
+++ b/packages/c/cntlm/package.yml
@@ -2,7 +2,7 @@ name       : cntlm
 version    : 0.92.3
 release    : 7
 source     :
-    - http://internode.dl.sourceforge.net/project/cntlm/cntlm/cntlm%200.92.3/cntlm-0.92.3.tar.gz : 9c3ad10924d43f7248df9ecd33cbc033afbd7ea8d9545de0d68a2782fed76298
+    - https://sourceforge.net/projects/cntlm/files/cntlm/cntlm%200.92.3/cntlm-0.92.3.tar.gz : 9c3ad10924d43f7248df9ecd33cbc033afbd7ea8d9545de0d68a2782fed76298
 homepage   : https://cntlm.sourceforge.net/
 license    : GPL-2.0-or-later
 component  : network.clients

--- a/packages/c/ctags/package.yml
+++ b/packages/c/ctags/package.yml
@@ -2,7 +2,7 @@ name        : ctags
 version     : 5.8
 release     : 5
 source      :
-    - http://internode.dl.sourceforge.net/project/ctags/ctags/5.8/ctags-5.8.tar.gz : 0e44b45dcabe969e0bbbb11e30c246f81abe5d32012db37395eb57d66e9e99c7
+    - https://sourceforge.net/projects/ctags/files/ctags/5.8/ctags-5.8.tar.gz : 0e44b45dcabe969e0bbbb11e30c246f81abe5d32012db37395eb57d66e9e99c7
 homepage    : http://ctags.sourceforge.net/
 license     : GPL-2.0-or-later
 component   : programming.tools

--- a/packages/d/deathcrush-lv2/package.yml
+++ b/packages/d/deathcrush-lv2/package.yml
@@ -2,7 +2,7 @@ name       : deathcrush-lv2
 version    : '04.10'
 release    : 2
 source     :
-    - http://downloads.sourceforge.net/project/intonarumori/Deathcrush/DeathcrushLV2-04.10.tar.bz2 : d94c03688fe4bdd2471c7370941f55cd93f77c0641f902441cb0e3b521f2037a
+    - https://sourceforge.net/projects/intonarumori/files/Deathcrush/DeathcrushLV2-04.10.tar.bz2 : d94c03688fe4bdd2471c7370941f55cd93f77c0641f902441cb0e3b521f2037a
 homepage   : https://intonarumori.sourceforge.net/
 license    : GPL-3.0
 component  : multimedia.audio

--- a/packages/d/dfu-util/package.yml
+++ b/packages/d/dfu-util/package.yml
@@ -2,7 +2,7 @@ name       : dfu-util
 version    : '0.11'
 release    : 3
 source     :
-    - http://dfu-util.sourceforge.net/releases/dfu-util-0.11.tar.gz : b4b53ba21a82ef7e3d4c47df2952adf5fa494f499b6b0b57c58c5d04ae8ff19e
+    - https://sourceforge.net/projects/dfu-util/files/dfu-util-0.11.tar.gz : b4b53ba21a82ef7e3d4c47df2952adf5fa494f499b6b0b57c58c5d04ae8ff19e
 homepage   : http://dfu-util.sourceforge.net
 license    : GPL-2.0-only
 component  : programming.tools

--- a/packages/d/disktype/package.yml
+++ b/packages/d/disktype/package.yml
@@ -2,7 +2,7 @@ name       : disktype
 version    : 9
 release    : 6
 source     :
-    - http://internode.dl.sourceforge.net/project/disktype/disktype/9/disktype-9.tar.gz : b6701254d88412bc5d2db869037745f65f94b900b59184157d072f35832c1111
+    - https://sourceforge.net/projects/disktype/files/disktype/9/disktype-9.tar.gz : b6701254d88412bc5d2db869037745f65f94b900b59184157d072f35832c1111
 homepage   : http://disktype.sourceforge.net/
 license    : MIT
 summary    : Detect the content format of a disk or disk image

--- a/packages/d/djvulibre/package.yml
+++ b/packages/d/djvulibre/package.yml
@@ -2,7 +2,7 @@ name       : djvulibre
 version    : 3.5.28
 release    : 8
 source     :
-    - https://download.sourceforge.net/project/djvu/DjVuLibre/3.5.28/djvulibre-3.5.28.tar.gz : fcd009ea7654fde5a83600eb80757bd3a76998e47d13c66b54c8db849f8f2edc
+    - https://sourceforge.net/projects/djvu/files/DjVuLibre/3.5.28/djvulibre-3.5.28.tar.gz : fcd009ea7654fde5a83600eb80757bd3a76998e47d13c66b54c8db849f8f2edc
 homepage   : http://djvu.sourceforge.net/
 license    : GPL-2.0-or-later
 component  : desktop.library

--- a/packages/d/dos2unix/package.yml
+++ b/packages/d/dos2unix/package.yml
@@ -2,7 +2,7 @@ name       : dos2unix
 version    : 7.5.0
 release    : 8
 source     :
-    - https://download.sourceforge.net/project/dos2unix/dos2unix/7.5.0/dos2unix-7.5.0.tar.gz : 7a3b01d01e214d62c2b3e04c3a92e0ddc728a385566e4c0356efa66fd6eb95af
+    - https://sourceforge.net/projects/dos2unix/files/dos2unix/7.5.0/dos2unix-7.5.0.tar.gz : 7a3b01d01e214d62c2b3e04c3a92e0ddc728a385566e4c0356efa66fd6eb95af
 license    : BSD-2-Clause-FreeBSD
 homepage   : https://dos2unix.sourceforge.io/
 component  : system.utils

--- a/packages/d/drumstick/package.yml
+++ b/packages/d/drumstick/package.yml
@@ -2,7 +2,7 @@ name       : drumstick
 version    : 2.9.0
 release    : 14
 source     :
-    - https://downloads.sourceforge.net/project/drumstick/2.9.0/drumstick-2.9.0.tar.bz2 : a7437c11e0ad5443c21b33f0891c4f748d574f95d0e6970a6040c95db6184eb3
+    - https://sourceforge.net/projects/drumstick/files/2.9.0/drumstick-2.9.0.tar.bz2 : a7437c11e0ad5443c21b33f0891c4f748d574f95d0e6970a6040c95db6184eb3
 homepage   : https://drumstick.sourceforge.io
 license    : GPL-2.0-or-later
 component  : programming.library

--- a/packages/d/dvdauthor/package.yml
+++ b/packages/d/dvdauthor/package.yml
@@ -2,7 +2,7 @@ name       : dvdauthor
 version    : 0.7.2
 release    : 11
 source     :
-    - https://netcologne.dl.sourceforge.net/project/dvdauthor/dvdauthor-0.7.2.tar.gz : 3020a92de9f78eb36f48b6f22d5a001c47107826634a785a62dfcd080f612eb7
+    - https://sourceforge.net/projects/dvdauthor/files/dvdauthor-0.7.2.tar.gz : 3020a92de9f78eb36f48b6f22d5a001c47107826634a785a62dfcd080f612eb7
 homepage   : https://dvdauthor.sourceforge.net/
 license    : GPL-2.0-or-later
 component  : multimedia.video

--- a/packages/d/dvgrab/package.yml
+++ b/packages/d/dvgrab/package.yml
@@ -2,7 +2,7 @@ name       : dvgrab
 version    : '3.5'
 release    : 4
 source     :
-    - http://netix.dl.sourceforge.net/project/kino/dvgrab/3.5/dvgrab-3.5.tar.gz : 5910183429d300221783d6054ff5add15bb2ae49ae33272d723a314bc2ce0af9
+    - https://sourceforge.net/projects/kino/files/dvgrab/3.5/dvgrab-3.5.tar.gz : 5910183429d300221783d6054ff5add15bb2ae49ae33272d723a314bc2ce0af9
 homepage   : https://www.kinodv.org/
 license    : GPL-2.0-or-later
 component  : multimedia.video

--- a/packages/e/enblend-enfuse/package.yml
+++ b/packages/e/enblend-enfuse/package.yml
@@ -2,7 +2,7 @@ name       : enblend-enfuse
 version    : '4.2'
 release    : 7
 source     :
-    - https://download.sourceforge.net/project/enblend/enblend-enfuse/enblend-enfuse-4.2/enblend-enfuse-4.2.tar.gz : 8703e324939ebd70d76afd350e56800f5ea2c053a040a5f5218b2a1a4300bd48
+    - https://sourceforge.net/projects/enblend/files/enblend-enfuse/enblend-enfuse-4.2/enblend-enfuse-4.2.tar.gz : 8703e324939ebd70d76afd350e56800f5ea2c053a040a5f5218b2a1a4300bd48
 homepage   : http://enblend.sourceforge.net/
 license    : GPL-2.0-or-later
 component  : multimedia.graphics

--- a/packages/e/expect/package.yml
+++ b/packages/e/expect/package.yml
@@ -2,7 +2,7 @@ name       : expect
 version    : 5.45.4
 release    : 6
 source     :
-    - https://download.sourceforge.net/project/expect/Expect/5.45.4/expect5.45.4.tar.gz : 49a7da83b0bdd9f46d04a04deec19c7767bb9a323e40c4781f89caf760b92c34
+    - https://sourceforge.net/projects/expect/files/Expect/5.45.4/expect5.45.4.tar.gz : 49a7da83b0bdd9f46d04a04deec19c7767bb9a323e40c4781f89caf760b92c34
 homepage   : https://www.nist.gov/services-resources/software/expect
 license    : Public-Domain
 component  : programming.tools

--- a/packages/f/fdk-aac/package.yml
+++ b/packages/f/fdk-aac/package.yml
@@ -2,7 +2,7 @@ name       : fdk-aac
 version    : 2.0.3
 release    : 7
 source     :
-    - https://netix.dl.sourceforge.net/project/opencore-amr/fdk-aac/fdk-aac-2.0.3.tar.gz : 829b6b89eef382409cda6857fd82af84fabb63417b08ede9ea7a553f811cb79e
+    - https://sourceforge.net/projects/opencore-amr/files/fdk-aac/fdk-aac-2.0.3.tar.gz : 829b6b89eef382409cda6857fd82af84fabb63417b08ede9ea7a553f811cb79e
 homepage   : https://sourceforge.net/projects/opencore-amr/
 license    : BSD-3-Clause
 component  : multimedia.codecs

--- a/packages/f/font-terminus-console/package.yml
+++ b/packages/f/font-terminus-console/package.yml
@@ -2,7 +2,7 @@ name       : font-terminus-console
 version    : 4.49.1
 release    : 3
 source     :
-    - http://netix.dl.sourceforge.net/project/terminus-font/terminus-font-4.49/terminus-font-4.49.1.tar.gz : d961c1b781627bf417f9b340693d64fc219e0113ad3a3af1a3424c7aa373ef79
+    - https://sourceforge.net/projects/terminus-font/files/terminus-font-4.49/terminus-font-4.49.1.tar.gz : d961c1b781627bf417f9b340693d64fc219e0113ad3a3af1a3424c7aa373ef79
 license    : OFL-1.1
 homepage   : https://terminus-font.sourceforge.net/
 component  : system.base

--- a/packages/f/foobillardplus/package.yml
+++ b/packages/f/foobillardplus/package.yml
@@ -2,7 +2,7 @@ name       : foobillardplus
 version    : '3.42'
 release    : 6
 source     :
-    - https://jaist.dl.sourceforge.net/project/foobillardplus/source/foobillardplus-3.42beta.tar.gz : e276b70674a7d788c45eeff89f1f5db5d48d871a1ab92103813d424a3761e1d9
+    - https://sourceforge.net/projects/foobillardplus/files/source/foobillardplus-3.42beta.tar.gz : e276b70674a7d788c45eeff89f1f5db5d48d871a1ab92103813d424a3761e1d9
 homepage   : https://foobillardplus.sourceforge.net/
 license    : GPL-2.0-or-later
 component  : games

--- a/packages/f/foremost/package.yml
+++ b/packages/f/foremost/package.yml
@@ -2,7 +2,7 @@ name       : foremost
 version    : 1.5.7
 release    : 2
 source     :
-    - http://foremost.sourceforge.net/pkg/foremost-1.5.7.tar.gz : 502054ef212e3d90b292e99c7f7ac91f89f024720cd5a7e7680c3d1901ef5f34
+    - https://foremost.sourceforge.net/pkg/foremost-1.5.7.tar.gz : 502054ef212e3d90b292e99c7f7ac91f89f024720cd5a7e7680c3d1901ef5f34
 homepage   : http://foremost.sourceforge.net/
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/f/freeimage/package.yml
+++ b/packages/f/freeimage/package.yml
@@ -2,7 +2,7 @@ name       : freeimage
 version    : 3.18.0
 release    : 12
 source     :
-    - https://netcologne.dl.sourceforge.net/project/freeimage/Source%20Distribution/3.18.0/FreeImage3180.zip : f41379682f9ada94ea7b34fe86bf9ee00935a3147be41b6569c9605a53e438fd
+    - https://sourceforge.net/projects/freeimage/files/Source%20Distribution/3.18.0/FreeImage3180.zip : f41379682f9ada94ea7b34fe86bf9ee00935a3147be41b6569c9605a53e438fd
 homepage   : https://freeimage.sourceforge.io/
 license    : GPL-2.0-or-later
 component  : multimedia.library

--- a/packages/f/fstrcmp/package.yml
+++ b/packages/f/fstrcmp/package.yml
@@ -2,7 +2,7 @@ name       : fstrcmp
 version    : 0.7
 release    : 3
 source     :
-    - http://fstrcmp.sourceforge.net/fstrcmp-0.7.D001.tar.gz : e4018e850f80700acee8da296e56e15b1eef711ab15157e542e7d7e1237c3476
+    - https://sourceforge.net/projects/fstrcmp/files/fstrcmp/0.7/fstrcmp-0.7.D001.tar.gz : e4018e850f80700acee8da296e56e15b1eef711ab15157e542e7d7e1237c3476
 homepage   : https://fstrcmp.sourceforge.net/
 license    : GPL-2.0-or-later
 component  : programming.library

--- a/packages/g/gavl/package.yml
+++ b/packages/g/gavl/package.yml
@@ -2,7 +2,7 @@ name       : gavl
 version    : 1.4.0
 release    : 2
 source     :
-    - https://ufpr.dl.sourceforge.net/project/gmerlin/gavl/1.4.0/gavl-1.4.0.tar.gz : 51aaac41391a915bd9bad07710957424b046410a276e7deaff24a870929d33ce
+    - https://sourceforge.net/projects/gmerlin/files/gavl/1.4.0/gavl-1.4.0.tar.gz : 51aaac41391a915bd9bad07710957424b046410a276e7deaff24a870929d33ce
 homepage   : https://gmerlin.sourceforge.net/
 license    : GPL-3.0
 component  : multimedia.video

--- a/packages/g/giflib/package.yml
+++ b/packages/g/giflib/package.yml
@@ -2,7 +2,7 @@ name       : giflib
 version    : 5.2.2
 release    : 10
 source     :
-    - https://netix.dl.sourceforge.net/project/giflib/giflib-5.2.2.tar.gz : be7ffbd057cadebe2aa144542fd90c6838c6a083b5e8a9048b8ee3b66b29d5fb
+    - https://sourceforge.net/projects/giflib/files/giflib-5.2.2.tar.gz : be7ffbd057cadebe2aa144542fd90c6838c6a083b5e8a9048b8ee3b66b29d5fb
 homepage   : http://giflib.sourceforge.net/
 license    : MIT
 component  : desktop.library

--- a/packages/g/glew/package.yml
+++ b/packages/g/glew/package.yml
@@ -2,7 +2,7 @@ name       : glew
 version    : 2.2.0
 release    : 9
 source     :
-    - https://jaist.dl.sourceforge.net/project/glew/glew/2.2.0/glew-2.2.0.tgz : d4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1
+    - https://sourceforge.net/projects/glew/files/glew/2.2.0/glew-2.2.0.tgz : d4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1
 homepage   : https://glew.sourceforge.net/
 license    :
     - BSD-3-Clause

--- a/packages/g/glew110/package.yml
+++ b/packages/g/glew110/package.yml
@@ -2,7 +2,7 @@ name       : glew110
 version    : 1.10.0
 release    : 9
 source     :
-    - http://jaist.dl.sourceforge.net/project/glew/glew/1.10.0/glew-1.10.0.tgz : 99c41320b63f6860869b5fb9af9a1854b15582796c64ee3dfd7096dc0c89f307
+    - https://sourceforge.net/projects/glew/files/glew/1.10.0/glew-1.10.0.tgz : 99c41320b63f6860869b5fb9af9a1854b15582796c64ee3dfd7096dc0c89f307
 homepage   : https://glew.sourceforge.net/
 license    :
     - BSD-3-Clause

--- a/packages/g/gnuplot/package.yml
+++ b/packages/g/gnuplot/package.yml
@@ -2,7 +2,7 @@ name       : gnuplot
 version    : 6.0.1
 release    : 25
 source     :
-    - https://netix.dl.sourceforge.net/project/gnuplot/gnuplot/6.0.1/gnuplot-6.0.1.tar.gz : e85a660c1a2a1808ff24f7e69981ffcbac66a45c9dcf711b65610b26ea71379a
+    - https://sourceforge.net/projects/gnuplot/files/gnuplot/6.0.1/gnuplot-6.0.1.tar.gz : e85a660c1a2a1808ff24f7e69981ffcbac66a45c9dcf711b65610b26ea71379a
 homepage   : http://www.gnuplot.info/
 license    : gnuplot
 component  : programming

--- a/packages/g/gpicview/package.yml
+++ b/packages/g/gpicview/package.yml
@@ -3,7 +3,7 @@ homepage   : http://wiki.lxde.org/en/GPicView
 version    : 0.2.5
 release    : 6
 source     :
-    - http://netcologne.dl.sourceforge.net/project/lxde/GPicView%20%28image%20Viewer%29/0.2.x/gpicview-0.2.5.tar.xz : 38466058e53702450e5899193c4b264339959b563dd5cd81f6f690de32d82942
+    - https://sourceforge.net/projects/lxde/files/GPicView%20%28image%20Viewer%29/0.2.x/gpicview-0.2.5.tar.xz : 38466058e53702450e5899193c4b264339959b563dd5cd81f6f690de32d82942
 license    : GPL-2.0-or-later
 component  : multimedia.graphics
 summary    : A Simple and Fast Image Viewer for X

--- a/packages/g/gretl/package.yml
+++ b/packages/g/gretl/package.yml
@@ -2,7 +2,7 @@ name       : gretl
 version    : 2024a
 release    : 22
 source     :
-    - http://prdownloads.sourceforge.net/gretl/gretl-2024a.tar.xz : ea16b477f9fbe577f48593341911cb3a7336ef83f587631eac1ffc48759387ea
+    - https://sourceforge.net/projects/gretl/files/gretl-2024a.tar.xz : ea16b477f9fbe577f48593341911cb3a7336ef83f587631eac1ffc48759387ea
 homepage   : https://gretl.sourceforge.net/
 license    : GPL-3.0-or-later
 component  : office.maths

--- a/packages/g/gsmartcontrol/package.yml
+++ b/packages/g/gsmartcontrol/package.yml
@@ -2,7 +2,7 @@ name       : gsmartcontrol
 version    : 1.1.4
 release    : 12
 source     :
-    - https://netcologne.dl.sourceforge.net/project/gsmartcontrol/1.1.4/gsmartcontrol-1.1.4.tar.bz2 : fc409f2b8a84cc40bb103d6c82401b9d4c0182d5a3b223c93959c7ad66191847
+    - https://sourceforge.net/projects/gsmartcontrol/files/1.1.4/gsmartcontrol-1.1.4.tar.bz2 : fc409f2b8a84cc40bb103d6c82401b9d4c0182d5a3b223c93959c7ad66191847
 homepage   : https://gsmartcontrol.shaduri.dev/
 license    :
     - BSD-3-Clause

--- a/packages/g/gtkdatabox3/package.yml
+++ b/packages/g/gtkdatabox3/package.yml
@@ -2,7 +2,7 @@ name       : gtkdatabox3
 version    : 1.0.0
 release    : 2
 source     :
-    - https://master.dl.sourceforge.net/project/gtkdatabox3/gtkdatabox-1.0.0.tar.gz : 7add2cd8fb4209f3970dbd33f5238e25b43f6251e7534607bf926c7c6175e14b
+    - https://sourceforge.net/projects/gtkdatabox3/files/gtkdatabox-1.0.0.tar.gz : 7add2cd8fb4209f3970dbd33f5238e25b43f6251e7534607bf926c7c6175e14b
 license    : GPL-3.0-or-later
 homepage   : https://gtkdatabox3.sourceforge.io
 component  : programming.library

--- a/packages/g/gtkglext/package.yml
+++ b/packages/g/gtkglext/package.yml
@@ -2,7 +2,7 @@ name       : gtkglext
 version    : 1.2.0
 release    : 5
 source     :
-    - http://downloads.sourceforge.net/gtkglext/gtkglext-1.2.0.tar.gz : e5073f3c6b816e7fa67d359d9745a5bb5de94a628ac85f624c992925a46844f9
+    - https://sourceforge.net/projects/gtkglext/files/gtkglext-1.2.0.tar.gz : e5073f3c6b816e7fa67d359d9745a5bb5de94a628ac85f624c992925a46844f9
 homepage   : https://sourceforge.net/projects/gtkglext/
 license    : LGPL-2.1-or-later
 component  : desktop.gtk

--- a/packages/g/gtkspell/package.yml
+++ b/packages/g/gtkspell/package.yml
@@ -2,7 +2,7 @@ name       : gtkspell
 version    : 2.0.16
 release    : 10
 source     :
-    - http://gtkspell.sourceforge.net/download/gtkspell-2.0.16.tar.gz : 8fc7dc560167b2cb7193e76aca625a152dc19b0ebf49816b78539cbb90d80d02
+    - https://sourceforge.net/projects/gtkspell/files/gtkspell-2.0.16.tar.gz : 8fc7dc560167b2cb7193e76aca625a152dc19b0ebf49816b78539cbb90d80d02
 homepage   : https://gtkspell.sourceforge.net/
 license    : GPL-2.0-only
 component  : office.spelling

--- a/packages/g/gtkspellmm/package.yml
+++ b/packages/g/gtkspellmm/package.yml
@@ -2,7 +2,7 @@ name       : gtkspellmm
 version    : 3.0.5
 release    : 9
 source     :
-    - http://download.sourceforge.net/project/gtkspell/gtkspellmm/gtkspellmm-3.0.5.tar.xz : 5b875a5753ce593274d0c6e803af6300973020c5443905999aba96ed3cef1545
+    - https://sourceforge.net/projects/gtkspell/files/gtkspellmm/gtkspellmm-3.0.5.tar.xz : 5b875a5753ce593274d0c6e803af6300973020c5443905999aba96ed3cef1545
 homepage   : https://gtkspell.sourceforge.net/
 license    : GPL-2.0-only
 component  : desktop.library

--- a/packages/g/gtkwave/package.yml
+++ b/packages/g/gtkwave/package.yml
@@ -2,7 +2,7 @@ name       : gtkwave
 version    : 3.3.111
 release    : 7
 source     :
-    - http://gtkwave.sourceforge.net/gtkwave-gtk3-3.3.111.tar.gz : b4e1c2f718fb3c4b4f412a220876b9da599fe11745fb6f7eb4aed107b1106233
+    - https://sourceforge.net/projects/gtkwave/files/gtkwave-gtk3-3.3.111/gtkwave-gtk3-3.3.111.tar.gz : b4e1c2f718fb3c4b4f412a220876b9da599fe11745fb6f7eb4aed107b1106233
 homepage   : http://gtkwave.sourceforge.net
 license    : GPL-2.0-or-later
 component  : office.scientific

--- a/packages/h/half/package.yml
+++ b/packages/h/half/package.yml
@@ -2,7 +2,7 @@ name       : half
 version    : 2.2.0
 release    : 4
 source     :
-    - https://downloads.sourceforge.net/project/half/half/2.2.0/half-2.2.0.zip : 1d1d9e482fb95fcd7cab0953a4bd35e00b86578f11cb6939a067811a055a563b
+    - https://sourceforge.net/projects/half/files/half/2.2.0/half-2.2.0.zip : 1d1d9e482fb95fcd7cab0953a4bd35e00b86578f11cb6939a067811a055a563b
 homepage   : https://half.sourceforge.net/
 license    : MIT
 component  : programming.library

--- a/packages/h/hplip/package.yml
+++ b/packages/h/hplip/package.yml
@@ -2,7 +2,7 @@ name       : hplip
 version    : 3.24.4
 release    : 63
 source     :
-    - https://downloads.sourceforge.net/project/hplip/hplip/3.24.4/hplip-3.24.4.tar.gz : 5d7643831893a5e2addf9d42d581a5dbfe5aaf023626886b8762c5645da0f1fb
+    - https://sourceforge.net/projects/hplip/files/hplip/3.24.4/hplip-3.24.4.tar.gz : 5d7643831893a5e2addf9d42d581a5dbfe5aaf023626886b8762c5645da0f1fb
 homepage   : https://developers.hp.com/hp-linux-imaging-and-printing/gethplip
 license    :
     - GPL-2.0-or-later

--- a/packages/h/hunspell-en/package.yml
+++ b/packages/h/hunspell-en/package.yml
@@ -2,9 +2,9 @@ name       : hunspell-en
 version    : 2020.12.07
 release    : 6
 source     :
-    - https://altushost-swe.dl.sourceforge.net/project/wordlist/speller/2020.12.07/hunspell-en_GB-large-2020.12.07.zip : f86beb77228c737c8c69468ffc4ea067512872278869b98a5d3ec18f125107bd
-    - https://kumisystems.dl.sourceforge.net/project/wordlist/speller/2020.12.07/hunspell-en_US-2020.12.07.zip: 616348ad645a716d91c8a6645065e710f15e9dda3ffef60cdf7ec8a4e27975af  
-    - https://altushost-swe.dl.sourceforge.net/project/wordlist/speller/2020.12.07/hunspell-en_CA-2020.12.07.zip: ff6b91e4ed768348c61ae7c326e848059810fa43a5d601df6b3f45ad9c0ef5bf 
+    - https://sourceforge.net/projects/wordlist/files/speller/2020.12.07/hunspell-en_GB-large-2020.12.07.zip : f86beb77228c737c8c69468ffc4ea067512872278869b98a5d3ec18f125107bd
+    - https://sourceforge.net/projects/wordlist/files/speller/2020.12.07/hunspell-en_US-2020.12.07.zip : 616348ad645a716d91c8a6645065e710f15e9dda3ffef60cdf7ec8a4e27975af
+    - https://sourceforge.net/projects/wordlist/files/speller/2020.12.07/hunspell-en_CA-2020.12.07.zip : ff6b91e4ed768348c61ae7c326e848059810fa43a5d601df6b3f45ad9c0ef5bf
 homepage   : http://wordlist.aspell.net/dicts/
 license    : BSD-3-Clause
 component  : office.spelling

--- a/packages/h/hunspell-hu/package.yml
+++ b/packages/h/hunspell-hu/package.yml
@@ -2,7 +2,7 @@ name       : hunspell-hu
 version    : 1.6.1
 release    : 3
 source     :
-    - http://downloads.sourceforge.net/magyarispell/hu_HU-1.6.1.tar.gz : 0a1ab4672bf75acc1c29c4b3fbcab5d10b7883ba1e7fc25e8054d2209f0352c2
+    - https://sourceforge.net/projects/magyarispell/files/hu_HU-1.6.1.tar.gz : 0a1ab4672bf75acc1c29c4b3fbcab5d10b7883ba1e7fc25e8054d2209f0352c2
 homepage   : https://magyarispell.sourceforge.net/
 license    : GPL-2.0-or-later
 component  : office.spelling

--- a/packages/h/hunspell-it/package.yml
+++ b/packages/h/hunspell-it/package.yml
@@ -2,7 +2,7 @@ name       : hunspell-it
 version    : 2.4
 release    : 5
 source     :
-  - http://prdownloads.sourceforge.net/linguistico/italiano_2_4_2007_09_01.zip: 2d37f687041f7eee306014915a75b8ac3d43482c5ed9f9d932857457cecf2e55
+  - https://sourceforge.net/projects/linguistico/files/Dizionario%20italiano%20per%20OOo/2_4_2007_09_01/italiano_2_4_2007_09_01.zip: 2d37f687041f7eee306014915a75b8ac3d43482c5ed9f9d932857457cecf2e55
 homepage   : http://linguistico.sourceforge.net/wiki
 license    : GPL-3.0-or-later
 component  : office.spelling

--- a/packages/h/hunspell-ro/package.yml
+++ b/packages/h/hunspell-ro/package.yml
@@ -2,7 +2,7 @@ name       : hunspell-ro
 version    : 3.3.10
 release    : 4
 source     :
-    - http://netix.dl.sourceforge.net/project/rospell/Romanian%20dictionaries/dict-3.3.10/ro_RO.3.3.10.zip : 7f128d64ea06c9e6711c30b118c0afeefb014d8f33c92daccdf455aba2d04519
+    - https://sourceforge.net/projects/rospell/files/Romanian%20dictionaries/dict-3.3.10/ro_RO.3.3.10.zip : 7f128d64ea06c9e6711c30b118c0afeefb014d8f33c92daccdf455aba2d04519
 homepage   : https://sourceforge.net/projects/rospell/
 license    : CC-BY-3.0
 component  : office.spelling

--- a/packages/h/hyphen/package.yml
+++ b/packages/h/hyphen/package.yml
@@ -2,7 +2,7 @@ name       : hyphen
 version    : 2.8.8
 release    : 3
 source     :
-    - https://altushost-swe.dl.sourceforge.net/project/hunspell/Hyphen/2.8/hyphen-2.8.8.tar.gz : 304636d4eccd81a14b6914d07b84c79ebb815288c76fe027b9ebff6ff24d5705
+    - https://sourceforge.net/projects/hunspell/files/Hyphen/2.8/hyphen-2.8.8.tar.gz : 304636d4eccd81a14b6914d07b84c79ebb815288c76fe027b9ebff6ff24d5705
 homepage   : https://hunspell.github.io/
 license    :
     - GPL-2.0-or-later

--- a/packages/i/ibus-libzhuyin/package.yml
+++ b/packages/i/ibus-libzhuyin/package.yml
@@ -2,7 +2,7 @@ name       : ibus-libzhuyin
 version    : 1.10.3
 release    : 7
 source     :
-    - http://downloads.sourceforge.net/libzhuyin/ibus-libzhuyin/ibus-libzhuyin-1.10.3.tar.gz : a87fa429854364e6c0faff03b8be4e803c6603ff2bde501e61643d1cb64f8223
+    - https://sourceforge.net/projects/libzhuyin/files/ibus-libzhuyin/ibus-libzhuyin-1.10.3.tar.gz : a87fa429854364e6c0faff03b8be4e803c6603ff2bde501e61643d1cb64f8223
 homepage   : https://sourceforge.net/p/libzhuyin/ibus-libzhuyin/ci/main/tree/
 license    : GPL-2.0
 component  : desktop

--- a/packages/k/keepass/package.yml
+++ b/packages/k/keepass/package.yml
@@ -2,7 +2,7 @@ name       : keepass
 version    : '2.57'
 release    : 43
 source     :
-    - https://downloads.sourceforge.net/project/keepass/KeePass%202.x/2.57/KeePass-2.57-Source.zip : 7a6278421848694a301b848053344aea151e9dd73f1fa247d3d26cd898bd3d0d
+    - https://sourceforge.net/projects/keepass/files/KeePass%202.x/2.57/KeePass-2.57-Source.zip : 7a6278421848694a301b848053344aea151e9dd73f1fa247d3d26cd898bd3d0d
 homepage   : https://keepass.info/
 license    : GPL-2.0-or-later
 component  : security

--- a/packages/k/klavaro/package.yml
+++ b/packages/k/klavaro/package.yml
@@ -2,7 +2,7 @@ name       : klavaro
 version    : '3.14'
 release    : 13
 source     :
-    - https://ixpeering.dl.sourceforge.net/project/klavaro/klavaro-3.14.tar.bz2 : 87187e49d301c510e6964098cdb612126bf030d2a875fd799eadcad3eae56dab
+    - https://sourceforge.net/projects/klavaro/files/klavaro-3.14.tar.bz2 : 87187e49d301c510e6964098cdb612126bf030d2a875fd799eadcad3eae56dab
 license    : GPL-3.0-or-later
 homepage   : https://klavaro.sourceforge.io
 component  : office

--- a/packages/l/lame/package.yml
+++ b/packages/l/lame/package.yml
@@ -2,7 +2,7 @@ name       : lame
 version    : '3.100'
 release    : 11
 source     :
-    - https://netcologne.dl.sourceforge.net/project/lame/lame/3.100/lame-3.100.tar.gz : ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e
+    - https://sourceforge.net/projects/lame/files/lame/3.100/lame-3.100.tar.gz : ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e
 license    : LGPL-2.0-or-later
 homepage   : https://lame.sourceforge.io/
 summary    : High quality MPEG Audio Layer III (MP3) encoder.

--- a/packages/l/libbs2b/package.yml
+++ b/packages/l/libbs2b/package.yml
@@ -2,7 +2,7 @@ name       : libbs2b
 version    : 3.1.0
 release    : 1
 source     :
-    - https://downloads.sourceforge.net/project/bs2b/libbs2b/3.1.0/libbs2b-3.1.0.tar.gz : 6aaafd81aae3898ee40148dd1349aab348db9bfae9767d0e66e0b07ddd4b2528
+    - https://sourceforge.net/projects/bs2b/files/libbs2b/3.1.0/libbs2b-3.1.0.tar.gz : 6aaafd81aae3898ee40148dd1349aab348db9bfae9767d0e66e0b07ddd4b2528
 homepage   : https://bs2b.sourceforge.net/
 license    : MIT
 component  : multimedia.library

--- a/packages/l/libcddb/package.yml
+++ b/packages/l/libcddb/package.yml
@@ -2,7 +2,7 @@ name       : libcddb
 version    : 1.3.2
 release    : 4
 source     :
-    - http://internode.dl.sourceforge.net/project/libcddb/libcddb/1.3.2/libcddb-1.3.2.tar.bz2 : 35ce0ee1741ea38def304ddfe84a958901413aa829698357f0bee5bb8f0a223b
+    - https://sourceforge.net/projects/libcddb/files/libcddb/1.3.2/libcddb-1.3.2.tar.bz2 : 35ce0ee1741ea38def304ddfe84a958901413aa829698357f0bee5bb8f0a223b
 homepage   : http://libcddb.sourceforge.net/
 license    : LGPL-2.1-or-later
 component  : programming.library

--- a/packages/l/libdbi-drivers/package.yml
+++ b/packages/l/libdbi-drivers/package.yml
@@ -2,7 +2,7 @@ name       : libdbi-drivers
 version    : 0.9.0
 release    : 8
 source     :
-    - https://netcologne.dl.sourceforge.net/project/libdbi-drivers/libdbi-drivers/libdbi-drivers-0.9.0/libdbi-drivers-0.9.0.tar.gz : 43d2eacd573a4faff296fa925dd97fbf2aedbf1ae35c6263478210c61004c854
+    - https://sourceforge.net/projects/libdbi-drivers/files/libdbi-drivers/libdbi-drivers-0.9.0/libdbi-drivers-0.9.0.tar.gz : 43d2eacd573a4faff296fa925dd97fbf2aedbf1ae35c6263478210c61004c854
 homepage   : http://libdbi-drivers.sourceforge.net/
 license    : LGPL-2.1-or-later
 component  : programming.devel

--- a/packages/l/libe-book/package.yml
+++ b/packages/l/libe-book/package.yml
@@ -2,7 +2,7 @@ name       : libe-book
 version    : 0.1.3
 release    : 17
 source     :
-    - https://download.sourceforge.net/project/libebook/libe-book-0.1.3/libe-book-0.1.3.tar.xz : 7e8d8ff34f27831aca3bc6f9cc532c2f90d2057c778963b884ff3d1e34dfe1f9
+    - https://sourceforge.net/projects/libebook/files/libe-book-0.1.3/libe-book-0.1.3.tar.xz : 7e8d8ff34f27831aca3bc6f9cc532c2f90d2057c778963b884ff3d1e34dfe1f9
 homepage   : https://sourceforge.net/projects/libebook/
 license    : MPL-2.0
 component  : programming.library

--- a/packages/l/libgaminggear/package.yml
+++ b/packages/l/libgaminggear/package.yml
@@ -2,7 +2,7 @@ name       : libgaminggear
 version    : 0.15.1
 release    : 6
 source     :
-    - https://download.sourceforge.net/project/libgaminggear/libgaminggear-0.15.1.tar.bz2 : ffbd59c62e3107b09ec99f1e5147529c61931987abc7f86a140449b46388c549
+    - https://sourceforge.net/projects/libgaminggear/files/libgaminggear-0.15.1.tar.bz2 : ffbd59c62e3107b09ec99f1e5147529c61931987abc7f86a140449b46388c549
 homepage   : https://sourceforge.net/projects/libgaminggear/
 license    : GPL-2.0-or-later
 component  : desktop.library

--- a/packages/l/libgnt/package.yml
+++ b/packages/l/libgnt/package.yml
@@ -2,7 +2,7 @@ name       : libgnt
 version    : 2.14.1
 release    : 4
 source     :
-    - https://downloads.sourceforge.net/project/pidgin/libgnt/2.14.1/libgnt-2.14.1.tar.xz : 5ec3e68e18f956e9998d79088b299fa3bca689bcc95c86001bc5da17c1eb4bd8
+    - https://sourceforge.net/projects/pidgin/files/libgnt/2.14.1/libgnt-2.14.1.tar.xz : 5ec3e68e18f956e9998d79088b299fa3bca689bcc95c86001bc5da17c1eb4bd8
 homepage   : https://keep.imfreedom.org/libgnt/libgnt
 license    : GPL-2.0-or-later
 component  : programming.library

--- a/packages/l/libiptcdata/package.yml
+++ b/packages/l/libiptcdata/package.yml
@@ -2,7 +2,7 @@ name       : libiptcdata
 version    : 1.0.4
 release    : 3
 source     :
-    - http://download.sourceforge.net/project/libiptcdata/libiptcdata/1.0.4/libiptcdata-1.0.4.tar.gz : 79f63b8ce71ee45cefd34efbb66e39a22101443f4060809b8fc29c5eebdcee0e
+    - https://sourceforge.net/projects/libiptcdata/files/libiptcdata/1.0.4/libiptcdata-1.0.4.tar.gz : 79f63b8ce71ee45cefd34efbb66e39a22101443f4060809b8fc29c5eebdcee0e
 homepage   : https://libiptcdata.sourceforge.net/
 license    : LGPL-2.0-or-later
 component  : programming

--- a/packages/l/libjpeg-turbo6/package.yml
+++ b/packages/l/libjpeg-turbo6/package.yml
@@ -2,7 +2,7 @@ name       : libjpeg-turbo6
 version    : 2.0.0
 release    : 11
 source     :
-    - https://kent.dl.sourceforge.net/project/libjpeg-turbo/2.0.0/libjpeg-turbo-2.0.0.tar.gz : 778876105d0d316203c928fd2a0374c8c01f755d0a00b12a1c8934aeccff8868
+    - https://sourceforge.net/projects/libjpeg-turbo/files/2.0.0/libjpeg-turbo-2.0.0.tar.gz : 778876105d0d316203c928fd2a0374c8c01f755d0a00b12a1c8934aeccff8868
 homepage   : https://libjpeg-turbo.org/
 component  : desktop.library
 license    :

--- a/packages/l/libmad/package.yml
+++ b/packages/l/libmad/package.yml
@@ -2,7 +2,7 @@ name       : libmad
 version    : 0.15.1b
 release    : 6
 source     :
-    - http://downloads.sourceforge.net/project/mad/libmad/0.15.1b/libmad-0.15.1b.tar.gz : bbfac3ed6bfbc2823d3775ebb931087371e142bb0e9bb1bee51a76a6e0078690
+    - https://sourceforge.net/projects/mad/files/libmad/0.15.1b/libmad-0.15.1b.tar.gz : bbfac3ed6bfbc2823d3775ebb931087371e142bb0e9bb1bee51a76a6e0078690
 homepage   : https://www.underbit.com/products/mad/
 license    : GPL-2.0-or-later
 component  : multimedia.codecs

--- a/packages/l/libmpeg2/package.yml
+++ b/packages/l/libmpeg2/package.yml
@@ -2,7 +2,7 @@ name       : libmpeg2
 version    : 0.5.1
 release    : 3
 source     :
-    - http://libmpeg2.sourceforge.net/files/libmpeg2-0.5.1.tar.gz : dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4
+    - https://libmpeg2.sourceforge.net/files/libmpeg2-0.5.1.tar.gz : dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4
 homepage   : http://libmpeg2.sourceforge.net/
 license    : GPL-2.0-or-later
 component  :

--- a/packages/l/libpano13/package.yml
+++ b/packages/l/libpano13/package.yml
@@ -2,7 +2,7 @@ name       : libpano13
 version    : 2.9.22
 release    : 7
 source     :
-    - https://downloads.sourceforge.net/project/panotools/libpano13/libpano13-2.9.22/libpano13-2.9.22.tar.gz : affc6830cdbe71c28d2731dcbf8dea2acda6d9ffd4609c6dbf3ba0c68440a8e3
+    - https://sourceforge.net/projects/panotools/files/libpano13/libpano13-2.9.22/libpano13-2.9.22.tar.gz : affc6830cdbe71c28d2731dcbf8dea2acda6d9ffd4609c6dbf3ba0c68440a8e3
 homepage   : http://panotools.sourceforge.net/
 license    : GPL-2.0-or-later
 component  : multimedia.library

--- a/packages/l/libpng12/package.yml
+++ b/packages/l/libpng12/package.yml
@@ -2,7 +2,7 @@ name       : libpng12
 version    : 1.2.59
 release    : 102
 source     :
-    - https://jaist.dl.sourceforge.net/project/libpng/libpng12/1.2.59/libpng-1.2.59.tar.xz : b4635f15b8adccc8ad0934eea485ef59cc4cae24d0f0300a9a941e51974ffcc7
+    - https://sourceforge.net/projects/libpng/files/libpng12/1.2.59/libpng-1.2.59.tar.xz : b4635f15b8adccc8ad0934eea485ef59cc4cae24d0f0300a9a941e51974ffcc7
 homepage   : http://www.libpng.org/pub/png/libpng.html
 license    : Libpng
 summary    : libpng12 (Binary Compatibility Library)

--- a/packages/l/log4cpp/package.yml
+++ b/packages/l/log4cpp/package.yml
@@ -2,7 +2,7 @@ name       : log4cpp
 version    : 1.1.4
 release    : 3
 source     :
-    - https://downloads.sourceforge.net/log4cpp/log4cpp-1.1.4.tar.gz : 696113659e426540625274a8b251052cc04306d8ee5c42a0c7639f39ca90c9d6
+    - https://sourceforge.net/projects/log4cpp/files/log4cpp-1.1.4.tar.gz : 696113659e426540625274a8b251052cc04306d8ee5c42a0c7639f39ca90c9d6
 homepage   : https://log4cpp.sourceforge.net
 license    : LGPL-2.1-or-later
 component  : programming.library

--- a/packages/m/minidlna/package.yml
+++ b/packages/m/minidlna/package.yml
@@ -2,7 +2,7 @@ name       : minidlna
 version    : 1.3.3
 release    : 18
 source     :
-    - https://ixpeering.dl.sourceforge.net/project/minidlna/minidlna/1.3.3/minidlna-1.3.3.tar.gz : 39026c6d4a139b9180192d1c37225aa3376fdf4f1a74d7debbdbb693d996afa4
+    - https://sourceforge.net/projects/minidlna/files/minidlna/1.3.3/minidlna-1.3.3.tar.gz : 39026c6d4a139b9180192d1c37225aa3376fdf4f1a74d7debbdbb693d996afa4
 homepage   : https://sourceforge.net/projects/minidlna/
 license    : GPL-2.0-or-later
 component  : network.util

--- a/packages/m/mp3gain/package.yml
+++ b/packages/m/mp3gain/package.yml
@@ -2,7 +2,7 @@ name       : mp3gain
 version    : 1.6.2
 release    : 5
 source     :
-    - https://nchc.dl.sourceforge.net/project/mp3gain/mp3gain/1.6.2/mp3gain-1_6_2-src.zip : 5cc04732ef32850d5878b28fbd8b85798d979a025990654aceeaa379bcc9596d
+    - https://sourceforge.net/projects/mp3gain/files/mp3gain/1.6.2/mp3gain-1_6_2-src.zip : 5cc04732ef32850d5878b28fbd8b85798d979a025990654aceeaa379bcc9596d
 homepage   : http://mp3gain.sourceforge.net/
 license    : LGPL-2.1-or-later
 component  : multimedia.audio

--- a/packages/n/nas/package.yml
+++ b/packages/n/nas/package.yml
@@ -2,7 +2,7 @@ name       : nas
 version    : 1.9.5
 release    : 3
 source     :
-    - http://downloads.sourceforge.net/nas/nas-1.9.5.tar.gz : b7884afb38feec03a196bd3b7e9c47b803c830ecd10d7455e9c97e122c37944c
+    - https://sourceforge.net/projects/nas/files/nas-1.9.5.tar.gz : b7884afb38feec03a196bd3b7e9c47b803c830ecd10d7455e9c97e122c37944c
 homepage   : https://www.radscan.com/nas.html
 license    : MIT
 component  : programming.library

--- a/packages/n/ngspice/package.yml
+++ b/packages/n/ngspice/package.yml
@@ -2,7 +2,7 @@ name       : ngspice
 version    : '43'
 release    : 8
 source     :
-    - https://cfhcable.dl.sourceforge.net/project/ngspice/ng-spice-rework/43/ngspice-43.tar.gz : 14dd6a6f08531f2051c13ae63790a45708bd43f3e77886a6a84898c297b13699
+    - https://sourceforge.net/projects/ngspice/files/ng-spice-rework/43/ngspice-43.tar.gz : 14dd6a6f08531f2051c13ae63790a45708bd43f3e77886a6a84898c297b13699
 homepage   : http://ngspice.sourceforge.net/
 license    :
     - BSD-3-Clause

--- a/packages/n/ninvaders/package.yml
+++ b/packages/n/ninvaders/package.yml
@@ -2,7 +2,7 @@ name       : ninvaders
 version    : 0.1.1
 release    : 3
 source     :
-    - http://ufpr.dl.sourceforge.net/project/ninvaders/ninvaders/0.1.1/ninvaders-0.1.1.tar.gz : bfbc5c378704d9cf5e7fed288dac88859149bee5ed0850175759d310b61fd30b
+    - https://sourceforge.net/projects/ninvaders/files/ninvaders/0.1.1/ninvaders-0.1.1.tar.gz : bfbc5c378704d9cf5e7fed288dac88859149bee5ed0850175759d310b61fd30b
 homepage   : http://ninvaders.sourceforge.net/
 license    : GPL-2.0-or-later
 component  : games.arcade

--- a/packages/o/opensp/package.yml
+++ b/packages/o/opensp/package.yml
@@ -2,7 +2,7 @@ name       : opensp
 version    : 1.5.2
 release    : 4
 source     :
-    - http://freefr.dl.sourceforge.net/project/openjade/opensp/1.5.2/OpenSP-1.5.2.tar.gz : 57f4898498a368918b0d49c826aa434bb5b703d2c3b169beb348016ab25617ce
+    - https://sourceforge.net/projects/openjade/files/opensp/1.5.2/OpenSP-1.5.2.tar.gz : 57f4898498a368918b0d49c826aa434bb5b703d2c3b169beb348016ab25617ce
 homepage   : https://openjade.sourceforge.net/doc/index.htm
 license    : MIT
 component  : programming

--- a/packages/o/optipng/package.yml
+++ b/packages/o/optipng/package.yml
@@ -2,7 +2,7 @@ name       : optipng
 version    : 0.7.8
 release    : 5
 source     :
-    - https://nchc.dl.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.8/optipng-0.7.8.tar.gz : 25a3bd68481f21502ccaa0f4c13f84dcf6b20338e4c4e8c51f2cefbd8513398c
+    - https://sourceforge.net/projects/optipng/files/OptiPNG/optipng-0.7.8/optipng-0.7.8.tar.gz : 25a3bd68481f21502ccaa0f4c13f84dcf6b20338e4c4e8c51f2cefbd8513398c
 homepage   : https://sourceforge.net/projects/optipng/
 license    : Zlib
 summary    : PNG optimizer recompresses image files to a smaller size, without losing any information

--- a/packages/p/pidgin-sipe/package.yml
+++ b/packages/p/pidgin-sipe/package.yml
@@ -2,7 +2,7 @@ name       : pidgin-sipe
 version    : 1.25.0
 release    : 14
 source     :
-    - https://netix.dl.sourceforge.net/project/sipe/sipe/pidgin-sipe-1.25.0/pidgin-sipe-1.25.0.tar.xz : 738b121b11f2b3f1744150c00cb381222eb6cf67161a7742797eb4f03e64a2ba
+    - https://sourceforge.net/projects/sipe/files/sipe/pidgin-sipe-1.25.0/pidgin-sipe-1.25.0.tar.xz : 738b121b11f2b3f1744150c00cb381222eb6cf67161a7742797eb4f03e64a2ba
 homepage   : https://sourceforge.net/projects/sipe/
 license    : GPL-2.0-or-later
 component  : network.im

--- a/packages/p/privoxy/package.yml
+++ b/packages/p/privoxy/package.yml
@@ -2,7 +2,7 @@ name       : privoxy
 version    : 3.0.34
 release    : 7
 source     :
-    - https://deac-ams.dl.sourceforge.net/project/ijbswa/Sources/3.0.34%20%28stable%29/privoxy-3.0.34-stable-src.tar.gz : e6ccbca1656f4e616b4657f8514e33a70f6697e9d7294356577839322a3c5d2c
+    - https://sourceforge.net/projects/ijbswa/files/Sources/3.0.34%20%28stable%29/privoxy-3.0.34-stable-src.tar.gz : e6ccbca1656f4e616b4657f8514e33a70f6697e9d7294356577839322a3c5d2c
 homepage   : https://www.privoxy.org/
 license    : GPL-2.0-or-later
 component  : network.clients

--- a/packages/p/psmisc/package.yml
+++ b/packages/p/psmisc/package.yml
@@ -2,7 +2,7 @@ name       : psmisc
 version    : '23.6'
 release    : 6
 source     :
-    - https://deac-fra.dl.sourceforge.net/project/psmisc/psmisc/psmisc-23.6.tar.xz : 257dde06159a4c49223d06f1cccbeb68933a4514fc8f1d77c64b54f0d108822a
+    - https://sourceforge.net/projects/psmisc/files/psmisc/psmisc-23.6.tar.xz : 257dde06159a4c49223d06f1cccbeb68933a4514fc8f1d77c64b54f0d108822a
 license    : GPL-2.0-or-later
 component  : system.base
 homepage   : https://gitlab.com/psmisc/psmisc

--- a/packages/p/pwgen/package.yml
+++ b/packages/p/pwgen/package.yml
@@ -2,7 +2,7 @@ name       : pwgen
 version    : '2.08'
 release    : 3
 source     :
-    - https://downloads.sourceforge.net/project/pwgen/pwgen/2.08/pwgen-2.08.tar.gz : dab03dd30ad5a58e578c5581241a6e87e184a18eb2c3b2e0fffa8a9cf105c97b
+    - https://sourceforge.net/projects/pwgen/files/pwgen/2.08/pwgen-2.08.tar.gz : dab03dd30ad5a58e578c5581241a6e87e184a18eb2c3b2e0fffa8a9cf105c97b
 homepage   : https://sourceforge.net/projects/pwgen/
 license    : GPL-2.0-only
 component  : security

--- a/packages/py/pysolfc/package.yml
+++ b/packages/py/pysolfc/package.yml
@@ -2,7 +2,7 @@ name       : pysolfc
 version    : 3.0.0
 release    : 15
 source     :
-    - https://download.sourceforge.net/project/pysolfc/PySolFC/PySolFC-3.0.0/PySolFC-3.0.0.tar.xz : 5047ca10e8d5d635a0fbf7387c71b6c5e090e51a3ad2ab8a1bad649c0c3c9a17
+    - https://sourceforge.net/projects/pysolfc/files/PySolFC/PySolFC-3.0.0/PySolFC-3.0.0.tar.xz : 5047ca10e8d5d635a0fbf7387c71b6c5e090e51a3ad2ab8a1bad649c0c3c9a17
 homepage   : https://pysolfc.sourceforge.io/
 license    : GPL-3.0-or-later
 component  : games.card

--- a/packages/q/qjackctl/package.yml
+++ b/packages/q/qjackctl/package.yml
@@ -2,7 +2,7 @@ name       : qjackctl
 version    : 0.9.13
 release    : 23
 source     :
-    - https://download.sourceforge.net/qjackctl/qjackctl-0.9.13.tar.gz : ebbc3774b8c2db6ded3c5553939c65e095ce796750d53ee1a299c113a33564b3
+    - https://sourceforge.net/projects/qjackctl/files/qjackctl-0.9.13.tar.gz : ebbc3774b8c2db6ded3c5553939c65e095ce796750d53ee1a299c113a33564b3
 homepage   : https://qjackctl.sourceforge.io/
 license    : GPL-2.0-or-later
 component  : multimedia.audio

--- a/packages/q/qodem/package.yml
+++ b/packages/q/qodem/package.yml
@@ -2,7 +2,7 @@ name       : qodem
 version    : 1.0.1
 release    : 5
 source     :
-    - http://downloads.sourceforge.net/project/qodem/qodem/1.0.1/qodem-1.0.1.tar.gz : dedc73bfa73ced5c6193f1baf1ffe91f7accaad55a749240db326cebb9323359
+    - https://sourceforge.net/projects/qodem/files/qodem/1.0.1/qodem-1.0.1.tar.gz : dedc73bfa73ced5c6193f1baf1ffe91f7accaad55a749240db326cebb9323359
 homepage   : https://qodem.sourceforge.io/
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/q/qrupdate/package.yml
+++ b/packages/q/qrupdate/package.yml
@@ -2,7 +2,7 @@ name       : qrupdate
 version    : 1.1.2
 release    : 8
 source     :
-    - https://nchc.dl.sourceforge.net/project/qrupdate/qrupdate/1.2/qrupdate-1.1.2.tar.gz : e2a1c711dc8ebc418e21195833814cb2f84b878b90a2774365f0166402308e08
+    - https://sourceforge.net/projects/qrupdate/files/qrupdate/1.2/qrupdate-1.1.2.tar.gz : e2a1c711dc8ebc418e21195833814cb2f84b878b90a2774365f0166402308e08
 license    : GPL-3.0
 component  : programming.library
 summary    : Library for fast updating of qr and cholesky decompositions

--- a/packages/s/sloccount/package.yml
+++ b/packages/s/sloccount/package.yml
@@ -2,7 +2,7 @@ name       : sloccount
 version    : 2.26
 release    : 2
 source     :
-    - http://tenet.dl.sourceforge.net/project/sloccount/sloccount-2.26.tar.gz : fa7fa2bbf2f627dd2d0fdb958bd8ec4527231254c120a8b4322405d8a4e3d12b
+    - https://sourceforge.net/projects/sloccount/files/sloccount-2.26.tar.gz : fa7fa2bbf2f627dd2d0fdb958bd8ec4527231254c120a8b4322405d8a4e3d12b
 homepage   : https://dwheeler.com/sloccount/
 license    : GPL-2.0-or-later
 component  : programming.tools

--- a/packages/s/sox/package.yml
+++ b/packages/s/sox/package.yml
@@ -2,7 +2,7 @@ name       : sox
 version    : 14.4.2
 release    : 12
 source     :
-    - https://download.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2.tar.bz2 : 81a6956d4330e75b5827316e44ae381e6f1e8928003c6aa45896da9041ea149c
+    - https://sourceforge.net/projects/sox/files/sox/14.4.2/sox-14.4.2.tar.bz2 : 81a6956d4330e75b5827316e44ae381e6f1e8928003c6aa45896da9041ea149c
 homepage   : https://sox.sourceforge.net/
 license    :
     - GPL-2.0-or-later

--- a/packages/t/tcl/package.yml
+++ b/packages/t/tcl/package.yml
@@ -2,7 +2,7 @@ name       : tcl
 version    : 8.6.13
 release    : 15
 source     :
-    - https://downloads.sourceforge.net/project/tcl/Tcl/8.6.13/tcl8.6.13-src.tar.gz : 43a1fae7412f61ff11de2cfd05d28cfc3a73762f354a417c62370a54e2caf066
+    - https://sourceforge.net/projects/tcl/files/Tcl/8.6.13/tcl8.6.13-src.tar.gz : 43a1fae7412f61ff11de2cfd05d28cfc3a73762f354a417c62370a54e2caf066
 homepage   : https://www.tcl.tk
 license    : TCL
 component  : programming.library

--- a/packages/t/tilp/package.yml
+++ b/packages/t/tilp/package.yml
@@ -2,7 +2,7 @@ name       : tilp
 version    : 1.18
 release    : 4
 source     :
-    - https://downloads.sourceforge.net/project/tilp/tilp2-linux/tilp2-1.18/tilp2-1.18.tar.bz2 : 7b3ab363eeb52504d6ef5811c5d264f8016060bb7bd427be5a064c2ed7384e47
+    - https://sourceforge.net/projects/tilp/files/tilp2-linux/tilp2-1.18/tilp2-1.18.tar.bz2 : 7b3ab363eeb52504d6ef5811c5d264f8016060bb7bd427be5a064c2ed7384e47
 homepage   : http://lpg.ticalc.org/prj_tilp/
 license    : GPL-2.0-or-later
 component  : office

--- a/packages/t/tk/package.yml
+++ b/packages/t/tk/package.yml
@@ -2,7 +2,7 @@ name       : tk
 version    : 8.6.11.1
 release    : 13
 source     :
-    - https://netcologne.dl.sourceforge.net/project/tcl/Tcl/8.6.11/tk8.6.11.1-src.tar.gz : 006cab171beeca6a968b6d617588538176f27be232a2b334a0e96173e89909be
+    - https://sourceforge.net/projects/tcl/files/Tcl/8.6.11/tk8.6.11.1-src.tar.gz : 006cab171beeca6a968b6d617588538176f27be232a2b334a0e96173e89909be
 homepage   : https://www.tcl.tk
 license    : TCL
 component  :

--- a/packages/t/tuxpaint/package.yml
+++ b/packages/t/tuxpaint/package.yml
@@ -2,7 +2,7 @@ name       : tuxpaint
 version    : 0.9.23
 release    : 8
 source     :
-    - http://kent.dl.sourceforge.net/project/tuxpaint/tuxpaint/0.9.23/tuxpaint-0.9.23.tar.gz : 349919c44e0fa252581be6e3242251fb62d20a82c971e99be96d648462bf6926
+    - https://sourceforge.net/projects/tuxpaint/files/tuxpaint/0.9.23/tuxpaint-0.9.23.tar.gz : 349919c44e0fa252581be6e3242251fb62d20a82c971e99be96d648462bf6926
 license    : GPL-2.0-or-later
 component  : games.learning
 summary    : Drawing program designed for young children

--- a/packages/u/uget/package.yml
+++ b/packages/u/uget/package.yml
@@ -2,7 +2,7 @@ name       : uget
 version    : 2.2.3
 release    : 14
 source     :
-    - https://downloads.sourceforge.net/urlget/uget-2.2.3-1.tar.gz : 11356e4242151b9014fa6209c1f0360b699b72ef8ab47dbeb81cc23be7db9049
+    - https://sourceforge.net/projects/urlget/files/uget-2.2.3-1.tar.gz : 11356e4242151b9014fa6209c1f0360b699b72ef8ab47dbeb81cc23be7db9049
 homepage   : https://ugetdm.com/
 license    : LGPL-2.1-or-later
 component  : network.download

--- a/packages/u/unzip/package.yml
+++ b/packages/u/unzip/package.yml
@@ -2,7 +2,7 @@ name       : unzip
 version    : '6.0'
 release    : 12
 source     :
-    - https://jaist.dl.sourceforge.net/project/infozip/UnZip%206.x%20%28latest%29/UnZip%206.0/unzip60.tar.gz : 036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37
+    - https://sourceforge.net/projects/infozip/files/UnZip%206.x%20%28latest%29/UnZip%206.0/unzip60.tar.gz : 036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37
 homepage   : http://www.info-zip.org/UnZip.html
 license    : Info-ZIP
 summary    : Info-ZIP unzip program

--- a/packages/u/uqm/package.yml
+++ b/packages/u/uqm/package.yml
@@ -2,10 +2,10 @@ name       : uqm
 version    : 0.7.0
 release    : 7
 source     :
-    - http://downloads.sourceforge.net/project/sc2/UQM/0.7/uqm-0.7.0-source.tgz : a3695c5f7f0be7ec9c0f80ec569907b382023a1fee6e635532bd53b7b53bb221
-    - http://downloads.sourceforge.net/project/sc2/UQM/0.7/uqm-0.7.0-3domusic.uqm : c57085e64dad4bddf8a679a9aa2adf63f2156d5f6cbabe63af80519033dbcb82
-    - http://downloads.sourceforge.net/project/sc2/UQM/0.7/uqm-0.7.0-content.uqm : b8f6db8ba29f0628fb1d5c233830896b19f441aee3744bda671ea264b44da3bf
-    - http://downloads.sourceforge.net/project/sc2/UQM/0.7/uqm-0.7.0-voice.uqm : bcccf801b4ba37594ff6217b292744ea586ee2d447e927804842ccae8b73c979
+    - https://sourceforge.net/projects/sc2/files/UQM/0.7/uqm-0.7.0-source.tgz : a3695c5f7f0be7ec9c0f80ec569907b382023a1fee6e635532bd53b7b53bb221
+    - https://sourceforge.net/projects/sc2/files/UQM/0.7/uqm-0.7.0-3domusic.uqm : c57085e64dad4bddf8a679a9aa2adf63f2156d5f6cbabe63af80519033dbcb82
+    - https://sourceforge.net/projects/sc2/files/UQM/0.7/uqm-0.7.0-content.uqm : b8f6db8ba29f0628fb1d5c233830896b19f441aee3744bda671ea264b44da3bf
+    - https://sourceforge.net/projects/sc2/files/UQM/0.7/uqm-0.7.0-voice.uqm : bcccf801b4ba37594ff6217b292744ea586ee2d447e927804842ccae8b73c979
 homepage   : http://sc2.sourceforge.net/
 license    :
     - CC-BY-2.0

--- a/packages/v/vmpk/package.yml
+++ b/packages/v/vmpk/package.yml
@@ -2,7 +2,7 @@ name       : vmpk
 version    : 0.9.0
 release    : 7
 source     :
-    - https://downloads.sourceforge.net/project/vmpk/vmpk/0.9.0/vmpk-0.9.0.tar.bz2 : c47ee14cbf1903075440acad729d8e0e02e4c98606183756676eeac1a1aebcd9
+    - https://sourceforge.net/projects/vmpk/files/vmpk/0.9.0/vmpk-0.9.0.tar.bz2 : c47ee14cbf1903075440acad729d8e0e02e4c98606183756676eeac1a1aebcd9
 homepage   : https://vmpk.sourceforge.io
 license    : GPL-3.0-only
 component  : multimedia.audio

--- a/packages/v/vo-aacenc/package.yml
+++ b/packages/v/vo-aacenc/package.yml
@@ -2,7 +2,7 @@ name       : vo-aacenc
 version    : 0.1.3
 release    : 2
 source     :
-    - https://downloads.sourceforge.net/project/opencore-amr/vo-aacenc/vo-aacenc-0.1.3.tar.gz : e51a7477a359f18df7c4f82d195dab4e14e7414cbd48cf79cc195fc446850f36
+    - https://sourceforge.net/projects/opencore-amr/files/vo-aacenc/vo-aacenc-0.1.3.tar.gz : e51a7477a359f18df7c4f82d195dab4e14e7414cbd48cf79cc195fc446850f36
 homepage   : http://sourceforge.net/projects/opencore-amr
 license    : Apache-2.0
 component  : multimedia.codecs

--- a/packages/z/zip/package.yml
+++ b/packages/z/zip/package.yml
@@ -2,7 +2,7 @@ name       : zip
 version    : '3.0'
 release    : 5
 source     :
-    - https://netix.dl.sourceforge.net/project/infozip/Zip%203.x%20%28latest%29/3.0/zip30.tar.gz : f0e8bb1f9b7eb0b01285495a2699df3a4b766784c1765a8f1aeedf63c0806369
+    - https://sourceforge.net/projects/infozip/files/Zip%203.x%20%28latest%29/3.0/zip30.tar.gz : f0e8bb1f9b7eb0b01285495a2699df3a4b766784c1765a8f1aeedf63c0806369
 homepage   : https://infozip.sourceforge.net/
 license    : Info-ZIP
 component  : system.base

--- a/packages/z/zsh/package.yml
+++ b/packages/z/zsh/package.yml
@@ -2,7 +2,7 @@ name       : zsh
 version    : '5.9'
 release    : 32
 source     :
-    - https://ixpeering.dl.sourceforge.net/project/zsh/zsh/5.9/zsh-5.9.tar.xz : 9b8d1ecedd5b5e81fbf1918e876752a7dd948e05c1a0dba10ab863842d45acd5
+    - https://sourceforge.net/projects/zsh/files/zsh/5.9/zsh-5.9.tar.xz : 9b8d1ecedd5b5e81fbf1918e876752a7dd948e05c1a0dba10ab863842d45acd5
 homepage   : https://www.zsh.org/
 license    : MIT
 summary    : The Z Shell


### PR DESCRIPTION
**Summary**

This changes old Sourceforge download URLs to the canonical format (or at least something closer to it)

This should fix issues with non-existent mirrors, and also updates some URLs from http to https

**Test Plan**
- Confirmed new download URLs were still working (might've missed some)

**Checklist**

- [x] Package was built and tested against unstable
