### PR TITLE
Undeprecate and Deprecate fonts

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -971,7 +971,6 @@
 		<Package>python-pyls-black</Package>
 		<Package>python3-jedi</Package>
 		<Package>python3-jedi-dbginfo</Package>
-		<Package>font-firago</Package>
 		<Package>font-ibm-plex</Package>
 		<Package>vte2-docs</Package>
 		<Package>gst-python-0.10</Package>
@@ -1183,7 +1182,6 @@
 		<Package>vala-panel-appmenu-devel</Package>
 		<Package>librsvg-docs</Package>
 		<Package>nautilus-terminal</Package>
-		<Package>font-weather-icons</Package>
 		<Package>nvidia-container-runtime</Package>
 		<Package>python-m2r</Package>
 		<Package>python-backports.entry_points_selectable</Package>
@@ -2734,5 +2732,9 @@
 		<Package>qt6-gamepad-demos</Package>
 		<Package>qt6-gamepad-devel</Package>
 		<Package>qt6-gamepad-dbginfo</Package>
+		<Package>font-firago-otf</Package>
+		<Package>font-firago-ttf</Package>
+		<Package>font-weather-icons-otf</Package>
+		<Package>font-weather-icons-ttf</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1351,7 +1351,6 @@
 		<Package>python3-jedi-dbginfo</Package>
 
 		<!-- Replaced with split otf and ttf packages -->
-		<Package>font-firago</Package>
 		<Package>font-ibm-plex</Package>
 
 		<!-- Old orphan package -->
@@ -1693,8 +1692,6 @@
 		<Package>vala-panel-appmenu-devel</Package>
 		<Package>librsvg-docs</Package>
 		<Package>nautilus-terminal</Package>
-		<!-- Splited later to -otf and -ttf -->
-		<Package>font-weather-icons</Package>
 
 		<!-- Integrated into nvidia-container-toolkit -->
 		<Package>nvidia-container-runtime</Package>
@@ -3652,6 +3649,11 @@
 		<Package>qt6-gamepad-devel</Package>
 		<Package>qt6-gamepad-dbginfo</Package>
 
+		<!-- Only ship .otf file to fix appstream metainfo generation -->
+		<Package>font-firago-otf</Package>
+		<Package>font-firago-ttf</Package>
+		<Package>font-weather-icons-otf</Package>
+		<Package>font-weather-icons-ttf</Package>
 	</Obsoletes>
 </PISI>
 


### PR DESCRIPTION
**Summary**

- Undeprecate font-firago
- Undeprecate font-weather-icons
- Deprecate :
    - font-firago-otf
    - font-firago-ttf
    - font-weather-icons-otf
	- font-weather-icons-ttf

Only land this PR after https://github.com/getsolus/packages/pull/4263 and https://github.com/getsolus/packages/pull/4264 get merged.
