### PR TITLE
yauto: Only scan "configure" files if they're text/plain

### DIFF
--- a/common/Scripts/yauto.py
+++ b/common/Scripts/yauto.py
@@ -14,6 +14,7 @@ import os
 import sys
 import os.path
 import dloader
+import mimetypes
 import shutil
 
 # What we term as needed doc files
@@ -143,12 +144,13 @@ class AutoPackage:
                 if "configure" in file:
                     # Check if we need to employ certain hacks needed in gnome packages
                     f_path = os.path.join(root, file)
-                    print("Checking %s for use of g-ir-scanner" % f_path)
-
-                    if self.check_is_gnomey(f_path):
-                        known_types.append(GNOMEY)
-                    else:
-                        known_types.append(AUTOTOOLS)
+                    # Check file type so we only scan text files
+                    if mimetypes.guess_type(f_path)[0] == "text/plain":
+                        print("Checking %s for use of g-ir-scanner" % f_path)
+                        if self.check_is_gnomey(f_path):
+                            known_types.append(GNOMEY)
+                        else:
+                            known_types.append(AUTOTOOLS)
                 if (
                     "setup.py" in file
                     or "pyproject.toml" in file


### PR DESCRIPTION
**Summary**

This slightly changes the `yauto` logic so after it discovers a file with "configure" in the name, it will first check if it's a plain text file before further scanning it. This avoids issues with it trying to analyze e.g. image files.

Error example without this patch:

```
C-_4.13.1/resources/icons/png/configure.png for use of g-ir-scanner
Traceback (most recent call last):
  File "/home/thomas/Projects/SolusPackaging/common/Scripts/yauto.py", line 410, in <module>
    p.examine_source()
  File "/home/thomas/Projects/SolusPackaging/common/Scripts/yauto.py", line 153, in examine_source
    if self.check_is_gnomey(f_path):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/thomas/Projects/SolusPackaging/common/Scripts/yauto.py", line 394, in check_is_gnomey
    lines = makefile.read()
            ^^^^^^^^^^^^^^^
  File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x89 in position 0: invalid start byte
task: Failed to run task "new": exit status 1
```

**Test Plan**

Successfully created new package recipes for previously problematic tarballs:
`go-task new -- calligra https://download.kde.org/stable/calligra/calligra-4.0.0.tar.xz`
`go-task new -- qlcplus https://github.com/mcallegari/qlcplus/archive/refs/tags/QLC+_4.13.1.tar.gz`
