### PR TITLE
github-cli: Update to 2.59.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.58.0
-release    : 56
+version    : 2.59.0
+release    : 57
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.58.0.tar.gz : 90894536c797147586db775d06ec2040c45cd7eef941f7ccbea46f4e5997c81c
+    - https://github.com/cli/cli/archive/refs/tags/v2.59.0.tar.gz : d24ed01e5aa1e8f42b397333462f9cd5c54e4845a5142044381fc8eb713fa001
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -169,6 +169,12 @@
             <Path fileType="man">/usr/share/man/man1/gh-repo-deploy-key.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-repo-edit.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-repo-fork.1</Path>
+            <Path fileType="man">/usr/share/man/man1/gh-repo-gitignore-list.1</Path>
+            <Path fileType="man">/usr/share/man/man1/gh-repo-gitignore-view.1</Path>
+            <Path fileType="man">/usr/share/man/man1/gh-repo-gitignore.1</Path>
+            <Path fileType="man">/usr/share/man/man1/gh-repo-license-list.1</Path>
+            <Path fileType="man">/usr/share/man/man1/gh-repo-license-view.1</Path>
+            <Path fileType="man">/usr/share/man/man1/gh-repo-license.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-repo-list.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-repo-rename.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-repo-set-default.1</Path>
@@ -219,9 +225,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="56">
-            <Date>2024-10-03</Date>
-            <Version>2.58.0</Version>
+        <Update release="57">
+            <Date>2024-10-17</Date>
+            <Version>2.59.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Allow community submitted design work
- Print the login URL even when opening a browser
- Handle errors when parsing hostname in auth flow
- Add `repo license list`/`view` and `repo gitignore list`/`view`
- Support `GH_ACCEPTANCE_SCRIPT` env var to target a single script
- Ensure Acceptance defer failures are debuggable
- Supporting filtering on `gist list`

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and make this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
