### PR TITLE
python-orjson: Update to v3.10.11

### DIFF
--- a/packages/py/python-orjson/abi_libs
+++ b/packages/py/python-orjson/abi_libs
@@ -1,1 +1,1 @@
-liborjson.so
+orjson.cpython-311-x86_64-linux-gnu.so

--- a/packages/py/python-orjson/abi_symbols
+++ b/packages/py/python-orjson/abi_symbols
@@ -1,7 +1,7 @@
-liborjson.so:PyInit_orjson
-liborjson.so:dumps
-liborjson.so:loads
-liborjson.so:orjson_fragment_dealloc
-liborjson.so:orjson_fragment_tp_new
-liborjson.so:orjson_fragmenttype_new
-liborjson.so:orjson_init_exec
+orjson.cpython-311-x86_64-linux-gnu.so:PyInit_orjson
+orjson.cpython-311-x86_64-linux-gnu.so:dumps
+orjson.cpython-311-x86_64-linux-gnu.so:loads
+orjson.cpython-311-x86_64-linux-gnu.so:orjson_fragment_dealloc
+orjson.cpython-311-x86_64-linux-gnu.so:orjson_fragment_tp_new
+orjson.cpython-311-x86_64-linux-gnu.so:orjson_fragmenttype_new
+orjson.cpython-311-x86_64-linux-gnu.so:orjson_init_exec

--- a/packages/py/python-orjson/package.yml
+++ b/packages/py/python-orjson/package.yml
@@ -1,8 +1,8 @@
 name       : python-orjson
-version    : 3.10.9
-release    : 44
+version    : 3.10.11
+release    : 45
 source     :
-    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.9.tar.gz : c378074e0c46035dc66e57006993233ec66bf8487d501bab41649b4b7289ed4d
+    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.11.tar.gz : e35b6d730de6384d5b2dab5fd23f0d76fae8bbc8c353c2f78210aa5fa4beb3ef
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-orjson/pspec_x86_64.xml
+++ b/packages/py/python-orjson/pspec_x86_64.xml
@@ -21,11 +21,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.9.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.9.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.9.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.9.dist-info/licenses/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.9.dist-info/licenses/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.11.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.11.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.11.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.11.dist-info/licenses/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.11.dist-info/licenses/LICENSE-MIT</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
@@ -35,9 +35,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="44">
-            <Date>2024-10-19</Date>
-            <Version>3.10.9</Version>
+        <Update release="45">
+            <Date>2024-11-02</Date>
+            <Version>3.10.11</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Release notes:
- [3.10.11](https://github.com/ijl/orjson/releases/tag/3.10.11)
- [3.10.10](https://github.com/ijl/orjson/releases/tag/3.10.10)

**Test Plan**

Ran some examples from the project's README

**Checklist**

- [x] Package was built and tested against unstable
