### PR TITLE
lime3ds: Update to v2119

### DIFF
--- a/packages/l/lime3ds/abi_used_libs
+++ b/packages/l/lime3ds/abi_used_libs
@@ -2,6 +2,7 @@ UNKNOWN
 ld-linux-x86-64.so.2
 libQt6Concurrent.so.6
 libQt6Core.so.6
+libQt6DBus.so.6
 libQt6Gui.so.6
 libQt6Multimedia.so.6
 libQt6Widgets.so.6

--- a/packages/l/lime3ds/abi_used_symbols
+++ b/packages/l/lime3ds/abi_used_symbols
@@ -47,6 +47,7 @@ libQt6Core.so.6:_Z9qBadAllocv
 libQt6Core.so.6:_ZN10QArrayData19reallocateUnalignedEPS_PvxxNS_16AllocationOptionE
 libQt6Core.so.6:_ZN10QArrayData8allocateEPPS_xxxNS_16AllocationOptionE
 libQt6Core.so.6:_ZN10QByteArray11reallocDataExN10QArrayData16AllocationOptionE
+libQt6Core.so.6:_ZN10QByteArray6_emptyE
 libQt6Core.so.6:_ZN10QByteArray6appendEc
 libQt6Core.so.6:_ZN10QByteArray6insertEx14QByteArrayView
 libQt6Core.so.6:_ZN10QByteArrayC1EPKcx
@@ -280,6 +281,7 @@ libQt6Core.so.6:_ZN7QString14toLower_helperERS_
 libQt6Core.so.6:_ZN7QString14toUpper_helperERKS_
 libQt6Core.so.6:_ZN7QString14toUpper_helperERS_
 libQt6Core.so.6:_ZN7QString14trimmed_helperERS_
+libQt6Core.so.6:_ZN7QString15toLatin1_helperERKS_
 libQt6Core.so.6:_ZN7QString17simplified_helperERKS_
 libQt6Core.so.6:_ZN7QString17toIntegral_helperE11QStringViewPbi
 libQt6Core.so.6:_ZN7QString17toIntegral_helperE11QStringViewPbj
@@ -321,6 +323,7 @@ libQt6Core.so.6:_ZN8QSysInfo17prettyProductNameEv
 libQt6Core.so.6:_ZN8QVariant13moveConstructE9QMetaTypePv
 libQt6Core.so.6:_ZN8QVariantC1E9QMetaTypePKv
 libQt6Core.so.6:_ZN8QVariantC1ERK10QByteArray
+libQt6Core.so.6:_ZN8QVariantC1ERK4QMapI7QStringS_E
 libQt6Core.so.6:_ZN8QVariantC1ERK5QListI7QStringE
 libQt6Core.so.6:_ZN8QVariantC1ERK5QListIS_E
 libQt6Core.so.6:_ZN8QVariantC1ERK7QString
@@ -550,6 +553,19 @@ libQt6Core.so.6:_ZTI9QRunnable
 libQt6Core.so.6:_ZTV20QFutureInterfaceBase
 libQt6Core.so.6:qt_resourceFeatureZstd
 libQt6Core.so.6:qt_version_tag
+libQt6DBus.so.6:_Z14qDBusReplyFillRK12QDBusMessageR10QDBusErrorR8QVariant
+libQt6DBus.so.6:_Z43qRegisterNormalizedMetaType_QDBusObjectPathRK10QByteArray
+libQt6DBus.so.6:_ZN10QDBusErrorC1Ev
+libQt6DBus.so.6:_ZN12QDBusMessageD1Ev
+libQt6DBus.so.6:_ZN14QDBusInterfaceC1ERK7QStringS2_S2_RK15QDBusConnectionP7QObject
+libQt6DBus.so.6:_ZN14QDBusInterfaceD1Ev
+libQt6DBus.so.6:_ZN15QDBusConnection10sessionBusEv
+libQt6DBus.so.6:_ZN15QDBusConnectionD1Ev
+libQt6DBus.so.6:_ZN22QDBusAbstractInterface6doCallEN5QDBus8CallModeERK7QStringPK8QVariantm
+libQt6DBus.so.6:_ZNK10QDBusError7isValidEv
+libQt6DBus.so.6:_ZNK10QDBusError7messageEv
+libQt6DBus.so.6:_ZNK15QDBusConnection11isConnectedEv
+libQt6DBus.so.6:_ZNK22QDBusAbstractInterface7isValidEv
 libQt6Gui.so.6:_ZN10QClipboard7setTextERK7QStringNS_4ModeE
 libQt6Gui.so.6:_ZN10QDropEvent13setDropActionEN2Qt10DropActionE
 libQt6Gui.so.6:_ZN10QValidator11qt_metacallEN11QMetaObject4CallEiPPv
