### PR TITLE
mousepad: Update to v0.6.3

### DIFF
--- a/packages/m/mousepad/abi_libs
+++ b/packages/m/mousepad/abi_libs
@@ -1,2 +1,4 @@
+libmousepad-plugin-gspell.so
+libmousepad-plugin-shortcuts.so
 libmousepad.so.0
 mousepad

--- a/packages/m/mousepad/abi_symbols
+++ b/packages/m/mousepad/abi_symbols
@@ -1,3 +1,11 @@
+libmousepad-plugin-gspell.so:gspell_plugin_get_type
+libmousepad-plugin-gspell.so:gspell_plugin_register
+libmousepad-plugin-gspell.so:mousepad_plugin_get_data
+libmousepad-plugin-gspell.so:mousepad_plugin_initialize
+libmousepad-plugin-shortcuts.so:mousepad_plugin_get_data
+libmousepad-plugin-shortcuts.so:mousepad_plugin_initialize
+libmousepad-plugin-shortcuts.so:shortcuts_plugin_get_type
+libmousepad-plugin-shortcuts.so:shortcuts_plugin_register
 libmousepad.so.0:_mousepad_marshal_VOID__FLAGS_STRING_STRING
 libmousepad.so.0:_mousepad_marshal_VOID__INT_INT_INT
 libmousepad.so.0:_mousepad_marshal_VOID__INT_INT_STRING_FLAGS

--- a/packages/m/mousepad/abi_used_libs
+++ b/packages/m/mousepad/abi_used_libs
@@ -4,7 +4,9 @@ libgio-2.0.so.0
 libglib-2.0.so.0
 libgmodule-2.0.so.0
 libgobject-2.0.so.0
+libgspell-1.so.3
 libgtk-3.so.0
 libgtksourceview-4.so.0
 libm.so.6
 libpango-1.0.so.0
+libxfce4kbd-private-3.so.0

--- a/packages/m/mousepad/abi_used_symbols
+++ b/packages/m/mousepad/abi_used_symbols
@@ -16,6 +16,7 @@ libc.so.6:strlen
 libc.so.6:textdomain
 libgdk-3.so.0:gdk_display_get_default
 libgdk-3.so.0:gdk_drag_context_get_suggested_action
+libgdk-3.so.0:gdk_drag_context_get_type
 libgdk-3.so.0:gdk_drag_status
 libgdk-3.so.0:gdk_event_copy
 libgdk-3.so.0:gdk_event_free
@@ -67,9 +68,12 @@ libgio-2.0.so.0:g_file_get_parent
 libgio-2.0.so.0:g_file_get_path
 libgio-2.0.so.0:g_file_get_type
 libgio-2.0.so.0:g_file_get_uri
+libgio-2.0.so.0:g_file_has_uri_scheme
 libgio-2.0.so.0:g_file_info_get_attribute_boolean
 libgio-2.0.so.0:g_file_load_contents
 libgio-2.0.so.0:g_file_monitor_file
+libgio-2.0.so.0:g_file_mount_enclosing_volume
+libgio-2.0.so.0:g_file_mount_enclosing_volume_finish
 libgio-2.0.so.0:g_file_new_for_path
 libgio-2.0.so.0:g_file_new_for_uri
 libgio-2.0.so.0:g_file_new_tmp
@@ -115,6 +119,7 @@ libgio-2.0.so.0:g_settings_set_strv
 libgio-2.0.so.0:g_settings_set_value
 libgio-2.0.so.0:g_settings_sync
 libgio-2.0.so.0:g_settings_unbind
+libgio-2.0.so.0:g_simple_action_new
 libgio-2.0.so.0:g_simple_action_new_stateful
 libgio-2.0.so.0:g_simple_action_set_enabled
 libgio-2.0.so.0:g_simple_action_set_state
@@ -179,6 +184,7 @@ libglib-2.0.so.0:g_key_file_to_data
 libglib-2.0.so.0:g_list_copy
 libglib-2.0.so.0:g_list_delete_link
 libglib-2.0.so.0:g_list_find
+libglib-2.0.so.0:g_list_find_custom
 libglib-2.0.so.0:g_list_free
 libglib-2.0.so.0:g_list_free_full
 libglib-2.0.so.0:g_list_index
