### PR TITLE
pentopi: Update to 25.1

### DIFF
--- a/packages/p/pentobi/abi_used_symbols
+++ b/packages/p/pentobi/abi_used_symbols
@@ -15,8 +15,10 @@ libQt6Core.so.6:_ZN11QDataStream11resetStatusEv
 libQt6Core.so.6:_ZN11QDataStream9setStatusENS_6StatusE
 libQt6Core.so.6:_ZN11QDataStreamlsEd
 libQt6Core.so.6:_ZN11QDataStreamlsEi
+libQt6Core.so.6:_ZN11QDataStreamlsEx
 libQt6Core.so.6:_ZN11QDataStreamrsERd
 libQt6Core.so.6:_ZN11QDataStreamrsERi
+libQt6Core.so.6:_ZN11QDataStreamrsERx
 libQt6Core.so.6:_ZN11QMetaObject10ConnectionD1Ev
 libQt6Core.so.6:_ZN11QMetaObject14normalizedTypeEPKc
 libQt6Core.so.6:_ZN11QMetaObject8activateEP7QObjectPKS_iPPv
@@ -152,6 +154,7 @@ libQt6Core.so.6:_ZN7QString6appendE20QBasicUtf8StringViewILb0EE
 libQt6Core.so.6:_ZN7QString6appendE5QChar
 libQt6Core.so.6:_ZN7QString6appendEPK5QCharx
 libQt6Core.so.6:_ZN7QString6appendERKS_
+libQt6Core.so.6:_ZN7QString6assignE14QAnyStringView
 libQt6Core.so.6:_ZN7QString6insertEx5QChar
 libQt6Core.so.6:_ZN7QString6numberEdci
 libQt6Core.so.6:_ZN7QString6numberEii
@@ -176,7 +179,6 @@ libQt6Core.so.6:_ZN8QVariantC1Ej
 libQt6Core.so.6:_ZN8QVariantC1Ex
 libQt6Core.so.6:_ZN8QVariantD1Ev
 libQt6Core.so.6:_ZN8QVariantaSERKS_
-libQt6Core.so.6:_ZN9QCalendarC1Ev
 libQt6Core.so.6:_ZN9QDateTime22currentMSecsSinceEpochEv
 libQt6Core.so.6:_ZN9QDateTimeD1Ev
 libQt6Core.so.6:_ZN9QFileInfo6existsERK7QString
@@ -209,6 +211,7 @@ libQt6Core.so.6:_ZN9QtPrivate12equalStringsE11QStringView13QLatin1String
 libQt6Core.so.6:_ZN9QtPrivate12equalStringsE11QStringViewS0_
 libQt6Core.so.6:_ZN9QtPrivate14compareStringsE11QStringViewS0_N2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZN9QtPrivate15ResultStoreBase9addResultEiPKv
+libQt6Core.so.6:_ZN9QtPrivate19QStringList_indexOfERK5QListI7QStringE11QStringViewxN2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperI10QByteArrayE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperI4QMapI7QString8QVariantEE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperI4QUrlE8metaTypeE
@@ -271,15 +274,13 @@ libQt6Core.so.6:_ZNK4QUrl11toLocalFileEv
 libQt6Core.so.6:_ZNK4QUrl4pathE6QFlagsINS_25ComponentFormattingOptionEE
 libQt6Core.so.6:_ZNK4QUrl6schemeEv
 libQt6Core.so.6:_ZNK4QUrl8toStringE12QUrlTwoFlagsINS_19UrlFormattingOptionENS_25ComponentFormattingOptionEE
-libQt6Core.so.6:_ZNK5QDate8toStringE11QStringView9QCalendar
-libQt6Core.so.6:_ZNK7QLocale4nameEv
+libQt6Core.so.6:_ZNK5QDate8toStringERK7QString
+libQt6Core.so.6:_ZNK7QLocale4nameENS_12TagSeparatorE
 libQt6Core.so.6:_ZNK7QString10startsWithE5QCharN2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString10startsWithERKS_N2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString3argERKS_i5QChar
 libQt6Core.so.6:_ZNK7QString3argEdici5QChar
 libQt6Core.so.6:_ZNK7QString3argEyii5QChar
