### PR TITLE
python-gphoto2: Update to 2.5.1

### DIFF
--- a/packages/py/python-gphoto2/monitoring.yml
+++ b/packages/py/python-gphoto2/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 76872
+  rss: https://github.com/jim-easterbrook/python-gphoto2/tags.atom
+# No known CPE, checked 2024-10-16
+security:
+  cpe: ~

--- a/packages/py/python-gphoto2/package.yml
+++ b/packages/py/python-gphoto2/package.yml
@@ -1,8 +1,8 @@
 name       : python-gphoto2
-version    : 2.5.0
-release    : 19
+version    : 2.5.1
+release    : 20
 source     :
-    - https://github.com/jim-easterbrook/python-gphoto2/archive/refs/tags/v2.5.0.tar.gz : a627444a910e4d9595c3e1da1d3e291ec4422269cf7dfd48e4432b6c8ae698ef
+    - https://github.com/jim-easterbrook/python-gphoto2/archive/refs/tags/v2.5.1.tar.gz : 2cdfd8ddb676a8041298bee32b7943d0f3a261067a5b0b95e238f1647ebe0316
 homepage   : https://github.com/jim-easterbrook/python-gphoto2
 license    : LGPL-3.0-or-later
 component  : programming.python

--- a/packages/py/python-gphoto2/pspec_x86_64.xml
+++ b/packages/py/python-gphoto2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-gphoto2</Name>
         <Homepage>https://github.com/jim-easterbrook/python-gphoto2</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Algent Albrahimi</Name>
+            <Email>algent@protonmail.com</Email>
         </Packager>
         <License>LGPL-3.0-or-later</License>
         <PartOf>programming.python</PartOf>
@@ -20,11 +20,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/gphoto2-2.5.0-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/gphoto2-2.5.0-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/gphoto2-2.5.0-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/gphoto2-2.5.0-py3.11.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/gphoto2-2.5.0-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/gphoto2-2.5.1-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/gphoto2-2.5.1-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/gphoto2-2.5.1-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/gphoto2-2.5.1-py3.11.egg-info/not-zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/gphoto2-2.5.1-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/gphoto2/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/gphoto2/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/gphoto2/__pycache__/__init__.cpython-311.pyc</Path>
@@ -119,12 +119,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2024-02-14</Date>
-            <Version>2.5.0</Version>
+        <Update release="20">
+            <Date>2024-10-16</Date>
+            <Version>2.5.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Algent Albrahimi</Name>
+            <Email>algent@protonmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Add Python 3.12 & 3.13 binary wheels.
- Add `__version_tuple__` for easy runtime version checking.

**Test Plan**
- Download new photos from my phone using `rapid-photo-downloader`
- Connect my phone via USB and run commands:
```
$ cd /usr/lib/python3.11/site-packages/gphoto2/examples
$ python3 camera-summary.py
$ python3 list-cameras.py
$ python3 gphoto2_version.py
```

**Checklist**

- [x] Package was built and tested against unstable
