### PR TITLE
Numix icons: Update to 24.10.13

### DIFF
--- a/packages/n/numix-icon-theme-circle/package.yml
+++ b/packages/n/numix-icon-theme-circle/package.yml
@@ -1,8 +1,8 @@
 name       : numix-icon-theme-circle
-version    : 24.10.01
-release    : 52
+version    : 24.10.13
+release    : 53
 source     :
-    - https://github.com/numixproject/numix-icon-theme-circle/archive/refs/tags/24.10.01.tar.gz : c74963a2781ee1334f6557dee54ae6a3911c53aeaa01f4c2dbc79ff197ca99c7
+    - https://github.com/numixproject/numix-icon-theme-circle/archive/refs/tags/24.10.13.tar.gz : 264c0ae98d6a336cadc0a632ba1b32c44ddb99593d37c3c58707cb01b58af8b2
 homepage   : https://numixproject.github.io/
 license    : GPL-3.0-or-later
 component  : desktop.theme

--- a/packages/n/numix-icon-theme-circle/pspec_x86_64.xml
+++ b/packages/n/numix-icon-theme-circle/pspec_x86_64.xml
@@ -145,6 +145,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/Anatine.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/AndYetItMoves.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/AndroidMessages.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/AppHub.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/AppImage.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/AppImageLauncher.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/AppImageUpdater.svg</Path>
@@ -212,6 +213,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/Element.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/ElmerGUI.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/EmojiMart.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/EmptyEpsilon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/Encryptr.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/Etermutilities-terminal.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/Etterna.svg</Path>
@@ -273,6 +275,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/KKEdit.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/KKEditRoot.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/KatharaGUI.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/Katharsis.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/Khoj.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/LabPlot2.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/Launchpad-launchpad.net.svg</Path>
@@ -365,6 +368,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/Rdio-www.rdio.com.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/Reddit-pay.reddit.com.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/Reddit-reddit.com.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/Retrom.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/Rlogo.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/RuneLite.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/Runner.svg</Path>
@@ -698,12 +702,16 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/app.drey.Elastic.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/app.drey.Envelope.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/app.drey.FlatSync.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/app.drey.Highscore.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/app.drey.KeyRack.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/app.drey.Lemmings.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/app.drey.MultiplicationPuzzle.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/app.drey.Navigator.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/app.drey.PaperPlane.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/app.drey.PikaBackup.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/app.drey.Planner.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/app.drey.Toggle.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/app.drey.Vocalis.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/app.drey.Warp.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/app.fotema.Fotema.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/app.furtherance.Furtherance.svg</Path>
@@ -1027,6 +1035,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/beaver-notes.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/beekeeper-studio.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/beeref.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/beersmith.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/beryl-manager.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/beryl-settings.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/beryl.svg</Path>
@@ -1460,6 +1469,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/cataclysm-dda.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/cataclysm-tiles.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/cataclysmdda.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/cataicon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/catarina.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/catfish.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/catia.svg</Path>
@@ -1515,6 +1525,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/chatbox.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/chatterino.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/chatty.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/checkaptgpg.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/checkbox-qt.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/checkbox-touch.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/checkbox.svg</Path>
@@ -1771,6 +1782,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/clocks.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/clogosm.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/cloudcompare.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/cloudotp.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/clubhouse.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/cmake-gui.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/cmake.svg</Path>
@@ -1802,6 +1814,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/coffee.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/cog.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/coin.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/coinkiller.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/collision.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/colobot.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/colon.svg</Path>
@@ -1879,6 +1892,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.chroniclogic.Zatikon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.cinecred.cinecred.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.clarahobbs.chessclock.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.cloudchewie.cloudotp.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.codemouse92.timecard.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.core447.StreamController.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.corifeus.onenote.svg</Path>
@@ -1940,6 +1954,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.felipekinoshita.Kana.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.felipekinoshita.Wildcard.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.frac_tion.teleport.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.francescogaglione.chronos.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.frogatto.Frogatto.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.fyralabs.Abacus.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.fyralabs.Accelerator.svg</Path>
@@ -1998,6 +2013,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.github.afrantzis.Bless.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.github.aggalex.wineglass.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.github.aharotias2.parapara.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.github.ahoneybun.Stellarshot.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.github.ahrm.sioyek.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.github.akiraux.akira.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.github.akiraux.akiraDevel.svg</Path>
@@ -2406,6 +2422,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.kgurgul.cpuinfo.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.kitware.F3D.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.kjxbyz.PicGuard.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.konstantintutsch.Caffeine.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.korbsstudio.penpot-desktop.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.ktechpit.whatsie.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.lablicate.OpenChrom.svg</Path>
@@ -2414,6 +2431,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.leinardi.gst.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.leinardi.gwe.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.leinardi.gx52.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.leohanney.Volaris.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.lettier.gifcurry.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.lettier.movie-monad.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.librumreader.librum.svg</Path>
@@ -2429,6 +2447,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.manexim.home.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.mardojai.Blanket.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.mardojai.DiccionarioLengua.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.mardojai.ForgeSparks.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.mardojai.WebfontKitGenerator.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.markopejic.downloader.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.mastermindzh.tidal-hifi.svg</Path>
@@ -2477,6 +2496,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.rabbit_company.passky.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.rabbitcompany.passky.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.rafaelmardojai.Blanket.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.rafaelmardojai.SharePreview.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.rafaelmardojai.WebfontKitGenerator.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.raggesilver.BlackBox.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.raggesilver.Proton.svg</Path>
@@ -2607,6 +2627,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.wings3d.WINGS.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.wire.Coax.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.wire.WireDesktop.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.wireframesketcher.WireframeSketcher.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.wiz.Note.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.wps.Office.etmain.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/com.wps.Office.wppmain.svg</Path>
@@ -2796,6 +2817,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/cura.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/curlew.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/currency.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/custom-toolbox.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/cutechess.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/cutecom.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/cutefish-calculator.svg</Path>
@@ -2930,6 +2952,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/de.z_ray.Facetracker.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/de.zwarf.picplanner.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/deadbeef.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/deb-installer.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/debian-installer-launcher.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/debian-logo.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/debian-plymouth-manager.svg</Path>
@@ -3026,6 +3049,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/desktop-environment-lxde.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/desktop-environment-lxqt.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/desktop-environment-mate.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/desktop-environment-plasma.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/desktop-environment-sugar.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/desktop-environment-tde.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/desktop-environment-unity.svg</Path>
@@ -3047,9 +3071,11 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/dev.bsnes.bsnes.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/dev.deedles.Trayscale.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/dev.edfloreshz.Blueprint.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/dev.edfloreshz.Calculator.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/dev.edfloreshz.CosmicTweaks.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/dev.edfloreshz.Done.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/dev.edfloreshz.Tasks.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/dev.fredol.open-tv.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/dev.gbstudio.gb-studio.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/dev.geopjr.Archives.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/dev.geopjr.Calligraphy.svg</Path>
@@ -3129,6 +3155,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/discord.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/disk-burner.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/disk-check.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/disk-manager.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/disk-usage-analyzer.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/diskmonitor.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/disks.svg</Path>
@@ -3514,6 +3541,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/emerillon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/emesene.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/empathy.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/emptyepsilon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/emulationstation.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/en-croissant.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/encryptpad.svg</Path>
@@ -3771,6 +3799,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/flatseal.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/flatsweep.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/flaw.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/flclash.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/flegita.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/flickr.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/flightgear.svg</Path>
@@ -3818,7 +3847,9 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/footnote.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/fooyin.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/forecast.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/forge-sparks.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/forkgram.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/formatusb.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/formiko.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/fosstriangulator.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/foto.svg</Path>
@@ -4665,6 +4696,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/hierarchyviewer.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/higan.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/highlight.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/hiit.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/hipchat-attention.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/hipchat.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/hipchat4.svg</Path>
@@ -4911,6 +4943,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.Cockatrice.oracle.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.Cockatrice.servatrice.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.EndlessSky.endless-sky.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.ExplosBlue.CoinKiller.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.FailurePoint.RandomNumberFive.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.FedericoCalzoni.EventRecorder.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.Figma_Linux.figma_linux.svg</Path>
@@ -4984,12 +5017,14 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.brunoherbelin.Vimix.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.btpf.alexandria.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.buonhobo.KatharaGUI.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.buonhobo.Katharsis.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.bytezz.IPLookup.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.cboxdoerfer.FSearch.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.celluloid-player.Celluloid.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.celluloid_player.Celluloid.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.ceprogramming.CEmu.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.cges30901.hmtimer.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.chen08209.FlClash.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.chilledheart.yass.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.chkr1011.mqttMultimeter.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.chris2511.xca.svg</Path>
@@ -5000,11 +5035,13 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.cmus.cmus.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.complexlogic.EasyAudioSync.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.congard.qnvsm.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.cosmic_utils.Examine.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.cudatext.CudaText-Qt.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.cudatext.Cudatext-Qt5.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.cudatext.Cudatext-Qt6.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.cudatext.Cudatext.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.dagargo.Elektroid.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.daid.EmptyEpsilon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.danirabbit.nimbus.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.danrabbit.harvey.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.danrabbit.lookbook.svg</Path>
@@ -5115,6 +5152,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.kitware.F3D.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.koromelodev.mindmate.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.ktgw0316.LightZone.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.labbots.NiimPrintX.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.labsquare.CutePeaks.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.lact-linux.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.lainsce.Colorway.svg</Path>
@@ -5136,6 +5174,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.limo_app.limo.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.listen1.Listen1.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.lo2dev.Echo.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.loissascha.mangoverlay.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.loot.loot.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.ltiber.Pwall.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.github.lucasew.regex101.svg</Path>
@@ -5434,6 +5473,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.thp.numptyphysics.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.typora.Typora.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.unobserved.espansoGUI.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.unobserved.furtherance.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.wavebox.Wavebox.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/io.webtorrent.WebTorrent.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/iok.svg</Path>
@@ -5562,6 +5602,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/jjazzlab.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/jmeter.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/jmol-icon.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/job-scheduler.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/jockey-gtk.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/jockey-kde.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/jockey.svg</Path>
@@ -5983,6 +6024,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/lepton-attrib.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/lepton-schematic.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/lepton-snippet-manager.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/letterpress.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/lftp-icon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/lftp.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/lgeneral.svg</Path>
@@ -6193,6 +6235,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/logview.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/logviewer.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/lokalize.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/lol.janjic.Splitcat.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/lolforlinuxinstaller.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/lollypop.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/loot.svg</Path>
@@ -6270,6 +6313,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mandelbulber2.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mandrivaupdate.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mangareader.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mangoverlay.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/manjaro-architect.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/manjaro.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mansa.svg</Path>
@@ -6359,6 +6403,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/me-tv.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/me.aandrew.ytdownloader.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/me.ahola.aphototoollibre.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/me.amankhanna.opendeck.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/me.dusansimic.DynamicWallpaper.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/me.hergert.Schemes.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/me.iepure.Ticketbooth.svg</Path>
@@ -6482,6 +6527,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/miro.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mirovideoconverter.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mirrorhall.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/missioncenter.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mist.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mitmproxy.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mitter.svg</Path>
@@ -6651,8 +6697,38 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mutt.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/muwire.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/muzika.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-alerts.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-boot-options.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-bootrepair.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-broadcom-manager.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-cleanup.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-clocky.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-codecs.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-conky.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-datetime.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-dockmaker.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-findshares.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-menu-editor.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-network-assistant.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-packageinstaller.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-qsi.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-repo-manager.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-samba-config.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-select-sound.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-service-manager.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-snapshot.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-timeset-gui-icon.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-tools.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-tour.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-tweak.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-update.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-usb-unmounter.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-user.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-viewer.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx-welcome.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mx.pwmc.Svgvi.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mxflux.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mxrm-icon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mygnuhealth.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mynotes.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/mynotex.svg</Path>
@@ -6668,6 +6744,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/naev.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/nagstamon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/naikari.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/name.abuchen.portfolio.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/nanonote.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/nasc.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/natron.svg</Path>
@@ -6688,6 +6765,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/nemo.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/neochat.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/neomutt.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/neoregex.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/neosurf.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/neothesia.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/neovide.svg</Path>
@@ -6749,6 +6827,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/net.granjow.slowmovideo.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/net.gwyddion.Gwyddion.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/net.hovancik.Stretchly.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/net.hypatiaproject.Hypatia.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/net.imaginaryinfinity.Squiid.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/net.jami.Jami.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/net.jammr.jammr.svg</Path>
@@ -6825,6 +6904,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/net.sourceforge.chromium-bsu.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/net.sourceforge.dmidiplayer.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/net.sourceforge.efaxgtk.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/net.sourceforge.fuse_emulator.Fuse.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/net.sourceforge.jmol.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/net.sourceforge.jpdftweak.jPdfTweak.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/net.sourceforge.kmetronome.svg</Path>
@@ -6898,6 +6978,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/newbreeze.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/newelle.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/news-feed.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/news-flash.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/newsflash.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/nextcloud-password-client.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/nextcloud.svg</Path>
@@ -7126,12 +7207,15 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/open-numismat.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/open-orienteering-mapper.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/open-stage-control.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/open-tv.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/open_tv.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/openage.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/openandroidinstaller.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/openarena.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/openarena128.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/openats-compass.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/openats.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/openbangla-keyboard.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/openbazaar.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/openbazaar2.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/openbazaar2client.svg</Path>
@@ -7145,6 +7229,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/opencloudsaves.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/opencomic.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/opencpn.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/opendeck.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/opendesktop-app.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/opendict.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/openerp-client.svg</Path>
@@ -7844,6 +7929,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.gustavoperedo.VideoDownloader.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.hedgewars.Hedgewars.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.hitchhiker_linux.vapad.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.hlwd.biblemultithelife.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.hlwd.sonofman.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.holylobster.nuntius.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.homelinuxserver.vance.biblereader.svg</Path>
@@ -7915,6 +8001,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.kde.choqok.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.kde.clip.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.kde.communicator.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.kde.cuttlefish.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.kde.daykountdown.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.kde.digikam.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.kde.discover.svg</Path>
@@ -8109,6 +8196,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.kde.mobile.angelfish.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.kde.mobile.calindori.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.kde.mobile.plasmasettings.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.kde.muon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.kde.mygnuhealth.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.kde.neochat.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/org.kde.nota.svg</Path>
@@ -8667,6 +8755,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/page.codeberg.foreverxml.Random.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/page.codeberg.lazyt.ubpm.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/page.codeberg.libre_menu_editor.LibreMenuEditor.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/page.codeberg.sungsphinx.Examine.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/page.codeberg.tpikonen.geobug.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/page.codeberg.tpikonen.satellite.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/page.codeberg.yeldham.Librerama.svg</Path>
@@ -9056,6 +9145,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/preferences-web-browser-stylesheets.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/prefixsuffix.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/press.freedom.dangerzone.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/principia.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/printer.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/printersandfax_q4os_startmenu.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/pritunl-client.svg</Path>
@@ -9462,6 +9552,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/retext.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/retro.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/retroarch.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/retrom.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/retroplus.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/retroshare.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/retux.svg</Path>
@@ -9511,6 +9602,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/rocketchat.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/rocks.koreader.KOReader.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/rocks.poopjournal.librelinkupdesktop.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/rocks.syng.Syng.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/rocks.thorium.Mercury.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/rocksndiamonds.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/rocs.svg</Path>
@@ -9569,6 +9661,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/samrewritten.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/samsung-driver.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/sandbox.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/sane-break.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/saods9.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/sasm.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/satdump-ui.svg</Path>
@@ -9629,6 +9722,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/sdrangel.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/sdrangel_icon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/se.manyver.Manyverse.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/se.principia_web.principia.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/se.sjoerd.DatMan.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/se.sjoerd.Graphs.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/se.trixon.Mapollage.svg</Path>
@@ -9698,6 +9792,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/shadow.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/shadowsocks-qt5.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/shadowsocks-qt6.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/share-preview.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/share.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/shares.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/sharik.svg</Path>
@@ -9892,6 +9987,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/spideroak.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/spine.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/spivak.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/splitcat.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/sportstracker.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/spot.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/spotify-client.svg</Path>
@@ -9935,6 +10031,8 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/stargate.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/start-here-archlinux.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/start-here-arcolinux.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/start-here-endeavoursos.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/start-here-eos.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/start-here-hyperbola.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/start-here-kde.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/start-here-pop-os.svg</Path>
@@ -10027,6 +10125,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_204360.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_204680.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_204940.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_20510.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_2060130.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_206310.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_206440.svg</Path>
@@ -10324,6 +10423,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_41500.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_415890.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_416770.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_41700.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_420.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_420110.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_420530.svg</Path>
@@ -10344,6 +10444,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_447530.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_447820.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_449380.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_4500.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_450140.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_452280.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_454060.svg</Path>
@@ -10352,6 +10453,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_457760.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_474750.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_475550.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_476240.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_48000.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_48950.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/steam_icon_489830.svg</Path>
@@ -10547,6 +10649,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/sunroof.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/sunvox.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/super-hexagon.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/superProductivity.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/superpaper.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/superproductivity.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/superslicer-gcodeviewer.svg</Path>
@@ -10596,6 +10699,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/synergy.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/synfig_icon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/synfigstudio.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/syng.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/syntalos.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/synthv1.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/sysdvr-qt.svg</Path>
@@ -10619,6 +10723,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/system-help.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/system-hibernate.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/system-installer.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/system-keyboard-qt.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/system-lock-screen.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/system-monitoring-center.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/system-restart.svg</Path>
@@ -10779,6 +10884,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/time.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/timecop.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/timeline.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/timeset-gui-icon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/timeshift.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/timeswitch.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/timetable.svg</Path>
@@ -11185,6 +11291,8 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/voicegen.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/vokoscreen.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/vokoscreenNG.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/volaris-gui.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/volaris.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/vollyball.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/volume-knob.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/vorta.svg</Path>
@@ -11495,6 +11603,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/xclicker.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/xcolor.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/xcos.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/xdelta3-gui.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/xdg-browser-launcher.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/xdiagnose.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/xdman.svg</Path>
@@ -11616,6 +11725,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/xyz.mx_moment.moment.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/xyz.parlatype.Parlatype.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/xyz.rescribe.rescribe.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/xyz.safeworlds.hiit.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/xyz.safeworlds.midiconn.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/xyz.slothlife.Jogger.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Circle/48/apps/xyz.splashmapper.Splash.svg</Path>
@@ -11725,9 +11835,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="52">
-            <Date>2024-10-03</Date>
-            <Version>24.10.01</Version>
+        <Update release="53">
+            <Date>2024-10-14</Date>
+            <Version>24.10.13</Version>
             <Comment>Packaging update</Comment>
             <Name>Algent Albrahimi</Name>
             <Email>algent@protonmail.com</Email>

