### PR TITLE
gpxsee: Update to 13.27

### DIFF
--- a/packages/g/gpxsee/abi_used_symbols
+++ b/packages/g/gpxsee/abi_used_symbols
@@ -272,10 +272,10 @@ libQt6Core.so.6:_ZN8QVariantC2ERK7QString
 libQt6Core.so.6:_ZN8QVariantD1Ev
 libQt6Core.so.6:_ZN8QVariantaSERKS_
 libQt6Core.so.6:_ZN9QDateTime10fromStringE11QStringViewN2Qt10DateFormatE
-libQt6Core.so.6:_ZN9QDateTime18fromSecsSinceEpochExN2Qt8TimeSpecEi
+libQt6Core.so.6:_ZN9QDateTime18fromSecsSinceEpochExRK9QTimeZone
 libQt6Core.so.6:_ZN9QDateTime19fromMSecsSinceEpochEx
-libQt6Core.so.6:_ZN9QDateTimeC1E5QDate5QTimeN2Qt8TimeSpecEi
 libQt6Core.so.6:_ZN9QDateTimeC1E5QDate5QTimeNS_20TransitionResolutionE
+libQt6Core.so.6:_ZN9QDateTimeC1E5QDate5QTimeRK9QTimeZoneNS_20TransitionResolutionE
 libQt6Core.so.6:_ZN9QDateTimeC1EOS_
 libQt6Core.so.6:_ZN9QDateTimeC1ERKS_
 libQt6Core.so.6:_ZN9QDateTimeC1Ev
@@ -782,6 +782,7 @@ libQt6Gui.so.6:_ZNK12QImageReader6formatEv
 libQt6Gui.so.6:_ZNK12QImageReader7canReadEv
 libQt6Gui.so.6:_ZNK12QKeySequence7isEmptyEv
 libQt6Gui.so.6:_ZNK12QKeySequence8toStringENS_14SequenceFormatE
+libQt6Gui.so.6:_ZNK12QPaintDevice16devicePixelRatioEv
 libQt6Gui.so.6:_ZNK12QPaintEngine11paintDeviceEv
 libQt6Gui.so.6:_ZNK12QPainterPath10intersectsERKS_
 libQt6Gui.so.6:_ZNK12QPainterPath10simplifiedEv

--- a/packages/g/gpxsee/monitoring.yml
+++ b/packages/g/gpxsee/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 16205
+  rss: https://github.com/tumic0/GPXSee/tags.atom
+# No known CPE, checked 2024-11-06
+security:
+  cpe: ~

--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.26'
-release    : 46
+version    : '13.27'
+release    : 47
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.26.tar.gz : 452743ab585f9f61fccf4e1344ab8eaddd689f3ad3463018626820884ea70027
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.27.tar.gz : b58e77381a55c7a9a39eda87f527ffd897bc7d2c669b0c8a87d6ff577fdc6ea5
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -172,9 +172,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="46">
-            <Date>2024-10-27</Date>
-            <Version>13.26</Version>
+        <Update release="47">
+            <Date>2024-11-05</Date>
+            <Version>13.27</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Multiple vector maps rendering improvements/fixes.
- package incl. monitoring.yml
- [changelog](https://build.opensuse.org/projects/home:tumic:GPXSee/packages/gpxsee/files/gpxsee.changes)

**Test Plan**
- open map, zoom, pan etc.

**Checklist**
- [X] Package was built and tested against unstable
