### PR TITLE
budgie-control-center: 2nd rebuild for samba-4.19.8

### DIFF
--- a/packages/b/budgie-control-center/files/fix-FTBFS-with-incompatible-pointer-types.patch
+++ b/packages/b/budgie-control-center/files/fix-FTBFS-with-incompatible-pointer-types.patch
@@ -1,0 +1,65 @@
+From 5d486ad2af74a6b5f643819f1000cb8388eba43d Mon Sep 17 00:00:00 2001
+From: Joshua Strobl <me@joshuastrobl.com>
+Date: Sat, 16 Mar 2024 16:44:46 +0200
+Subject: [PATCH] fix: FTBFS with incompatible-pointer-types
+
+---
+ meson.build                          | 3 ++-
+ panels/display/cc-display-panel.c    | 2 +-
+ panels/display/cc-display-settings.c | 2 +-
+ panels/sound/cc-sound-panel.c        | 2 +-
+ 4 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index d0744aa891..c8dde2c2ba 100644
+--- a/meson.build
++++ b/meson.build
+@@ -77,7 +77,8 @@ if get_option('buildtype').contains('debug')
+     '-Wmissing-prototypes',
+     '-Wnested-externs',
+     '-Wno-strict-aliasing',
+-    '-Wno-sign-compare'
++    '-Wno-sign-compare',
++    '-Wno-incompatible-pointer-types'
+   ]
+ 
+   common_flags += cc.get_supported_arguments(test_cflags)
+diff --git a/panels/display/cc-display-panel.c b/panels/display/cc-display-panel.c
+index 07ac4f291b..61a6dab84f 100644
+--- a/panels/display/cc-display-panel.c
++++ b/panels/display/cc-display-panel.c
+@@ -959,7 +959,7 @@ set_current_output (CcDisplayPanel   *panel,
+       if (cc_has_fractional_key())
+         {
+           lockdown=cc_display_config_get_fractional_scaling (panel->current_config);
+-          gtk_widget_set_sensitive(panel->automatic_screen_lock_switch, !lockdown);
++          gtk_widget_set_sensitive(GTK_WIDGET (panel->automatic_screen_lock_switch), !lockdown);
+         }
+     }
+ 
+diff --git a/panels/display/cc-display-settings.c b/panels/display/cc-display-settings.c
+index 406e7fe7ca..0cf1369b4b 100644
+--- a/panels/display/cc-display-settings.c
++++ b/panels/display/cc-display-settings.c
+@@ -450,7 +450,7 @@ cc_display_settings_rebuild_ui (CcDisplaySettings *self)
+                          cc_display_config_get_fractional_scaling (self->config));
+ 
+   gtk_switch_set_active (GTK_SWITCH (self->scale_fractional_switch), cc_display_config_get_fractional_scaling (self->config));
+-  gtk_widget_set_visible(self->scale_fractional_row, cc_has_fractional_key());
++  gtk_widget_set_visible(GTK_WIDGET (self->scale_fractional_row), cc_has_fractional_key());
+ 
+   gtk_widget_set_visible (self->underscanning_row,
+                           cc_display_monitor_supports_underscanning (self->selected_output) &&
+diff --git a/panels/sound/cc-sound-panel.c b/panels/sound/cc-sound-panel.c
+index c447bbf9a1..75291d5472 100644
+--- a/panels/sound/cc-sound-panel.c
++++ b/panels/sound/cc-sound-panel.c
+@@ -300,7 +300,7 @@ cc_sound_panel_init (CcSoundPanel *self)
+                            G_CONNECT_SWAPPED);
+   allow_amplified_changed_cb (self);
+ 
+-  gtk_widget_set_visible(self->budgie_output_listbox, TRUE);
++  gtk_widget_set_visible(GTK_WIDGET (self->budgie_output_listbox), TRUE);
+   gtk_widget_set_visible(GTK_WIDGET (self->output_volume_slider), FALSE);
+   g_settings_bind (self->sound_settings, "allow-volume-overdrive",
+                     self->allow_amplify_switch, "active", G_SETTINGS_BIND_DEFAULT);

--- a/packages/b/budgie-control-center/package.yml
+++ b/packages/b/budgie-control-center/package.yml
@@ -1,6 +1,6 @@
 name       : budgie-control-center
 version    : 1.4.0
-release    : 25
+release    : 26
 source     :
     - https://github.com/BuddiesOfBudgie/budgie-control-center/releases/download/v1.4.0/budgie-control-center-1.4.0.tar.xz : 120d760b6c1190e937cc7f3b3c50227682960123ff0bccfe3ff4902785550d82
 homepage   : https://buddiesofbudgie.org

--- a/packages/b/budgie-control-center/pspec_x86_64.xml
+++ b/packages/b/budgie-control-center/pspec_x86_64.xml
@@ -315,7 +315,7 @@
         </Files>
     </Package>
     <History>
-        <Update release="25">
+        <Update release="26">
             <Date>2024-10-23</Date>
             <Version>1.4.0</Version>
             <Comment>Packaging update</Comment>


### PR DESCRIPTION
**Summary**

_Actually_ add a patch from upstream, which fixes a FTBFS issue.

Fixes https://github.com/getsolus/packages/issues/4136

**Test Plan**

Check that budgie-control-center still builds and that the newly added patch file is part of the changeset.

**Checklist**

- [x] Package was built and tested against unstable
