### PR TITLE
eqonomize: Update to 1.5.8

### DIFF
--- a/packages/e/eqonomize/abi_used_symbols
+++ b/packages/e/eqonomize/abi_used_symbols
@@ -212,7 +212,7 @@ libQt5Core.so.5:_ZN4QDir11currentPathEv
 libQt5Core.so.5:_ZN4QDirC1ERK7QString
 libQt5Core.so.5:_ZN4QDirD1Ev
 libQt5Core.so.5:_ZN4QUrl13fromLocalFileERK7QString
-libQt5Core.so.5:_ZN4QUrl13fromUserInputERK7QString
+libQt5Core.so.5:_ZN4QUrl13fromUserInputERK7QStringS2_6QFlagsINS_25UserInputResolutionOptionEE
 libQt5Core.so.5:_ZN4QUrlC1ERK7QStringNS_11ParsingModeE
 libQt5Core.so.5:_ZN4QUrlC1ERKS_
 libQt5Core.so.5:_ZN4QUrlC1Ev
@@ -420,7 +420,6 @@ libQt5Core.so.5:_ZNK13QJsonValueRef8toObjectEv
 libQt5Core.so.5:_ZNK13QMimeDatabase15mimeTypeForFileERK7QStringNS_9MatchModeE
 libQt5Core.so.5:_ZNK13QMimeDatabase15mimeTypeForNameERK7QString
 libQt5Core.so.5:_ZNK14QMessageLogger4infoEv
-libQt5Core.so.5:_ZNK14QMessageLogger5debugEv
 libQt5Core.so.5:_ZNK14QMessageLogger7warningEv
 libQt5Core.so.5:_ZNK14QMessageLogger8criticalEv
 libQt5Core.so.5:_ZNK14QTemporaryFile8fileNameEv
@@ -518,6 +517,7 @@ libQt5Core.so.5:_ZNK8QVariant12toStringListEv
 libQt5Core.so.5:_ZNK8QVariant3cmpERKS_
 libQt5Core.so.5:_ZNK8QVariant5toIntEPb
 libQt5Core.so.5:_ZNK8QVariant5toMapEv
+libQt5Core.so.5:_ZNK8QVariant6isNullEv
 libQt5Core.so.5:_ZNK8QVariant6toBoolEv
 libQt5Core.so.5:_ZNK8QVariant6toDateEv
 libQt5Core.so.5:_ZNK8QVariant6toListEv
@@ -642,6 +642,7 @@ libQt5Gui.so.5:_ZNK11QFocusEvent6reasonEv
 libQt5Gui.so.5:_ZNK12QFontMetrics11lineSpacingEv
 libQt5Gui.so.5:_ZNK12QFontMetrics12boundingRectERK5QRectiRK7QStringiPi
 libQt5Gui.so.5:_ZNK12QFontMetrics12boundingRectERK7QString
+libQt5Gui.so.5:_ZNK12QFontMetrics16averageCharWidthEv
 libQt5Gui.so.5:_ZNK12QKeySequenceeqERKS_
 libQt5Gui.so.5:_ZNK12QPainterPath10simplifiedEv
 libQt5Gui.so.5:_ZNK13QStandardItem5flagsEv
@@ -860,6 +861,7 @@ libQt5Widgets.so.5:_ZN12QTextBrowserC1EP7QWidget
 libQt5Widgets.so.5:_ZN13QDateTimeEdit10paintEventEP11QPaintEvent
 libQt5Widgets.so.5:_ZN13QDateTimeEdit10wheelEventEP11QWheelEvent
 libQt5Widgets.so.5:_ZN13QDateTimeEdit12focusInEventEP11QFocusEvent
+libQt5Widgets.so.5:_ZN13QDateTimeEdit12setDateRangeERK5QDateS2_
 libQt5Widgets.so.5:_ZN13QDateTimeEdit13keyPressEventEP9QKeyEvent
 libQt5Widgets.so.5:_ZN13QDateTimeEdit14setMaximumDateERK5QDate
 libQt5Widgets.so.5:_ZN13QDateTimeEdit15mousePressEventEP11QMouseEvent
@@ -1246,7 +1248,6 @@ libQt5Widgets.so.5:_ZN7QWizard11qt_metacastEPKc
 libQt5Widgets.so.5:_ZN7QWizard11resizeEventEP12QResizeEvent
 libQt5Widgets.so.5:_ZN7QWizard13setButtonTextENS_12WizardButtonERK7QString
 libQt5Widgets.so.5:_ZN7QWizard14initializePageEi
-libQt5Widgets.so.5:_ZN7QWizard14setWizardStyleENS_11WizardStyleE
 libQt5Widgets.so.5:_ZN7QWizard16staticMetaObjectE
 libQt5Widgets.so.5:_ZN7QWizard19validateCurrentPageEv
 libQt5Widgets.so.5:_ZN7QWizard4doneEi

--- a/packages/e/eqonomize/package.yml
+++ b/packages/e/eqonomize/package.yml
@@ -1,8 +1,8 @@
 name       : eqonomize
-version    : 1.5.7
-release    : 19
+version    : 1.5.8
+release    : 20
 source     :
-    - https://github.com/Eqonomize/Eqonomize/releases/download/v1.5.7/eqonomize-1.5.7.tar.gz : 90c730eeac3bafc15a8db2b4bc1867eecaf18b1828bcc059a58c8f22ab22dabc
+    - https://github.com/Eqonomize/Eqonomize/releases/download/v1.5.8/eqonomize-1.5.8.tar.gz : 4a08dfa726b6a03f4f58c542d052934766860b86b8b603ab42cd0c3e13ade710
 homepage   : https://eqonomize.github.io/
 license    : GPL-3.0-or-later
 component  : office.finance

--- a/packages/e/eqonomize/pspec_x86_64.xml
+++ b/packages/e/eqonomize/pspec_x86_64.xml
@@ -276,9 +276,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2024-05-13</Date>
-            <Version>1.5.7</Version>
+        <Update release="20">
+            <Date>2024-10-13</Date>
+            <Version>1.5.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Algent Albrahimi</Name>
             <Email>algent@protonmail.com</Email>


### PR DESCRIPTION
**Summary**
- Add option to group accounts by type, bank, or currency
- Allowing collapsing of Assets, Liabilities, Incomes, and Expenses in Accounts & Categories using double-click
- Option to edit assets group name (using "Edit..." menu item)
- Ask if user want to save changes before opening file from command line or file manager
- Set allowed range for ledger print time period date fields (fixes ledger print error not shown when to date is before date of first transaction)
- Disable close account menu item for debts
- Place cash, current, and credit card accounts first in account selection list when appropriate
- Fix segfault and duplicating character when tag contains ampersand
- Fix initial group in new account dialog

**Test Plan**

Load an account, add incomes and expenses. Show chart.

**Checklist**

- [x] Package was built and tested against unstable