-libQt6Core.so.6:_ZNK7QString3midExx
-libQt6Core.so.6:_ZNK7QString4leftEx
 libQt6Core.so.6:_ZNK7QString5splitE5QChar6QFlagsIN2Qt18SplitBehaviorFlagsEENS2_15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString7indexOfE13QLatin1StringxN2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString8endsWithERKS_N2Qt15CaseSensitivityE
@@ -307,6 +308,7 @@ libQt6Core.so.6:_ZNK9QtPrivate15ResultStoreBase10filterModeEv
 libQt6Core.so.6:_ZNK9QtPrivate15ResultStoreBase23containsValidResultItemEi
 libQt6Core.so.6:_ZNK9QtPrivate15ResultStoreBase5countEv
 libQt6Core.so.6:_ZNK9QtPrivate15ResultStoreBase8resultAtEi
+libQt6Core.so.6:_ZNKR7QString3midExx
 libQt6Core.so.6:_ZTI10QException
 libQt6Core.so.6:_ZTI18QFutureWatcherBase
 libQt6Core.so.6:_ZTI19QAbstractTableModel
@@ -368,6 +370,7 @@ libQt6Qml.so.6:_ZN8QJSValueD1Ev
 libQt6Qml.so.6:_ZN9QJSEngine13convertStringERK7QString9QMetaTypePv
 libQt6Qml.so.6:_ZN9QJSEngine14convertManagedERK15QJSManagedValue9QMetaTypePv
 libQt6Qml.so.6:_ZN9QJSEngine14convertVariantERK8QVariant9QMetaTypePv
+libQt6Qml.so.6:_ZN9QJSEngine15createPrimitiveE9QMetaTypePKv
 libQt6Qml.so.6:_ZN9QJSEngine6createE9QMetaTypePKv
 libQt6Qml.so.6:_ZN9QJSEngine9convertV2ERK8QJSValue9QMetaTypePv
 libQt6Qml.so.6:_ZNK10QQmlEngine11rootContextEv

--- a/packages/p/pentobi/package.yml
+++ b/packages/p/pentobi/package.yml
@@ -1,8 +1,8 @@
 name       : pentobi
-version    : '25.0'
-release    : 16
+version    : '25.1'
+release    : 17
 source     :
-    - https://sourceforge.net/projects/pentobi/files/25.0/pentobi-25.0.tar.xz : 663eae6ecf2a55c527c368244c0546453964e4385059af4bbb4ab6c8cb5579c4
+    - https://sourceforge.net/projects/pentobi/files/25.1/pentobi-25.1.tar.xz : 8b0310ebc23595a6175ca8b87f4b18bc4af0d29098ca85ab344aaff4475d5287
 homepage   : https://pentobi.sourceforge.io/
 license    : GPL-3.0-or-later
 component  : games.puzzle

--- a/packages/p/pentobi/pspec_x86_64.xml
+++ b/packages/p/pentobi/pspec_x86_64.xml
@@ -45,9 +45,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2024-05-04</Date>
-            <Version>25.0</Version>
+        <Update release="17">
+            <Date>2024-10-19</Date>
+            <Version>25.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Algent Albrahimi</Name>
             <Email>algent@protonmail.com</Email>


### PR DESCRIPTION
**Summary**
- Don't ask for continuing computer move anymore if computer is to play in current position after program startup.
- Workaround for QTBUG-119198 (Disabled menu item indistinguishable from enabled one).
- Fixed formatting of written game files.
- Improved visibility of analysis graph lines in theme System.
- Minor fixes.

**Test Plan**

- Play a game.

**Checklist**

- [x] Package was built and tested against unstable
