### PR TITLE
fb2converter: Update to 1.76.0

### DIFF
--- a/packages/f/fb2converter/files/0002_nerf_colors
+++ b/packages/f/fb2converter/files/0002_nerf_colors
@@ -1,18 +1,15 @@
-# Turn off their colors
-# See https://github.com/getsolus/packages/pull/1826
-
 diff --git a/Taskfile.yaml b/Taskfile.yaml
-index a4bd2d8..40947da 100644
+index 4d0d1dc..1e37f18 100644
 --- a/Taskfile.yaml
 +++ b/Taskfile.yaml
-@@ -19,8 +19,8 @@ vars:
-   # this is coming from github actions
+@@ -9,8 +9,8 @@ vars:
+ 
    REF_VER: '{{regexFind "refs/tags/v[0-9]+\\.[0-9]+\\.?[0-9]*[-a-zA-Z0-9+]*" (env "GITHUB_REF")}}'
-
--  TATN: { sh: '{{if (env "TERM")}}tput setaf 4{{end}}' }
--  TOFF: { sh: '{{if (env "TERM")}}tput sgr0{{end}}' }
-+  TATN: { sh: '{{if (env "TERM")}} {{end}}' }
-+  TOFF: { sh: '{{if (env "TERM")}} {{end}}' }
-
+ 
+-  TATN: {sh: '{{if (env "TERM")}}tput setaf 4{{end}}'}
+-  TOFF: {sh: '{{if (env "TERM")}}tput sgr0{{end}}'}
++  TATN: {sh: '{{if (env "TERM")}} {{end}}'}
++  TOFF: {sh: '{{if (env "TERM")}} {{end}}'}
+ 
  env:
    CGO_ENABLED: '0'

--- a/packages/f/fb2converter/package.yml
+++ b/packages/f/fb2converter/package.yml
@@ -1,8 +1,8 @@
 name       : fb2converter
-version    : 1.75.4
-release    : 27
+version    : 1.76.0
+release    : 28
 source     :
-    - git|https://github.com/rupor-github/fb2converter.git : v1.75.4
+    - git|https://github.com/rupor-github/fb2converter.git : v1.76.0
 homepage   : https://github.com/rupor-github/fb2converter
 license    : GPL-3.0-only
 component  : office.viewers

--- a/packages/f/fb2converter/pspec_x86_64.xml
+++ b/packages/f/fb2converter/pspec_x86_64.xml
@@ -26,9 +26,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2024-08-24</Date>
-            <Version>1.75.4</Version>
+        <Update release="28">
+            <Date>2024-10-31</Date>
+            <Version>1.76.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Latest go toolchain: go1.23.2
- Regenerating all dependencies
- Cleaning up taskfile
- Re-formatting and linting all sources using up to date tools
- [changelog](https://github.com/rupor-github/fb2converter/releases/tag/v1.76.0)

**Test Plan**
- fb2c convert --to epub in.fb2

**Checklist**
- [X] Package was built and tested against unstable
