### PR TITLE
tailscale: Update to 1.76.1

### DIFF
--- a/packages/t/tailscale/package.yml
+++ b/packages/t/tailscale/package.yml
@@ -1,8 +1,8 @@
 name       : tailscale
-version    : 1.76.0
-release    : 27
+version    : 1.76.1
+release    : 28
 source     :
-    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.76.0.tar.gz : eaec1fa9a882d877ce6e5fb6ef47b3387124321a8963c66c4c37319106b5c5c2
+    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.76.1.tar.gz : ce87e52fd4e8e52540162a2529c5d73f5f76c6679147a7887058865c9e01ec36
 homepage   : https://tailscale.com
 license    : BSD-3-Clause
 component  : network.clients

--- a/packages/t/tailscale/pspec_x86_64.xml
+++ b/packages/t/tailscale/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2024-10-16</Date>
-            <Version>1.76.0</Version>
+        <Update release="28">
+            <Date>2024-10-31</Date>
+            <Version>1.76.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- [changelog](https://tailscale.com/changelog#2024-10-16-client)
- [known issue](https://github.com/tailscale/tailscale/issues/13863)

**Test Plan**
- boot unaffected kernel e.g.  linux-lts, version: 6.6.54, release: 256
- tailscale status - all ok

**Checklist**
- [X] Package was built and tested against unstable