@@ -280,6 +286,7 @@ libglib-2.0.so.0:g_variant_new_boolean
 libglib-2.0.so.0:g_variant_new_int32
 libglib-2.0.so.0:g_variant_new_string
 libglib-2.0.so.0:g_variant_new_va
+libglib-2.0.so.0:g_variant_print
 libglib-2.0.so.0:g_variant_ref_sink
 libglib-2.0.so.0:g_variant_type_equal
 libglib-2.0.so.0:g_variant_unref
@@ -326,6 +333,7 @@ libgobject-2.0.so.0:g_signal_lookup
 libgobject-2.0.so.0:g_signal_new
 libgobject-2.0.so.0:g_type_add_instance_private
 libgobject-2.0.so.0:g_type_check_instance_is_a
+libgobject-2.0.so.0:g_type_check_instance_is_fundamentally_a
 libgobject-2.0.so.0:g_type_class_adjust_private_offset
 libgobject-2.0.so.0:g_type_class_peek
 libgobject-2.0.so.0:g_type_class_peek_parent
@@ -333,6 +341,7 @@ libgobject-2.0.so.0:g_type_class_ref
 libgobject-2.0.so.0:g_type_class_unref
 libgobject-2.0.so.0:g_type_is_a
 libgobject-2.0.so.0:g_type_module_get_type
+libgobject-2.0.so.0:g_type_module_register_type
 libgobject-2.0.so.0:g_type_module_set_name
 libgobject-2.0.so.0:g_type_module_unuse
 libgobject-2.0.so.0:g_type_module_use
@@ -345,17 +354,32 @@ libgobject-2.0.so.0:g_value_set_flags
 libgobject-2.0.so.0:g_value_set_string
 libgobject-2.0.so.0:g_value_take_object
 libgobject-2.0.so.0:g_value_unset
+libgspell-1.so.3:gspell_checker_new
+libgspell-1.so.3:gspell_checker_set_language
+libgspell-1.so.3:gspell_language_get_available
+libgspell-1.so.3:gspell_language_get_code
+libgspell-1.so.3:gspell_language_get_default
+libgspell-1.so.3:gspell_language_get_name
+libgspell-1.so.3:gspell_language_lookup
+libgspell-1.so.3:gspell_text_buffer_get_from_gtk_text_buffer
+libgspell-1.so.3:gspell_text_buffer_set_spell_checker
+libgspell-1.so.3:gspell_text_view_get_from_gtk_text_view
+libgspell-1.so.3:gspell_text_view_set_enable_language_menu
+libgspell-1.so.3:gspell_text_view_set_inline_spell_checking
 libgtk-3.so.0:gtk_accel_label_new
 libgtk-3.so.0:gtk_accel_label_set_accel
 libgtk-3.so.0:gtk_accel_map_add_entry
 libgtk-3.so.0:gtk_accel_map_add_filter
+libgtk-3.so.0:gtk_accel_map_foreach
 libgtk-3.so.0:gtk_accel_map_get
 libgtk-3.so.0:gtk_accel_map_load
 libgtk-3.so.0:gtk_accel_map_lookup_entry
 libgtk-3.so.0:gtk_accel_map_save
 libgtk-3.so.0:gtk_accelerator_name
 libgtk-3.so.0:gtk_accelerator_parse
+libgtk-3.so.0:gtk_actionable_get_action_name
 libgtk-3.so.0:gtk_actionable_set_action_name
+libgtk-3.so.0:gtk_actionable_set_action_target_value
 libgtk-3.so.0:gtk_adjustment_new
 libgtk-3.so.0:gtk_application_get_accels_for_action
 libgtk-3.so.0:gtk_application_get_active_window
@@ -381,6 +405,7 @@ libgtk-3.so.0:gtk_builder_add_from_resource
 libgtk-3.so.0:gtk_builder_get_object
 libgtk-3.so.0:gtk_builder_new
 libgtk-3.so.0:gtk_button_get_image
+libgtk-3.so.0:gtk_button_get_label
 libgtk-3.so.0:gtk_button_get_type
 libgtk-3.so.0:gtk_button_new_from_icon_name
 libgtk-3.so.0:gtk_button_new_with_mnemonic
@@ -390,6 +415,7 @@ libgtk-3.so.0:gtk_button_set_relief
 libgtk-3.so.0:gtk_cell_layout_pack_start
 libgtk-3.so.0:gtk_cell_layout_set_attributes
 libgtk-3.so.0:gtk_cell_renderer_text_new
