### PR TITLE
xfce updates

### DIFF
--- a/packages/x/xfburn/MAINTAINERS.md
+++ b/packages/x/xfburn/MAINTAINERS.md
@@ -1,5 +1,9 @@
 This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
 
-- Name Surname
-  - Matrix: thatzachbacon:matrix.org
+- Evan Maddock
+  - Matrix: @ebonjaeger:matrix.org
+  - Email: maddock.evan@vivaldi.net
+
+- Zach Bacon
+  - Matrix: @thatzachbacon:matrix.org
   - Email: zachbacon@vba-m.com

--- a/packages/x/xfburn/abi_used_symbols
+++ b/packages/x/xfburn/abi_used_symbols
@@ -586,6 +586,7 @@ libisofs.so.6:iso_write_opts_set_joliet
 libisofs.so.6:iso_write_opts_set_rockridge
 libm.so.6:floorf
 libxfce4ui-2.so.0:xfce_dialog_show_error
+libxfce4ui-2.so.0:xfce_dialog_show_help
 libxfce4ui-2.so.0:xfce_dialog_show_info
 libxfce4ui-2.so.0:xfce_dialog_show_warning
 libxfce4ui-2.so.0:xfce_gtk_button_new_mixed

--- a/packages/x/xfburn/monitoring.yml
+++ b/packages/x/xfburn/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 10158
+  rss: https://gitlab.xfce.org/apps/xfburn/-/tags?format=atom
+# No known CPE, checked 2024-10-17
+security:
+  cpe: ~

--- a/packages/x/xfburn/package.yml
+++ b/packages/x/xfburn/package.yml
@@ -1,8 +1,8 @@
 name       : xfburn
-version    : 0.7.0
-release    : 2
+version    : 0.7.2
+release    : 3
 source     :
-    - https://archive.xfce.org/src/apps/xfburn/0.7/xfburn-0.7.0.tar.bz2 : ba960ea79a044b93e513f7c32bca1a599472d687ed0e0184bde8c84aeebb1f45
+    - https://archive.xfce.org/src/apps/xfburn/0.7/xfburn-0.7.2.tar.bz2 : c2bb01d9f7335e487f91db40ebddeea30d071364c1c3b56838466fd3367a9925
 homepage   : https://docs.xfce.org/apps/xfburn/start
 license    : GPL-2.0-or-later
 component  : desktop.xfce

--- a/packages/x/xfburn/pspec_x86_64.xml
+++ b/packages/x/xfburn/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xfburn</Name>
         <Homepage>https://docs.xfce.org/apps/xfburn/start</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.xfce</PartOf>
@@ -133,12 +133,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2023-10-31</Date>
-            <Version>0.7.0</Version>
+        <Update release="3">
+            <Date>2024-10-17</Date>
+            <Version>0.7.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/x/xfce4-notifyd/MAINTAINERS.md
+++ b/packages/x/xfce4-notifyd/MAINTAINERS.md
@@ -1,5 +1,9 @@
 This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
 
-- Name Surname
-  - Matrix: thatzachbacon:matrix.org
+- Evan Maddock
+  - Matrix: @ebonjaeger:matrix.org
+  - Email: maddock.evan@vivaldi.net
+
+- Zach Bacon
+  - Matrix: @thatzachbacon:matrix.org
   - Email: zachbacon@vba-m.com

--- a/packages/x/xfce4-notifyd/abi_used_symbols
+++ b/packages/x/xfce4-notifyd/abi_used_symbols
@@ -14,6 +14,7 @@ libc.so.6:strchr
 libc.so.6:strcmp
 libc.so.6:strlen
 libc.so.6:strncmp
+libc.so.6:strstr
 libcairo.so.2:cairo_arc
 libcairo.so.2:cairo_create
 libcairo.so.2:cairo_destroy
@@ -42,6 +43,7 @@ libgdk-3.so.0:gdk_display_get_default
 libgdk-3.so.0:gdk_display_get_default_seat
 libgdk-3.so.0:gdk_display_get_monitor
 libgdk-3.so.0:gdk_display_get_monitor_at_point
+libgdk-3.so.0:gdk_display_get_monitor_at_window
 libgdk-3.so.0:gdk_display_get_n_monitors
 libgdk-3.so.0:gdk_display_get_primary_monitor
 libgdk-3.so.0:gdk_event_copy
@@ -51,9 +53,7 @@ libgdk-3.so.0:gdk_monitor_get_geometry
 libgdk-3.so.0:gdk_monitor_get_type
 libgdk-3.so.0:gdk_monitor_get_workarea
 libgdk-3.so.0:gdk_notify_startup_complete
-libgdk-3.so.0:gdk_rectangle_equal
 libgdk-3.so.0:gdk_rectangle_intersect
