### PR TITLE
fotocx: Update to 24.60

### DIFF
--- a/packages/f/fotocx/abi_used_symbols
+++ b/packages/f/fotocx/abi_used_symbols
@@ -84,6 +84,7 @@ libc.so.6:pthread_join
 libc.so.6:pthread_mutex_lock
 libc.so.6:pthread_mutex_unlock
 libc.so.6:pthread_self
+libc.so.6:puts
 libc.so.6:read
 libc.so.6:readdir
 libc.so.6:readlink
@@ -336,7 +337,6 @@ libgtk-3.so.0:gtk_menu_item_get_submenu
 libgtk-3.so.0:gtk_menu_item_new_with_label
 libgtk-3.so.0:gtk_menu_item_set_submenu
 libgtk-3.so.0:gtk_menu_new
-libgtk-3.so.0:gtk_menu_popdown
 libgtk-3.so.0:gtk_menu_popup_at_pointer
 libgtk-3.so.0:gtk_menu_shell_append
 libgtk-3.so.0:gtk_page_setup_get_paper_height

--- a/packages/f/fotocx/monitoring.yml
+++ b/packages/f/fotocx/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 371590
+  rss: ~
+# No known CPE, checked 2024-10-09
+security:
+  cpe: ~

--- a/packages/f/fotocx/package.yml
+++ b/packages/f/fotocx/package.yml
@@ -1,8 +1,8 @@
 name       : fotocx
-version    : '24.50'
-release    : 4
+version    : '24.60'
+release    : 5
 source     :
-    - https://kornelix.net/downloads/downloads/fotocx-24.50-source.tar.gz : d147d082b531b367c82ff5af5c86a302f34d29f32765a599f130b8f877610cf4
+    - https://kornelix.net/downloads/downloads/fotocx-24.60-source.tar.gz : fcdc45625850057ed7bb89743f5188b16c277c3341ffbee3cb54b3330e1be069
 homepage   : https://kornelix.net/fotocx/fotocx.html
 license    : GPL-3.0-or-later
 component  : multimedia.graphics

--- a/packages/f/fotocx/pspec_x86_64.xml
+++ b/packages/f/fotocx/pspec_x86_64.xml
@@ -25,9 +25,9 @@
             <Path fileType="doc">/usr/share/doc/fotocx/changelog</Path>
             <Path fileType="doc">/usr/share/doc/fotocx/copyright</Path>
             <Path fileType="data">/usr/share/fotocx/data/CIE1931.jpg</Path>
-            <Path fileType="data">/usr/share/fotocx/data/KB_shortcuts_G</Path>
-            <Path fileType="data">/usr/share/fotocx/data/README_G</Path>
-            <Path fileType="data">/usr/share/fotocx/data/capskeys_G</Path>
+            <Path fileType="data">/usr/share/fotocx/data/KB_shortcuts_H</Path>
+            <Path fileType="data">/usr/share/fotocx/data/README_H</Path>
+            <Path fileType="data">/usr/share/fotocx/data/capskeys_H</Path>
             <Path fileType="data">/usr/share/fotocx/data/custom_kernel/blur5</Path>
             <Path fileType="data">/usr/share/fotocx/data/custom_kernel/brighten3</Path>
             <Path fileType="data">/usr/share/fotocx/data/custom_kernel/color lines 3</Path>
@@ -48,13 +48,14 @@
             <Path fileType="data">/usr/share/fotocx/data/custom_kernel/sketch3</Path>
             <Path fileType="data">/usr/share/fotocx/data/custom_kernel/sobel3 v+h</Path>
             <Path fileType="data">/usr/share/fotocx/data/custom_kernel/sobel5 v+h</Path>
-            <Path fileType="data">/usr/share/fotocx/data/custom_menu_G</Path>
+            <Path fileType="data">/usr/share/fotocx/data/custom_menu_H</Path>
             <Path fileType="data">/usr/share/fotocx/data/custom_scripts/brightness and white point</Path>
             <Path fileType="data">/usr/share/fotocx/data/custom_scripts/cartoon-emboss</Path>
             <Path fileType="data">/usr/share/fotocx/data/custom_scripts/ektar film process</Path>
-            <Path fileType="data">/usr/share/fotocx/data/custom_scripts/emboss-test</Path>
-            <Path fileType="data">/usr/share/fotocx/data/map_regions_G</Path>
-            <Path fileType="data">/usr/share/fotocx/data/meta_picklist_G</Path>
+            <Path fileType="data">/usr/share/fotocx/data/custom_scripts/emboss</Path>
+            <Path fileType="data">/usr/share/fotocx/data/custom_scripts/voodoo</Path>
+            <Path fileType="data">/usr/share/fotocx/data/map_regions_H</Path>
+            <Path fileType="data">/usr/share/fotocx/data/meta_picklist_H</Path>
             <Path fileType="data">/usr/share/fotocx/data/palettes/Bears.gpl</Path>
             <Path fileType="data">/usr/share/fotocx/data/palettes/Bgold.gpl</Path>
             <Path fileType="data">/usr/share/fotocx/data/palettes/Blues.gpl</Path>
