### PR TITLE
calamares: Remove leftover files in /etc

### DIFF
--- a/packages/c/calamares/files/install/modules/shellprocess_removeliveos.conf
+++ b/packages/c/calamares/files/install/modules/shellprocess_removeliveos.conf
@@ -12,7 +12,8 @@ script:
     - command: "eopkg rmf -y calamares"
       timeout: 300
     - "-rm /etc/gdm/custom.conf"
-    - "rm /etc/sudoers.d/os-installer"
+    - "rm -rf /etc/sudoers.d"
+    - "rm -rf /etc/pam.d"
 
 i18n:
     name: "Removing LiveOS configuration"

--- a/packages/c/calamares/files/install/modules/users.conf
+++ b/packages/c/calamares/files/install/modules/users.conf
@@ -21,8 +21,6 @@ defaultGroups:
 
 doAutoLogin: false
 
-sudoersGroup:    sudo
-
 setRootPassword: false
 
 doReusePassword: true

--- a/packages/c/calamares/package.yml
+++ b/packages/c/calamares/package.yml
@@ -1,6 +1,6 @@
 name       : calamares
 version    : 3.3.9
-release    : 23
+release    : 24
 source     :
     - https://github.com/calamares/calamares/releases/download/v3.3.9/calamares-3.3.9.tar.gz : d8f70fa682ca732f448c7033e66c5d4f747161031f74f46778e20728ceff6b45
 homepage   : https://calamares.io

--- a/packages/c/calamares/pspec_x86_64.xml
+++ b/packages/c/calamares/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>calamares</Name>
         <Homepage>https://calamares.io</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <License>CC-BY-4.0</License>
@@ -290,7 +290,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="23">calamares</Dependency>
+            <Dependency release="24">calamares</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libcalamares/Branding.h</Path>
@@ -411,12 +411,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2024-09-28</Date>
+        <Update release="24">
+            <Date>2024-10-05</Date>
             <Version>3.3.9</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Remove additional files created for/by the installer in `/etc/pam.d` and `/etc/sudoers.d`. Both directories should generally not exist in a clean install.

**Test Plan**

1. Install Solus using an ISO with this version of Calamares included.
2. Verify that `/etc/pam.d` and `/etc/sudoers.d` do not exist.

**Checklist**

- [x] Package was built and tested against unstable
