### PR TITLE
starship: Update to 1.21.0

### DIFF
--- a/packages/s/starship/abi_used_symbols
+++ b/packages/s/starship/abi_used_symbols
@@ -35,10 +35,10 @@ libc.so.6:getegid
 libc.so.6:getenv
 libc.so.6:geteuid
 libc.so.6:getgroups
+libc.so.6:gethostname
 libc.so.6:getpeername
 libc.so.6:getpid
 libc.so.6:getpwnam
-libc.so.6:getpwuid
 libc.so.6:getpwuid_r
 libc.so.6:getsockname
 libc.so.6:getsockopt
@@ -58,10 +58,10 @@ libc.so.6:mkdir
 libc.so.6:mmap64
 libc.so.6:mprotect
 libc.so.6:munmap
-libc.so.6:nanosleep
 libc.so.6:open
 libc.so.6:open64
 libc.so.6:opendir
+libc.so.6:pause
 libc.so.6:pipe2
 libc.so.6:poll
 libc.so.6:posix_memalign
@@ -83,7 +83,6 @@ libc.so.6:pthread_attr_setstacksize
 libc.so.6:pthread_create
 libc.so.6:pthread_detach
 libc.so.6:pthread_getattr_np
-libc.so.6:pthread_getspecific
 libc.so.6:pthread_join
 libc.so.6:pthread_key_create
 libc.so.6:pthread_key_delete

--- a/packages/s/starship/package.yml
+++ b/packages/s/starship/package.yml
@@ -1,8 +1,8 @@
 name       : starship
-version    : 1.20.0
-release    : 19
+version    : 1.21.0
+release    : 20
 source     :
-    - https://github.com/starship/starship/archive/refs/tags/v1.20.0.tar.gz : ea73a5463d30c5d5dfd473b11a27f2f25942635121dc3fc89297eeb22755ce8f
+    - https://github.com/starship/starship/archive/refs/tags/v1.21.0.tar.gz : 2f068545f270733add06c90592f3fb36422b8f650853f707956d24c06041b751
 homepage   : https://starship.rs/
 license    : ISC
 component  : system.utils

--- a/packages/s/starship/pspec_x86_64.xml
+++ b/packages/s/starship/pspec_x86_64.xml
@@ -32,9 +32,9 @@ Every little detail is customizable to your liking, to make this prompt as minim
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2024-07-27</Date>
-            <Version>1.20.0</Version>
+        <Update release="20">
+            <Date>2024-10-17</Date>
+            <Version>1.21.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- deno: add `deno.lock` file to default `detect_files` list
- hostname: add option to replace hostnames with aliases
- mojo: add module for Mojo language
- package: support alternative gradle module version syntax
- python: Add detect env vars option
- python: detect pixi and ipynb files
- bash: fix variable leak in Bash integration
- cmd_duration: Make render_time format more consistent
- docker_context: Ignore Docker Desktop "desktop-linux" context
- fish: add missing arguments for fish transient prompt functions
- fish: improve fish transient prompt
- fish: use correct input function in transient execute
- Fixed "Click to download TOML" links
- git_status: read proper name for core.fsmonitor flag
- python: improve parsing of `pyvenv.cfg` files
- Use `whoami` for user/hostname queries again
- fish: Skip unnecessary indirection in `starship init fish`

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new terminal session, navigate between directories, see the prompt change accordingly.

**Checklist**

- [x] Package was built and tested against unstable
