### PR TITLE
mate-notification-daemon: Update to 1.28.1

### DIFF
--- a/packages/m/mate-notification-daemon/abi_symbols
+++ b/packages/m/mate-notification-daemon/abi_symbols
@@ -89,6 +89,7 @@ mate-notification-daemon:notify_daemon_notifications_skeleton_get_type
 mate-notification-daemon:notify_daemon_notifications_skeleton_new
 mate-notification-daemon:notify_stack_add_window
 mate-notification-daemon:notify_stack_destroy
+mate-notification-daemon:notify_stack_get_monitor
 mate-notification-daemon:notify_stack_get_windows
 mate-notification-daemon:notify_stack_new
 mate-notification-daemon:notify_stack_queue_update_position

--- a/packages/m/mate-notification-daemon/package.yml
+++ b/packages/m/mate-notification-daemon/package.yml
@@ -1,8 +1,8 @@
 name       : mate-notification-daemon
-version    : 1.28.0
-release    : 19
+version    : 1.28.1
+release    : 20
 source     :
-    - https://github.com/mate-desktop/mate-notification-daemon/releases/download/v1.28.0/mate-notification-daemon-1.28.0.tar.xz : a4310348ead866cbcb9b4c463f4d265cc6a96a1a782a9411a08b23bd65dbb2e0
+    - https://github.com/mate-desktop/mate-notification-daemon/releases/download/v1.28.1/mate-notification-daemon-1.28.1.tar.xz : f575353c988181557d1394031f3b9a6bb6939fb23403cae17d188201bb8026b4
 homepage   : https://mate-desktop.org/
 license    : GPL-2.0-or-later
 component  : desktop.mate

--- a/packages/m/mate-notification-daemon/pspec_x86_64.xml
+++ b/packages/m/mate-notification-daemon/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mate-notification-daemon</Name>
         <Homepage>https://mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.mate</PartOf>
@@ -154,12 +154,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2024-08-28</Date>
-            <Version>1.28.0</Version>
+        <Update release="20">
+            <Date>2024-10-03</Date>
+            <Version>1.28.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- daemon: Properly update the set of monitors when it changes

**Test Plan**

Confirmed notifications in a MATE sessions worked and looked correctly

**Checklist**

- [x] Package was built and tested against unstable
