### PR TITLE
godot: Update to 3.6

### DIFF
--- a/packages/g/godot/abi_used_symbols
+++ b/packages/g/godot/abi_used_symbols
@@ -8,6 +8,7 @@ UNKNOWN:_ZTV13btSphereShape
 UNKNOWN:_ZTV23btConvexPointCloudShape
 UNKNOWN:_ZTV30btGjkEpaPenetrationDepthSolver
 ld-linux-x86-64.so.2:__tls_get_addr
+ld-linux-x86-64.so.2:_r_debug
 libBulletCollision.so.3.25:_Z26btGenerateInternalEdgeInfoP22btBvhTriangleMeshShapeP17btTriangleInfoMap
 libBulletCollision.so.3.25:_Z28btAdjustInternalEdgeContactsR15btManifoldPointPK24btCollisionObjectWrapperS3_iii
 libBulletCollision.so.3.25:_ZN10btBoxShapeC1ERK9btVector3
@@ -44,7 +45,6 @@ libBulletCollision.so.3.25:_ZN21btCollisionDispatcherD2Ev
 libBulletCollision.so.3.25:_ZN21btConvexInternalShape15setLocalScalingERK9btVector3
 libBulletCollision.so.3.25:_ZN21btConvexInternalShapeC2Ev
 libBulletCollision.so.3.25:_ZN22btBvhTriangleMeshShapeC1EP23btStridingMeshInterfacebb
-libBulletCollision.so.3.25:_ZN23btPolyhedralConvexShapeD2Ev
 libBulletCollision.so.3.25:_ZN25btHeightfieldTerrainShape16buildAcceleratorEi
 libBulletCollision.so.3.25:_ZN25btHeightfieldTerrainShapeC1EiiPKvdddi14PHY_ScalarTypeb
 libBulletCollision.so.3.25:_ZN28btScaledBvhTriangleMeshShapeC1EP22btBvhTriangleMeshShapeRK9btVector3
@@ -293,6 +293,7 @@ libc.so.6:fflush
 libc.so.6:fgetc
 libc.so.6:fgets
 libc.so.6:fileno
+libc.so.6:fopen
 libc.so.6:fopen64
 libc.so.6:fork
 libc.so.6:fprintf
@@ -304,6 +305,7 @@ libc.so.6:freeaddrinfo
 libc.so.6:freeifaddrs
 libc.so.6:fseek
 libc.so.6:fseeko64
+libc.so.6:fstat
 libc.so.6:fstat64
 libc.so.6:ftell
 libc.so.6:ftello64
@@ -339,7 +341,7 @@ libc.so.6:kill
 libc.so.6:listen
 libc.so.6:localtime_r
 libc.so.6:longjmp
-libc.so.6:lseek64
+libc.so.6:lseek
 libc.so.6:lstat64
 libc.so.6:madvise
 libc.so.6:malloc
@@ -387,9 +389,6 @@ libc.so.6:pthread_mutex_init
 libc.so.6:pthread_mutex_lock
 libc.so.6:pthread_mutex_trylock
 libc.so.6:pthread_mutex_unlock
-libc.so.6:pthread_mutexattr_destroy
-libc.so.6:pthread_mutexattr_init
-libc.so.6:pthread_mutexattr_settype
 libc.so.6:pthread_once
 libc.so.6:pthread_rwlock_rdlock
 libc.so.6:pthread_rwlock_unlock

--- a/packages/g/godot/package.yml
+++ b/packages/g/godot/package.yml
@@ -1,8 +1,8 @@
 name       : godot-classic
-version    : 3.5.3
-release    : 55
+version    : '3.6'
+release    : 56
 source     :
-    - https://github.com/godotengine/godot/archive/3.5.3-stable.tar.gz : 643366a288fc529564d8bb42a42093d72071c8186f57ff03cae6d5929f81bd1d
+    - https://github.com/godotengine/godot/archive/3.6-stable.tar.gz : 771ae03e20f74907a11c12c8d0de046952d12593aafde99ffb2feb55c4866cd5
 homepage   : https://godotengine.org/
 license    :
     - CC-BY-3.0
@@ -32,6 +32,7 @@ builddeps  :
     - pkgconfig(libpulse)
     - pkgconfig(libwebp)
     - pkgconfig(libzstd)
+    - pkgconfig(mbedtls)
     - pkgconfig(mono)
     - pkgconfig(opusfile)
     - pkgconfig(theora)
@@ -43,7 +44,6 @@ builddeps  :
     - pkgconfig(xrandr)
     - alsa-plugins
     - llvm-clang
-    - mbedtls-devel
     - mono-msbuild
     - nuget
     - scons

--- a/packages/g/godot/pspec_x86_64.xml
+++ b/packages/g/godot/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>godot-classic</Name>
         <Homepage>https://godotengine.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>CC-BY-3.0</License>
         <License>MIT</License>
@@ -21,7 +21,7 @@
 </Description>
         <PartOf>games</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="55">godot-common</Dependency>
+            <Dependency releaseFrom="56">godot-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/godot</Path>
@@ -51,7 +51,7 @@
 </Description>
         <PartOf>games</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="55">godot-common</Dependency>
+            <Dependency releaseFrom="56">godot-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/godot.mono</Path>
@@ -100,12 +100,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="55">
-            <Date>2024-07-06</Date>
-            <Version>3.5.3</Version>
+        <Update release="56">
+            <Date>2024-10-04</Date>
+            <Version>3.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Highlighted changes:
- 2D physics interpolation
- 2D hierarchical culling
- Tighter shadow culling
- Mesh merging
- Discrete level of detail
- ORM materials
- Vertex cache optimization
- Light probes and directional shadows performance improvements
- View selected mesh stats
- SceneTree dock’s filter improvements
- Text-to-Speech support
- In-editor documentation for Editor Settings
- Update supported versions for Android, iOS, and macOS

Full release notes available [here](https://godotengine.org/article/godot-3-6-finally-released/)

**Test Plan**

Opened, edited and ran a small example project in both -classic and -mono

**Checklist**

- [x] Package was built and tested against unstable
