### PR TITLE
lazarus: Update to 3.6.0

### DIFF
--- a/packages/d/doublecmd/package.yml
+++ b/packages/d/doublecmd/package.yml
@@ -1,6 +1,6 @@
 name       : doublecmd
 version    : 1.1.19
-release    : 28
+release    : 29
 source     :
     - https://sourceforge.net/projects/doublecmd/files/Double%20Commander%20Source/doublecmd-1.1.19-src.tar.gz : 25df113132510859a99d74af9cfffb6d15389070f50607064c7289e0e1c728e9
 homepage   : https://doublecmd.sourceforge.io/

--- a/packages/d/doublecmd/pspec_x86_64.xml
+++ b/packages/d/doublecmd/pspec_x86_64.xml
@@ -2514,8 +2514,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2024-10-06</Date>
+        <Update release="29">
+            <Date>2024-10-13</Date>
             <Version>1.1.19</Version>
             <Comment>Packaging update</Comment>
             <Name>Algent Albrahimi</Name>

--- a/packages/g/goverlay/package.yml
+++ b/packages/g/goverlay/package.yml
@@ -1,6 +1,6 @@
 name       : goverlay
 version    : 1.2.0
-release    : 18
+release    : 19
 source     :
     - https://github.com/benjamimgois/goverlay/archive/refs/tags/1.2.tar.gz : ce18c2a0810f6dc5f4e27f35d5f8d8353ef3bc78e36de57eaeb50a0821691c24
 homepage   : https://github.com/benjamimgois/goverlay

--- a/packages/g/goverlay/pspec_x86_64.xml
+++ b/packages/g/goverlay/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>goverlay</Name>
         <Homepage>https://github.com/benjamimgois/goverlay</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Algent Albrahimi</Name>
+            <Email>algent@protonmail.com</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <PartOf>system.utils</PartOf>
@@ -33,12 +33,12 @@ It also serves as an alternative to Nvidia Shadowplay, alowing you to record gam
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2024-08-14</Date>
+        <Update release="19">
+            <Date>2024-10-13</Date>
             <Version>1.2.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Algent Albrahimi</Name>
+            <Email>algent@protonmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/l/lazarus/package.yml
+++ b/packages/l/lazarus/package.yml
@@ -1,8 +1,8 @@
 name       : lazarus
-version    : 3.4.0
-release    : 18
+version    : 3.6.0
+release    : 19
 source     :
-    - https://sourceforge.net/projects/lazarus/files/Lazarus%20Zip%20_%20GZip/Lazarus%203.4/lazarus-3.4-0.tar.gz : b27c0feabf90ef49034acffb71947d3ee77d4ccf597d348473f5c5a2485e80ff
+    - https://sourceforge.net/projects/lazarus/files/Lazarus%20Zip%20_%20GZip/Lazarus%203.6/lazarus-3.6-0.tar.gz/download : e65b90367f63bf17cb7bf35f5be69c9ef704ca494e91d8c67d072e3373fab085
 homepage   : https://www.lazarus-ide.org
 license    :
     - GPL-2.0-or-later

--- a/packages/l/lazarus/pspec_x86_64.xml
+++ b/packages/l/lazarus/pspec_x86_64.xml
@@ -11509,7 +11509,6 @@
             <Path fileType="library">/usr/lib64/lazarus/docs/xml/lcl/forms.xml</Path>
             <Path fileType="library">/usr/lib64/lazarus/docs/xml/lcl/forms/tapplication_queueasynccall.pas</Path>
             <Path fileType="library">/usr/lib64/lazarus/docs/xml/lcl/graphics.xml</Path>
-            <Path fileType="library">/usr/lib64/lazarus/docs/xml/lcl/graphmath.xml</Path>
             <Path fileType="library">/usr/lib64/lazarus/docs/xml/lcl/graphutil.xml</Path>
             <Path fileType="library">/usr/lib64/lazarus/docs/xml/lcl/grids.xml</Path>
             <Path fileType="library">/usr/lib64/lazarus/docs/xml/lcl/groupededit.xml</Path>
@@ -18874,6 +18873,7 @@
             <Path fileType="library">/usr/lib64/lazarus/lcl/interfaces/cocoa/cocoawsfactory.pas</Path>
             <Path fileType="library">/usr/lib64/lazarus/lcl/interfaces/cocoa/cocoawsforms.pas</Path>
             <Path fileType="library">/usr/lib64/lazarus/lcl/interfaces/cocoa/cocoawsmenus.pas</Path>
