### PR TITLE
yaru-theme: Update to 24.10.4

### DIFF
--- a/packages/y/yaru-theme/package.yml
+++ b/packages/y/yaru-theme/package.yml
@@ -1,8 +1,8 @@
 name       : yaru-theme
-version    : 24.10.2
-release    : 27
+version    : 24.10.4
+release    : 28
 source     :
-    - https://github.com/ubuntu/yaru/archive/refs/tags/24.10.2-0ubuntu1.tar.gz : e957b59c639fb65e6ad21d2c3c7b6d2fdd35a88eea21fa9cb29ef90ee9bc6e94
+    - https://github.com/ubuntu/yaru/archive/refs/tags/24.10.4-0ubuntu1.tar.gz : a1d34f3bd7fb340fda4af6b7a909f8444185c9ac068b08380842a8a2a62daded
 license    :
     - CC-BY-SA-4.0
     - GPL-3.0-or-later

--- a/packages/y/yaru-theme/pspec_x86_64.xml
+++ b/packages/y/yaru-theme/pspec_x86_64.xml
@@ -19824,6 +19824,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/index.theme</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable-max-32/status/process-working-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/action-unavailable-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/add-reminder-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/address-book-new-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/adw-entry-apply-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/adw-mail-send-symbolic.svg</Path>
@@ -19846,6 +19847,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/color-select-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/configure-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/contact-new-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/contact-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/crop-pivot-reticle-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/crop-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/detach-symbolic.svg</Path>
@@ -19862,6 +19864,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/document-save-as-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/document-save-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/document-send-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/donate-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/edit-clear-all-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/edit-clear-rtl-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/edit-clear-symbolic-rtl.svg</Path>
@@ -19959,9 +19962,9 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/insert-object-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/insert-text-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/list-add-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/list-high-priority-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/list-remove-all-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/list-remove-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/lock-small-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/mail-archive-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/mail-drafts-symbolic-rtl.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/mail-drafts-symbolic.svg</Path>
@@ -20011,6 +20014,8 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/media-skip-forward-symbolic-rtl.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/media-skip-forward-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/media-view-subtitles-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/mouse-test-click-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/mouse-test-scroll-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/multimedia-equalizer-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/multiple-events-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/multiple-tags-symbolic.svg</Path>
@@ -20027,6 +20032,9 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/outline-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/process-stop-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/qr-code-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/review-rate-negative-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/review-rate-positive-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/review-report-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/review-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/scan-type-adf-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/scan-type-batch-symbolic.svg</Path>
@@ -20052,6 +20060,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/system-run-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/system-search-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/system-shutdown-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/system-update-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/tag-symbolic-rtl.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/tag-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/actions/tools-check-spelling-symbolic.svg</Path>
@@ -20241,6 +20250,14 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Rhythmbox-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Rhythmbox3-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Screenshot-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Settings-accessibility-hearing-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Settings-accessibility-pointing-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Settings-accessibility-seeing-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Settings-accessibility-typing-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Settings-accessibility-zoom-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Settings-desktop-sharing-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Settings-secure-shell-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Settings-wellbeing-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Shell.CaptivePortal-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Shell.Extensions-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/apps/org.gnome.Shotwell-symbolic.svg</Path>
@@ -20358,6 +20375,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/applications-other-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/applications-science-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/applications-utilities-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/audio-input-microphone-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/bolt-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/calendar-month-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/calendar-today-symbolic.svg</Path>
@@ -20387,7 +20405,23 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/location-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/lock-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/multitasking-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-camera-access-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-device-diagnostics-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-device-security-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-location-access-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-network-proxy-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-removable-media-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-thunderbolt-access-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/org.gnome.Settings-trash-file-history-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/package-flatpak-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/package-generic-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/package-snap-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/permissions-legacy-windowing-system-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/permissions-microphone-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/permissions-sandboxed-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/permissions-screen-contents-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/permissions-system-devices-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/permissions-warning-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/preferences-color-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/preferences-desktop-accessibility-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/preferences-desktop-appearance-symbolic.svg</Path>
@@ -20401,6 +20435,10 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/preferences-system-network-proxy-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/preferences-system-parental-controls-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/preferences-ubuntu-panel-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/proprietary-code-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/software-explore-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/software-updates-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/translations-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/trash-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/view-tasks-today-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/categories/view-tasks-week-symbolic.svg</Path>
@@ -20507,10 +20545,19 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/devices/ups-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/devices/video-display-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/adaptive-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/advertising-none-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/advertising-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/adw-external-link-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/alcohol-use-none-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/alcohol-use-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/app-installed-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/app-remove-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/audio-chat-none-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/audio-chat-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/contacts-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/desktop-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/drug-use-none-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/drug-use-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/emblem-default-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/emblem-documents-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/emblem-favorite-symbolic.svg</Path>
@@ -20526,12 +20573,24 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/explore2-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/external-link-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/flag-outline-thin-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/gambling-none-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/gambling-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/gay-content-none-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/gay-content-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/graveyard-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/hand-open-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/heart-filled-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/human-remains-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/messaging-none-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/messaging-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/padlock-open-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/pub-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/safety-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/sign-language-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/smoking-none-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/smoking-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/social-info-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/software-license-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/test-pass-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/test-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emblems/yelp-page-video-symbolic.svg</Path>
@@ -20561,7 +20620,6 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emotes/face-wink-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emotes/face-worried-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/emotes/face-yawn-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/Yaru/scalable/emotes/hand-open-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/generic-symbols/chat-none-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/generic-symbols/chat-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/generic-symbols/cigarette-none-symbolic.svg</Path>
@@ -20720,6 +20778,10 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/adw-tab-overflow-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/adw-tab-unpin-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/airplane-mode-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/status/app-beta-software-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/status/app-info-loading-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/status/app-safety-ok-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/status/app-verified-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/appointment-missed-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/appointment-soon-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/audio-input-microphone-high-symbolic.svg</Path>
@@ -20736,6 +20798,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/audio-volume-muted-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/audio-volume-overamplified-rtl-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/audio-volume-overamplified-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/status/auditable-code-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/auth-sim-locked-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/auth-sim-missing-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/avatar-default-symbolic.svg</Path>
@@ -20779,11 +20842,20 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/changes-prevent-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/channel-insecure-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/channel-secure-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/status/community-approved-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/status/community-blocked-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/community-none-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/status/community-supported-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/computer-fail-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/content-loading-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/daytime-sunrise-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/daytime-sunset-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/status/device-support-adaptive-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/status/device-support-desktop-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/status/device-support-mobile-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/status/device-support-touch-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/status/device-support-unknown-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/status/device-supported-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/dialog-error-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/dialog-information-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/dialog-password-symbolic.svg</Path>
@@ -20801,10 +20873,12 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/hdy-tab-icon-missing-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/image-loading-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/image-missing-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/status/info-outline-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/info-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/keyboard-brightness-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/location-services-active-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/location-services-disabled-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/status/lock-small-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/mail-attachment-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/mail-read-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/mail-replied-rtl-symbolic.svg</Path>
@@ -20940,6 +21014,8 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/printer-printing-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/printer-warning-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/process-working-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/status/processes-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/status/resources-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/rotation-allowed-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/rotation-locked-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/screen-shared-symbolic.svg</Path>
@@ -20978,6 +21054,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/view-wrapped-symbolic-rtl.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/view-wrapped-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/volume-warning-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/status/warning-outline-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/warning-small-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/weather-clear-night-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/status/weather-clear-symbolic.svg</Path>
@@ -21017,6 +21094,7 @@
             <Path fileType="data">/usr/share/icons/Yaru/scalable/ui/checkbox-checked-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/ui/checkbox-mixed-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/ui/checkbox-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/Yaru/scalable/ui/cross-small-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/ui/drag-handle-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/ui/focus-legacy-systray-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/Yaru/scalable/ui/focus-top-bar-symbolic.svg</Path>
@@ -21050,9 +21128,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2024-09-06</Date>
-            <Version>24.10.2</Version>
+        <Update release="28">
+            <Date>2024-10-09</Date>
+            <Version>24.10.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Update gnome-system-monitor symbolics
- Update gnome-calendar symbolics
- Update gnome-control-center symbolics
- Update gnome-software symbolics
- gnome-shell: Use button style for auth dialog list items
- icons: Update rendered icons and symlinks
- gnome-shell: Sync dock theming with upstream
- gnome-shell/dock: Use the same style for the notification badges in overview
- gnome-shell/dock: Move the progress bar at the bottom of the icon
- gnome-shell/slider: Drop yaru customization as border is not supported
- gnome-shell/slider: Use lighter color for the handler on light themes

**Test Plan**

Set system style to Yaru gtk and icon theme and confirmed everything looks alright

**Checklist**

- [x] Package was built and tested against unstable
