### PR TITLE
python-orjson: Update to 3.10.9

### DIFF
--- a/packages/py/python-orjson/abi_libs
+++ b/packages/py/python-orjson/abi_libs
@@ -1,1 +1,1 @@
-orjson.cpython-311-x86_64-linux-gnu.so
+liborjson.so

--- a/packages/py/python-orjson/abi_symbols
+++ b/packages/py/python-orjson/abi_symbols
@@ -1,7 +1,7 @@
-orjson.cpython-311-x86_64-linux-gnu.so:PyInit_orjson
-orjson.cpython-311-x86_64-linux-gnu.so:dumps
-orjson.cpython-311-x86_64-linux-gnu.so:loads
-orjson.cpython-311-x86_64-linux-gnu.so:orjson_fragment_dealloc
-orjson.cpython-311-x86_64-linux-gnu.so:orjson_fragment_tp_new
-orjson.cpython-311-x86_64-linux-gnu.so:orjson_fragmenttype_new
-orjson.cpython-311-x86_64-linux-gnu.so:orjson_init_exec
+liborjson.so:PyInit_orjson
+liborjson.so:dumps
+liborjson.so:loads
+liborjson.so:orjson_fragment_dealloc
+liborjson.so:orjson_fragment_tp_new
+liborjson.so:orjson_fragmenttype_new
+liborjson.so:orjson_init_exec

--- a/packages/py/python-orjson/abi_used_symbols
+++ b/packages/py/python-orjson/abi_used_symbols
@@ -77,7 +77,6 @@ libc.so.6:mmap64
 libc.so.6:munmap
 libc.so.6:open64
 libc.so.6:posix_memalign
-libc.so.6:pthread_getspecific
 libc.so.6:pthread_key_create
 libc.so.6:pthread_key_delete
 libc.so.6:pthread_setspecific

--- a/packages/py/python-orjson/package.yml
+++ b/packages/py/python-orjson/package.yml
@@ -1,8 +1,8 @@
 name       : python-orjson
-version    : 3.10.7
-release    : 43
+version    : 3.10.9
+release    : 44
 source     :
-    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.7.tar.gz : 75ef0640403f945f3a1f9f6400686560dbfb0fb5b16589ad62cd477043c4eee3
+    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.9.tar.gz : c378074e0c46035dc66e57006993233ec66bf8487d501bab41649b4b7289ed4d
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-orjson/pspec_x86_64.xml
+++ b/packages/py/python-orjson/pspec_x86_64.xml
@@ -21,11 +21,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.7.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.7.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.7.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.7.dist-info/license_files/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.7.dist-info/license_files/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.9.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.9.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.9.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.9.dist-info/licenses/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.9.dist-info/licenses/LICENSE-MIT</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
@@ -35,9 +35,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="43">
-            <Date>2024-08-11</Date>
-            <Version>3.10.7</Version>
+        <Update release="44">
+            <Date>2024-10-19</Date>
+            <Version>3.10.9</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- `int` serialization no longer chains `OverflowError` to the the `__cause__` attribute of `orjson.JSONEncodeError` when range exceeded
- Compatibility with CPython 3.14 alpha 1
- Improve performance

**Test Plan**
- Ran some examples from the project's README
- Built and used `anki`

**Checklist**

- [x] Package was built and tested against unstable
