### PR TITLE
heroic-games-launcher: Update to 2.15.2

### DIFF
--- a/packages/h/heroic-games-launcher/package.yml
+++ b/packages/h/heroic-games-launcher/package.yml
@@ -1,8 +1,8 @@
 name       : heroic-games-launcher
-version    : 2.15.1
-release    : 29
+version    : 2.15.2
+release    : 30
 source     :
-    - git|https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher.git : v2.15.1
+    - git|https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher.git : v2.15.2
 homepage   : https://heroicgameslauncher.com/
 license    : GPL-3.0-or-later
 component  : games
@@ -30,9 +30,12 @@ install    : |
     # Copy dist files and link binaries
     cp -R ./dist/linux-unpacked/* $installdir/$heroicdir/
     ln -s $heroicdir/heroic $installdir/usr/bin/heroic-run
-    ln -s $heroicdir/resources/app.asar.unpacked/build/bin/x64/linux/legendary $installdir/usr/bin/legendary
-    ln -s $heroicdir/resources/app.asar.unpacked/build/bin/x64/linux/gogdl $installdir/usr/bin/gogdl
-    ln -s $heroicdir/resources/app.asar.unpacked/build/bin/x64/linux/nile $installdir/usr/bin/nile
+    pushd ./dist/linux-unpacked/resources/app.asar.unpacked/build/bin/x64/linux/
+    for binfile in `ls .`
+    do
+        ln -s $heroicdir/resources/app.asar.unpacked/build/bin/x64/linux/$binfile $installdir/usr/bin/$binfile
+    done
+    popd
 
     # Copy icon
     install -Dm00644 ./dist/linux-unpacked/resources/app.asar.unpacked/build/icon.png $installdir/usr/share/icons/hicolor/512x512/apps/com.heroicgameslauncher.hgl.png

--- a/packages/h/heroic-games-launcher/pspec_x86_64.xml
+++ b/packages/h/heroic-games-launcher/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>heroic-games-launcher</Name>
         <Homepage>https://heroicgameslauncher.com/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>games</PartOf>
@@ -20,10 +20,12 @@
 </Description>
         <PartOf>games</PartOf>
         <Files>
+            <Path fileType="executable">/usr/bin/comet</Path>
             <Path fileType="executable">/usr/bin/gogdl</Path>
             <Path fileType="executable">/usr/bin/heroic-run</Path>
             <Path fileType="executable">/usr/bin/legendary</Path>
             <Path fileType="executable">/usr/bin/nile</Path>
+            <Path fileType="executable">/usr/bin/vulkan-helper</Path>
             <Path fileType="data">/usr/share/applications/com.heroicgameslauncher.hgl.desktop</Path>
             <Path fileType="data">/usr/share/heroic/LICENSE.electron.txt</Path>
             <Path fileType="data">/usr/share/heroic/LICENSES.chromium.html</Path>
@@ -128,12 +130,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="29">
-            <Date>2024-09-04</Date>
-            <Version>2.15.1</Version>
+        <Update release="30">
+            <Date>2024-10-26</Date>
+            <Version>2.15.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
Resolves #4025 

**Summary**

Bugfixes:

- Fixed Amazon Games library synchronization failure
- Fixed issues with CYGNI: All Guns Blazing and Black Myth: Wukong from Epic Games
- Fixed GOG cloud saves issues, when files were removed using utility on GOG's website

Full changelog available [here](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/compare/v2.15.1...v2.15.2)

**Test Plan**

Launch Heroic and navigate through stores, download manager, settings, etc. Make sure things look and function normally. Launch a game and make sure it runs as expected.

**Checklist**

- [x] Package was built and tested against unstable
