### PR TITLE
eza: Update to 0.20.3

### DIFF
--- a/packages/e/eza/abi_used_symbols
+++ b/packages/e/eza/abi_used_symbols
@@ -15,6 +15,7 @@ libc.so.6:fcntl
 libc.so.6:free
 libc.so.6:freelocale
 libc.so.6:fstat64
+libc.so.6:fstatat64
 libc.so.6:getauxval
 libc.so.6:getcwd
 libc.so.6:getenv

--- a/packages/e/eza/package.yml
+++ b/packages/e/eza/package.yml
@@ -1,8 +1,8 @@
 name       : eza
-version    : 0.20.2
-release    : 33
+version    : 0.20.3
+release    : 34
 source     :
-    - https://github.com/eza-community/eza/archive/refs/tags/v0.20.2.tar.gz : 8d5a573906fd362e27c601e8413b2c96b546bbac7cdedcbd1defe1332f42265d
+    - https://github.com/eza-community/eza/archive/refs/tags/v0.20.3.tar.gz : 51a61bba14d1e4043981cabc5cf3d14352bf6a4ca0e308f437d0c8d00f42c2f7
 homepage   : https://github.com/eza-community/eza
 license    : EUPL-1.2
 component  : system.utils

--- a/packages/e/eza/pspec_x86_64.xml
+++ b/packages/e/eza/pspec_x86_64.xml
@@ -33,9 +33,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2024-10-15</Date>
-            <Version>0.20.2</Version>
+        <Update release="34">
+            <Date>2024-10-17</Date>
+            <Version>0.20.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Fix git cliff docs issue
- Reuse filetype from DirEntry
  This yields approximately a ~24% speedup for most common operations.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

List files and folders in a directory.

**Checklist**

- [x] Package was built and tested against unstable