--- a/packages/n/numix-icon-theme-square/package.yml
+++ b/packages/n/numix-icon-theme-square/package.yml
@@ -1,8 +1,8 @@
 name       : numix-icon-theme-square
-version    : 24.10.01
-release    : 45
+version    : 24.10.13
+release    : 46
 source     :
-    - https://github.com/numixproject/numix-icon-theme-square/archive/refs/tags/24.10.01.tar.gz : c8cd3d259e6833979029e629de014f78c67f7df07a2a46212f676d0e1a45eb13
+    - https://github.com/numixproject/numix-icon-theme-square/archive/refs/tags/24.10.13.tar.gz : 4a58cb833c511d5d6aafee0681efc49ea04d9ec91a0af41bace3e48604a54646
 homepage   : https://numixproject.github.io/
 license    : GPL-3.0-or-later
 component  : desktop.theme

--- a/packages/n/numix-icon-theme-square/pspec_x86_64.xml
+++ b/packages/n/numix-icon-theme-square/pspec_x86_64.xml
@@ -145,6 +145,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/Anatine.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/AndYetItMoves.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/AndroidMessages.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/AppHub.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/AppImage.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/AppImageLauncher.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/AppImageUpdater.svg</Path>
@@ -212,6 +213,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/Element.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/ElmerGUI.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/EmojiMart.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/EmptyEpsilon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/Encryptr.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/Etermutilities-terminal.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/Etterna.svg</Path>
@@ -273,6 +275,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/KKEdit.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/KKEditRoot.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/KatharaGUI.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/Katharsis.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/Khoj.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/LabPlot2.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/Launchpad-launchpad.net.svg</Path>
@@ -365,6 +368,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/Rdio-www.rdio.com.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/Reddit-pay.reddit.com.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/Reddit-reddit.com.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/Retrom.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/Rlogo.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/RuneLite.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/Runner.svg</Path>
@@ -698,12 +702,16 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/app.drey.Elastic.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/app.drey.Envelope.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/app.drey.FlatSync.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/app.drey.Highscore.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/app.drey.KeyRack.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/app.drey.Lemmings.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/app.drey.MultiplicationPuzzle.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/app.drey.Navigator.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/app.drey.PaperPlane.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/app.drey.PikaBackup.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/app.drey.Planner.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/app.drey.Toggle.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/app.drey.Vocalis.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/app.drey.Warp.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/app.fotema.Fotema.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/app.furtherance.Furtherance.svg</Path>
@@ -1027,6 +1035,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/beaver-notes.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/beekeeper-studio.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/beeref.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/beersmith.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/beryl-manager.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/beryl-settings.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/beryl.svg</Path>
@@ -1460,6 +1469,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/cataclysm-dda.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/cataclysm-tiles.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/cataclysmdda.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/cataicon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/catarina.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/catfish.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/catia.svg</Path>
@@ -1515,6 +1525,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/chatbox.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/chatterino.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/chatty.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/checkaptgpg.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/checkbox-qt.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/checkbox-touch.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/checkbox.svg</Path>
@@ -1771,6 +1782,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/clocks.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/clogosm.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/cloudcompare.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/cloudotp.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/clubhouse.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/cmake-gui.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/cmake.svg</Path>
@@ -1802,6 +1814,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/coffee.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/cog.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/coin.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/coinkiller.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/collision.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/colobot.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/colon.svg</Path>
@@ -1879,6 +1892,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.chroniclogic.Zatikon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.cinecred.cinecred.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.clarahobbs.chessclock.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.cloudchewie.cloudotp.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.codemouse92.timecard.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.core447.StreamController.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.corifeus.onenote.svg</Path>
@@ -1940,6 +1954,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.felipekinoshita.Kana.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.felipekinoshita.Wildcard.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.frac_tion.teleport.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.francescogaglione.chronos.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.frogatto.Frogatto.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.fyralabs.Abacus.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.fyralabs.Accelerator.svg</Path>
@@ -1998,6 +2013,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.github.afrantzis.Bless.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.github.aggalex.wineglass.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.github.aharotias2.parapara.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.github.ahoneybun.Stellarshot.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.github.ahrm.sioyek.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.github.akiraux.akira.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.github.akiraux.akiraDevel.svg</Path>
@@ -2406,6 +2422,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.kgurgul.cpuinfo.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.kitware.F3D.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.kjxbyz.PicGuard.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.konstantintutsch.Caffeine.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.korbsstudio.penpot-desktop.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.ktechpit.whatsie.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.lablicate.OpenChrom.svg</Path>
@@ -2414,6 +2431,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.leinardi.gst.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.leinardi.gwe.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.leinardi.gx52.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.leohanney.Volaris.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.lettier.gifcurry.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.lettier.movie-monad.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.librumreader.librum.svg</Path>
@@ -2429,6 +2447,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.manexim.home.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.mardojai.Blanket.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.mardojai.DiccionarioLengua.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.mardojai.ForgeSparks.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.mardojai.WebfontKitGenerator.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.markopejic.downloader.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.mastermindzh.tidal-hifi.svg</Path>
@@ -2477,6 +2496,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.rabbit_company.passky.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.rabbitcompany.passky.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.rafaelmardojai.Blanket.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.rafaelmardojai.SharePreview.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.rafaelmardojai.WebfontKitGenerator.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.raggesilver.BlackBox.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.raggesilver.Proton.svg</Path>
@@ -2607,6 +2627,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.wings3d.WINGS.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.wire.Coax.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.wire.WireDesktop.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.wireframesketcher.WireframeSketcher.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.wiz.Note.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.wps.Office.etmain.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/com.wps.Office.wppmain.svg</Path>
@@ -2796,6 +2817,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/cura.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/curlew.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/currency.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/custom-toolbox.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/cutechess.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/cutecom.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/cutefish-calculator.svg</Path>
@@ -2930,6 +2952,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/de.z_ray.Facetracker.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/de.zwarf.picplanner.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/deadbeef.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/deb-installer.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/debian-installer-launcher.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/debian-logo.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/debian-plymouth-manager.svg</Path>
@@ -3026,6 +3049,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/desktop-environment-lxde.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/desktop-environment-lxqt.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/desktop-environment-mate.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/desktop-environment-plasma.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/desktop-environment-sugar.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/desktop-environment-tde.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/desktop-environment-unity.svg</Path>
@@ -3047,9 +3071,11 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/dev.bsnes.bsnes.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/dev.deedles.Trayscale.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/dev.edfloreshz.Blueprint.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/dev.edfloreshz.Calculator.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/dev.edfloreshz.CosmicTweaks.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/dev.edfloreshz.Done.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/dev.edfloreshz.Tasks.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/dev.fredol.open-tv.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/dev.gbstudio.gb-studio.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/dev.geopjr.Archives.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/dev.geopjr.Calligraphy.svg</Path>
@@ -3129,6 +3155,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/discord.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/disk-burner.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/disk-check.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/disk-manager.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/disk-usage-analyzer.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/diskmonitor.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/disks.svg</Path>
@@ -3514,6 +3541,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/emerillon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/emesene.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/empathy.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/emptyepsilon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/emulationstation.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/en-croissant.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/encryptpad.svg</Path>
@@ -3771,6 +3799,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/flatseal.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/flatsweep.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/flaw.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/flclash.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/flegita.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/flickr.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/flightgear.svg</Path>
@@ -3818,7 +3847,9 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/footnote.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/fooyin.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/forecast.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/forge-sparks.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/forkgram.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/formatusb.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/formiko.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/fosstriangulator.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/foto.svg</Path>
@@ -4665,6 +4696,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/hierarchyviewer.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/higan.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/highlight.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/hiit.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/hipchat-attention.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/hipchat.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/hipchat4.svg</Path>
@@ -4911,6 +4943,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.Cockatrice.oracle.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.Cockatrice.servatrice.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.EndlessSky.endless-sky.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.ExplosBlue.CoinKiller.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.FailurePoint.RandomNumberFive.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.FedericoCalzoni.EventRecorder.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.Figma_Linux.figma_linux.svg</Path>
@@ -4984,12 +5017,14 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.brunoherbelin.Vimix.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.btpf.alexandria.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.buonhobo.KatharaGUI.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.buonhobo.Katharsis.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.bytezz.IPLookup.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.cboxdoerfer.FSearch.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.celluloid-player.Celluloid.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.celluloid_player.Celluloid.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.ceprogramming.CEmu.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.cges30901.hmtimer.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.chen08209.FlClash.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.chilledheart.yass.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.chkr1011.mqttMultimeter.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.chris2511.xca.svg</Path>
@@ -5000,11 +5035,13 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.cmus.cmus.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.complexlogic.EasyAudioSync.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.congard.qnvsm.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.cosmic_utils.Examine.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.cudatext.CudaText-Qt.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.cudatext.Cudatext-Qt5.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.cudatext.Cudatext-Qt6.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.cudatext.Cudatext.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.dagargo.Elektroid.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.daid.EmptyEpsilon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.danirabbit.nimbus.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.danrabbit.harvey.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.danrabbit.lookbook.svg</Path>
@@ -5115,6 +5152,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.kitware.F3D.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.koromelodev.mindmate.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.ktgw0316.LightZone.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.labbots.NiimPrintX.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.labsquare.CutePeaks.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.lact-linux.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.lainsce.Colorway.svg</Path>
@@ -5136,6 +5174,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.limo_app.limo.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.listen1.Listen1.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.lo2dev.Echo.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.loissascha.mangoverlay.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.loot.loot.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.ltiber.Pwall.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.github.lucasew.regex101.svg</Path>
@@ -5434,6 +5473,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.thp.numptyphysics.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.typora.Typora.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.unobserved.espansoGUI.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.unobserved.furtherance.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.wavebox.Wavebox.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/io.webtorrent.WebTorrent.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/iok.svg</Path>
@@ -5562,6 +5602,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/jjazzlab.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/jmeter.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/jmol-icon.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/job-scheduler.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/jockey-gtk.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/jockey-kde.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/jockey.svg</Path>
@@ -5983,6 +6024,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/lepton-attrib.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/lepton-schematic.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/lepton-snippet-manager.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/letterpress.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/lftp-icon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/lftp.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/lgeneral.svg</Path>
@@ -6193,6 +6235,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/logview.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/logviewer.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/lokalize.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/lol.janjic.Splitcat.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/lolforlinuxinstaller.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/lollypop.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/loot.svg</Path>
@@ -6270,6 +6313,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mandelbulber2.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mandrivaupdate.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mangareader.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mangoverlay.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/manjaro-architect.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/manjaro.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mansa.svg</Path>
@@ -6359,6 +6403,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/me-tv.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/me.aandrew.ytdownloader.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/me.ahola.aphototoollibre.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/me.amankhanna.opendeck.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/me.dusansimic.DynamicWallpaper.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/me.hergert.Schemes.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/me.iepure.Ticketbooth.svg</Path>
@@ -6482,6 +6527,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/miro.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mirovideoconverter.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mirrorhall.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/missioncenter.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mist.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mitmproxy.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mitter.svg</Path>
@@ -6651,8 +6697,38 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mutt.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/muwire.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/muzika.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-alerts.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-boot-options.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-bootrepair.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-broadcom-manager.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-cleanup.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-clocky.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-codecs.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-conky.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-datetime.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-dockmaker.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-findshares.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-menu-editor.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-network-assistant.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-packageinstaller.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-qsi.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-repo-manager.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-samba-config.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-select-sound.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-service-manager.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-snapshot.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-timeset-gui-icon.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-tools.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-tour.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-tweak.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-update.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-usb-unmounter.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-user.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-viewer.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx-welcome.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mx.pwmc.Svgvi.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mxflux.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mxrm-icon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mygnuhealth.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mynotes.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/mynotex.svg</Path>
@@ -6668,6 +6744,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/naev.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/nagstamon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/naikari.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/name.abuchen.portfolio.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/nanonote.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/nasc.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/natron.svg</Path>
@@ -6688,6 +6765,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/nemo.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/neochat.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/neomutt.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/neoregex.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/neosurf.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/neothesia.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/neovide.svg</Path>
@@ -6749,6 +6827,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/net.granjow.slowmovideo.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/net.gwyddion.Gwyddion.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/net.hovancik.Stretchly.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/net.hypatiaproject.Hypatia.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/net.imaginaryinfinity.Squiid.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/net.jami.Jami.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/net.jammr.jammr.svg</Path>
@@ -6825,6 +6904,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/net.sourceforge.chromium-bsu.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/net.sourceforge.dmidiplayer.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/net.sourceforge.efaxgtk.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/net.sourceforge.fuse_emulator.Fuse.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/net.sourceforge.jmol.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/net.sourceforge.jpdftweak.jPdfTweak.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/net.sourceforge.kmetronome.svg</Path>
@@ -6898,6 +6978,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/newbreeze.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/newelle.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/news-feed.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/news-flash.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/newsflash.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/nextcloud-password-client.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/nextcloud.svg</Path>
@@ -7126,12 +7207,15 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/open-numismat.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/open-orienteering-mapper.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/open-stage-control.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/open-tv.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/open_tv.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/openage.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/openandroidinstaller.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/openarena.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/openarena128.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/openats-compass.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/openats.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/openbangla-keyboard.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/openbazaar.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/openbazaar2.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/openbazaar2client.svg</Path>
@@ -7145,6 +7229,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/opencloudsaves.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/opencomic.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/opencpn.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/opendeck.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/opendesktop-app.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/opendict.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/openerp-client.svg</Path>
@@ -7844,6 +7929,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.gustavoperedo.VideoDownloader.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.hedgewars.Hedgewars.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.hitchhiker_linux.vapad.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.hlwd.biblemultithelife.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.hlwd.sonofman.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.holylobster.nuntius.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.homelinuxserver.vance.biblereader.svg</Path>
@@ -7915,6 +8001,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.kde.choqok.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.kde.clip.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.kde.communicator.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.kde.cuttlefish.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.kde.daykountdown.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.kde.digikam.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.kde.discover.svg</Path>
@@ -8109,6 +8196,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.kde.mobile.angelfish.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.kde.mobile.calindori.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.kde.mobile.plasmasettings.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.kde.muon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.kde.mygnuhealth.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.kde.neochat.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/org.kde.nota.svg</Path>
@@ -8667,6 +8755,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/page.codeberg.foreverxml.Random.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/page.codeberg.lazyt.ubpm.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/page.codeberg.libre_menu_editor.LibreMenuEditor.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/page.codeberg.sungsphinx.Examine.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/page.codeberg.tpikonen.geobug.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/page.codeberg.tpikonen.satellite.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/page.codeberg.yeldham.Librerama.svg</Path>
@@ -9056,6 +9145,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/preferences-web-browser-stylesheets.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/prefixsuffix.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/press.freedom.dangerzone.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/principia.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/printer.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/printersandfax_q4os_startmenu.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/pritunl-client.svg</Path>
@@ -9462,6 +9552,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/retext.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/retro.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/retroarch.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/retrom.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/retroplus.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/retroshare.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/retux.svg</Path>
@@ -9511,6 +9602,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/rocketchat.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/rocks.koreader.KOReader.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/rocks.poopjournal.librelinkupdesktop.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/rocks.syng.Syng.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/rocks.thorium.Mercury.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/rocksndiamonds.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/rocs.svg</Path>
@@ -9569,6 +9661,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/samrewritten.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/samsung-driver.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/sandbox.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/sane-break.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/saods9.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/sasm.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/satdump-ui.svg</Path>
@@ -9629,6 +9722,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/sdrangel.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/sdrangel_icon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/se.manyver.Manyverse.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/se.principia_web.principia.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/se.sjoerd.DatMan.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/se.sjoerd.Graphs.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/se.trixon.Mapollage.svg</Path>
@@ -9698,6 +9792,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/shadow.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/shadowsocks-qt5.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/shadowsocks-qt6.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/share-preview.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/share.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/shares.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/sharik.svg</Path>
@@ -9892,6 +9987,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/spideroak.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/spine.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/spivak.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/splitcat.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/sportstracker.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/spot.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/spotify-client.svg</Path>
@@ -9935,6 +10031,8 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/stargate.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/start-here-archlinux.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/start-here-arcolinux.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/start-here-endeavoursos.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/start-here-eos.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/start-here-hyperbola.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/start-here-kde.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/start-here-pop-os.svg</Path>
@@ -10027,6 +10125,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_204360.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_204680.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_204940.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_20510.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_2060130.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_206310.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_206440.svg</Path>
@@ -10324,6 +10423,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_41500.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_415890.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_416770.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_41700.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_420.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_420110.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_420530.svg</Path>
@@ -10344,6 +10444,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_447530.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_447820.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_449380.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_4500.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_450140.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_452280.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_454060.svg</Path>
@@ -10352,6 +10453,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_457760.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_474750.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_475550.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_476240.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_48000.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_48950.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/steam_icon_489830.svg</Path>
@@ -10547,6 +10649,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/sunroof.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/sunvox.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/super-hexagon.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/superProductivity.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/superpaper.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/superproductivity.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/superslicer-gcodeviewer.svg</Path>
@@ -10596,6 +10699,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/synergy.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/synfig_icon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/synfigstudio.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/syng.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/syntalos.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/synthv1.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/sysdvr-qt.svg</Path>
@@ -10619,6 +10723,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/system-help.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/system-hibernate.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/system-installer.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/system-keyboard-qt.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/system-lock-screen.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/system-monitoring-center.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/system-restart.svg</Path>
@@ -10779,6 +10884,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/time.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/timecop.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/timeline.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/timeset-gui-icon.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/timeshift.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/timeswitch.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/timetable.svg</Path>
@@ -11185,6 +11291,8 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/voicegen.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/vokoscreen.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/vokoscreenNG.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/volaris-gui.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/volaris.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/vollyball.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/volume-knob.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/vorta.svg</Path>
@@ -11495,6 +11603,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/xclicker.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/xcolor.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/xcos.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/xdelta3-gui.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/xdg-browser-launcher.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/xdiagnose.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/xdman.svg</Path>
@@ -11616,6 +11725,7 @@
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/xyz.mx_moment.moment.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/xyz.parlatype.Parlatype.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/xyz.rescribe.rescribe.svg</Path>
+            <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/xyz.safeworlds.hiit.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/xyz.safeworlds.midiconn.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/xyz.slothlife.Jogger.svg</Path>
             <Path fileType="data">/usr/share/icons/Numix-Square/48/apps/xyz.splashmapper.Splash.svg</Path>
@@ -11725,9 +11835,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="45">
-            <Date>2024-10-03</Date>
-            <Version>24.10.01</Version>
+        <Update release="46">
+            <Date>2024-10-14</Date>
+            <Version>24.10.13</Version>
             <Comment>Packaging update</Comment>
             <Name>Algent Albrahimi</Name>
             <Email>algent@protonmail.com</Email>


### PR DESCRIPTION
**Summary**
- New icons:
  - Update numix-icon-theme-square to 24.10.13
  - Update numix-icon-theme-circle to 24.10.13


**Test Plan**

Change system icon theme and check the icons

**Checklist**

- [x] Package was built and tested against unstable