+            <Path fileType="library">/usr/lib64/lazarus/lcl/interfaces/cocoa/cocoawsscrollers.pas</Path>
             <Path fileType="library">/usr/lib64/lazarus/lcl/interfaces/cocoa/cocoawsspin.pas</Path>
             <Path fileType="library">/usr/lib64/lazarus/lcl/interfaces/cocoa/cocoawsstdctrls.pas</Path>
             <Path fileType="library">/usr/lib64/lazarus/lcl/interfaces/cocoa/interfaces.pas</Path>
@@ -21635,8 +21635,8 @@
             <Path fileType="library">/usr/lib64/lazarus/packager/globallinks/lazutils-1.lpl</Path>
             <Path fileType="library">/usr/lib64/lazarus/packager/globallinks/lazvlc-1.lpl</Path>
             <Path fileType="library">/usr/lib64/lazarus/packager/globallinks/lazwiki-1.0.1.lpl</Path>
-            <Path fileType="library">/usr/lib64/lazarus/packager/globallinks/lcl-3.4.lpl</Path>
-            <Path fileType="library">/usr/lib64/lazarus/packager/globallinks/lclbase-3.4.lpl</Path>
+            <Path fileType="library">/usr/lib64/lazarus/packager/globallinks/lcl-3.6.lpl</Path>
+            <Path fileType="library">/usr/lib64/lazarus/packager/globallinks/lclbase-3.6.lpl</Path>
             <Path fileType="library">/usr/lib64/lazarus/packager/globallinks/lclextensions_package-0.6.1.lpl</Path>
             <Path fileType="library">/usr/lib64/lazarus/packager/globallinks/lclfpreport-0.lpl</Path>
             <Path fileType="library">/usr/lib64/lazarus/packager/globallinks/leakview-1.lpl</Path>
@@ -23857,9 +23857,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2024-06-02</Date>
-            <Version>3.4.0</Version>
+        <Update release="19">
+            <Date>2024-10-13</Date>
+            <Version>3.6.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Algent Albrahimi</Name>
             <Email>algent@protonmail.com</Email>

--- a/packages/q/qt6pas/package.yml
+++ b/packages/q/qt6pas/package.yml
@@ -1,8 +1,8 @@
 name       : qt6pas
-version    : '3.4'
-release    : 19
+version    : 3.6.0
+release    : 20
 source     :
-    - https://sourceforge.net/projects/lazarus/files/Lazarus%20Zip%20_%20GZip/Lazarus%203.4/lazarus-3.4-0.tar.gz : b27c0feabf90ef49034acffb71947d3ee77d4ccf597d348473f5c5a2485e80ff
+    - https://sourceforge.net/projects/lazarus/files/Lazarus%20Zip%20_%20GZip/Lazarus%203.6/lazarus-3.6-0.tar.gz/download : e65b90367f63bf17cb7bf35f5be69c9ef704ca494e91d8c67d072e3373fab085
 homepage   : https://www.lazarus-ide.org
 license    :
     - GPL-2.0-or-later

--- a/packages/q/qt6pas/pspec_x86_64.xml
+++ b/packages/q/qt6pas/pspec_x86_64.xml
@@ -34,16 +34,16 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="19">qt6pas</Dependency>
+            <Dependency release="20">qt6pas</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libQt6Pas.so</Path>
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2024-06-02</Date>
-            <Version>3.4</Version>
+        <Update release="20">
+            <Date>2024-10-13</Date>
+            <Version>3.6.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Algent Albrahimi</Name>
             <Email>algent@protonmail.com</Email>

--- a/packages/t/transgui/package.yml
+++ b/packages/t/transgui/package.yml
@@ -1,6 +1,6 @@
 name       : transgui
 version    : 5.18.0
-release    : 8
+release    : 9
 source     :
     - https://github.com/transmission-remote-gui/transgui/archive/v5.18.0.tar.gz : d1cbb16eb35d41e76f4a171a3887053899e8dc6a1124afc21615b5038ea60d78
 homepage   : https://github.com/transmission-remote-gui/transgui/

--- a/packages/t/transgui/pspec_x86_64.xml
+++ b/packages/t/transgui/pspec_x86_64.xml
@@ -55,8 +55,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2024-06-02</Date>
+        <Update release="9">
+            <Date>2024-10-13</Date>
             <Version>5.18.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Algent Albrahimi</Name>


### PR DESCRIPTION
**Summary**

Update Lazarus to latest version. v3.6.0

**Test Plan**

Rebuild and run: `transgui` `winff` `goverlay` and `doublecmd`

**Checklist**

- [x] Package was built and tested against unstable
