### PR TITLE
baselayout: Make compatible with usr merged systems

### DIFF
--- a/packages/b/baselayout/package.yml
+++ b/packages/b/baselayout/package.yml
@@ -1,6 +1,6 @@
 name       : baselayout
 version    : 1.9.0
-release    : 81
+release    : 82
 source     :
     - https://github.com/getsolus/baselayout/releases/download/v1.9.0/baselayout-1.9.0.tar.gz : a2a3e4fdb6349b479a16d9ffcf2335fb0f4d75d2cdd1cdbb80cb6c02652f37de
 homepage   : https://github.com/getsolus/baselayout
@@ -13,7 +13,6 @@ description: |
 install    : |
     # Create our baselayout filesystem
     install -dm00755 %installroot%/usr
-    install -dm00755 %installroot%/lib64
     install -dm00755 %installroot%/usr/lib64
     install -dm00755 %installroot%/usr/bin
     install -dm00755 %installroot%/usr/sbin
@@ -32,7 +31,6 @@ install    : |
     install -dm01777 %installroot%/var/tmp
 
     # Setup symlinks
-    ln -sv lib64 %installroot%/lib
     ln -sv lib64 %installroot%/usr/lib
 
     ln -sv ../run %installroot%/var/run
@@ -40,8 +38,14 @@ install    : |
 
     ln -sv /proc/self/mounts %installroot%/etc/mtab
 
-    ln -srv %installroot%/usr/bin %installroot%/bin
-    ln -srv %installroot%/usr/sbin %installroot%/sbin
+    # /usr merge symlinks
+    # These need to be compatible with usysconf-epoch,
+    # test by running `/usr/lib64/usysconf/usr-merge.sh`
+    ln -sv usr/bin   %installroot%/bin
+    ln -sv usr/sbin  %installroot%/sbin
+    ln -sv usr/lib   %installroot%/lib
+    ln -sv usr/lib32 %installroot%/lib32
+    ln -sv usr/lib64 %installroot%/lib64
 
     # Install our files
     cp -a $workdir/* $installdir/
@@ -69,7 +73,6 @@ permanent  :
     - /tmp
     - /etc
     - /dev/
-    - /lib*
     - /proc
     - /sys
     - /run/lock

--- a/packages/b/baselayout/pspec_x86_64.xml
+++ b/packages/b/baselayout/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>baselayout</Name>
         <Homepage>https://github.com/getsolus/baselayout</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -37,6 +37,7 @@
             <Path fileType="config">/etc/solus-release</Path>
             <Path fileType="data">/home</Path>
             <Path fileType="data">/lib</Path>
+            <Path fileType="data">/lib32</Path>
             <Path fileType="data">/lib64</Path>
             <Path fileType="data">/media</Path>
             <Path fileType="data">/proc</Path>
@@ -70,12 +71,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="81">
-            <Date>2024-05-13</Date>
+        <Update release="82">
+            <Date>2024-10-22</Date>
             <Version>1.9.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Update baselayout to be fully compatible with usr merged systems. This makes it safe to install on merged systems, but dangerous to install on non-merged systems.

⚠️ Do not publish this PR after merging, it will break upgrades from non-merged systems! ⚠️

**Test Plan**

```console
$ sudo eopkg.bin it baselayout-1.9.0-82-1-x86_64.eopkg
<snip>
$ sudo /usr/lib64/usysconf/usr-merge.sh
Skipping usr-merge: already done!
$ ls -l /bin /sbin /lib64 /lib32 /lib
lrwxrwxrwx 1 root root 7 22 okt 12:58 /bin -> usr/bin/
lrwxrwxrwx 1 root root 7 22 okt 12:58 /lib -> usr/lib/
lrwxrwxrwx 1 root root 9 22 okt 12:58 /lib32 -> usr/lib32/
lrwxrwxrwx 1 root root 9 22 okt 12:58 /lib64 -> usr/lib64/
lrwxrwxrwx 1 root root 8 22 okt 12:58 /sbin -> usr/sbin/
```

**Checklist**

- [x] Package was built and tested against unstable
