### PR TITLE
juliaup: Update to 1.17.9

### DIFF
--- a/packages/j/juliaup/abi_used_symbols
+++ b/packages/j/juliaup/abi_used_symbols
@@ -1,4 +1,3 @@
-libc.so.6:__environ
 libc.so.6:__errno_location
 libc.so.6:__libc_start_main
 libc.so.6:__res_init
@@ -15,11 +14,11 @@ libc.so.6:clock_gettime
 libc.so.6:close
 libc.so.6:closedir
 libc.so.6:connect
+libc.so.6:dirfd
 libc.so.6:dl_iterate_phdr
 libc.so.6:dlsym
 libc.so.6:dup2
 libc.so.6:environ
-libc.so.6:epoll_create
 libc.so.6:epoll_create1
 libc.so.6:epoll_ctl
 libc.so.6:epoll_wait
@@ -40,9 +39,11 @@ libc.so.6:ftruncate64
 libc.so.6:futimes
 libc.so.6:gai_strerror
 libc.so.6:getaddrinfo
+libc.so.6:getauxval
 libc.so.6:getcwd
 libc.so.6:getenv
 libc.so.6:getpeername
+libc.so.6:getpid
 libc.so.6:getpwuid_r
 libc.so.6:getsockname
 libc.so.6:getsockopt
@@ -53,15 +54,12 @@ libc.so.6:isatty
 libc.so.6:lchown
 libc.so.6:linkat
 libc.so.6:lseek64
-libc.so.6:lsetxattr
 libc.so.6:lstat64
 libc.so.6:lutimes
 libc.so.6:malloc
-libc.so.6:memchr
 libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
-libc.so.6:memrchr
 libc.so.6:memset
 libc.so.6:mkdir
 libc.so.6:mmap64
@@ -71,6 +69,7 @@ libc.so.6:open
 libc.so.6:open64
 libc.so.6:openat64
 libc.so.6:opendir
+libc.so.6:pause
 libc.so.6:pipe2
 libc.so.6:poll
 libc.so.6:posix_memalign
@@ -91,7 +90,6 @@ libc.so.6:pthread_attr_setstacksize
 libc.so.6:pthread_create
 libc.so.6:pthread_detach
 libc.so.6:pthread_getattr_np
-libc.so.6:pthread_getspecific
 libc.so.6:pthread_join
 libc.so.6:pthread_key_create
 libc.so.6:pthread_key_delete
@@ -100,16 +98,17 @@ libc.so.6:pthread_mutex_unlock
 libc.so.6:pthread_self
 libc.so.6:pthread_setname_np
 libc.so.6:pthread_setspecific
-libc.so.6:raise
 libc.so.6:read
 libc.so.6:readdir64
 libc.so.6:readlink
-libc.so.6:readv
 libc.so.6:realloc
 libc.so.6:realpath
 libc.so.6:recv
+libc.so.6:recvmsg
+libc.so.6:rename
 libc.so.6:sched_yield
 libc.so.6:send
+libc.so.6:sendmsg
 libc.so.6:setgid
 libc.so.6:setgroups
 libc.so.6:setpgid
@@ -122,6 +121,7 @@ libc.so.6:sigaltstack
 libc.so.6:sigemptyset
 libc.so.6:signal
 libc.so.6:socket
+libc.so.6:socketpair
 libc.so.6:stat64
 libc.so.6:strlen
 libc.so.6:symlink
@@ -130,6 +130,7 @@ libc.so.6:sysconf
 libc.so.6:unlink
 libc.so.6:unlinkat
 libc.so.6:utimensat
+libc.so.6:waitid
 libc.so.6:waitpid
 libc.so.6:write
 libc.so.6:writev

--- a/packages/j/juliaup/package.yml
+++ b/packages/j/juliaup/package.yml
@@ -1,12 +1,12 @@
 name       : juliaup
-version    : 1.11.22
-release    : 1
+version    : 1.17.9
+release    : 2
 source     :
-    - https://github.com/JuliaLang/juliaup/archive/refs/tags/v1.11.22.tar.gz : 8a0b4540262a8bea9e61a4f287ced32ec4ad2ac4cb528a1b473eea6f139256df
+    - https://github.com/JuliaLang/juliaup/archive/refs/tags/v1.17.9.tar.gz : 3072a404573e0e64a7d586f32ac1ba5fcbacd142e2050f7a3b452d1697181f4f
 homepage   : https://github.com/JuliaLang/juliaup
 license    : MIT
 component  : programming.tools
-summary    : Julia installer and version multiplexer 
+summary    : Julia installer and version multiplexer
 description: |
     A cross-platform installer for the Julia programming language.
 replaces   : julia
@@ -14,13 +14,9 @@ networking : yes
 builddeps  :
     - rust
 setup      : |
-    # It seems like the `built` crate is having trouble fetching system
-    # information inside solbuild's container environment
-    sed -i 's|built::write_built_file().expect("Failed to acquire build-time information");||' build.rs
-    sed -i 's|include!(concat!(env!("OUT_DIR"), "/built.rs"))|pub const PKG_VERSION: \&str = "%version%"|' src/lib.rs
-    cargo fetch --locked
+    %cargo_fetch
 build      : |
-    cargo build --frozen %JOBS% --release --bin juliaup --bin julialauncher --features binjulialauncher
+    %cargo_build --bin juliaup --bin julialauncher --features binjulialauncher
 install    : |
-    install -Dm00755 target/release/{juliaup,julialauncher} -t $installdir/usr/bin
+    %cargo_install juliaup julialauncher
     ln -s /usr/bin/julialauncher $installdir/usr/bin/julia

--- a/packages/j/juliaup/pspec_x86_64.xml
+++ b/packages/j/juliaup/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>juliaup</Name>
         <Homepage>https://github.com/JuliaLang/juliaup</Homepage>
         <Packager>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.tools</PartOf>
         <Summary xml:lang="en">Julia installer and version multiplexer</Summary>
         <Description xml:lang="en">A cross-platform installer for the Julia programming language.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>juliaup</Name>
@@ -29,12 +29,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2023-09-23</Date>
-            <Version>1.11.22</Version>
+        <Update release="2">
+            <Date>2024-10-21</Date>
+            <Version>1.17.9</Version>
             <Comment>Packaging update</Comment>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Updated juliaup to 1.17.9
- Release notes can be found [here](https://github.com/JuliaLang/juliaup/releases/tag/v1.17.9)
- Part of getsolus/packages#3111

**Test Plan**

installed julia

**Checklist**

- [x] Package was built and tested against unstable
