### PR TITLE
typst: Update to 0.12.0

### DIFF
--- a/packages/t/typst/abi_used_symbols
+++ b/packages/t/typst/abi_used_symbols
@@ -70,6 +70,7 @@ libc.so.6:munmap
 libc.so.6:open64
 libc.so.6:openat64
 libc.so.6:opendir
+libc.so.6:pause
 libc.so.6:pipe2
 libc.so.6:poll
 libc.so.6:posix_memalign
@@ -90,7 +91,6 @@ libc.so.6:pthread_attr_setstacksize
 libc.so.6:pthread_create
 libc.so.6:pthread_detach
 libc.so.6:pthread_getattr_np
-libc.so.6:pthread_getspecific
 libc.so.6:pthread_key_create
 libc.so.6:pthread_key_delete
 libc.so.6:pthread_self
@@ -112,6 +112,7 @@ libc.so.6:setenv
 libc.so.6:setgid
 libc.so.6:setgroups
 libc.so.6:setpgid
+libc.so.6:setsid
 libc.so.6:setsockopt
 libc.so.6:setuid
 libc.so.6:sigaction
@@ -158,7 +159,6 @@ libcrypto.so.3:EVP_PKEY_free
 libcrypto.so.3:OpenSSL_version_num
 libcrypto.so.3:PEM_read_bio_X509
 libcrypto.so.3:X509_STORE_add_cert
-libcrypto.so.3:X509_STORE_free
 libcrypto.so.3:X509_STORE_new
 libcrypto.so.3:X509_VERIFY_PARAM_set1_host
 libcrypto.so.3:X509_VERIFY_PARAM_set1_ip
@@ -206,6 +206,8 @@ libm.so.6:log2
 libm.so.6:log2f
 libm.so.6:pow
 libm.so.6:powf
+libm.so.6:rint
+libm.so.6:rintf
 libm.so.6:round
 libm.so.6:roundf
 libm.so.6:sin

--- a/packages/t/typst/package.yml
+++ b/packages/t/typst/package.yml
@@ -1,8 +1,8 @@
 name       : typst
-version    : 0.11.1
-release    : 4
+version    : 0.12.0
+release    : 5
 source     :
-    - https://github.com/typst/typst/archive/refs/tags/v0.11.1.tar.gz : b1ba054e821073daafd90675c4822bcd8166f33fe2e3acba87ba1451a0d1fc56
+    - https://github.com/typst/typst/archive/refs/tags/v0.12.0.tar.gz : 5e92463965c0cf6aa003a3bacd1c68591ef2dc0db59dcdccb8f7b084836a1266
 homepage   : https://typst.app
 license    : Apache-2.0
 component  : office

--- a/packages/t/typst/pspec_x86_64.xml
+++ b/packages/t/typst/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>typst</Name>
         <Homepage>https://typst.app</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>office</PartOf>
@@ -24,12 +24,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-07-15</Date>
-            <Version>0.11.1</Version>
+        <Update release="5">
+            <Date>2024-10-26</Date>
+            <Version>0.12.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Enhancements:

- Added support for multi-column floating placement and figures
- Added support for automatic line numbering
- Typst's layout engine is now multithreaded. Typical speedups are 2-3x for larger documents.
- Paragraph justification was optimized with a new two-pass algorithm. Speedups are larger for shorter paragraphs and go up to 6x.
- Highly reduced PDF file sizes due to better font subsetting
- Emoji are now exported properly in PDF
- Added initial support for PDF/A
- Added various options for configuring the CLI's environment (fonts, package paths, etc.)
- Text show rules now match across multiple text elements
- Block-level equations can now optionally break over multiple pages

Bugfixes:

- Fixed a bug where some fonts would not print correctly on professional printers
- Fixed a long-standing bug which could cause headings to be orphaned at the bottom of the page

View the complete changelog [here](https://typst.app/docs/changelog/0.12.0/)

**Test Plan**

Compiled my homework and verified that new symbols (crossmark in my case) are working

**Checklist**

- [x] Package was built and tested against unstable