-libgdk-3.so.0:gdk_rectangle_union
 libgdk-3.so.0:gdk_screen_get_default
 libgdk-3.so.0:gdk_screen_get_display
 libgdk-3.so.0:gdk_screen_get_rgba_visual
@@ -269,6 +269,7 @@ libglib-2.0.so.0:g_string_insert_c
 libglib-2.0.so.0:g_string_insert_len
 libglib-2.0.so.0:g_string_sized_new
 libglib-2.0.so.0:g_strndup
+libglib-2.0.so.0:g_strrstr
 libglib-2.0.so.0:g_strv_builder_add
 libglib-2.0.so.0:g_strv_builder_end
 libglib-2.0.so.0:g_strv_builder_new
@@ -445,6 +446,7 @@ libgtk-3.so.0:gtk_grid_attach
 libgtk-3.so.0:gtk_grid_new
 libgtk-3.so.0:gtk_grid_set_column_spacing
 libgtk-3.so.0:gtk_grid_set_row_spacing
+libgtk-3.so.0:gtk_icon_info_get_filename
 libgtk-3.so.0:gtk_icon_info_load_symbolic_for_context
 libgtk-3.so.0:gtk_icon_size_lookup
 libgtk-3.so.0:gtk_icon_theme_get_default
@@ -510,7 +512,6 @@ libgtk-3.so.0:gtk_menu_item_new_with_mnemonic
 libgtk-3.so.0:gtk_menu_new
 libgtk-3.so.0:gtk_menu_popup_at_pointer
 libgtk-3.so.0:gtk_menu_popup_at_widget
-libgtk-3.so.0:gtk_menu_reposition
 libgtk-3.so.0:gtk_menu_shell_append
 libgtk-3.so.0:gtk_plug_new
 libgtk-3.so.0:gtk_progress_bar_get_fraction
@@ -526,6 +527,7 @@ libgtk-3.so.0:gtk_scrolled_window_set_shadow_type
 libgtk-3.so.0:gtk_separator_menu_item_new
 libgtk-3.so.0:gtk_separator_new
 libgtk-3.so.0:gtk_show_about_dialog
+libgtk-3.so.0:gtk_spin_button_set_value
 libgtk-3.so.0:gtk_style_context_add_class
 libgtk-3.so.0:gtk_style_context_add_provider
 libgtk-3.so.0:gtk_style_context_get_padding
@@ -551,6 +553,7 @@ libgtk-3.so.0:gtk_widget_destroy
 libgtk-3.so.0:gtk_widget_get_accessible
 libgtk-3.so.0:gtk_widget_get_allocation
 libgtk-3.so.0:gtk_widget_get_direction
+libgtk-3.so.0:gtk_widget_get_display
 libgtk-3.so.0:gtk_widget_get_opacity
 libgtk-3.so.0:gtk_widget_get_parent
 libgtk-3.so.0:gtk_widget_get_preferred_size

--- a/packages/x/xfce4-notifyd/monitoring.yml
+++ b/packages/x/xfce4-notifyd/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 15832
+  rss: https://gitlab.xfce.org/xfce/xfce4-notifyd/-/tags?format=atom
+# No known CPE, checked 2024-10-17
+security:
+  cpe: ~

--- a/packages/x/xfce4-notifyd/package.yml
+++ b/packages/x/xfce4-notifyd/package.yml
@@ -1,8 +1,8 @@
 name       : xfce4-notifyd
-version    : 0.9.4
-release    : 5
+version    : 0.9.6
+release    : 6
 source     :
-    - https://archive.xfce.org/src/apps/xfce4-notifyd/0.9/xfce4-notifyd-0.9.4.tar.bz2 : ae6c128c055c44bd07202f73ae69ad833c5e4754f3530696965136e4d9ea7818
+    - https://archive.xfce.org/src/apps/xfce4-notifyd/0.9/xfce4-notifyd-0.9.6.tar.bz2 : 9e53265cca7d835c31b3c2c0d3ae961704870839ef583dcca3e4cc98ae3d2671
 homepage   : https://docs.xfce.org/apps/notifyd/start
 license    : GPL-2.0-or-later
 component  : desktop.xfce

--- a/packages/x/xfce4-notifyd/pspec_x86_64.xml
+++ b/packages/x/xfce4-notifyd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xfce4-notifyd</Name>
         <Homepage>https://docs.xfce.org/apps/notifyd/start</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.xfce</PartOf>
@@ -100,12 +100,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2024-02-13</Date>
-            <Version>0.9.4</Version>
+        <Update release="6">
+            <Date>2024-10-17</Date>
+            <Version>0.9.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- **xfburn: Update to 0.7.2**
- **xfce4-notifyd: Update to 0.9.6**

**Test Plan**

Reboot and see that notifications still work correctly.

**Checklist**

- [x] Package was built and tested against unstable
