### PR TITLE
github-cli: Update to v2.60.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.59.0
-release    : 57
+version    : 2.60.0
+release    : 58
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.59.0.tar.gz : d24ed01e5aa1e8f42b397333462f9cd5c54e4845a5142044381fc8eb713fa001
+    - https://github.com/cli/cli/archive/refs/tags/v2.60.0.tar.gz : 1936a80a668caef437b2f409eaa10e48613a3502db7da9eea011b163769218a7
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -225,9 +225,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="57">
-            <Date>2024-10-17</Date>
-            <Version>2.59.0</Version>
+        <Update release="58">
+            <Date>2024-10-24</Date>
+            <Version>2.60.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Add ArchivedAt field
- Include startedAt, completedAt in run steps data
- Adjust environment help for host and tokens
- Add handling of empty titles for Issues and PRs
- `LiveSigstoreVerifier.Verify` should error if no attestations are present
- `gh at verify` retries fetching attestations if it receives a 5xx
- Prevent local extension installations with invalid names and conflicts with core commands and other extensions
- Use new GitHub previews terminology in attestation commands' help docs

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
