### PR TITLE
ci/package_checks: Add check for monitoring.yml

### DIFF
--- a/common/CI/package_checks.py
+++ b/common/CI/package_checks.py
@@ -301,6 +301,9 @@ class PullRequestCheck:
         with self._open(path) as f:
             return str(f.read())
 
+    def _exists(self, path: str) -> bool:
+        return os.path.exists(self._path(path))
+
     def load_package_yml(self, file: str) -> PackageYML:
         with self._open(file) as f:
             return PackageYML(f)
@@ -415,6 +418,19 @@ class Homepage(PullRequestCheck):
             yaml = YAML(typ='safe', pure=True)
             yaml.default_flow_style = False
             return 'homepage' in yaml.load(f)
+
+
+class Monitoring(PullRequestCheck):
+    _error = '`monitoring.yml` is missing'
+    _level = Level.WARNING
+
+    def run(self) -> List[Result]:
+        return [Result(message=self._error, file=f, level=self._level)
+                for f in self.package_files
+                if not self._has_monitoring_yml(f)]
+
+    def _has_monitoring_yml(self, file: str) -> bool:
+        return self._exists(os.path.join(os.path.dirname(file), 'monitoring.yml'))
 
 
 class PackageBumped(PullRequestCheck):
@@ -782,6 +798,7 @@ class Checker:
         CommitMessage,
         FrozenPackage,
         Homepage,
+        Monitoring,
         PackageBumped,
         PackageDependenciesOrder,
         PackageDirectory,


### PR DESCRIPTION
**Summary**

Add a check that errors when `monitoring.yml` does not exist. This makes the existence of `monitoring.yml` mandatory for all packages.

Related to https://github.com/getsolus/packages/issues/4121

**Test Plan**

Run manually against a known bad package:

```console
$ common/CI/package_checks.py packages/g/glog/package.yml 
Checking files: packages/g/glog/package.yml
Found 4 result(s), 1 warnings and 2 error(s)
INF packages/g/glog/package.yml:1: This package is included in the ISO. Consider validating the functionality in a newly built ISO.
ERR packages/g/glog/package.yml:1: `homepage` is not set
ERR packages/g/glog/package.yml:1: `monitoring.yml` is missing
WRN packages/g/glog/package.yml:1: Package release is not incremented by 1
```

Run manually against a known good package:

```console
$ common/CI/package_checks.py packages/l/linux-current/package.yml 
Checking files: packages/l/linux-current/package.yml
Found 2 result(s), 1 warnings and 0 error(s)
INF packages/l/linux-current/package.yml:1: This package is included in the ISO. Consider validating the functionality in a newly built ISO.
WRN packages/l/linux-current/package.yml:1: Package release is not incremented by 1
```

**Checklist**

- [x] Package was built and tested against unstable
