### PR TITLE
[NFC] repo-wide: Replace mbedtls-devel with pkgconfig(mbedtls)

### DIFF
--- a/packages/d/dolphin-emu/package.yml
+++ b/packages/d/dolphin-emu/package.yml
@@ -27,6 +27,7 @@ builddeps  :
     - pkgconfig(libxxhash)
     - pkgconfig(libzstd)
     - pkgconfig(lzo2)
+    - pkgconfig(mbedtls)
     - pkgconfig(miniupnpc)
     - pkgconfig(minizip-ng)
     - pkgconfig(openal)
@@ -41,7 +42,6 @@ builddeps  :
     - pkgconfig(xrandr)
     - cubeb-devel
     - llvm-clang-devel
-    - mbedtls-devel
 optimize   :
     - thin-lto
 clang      : yes

--- a/packages/h/haxe/package.yml
+++ b/packages/h/haxe/package.yml
@@ -14,8 +14,8 @@ description: |
 networking : yes
 builddeps  :
     - pkgconfig(libpcre)
+    - pkgconfig(mbedtls)
     - camlp4
-    - mbedtls-devel
     - neko
     - opam
     - perl-ipc-system-simple

--- a/packages/l/librist/package.yml
+++ b/packages/l/librist/package.yml
@@ -10,7 +10,7 @@ summary    : A library that can be used to easily add the RIST protocol to your 
 description: |
     A library that can be used to easily add the Reliable Internet Stream Transport (RIST) protocol to your application, written to comply with the Video Services Forum (VSF) Technical Recommendations TR-06-1 and TR-06-2.
 builddeps  :
-    - mbedtls-devel
+    - pkgconfig(mbedtls)
 setup      : |
     %meson_configure
 build      : |

--- a/packages/n/neko/package.yml
+++ b/packages/n/neko/package.yml
@@ -21,10 +21,10 @@ builddeps  :
     - pkgconfig(gtk+-3.0)
     - pkgconfig(libpcre)
     - pkgconfig(mariadb)
+    - pkgconfig(mbedtls)
     - pkgconfig(sqlite3)
     - git
     - httpd-devel
-    - mbedtls-devel
 setup      : |
     %patch -p1 -i $pkgfiles/neko-discard-xlocale.patch
     %patch -p1 -i $pkgfiles/neko-gtk3.patch

--- a/packages/o/obs-studio/package.yml
+++ b/packages/o/obs-studio/package.yml
@@ -29,6 +29,7 @@ builddeps  :
     - pkgconfig(libva)
     - pkgconfig(libvlc)
     - pkgconfig(luajit)
+    - pkgconfig(mbedtls)
     - pkgconfig(nlohmann_json)
     - pkgconfig(python3)
     - pkgconfig(qrcodegencpp)
@@ -44,7 +45,6 @@ builddeps  :
     - pkgconfig(xkbcommon-x11)
     - cef-minimal-devel
     - libdatachannel-devel
-    - mbedtls-devel
     - swig
     - websocketpp
 setup      : |

--- a/packages/o/openrgb/package.yml
+++ b/packages/o/openrgb/package.yml
@@ -13,7 +13,7 @@ builddeps  :
     - pkgconfig(Qt5Core)
     - pkgconfig(hidapi-libusb)
     - pkgconfig(libusb-1.0)
-    - mbedtls-devel
+    - pkgconfig(mbedtls)
     - qt5-tools-devel
 setup      : |
     %qmake OpenRGB.pro

--- a/packages/r/retroarch/package.yml
+++ b/packages/r/retroarch/package.yml
@@ -22,6 +22,7 @@ builddeps  :
     - pkgconfig(libdecor-0)
     - pkgconfig(libpulse)
     - pkgconfig(libv4l2)
+    - pkgconfig(mbedtls)
     - pkgconfig(openal)
     - pkgconfig(sdl2)
     - pkgconfig(vulkan)
@@ -33,7 +34,6 @@ builddeps  :
     - pkgconfig(xv)
     - pkgconfig(xxf86vm)
     - glslang-devel
-    - mbedtls-devel
 rundeps    :
     - libdecor
 setup      : |


### PR DESCRIPTION
**Summary**

Replaces mbedtls-devel build dependencies with the new-ish pkgconfig

**Test Plan**

Built Godot using the pkgconfig in build deps (that's a separate PR though)

**Checklist**

- [x] Package was built and tested against unstable
