### PR TITLE
github-cli: Update to 2.58.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.57.0
-release    : 55
+version    : 2.58.0
+release    : 56
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.57.0.tar.gz : 6433bca534da722a980126541fe28d278f4b3518a6f7a7ef4a23949a3968e8b9
+    - https://github.com/cli/cli/archive/refs/tags/v2.58.0.tar.gz : 90894536c797147586db775d06ec2040c45cd7eef941f7ccbea46f4e5997c81c
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -219,9 +219,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="55">
-            <Date>2024-09-25</Date>
-            <Version>2.57.0</Version>
+        <Update release="56">
+            <Date>2024-10-03</Date>
+            <Version>2.58.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Better messaging for `attestation verify` custom issuer mismatch error
- Enhance `gh repo create` docs, fix random cmd link
- Add HasActiveToken method to AuthConfig to refactor auth check for `attestation trusted-root` command
- Improve the suggested command for creating an issue when an extension doesn't have a binary for your platform
- Disable auth check for `attestation trusted-root` command
- Fix tenant-awareness for `trusted-root` command
- Replace "GitHub Enterprise Server" option with "other" in gh auth login prompting

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and make this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
