### PR TITLE
qutebrowser: Update to 3.3.1

### DIFF
--- a/packages/q/qutebrowser/package.yml
+++ b/packages/q/qutebrowser/package.yml
@@ -1,8 +1,8 @@
 name       : qutebrowser
-version    : 3.2.1
-release    : 46
+version    : 3.3.1
+release    : 47
 source     :
-    - https://github.com/qutebrowser/qutebrowser/archive/refs/tags/v3.2.1.tar.gz : c062782d35b49d085f9b44cedeb85dc7af83c11a23884e634c84bbd3865f7186
+    - https://github.com/qutebrowser/qutebrowser/releases/download/v3.3.1/qutebrowser-3.3.1.tar.gz : aadb64accc730bc9a15ce341c9a0580b1f36383ed4874f54d31ce1dabe94e17a
 homepage   : https://qutebrowser.org
 license    : GPL-3.0-or-later
 component  : network.web.browser

--- a/packages/q/qutebrowser/pspec_x86_64.xml
+++ b/packages/q/qutebrowser/pspec_x86_64.xml
@@ -21,13 +21,13 @@
         <PartOf>network.web.browser</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/qutebrowser</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.1-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.1-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.1-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.1-py3.11.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.1-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.1-py3.11.egg-info/top_level.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.2.1-py3.11.egg-info/zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.3.1-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.3.1-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.3.1-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.3.1-py3.11.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.3.1-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.3.1-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.3.1-py3.11.egg-info/zip-safe</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
@@ -379,6 +379,19 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/bindings.html</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/bookmarks.html</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/dirbrowser.html</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/changelog.html</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/commands.html</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/configuring.html</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/contributing.html</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/faq.html</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/img/cheatsheet-big.png</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/img/cheatsheet-small.png</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/index.html</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/install.html</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/quickstart.html</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/settings.html</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/stacktrace.html</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/doc/userscripts.html</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/error.html</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/history.html</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/html/license.html</Path>
@@ -758,9 +771,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="46">
-            <Date>2024-06-25</Date>
-            <Version>3.2.1</Version>
+        <Update release="47">
+            <Date>2024-10-13</Date>
+            <Version>3.3.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/qutebrowser/qutebrowser/blob/main/doc/changelog.asciidoc#v330-2024-10-12) for 3.3.0.
- 3.3.1 updated the workaround for Google sign-in issues.

**Test Plan**
- Installed and surfed the web.

**Checklist**

- [X] Package was built and tested against unstable
