### PR TITLE
neochat: Allow system tray support in GNOME

### DIFF
--- a/packages/n/neochat/files/0001-controller-Fuck-you-give-me-a-system-tray.patch
+++ b/packages/n/neochat/files/0001-controller-Fuck-you-give-me-a-system-tray.patch
@@ -1,0 +1,25 @@
+From 6e98e83b1b4b199ac8c1f5eccd7884d8d43c8a2c Mon Sep 17 00:00:00 2001
+From: Joey Riches <josephriches@gmail.com>
+Date: Sun, 29 Sep 2024 17:06:12 +0100
+Subject: [PATCH 1/1] controller: Fuck you give me a system tray
+
+---
+ src/controller.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/controller.cpp b/src/controller.cpp
+index 916b33c35..6cf1be2f4 100644
+--- a/src/controller.cpp
++++ b/src/controller.cpp
+@@ -292,7 +292,7 @@ bool Controller::supportSystemTray() const
+     return false;
+ #else
+     auto de = QString::fromLatin1(qgetenv("XDG_CURRENT_DESKTOP"));
+-    return de != QStringLiteral("GNOME") && de != QStringLiteral("Pantheon");
++    return de != QStringLiteral("Pantheon");
+ #endif
+ }
+ 
+-- 
+2.46.1
+

--- a/packages/n/neochat/package.yml
+++ b/packages/n/neochat/package.yml
@@ -1,6 +1,6 @@
 name       : neochat
 version    : 24.08.1
-release    : 29
+release    : 30
 source     :
     - https://download.kde.org/stable/release-service/24.08.1/src/neochat-24.08.1.tar.xz : a394f04cf19d5567437e558075c9f7ce5c37bf73943b13c47739ff56acde571d
 homepage   : https://apps.kde.org/neochat/
@@ -60,6 +60,7 @@ optimize   :
     - speed
     - thin-lto
 setup      : |
+    %patch -p1 -i $pkgfiles/0001-controller-Fuck-you-give-me-a-system-tray.patch
     %cmake_kf6
 build      : |
     %ninja_build

--- a/packages/n/neochat/pspec_x86_64.xml
+++ b/packages/n/neochat/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>neochat</Name>
         <Homepage>https://apps.kde.org/neochat/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <License>GPL-2.0-or-later</License>
@@ -85,12 +85,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="29">
-            <Date>2024-09-12</Date>
+        <Update release="30">
+            <Date>2024-09-29</Date>
             <Version>24.08.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- We use https://github.com/ubuntu/gnome-shell-extension-appindicator OOTB so let us use the damn tray

**Test Plan**

- System tray setting is no longer hidden, system tray works when enabled

**Checklist**

- [x] Package was built and tested against unstable
