### PR TITLE
adw-gtk3-theme: Update to 5.5

### DIFF
--- a/packages/a/adw-gtk3-theme/package.yml
+++ b/packages/a/adw-gtk3-theme/package.yml
@@ -1,8 +1,8 @@
 name       : adw-gtk3-theme
-version    : '5.4'
-release    : 14
+version    : '5.5'
+release    : 15
 source     :
-    - https://github.com/lassekongo83/adw-gtk3/archive/refs/tags/v5.4.tar.gz : 1e3c7d6517c254ad7cc233274b1ded600db50f52c11f96d7000c098f9e9c0f9e
+    - https://github.com/lassekongo83/adw-gtk3/archive/refs/tags/v5.5.tar.gz : 02433c9ef67267776e0a4c822e28b6810063a68c1ecf2f17f0936a9c45a20b9b
 license    : LGPL-2.1-only
 homepage   : https://github.com/lassekongo83/adw-gtk3
 component  : desktop.theme

--- a/packages/a/adw-gtk3-theme/pspec_x86_64.xml
+++ b/packages/a/adw-gtk3-theme/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>adw-gtk3-theme</Name>
         <Homepage>https://github.com/lassekongo83/adw-gtk3</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-only</License>
         <PartOf>desktop.theme</PartOf>
@@ -145,12 +145,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2024-09-27</Date>
-            <Version>5.4</Version>
+        <Update release="15">
+            <Date>2024-10-20</Date>
+            <Version>5.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fix black selection in GTK4 apps

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Switch to the theme on Budgie Desktop.

**Checklist**

- [x] Package was built and tested against unstable
