### PR TITLE
sof-firmware: update to 2.11.1

### DIFF
--- a/packages/s/sof-firmware/package.yml
+++ b/packages/s/sof-firmware/package.yml
@@ -1,9 +1,9 @@
 name       : sof-firmware
 homepage   : https://github.com/thesofproject/sof-bin
-version    : '2.10'
-release    : 22
+version    : '2.11'
+release    : 23
 source     :
-    - https://github.com/thesofproject/sof-bin/releases/download/v2024.06/sof-bin-2024.06.tar.gz : 581ca3285bb56837a8954953f629ebddce644152b673ecd4bbfae1504306d7d6
+    - https://github.com/thesofproject/sof-bin/releases/download/v2024.09/sof-bin-2024.09.tar.gz : ea47d99f81359008d07618bca103cf78f82d84e940bfe941a28afe07c8cbc620
 license    :
     - BSD-3-Clause
     - ISC

--- a/packages/s/sof-firmware/pspec_x86_64.xml
+++ b/packages/s/sof-firmware/pspec_x86_64.xml
@@ -22,19 +22,39 @@
         <PartOf>kernel</PartOf>
         <Files>
             <Path fileType="data">/lib64/firmware/intel/sof-ace-tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-lib/lnl/B36EE4DA-006F-47F9-A06D-FECBE2D8B6CE.bin</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-lib/lnl/community/B36EE4DA-006F-47F9-A06D-FECBE2D8B6CE.bin</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-lib/lnl/community/drc.llext</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-lib/lnl/intel-signed/B36EE4DA-006F-47F9-A06D-FECBE2D8B6CE.bin</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-lib/lnl/intel-signed/drc.llext</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-adl-cs42l43-l0-cs35l56-l23.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-adl-rt711-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-adl-rt711-l0-rt1308-l12-rt715-l3.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-adl-rt711-l0-rt1316-l12-rt714-l3.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-adl-rt711-l0-rt1316-l13-rt714-l2.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-arl-cs42l43-l0-cs35l56-l2.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-arl-cs42l43-l0-cs35l56-l23.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-arl-cs42l43-l0.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-arl-cs42l43-l2-cs35l56-l3.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-arl-cs42l43-l2.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-2ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace1-2ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace1-4ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace1-idisp-2ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace1-idisp-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-cavs25-2ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-cavs25-4ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-cavs25-idisp-2ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-cavs25-idisp-4ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-idisp-2ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-idisp-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-idisp.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-imx8mp-wm8960.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l23.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l3.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt1318-l12-rt714-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt711-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt711-l0-rt1316-l23-rt714-l1.tplg</Path>
@@ -42,6 +62,7 @@
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt722-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0-cs35l56-l12.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0-cs35l56-l23.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-es83x6-ssp1-hdmi-ssp02.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-hdmi-ssp02.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-max98357a-rt5682-google-aec.tplg</Path>
@@ -60,6 +81,8 @@
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt711-l0-rt1316-l3-2ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt711-l0-rt1316-l3-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt711-l0-rt1316-l3.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt712-l0-2ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt712-l0-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt712-l0-rt1712-l3.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt712-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt712-vb-l0.tplg</Path>
@@ -69,6 +92,8 @@
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt713-l0-rt1318-l12-rt1713-l3.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt722-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-sdw-cs42l42-l0-max98363-l2.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-ptl-rt722.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-rpl-cs42l43-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-tgl-cs42l43-l3-cs35l56-l01.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-tgl-rt711-rt1308-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-tgl-rt711-rt1308-rt715.tplg</Path>
@@ -276,6 +301,7 @@
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-hda-generic-2ch-pdm1.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-hda-generic-2ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-hda-generic-3ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-hda-generic-4ch-bt.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-hda-generic-4ch-kwd.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-hda-generic-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-hda-generic-idisp-2ch.tplg</Path>
@@ -333,6 +359,7 @@
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-jsl-es8336-ssp1.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-jsl-es8336-ssp2.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-jsl-nocodec.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-jsl-rt5650.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-jsl-rt5682-mx98360a.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-jsl-rt5682-rt1015-xperi.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-jsl-rt5682-rt1015.tplg</Path>
@@ -464,19 +491,39 @@
             <Path fileType="data">/lib64/firmware/intel/sof/sof-tgl.ldc</Path>
             <Path fileType="data">/lib64/firmware/intel/sof/sof-tgl.ri</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ace-tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-lib/lnl/B36EE4DA-006F-47F9-A06D-FECBE2D8B6CE.bin</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-lib/lnl/community/B36EE4DA-006F-47F9-A06D-FECBE2D8B6CE.bin</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-lib/lnl/community/drc.llext</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-lib/lnl/intel-signed/B36EE4DA-006F-47F9-A06D-FECBE2D8B6CE.bin</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-lib/lnl/intel-signed/drc.llext</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-adl-cs42l43-l0-cs35l56-l23.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-adl-rt711-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-adl-rt711-l0-rt1308-l12-rt715-l3.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-adl-rt711-l0-rt1316-l12-rt714-l3.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-adl-rt711-l0-rt1316-l13-rt714-l2.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-arl-cs42l43-l0-cs35l56-l2.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-arl-cs42l43-l0-cs35l56-l23.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-arl-cs42l43-l0.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-arl-cs42l43-l2-cs35l56-l3.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-arl-cs42l43-l2.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-2ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace1-2ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace1-4ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace1-idisp-2ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace1-idisp-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-cavs25-2ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-cavs25-4ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-cavs25-idisp-2ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-cavs25-idisp-4ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-idisp-2ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-idisp-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-idisp.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-imx8mp-wm8960.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l23.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l3.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt1318-l12-rt714-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt711-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt711-l0-rt1316-l23-rt714-l1.tplg</Path>
