### PR TITLE
ripgrep: Switch to `%cargo_test` macro

### DIFF
--- a/packages/r/ripgrep/abi_used_symbols
+++ b/packages/r/ripgrep/abi_used_symbols
@@ -44,6 +44,7 @@ libc.so.6:munmap
 libc.so.6:nanosleep
 libc.so.6:open64
 libc.so.6:opendir
+libc.so.6:pause
 libc.so.6:pipe2
 libc.so.6:poll
 libc.so.6:posix_memalign
@@ -64,7 +65,6 @@ libc.so.6:pthread_attr_setstacksize
 libc.so.6:pthread_create
 libc.so.6:pthread_detach
 libc.so.6:pthread_getattr_np
-libc.so.6:pthread_getspecific
 libc.so.6:pthread_join
 libc.so.6:pthread_key_create
 libc.so.6:pthread_key_delete

--- a/packages/r/ripgrep/package.yml
+++ b/packages/r/ripgrep/package.yml
@@ -1,6 +1,6 @@
 name       : ripgrep
 version    : 14.1.0
-release    : 16
+release    : 17
 source     :
     - https://github.com/BurntSushi/ripgrep/archive/refs/tags/14.1.0.tar.gz : 33c6169596a6bbfdc81415910008f26e0809422fda2d849562637996553b2ab6
 homepage   : https://github.com/BurntSushi/ripgrep
@@ -35,4 +35,4 @@ install    : |
     install -dm00644 $installdir/usr/share/man/man1/
     target/release/rg --generate man > $installdir/usr/share/man/man1/rg.1
 check      : |
-    cargo test --all
+    %cargo_test --all

--- a/packages/r/ripgrep/pspec_x86_64.xml
+++ b/packages/r/ripgrep/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ripgrep</Name>
         <Homepage>https://github.com/BurntSushi/ripgrep</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.tools</PartOf>
@@ -28,12 +28,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2024-07-14</Date>
+        <Update release="17">
+            <Date>2024-10-22</Date>
             <Version>14.1.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Use the new `%cargo_test` macro for `ripgrep`

**Test Plan**

Successfully built package with tests enabled

**Checklist**

- [x] Package was built and tested against unstable
