### PR TITLE
usysconf-epoch: Only skip if properly merged

### DIFF
--- a/packages/u/usysconf-epoch/package.yml
+++ b/packages/u/usysconf-epoch/package.yml
@@ -1,6 +1,6 @@
 name       : usysconf-epoch
-version    : 0.0.1
-release    : 16
+version    : 1.0.0
+release    : 17
 source     :
     # We need something for a source
     - https://getsol.us/sources/hotspot.txt : a12b7cb43c9d9134b5bb1b35e9096b66775d9e92e7611d1cc92b02edd6782a87

--- a/packages/u/usysconf-epoch/pspec_x86_64.xml
+++ b/packages/u/usysconf-epoch/pspec_x86_64.xml
@@ -26,9 +26,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2024-09-29</Date>
-            <Version>0.0.1</Version>
+        <Update release="17">
+            <Date>2024-10-22</Date>
+            <Version>1.0.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Silke Hofstra</Name>
             <Email>silke@slxh.eu</Email>


### PR DESCRIPTION
**Summary**

Instead of skipping the usr-merge when it was performed (once), do it when it is needed. This means that anything that causes the system to not be merged (like reinstalling baselayout) is recovered from on the next boot.

Resolves #4118

**Test Plan**

```console
$ sudo /usr/lib64/usysconf/usr-merge.sh
Skipping usr-merge: already done!
$ sudo eopkg.bin it --reinstall baselayout
<snip>
$ ls -l /bin /sbin /lib64 /lib32 /lib
lrwxrwxrwx 1 root root 7 Oct 22 12:10 /bin -> usr/bin
lrwxrwxrwx 1 root root 5 Oct 22 12:24 /lib -> lib64
lrwxrwxrwx 1 root root 9 Oct 22 12:10 /lib32 -> usr/lib32
lrwxrwxrwx 1 root root 8 Oct 22 12:10 /sbin -> usr/sbin

/lib64:
total 0
$ sudo /usr/lib64/usysconf/usr-merge.sh
Starting merge:
[/bin]: is a symlink to usr/bin
[/bin]: is the correct symlink
[/sbin]: is a symlink to usr/sbin
[/sbin]: is the correct symlink
[/lib64]: not a symlink
[/lib64]: ready for merge
[/lib64]: usr-merging to usr/lib64
[/lib64]: merged
[/lib32]: is a symlink to usr/lib32
[/lib32]: is the correct symlink
[/lib]: is a symlink to lib64
[/lib]: needs to be changed
[/lib]: ready for merge
[/lib]: usr-merging to usr/lib
[/lib]: merged
Result:
lrwxrwxrwx 1 root root 7 22 okt 12:10 /bin -> usr/bin
lrwxrwxrwx 1 root root 7 22 okt 12:23 /lib -> usr/lib
lrwxrwxrwx 1 root root 9 22 okt 12:10 /lib32 -> usr/lib32
lrwxrwxrwx 1 root root 9 22 okt 12:23 /lib64 -> usr/lib64
lrwxrwxrwx 1 root root 8 22 okt 12:10 /sbin -> usr/sbin
$ sudo /usr/lib64/usysconf/usr-merge.sh
Skipping usr-merge: already done!
$ sudo rm /bin /sbin /lib64 /lib32 /lib
$ sudo /usr/lib64/usysconf/usr-merge.sh
Starting merge:
[/bin]: not a symlink
[/bin]: linking to usr/bin
[/sbin]: not a symlink
[/sbin]: linking to usr/sbin
[/lib64]: not a symlink
[/lib64]: linking to usr/lib64
[/lib32]: not a symlink
[/lib32]: linking to usr/lib32
[/lib]: not a symlink
[/lib]: linking to usr/lib
Result:
lrwxrwxrwx 1 root root 7 22 okt 12:27 /bin -> usr/bin
lrwxrwxrwx 1 root root 7 22 okt 12:27 /lib -> usr/lib
lrwxrwxrwx 1 root root 9 22 okt 12:27 /lib32 -> usr/lib32
lrwxrwxrwx 1 root root 9 22 okt 12:27 /lib64 -> usr/lib64
lrwxrwxrwx 1 root root 8 22 okt 12:27 /sbin -> usr/sbin
```

**Checklist**

- [x] Package was built and tested against unstable
