### PR TITLE
morewaita-icon-theme: Update to v47.1

### DIFF
--- a/packages/m/morewaita-icon-theme/package.yml
+++ b/packages/m/morewaita-icon-theme/package.yml
@@ -1,8 +1,8 @@
 name       : morewaita-icon-theme
-version    : '47'
-release    : 1
+version    : '47.1'
+release    : 2
 source     :
-    - https://github.com/somepaulo/MoreWaita/archive/refs/tags/v47.tar.gz : 17de281cfdc95b7600ee343eda92351ef809b187be26c8f84710845d3b658df2
+    - https://github.com/somepaulo/MoreWaita/archive/refs/tags/47.1.tar.gz : 580a3b1609a49420a85b35c2e2dd8c5c774b81eef41cb7ad818b775ea299718d
 homepage   : https://github.com/somepaulo/MoreWaita/
 license    : GPL-3.0-or-later
 component  : desktop.theme

--- a/packages/m/morewaita-icon-theme/pspec_x86_64.xml
+++ b/packages/m/morewaita-icon-theme/pspec_x86_64.xml
@@ -72,6 +72,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/appimagekit-unityeditor.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/appimagekit-unityhub.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/appimagekit-yuzu.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/appimagekit-zen-browser.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/applications-java.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/ardour.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/ardour6.svg</Path>
@@ -141,6 +142,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/com.getmailspring.Mailspring.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/com.getpostman.Postman.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/com.gigitux.gtkwhats.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/com.github.Eloston.UngoogledChromium.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/com.github.IsmaelMartinez.teams_for_linux.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/com.github.eneshecan.WhatsAppForLinux.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/com.github.gkarsay.parlatype.svg</Path>
@@ -182,6 +184,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/com.sublimemerge.App.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/com.sublimetext.three.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/com.todoist.Todoist.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/com.tominlab.wonderpen.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/com.tonikelope.MegaBasterd.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/com.unityhub.UnityEditor.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/com.unityhub.UnityHub.svg</Path>
@@ -254,6 +257,9 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/foobar2000.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/fr.handbrake.ghb.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/freac.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/freecad-daily.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/freecad.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/freedroidrpg.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/freetube-bin.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/freetube.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/fuse-emulator.svg</Path>
@@ -330,6 +336,8 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/io.github.rinigus.PureMaps.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/io.github.shiftey.Desktop.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/io.github.spacingbat3.webcord.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/io.github.ungoogled_software.ungoogled_chromium.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/io.github.zen_browser.zen.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/io.gitlab.LibreWolf.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/io.gitlab.caveman250.headlines.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/io.gitlab.librewolf-community.svg</Path>
@@ -362,6 +370,10 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/java19-openjdk.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/java20-openjdk.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/java21-openjdk.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/java22-openjdk.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/java23-openjdk.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/java24-openjdk.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/java25-openjdk.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/java8-openjdk.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/java9-openjdk.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/javaws.svg</Path>
@@ -378,6 +390,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/kate2.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/kdenlive.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/keepassxc.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/kicad.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/kitty.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/kolourpaint.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/krita.svg</Path>
@@ -551,6 +564,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/lutris_minecraft.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/lvim.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/mailspring.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/maple.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/mathematica.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/mattermost-desktop-bin.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/mattermost-desktop.svg</Path>
@@ -609,6 +623,8 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/nvtop.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/obs.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/obsidian.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/octave.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/okular.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/one.alynx.showmethekey.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/onetagger.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/onlyoffice-desktopeditors.svg</Path>
@@ -616,6 +632,8 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/openra-cnc.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/openra-d2k.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/openra-ra.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/openscad.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/opensnitch-ui.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/opera-cifhbcnohmdccbgoicgdjpfamggdegmo-Default.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/opera.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/oracle-javaws.svg</Path>
@@ -642,6 +660,8 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.flightgear.FGCom.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.flightgear.FlightGear.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.freac.freac.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.freecad.FreeCAD.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.freecadweb.FreeCAD.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.geany.Geany.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.geogebra.GeoGebra.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.getmonero.Monero.svg</Path>
@@ -660,8 +680,10 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.kde.kolourpaint.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.kde.krita.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.kde.kruler.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.kde.okular.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.kde.plasma.katesessions.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.keepassxc.KeePassXC.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.kicad.KiCad.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.libreoffice.LibreOffice.base.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.libreoffice.LibreOffice.basic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.libreoffice.LibreOffice.calc.svg</Path>
@@ -681,15 +703,19 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.mozilla.Thunderbird.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.mozilla.firefox.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.nextcloud.Nextcloud.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.octave.Octave.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.onlyoffice.desktopeditors.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.openscad.OpenSCAD.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.openstreetmap.josm.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.parlatype.Parlatype.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.prismlauncher.PrismLauncher.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.pulseaudio.pavucontrol.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.pwmt.zathura.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.qbittorrent.qBittorrent.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.qutebrowser.qutebrowser.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.signal.Signal.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.soundconverter.SoundConverter.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.sqlitebrowser.sqlitebrowser.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.standardnotes.standardnotes.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.stellarium.Stellarium.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/org.strawberrymusicplayer.strawberry.svg</Path>
@@ -742,6 +768,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/qtconfig.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/qtdbusviewer.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/qtlinguist.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/qtoctave.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/qtscrcpy.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/qutebrowser.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/qv4l2.svg</Path>
@@ -778,6 +805,8 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/spotify.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/spyder.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/spyder3.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/sqlitebrowser.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/sqliteman.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/standard-notes.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/steam-icon.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/steam-launcher.svg</Path>
@@ -846,6 +875,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/tor.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/torbrowser.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/uk.co.ibboard.cawbird.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/ungoogled-chromium.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/unity-editor-icon.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/unityeditor.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/unityhub.svg</Path>
@@ -875,6 +905,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/whatsdesk.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/windscribe.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/wolfram-mathematica.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/wonderpen.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/xdvi.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/xsane.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/yandex-browser-beta.svg</Path>
@@ -882,7 +913,9 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/yast-scanner.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/yuzu.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/zaproxy.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/zathura.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/zed.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/zen-browser.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/zoom-desktop.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/zoom-icon.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/apps/zrythm.svg</Path>
@@ -898,6 +931,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-javascript.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-json.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-mathematica.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-mathematicaplayer.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-metalink+xml.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-metalink4+xml.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-octet-stream.svg</Path>
@@ -963,6 +997,12 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-vnd.sqlite2.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-vnd.sqlite3.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-vnd.squashfs.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-vnd.wolfram.cdf.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-vnd.wolfram.mathematica.package.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-vnd.wolfram.nb.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-vnd.wolfram.player.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-vnd.wolfram.wl.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-vnd.wolfram.wls.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-x-adobe-indesign.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-x-apple-diskimage.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-x-applix-spreadsheet.svg</Path>
@@ -982,6 +1022,8 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-x-cbt.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-x-cbz.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-x-cd-image.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-x-clojure.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-x-clojurescript.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-x-com.bitwig-clip.BitwigStudio.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-x-com.bitwig-device.BitwigStudio.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-x-com.bitwig.BitwigStudio.svg</Path>
@@ -1002,6 +1044,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-x-godot-shader.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-x-gzpostscript.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-x-ips-patch.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-x-ipynb+json.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-x-iso.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-x-iso9600-appimage.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/application-x-jar.svg</Path>
@@ -1181,11 +1224,14 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-rust.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-spreadsheet.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-tab-separated-values.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-x-R.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-x-c++.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-x-c++hdr.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-x-c++src.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-x-c.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-x-chdr.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-x-clojure.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-x-clojurescript.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-x-cmake.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-x-cpp.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-x-cpphdr.svg</Path>
@@ -1205,6 +1251,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-x-makefile.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-x-markdown.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-x-meson.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-x-octave.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-x-patch.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-x-php.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/mimes/text-x-python.svg</Path>
@@ -1271,6 +1318,8 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-extensions.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-fedora-legacy.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-fedora.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-flatpak-legacy.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-flatpak.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-freecad-legacy.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-freecad.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-games-legacy.svg</Path>
@@ -1307,6 +1356,8 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-neovim.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-nextcloud-legacy.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-nextcloud.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-nix-legacy.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-nix.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-openscad-legacy.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-openscad.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-opensuse-legacy.svg</Path>
@@ -1345,6 +1396,8 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-user.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-vala-legacy.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-vala.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-wine-legacy.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-wine.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-work-legacy.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/folder-work.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/scalable/places/meson.build</Path>
@@ -1398,6 +1451,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/appimagekit-unityeditor-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/appimagekit-unityhub-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/appimagekit-yuzu-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/appimagekit-zen-browser-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/applications-java-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/ardour-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/ardour6-symbolic.svg</Path>
@@ -1463,6 +1517,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/com.discordapp.DiscordCanary-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/com.getmailspring.Mailspring-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/com.gigitux.gtkwhats-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/com.github.Eloston.UngoogledChromium-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/com.github.IsmaelMartinez.teams_for_linux-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/com.github.eneshecan.WhatsAppForLinux-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/com.github.micahflee.torbrowser-launcher-symbolic.svg</Path>
@@ -1503,6 +1558,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/com.sublimemerge.App-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/com.sublimetext.three-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/com.todoist.Todoist-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/com.tominlab.wonderpen-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/com.tonikelope.MegaBasterd-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/com.unityhub.UnityEditor-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/com.unityhub.UnityHub-symbolic.svg</Path>
@@ -1575,6 +1631,9 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/foobar2000-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/fr.handbrake.ghb-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/freac-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/freecad-daily-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/freecad-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/freedroidrpg-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/freetube-bin-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/freetube-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/fuse-emulator-symbolic.svg</Path>
@@ -1644,6 +1703,8 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/io.github.rinigus.PureMaps-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/io.github.shiftey.Desktop-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/io.github.spacingbat3.webcord-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/io.github.ungoogled_software.ungoogled_chromium-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/io.github.zen_browser.zen-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/io.gitlab.LibreWolf-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/io.gitlab.caveman250.headlines-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/io.gitlab.librewolf-community-symbolic.svg</Path>
@@ -1675,6 +1736,10 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/java19-openjdk-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/java20-openjdk-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/java21-openjdk-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/java22-openjdk-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/java23-openjdk-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/java24-openjdk-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/java25-openjdk-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/java8-openjdk-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/java9-openjdk-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/javaws-symbolic.svg</Path>
@@ -1691,6 +1756,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/kate2-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/kdenlive-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/keepassxc-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/kicad-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/kitty-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/kolourpaint-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/krita-symbolic.svg</Path>
@@ -1864,6 +1930,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/lutris_minecraft-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/lvim-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/mailspring-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/maple-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/mathematica-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/mattermost-desktop-bin-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/mattermost-desktop-symbolic.svg</Path>
@@ -1918,6 +1985,8 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/nvtop-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/obs-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/obsidian-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/octave-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/okular-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/om.getpostman.Postman-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/one.alynx.showmethekey-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/onetagger-symbolic.svg</Path>
@@ -1926,6 +1995,8 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/openra-cnc-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/openra-d2k-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/openra-ra-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/openscad-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/opensnitch-ui-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/opera-cifhbcnohmdccbgoicgdjpfamggdegmo-Default-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/opera-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/oracle_java6-symbolic.svg</Path>
@@ -1952,6 +2023,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.flightgear.FGCom-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.flightgear.FlightGear-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.freac.freac-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.freecadweb.FreeCAD-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.geany.Geany-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.geogebra.GeoGebra-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.getmonero.Monero-symbolic.svg</Path>
@@ -1968,8 +2040,10 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.kde.kolourpaint-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.kde.krita-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.kde.kruler-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.kde.okular-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.kde.plasma.katesessions-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.keepassxc.KeePassXC-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.kicad.KiCad-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.libreoffice.LibreOffice.base-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.libreoffice.LibreOffice.basic-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.libreoffice.LibreOffice.calc-symbolic.svg</Path>
@@ -1989,13 +2063,17 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.mozilla.Thunderbird-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.mozilla.firefox-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.nextcloud.Nextcloud-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.octave.Octave-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.onlyoffice.desktopeditors-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.openscad.OpenSCAD-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.openstreetmap.josm-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.prismlauncher.PrismLauncher-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.pwmt.zathura-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.qbittorrent.qBittorrent-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.qutebrowser.qutebrowser-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.signal.Signal-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.soundconverter.SoundConverter-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.sqlitebrowser.sqlitebrowser-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.standardnotes.standardnotes-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.stellarium.Stellarium-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/org.strawberrymusicplayer.strawberry-symbolic.svg</Path>
@@ -2046,6 +2124,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/qtconfig-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/qtdbusviewer-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/qtlinguist-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/qtoctave-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/qtscrcpy-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/qutebrowser-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/qv4l2-symbolic.svg</Path>
@@ -2082,6 +2161,8 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/spotify-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/spyder-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/spyder3-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/sqlitebrowser-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/sqliteman-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/standard-notes-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/steam-icon-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/steam-launcher-symbolic.svg</Path>
@@ -2149,6 +2230,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/tor-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/torbrowser-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/uk.co.ibboard.cawbird-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/ungoogled-chromium-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/unity-editor-icon-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/unityeditor-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/unityhub-symbolic.svg</Path>
@@ -2177,6 +2259,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/whatsdesk-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/windscribe-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/wolfram-mathematica-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/wonderpen-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/xdvi-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/xsane-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/yandex-browser-beta-symbolic.svg</Path>
@@ -2184,7 +2267,9 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/yast-scanner-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/yuzu-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/zaproxy-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/zathura-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/zed-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/zen-browser-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/zoom-desktop-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/zoom-icon-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/apps/zrythm-symbolic.svg</Path>
@@ -2277,6 +2362,7 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-extensions-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-fedora-legacy-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-fedora-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-flatpak-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-freecad-legacy-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-freecad-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-games-legacy-symbolic.svg</Path>
@@ -2313,6 +2399,8 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-neovim-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-nextcloud-legacy-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-nextcloud-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-nix-legacy-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-nix-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-openscad-legacy-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-openscad-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-opensuse-legacy-symbolic.svg</Path>
@@ -2351,15 +2439,17 @@
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-user-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-vala-legacy-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-vala-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-wine-legacy-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-wine-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-work-legacy-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/folder-work-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/MoreWaita/symbolic/places/meson.build</Path>
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-10-21</Date>
-            <Version>47</Version>
+        <Update release="2">
+            <Date>2024-11-06</Date>
+            <Version>47.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
             <Email>malfisya.dev@hotmail.com</Email>


### PR DESCRIPTION
**Summary**

- Added folder: wine
- Added Zen Browser icon
- Added FreeCAD Icon
- Added folder: Flatpak
- Added OpenSCAD Icon
- Full release note can be read [here](https://github.com/somepaulo/MoreWaita/releases/tag/47.1)

**Test Plan**

<!-- Short description of how the package was tested -->
Set icon theme and check everything works as it supposed to

**Checklist**

- [x] Package was built and tested against unstable