+libgtk-3.so.0:gtk_check_button_get_type
 libgtk-3.so.0:gtk_check_button_new
 libgtk-3.so.0:gtk_check_button_new_with_mnemonic
 libgtk-3.so.0:gtk_check_menu_item_new
@@ -403,11 +429,14 @@ libgtk-3.so.0:gtk_combo_box_get_model
 libgtk-3.so.0:gtk_combo_box_new_with_model
 libgtk-3.so.0:gtk_combo_box_popup
 libgtk-3.so.0:gtk_combo_box_set_active
+libgtk-3.so.0:gtk_combo_box_set_active_id
 libgtk-3.so.0:gtk_combo_box_set_active_iter
+libgtk-3.so.0:gtk_combo_box_set_id_column
 libgtk-3.so.0:gtk_combo_box_set_model
 libgtk-3.so.0:gtk_combo_box_set_row_separator_func
 libgtk-3.so.0:gtk_combo_box_set_wrap_width
 libgtk-3.so.0:gtk_combo_box_text_append_text
+libgtk-3.so.0:gtk_combo_box_text_get_type
 libgtk-3.so.0:gtk_combo_box_text_insert
 libgtk-3.so.0:gtk_combo_box_text_new
 libgtk-3.so.0:gtk_combo_box_text_new_with_entry
@@ -418,6 +447,7 @@ libgtk-3.so.0:gtk_container_add
 libgtk-3.so.0:gtk_container_forall
 libgtk-3.so.0:gtk_container_foreach
 libgtk-3.so.0:gtk_container_get_children
+libgtk-3.so.0:gtk_container_get_type
 libgtk-3.so.0:gtk_container_remove
 libgtk-3.so.0:gtk_container_set_border_width
 libgtk-3.so.0:gtk_css_provider_load_from_data
@@ -428,6 +458,7 @@ libgtk-3.so.0:gtk_dialog_add_button
 libgtk-3.so.0:gtk_dialog_add_buttons
 libgtk-3.so.0:gtk_dialog_get_content_area
 libgtk-3.so.0:gtk_dialog_get_type
+libgtk-3.so.0:gtk_dialog_new
 libgtk-3.so.0:gtk_dialog_new_with_buttons
 libgtk-3.so.0:gtk_dialog_response
 libgtk-3.so.0:gtk_dialog_run
@@ -487,6 +518,7 @@ libgtk-3.so.0:gtk_image_new_from_icon_name
 libgtk-3.so.0:gtk_image_set_from_icon_name
 libgtk-3.so.0:gtk_label_get_label
 libgtk-3.so.0:gtk_label_get_mnemonic_keyval
+libgtk-3.so.0:gtk_label_get_type
 libgtk-3.so.0:gtk_label_new
 libgtk-3.so.0:gtk_label_new_with_mnemonic
 libgtk-3.so.0:gtk_label_set_attributes
@@ -508,8 +540,11 @@ libgtk-3.so.0:gtk_main_iteration
 libgtk-3.so.0:gtk_menu_attach_to_widget
 libgtk-3.so.0:gtk_menu_bar_get_type
 libgtk-3.so.0:gtk_menu_bar_new_from_model
+libgtk-3.so.0:gtk_menu_get_attach_widget
+libgtk-3.so.0:gtk_menu_get_type
 libgtk-3.so.0:gtk_menu_item_get_label
 libgtk-3.so.0:gtk_menu_item_get_submenu
+libgtk-3.so.0:gtk_menu_item_get_type
 libgtk-3.so.0:gtk_menu_item_new
 libgtk-3.so.0:gtk_menu_item_new_with_label
 libgtk-3.so.0:gtk_menu_new
@@ -518,6 +553,7 @@ libgtk-3.so.0:gtk_menu_popup_at_pointer
 libgtk-3.so.0:gtk_menu_popup_at_rect
 libgtk-3.so.0:gtk_menu_set_reserve_toggle_size
 libgtk-3.so.0:gtk_menu_shell_append
+libgtk-3.so.0:gtk_menu_shell_get_type
 libgtk-3.so.0:gtk_menu_shell_insert
 libgtk-3.so.0:gtk_menu_shell_select_first
 libgtk-3.so.0:gtk_message_dialog_format_secondary_text