@@ -735,6 +751,7 @@ libQt6Gui.so.6:_ZNK12QKeySequence8toStringENS_14SequenceFormatE
 libQt6Gui.so.6:_ZNK12QKeySequenceeqERKS_
 libQt6Gui.so.6:_ZNK12QKeySequenceixEj
 libQt6Gui.so.6:_ZNK12QKeySequenceltERKS_
+libQt6Gui.so.6:_ZNK12QPaintDevice16devicePixelRatioEv
 libQt6Gui.so.6:_ZNK13QStandardItem11hasChildrenEv
 libQt6Gui.so.6:_ZNK13QStandardItem3rowEv
 libQt6Gui.so.6:_ZNK13QStandardItem4dataEi
@@ -1241,8 +1258,8 @@ libQt6Widgets.so.6:_ZN8QSpinBox8setRangeEii
 libQt6Widgets.so.6:_ZN8QSpinBox8setValueEi
 libQt6Widgets.so.6:_ZN8QSpinBox9setSuffixERK7QString
 libQt6Widgets.so.6:_ZN8QSpinBoxC1EP7QWidget
-libQt6Widgets.so.6:_ZN9QCheckBox12stateChangedEi
 libQt6Widgets.so.6:_ZN9QCheckBox16staticMetaObjectE
+libQt6Widgets.so.6:_ZN9QCheckBox17checkStateChangedEN2Qt10CheckStateE
 libQt6Widgets.so.6:_ZN9QCheckBoxC1EP7QWidget
 libQt6Widgets.so.6:_ZN9QCheckBoxC1ERK7QStringP7QWidget
 libQt6Widgets.so.6:_ZN9QComboBox10insertItemEiRK5QIconRK7QStringRK8QVariant
@@ -1384,6 +1401,7 @@ libQt6Widgets.so.6:_ZNK7QWidget16inputMethodQueryEN2Qt16InputMethodQueryE
 libQt6Widgets.so.6:_ZNK7QWidget17hasHeightForWidthEv
 libQt6Widgets.so.6:_ZNK7QWidget1yEv
 libQt6Widgets.so.6:_ZNK7QWidget5styleEv
+libQt6Widgets.so.6:_ZNK7QWidget5winIdEv
 libQt6Widgets.so.6:_ZNK7QWidget6layoutEv
 libQt6Widgets.so.6:_ZNK7QWidget6metricEN12QPaintDevice17PaintDeviceMetricE
 libQt6Widgets.so.6:_ZNK7QWidget6screenEv
@@ -1427,6 +1445,8 @@ libQt6Widgets.so.6:_Zls6QDebugPK7QWidget
 libSDL2-2.0.so.0:SDL_AddEventWatch
 libSDL2-2.0.so.0:SDL_CloseAudioDevice
 libSDL2-2.0.so.0:SDL_DelEventWatch
+libSDL2-2.0.so.0:SDL_DisableScreenSaver
+libSDL2-2.0.so.0:SDL_EnableScreenSaver
 libSDL2-2.0.so.0:SDL_GameControllerClose
 libSDL2-2.0.so.0:SDL_GameControllerGetBindForAxis
 libSDL2-2.0.so.0:SDL_GameControllerGetBindForButton

--- a/packages/l/lime3ds/package.yml
+++ b/packages/l/lime3ds/package.yml
@@ -1,8 +1,8 @@
 name       : lime3ds
-version    : '2118.2'
-release    : 8
+version    : '2119'
+release    : 9
 source     :
-    - https://github.com/Lime3DS/Lime3DS/releases/download/2118.2/lime3ds-unified-source-2118.2.tar.xz : ee8303e4fe1d4b6ee8c2cffc9d7314d2ce126211ff95b6fa287a1fc955486604
+    - https://github.com/Lime3DS/Lime3DS/releases/download/2119/lime3ds-unified-source-2119.tar.xz : c2599d913664621a773d529af6d1e58b98b788e691f84694cc39fb68b6dae6e1
 homepage   : https://lime3ds.github.io/
 license    : GPL-2.0-or-later
 component  : games.emulator

--- a/packages/l/lime3ds/pspec_x86_64.xml
+++ b/packages/l/lime3ds/pspec_x86_64.xml
@@ -32,9 +32,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2024-10-01</Date>
-            <Version>2118.2</Version>
+        <Update release="9">
+            <Date>2024-11-06</Date>
+            <Version>2119</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
             <Email>malfisya.dev@hotmail.com</Email>


### PR DESCRIPTION
**Summary**

- Added a "Small Screen Position" feature which can be used with the Large Screen layout
- Diagonal inputs for the circlepad and c-stick can now be bound from the Controls menu
- Added new command line options for the `lime3ds` executable which mirror those that were available with the `-cli` executable
- Fixed the labels in the Texture Filter dropdown menu being mismatched
- Full release note can read [here](https://github.com/Lime3DS/Lime3DS/releases/tag/2119)

**Test Plan**

<!-- Short description of how the package was tested -->
Play Fire Emblem: Shadow of Valentia

**Checklist**

- [x] Package was built and tested against unstable
