### PR TITLE
appstream-data: Update to 49

### DIFF
--- a/packages/a/appstream-data/package.yml
+++ b/packages/a/appstream-data/package.yml
@@ -1,8 +1,8 @@
 name       : appstream-data
-version    : '48'
-release    : 50
+version    : '49'
+release    : 51
 source     :
-    - https://github.com/getsolus/solus-appstream-data/archive/refs/tags/v48.tar.gz : 4c0183399248cbbe4771660b1e3f3a657ff2862ecb2f2d4432ce3891bdc22eaf
+    - https://github.com/getsolus/solus-appstream-data/archive/refs/tags/v49.tar.gz : eb030a6c1d2cd3c2b52cdc26809f46f6ae65f6273ee295d470aded26eb934635
 homepage   : https://www.freedesktop.org/wiki/Distributions/AppStream/
 license    :
     - CC-BY-SA-3.0

--- a/packages/a/appstream-data/pspec_x86_64.xml
+++ b/packages/a/appstream-data/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>appstream-data</Name>
         <Homepage>https://www.freedesktop.org/wiki/Distributions/AppStream/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Hans Kelson</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>CC-BY-SA-3.0</License>
         <License>CC-BY-SA-4.0</License>
@@ -59,7 +59,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.bitwarden.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.borgbase.Vorta.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.cubicsdr.cubicsdr.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.dosbox.DOSBox.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.etlegacy.ETLegacy.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.gexperts.Tilix.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.github.Flacon.png</Path>
@@ -86,9 +85,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.github.spheras.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.github.tkashkin.gamehub.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.github.wwmm.easyeffects.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.github.wwmm.pulseeffects.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.github.xournalpp.xournalpp.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.gitlab.cunidev.Gestures.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.gitlab.dogtail.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.heroicgameslauncher.hgl.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.kvibes.MediaElch.png</Path>
@@ -110,11 +107,9 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.tv_lite.tv_lite.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.ulduzsoft.Birdtray.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.ultimaker.cura.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.uploadedlobster.peek.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.valvesoftware.Steam.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.viewizard.AstroMenace.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.yacreader.YACReader.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.yubico.yubikey_manager.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/conky-manager2.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/cool-retro-term.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/de.haeckerfelix.Shortwave.png</Path>
@@ -143,7 +138,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/gimagereader-gtk.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/git-cola.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/git-dag.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/glabels-3.0.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/gmusicbrowser.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/gparted.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/gpxsee.png</Path>
@@ -160,7 +154,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.Hexchat.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.OpenToonz.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.TransmissionRemoteGtk.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.ajour.ajour.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.antimicrox.antimicrox.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.aristocratos.btop.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.astroidmail.astroid.png</Path>
@@ -234,7 +227,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/net.kuribo64.melonDS.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/net.launchpad.xpad.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/net.lutris.Lutris.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/net.minetest.minetest.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/net.maniacsvault.ecwolf.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/net.nitroshare.nitroshare.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/net.pioneerspacesim.Pioneer.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/net.poedit.Poedit.png</Path>
@@ -278,7 +271,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.calf_studio_gear.calf.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.cataclysmdda.CataclysmDDA.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.cinelerra.gg.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.citra_emu.citra.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.claws_mail.Claws-Mail.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.codelite.codelite.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.corectrl.CoreCtrl.png</Path>
@@ -383,7 +375,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnome.pan.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnome.seahorse.Application.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnome.tweaks.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnome.wiki.dia.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnu.emacs.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnu.gnubg.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.gnu.xboard.png</Path>
@@ -444,7 +435,8 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kgeography.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kget.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kgpg.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kid3_qt.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kid3-qt.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kid3.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kinfocenter.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kleopatra.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kmag.png</Path>
@@ -453,7 +445,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kmines.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kmix.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kmymoney.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.knotes.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kolourpaint.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kompare.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kontact.png</Path>
@@ -461,7 +452,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.korganizer.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kpat.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.krdc.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.krita.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.krusader.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kshisen.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kstars.png</Path>
@@ -469,7 +459,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.ktorrent.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kwalletmanager5.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kwave.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.kwrite.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.lokalize.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.marble.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.kde.marknote.png</Path>
@@ -566,12 +555,12 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.ubuntubudgie.previewscontrols.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.ubuntubudgie.shufflercontrol.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.videolan.vlc.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.visualboyadvance_m.visualboyadvance_m.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.wesnoth.Wesnoth.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.widelands.Widelands.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.wireshark.Wireshark.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.workrave.workrave.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.x.Warpinator.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.xbmc.kodi.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.xfce.Catfish.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.xfce.PanelProfiles.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.xfce.Parole.png</Path>
@@ -594,7 +583,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/qelectrotech.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/qgit.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/radiotray-ng.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/re.chiaki.Chiaki.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/re.rizin.cutter.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/redeclipse.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/rednotebook.png</Path>
@@ -617,11 +605,9 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/transmission-gtk.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/uk.co.powdertoy.tpt.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/uk.org.greenend.chiark.sgtatham.puzzles.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/unknown-horizons.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/variety.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/viewnior.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/virt-manager.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/visualboyadvance-m.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/vivaldi-snapshot.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/vivaldi-stable.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/vn.evolus.pencil.pencil.png</Path>
@@ -674,7 +660,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.borgbase.Vorta.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.cubicsdr.cubicsdr.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.dev47apps.droidcam.DroidCam.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.dosbox.DOSBox.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.etlegacy.ETLegacy.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.gexperts.Tilix.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.github.Flacon.png</Path>
@@ -704,9 +689,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.github.spheras.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.github.tkashkin.gamehub.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.github.wwmm.easyeffects.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.github.wwmm.pulseeffects.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.github.xournalpp.xournalpp.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.gitlab.cunidev.Gestures.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.gitlab.dogtail.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.heroicgameslauncher.hgl.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.httrack.httrack_website_copier.png</Path>
@@ -729,12 +712,10 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.tv_lite.tv_lite.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.ulduzsoft.Birdtray.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.ultimaker.cura.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.uploadedlobster.peek.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.valvesoftware.Steam.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.viewizard.AstroMenace.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.wordpress.firejail.firetools.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.yacreader.YACReader.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.yubico.yubikey_manager.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/conky-manager2.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/cool-retro-term.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/de.haeckerfelix.Shortwave.png</Path>
@@ -790,7 +771,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/gimagereader-gtk.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/git-cola.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/git-dag.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/glabels-3.0.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/gmusicbrowser.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/gparted.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/gpxsee.png</Path>
@@ -812,7 +792,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.Hexchat.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.OpenToonz.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.TransmissionRemoteGtk.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.ajour.ajour.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.antimicrox.antimicrox.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.aristocratos.btop.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.astroidmail.astroid.png</Path>
@@ -900,7 +879,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/net.kuribo64.melonDS.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/net.launchpad.xpad.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/net.lutris.Lutris.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/net.minetest.minetest.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/net.maniacsvault.ecwolf.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/net.nitroshare.nitroshare.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/net.pcsx2.PCSX2.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/net.pioneerspacesim.Pioneer.png</Path>
@@ -956,7 +935,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.calf_studio_gear.calf.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.cataclysmdda.CataclysmDDA.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.cinelerra.gg.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.citra_emu.citra.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.claws_mail.Claws-Mail.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.codelite.codelite.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.corectrl.CoreCtrl.png</Path>
@@ -1062,7 +1040,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnome.pan.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnome.seahorse.Application.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnome.tweaks.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnome.wiki.dia.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnu.dfarc.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnu.emacs.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.gnu.gnubg.png</Path>
@@ -1126,7 +1103,8 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kget.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kgpg.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kgraphviewer.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kid3_qt.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kid3-qt.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kid3.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kinfocenter.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kleopatra.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kmag.png</Path>
@@ -1136,7 +1114,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kmines.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kmix.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kmymoney.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.knotes.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kolourpaint.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kompare.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kontact.png</Path>
@@ -1146,7 +1123,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.krdc.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.krename.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.krfb.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.krita.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.krusader.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kshisen.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kstars.png</Path>
@@ -1155,7 +1131,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.ktorrent.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kwalletmanager5.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kwave.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.kwrite.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.lokalize.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.marble.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.kde.marknote.png</Path>
@@ -1254,12 +1229,12 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.ubuntubudgie.previewscontrols.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.ubuntubudgie.shufflercontrol.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.videolan.vlc.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.visualboyadvance_m.visualboyadvance_m.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.wesnoth.Wesnoth.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.widelands.Widelands.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.wireshark.Wireshark.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.workrave.workrave.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.x.Warpinator.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.xbmc.kodi.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.xfce.Catfish.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.xfce.PanelProfiles.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.xfce.Parole.png</Path>
@@ -1286,7 +1261,6 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/qgit.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/radiotray-ng.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/rawstudio.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/re.chiaki.Chiaki.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/re.rizin.cutter.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/recoll.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/redeclipse.png</Path>
@@ -1315,11 +1289,9 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/uk.co.powdertoy.tpt.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/uk.org.greenend.chiark.sgtatham.putty.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/uk.org.greenend.chiark.sgtatham.puzzles.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/unknown-horizons.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/variety.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/viewnior.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/virt-manager.png</Path>
-            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/visualboyadvance-m.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/vivaldi-snapshot.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/vivaldi-stable.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/vn.evolus.pencil.pencil.png</Path>
@@ -1341,12 +1313,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="50">
-            <Date>2024-09-14</Date>
-            <Version>48</Version>
+        <Update release="51">
+            <Date>2024-10-14</Date>
+            <Version>49</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Hans Kelson</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Update Appstream Metainfo to v49

**Test Plan**

1. Build appstream-data from this PR.
2. Install the updated package.
3. Check that one of KDE Discover or GNOME Software works and has sane content.
4. Check that Solus SC works and has sane content.

**Checklist**

- [x] Package was built and tested against unstable
