### PR TITLE
noto-sans-ttf: Update to v2024.11.01

### DIFF
--- a/packages/n/noto-sans-ttf/package.yml
+++ b/packages/n/noto-sans-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : noto-sans-ttf
-version    : 24.9.1
-release    : 33
+version    : 2024.11.01
+release    : 34
 source     :
-    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-24.9.1.tar.gz : 73fc256356e4ed66c54aa300a71c390695603547e127f27cd6eefdeb942726b0
+    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-2024.11.01.tar.gz : f2cfbc9c3b7794819fc12f0b95b6637727e875934f6ee6110b1f4c12ce7114eb
     - https://github.com/googlefonts/noto-emoji/archive/refs/tags/v2.047.tar.gz : 2cfaf5a427eb26334cdb30d98e4a0c005b660504a339249dc54373e566f09b50
 homepage   : https://fonts.google.com/noto
 extract    : no

--- a/packages/n/noto-sans-ttf/pspec_x86_64.xml
+++ b/packages/n/noto-sans-ttf/pspec_x86_64.xml
@@ -1538,9 +1538,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2024-10-03</Date>
-            <Version>24.9.1</Version>
+        <Update release="34">
+            <Date>2024-11-02</Date>
+            <Version>2024.11.01</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Full commit log available [here](https://github.com/notofonts/notofonts.github.io/compare/noto-monthly-release-24.9.1...noto-monthly-release-2024.11.01)

**Test Plan**
- Typed some text in Noto Sans and Noto Serif
- Confirmed my system UI looked alright with Noto Sans set as system font

**Checklist**

- [x] Package was built and tested against unstable
