### PR TITLE
yt-dlp: Update to 2024.10.22

### DIFF
--- a/packages/y/yt-dlp/package.yml
+++ b/packages/y/yt-dlp/package.yml
@@ -1,8 +1,8 @@
 name       : yt-dlp
-version    : 2024.10.07
-release    : 227
+version    : 2024.10.22
+release    : 228
 source     :
-    - https://github.com/yt-dlp/yt-dlp/archive/refs/tags/2024.10.07.tar.gz : 63cdc90d40e3bb8b1d3d2afcdad9d4ede16a13492a07fc9adc83d887127f40a1
+    - https://github.com/yt-dlp/yt-dlp/archive/refs/tags/2024.10.22.tar.gz : 720f63c96974489664f3011ef4afd71af3ead06e5d3ed36bd217cf368aa4c259
 license    : Unlicense
 component  : network.download
 homepage   : https://github.com/yt-dlp/yt-dlp
@@ -24,6 +24,8 @@ rundeps    :
     - python-websockets
     - python3
     - python3-pycryptodome
+setup      : |
+    sed -i "/Programming Language :: Python :: 3.13/d" pyproject.toml
 build      : |
     %make PREFIX=$installdir/usr yt-dlp.1 completion-bash completion-fish completion-zsh
     python3 -m build --wheel --no-isolation

--- a/packages/y/yt-dlp/pspec_x86_64.xml
+++ b/packages/y/yt-dlp/pspec_x86_64.xml
@@ -23,11 +23,11 @@
             <Path fileType="executable">/usr/bin/youtube-dl</Path>
             <Path fileType="executable">/usr/bin/yt-dlc</Path>
             <Path fileType="executable">/usr/bin/yt-dlp</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/yt_dlp-2024.10.7.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/yt_dlp-2024.10.7.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/yt_dlp-2024.10.7.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/yt_dlp-2024.10.7.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/yt_dlp-2024.10.7.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/yt_dlp-2024.10.22.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/yt_dlp-2024.10.22.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/yt_dlp-2024.10.22.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/yt_dlp-2024.10.22.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/yt_dlp-2024.10.22.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/yt_dlp/YoutubeDL.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/yt_dlp/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/yt_dlp/__main__.py</Path>
@@ -3279,9 +3279,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="227">
-            <Date>2024-10-14</Date>
-            <Version>2024.10.07</Version>
+        <Update release="228">
+            <Date>2024-10-22</Date>
+            <Version>2024.10.22</Version>
             <Comment>Packaging update</Comment>
             <Name>Troy Harvey</Name>
             <Email>harveydevel@gmail.com</Email>


### PR DESCRIPTION
**Summary**
- Updated yt-dlp to 2024.10.22
- Changelog available [here](https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/Changelog.md)

**Test Plan**

Download an watch a video.

**Checklist**

- [X] Package was built and tested against unstable