@@ -484,6 +531,7 @@
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt722-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0-cs35l56-l12.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0-cs35l56-l23.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-es83x6-ssp1-hdmi-ssp02.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-hdmi-ssp02.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-max98357a-rt5682-google-aec.tplg</Path>
@@ -502,6 +550,8 @@
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt711-l0-rt1316-l3-2ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt711-l0-rt1316-l3-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt711-l0-rt1316-l3.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt712-l0-2ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt712-l0-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt712-l0-rt1712-l3.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt712-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt712-vb-l0.tplg</Path>
@@ -511,6 +561,8 @@
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt713-l0-rt1318-l12-rt1713-l3.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt722-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-sdw-cs42l42-l0-max98363-l2.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-ptl-rt722.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-rpl-cs42l43-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-tgl-cs42l43-l3-cs35l56-l01.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-tgl-rt711-rt1308-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-tgl-rt711-rt1308-rt715.tplg</Path>
@@ -718,6 +770,7 @@
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-hda-generic-2ch-pdm1.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-hda-generic-2ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-hda-generic-3ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-hda-generic-4ch-bt.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-hda-generic-4ch-kwd.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-hda-generic-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-hda-generic-idisp-2ch.tplg</Path>
@@ -775,6 +828,7 @@
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-jsl-es8336-ssp1.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-jsl-es8336-ssp2.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-jsl-nocodec.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-jsl-rt5650.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-jsl-rt5682-mx98360a.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-jsl-rt5682-rt1015-xperi.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-jsl-rt5682-rt1015.tplg</Path>
@@ -909,9 +963,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2024-07-26</Date>
-            <Version>2.10</Version>
+        <Update release="23">
+            <Date>2024-10-24</Date>
+            <Version>2.11</Version>
             <Comment>Packaging update</Comment>
             <Name>Tracey Clark</Name>
             <Email>traceyc.dev@tlcnet.info</Email>


### PR DESCRIPTION
**Summary**

### New DSP topologies added

For v2.11 series (Meteor Lake and newer), the following new topology files have been added since v2.10:

v2.11.x/sof-ipc4-tplg-v2.11  
├── sof-adl-cs42l43-l0-cs35l56-l23.tplg  
├── sof-arl-cs42l43-l0-cs35l56-l23.tplg  
├── sof-arl-cs42l43-l0-cs35l56-l2.tplg  
├── sof-arl-cs42l43-l0.tplg  
├── sof-arl-cs42l43-l2-cs35l56-l3.tplg  
├── sof-arl-cs42l43-l2.tplg  
├── sof-hda-generic-ace1-idisp-2ch.tplg  
├── sof-hda-generic-ace1-idisp-4ch.tplg  
├── sof-hda-generic-cavs25-idisp-2ch.tplg  
├── sof-hda-generic-cavs25-idisp-4ch.tplg  
├── sof-hda-generic-idisp-2ch.tplg  
├── sof-hda-generic-idisp-4ch.tplg  
├── sof-lnl-cs42l43-l0-cs35l56-l23.tplg  
├── sof-lnl-cs42l43-l0-cs35l56-l3.tplg  
├── sof-lnl-cs42l43-l0.tplg  
├── sof-mtl-cs42l43-l0.tplg  
├── sof-mtl-rt712-l0-2ch.tplg  
├── sof-mtl-rt712-l0-4ch.tplg  
├── sof-ptl-rt722.tplg  
├── sof-rpl-cs42l43-l0.tplg

Full release notes [here](https://github.com/thesofproject/sof-bin/releases)

**Test Plan**

Verified firmware files were installed to correct paths.
Restarted pipewire.
    systemctl --user restart pipewire.service
Listened to music and triggered system sounds to verify that sound still works.

**Checklist**

- [x] Package was built and tested against unstable