### PR TITLE
svtplay-dl: Update to v4.101

### DIFF
--- a/packages/s/svtplay-dl/package.yml
+++ b/packages/s/svtplay-dl/package.yml
@@ -1,8 +1,8 @@
 name       : svtplay-dl
-version    : 4.97.1
-release    : 24
+version    : '4.101'
+release    : 25
 source     :
-    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.97.1.tar.gz : 713d55f20719d2543360711a7b5b605b6d01b9574c657549c7794b777ab685b8
+    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.101.tar.gz : c27a7d914c3d699ec6438dda9dc0287539e9ff0f9016c2a0d973a6a8bae01fde
 homepage   : https://svtplay-dl.se/
 license    : MIT
 component  : network.download

--- a/packages/s/svtplay-dl/pspec_x86_64.xml
+++ b/packages/s/svtplay-dl/pspec_x86_64.xml
@@ -21,12 +21,12 @@
         <PartOf>network.download</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/svtplay-dl</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.97.1-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.97.1-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.97.1-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.97.1-py3.11.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.97.1-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.97.1-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.101-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.101-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.101-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.101-py3.11.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.101-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.101-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/__pycache__/__init__.cpython-311.pyc</Path>
@@ -170,9 +170,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2024-08-01</Date>
-            <Version>4.97.1</Version>
+        <Update release="25">
+            <Date>2024-10-26</Date>
+            <Version>4.101</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
- tv4play: fixed a crash using -A
- tv4play: improved DRM message a bit.
- tv4play: improved detection on what videos we can download in -A
- dr.dk: fixed so its working again
- hls: fixed some videos got the wrong alt stremas.
- aftonbladet: fixed so we can download premium videos via a token
- svtplay: fixed a crash in some specific videos
- Avoid overwrite config for merge subtitle

**Test Plan**
- Downloaded a video.

**Checklist**

- [X] Package was built and tested against unstable
