### PR TITLE
python-toolz: Update to 1.0.0, add monitoring, enable tests

### DIFF
--- a/packages/py/python-toolz/monitoring.yml
+++ b/packages/py/python-toolz/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 136798
+  rss: https://github.com/pytoolz/toolz/releases.atom
+# No known CPE, checked 2024-10-06
+security:
+  cpe: ~

--- a/packages/py/python-toolz/package.yml
+++ b/packages/py/python-toolz/package.yml
@@ -1,15 +1,19 @@
 name       : python-toolz
-version    : 0.12.1
-release    : 3
+version    : 1.0.0
+release    : 4
 source     :
-    - https://files.pythonhosted.org/packages/source/t/toolz/toolz-0.12.1.tar.gz : ecca342664893f177a13dac0e6b41cbd8ac25a358e5f215316d43e2100224f4d
+    - https://files.pythonhosted.org/packages/source/t/toolz/toolz-1.0.0.tar.gz : 2c86e3d9a04798ac556793bced838816296a2f085017664e4995cb40a1047a02
 license    : BSD-3-Clause
 homepage   : https://github.com/pytoolz/toolz/
 component  : programming.python
 summary    : A functional standard library for Python
 description: |
     A set of utility functions for iterators, functions, and dictionaries for Python
+checkdeps  :
+    - python-pytest
 build      : |
     %python3_setup
 install    : |
     %python3_install
+check      : |
+    %python3_test pytest

--- a/packages/py/python-toolz/pspec_x86_64.xml
+++ b/packages/py/python-toolz/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-toolz</Name>
         <Homepage>https://github.com/pytoolz/toolz/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -24,11 +24,11 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/tlz/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/tlz/__pycache__/_build_tlz.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/tlz/_build_tlz.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/toolz-0.12.1-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/toolz-0.12.1-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/toolz-0.12.1-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/toolz-0.12.1-py3.11.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/toolz-0.12.1-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/toolz-1.0.0-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/toolz-1.0.0-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/toolz-1.0.0-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/toolz-1.0.0-py3.11.egg-info/not-zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/toolz-1.0.0-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/toolz/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/toolz/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/toolz/__pycache__/_signatures.cpython-311.pyc</Path>
@@ -86,12 +86,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-02-15</Date>
-            <Version>0.12.1</Version>
+        <Update release="4">
+            <Date>2024-10-06</Date>
+            <Version>1.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Test fixes for changes in recent upstream Python
- Drop Python 3.7
- Test against Python 3.13

**Test Plan**
- Ran some examples from the project's documentation

**Checklist**

- [x] Package was built and tested against unstable
