### PR TITLE
pisi/eopkg: Add versioned FilesDB and LazyDB instances

### DIFF
--- a/packages/e/eopkg/package.yml
+++ b/packages/e/eopkg/package.yml
@@ -1,10 +1,10 @@
 name       : eopkg
-version    : 4.1.4
-release    : 16
+version    : 4.1.6
+release    : 17
 source     :
-    - git|https://github.com/getsolus/eopkg.git : 6638c24b1a7580a8cb3380e045da73d81a211f73
+    - git|https://github.com/getsolus/eopkg.git : aeeeb0b6b1013ce11814b31c6673b0425e17693b
     # HEAD commit of https://github.com/getsolus/PackageKit/tree/eopkg4 unless stated otherwise
-    - git|https://github.com/getsolus/PackageKit.git : ec73537c8c508ee8797c252072087fabe26a3273
+    - git|https://github.com/getsolus/PackageKit.git : 9b0f17c1ba6addc1c85bff34b64efad6a905ca50
 homepage   : https://github.com/getsolus/eopkg
 license    : GPL-2.0-or-later
 component  : system.base

--- a/packages/e/eopkg/pspec_x86_64.xml
+++ b/packages/e/eopkg/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>eopkg</Name>
         <Homepage>https://github.com/getsolus/eopkg</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -34,12 +34,12 @@
             <Path fileType="executable">/usr/bin/eopkg.py3</Path>
             <Path fileType="executable">/usr/bin/lseopkg.py3</Path>
             <Path fileType="executable">/usr/bin/uneopkg.py3</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.4.dist-info/AUTHORS</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.4.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.4.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.4.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.4.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.4.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.6.dist-info/AUTHORS</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.6.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.6.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.6.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.6.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.6.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/__pycache__/__init__.cpython-311.pyc</Path>
@@ -444,12 +444,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2024-09-12</Date>
-            <Version>4.1.4</Version>
+        <Update release="17">
+            <Date>2024-10-23</Date>
+            <Version>4.1.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/p/pisi/pspec.xml
+++ b/packages/p/pisi/pspec.xml
@@ -12,7 +12,7 @@
         <IsA>app:console</IsA>
         <Summary>PISI</Summary>
         <Description>PISI is a modern package management system implemented in Python. Some of its main features are: package sources are written in XML and python, implements all functions through a simple-to-use API, integrates low-level and high-level package management features.</Description>
-        <Archive sha1sum="4b78105fd4658cd3407da9b74980082522ce10b4" type="targz">https://github.com/getsolus/eopkg/archive/refs/tags/v3.12.4.tar.gz</Archive>
+        <Archive sha1sum="581975f8471ff27a3953c73c2f08f9889f8e28a2" type="targz">https://github.com/getsolus/eopkg/archive/refs/tags/v3.12.5.tar.gz</Archive>
         <BuildDependencies>
             <Dependency>db5</Dependency>
             <Dependency>intltool</Dependency>
@@ -67,6 +67,13 @@
     </Package>
 
     <History>
+        <Update release="118">
+            <Date>10-15-2024</Date>
+            <Version>3.12.5</Version>
+            <Comment>Update to v3.12.5</Comment>
+            <Name>Rune Morling</Name>
+            <Email>ermo@serpentos.com</Email>
+        </Update>
         <Update release="117">
             <Date>09-11-2024</Date>
             <Version>3.12.4</Version>
@@ -82,7 +89,7 @@
             <Email>silke@slxh.eu</Email>
         </Update>
         <Update release="115">
-            <Date>19-07-2024</Date>
+            <Date>07-19-2024</Date>
             <Version>3.12.2</Version>
             <Comment>Fix eopkg check with usr-merged directories
 </Comment>
@@ -90,7 +97,7 @@
             <Email>solus@reillybrogan.com</Email>
         </Update>
         <Update release="114">
-            <Date>04-07-2024</Date>
+            <Date>07-04-2024</Date>
             <Version>3.12.2</Version>
             <Comment>Update to v3.12.2, tweak reordering code
 **Summary**
@@ -102,7 +109,7 @@ In addition, a cosmetic tweak was added which doesn't show the "reordering syste
             <Email>ermo@serpentos.com</Email>
         </Update>
         <Update release="113">
-            <Date>29-06-2024</Date>
+            <Date>06-29-2024</Date>
             <Version>3.12.2</Version>
             <Comment>Update to v3.12.2, tweak reordering code
 **Summary**
