### PR TITLE
mpv: Update to 0.39.0

### DIFF
--- a/packages/m/mpv/abi_used_symbols
+++ b/packages/m/mpv/abi_used_symbols
@@ -291,6 +291,7 @@ libavcodec.so.60:av_codec_iterate
 libavcodec.so.60:av_get_bits_per_sample
 libavcodec.so.60:av_get_profile_name
 libavcodec.so.60:av_new_packet
+libavcodec.so.60:av_packet_add_side_data
 libavcodec.so.60:av_packet_alloc
 libavcodec.so.60:av_packet_clone
 libavcodec.so.60:av_packet_copy_props
@@ -335,6 +336,7 @@ libavcodec.so.60:avcodec_send_packet
 libavcodec.so.60:avcodec_version
 libavcodec.so.60:avsubtitle_free
 libavdevice.so.60:avdevice_register_all
+libavdevice.so.60:avdevice_version
 libavfilter.so.9:av_buffersink_get_frame_flags
 libavfilter.so.9:av_buffersink_get_frame_rate
 libavfilter.so.9:av_buffersrc_add_frame
@@ -391,6 +393,7 @@ libavformat.so.60:avio_close
 libavformat.so.60:avio_close_dyn_buf
 libavformat.so.60:avio_closep
 libavformat.so.60:avio_context_free
+libavformat.so.60:avio_enum_protocols
 libavformat.so.60:avio_flush
 libavformat.so.60:avio_open
 libavformat.so.60:avio_open2
@@ -433,6 +436,9 @@ libavutil.so.58:av_dict_set_int
 libavutil.so.58:av_display_rotation_get
 libavutil.so.58:av_display_rotation_set
 libavutil.so.58:av_div_q
+libavutil.so.58:av_dovi_alloc
+libavutil.so.58:av_dynamic_hdr_plus_alloc
+libavutil.so.58:av_dynamic_hdr_plus_from_t35
 libavutil.so.58:av_find_nearest_q_idx
 libavutil.so.58:av_frame_alloc
 libavutil.so.58:av_frame_clone
@@ -475,6 +481,7 @@ libavutil.so.58:av_malloc_array
 libavutil.so.58:av_mallocz
 libavutil.so.58:av_md5_sum
 libavutil.so.58:av_opt_get
+libavutil.so.58:av_opt_get_int
 libavutil.so.58:av_opt_get_q
 libavutil.so.58:av_opt_next
 libavutil.so.58:av_opt_set
@@ -532,6 +539,7 @@ libc.so.6:__memcpy_chk
 libc.so.6:__memmove_chk
 libc.so.6:__memset_chk
 libc.so.6:__poll_chk
+libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__vfprintf_chk
@@ -593,9 +601,9 @@ libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memfd_create
 libc.so.6:memmove
+libc.so.6:memrchr
 libc.so.6:memset
 libc.so.6:mkdir
-libc.so.6:mkstemp64
 libc.so.6:mmap64
 libc.so.6:munmap
 libc.so.6:nanosleep
@@ -637,6 +645,7 @@ libc.so.6:raise
 libc.so.6:read
 libc.so.6:readdir64
 libc.so.6:realloc
+libc.so.6:realpath
 libc.so.6:regcomp
 libc.so.6:regerror
 libc.so.6:regexec
@@ -709,9 +718,11 @@ libcdio_paranoia.so.2:cdio_paranoia_overlapset
 libcdio_paranoia.so.2:cdio_paranoia_read
 libcdio_paranoia.so.2:cdio_paranoia_seek
 libdrm.so.2:drmDropMaster
+libdrm.so.2:drmFreeDevice
 libdrm.so.2:drmFreeDevices
 libdrm.so.2:drmFreeVersion
 libdrm.so.2:drmGetCap
+libdrm.so.2:drmGetDeviceFromDevId
 libdrm.so.2:drmGetDeviceNameFromFd2
 libdrm.so.2:drmGetDevices2
 libdrm.so.2:drmGetRenderDeviceNameFromFd
@@ -776,13 +787,11 @@ libdvdnav.so.4:dvdnav_still_skip
 libdvdnav.so.4:dvdnav_time_search
 libdvdnav.so.4:dvdnav_title_play
 libdvdnav.so.4:dvdnav_wait_skip
-libgbm.so.1:gbm_bo_get_handle
 libgbm.so.1:gbm_bo_get_handle_for_plane
 libgbm.so.1:gbm_bo_get_height
 libgbm.so.1:gbm_bo_get_modifier
 libgbm.so.1:gbm_bo_get_offset
 libgbm.so.1:gbm_bo_get_plane_count
