### PR TITLE
Allow apparmor removal

### DIFF
--- a/packages/a/aa-lsm-hook/package.yml
+++ b/packages/a/aa-lsm-hook/package.yml
@@ -1,11 +1,11 @@
 name       : aa-lsm-hook
 version    : 0.1.5
-release    : 17
+release    : 18
 source     :
     - https://github.com/getsolus/aa-lsm-hook/archive/refs/tags/0.1.5.tar.gz : 1e2e6fc25bd6d949a2c30d7555ea02de2b44ec78f11924f792d77079135fcc96
 homepage   : https://github.com/getsolus/aa-lsm-hook/
 license    : Apache-2.0
-component  : system.base
+component  : security.library
 summary    : AppArmor system integration
 description: |
     AppArmor system integration

--- a/packages/a/aa-lsm-hook/pspec_x86_64.xml
+++ b/packages/a/aa-lsm-hook/pspec_x86_64.xml
@@ -3,11 +3,11 @@
         <Name>aa-lsm-hook</Name>
         <Homepage>https://github.com/getsolus/aa-lsm-hook/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>Apache-2.0</License>
-        <PartOf>system.base</PartOf>
+        <PartOf>security.library</PartOf>
         <Summary xml:lang="en">AppArmor system integration</Summary>
         <Description xml:lang="en">AppArmor system integration
 </Description>
@@ -18,7 +18,7 @@
         <Summary xml:lang="en">AppArmor system integration</Summary>
         <Description xml:lang="en">AppArmor system integration
 </Description>
-        <PartOf>system.base</PartOf>
+        <PartOf>security.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib/systemd/system/aa-lsm-hook.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/sysinit.target.wants/aa-lsm-hook.service</Path>
@@ -27,12 +27,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2023-11-06</Date>
+        <Update release="18">
+            <Date>2024-09-29</Date>
             <Version>0.1.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/a/apparmor/abi_used_symbols
+++ b/packages/a/apparmor/abi_used_symbols
@@ -142,7 +142,6 @@ libc.so.6:fgets
 libc.so.6:fileno
 libc.so.6:fnmatch
 libc.so.6:fopen
-libc.so.6:fopen64
 libc.so.6:fork
 libc.so.6:fputc
 libc.so.6:fputs
@@ -150,7 +149,6 @@ libc.so.6:fread
 libc.so.6:free
 libc.so.6:fseeko64
 libc.so.6:fstat
-libc.so.6:fstat64
 libc.so.6:fstatat
 libc.so.6:ftello64
 libc.so.6:fwrite
@@ -173,7 +171,7 @@ libc.so.6:isalpha
 libc.so.6:isatty
 libc.so.6:isprint
 libc.so.6:isspace
-libc.so.6:lseek64
+libc.so.6:lseek
 libc.so.6:malloc
 libc.so.6:mbrtowc
 libc.so.6:mbsnrtowcs
@@ -195,6 +193,8 @@ libc.so.6:opterr
 libc.so.6:optind
 libc.so.6:perror
 libc.so.6:poll
+libc.so.6:pthread_cond_broadcast
+libc.so.6:pthread_cond_wait
 libc.so.6:pthread_mutex_lock
 libc.so.6:pthread_mutex_unlock
 libc.so.6:pthread_once

--- a/packages/a/apparmor/package.yml
+++ b/packages/a/apparmor/package.yml
@@ -1,6 +1,6 @@
 name       : apparmor
 version    : 3.1.7
-release    : 32
+release    : 33
 source     :
     - https://launchpad.net/apparmor/3.1/3.1.7/+download/apparmor-3.1.7.tar.gz : c6c161d6dbd99c2f10758ff347cbc6848223c7381f311de62522f22b0a16de64
 license    :
@@ -18,6 +18,7 @@ builddeps  :
     - pyflakes     # Tests
     - swig
 rundeps    :
+    - aa-lsm-hook
     - python-notify2
     - python3
 networking : yes

--- a/packages/a/apparmor/pspec_x86_64.xml
+++ b/packages/a/apparmor/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>apparmor</Name>
         <Homepage>https://gitlab.com/apparmor/apparmor</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <License>LGPL-2.1-or-later</License>
@@ -586,7 +586,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="32">apparmor</Dependency>
+            <Dependency release="33">apparmor</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/aalogparse/aalogparse.h</Path>
@@ -602,12 +602,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2024-06-28</Date>
+        <Update release="33">
+            <Date>2024-09-29</Date>
             <Version>3.1.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Move `aa-lsm-hook` out of system.base.

Resolves getsolus/packages#3934.

**Test Plan**

- Install and check component.
- Remove and verify errors are gone.

**Checklist**

- [x] Package was built and tested against unstable
