### PR TITLE
weston: Fix runtime dependency name

### DIFF
--- a/packages/w/weston/package.yml
+++ b/packages/w/weston/package.yml
@@ -1,6 +1,6 @@
 name       : weston
 version    : 14.0.1
-release    : 32
+release    : 33
 source     :
     - https://gitlab.freedesktop.org/wayland/weston/-/archive/14.0.1/weston-14.0.1.tar.gz : 0cd789cf0a2a4db43733078bc69d99c296cf79c7cbed439af8593359e3a97678
 homepage   : https://gitlab.freedesktop.org/wayland/weston
@@ -39,7 +39,7 @@ builddeps  :
     - pkgconfig(xwayland)
 rundeps    :
     - libs :
-        - xwayland
+        - xorg-xwayland
     - session :
         - weston
 setup      : |

--- a/packages/w/weston/pspec_x86_64.xml
+++ b/packages/w/weston/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>weston</Name>
         <Homepage>https://gitlab.freedesktop.org/wayland/weston</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>desktop.wayland</PartOf>
@@ -20,7 +20,7 @@
 </Description>
         <PartOf>desktop.wayland</PartOf>
         <RuntimeDependencies>
-            <Dependency release="32">weston-libs</Dependency>
+            <Dependency release="33">weston-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/wcap-decode</Path>
@@ -118,7 +118,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="32">weston</Dependency>
+            <Dependency release="33">weston</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libweston-14/libweston/backend-drm.h</Path>
@@ -181,19 +181,19 @@
 </Description>
         <PartOf>desktop.wayland</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="32">weston</Dependency>
+            <Dependency releaseFrom="33">weston</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/wayland-sessions/weston.desktop</Path>
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2024-10-28</Date>
+        <Update release="33">
+            <Date>2024-11-01</Date>
             <Version>14.0.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Fix runtime dependency name.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run a full system upgrade successfully.

**Checklist**

- [x] Package was built and tested against unstable
