### PR TITLE
magpie: Update to 0.9.4

### DIFF
--- a/packages/m/magpie/abi_symbols
+++ b/packages/m/magpie/abi_symbols
@@ -397,6 +397,8 @@ libmagpie-0.so.0:meta_monitor_config_store_reset
 libmagpie-0.so.0:meta_monitor_config_store_set_custom
 libmagpie-0.so.0:meta_monitor_crtc_to_logical_transform
 libmagpie-0.so.0:meta_monitor_derive_current_mode
+libmagpie-0.so.0:meta_monitor_get_backlight
+libmagpie-0.so.0:meta_monitor_get_backlight_info
 libmagpie-0.so.0:meta_monitor_get_connector
 libmagpie-0.so.0:meta_monitor_get_connector_type
 libmagpie-0.so.0:meta_monitor_get_current_mode

--- a/packages/m/magpie/abi_used_symbols
+++ b/packages/m/magpie/abi_used_symbols
@@ -999,7 +999,9 @@ libglib-2.0.so.0:g_mutex_init
 libglib-2.0.so.0:g_mutex_lock
 libglib-2.0.so.0:g_mutex_unlock
 libglib-2.0.so.0:g_once_init_enter
+libglib-2.0.so.0:g_once_init_enter_pointer
 libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_group
 libglib-2.0.so.0:g_option_context_add_main_entries
 libglib-2.0.so.0:g_option_context_free
@@ -1173,8 +1175,10 @@ libglib-2.0.so.0:g_utf8_validate
 libglib-2.0.so.0:g_uuid_string_random
 libglib-2.0.so.0:g_variant_builder_add
 libglib-2.0.so.0:g_variant_builder_clear
+libglib-2.0.so.0:g_variant_builder_close
 libglib-2.0.so.0:g_variant_builder_end
 libglib-2.0.so.0:g_variant_builder_init
+libglib-2.0.so.0:g_variant_builder_open
 libglib-2.0.so.0:g_variant_equal
 libglib-2.0.so.0:g_variant_get
 libglib-2.0.so.0:g_variant_get_boolean

--- a/packages/m/magpie/package.yml
+++ b/packages/m/magpie/package.yml
@@ -1,8 +1,8 @@
 name       : magpie
-version    : 0.9.3
-release    : 4
+version    : 0.9.4
+release    : 5
 source     :
-    - https://github.com/BuddiesOfBudgie/magpie/releases/download/v0.9.3/magpie-0.9.3.tar.xz : 99060cefe4684be05daf8e82b414b78d15cbe2c723993db902681ab4017bbbe9
+    - https://github.com/BuddiesOfBudgie/magpie/releases/download/v0.9.4/magpie-0.9.4.tar.xz : 348a572a78e6f199761fa45ebc2a7a8bbf267b8960d32cc4bf6fd4e6012dabdb
 homepage   : https://buddiesofbudgie.org
 license    : GPL-2.0-or-later
 component  : desktop.budgie
@@ -17,22 +17,22 @@ builddeps  :
     - pkgconfig(gnome-desktop-3.0)
     - pkgconfig(gnome-settings-daemon)
     - pkgconfig(gobject-introspection-1.0)
-    - pkgconfig(gsettings-desktop-schemas)
     - pkgconfig(graphene-1.0)
+    - pkgconfig(gsettings-desktop-schemas)
     - pkgconfig(gtk+-3.0)
     - pkgconfig(gudev-1.0)
     - pkgconfig(json-glib-1.0)
+    - pkgconfig(lcms2)
     - pkgconfig(libcanberra-gtk3)
     - pkgconfig(libinput)
-    - pkgconfig(lcms2)
     - pkgconfig(libpipewire-0.3)
     - pkgconfig(libstartup-notification-1.0)
     - pkgconfig(libwacom)
     - pkgconfig(sm)
     - pkgconfig(upower-glib)
     - pkgconfig(wayland-eglstream)
-    - pkgconfig(wayland-server)
     - pkgconfig(wayland-protocols)
+    - pkgconfig(wayland-server)
     - pkgconfig(xcursor)
     - pkgconfig(xkbfile)
     - pkgconfig(xkeyboard-config)
@@ -41,9 +41,9 @@ builddeps  :
     - pkgconfig(xwayland)
     - zenity
 rundeps    :
+    - devel : mesalib-devel # Internal cogl requires EGL/eglmesaext.h from mesalib-devel
     - mutter-common
     - zenity
-    - devel : mesalib-devel # Internal cogl requires EGL/eglmesaext.h from mesalib-devel
 setup      : |
     %patch -p1 -i $pkgfiles/0003-core-Disable-disastrous-NET_WM_PING-deletion-dialogs.patch
     %meson_configure \

--- a/packages/m/magpie/pspec_x86_64.xml
+++ b/packages/m/magpie/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>magpie</Name>
         <Homepage>https://buddiesofbudgie.org</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.budgie</PartOf>
@@ -153,7 +153,7 @@ It contains functionality related to, among other things, window management, win
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="4">magpie</Dependency>
+            <Dependency release="5">magpie</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/magpie-0/clutter/cally/cally-actor.h</Path>
@@ -376,12 +376,12 @@ It contains functionality related to, among other things, window management, win
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2023-10-21</Date>
-            <Version>0.9.3</Version>
+        <Update release="5">
+            <Date>2024-09-28</Date>
+            <Version>0.9.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Add API replacing gsd-power's use of libgnome-rr.
  Resolves backlight crashes due to new GSD api requirement.
- Resolve GNOME 47 Scaling issues due to GSD api new requirement

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install updated package, reboot and login successfully, change scaling to 200% and back to 100%.

**Checklist**

- [x] Package was built and tested against unstable
