### PR TITLE
bash: Add /etc/skel files

### DIFF
--- a/packages/b/bash/files/skel/.bashrc
+++ b/packages/b/bash/files/skel/.bashrc
@@ -1,0 +1,1 @@
+source /usr/share/defaults/etc/profile

--- a/packages/b/bash/files/skel/.profile
+++ b/packages/b/bash/files/skel/.profile
@@ -1,0 +1,1 @@
+source /usr/share/defaults/etc/profile

--- a/packages/b/bash/package.yml
+++ b/packages/b/bash/package.yml
@@ -1,6 +1,6 @@
 name       : bash
 version    : 5.2.32
-release    : 82
+release    : 83
 source     :
     - https://ftp.gnu.org/gnu/bash/bash-5.2.21.tar.gz : c8e31bdc59b69aaffc5b36509905ba3e5cbb12747091d27b4b977f078560d5b8
 license    :
@@ -53,6 +53,9 @@ install    : |
     install -D -d $installdir/usr/share/defaults/etc/profile.d
     install -m 0644 $pkgfiles/profile/*.sh $installdir/usr/share/defaults/etc/profile.d/.
     install -m 0644 $pkgfiles/profile/profile $installdir/usr/share/defaults/etc/profile
+
+    # Install defaults to /etc/skel
+    install -Dm0644 -t $installdir/etc/skel $pkgfiles/skel/.{bashrc,profile}
 
     # Use tmpfiles to create the symlink in order to make this completely stateless
     install -Dm00644 $pkgfiles/bash.tmpfiles $installdir/%libdir%/tmpfiles.d/bash.conf

--- a/packages/b/bash/pspec_x86_64.xml
+++ b/packages/b/bash/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>bash</Name>
         <Homepage>https://www.gnu.org/software/bash</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -22,6 +22,8 @@
         <Files>
             <Path fileType="executable">/bin/bash</Path>
             <Path fileType="executable">/bin/sh</Path>
+            <Path fileType="config">/etc/skel/.bashrc</Path>
+            <Path fileType="config">/etc/skel/.profile</Path>
             <Path fileType="executable">/usr/bin/bash</Path>
             <Path fileType="executable">/usr/bin/bashbug</Path>
             <Path fileType="executable">/usr/bin/sh</Path>
@@ -133,7 +135,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="82">bash</Dependency>
+            <Dependency release="83">bash</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/bash/alias.h</Path>
@@ -199,12 +201,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="82">
-            <Date>2024-09-11</Date>
+        <Update release="83">
+            <Date>2024-09-29</Date>
             <Version>5.2.32</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add /etc/skel files so new users have sane defaults.

Resolves getsolus/packages#3795

**Test Plan**

Generate ISO with this package. See shell colours in ISO and in fresh install:

![budgie-uefi-ext4](https://github.com/user-attachments/assets/5ac31e04-577e-4731-916e-b73d02b359c1)

**Checklist**

- [x] Package was built and tested against unstable
