### PR TITLE
kitty: Update to 0.37.0

### DIFF
--- a/packages/k/kitty/abi_used_symbols
+++ b/packages/k/kitty/abi_used_symbols
@@ -4,6 +4,7 @@ UNKNOWN:ceil
 UNKNOWN:chdir
 UNKNOWN:close
 UNKNOWN:closedir
+UNKNOWN:dup
 UNKNOWN:dup2
 UNKNOWN:environ
 UNKNOWN:fcntl
@@ -11,6 +12,8 @@ UNKNOWN:fcntl64
 UNKNOWN:feof
 UNKNOWN:ferror
 UNKNOWN:fileno
+UNKNOWN:fmaxf
+UNKNOWN:fminf
 UNKNOWN:fopen64
 UNKNOWN:fork
 UNKNOWN:fread
@@ -161,6 +164,7 @@ libXcursor.so.1:XcursorLibraryLoadCursor
 libc.so.6:__ctype_b_loc
 libc.so.6:__environ
 libc.so.6:__errno_location
+libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
 libc.so.6:__isoc23_strtol
 libc.so.6:__isoc99_sscanf
@@ -367,7 +371,6 @@ libdbus-1.so.3:dbus_error_free
 libdbus-1.so.3:dbus_error_init
 libdbus-1.so.3:dbus_error_is_set
 libdbus-1.so.3:dbus_free
-libdbus-1.so.3:dbus_get_local_machine_id
 libdbus-1.so.3:dbus_message_append_args_valist
 libdbus-1.so.3:dbus_message_get_args
 libdbus-1.so.3:dbus_message_get_args_valist
@@ -396,6 +399,7 @@ libdbus-1.so.3:dbus_timeout_get_enabled
 libdbus-1.so.3:dbus_timeout_get_interval
 libdbus-1.so.3:dbus_timeout_handle
 libdbus-1.so.3:dbus_timeout_set_data
+libdbus-1.so.3:dbus_try_get_local_machine_id
 libdbus-1.so.3:dbus_watch_get_data
 libdbus-1.so.3:dbus_watch_get_enabled
 libdbus-1.so.3:dbus_watch_get_flags
@@ -457,6 +461,7 @@ liblcms2.so.2:cmsDeleteTransform
 liblcms2.so.2:cmsDoTransform
 liblcms2.so.2:cmsOpenProfileFromMem
 libm.so.6:exp
+libm.so.6:exp2f
 libm.so.6:fmaxf
 libm.so.6:fminf
 libm.so.6:powf
@@ -577,6 +582,7 @@ libpython3.11.so.1.0:PyOS_AfterFork_Parent
 libpython3.11.so.1.0:PyOS_BeforeFork
 libpython3.11.so.1.0:PyOS_snprintf
 libpython3.11.so.1.0:PyObject_CallFunctionObjArgs
+libpython3.11.so.1.0:PyObject_CallOneArg
 libpython3.11.so.1.0:PyObject_GetAttrString
 libpython3.11.so.1.0:PyObject_GetBuffer
 libpython3.11.so.1.0:PyObject_HasAttrString
@@ -600,7 +606,6 @@ libpython3.11.so.1.0:PyType_GenericAlloc
 libpython3.11.so.1.0:PyType_GenericNew
 libpython3.11.so.1.0:PyType_IsSubtype
 libpython3.11.so.1.0:PyType_Ready
-libpython3.11.so.1.0:PyUnicode_AsEncodedString
 libpython3.11.so.1.0:PyUnicode_AsUCS4
 libpython3.11.so.1.0:PyUnicode_AsUCS4Copy
 libpython3.11.so.1.0:PyUnicode_AsUTF8

--- a/packages/k/kitty/package.yml
+++ b/packages/k/kitty/package.yml
@@ -1,8 +1,8 @@
 name       : kitty
-version    : 0.36.4
-release    : 74
+version    : 0.37.0
+release    : 75
 source     :
-    - https://github.com/kovidgoyal/kitty/releases/download/v0.36.4/kitty-0.36.4.tar.xz : 10ebf00a8576bca34ae683866c5be307a35f3c517906d6441923fd740db059bd
+    - https://github.com/kovidgoyal/kitty/releases/download/v0.37.0/kitty-0.37.0.tar.xz : efbf933dfe930abd7c88ad0860997633c9c23b46c5000c5872ae3859dfbc50ff
     - git|https://github.com/simd-everywhere/simde.git : v0.7.6
     - https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/NerdFontsSymbolsOnly.tar.xz : b7a3eee24d2b0910f3a07705f1e053221d2535f07c5a13614c4dead2620e9978
 license    :

--- a/packages/k/kitty/pspec_x86_64.xml
+++ b/packages/k/kitty/pspec_x86_64.xml
@@ -715,6 +715,8 @@ Kitty is designed from the ground up to support all modern terminal features, su
             <Path fileType="library">/usr/lib/kitty/kitty/terminfo.py</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/tint_fragment.glsl</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/tint_vertex.glsl</Path>
+            <Path fileType="library">/usr/lib/kitty/kitty/trail_fragment.glsl</Path>
+            <Path fileType="library">/usr/lib/kitty/kitty/trail_vertex.glsl</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/types.py</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/typing.py</Path>
             <Path fileType="library">/usr/lib/kitty/kitty/update_check.py</Path>
@@ -817,9 +819,9 @@ Kitty is designed from the ground up to support all modern terminal features, su
         </Files>
     </Package>
     <History>
-        <Update release="74">
-            <Date>2024-09-28</Date>
-            <Version>0.36.4</Version>
+        <Update release="75">
+            <Date>2024-10-31</Date>
+            <Version>0.37.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- A new optional text cursor movement animation that shows a “trail” following the movement of the cursor making it easy to follow large cursor jumps
- Custom kittens: Add a framework for easily and securely using remote control from within a kitten’s main() function
- kitten icat: Fix the kitty +kitten icat --no-trailing-newline not working when using unicode placeholders
- tab_title_template allow using the 256 terminal colors for formatting
- Fix resizing window when alternate screen is active does not preserve trailing blank output line in the main screen
- Wayland: Fix background_opacity less than one causing flicker on startup when the Wayland compositor supports single pixel buffers
- Fix background image flashing when closing a tab
- When running a kitten that modifies the kitty config file if no config file exists create a commented out default config file and then modify it

**Test Plan**
- open terminal, run cli, view output with pager-kitten

**Checklist**
- [X] Package was built and tested against unstable
