### PR TITLE
Potential fix for options label in report-packaging-problems.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-packaging-problems.yml
+++ b/.github/ISSUE_TEMPLATE/report-packaging-problems.yml
@@ -11,7 +11,7 @@ body:
       description: Before opening a new packaging problem report, please search [existing reports](https://github.com/getsolus/packages/labels/Package%20Problem%20Report) to ensure there is not an existing one.
       options:
         - label: I have searched through package problem reports
-            required: true
+          required: true
   - type: input
     id: name
     attributes:
@@ -32,7 +32,7 @@ body:
       placeholder: ex. The foo package fails to build.
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: details
     attributes:
       label: More information


### PR DESCRIPTION
The report-packaging-problems.yml template has a syntax error. This may fix it.

