### PR TITLE
brave: Update to 1.70.126

### DIFF
--- a/packages/b/brave/package.yml
+++ b/packages/b/brave/package.yml
@@ -1,8 +1,8 @@
 name       : brave
-version    : 1.70.123
-release    : 208
+version    : 1.70.126
+release    : 209
 source     :
-    - https://github.com/brave/brave-browser/releases/download/v1.70.123/brave-browser_1.70.123_amd64.deb : 1ebeff62bcbb7e14837b5833a59aad8ee203adb07a1ee0b53d27814371e501d1
+    - https://github.com/brave/brave-browser/releases/download/v1.70.126/brave-browser_1.70.126_amd64.deb : 78d8a76c2c20cc31b0f16c148c3fcb634212b0633af0df10759da60e97167089
 homepage   : https://brave.com
 license    :
     - GPL-2.0-or-later # Privacy Badger

--- a/packages/b/brave/pspec_x86_64.xml
+++ b/packages/b/brave/pspec_x86_64.xml
@@ -179,9 +179,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="208">
-            <Date>2024-10-03</Date>
-            <Version>1.70.123</Version>
+        <Update release="209">
+            <Date>2024-10-09</Date>
+            <Version>1.70.126</Version>
             <Comment>Packaging update</Comment>
             <Name>Algent Albrahimi</Name>
             <Email>algent@protonmail.com</Email>


### PR DESCRIPTION
**Summary**

- Fixed issue where unchecking the “Show on startup” checkbox of the profile picker was not being retained.
- Fixed toggling on “Enable AdGuard” under brave://settings/extensions/v2 was installing the MV3 version of the AdGuard Blocker extension.
- Upgraded Chromium to 129.0.6668.100.

**Test Plan**

Browse some websites, youtube, getsolus, github.

**Checklist**

- [x] Package was built and tested against unstable
