### PR TITLE
wine: Update to 9.20

### DIFF
--- a/packages/w/wine/abi_symbols
+++ b/packages/w/wine/abi_symbols
@@ -34,6 +34,7 @@ ntdll.so:NtAlertResumeThread
 ntdll.so:NtAlertThread
 ntdll.so:NtAlertThreadByThreadId
 ntdll.so:NtAllocateLocallyUniqueId
+ntdll.so:NtAllocateReserveObject
 ntdll.so:NtAllocateUuids
 ntdll.so:NtAllocateVirtualMemory
 ntdll.so:NtAllocateVirtualMemoryEx

--- a/packages/w/wine/abi_symbols32
+++ b/packages/w/wine/abi_symbols32
@@ -23,6 +23,7 @@ ntdll.so:NtAlertResumeThread
 ntdll.so:NtAlertThread
 ntdll.so:NtAlertThreadByThreadId
 ntdll.so:NtAllocateLocallyUniqueId
+ntdll.so:NtAllocateReserveObject
 ntdll.so:NtAllocateUuids
 ntdll.so:NtAllocateVirtualMemory
 ntdll.so:NtAllocateVirtualMemoryEx

--- a/packages/w/wine/package.yml
+++ b/packages/w/wine/package.yml
@@ -1,8 +1,8 @@
 name       : wine
-version    : '9.19'
-release    : 186
+version    : '9.20'
+release    : 187
 source     :
-    - https://dl.winehq.org/wine/source/9.x/wine-9.19.tar.xz : 2c13a0c3f31f25a54d415d86785a1ad46ef8a07ae973b6b699345a45206ac015
+    - https://dl.winehq.org/wine/source/9.x/wine-9.20.tar.xz : 95f2b45b1458125be7d9fccc94ca5f8cce0a5e4ae11d0d193cfb7dddb35e7a86
 license    : LGPL-2.1-or-later
 component  : virt
 homepage   : https://www.winehq.org/

--- a/packages/w/wine/pspec_x86_64.xml
+++ b/packages/w/wine/pspec_x86_64.xml
@@ -604,6 +604,7 @@
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/slc.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/snmpapi.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/softpub.dll</Path>
+            <Path fileType="library">/usr/lib64/wine/x86_64-windows/sort.exe</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/spoolss.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/spoolsv.exe</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/sppc.dll</Path>
@@ -999,7 +1000,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="186">wine</Dependency>
+            <Dependency release="187">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/wine</Path>
@@ -1590,6 +1591,7 @@
             <Path fileType="library">/usr/lib32/wine/i386-windows/slc.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/snmpapi.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/softpub.dll</Path>
+            <Path fileType="library">/usr/lib32/wine/i386-windows/sort.exe</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/sound.drv16</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/spoolss.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/spoolsv.exe</Path>
@@ -1846,7 +1848,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="186">wine</Dependency>
+            <Dependency release="187">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wine/debug.h</Path>
@@ -2916,6 +2918,8 @@
             <Path fileType="header">/usr/include/wine/windows/windows.applicationmodel.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.data.json.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.data.json.idl</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.data.xml.dom.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.data.xml.dom.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.devices.bluetooth.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.devices.bluetooth.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.devices.enumeration.h</Path>
@@ -2997,6 +3001,8 @@
             <Path fileType="header">/usr/include/wine/windows/windows.perception.spatial.surfaces.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.security.authentication.onlineid.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.security.authentication.onlineid.idl</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.security.authorization.appcapabilityaccess.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.security.authorization.appcapabilityaccess.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.security.credentials.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.security.credentials.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.security.credentials.ui.h</Path>
@@ -3037,6 +3043,8 @@
             <Path fileType="header">/usr/include/wine/windows/windows.ui.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.ui.input.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.ui.input.idl</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.ui.notifications.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.ui.notifications.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.ui.viewmanagement.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.ui.viewmanagement.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.ui.xaml.h</Path>
@@ -3168,9 +3176,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="186">
-            <Date>2024-10-05</Date>
-            <Version>9.19</Version>
+        <Update release="187">
+            <Date>2024-10-19</Date>
+            <Version>9.20</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Highlighted changes:
- Bundled Capstone library for disassembly in WineDbg
- More formats supported in D3DX9
- More support for network sessions in DirectPlay
- Various bug fixes

Full release notes available [here](https://gitlab.winehq.org/wine/wine/-/releases/wine-9.20)

**Test Plan**
- Ran `winefile`, `winemine`, `winecfg`, `wineconsole`
- Played Age of Empires I Trial

**Checklist**

- [x] Package was built and tested against unstable
