### PR TITLE
nvidia-vaapi-driver: Update to v0.0.13

### DIFF
--- a/packages/n/nvidia-vaapi-driver/abi_used_symbols
+++ b/packages/n/nvidia-vaapi-driver/abi_used_symbols
@@ -25,7 +25,6 @@ libc.so.6:getenv
 libc.so.6:getpid
 libc.so.6:gettid
 libc.so.6:ioctl
-libc.so.6:malloc
 libc.so.6:memalign
 libc.so.6:memcpy
 libc.so.6:memmove
@@ -42,6 +41,7 @@ libc.so.6:pthread_mutexattr_init
 libc.so.6:pthread_mutexattr_settype
 libc.so.6:pthread_timedjoin_np
 libc.so.6:qsort_r
+libc.so.6:read
 libc.so.6:realloc
 libc.so.6:stat64
 libc.so.6:stderr
@@ -49,6 +49,7 @@ libc.so.6:stdout
 libc.so.6:strcmp
 libc.so.6:strdup
 libc.so.6:strncmp
+libc.so.6:strstr
 libgstcodecparsers-1.0.so.0:gst_vp9_parser_new
 libgstcodecparsers-1.0.so.0:gst_vp9_parser_parse_frame_header
 libm.so.6:log2l

--- a/packages/n/nvidia-vaapi-driver/package.yml
+++ b/packages/n/nvidia-vaapi-driver/package.yml
@@ -1,9 +1,9 @@
 name       : nvidia-vaapi-driver
-version    : 0.0.12
-release    : 16
+version    : 0.0.13
+release    : 17
 homepage   : https://github.com/elFarto/nvidia-vaapi-driver
 source     :
-    - git|https://github.com/elFarto/nvidia-vaapi-driver.git : v0.0.12
+    - https://github.com/elFarto/nvidia-vaapi-driver/archive/refs/tags/v0.0.13.tar.gz : 0bd10013b183eeef1676f99213f449482b86cbb9cd8883e7fb3801f6f59de231
 license    : MIT
 component  : xorg.display
 summary    : A VA-API implemention using NVIDIA's NVDEC as the backend (UNSUPPORTED)

--- a/packages/n/nvidia-vaapi-driver/pspec_x86_64.xml
+++ b/packages/n/nvidia-vaapi-driver/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nvidia-vaapi-driver</Name>
         <Homepage>https://github.com/elFarto/nvidia-vaapi-driver</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>xorg.display</PartOf>
@@ -27,12 +27,12 @@
         </Conflicts>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2024-07-04</Date>
-            <Version>0.0.12</Version>
+        <Update release="17">
+            <Date>2024-11-03</Date>
+            <Version>0.0.13</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

This release is mainly just to fix the issue with newer versions of FFmpeg passing a single surface rather than the actual amount

Changes:
- Fix memory issues
- vabackend: Treat surfaceCount == 1 the same as surfaceCount == 0
- Unbreak build on FreeBSD < 14

**Test Plan**

Played a couple videos in firefox and confirmed acceleration was active

**Checklist**

- [x] Package was built and tested against unstable