@@ -529,6 +565,7 @@ libgtk-3.so.0:gtk_notebook_get_n_pages
 libgtk-3.so.0:gtk_notebook_get_nth_page
 libgtk-3.so.0:gtk_notebook_get_scrollable
 libgtk-3.so.0:gtk_notebook_get_tab_label
+libgtk-3.so.0:gtk_notebook_get_tab_label_text
 libgtk-3.so.0:gtk_notebook_get_tab_pos
 libgtk-3.so.0:gtk_notebook_get_type
 libgtk-3.so.0:gtk_notebook_insert_page
@@ -555,6 +592,7 @@ libgtk-3.so.0:gtk_page_setup_set_right_margin
 libgtk-3.so.0:gtk_page_setup_set_top_margin
 libgtk-3.so.0:gtk_paper_size_free
 libgtk-3.so.0:gtk_popover_get_relative_to
+libgtk-3.so.0:gtk_popover_get_type
 libgtk-3.so.0:gtk_popover_new
 libgtk-3.so.0:gtk_popover_set_position
 libgtk-3.so.0:gtk_print_operation_get_default_page_setup
@@ -605,7 +643,10 @@ libgtk-3.so.0:gtk_scale_set_digits
 libgtk-3.so.0:gtk_scale_set_draw_value
 libgtk-3.so.0:gtk_scale_set_value_pos
 libgtk-3.so.0:gtk_scrolled_window_get_type
+libgtk-3.so.0:gtk_scrolled_window_new
 libgtk-3.so.0:gtk_scrolled_window_set_hadjustment
+libgtk-3.so.0:gtk_scrolled_window_set_min_content_height
+libgtk-3.so.0:gtk_scrolled_window_set_min_content_width
 libgtk-3.so.0:gtk_scrolled_window_set_policy
 libgtk-3.so.0:gtk_scrolled_window_set_shadow_type
 libgtk-3.so.0:gtk_scrolled_window_set_vadjustment
@@ -614,6 +655,7 @@ libgtk-3.so.0:gtk_selection_data_get_format
 libgtk-3.so.0:gtk_selection_data_get_length
 libgtk-3.so.0:gtk_selection_data_get_uris
 libgtk-3.so.0:gtk_separator_menu_item_get_type
+libgtk-3.so.0:gtk_separator_menu_item_new
 libgtk-3.so.0:gtk_separator_new
 libgtk-3.so.0:gtk_separator_tool_item_new
 libgtk-3.so.0:gtk_separator_tool_item_set_draw
@@ -622,6 +664,7 @@ libgtk-3.so.0:gtk_show_about_dialog
 libgtk-3.so.0:gtk_show_uri_on_window
 libgtk-3.so.0:gtk_size_group_add_widget
 libgtk-3.so.0:gtk_size_group_new
+libgtk-3.so.0:gtk_spin_button_get_type
 libgtk-3.so.0:gtk_spin_button_get_value
 libgtk-3.so.0:gtk_spin_button_get_value_as_int
 libgtk-3.so.0:gtk_spin_button_new
@@ -742,6 +785,7 @@ libgtk-3.so.0:gtk_widget_get_parent_window
 libgtk-3.so.0:gtk_widget_get_sensitive
 libgtk-3.so.0:gtk_widget_get_style_context
 libgtk-3.so.0:gtk_widget_get_tooltip_text
+libgtk-3.so.0:gtk_widget_get_type
 libgtk-3.so.0:gtk_widget_get_visible
 libgtk-3.so.0:gtk_widget_get_window
 libgtk-3.so.0:gtk_widget_grab_focus
@@ -760,6 +804,7 @@ libgtk-3.so.0:gtk_widget_set_margin_start
 libgtk-3.so.0:gtk_widget_set_margin_top
 libgtk-3.so.0:gtk_widget_set_sensitive
 libgtk-3.so.0:gtk_widget_set_tooltip_text
+libgtk-3.so.0:gtk_widget_set_vexpand
 libgtk-3.so.0:gtk_widget_set_visible
 libgtk-3.so.0:gtk_widget_show
 libgtk-3.so.0:gtk_widget_show_all
@@ -772,6 +817,7 @@ libgtk-3.so.0:gtk_window_get_size
 libgtk-3.so.0:gtk_window_get_title
 libgtk-3.so.0:gtk_window_get_titlebar
 libgtk-3.so.0:gtk_window_get_transient_for