@@ -112,7 +119,7 @@ The install order reordering code now puts baselayout first and doesn't attempt 
             <Email>ermo@serpentos.com</Email>
         </Update>
          <Update release="112">
-            <Date>24-06-2024</Date>
+            <Date>06-24-2024</Date>
             <Version>3.12.1</Version>
             <Comment>sync to v3.12.1, add dep on python2-ordered-set
 **Summary**
@@ -129,7 +136,7 @@ The install order reordering code now puts baselayout first and doesn't attempt 
             <Email>ermo@serpentos.com</Email>
         </Update>
         <Update release="111">
-            <Date>10-06-2024</Date>
+            <Date>06-10-2024</Date>
             <Version>3.11</Version>
             <Comment>Update to v3.11</Comment>
             <Name>Rune Morling</Name>

--- a/packages/y/ypkg/package.yml
+++ b/packages/y/ypkg/package.yml
@@ -1,8 +1,8 @@
 name       : ypkg
-version    : '33'
-release    : 194
+version    : '34'
+release    : 196
 source     :
-    - git|https://github.com/getsolus/ypkg.git : f07d8770ef57456df90e834bcaaf877634cafda2
+    - git|https://github.com/getsolus/ypkg.git : e366d2765674ffa008c378dcff5e74477b472b3a
 homepage   : https://github.com/getsolus/ypkg
 license    : GPL-3.0-or-later
 component  : system.devel

--- a/packages/y/ypkg/pspec_x86_64.xml
+++ b/packages/y/ypkg/pspec_x86_64.xml
@@ -4,7 +4,7 @@
         <Homepage>https://github.com/getsolus/ypkg</Homepage>
         <Packager>
             <Name>Rune Morling</Name>
-            <Email>ermo.solus-project.com@spammesenseless.net</Email>
+            <Email>ermo@serpentos.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.devel</PartOf>
@@ -75,12 +75,12 @@ Simply put, it is a tool to convert a build process into a packaging operation.
         </Files>
     </Package>
     <History>
-        <Update release="194">
-            <Date>2024-09-16</Date>
-            <Version>33</Version>
+        <Update release="196">
+            <Date>2024-10-23</Date>
+            <Version>34</Version>
             <Comment>Packaging update</Comment>
             <Name>Rune Morling</Name>
-            <Email>ermo.solus-project.com@spammesenseless.net</Email>
+            <Email>ermo@serpentos.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- `eopkg.py2` now writes versioned (v3), gdbm format FilesDB shelves, and versioned LazyDB caches; both using Pickle Protocol Version 2.
- `eopkg.py3/bin` now writes versioned (v4), gdbm format FilesDB shelves, and versioned LazyDB caches; both using Pickle Protocol Version 2.
- FilesDB and LazyDBs are autoupgraded on version mismatch.
- The output of `sudo eopkg.py2/py3/bin rdb` operations has been cleaned up significantly.
- Taskfile now uses `eopkg.bin` for indexing operations due to the improved output it provides.
- ypkg-install-deps supports an optional -e/--eopkg-cmd argument, which defaults to `eopkg.py3`
  (look at https://github.com/getsolus/solbuild/pull/117 for how this will be leveraged in solbuild).

This is intended to help make the transition between using `eopkg.py2` and `eopkg.py3/bin` much smoother.

**Changelog**

- [eopkg.py2 3.12.5](https://github.com/getsolus/eopkg/releases/tag/v3.12.5)
- [eopkg.py3 4.1.5](https://github.com/getsolus/eopkg/releases/tag/v4.1.5)
- [eopkg.py3 4.1.6](https://github.com/getsolus/eopkg/releases/tag/v4.1.6)

**Test Plan**

- Check out this branch
- Clean out the local repo with `go-task clean-local`
- Build pisi w/ `go-task localcp` and install it
  - Pay attention to any mentions of FilesDB rebuilds in subsequent build logs (e.g. eopkg, ypkg and whatever else you decide to build for testing purposes). In particular, pay attention to the `FilesDB (version:` part.
- Build eopkg w/ `go-task localcp` and install it and its `python-eopkg` subpackage
  - Notice how after installing the updated eopkg, subsequent builds will now show a list of which packages are indexed in the local repo prior to the build.
- Build ypkg w/ `go-task localcp` and install it
- Follow the Test Plan in #3850 

**Checklist**

- [x] Package was built and tested against unstable
