### PR TITLE
zellij: Update to v0.41.1

### DIFF
--- a/packages/z/zellij/abi_used_symbols
+++ b/packages/z/zellij/abi_used_symbols
@@ -11,7 +11,6 @@ libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__memset_chk
 libc.so.6:__register_atfork
-libc.so.6:__res_init
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__strcpy_chk
@@ -23,7 +22,6 @@ libc.so.6:_longjmp
 libc.so.6:_setjmp
 libc.so.6:abort
 libc.so.6:accept
-libc.so.6:accept4
 libc.so.6:access
 libc.so.6:bcmp
 libc.so.6:bind
@@ -33,7 +31,6 @@ libc.so.6:chdir
 libc.so.6:chmod
 libc.so.6:chown
 libc.so.6:chroot
-libc.so.6:clock_getres
 libc.so.6:clock_gettime
 libc.so.6:close
 libc.so.6:closedir
@@ -54,6 +51,7 @@ libc.so.6:exit
 libc.so.6:fchmod
 libc.so.6:fclose
 libc.so.6:fcntl
+libc.so.6:fdatasync
 libc.so.6:fdopen
 libc.so.6:fdopendir
 libc.so.6:feof
@@ -79,7 +77,6 @@ libc.so.6:ftell
 libc.so.6:ftruncate
 libc.so.6:ftruncate64
 libc.so.6:fwrite
-libc.so.6:gai_strerror
 libc.so.6:getaddrinfo
 libc.so.6:getauxval
 libc.so.6:getcontext
@@ -131,6 +128,7 @@ libc.so.6:open64
 libc.so.6:openat64
 libc.so.6:opendir
 libc.so.6:openpty
+libc.so.6:pause
 libc.so.6:perror
 libc.so.6:pipe2
 libc.so.6:poll
@@ -144,6 +142,7 @@ libc.so.6:posix_spawnattr_setflags
 libc.so.6:posix_spawnattr_setpgroup
 libc.so.6:posix_spawnattr_setsigdefault
 libc.so.6:posix_spawnp
+libc.so.6:pread64
 libc.so.6:pthread_attr_destroy
 libc.so.6:pthread_attr_getguardsize
 libc.so.6:pthread_attr_getstack
@@ -169,6 +168,7 @@ libc.so.6:pthread_rwlock_wrlock
 libc.so.6:pthread_self
 libc.so.6:pthread_setname_np
 libc.so.6:pthread_setspecific
+libc.so.6:pwrite64
 libc.so.6:qsort
 libc.so.6:raise
 libc.so.6:read
@@ -179,17 +179,14 @@ libc.so.6:readv
 libc.so.6:realloc
 libc.so.6:realpath
 libc.so.6:recv
-libc.so.6:recvfrom
 libc.so.6:recvmsg
 libc.so.6:rename
-libc.so.6:rmdir
 libc.so.6:sched_getaffinity
 libc.so.6:sched_yield
 libc.so.6:secure_getenv
 libc.so.6:select
 libc.so.6:send
 libc.so.6:sendmsg
-libc.so.6:sendto
 libc.so.6:setcontext
 libc.so.6:setenv
 libc.so.6:setgid
@@ -203,7 +200,6 @@ libc.so.6:setvbuf
 libc.so.6:shmat
 libc.so.6:shmdt
 libc.so.6:shmget
-libc.so.6:shutdown
 libc.so.6:sigaction
 libc.so.6:sigaddset
 libc.so.6:sigaltstack
@@ -267,8 +263,11 @@ libm.so.6:ceil
 libm.so.6:ceilf
 libm.so.6:floor
 libm.so.6:floorf
+libm.so.6:fma
+libm.so.6:fmaf
 libm.so.6:fmod
 libm.so.6:fmodf
+libm.so.6:pow
 libm.so.6:powf
 libm.so.6:round
 libm.so.6:sincosf

--- a/packages/z/zellij/package.yml
+++ b/packages/z/zellij/package.yml
@@ -1,8 +1,8 @@
 name       : zellij
-version    : 0.40.1
-release    : 7
+version    : 0.41.1
+release    : 8
 source     :
-    - https://github.com/zellij-org/zellij/archive/refs/tags/v0.40.1.tar.gz : 1f0bfa13f2dbe657d76341a196f98a3b4caa47ac63abee06b39883a11ca220a8
+    - https://github.com/zellij-org/zellij/archive/refs/tags/v0.41.1.tar.gz : 72db7eb7257db08f338f37f0294791ea815140f739fbcb7059ccb0c8165a99d3
 homepage   : https://zellij.dev
 license    : MIT
 component  : system.utils

--- a/packages/z/zellij/pspec_x86_64.xml
+++ b/packages/z/zellij/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>zellij</Name>
         <Homepage>https://zellij.dev</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -31,12 +31,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2024-07-14</Date>
-            <Version>0.40.1</Version>
+        <Update release="8">
+            <Date>2024-11-04</Date>
+            <Version>0.41.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- A "non-colliding" keybinding preset: This is a UX change to allow users to opt-in to a different keybinding setup and default_mode.
- A new Configuration screen: Allowing users to switch between the default and non-colliding keybinding presets (temporarily per session or permanently by updating the configuration file), as well as change the Ctrl and Alt leader keys. Accessible by default with Ctrl o + c.
- A first run Setup Wizard: When Zellij runs for the first time, a special version of the Configuration screen will run, titled "First Time Setup Wizard Step 1/1", inviting the user to choose the default keybindings or the new "non-colliding" keybindings.
- Support for the Kitty Keyboard Protocol
- Configuration live reloading
- A new WebAssembly/WASI runtime
- A new Plugin Manager
- `--layout` now supports URLs
- New status-bar
- Loading background plugins on startup: There is a new load_plugins section in the configuration - by default empty - to which plugins can be added in the form of paths/URLs/aliases with an optional configuration (similar to how they are loaded in layouts). These plugins will be loaded in the background (suspended by default) on session start.
- Many new themes

**Breaking changes**
- The `--layout` flag is not idempotent
- The `ENTER` key event changed in plugins: The `ENTER` key is now explicitly sent to plugins, rather than being sent as `Char('\n')`
- zellij-tile API change for plugins: zellij-tile now has new types representing keybindings, reflecting the fact the users can now use multiple modifiers to communicate with plugins.
- Key forwarding is now based on default_mode

Full changelog available [here](https://github.com/zellij-org/zellij/releases/tag/v0.41.0).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new terminal session, create a new tab, open and close a floating pane.

**Checklist**

- [x] Package was built and tested against unstable