+libgtk-3.so.0:gtk_window_get_type
 libgtk-3.so.0:gtk_window_group_add_window
 libgtk-3.so.0:gtk_window_group_new
 libgtk-3.so.0:gtk_window_is_active
@@ -793,6 +839,7 @@ libgtksourceview-4.so.0:gtk_source_buffer_can_redo
 libgtksourceview-4.so.0:gtk_source_buffer_can_undo
 libgtksourceview-4.so.0:gtk_source_buffer_end_not_undoable_action
 libgtksourceview-4.so.0:gtk_source_buffer_get_language
+libgtksourceview-4.so.0:gtk_source_buffer_get_type
 libgtksourceview-4.so.0:gtk_source_buffer_new
 libgtksourceview-4.so.0:gtk_source_buffer_set_highlight_matching_brackets
 libgtksourceview-4.so.0:gtk_source_buffer_set_highlight_syntax
@@ -880,3 +927,5 @@ libpango-1.0.so.0:pango_font_description_get_variant
 libpango-1.0.so.0:pango_font_description_get_weight
 libpango-1.0.so.0:pango_font_description_set_size
 libpango-1.0.so.0:pango_font_description_to_string
+libxfce4kbd-private-3.so.0:xfce_shortcuts_editor_new
+libxfce4kbd-private-3.so.0:xfce_shortcuts_editor_new_array

--- a/packages/m/mousepad/package.yml
+++ b/packages/m/mousepad/package.yml
@@ -1,8 +1,8 @@
 name       : mousepad
-version    : 0.6.2
-release    : 2
+version    : 0.6.3
+release    : 3
 source     :
-    - https://archive.xfce.org/src/apps/mousepad/0.6/mousepad-0.6.2.tar.bz2 : e7cacb3b8cb1cd689e6341484691069e73032810ca51fc747536fc36eb18d19d
+    - https://archive.xfce.org/src/apps/mousepad/0.6/mousepad-0.6.3.tar.bz2 : 2ff162c185f18014ab9c82c2ac2dfce4fba20eb0005e7690ee27f00b9cb929b9
 homepage   : https://docs.xfce.org/apps/mousepad/start
 license    : GPL-2.0-or-later
 component  : desktop.xfce
@@ -10,7 +10,9 @@ summary    : Mousepad is a simple text editor for the Xfce desktop environment..
 description: |
     Mousepad is a simple text editor for the Xfce desktop environment.
 builddeps  :
+    - pkgconfig(gspell-1)
     - pkgconfig(gtksourceview-4)
+    - pkgconfig(libxfce4ui-2)
 setup      : |
     %configure
 build      : |

--- a/packages/m/mousepad/pspec_x86_64.xml
+++ b/packages/m/mousepad/pspec_x86_64.xml
@@ -23,9 +23,12 @@
             <Path fileType="executable">/usr/bin/mousepad</Path>
             <Path fileType="library">/usr/lib64/libmousepad.so.0</Path>
             <Path fileType="library">/usr/lib64/libmousepad.so.0.0.0</Path>
+            <Path fileType="library">/usr/lib64/mousepad/plugins/libmousepad-plugin-gspell.so</Path>
+            <Path fileType="library">/usr/lib64/mousepad/plugins/libmousepad-plugin-shortcuts.so</Path>
             <Path fileType="data">/usr/share/applications/org.xfce.mousepad-settings.desktop</Path>
             <Path fileType="data">/usr/share/applications/org.xfce.mousepad.desktop</Path>
             <Path fileType="data">/usr/share/glib-2.0/schemas/org.xfce.mousepad.gschema.xml</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/org.xfce.mousepad.plugins.gspell.gschema.xml</Path>
             <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/org.xfce.mousepad.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/16x16/apps/org.xfce.mousepad.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/24x24/apps/org.xfce.mousepad.png</Path>
@@ -98,16 +101,16 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">mousepad</Dependency>
+            <Dependency release="3">mousepad</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libmousepad.so</Path>
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-03-07</Date>
-            <Version>0.6.2</Version>
+        <Update release="3">
+            <Date>2024-11-04</Date>
+            <Version>0.6.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://www.mail-archive.com/xfce-announce@xfce.org/msg00974.html).

Note that while this is an XFCE app, it is not a part of 4.20.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Open the `package.yml` for `mousepad`, enable the spellchecker plugin.

**Checklist**

- [x] Package was built and tested against unstable