-libgbm.so.1:gbm_bo_get_stride
 libgbm.so.1:gbm_bo_get_stride_for_plane
 libgbm.so.1:gbm_bo_get_user_data
 libgbm.so.1:gbm_bo_get_width
@@ -875,12 +884,8 @@ libm.so.6:fmax
 libm.so.6:j1
 libm.so.6:log
 libm.so.6:log10
-libm.so.6:lround
-libm.so.6:lroundf
 libm.so.6:pow
 libm.so.6:powf
-libm.so.6:round
-libm.so.6:roundf
 libm.so.6:sin
 libm.so.6:sincos
 libpipewire-0.3.so.0:pw_context_connect
@@ -1201,16 +1206,7 @@ libva.so.2:vaSetInfoCallback
 libva.so.2:vaSyncSurface
 libva.so.2:vaTerminate
 libva.so.2:vaUnmapBuffer
-libvapoursynth-script.so.0:vsscript_createScript
-libvapoursynth-script.so.0:vsscript_evaluateFile
-libvapoursynth-script.so.0:vsscript_finalize
-libvapoursynth-script.so.0:vsscript_freeScript
-libvapoursynth-script.so.0:vsscript_getCore
-libvapoursynth-script.so.0:vsscript_getError
-libvapoursynth-script.so.0:vsscript_getOutput
-libvapoursynth-script.so.0:vsscript_getVSApi
-libvapoursynth-script.so.0:vsscript_init
-libvapoursynth-script.so.0:vsscript_setVariable
+libvapoursynth-script.so.0:getVSScriptAPI
 libvdpau.so.1:vdp_device_create_x11
 libvulkan.so.1:vkCreateDisplayPlaneSurfaceKHR
 libvulkan.so.1:vkCreateWaylandSurfaceKHR
@@ -1223,7 +1219,7 @@ libvulkan.so.1:vkGetPhysicalDeviceDisplayPlanePropertiesKHR
 libvulkan.so.1:vkGetPhysicalDeviceDisplayPropertiesKHR
 libvulkan.so.1:vkGetPhysicalDeviceProperties
 libvulkan.so.1:vkGetPhysicalDeviceProperties2
-libvulkan.so.1:vkGetPhysicalDeviceQueueFamilyProperties
+libvulkan.so.1:vkGetPhysicalDeviceQueueFamilyProperties2
 libwayland-client.so.0:wl_buffer_interface
 libwayland-client.so.0:wl_callback_interface
 libwayland-client.so.0:wl_compositor_interface
@@ -1240,6 +1236,7 @@ libwayland-client.so.0:wl_display_prepare_read
 libwayland-client.so.0:wl_display_read_events
 libwayland-client.so.0:wl_display_roundtrip
 libwayland-client.so.0:wl_keyboard_interface
+libwayland-client.so.0:wl_list_empty
 libwayland-client.so.0:wl_list_init
 libwayland-client.so.0:wl_list_insert
 libwayland-client.so.0:wl_list_length

--- a/packages/m/mpv/package.yml
+++ b/packages/m/mpv/package.yml
@@ -1,9 +1,9 @@
 name       : mpv
 homepage   : https://mpv.io/
-version    : 0.38.0
-release    : 119
+version    : 0.39.0
+release    : 120
 source     :
-    - https://github.com/mpv-player/mpv/archive/refs/tags/v0.38.0.tar.gz : 86d9ef40b6058732f67b46d0bbda24a074fae860b3eaae05bab3145041303066
+    - https://github.com/mpv-player/mpv/archive/refs/tags/v0.39.0.tar.gz : 2ca92437affb62c2b559b4419ea4785c70d023590500e8a52e95ea3ab4554683
 license    :
     - GPL-2.0-or-later
     - LGPL-2.1-or-later

--- a/packages/m/mpv/pspec_x86_64.xml
+++ b/packages/m/mpv/pspec_x86_64.xml
@@ -58,7 +58,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="119">mpv-libs</Dependency>
+            <Dependency releaseFrom="120">mpv-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/mpv/client.h</Path>
@@ -73,9 +73,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="119">
-            <Date>2024-08-16</Date>
-            <Version>0.38.0</Version>
+        <Update release="120">
+            <Date>2024-10-02</Date>
+            <Version>0.39.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/mpv-player/mpv/releases/tag/v0.39.0).
- Resolves https://github.com/getsolus/packages/issues/3972

**Test Plan**
- Installed, ran some commands.

**Checklist**

-  [X] Package was built and tested against unstable
