### PR TITLE
obs-cmd: Update to v0.17.9

### DIFF
--- a/packages/o/obs-cmd/files/fix-version.patch
+++ b/packages/o/obs-cmd/files/fix-version.patch
@@ -1,12 +1,25 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index d92760a..91690cb 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -586,7 +586,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "obs-cmd"
+-version = "0.17.8"
++version = "0.17.9"
+ dependencies = [
+  "clap",
+  "obws",
 diff --git a/Cargo.toml b/Cargo.toml
-index bcb4b83..375a4c6 100644
+index 375a4c6..aed29e8 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
 @@ -1,6 +1,6 @@
  [package]
  name = "obs-cmd"
--version = "0.17.7"
-+version = "0.17.8"
+-version = "0.17.8"
++version = "0.17.9"
  edition = "2021"
  description = "A minimal command to control obs via obs-websocket"
  authors = ["Luigi Maselli <luigi@grigio.org>"]

--- a/packages/o/obs-cmd/package.yml
+++ b/packages/o/obs-cmd/package.yml
@@ -1,8 +1,8 @@
 name       : obs-cmd
-version    : 0.17.8
-release    : 2
+version    : 0.17.9
+release    : 3
 source     :
-    - https://github.com/grigio/obs-cmd/archive/refs/tags/v0.17.8.tar.gz : cc0cf8897ddaf13d72cfacfc7af54cd4ba7987bb0619aff31911f919d75bf6ec
+    - https://github.com/grigio/obs-cmd/archive/refs/tags/v0.17.9.tar.gz : 790951c3b87a04d604ae7b1a35e7ca3482d00e2f246043c6aac9e10609122a34
 homepage   : https://github.com/grigio/obs-cmd
 license    : MIT
 component  : system.utils

--- a/packages/o/obs-cmd/pspec_x86_64.xml
+++ b/packages/o/obs-cmd/pspec_x86_64.xml
@@ -24,9 +24,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-09-16</Date>
-            <Version>0.17.8</Version>
+        <Update release="3">
+            <Date>2024-10-14</Date>
+            <Version>0.17.9</Version>
             <Comment>Packaging update</Comment>
             <Name>Ian M. Jones</Name>
             <Email>ian@ianmjones.com</Email>


### PR DESCRIPTION
**Summary**

* Expose `recording toggle-pause` command.

Full changelog: https://github.com/grigio/obs-cmd/releases/tag/v0.17.9

**Test Plan**

* Built and installed package locally.
* Ran a few manual commands.
* Ran a few scripted commands (via deckmaster).
* Ran new `obs-cmd recording toggle-pause` while recording in OBS.

**Checklist**

- [x] Package was built and tested against unstable
