### PR TITLE
noto-sans-ttf: Update emoji font to 2.047

### DIFF
--- a/packages/n/noto-sans-ttf/package.yml
+++ b/packages/n/noto-sans-ttf/package.yml
@@ -1,9 +1,9 @@
 name       : noto-sans-ttf
 version    : 24.9.1
-release    : 32
+release    : 33
 source     :
     - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-24.9.1.tar.gz : 73fc256356e4ed66c54aa300a71c390695603547e127f27cd6eefdeb942726b0
-    - https://github.com/googlefonts/noto-emoji/archive/refs/tags/v2.042.tar.gz : b56bd2fa4029d0f057b66b742ac59af243dbc91067fed3eb4929dac762440fc9
+    - https://github.com/googlefonts/noto-emoji/archive/refs/tags/v2.047.tar.gz : 2cfaf5a427eb26334cdb30d98e4a0c005b660504a339249dc54373e566f09b50
 homepage   : https://fonts.google.com/noto
 extract    : no
 license    : OFL-1.1

--- a/packages/n/noto-sans-ttf/pspec_x86_64.xml
+++ b/packages/n/noto-sans-ttf/pspec_x86_64.xml
@@ -1538,8 +1538,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2024-09-01</Date>
+        <Update release="33">
+            <Date>2024-10-03</Date>
             <Version>24.9.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>


### PR DESCRIPTION
**Summary**

Enables Unicode 16 emoji support

For more details see [here](https://blog.emojipedia.org/whats-new-in-unicode-16-0/)

**Test Plan**

Entered the new emojis in my text editor of choice (`gedit`)

**Checklist**

- [x] Package was built and tested against unstable
