### PR TITLE
eza: Update to v0.20.6

### DIFF
--- a/packages/e/eza/package.yml
+++ b/packages/e/eza/package.yml
@@ -1,8 +1,8 @@
 name       : eza
-version    : 0.20.5
-release    : 36
+version    : 0.20.6
+release    : 37
 source     :
-    - https://github.com/eza-community/eza/archive/refs/tags/v0.20.5.tar.gz : 3455907abddd72ab405613588f82e2b5f6771facf215e5bcd92bca1a82520819
+    - https://github.com/eza-community/eza/archive/refs/tags/v0.20.6.tar.gz : bf7c30789be7866a36fda9d2b1bb351f41675f4c8bb8c89e7ff85619cc894bfa
 homepage   : https://github.com/eza-community/eza
 license    : EUPL-1.2
 component  : system.utils

--- a/packages/e/eza/pspec_x86_64.xml
+++ b/packages/e/eza/pspec_x86_64.xml
@@ -33,9 +33,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2024-10-25</Date>
-            <Version>0.20.5</Version>
+        <Update release="37">
+            <Date>2024-11-01</Date>
+            <Version>0.20.6</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Fix typo `--get-repos-no-status` to `--git-repos-no-status`

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

List files and folders in a directory.

**Checklist**

- [x] Package was built and tested against unstable
