### PR TITLE
quickemu: Add at v4.9.6

### DIFF
--- a/packages/q/quickemu/monitoring.yml
+++ b/packages/q/quickemu/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  # No ID, last checked on 2024-10-27
+  id: ~
+  rss: https://github.com/quickemu-project/quickemu/releases.atom
+security:
+  # No known CPE, last checked on 2024-10-27
+  cpe: ~

--- a/packages/q/quickemu/package.yml
+++ b/packages/q/quickemu/package.yml
@@ -1,0 +1,35 @@
+name       : quickemu
+version    : 4.9.6
+release    : 1
+source     :
+    - https://github.com/quickemu-project/quickemu/archive/refs/tags/4.9.6.tar.gz : 796a047b0bfabb91eb143e5422ff74f5d2812f47120ed6b34eaf82bbdfe3e2a3
+homepage   : https://github.com/quickemu-project/quickemu
+license    : MIT
+component  : virt
+summary    : Quickly create and run optimised Windows, macOS and Linux virtual machines
+description: |
+    Quickemu is a wrapper for the excellent QEMU that automatically "does the right thing" when creating virtual machines. No requirement for exhaustive configuration options. You decide what operating system you want to run and Quickemu takes care of the rest.
+rundeps    :
+    - cdrtools # for mkisofs
+    - edk2-ovmf
+    - jq
+    - mesa-demos # for glxinfo
+    - pciutils
+    - python3
+    - qemu
+    - socat
+    - spice-gtk # for spicy
+    - swtpm
+    - xdg-user-dirs
+    - xrandr
+    - zsync
+install    : |
+  install -Dm0755 -t $installdir/usr/bin \
+    chunkcheck \
+    quickemu \
+    quickget \
+    quickreport
+
+  install -Dm0644 -t $installdir/usr/share/man/man1 docs/*.1
+  # For next release:
+  # install -Dm0644 -t $installdir/usr/share/man/man5 docs/*.5

--- a/packages/q/quickemu/pspec_x86_64.xml
+++ b/packages/q/quickemu/pspec_x86_64.xml
@@ -1,0 +1,41 @@
+<PISI>
+    <Source>
+        <Name>quickemu</Name>
+        <Homepage>https://github.com/quickemu-project/quickemu</Homepage>
+        <Packager>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
+        </Packager>
+        <License>MIT</License>
+        <PartOf>virt</PartOf>
+        <Summary xml:lang="en">Quickly create and run optimised Windows, macOS and Linux virtual machines</Summary>
+        <Description xml:lang="en">Quickemu is a wrapper for the excellent QEMU that automatically &quot;does the right thing&quot; when creating virtual machines. No requirement for exhaustive configuration options. You decide what operating system you want to run and Quickemu takes care of the rest.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>quickemu</Name>
+        <Summary xml:lang="en">Quickly create and run optimised Windows, macOS and Linux virtual machines</Summary>
+        <Description xml:lang="en">Quickemu is a wrapper for the excellent QEMU that automatically &quot;does the right thing&quot; when creating virtual machines. No requirement for exhaustive configuration options. You decide what operating system you want to run and Quickemu takes care of the rest.
+</Description>
+        <PartOf>virt</PartOf>
+        <Files>
+            <Path fileType="executable">/usr/bin/chunkcheck</Path>
+            <Path fileType="executable">/usr/bin/quickemu</Path>
+            <Path fileType="executable">/usr/bin/quickget</Path>
+            <Path fileType="executable">/usr/bin/quickreport</Path>
+            <Path fileType="man">/usr/share/man/man1/quickemu.1</Path>
+            <Path fileType="man">/usr/share/man/man1/quickemu_conf.1</Path>
+            <Path fileType="man">/usr/share/man/man1/quickget.1</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2024-10-27</Date>
+            <Version>4.9.6</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**

Initial addition of Quickemu, a tool for quickly spinning up disposable VMs.

Resolves getsolus/packages#3487

**Test Plan**

Download and start an Alpine VM:

```
quickget alpine v3.20
quickemu --vm alpine-v3.20.conf --viewer spicy --width 1920 --height 1080
```

Remove it after starting:

```
quickemu --vm alpine-v3.20.conf --kill --delete-vm
```

**Checklist**

- [x] Package was built and tested against unstable