@@ -137,8 +138,8 @@
             <Path fileType="data">/usr/share/fotocx/data/patterns/wall-grey.jpg</Path>
             <Path fileType="data">/usr/share/fotocx/data/patterns/wet-turquoise.jpg</Path>
             <Path fileType="data">/usr/share/fotocx/data/patterns/wood.jpg</Path>
-            <Path fileType="data">/usr/share/fotocx/data/plugins_G</Path>
-            <Path fileType="data">/usr/share/fotocx/data/raw_commands_G</Path>
+            <Path fileType="data">/usr/share/fotocx/data/plugins_H</Path>
+            <Path fileType="data">/usr/share/fotocx/data/raw_commands_H</Path>
             <Path fileType="data">/usr/share/fotocx/data/slideshow-tone.oga</Path>
             <Path fileType="data">/usr/share/fotocx/data/tags_defined</Path>
             <Path fileType="data">/usr/share/fotocx/data/userguide</Path>
@@ -150,10 +151,9 @@
             <Path fileType="data">/usr/share/fotocx/images/HDR.jpg</Path>
             <Path fileType="data">/usr/share/fotocx/images/KB-shortcuts.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/KB-shortcuts2.png</Path>
-            <Path fileType="data">/usr/share/fotocx/images/RGB-dist.png</Path>
+            <Path fileType="data">/usr/share/fotocx/images/RGB-hist.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/add-meta-items.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/add-motionblur1.jpg</Path>
-            <Path fileType="data">/usr/share/fotocx/images/add-motionblur2.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/add-noise.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/add-subfolder.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/adjust-HSL.png</Path>
@@ -162,6 +162,8 @@
             <Path fileType="data">/usr/share/fotocx/images/album-replace-file.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/alien-colors1.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/alien-colors2.png</Path>
+            <Path fileType="data">/usr/share/fotocx/images/amplify-contrast.png</Path>
+            <Path fileType="data">/usr/share/fotocx/images/amplify-contrast2.jpg</Path>
             <Path fileType="data">/usr/share/fotocx/images/anti-alias.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/area-blend.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/area-blend2.jpg</Path>
@@ -211,7 +213,7 @@
             <Path fileType="data">/usr/share/fotocx/images/crop-buttons.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/crop.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/custom-kernel.png</Path>
-            <Path fileType="data">/usr/share/fotocx/images/custom-menu.jpg</Path>
+            <Path fileType="data">/usr/share/fotocx/images/custom-menu.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/custom-widgets.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/custom.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/dark-bright-pixels.png</Path>
@@ -228,7 +230,7 @@
             <Path fileType="data">/usr/share/fotocx/images/draw-text.jpg</Path>
             <Path fileType="data">/usr/share/fotocx/images/edit-any-metadata.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/edit-bookmarks.png</Path>
-            <Path fileType="data">/usr/share/fotocx/images/edit-dist.png</Path>
+            <Path fileType="data">/usr/share/fotocx/images/edit-hist.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/edit-meta.jpg</Path>
             <Path fileType="data">/usr/share/fotocx/images/edit.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/effects.png</Path>
@@ -247,7 +249,6 @@
             <Path fileType="data">/usr/share/fotocx/images/first-index.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/fix-motion-blur.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/fix-motion-blur1.jpg</Path>
-            <Path fileType="data">/usr/share/fotocx/images/flatten-histogram2.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/flatten-photo1.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/flatten-photo2.jpg</Path>
             <Path fileType="data">/usr/share/fotocx/images/flatten-photo3.jpg</Path>
@@ -265,8 +266,6 @@
             <Path fileType="data">/usr/share/fotocx/images/gallery.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/global-retx.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/global-retx2.png</Path>
-            <Path fileType="data">/usr/share/fotocx/images/gradients.png</Path>
-            <Path fileType="data">/usr/share/fotocx/images/gradients2.jpg</Path>
             <Path fileType="data">/usr/share/fotocx/images/greenball.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/grid-lines.png</Path>
             <Path fileType="data">/usr/share/fotocx/images/help.png</Path>
@@ -447,9 +446,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-07-08</Date>
-            <Version>24.50</Version>
+        <Update release="5">
+            <Date>2024-10-09</Date>
+            <Version>24.60</Version>
             <Comment>Packaging update</Comment>
             <Name>Algent Albrahimi</Name>
             <Email>algent@protonmail.com</Email>


### PR DESCRIPTION
**Summary**
- Full changelog [here](https://kornelix.net/downloads/recent_changes.txt)

**Test Plan**
- Open a few photos.

**Checklist**
- [x] Package was built and tested against unstable
