### PR TITLE
common/Hooks: Add support for 'Add at' and '[NFC]' commits

### DIFF
--- a/common/Hooks/prepare-commit-msg.py
+++ b/common/Hooks/prepare-commit-msg.py
@@ -29,8 +29,16 @@ def commit_scope(commit_dir: str) -> str:
                                             stdout=subprocess.PIPE)
         if "+version" in recipe_diff_result.stdout.decode('utf-8'):
             with open(os.path.join(commit_dir, 'package.yml')) as recipe:
-                version = yaml.safe_load(recipe)['version']
-                return os.path.basename(commit_dir) + ': Update to ' + str(version)
+                data = yaml.safe_load(recipe)
+                if str(data['release']) == '1':
+                    return os.path.basename(commit_dir) + ': Add at ' + str(data['version'])
+                return os.path.basename(commit_dir) + ': Update to ' + str(data['version'])
+
+        # Detect non-functional changes ([NFC])
+        staged_files_res = subprocess.run(['git', 'diff', '--name-only', '--staged', commit_dir],
+                                          stdout=subprocess.PIPE)
+        if 'pspec_x86_64.xml' not in staged_files_res.stdout.decode('utf-8'):
+            return "[NFC] " + os.path.basename(commit_dir) + ': '
 
         return os.path.basename(commit_dir) + ': '
 


### PR DESCRIPTION
**Summary**
- Add at for initial package inclusion
- Non functional change when the package isn't rebuilt

**Test Plan**

- Only NFC tested

**Checklist**

- [x] Package was built and tested against unstable
