### PR TITLE
newsboat: Update to 2.37

### DIFF
--- a/packages/n/newsboat/abi_used_symbols
+++ b/packages/n/newsboat/abi_used_symbols
@@ -119,6 +119,7 @@ libc.so.6:open64
 libc.so.6:openat64
 libc.so.6:opendir
 libc.so.6:optarg
+libc.so.6:pause
 libc.so.6:pclose
 libc.so.6:pipe2
 libc.so.6:poll
@@ -143,7 +144,6 @@ libc.so.6:pthread_attr_setstacksize
 libc.so.6:pthread_create
 libc.so.6:pthread_detach
 libc.so.6:pthread_getattr_np
-libc.so.6:pthread_getspecific
 libc.so.6:pthread_join
 libc.so.6:pthread_key_create
 libc.so.6:pthread_key_delete
@@ -205,7 +205,6 @@ libc.so.6:strdup
 libc.so.6:strerror
 libc.so.6:strftime
 libc.so.6:strlen
-libc.so.6:strncasecmp
 libc.so.6:strncmp
 libc.so.6:strptime
 libc.so.6:strtod
@@ -303,7 +302,6 @@ libstdc++.so.6:_ZNKSt13runtime_error4whatEv
 libstdc++.so.6:_ZNKSt5ctypeIcE13_M_widen_initEv
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE13find_first_ofEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE17find_first_not_ofEPKcmm
-libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEPKcm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEcm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE5rfindEPKcmm
@@ -380,7 +378,6 @@ libstdc++.so.6:_ZNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE14__xfer_
 libstdc++.so.6:_ZNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE7_M_syncEPcmm
 libstdc++.so.6:_ZNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE8_M_pbumpEPcS5_l
 libstdc++.so.6:_ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEED1Ev
-libstdc++.so.6:_ZNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEEC1ERKNS_12basic_stringIcS2_S3_EESt13_Ios_Openmode
 libstdc++.so.6:_ZNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt8ios_base7_M_swapERS_
@@ -448,6 +445,7 @@ libstdc++.so.6:_Znwm
 libstdc++.so.6:_ZnwmRKSt9nothrow_t
 libstdc++.so.6:__cxa_allocate_exception
 libstdc++.so.6:__cxa_begin_catch
+libstdc++.so.6:__cxa_call_terminate
 libstdc++.so.6:__cxa_call_unexpected
 libstdc++.so.6:__cxa_end_catch
 libstdc++.so.6:__cxa_free_exception

--- a/packages/n/newsboat/package.yml
+++ b/packages/n/newsboat/package.yml
@@ -1,8 +1,8 @@
 name       : newsboat
-version    : '2.36'
-release    : 3
+version    : '2.37'
+release    : 4
 source     :
-    - https://newsboat.org/releases/2.36/newsboat-2.36.tar.xz : 61a67a397cc9df7fbb7d73bb156e89e5b4a2b31fc9360e1e7384e710a2cf037a
+    - https://newsboat.org/releases/2.37/newsboat-2.37.tar.xz : 4f54dea385c25b95e8ce0df1107f0336db41b18c645368e6164ce1070efba77c
 homepage   : https://newsboat.org/
 license    : MIT
 component  : network.news

--- a/packages/n/newsboat/pspec_x86_64.xml
+++ b/packages/n/newsboat/pspec_x86_64.xml
@@ -65,8 +65,12 @@
             <Path fileType="doc">/usr/share/doc/newsboat/contrib/linkding/linkding.rb</Path>
             <Path fileType="doc">/usr/share/doc/newsboat/contrib/miniflux/docker-compose.yml</Path>
             <Path fileType="doc">/usr/share/doc/newsboat/contrib/move_url.py</Path>
+            <Path fileType="doc">/usr/share/doc/newsboat/contrib/newsboat.fish</Path>
             <Path fileType="doc">/usr/share/doc/newsboat/contrib/newsboat_reorganize.py</Path>
             <Path fileType="doc">/usr/share/doc/newsboat/contrib/pinboard.pl</Path>
+            <Path fileType="doc">/usr/share/doc/newsboat/contrib/readeck/README.md</Path>
+            <Path fileType="doc">/usr/share/doc/newsboat/contrib/readeck/interactive-labels-readeck.clj</Path>
+            <Path fileType="doc">/usr/share/doc/newsboat/contrib/readeck/standard-readeck.clj</Path>
             <Path fileType="doc">/usr/share/doc/newsboat/contrib/slashdot-replace-newlines.xslt</Path>
             <Path fileType="doc">/usr/share/doc/newsboat/contrib/slashdot.rb</Path>
             <Path fileType="doc">/usr/share/doc/newsboat/contrib/urls-maintenance.sh</Path>
@@ -101,9 +105,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-06-24</Date>
-            <Version>2.36</Version>
+        <Update release="4">
+            <Date>2024-10-01</Date>
+            <Version>2.37</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
             <Email>malfisya.dev@hotmail.com</Email>


### PR DESCRIPTION
**Summary**

Changelog can be read [here](https://raw.githubusercontent.com/newsboat/newsboat/refs/tags/r2.37/CHANGELOG.md)

**Test Plan**

<!-- Short description of how the package was tested -->
Open rss feed

**Checklist**

- [x] Package was built and tested against unstable
