### PR TITLE
signal-desktop: Update to 7.29.0

### DIFF
--- a/packages/s/signal-desktop/abi_used_symbols
+++ b/packages/s/signal-desktop/abi_used_symbols
@@ -313,6 +313,7 @@ libc.so.6:__sched_cpucount
 libc.so.6:__sched_cpufree
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
+libc.so.6:__strcat_chk
 libc.so.6:__strncat_chk
 libc.so.6:__timezone
 libc.so.6:__vfprintf_chk
@@ -1419,6 +1420,9 @@ libsmime3.so:SEC_PKCS12DecoderVerify
 libsmime3.so:SEC_PKCS12EnableCipher
 libsmime3.so:SEC_PKCS12SetPreferredCipher
 libstdc++.so.6:_ZNKSt8__detail20_Prime_rehash_policy14_M_need_rehashEmmm
+libstdc++.so.6:_ZNSt6thread15_M_start_threadESt10unique_ptrINS_6_StateESt14default_deleteIS1_EEPFvvE
+libstdc++.so.6:_ZNSt6thread4joinEv
+libstdc++.so.6:_ZNSt6thread6_StateD2Ev
 libstdc++.so.6:_ZSt17__throw_bad_allocv
 libstdc++.so.6:_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_incrementPKSt18_Rb_tree_node_base

--- a/packages/s/signal-desktop/package.yml
+++ b/packages/s/signal-desktop/package.yml
@@ -1,8 +1,8 @@
 name       : signal-desktop
-version    : 7.27.0
-release    : 172
+version    : 7.29.0
+release    : 173
 source     :
-    - https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.27.0_amd64.deb : daa6bc9b6be7013172c8674ec439c131126477c02f126b283aa10ece62f94218
+    - https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.29.0_amd64.deb : a9eeeccdd74feb76b873948a317b3f501fc95e3530396d479adae6a81894b2a0
 homepage   : https://signal.org
 license    : AGPL-3.0-or-later
 component  : network.im

--- a/packages/s/signal-desktop/pspec_x86_64.xml
+++ b/packages/s/signal-desktop/pspec_x86_64.xml
@@ -139,7 +139,6 @@
             <Path fileType="data">/usr/share/signal-desktop/resources.pak</Path>
             <Path fileType="data">/usr/share/signal-desktop/resources/app-update.yml</Path>
             <Path fileType="data">/usr/share/signal-desktop/resources/app.asar</Path>
-            <Path fileType="data">/usr/share/signal-desktop/resources/app.asar.unpacked/node_modules/@indutny/simple-windows-notifications/build/Release/simple-windows-notifications.node</Path>
             <Path fileType="data">/usr/share/signal-desktop/resources/app.asar.unpacked/node_modules/@signalapp/better-sqlite3/build/Release/better_sqlite3.node</Path>
             <Path fileType="data">/usr/share/signal-desktop/resources/app.asar.unpacked/node_modules/@signalapp/libsignal-client/prebuilds/linux-x64/@signalapp+libsignal-client.node</Path>
             <Path fileType="data">/usr/share/signal-desktop/resources/app.asar.unpacked/node_modules/@signalapp/ringrtc/build/linux/libringrtc-x64.node</Path>
@@ -152,9 +151,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="172">
-            <Date>2024-10-03</Date>
-            <Version>7.27.0</Version>
+        <Update release="173">
+            <Date>2024-10-16</Date>
+            <Version>7.29.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Algent Albrahimi</Name>
             <Email>algent@protonmail.com</Email>


### PR DESCRIPTION
**Summary**

- This update improves startup speed by around 5%, so feel free to slow down a little bit in other areas of your life.
- We fixed a bug that prevented stickers from working correctly in the media editor, and now the picker no longer gets stuck when you're trying to stick a sticker on a picture.

**Test Plan**

- Open app and chat.

**Checklist**

- [x] Package was built and tested against unstable
