### PR TITLE
jellyfin-media-player: remove dependency on libcec

### DIFF
--- a/packages/j/jellyfin-media-player/abi_used_libs
+++ b/packages/j/jellyfin-media-player/abi_used_libs
@@ -14,7 +14,6 @@ libSDL2-2.0.so.0
 libX11.so.6
 libXrandr.so.2
 libc.so.6
-libcec.so.4
 libgcc_s.so.1
 libm.so.6
 libmpv.so.2

--- a/packages/j/jellyfin-media-player/abi_used_symbols
+++ b/packages/j/jellyfin-media-player/abi_used_symbols
@@ -9,7 +9,6 @@ libQt5Core.so.5:_Z26qt_QMetaEnum_debugOperatorR6QDebugiPK11QMetaObjectPKc
 libQt5Core.so.5:_Z5qHashRK7QStringj
 libQt5Core.so.5:_Z7qgetenvPKc
 libQt5Core.so.5:_Z7qputenvPKcRK10QByteArray
-libQt5Core.so.5:_Z7qstrcpyPcPKc
 libQt5Core.so.5:_Z7qstrdupPKc
 libQt5Core.so.5:_Z9qBadAllocv
 libQt5Core.so.5:_Z9qt_assertPKcS0_i
@@ -160,7 +159,6 @@ libQt5Core.so.5:_ZN7QObject11qt_metacastEPKc
 libQt5Core.so.5:_ZN7QObject11setPropertyEPKcRK8QVariant
 libQt5Core.so.5:_ZN7QObject12moveToThreadEP7QThread
 libQt5Core.so.5:_ZN7QObject13connectNotifyERK11QMetaMethod
-libQt5Core.so.5:_ZN7QObject13setObjectNameERK7QString
 libQt5Core.so.5:_ZN7QObject16disconnectNotifyERK11QMetaMethod
 libQt5Core.so.5:_ZN7QObject16staticMetaObjectE
 libQt5Core.so.5:_ZN7QObject18installEventFilterEPS_
@@ -177,7 +175,6 @@ libQt5Core.so.5:_ZN7QRegExpD1Ev
 libQt5Core.so.5:_ZN7QString11reallocDataEjb
 libQt5Core.so.5:_ZN7QString13toUtf8_helperERKS_
 libQt5Core.so.5:_ZN7QString14compare_helperEPK5QChariPKciN2Qt15CaseSensitivityE
-libQt5Core.so.5:_ZN7QString14toUpper_helperERS_
 libQt5Core.so.5:_ZN7QString14trimmed_helperERKS_
 libQt5Core.so.5:_ZN7QString15fromUtf8_helperEPKci
 libQt5Core.so.5:_ZN7QString15toLatin1_helperERKS_
@@ -681,7 +678,9 @@ libXrandr.so.2:XRRQueryExtension
 libXrandr.so.2:XRRSetCrtcConfig
 libc.so.6:__cxa_atexit
 libc.so.6:__libc_start_main
+libc.so.6:__read_chk
 libc.so.6:__stack_chk_fail
+libc.so.6:__vprintf_chk
 libc.so.6:abort
 libc.so.6:access
 libc.so.6:calloc
@@ -690,17 +689,13 @@ libc.so.6:malloc
 libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memset
-libc.so.6:printf
 libc.so.6:pthread_once
-libc.so.6:read
 libc.so.6:sigaction
 libc.so.6:sigemptyset
 libc.so.6:socketpair
 libc.so.6:strcmp
 libc.so.6:strlen
 libc.so.6:write
-libcec.so.4:CECDestroy
-libcec.so.4:CECInitialise
 libgcc_s.so.1:_Unwind_Resume
 libm.so.6:lrintf
 libmpv.so.2:mpv_command_node
@@ -729,13 +724,11 @@ libstdc++.so.6:_ZNKSt5ctypeIcE13_M_widen_initEv
 libstdc++.so.6:_ZNKSt9exception4whatEv
 libstdc++.so.6:_ZNSo3putEc
 libstdc++.so.6:_ZNSo5flushEv
-libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createERmm
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE5clearESt12_Ios_Iostate
 libstdc++.so.6:_ZSt11__once_call
 libstdc++.so.6:_ZSt15__once_callable
 libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
 libstdc++.so.6:_ZSt16__throw_bad_castv
-libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_system_errori
 libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZSt25__throw_bad_function_callv

--- a/packages/j/jellyfin-media-player/package.yml
+++ b/packages/j/jellyfin-media-player/package.yml
@@ -1,6 +1,6 @@
 name       : jellyfin-media-player
 version    : 1.11.1
-release    : 1
+release    : 2
 source     :
     - https://github.com/jellyfin/jellyfin-media-player/archive/refs/tags/v1.11.1.tar.gz : 75499ed2721b77ea0f757da20615aff8e5e9d8e9ff9d4b2572e71067be17ea29
 homepage   : https://jellyfin.org/
@@ -14,7 +14,6 @@ builddeps  :
     - pkgconfig(Qt5WebChannel)
     - pkgconfig(Qt5WebEngineWidgets)
     - pkgconfig(Qt5X11Extras)
-    - pkgconfig(libcec)
     - pkgconfig(mpv)
     - pkgconfig(sdl2)
 rundeps    :

--- a/packages/j/jellyfin-media-player/pspec_x86_64.xml
+++ b/packages/j/jellyfin-media-player/pspec_x86_64.xml
@@ -38,8 +38,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-07-12</Date>
+        <Update release="2">
+            <Date>2024-10-25</Date>
             <Version>1.11.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>


### PR DESCRIPTION
**Summary**
- Remove dependency on libcec

**Test Plan**
- Checked it build.

**Checklist**

- [X] Package was built and tested against unstable

**Packaging notes**
- Libcec does not build so removed it here so that it can be deprecated.
