### PR TITLE
hicolor-icon-theme: Update to v0.18

### DIFF
--- a/packages/h/hicolor-icon-theme/package.yml
+++ b/packages/h/hicolor-icon-theme/package.yml
@@ -1,18 +1,21 @@
-name        : hicolor-icon-theme
-version     : 0.17
-release     : 7
-source      :
-    - https://icon-theme.freedesktop.org/releases/hicolor-icon-theme-0.17.tar.xz : 317484352271d18cbbcfac3868eab798d67fff1b8402e740baa6ff41d588a9d8
-homepage    : http://www.freedesktop.org/wiki/Software/icon-theme/
-license     :
-    - GPL-2.0
-summary     : Default fallback icon theme
-component   : desktop.theme
-description : |
+name       : hicolor-icon-theme
+version    : '0.18'
+release    : 8
+source     :
+    - https://icon-theme.freedesktop.org/releases/hicolor-icon-theme-0.18.tar.xz : db0e50a80aa3bf64bb45cbca5cf9f75efd9348cf2ac690b907435238c3cf81d7
+homepage   : http://www.freedesktop.org/wiki/Software/icon-theme/
+license    :
+    - GPL-2.0-or-later
+component  : desktop.theme
+summary    : Default fallback icon theme
+description: |
     The hicolor-icon-theme package contains a default fallback theme for implementations of the icon theme specification.
+# no point creating a -devel subpackage just for the pkgconfig file
+patterns   :
+    - /*
 setup      : |
-    %configure
+    %meson_configure
 build      : |
-    %make
+    %ninja_build
 install    : |
-    %make_install
+    %ninja_install

--- a/packages/h/hicolor-icon-theme/pspec_x86_64.xml
+++ b/packages/h/hicolor-icon-theme/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>hicolor-icon-theme</Name>
         <Homepage>http://www.freedesktop.org/wiki/Software/icon-theme/</Homepage>
         <Packager>
-            <Name>Ikey Doherty</Name>
-            <Email>ikey@solus-project.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
-        <License>GPL-2.0</License>
+        <License>GPL-2.0-or-later</License>
         <PartOf>desktop.theme</PartOf>
         <Summary xml:lang="en">Default fallback icon theme</Summary>
         <Description xml:lang="en">The hicolor-icon-theme package contains a default fallback theme for implementations of the icon theme specification.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://solus-project.com/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>hicolor-icon-theme</Name>
@@ -44,6 +44,30 @@
             <Path fileType="data">/usr/share/icons/hicolor/128x128/stock/object</Path>
             <Path fileType="data">/usr/share/icons/hicolor/128x128/stock/table</Path>
             <Path fileType="data">/usr/share/icons/hicolor/128x128/stock/text</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/actions</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/animations</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/apps</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/categories</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/devices</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/emblems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/emotes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/filesystems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/intl</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/mimetypes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/places</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/status</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/stock/chart</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/stock/code</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/stock/data</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/stock/form</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/stock/image</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/stock/io</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/stock/media</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/stock/navigation</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/stock/net</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/stock/object</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/stock/table</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128@2/stock/text</Path>
             <Path fileType="data">/usr/share/icons/hicolor/16x16/actions</Path>
             <Path fileType="data">/usr/share/icons/hicolor/16x16/animations</Path>
             <Path fileType="data">/usr/share/icons/hicolor/16x16/apps</Path>
@@ -68,6 +92,30 @@
             <Path fileType="data">/usr/share/icons/hicolor/16x16/stock/object</Path>
             <Path fileType="data">/usr/share/icons/hicolor/16x16/stock/table</Path>
             <Path fileType="data">/usr/share/icons/hicolor/16x16/stock/text</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/actions</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/animations</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/apps</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/categories</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/devices</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/emblems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/emotes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/filesystems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/intl</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/mimetypes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/places</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/status</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/stock/chart</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/stock/code</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/stock/data</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/stock/form</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/stock/image</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/stock/io</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/stock/media</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/stock/navigation</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/stock/net</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/stock/object</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/stock/table</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16@2/stock/text</Path>
             <Path fileType="data">/usr/share/icons/hicolor/192x192/actions</Path>
             <Path fileType="data">/usr/share/icons/hicolor/192x192/animations</Path>
             <Path fileType="data">/usr/share/icons/hicolor/192x192/apps</Path>
@@ -92,6 +140,30 @@
             <Path fileType="data">/usr/share/icons/hicolor/192x192/stock/object</Path>
             <Path fileType="data">/usr/share/icons/hicolor/192x192/stock/table</Path>
             <Path fileType="data">/usr/share/icons/hicolor/192x192/stock/text</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/actions</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/animations</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/apps</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/categories</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/devices</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/emblems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/emotes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/filesystems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/intl</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/mimetypes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/places</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/status</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/stock/chart</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/stock/code</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/stock/data</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/stock/form</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/stock/image</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/stock/io</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/stock/media</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/stock/navigation</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/stock/net</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/stock/object</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/stock/table</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192@2/stock/text</Path>
             <Path fileType="data">/usr/share/icons/hicolor/22x22/actions</Path>
             <Path fileType="data">/usr/share/icons/hicolor/22x22/animations</Path>
             <Path fileType="data">/usr/share/icons/hicolor/22x22/apps</Path>
@@ -116,6 +188,30 @@
             <Path fileType="data">/usr/share/icons/hicolor/22x22/stock/object</Path>
             <Path fileType="data">/usr/share/icons/hicolor/22x22/stock/table</Path>
             <Path fileType="data">/usr/share/icons/hicolor/22x22/stock/text</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/actions</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/animations</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/apps</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/categories</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/devices</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/emblems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/emotes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/filesystems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/intl</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/mimetypes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/places</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/status</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/stock/chart</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/stock/code</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/stock/data</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/stock/form</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/stock/image</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/stock/io</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/stock/media</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/stock/navigation</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/stock/net</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/stock/object</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/stock/table</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22@2/stock/text</Path>
             <Path fileType="data">/usr/share/icons/hicolor/24x24/actions</Path>
             <Path fileType="data">/usr/share/icons/hicolor/24x24/animations</Path>
             <Path fileType="data">/usr/share/icons/hicolor/24x24/apps</Path>
@@ -140,6 +236,30 @@
             <Path fileType="data">/usr/share/icons/hicolor/24x24/stock/object</Path>
             <Path fileType="data">/usr/share/icons/hicolor/24x24/stock/table</Path>
             <Path fileType="data">/usr/share/icons/hicolor/24x24/stock/text</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/actions</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/animations</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/apps</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/categories</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/devices</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/emblems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/emotes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/filesystems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/intl</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/mimetypes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/places</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/status</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/stock/chart</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/stock/code</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/stock/data</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/stock/form</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/stock/image</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/stock/io</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/stock/media</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/stock/navigation</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/stock/net</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/stock/object</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/stock/table</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24@2/stock/text</Path>
             <Path fileType="data">/usr/share/icons/hicolor/256x256/actions</Path>
             <Path fileType="data">/usr/share/icons/hicolor/256x256/animations</Path>
             <Path fileType="data">/usr/share/icons/hicolor/256x256/apps</Path>
@@ -164,6 +284,30 @@
             <Path fileType="data">/usr/share/icons/hicolor/256x256/stock/object</Path>
             <Path fileType="data">/usr/share/icons/hicolor/256x256/stock/table</Path>
             <Path fileType="data">/usr/share/icons/hicolor/256x256/stock/text</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/actions</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/animations</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/apps</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/categories</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/devices</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/emblems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/emotes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/filesystems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/intl</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/mimetypes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/places</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/status</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/stock/chart</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/stock/code</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/stock/data</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/stock/form</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/stock/image</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/stock/io</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/stock/media</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/stock/navigation</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/stock/net</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/stock/object</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/stock/table</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256@2/stock/text</Path>
             <Path fileType="data">/usr/share/icons/hicolor/32x32/actions</Path>
             <Path fileType="data">/usr/share/icons/hicolor/32x32/animations</Path>
             <Path fileType="data">/usr/share/icons/hicolor/32x32/apps</Path>
@@ -188,6 +332,30 @@
             <Path fileType="data">/usr/share/icons/hicolor/32x32/stock/object</Path>
             <Path fileType="data">/usr/share/icons/hicolor/32x32/stock/table</Path>
             <Path fileType="data">/usr/share/icons/hicolor/32x32/stock/text</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/actions</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/animations</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/apps</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/categories</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/devices</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/emblems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/emotes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/filesystems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/intl</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/mimetypes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/places</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/status</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/stock/chart</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/stock/code</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/stock/data</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/stock/form</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/stock/image</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/stock/io</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/stock/media</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/stock/navigation</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/stock/net</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/stock/object</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/stock/table</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32@2/stock/text</Path>
             <Path fileType="data">/usr/share/icons/hicolor/36x36/actions</Path>
             <Path fileType="data">/usr/share/icons/hicolor/36x36/animations</Path>
             <Path fileType="data">/usr/share/icons/hicolor/36x36/apps</Path>
@@ -212,6 +380,30 @@
             <Path fileType="data">/usr/share/icons/hicolor/36x36/stock/object</Path>
             <Path fileType="data">/usr/share/icons/hicolor/36x36/stock/table</Path>
             <Path fileType="data">/usr/share/icons/hicolor/36x36/stock/text</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/actions</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/animations</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/apps</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/categories</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/devices</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/emblems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/emotes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/filesystems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/intl</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/mimetypes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/places</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/status</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/stock/chart</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/stock/code</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/stock/data</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/stock/form</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/stock/image</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/stock/io</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/stock/media</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/stock/navigation</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/stock/net</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/stock/object</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/stock/table</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/36x36@2/stock/text</Path>
             <Path fileType="data">/usr/share/icons/hicolor/48x48/actions</Path>
             <Path fileType="data">/usr/share/icons/hicolor/48x48/animations</Path>
             <Path fileType="data">/usr/share/icons/hicolor/48x48/apps</Path>
@@ -236,6 +428,30 @@
             <Path fileType="data">/usr/share/icons/hicolor/48x48/stock/object</Path>
             <Path fileType="data">/usr/share/icons/hicolor/48x48/stock/table</Path>
             <Path fileType="data">/usr/share/icons/hicolor/48x48/stock/text</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/actions</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/animations</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/apps</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/categories</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/devices</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/emblems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/emotes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/filesystems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/intl</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/mimetypes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/places</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/status</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/stock/chart</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/stock/code</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/stock/data</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/stock/form</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/stock/image</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/stock/io</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/stock/media</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/stock/navigation</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/stock/net</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/stock/object</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/stock/table</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48@2/stock/text</Path>
             <Path fileType="data">/usr/share/icons/hicolor/512x512/actions</Path>
             <Path fileType="data">/usr/share/icons/hicolor/512x512/animations</Path>
             <Path fileType="data">/usr/share/icons/hicolor/512x512/apps</Path>
@@ -260,6 +476,30 @@
             <Path fileType="data">/usr/share/icons/hicolor/512x512/stock/object</Path>
             <Path fileType="data">/usr/share/icons/hicolor/512x512/stock/table</Path>
             <Path fileType="data">/usr/share/icons/hicolor/512x512/stock/text</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/actions</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/animations</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/apps</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/categories</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/devices</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/emblems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/emotes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/filesystems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/intl</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/mimetypes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/places</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/status</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/stock/chart</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/stock/code</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/stock/data</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/stock/form</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/stock/image</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/stock/io</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/stock/media</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/stock/navigation</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/stock/net</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/stock/object</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/stock/table</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512@2/stock/text</Path>
             <Path fileType="data">/usr/share/icons/hicolor/64x64/actions</Path>
             <Path fileType="data">/usr/share/icons/hicolor/64x64/animations</Path>
             <Path fileType="data">/usr/share/icons/hicolor/64x64/apps</Path>
@@ -284,6 +524,30 @@
             <Path fileType="data">/usr/share/icons/hicolor/64x64/stock/object</Path>
             <Path fileType="data">/usr/share/icons/hicolor/64x64/stock/table</Path>
             <Path fileType="data">/usr/share/icons/hicolor/64x64/stock/text</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/actions</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/animations</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/apps</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/categories</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/devices</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/emblems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/emotes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/filesystems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/intl</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/mimetypes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/places</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/status</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/stock/chart</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/stock/code</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/stock/data</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/stock/form</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/stock/image</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/stock/io</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/stock/media</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/stock/navigation</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/stock/net</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/stock/object</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/stock/table</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64@2/stock/text</Path>
             <Path fileType="data">/usr/share/icons/hicolor/72x72/actions</Path>
             <Path fileType="data">/usr/share/icons/hicolor/72x72/animations</Path>
             <Path fileType="data">/usr/share/icons/hicolor/72x72/apps</Path>
@@ -308,6 +572,30 @@
             <Path fileType="data">/usr/share/icons/hicolor/72x72/stock/object</Path>
             <Path fileType="data">/usr/share/icons/hicolor/72x72/stock/table</Path>
             <Path fileType="data">/usr/share/icons/hicolor/72x72/stock/text</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/actions</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/animations</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/apps</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/categories</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/devices</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/emblems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/emotes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/filesystems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/intl</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/mimetypes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/places</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/status</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/stock/chart</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/stock/code</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/stock/data</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/stock/form</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/stock/image</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/stock/io</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/stock/media</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/stock/navigation</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/stock/net</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/stock/object</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/stock/table</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/72x72@2/stock/text</Path>
             <Path fileType="data">/usr/share/icons/hicolor/96x96/actions</Path>
             <Path fileType="data">/usr/share/icons/hicolor/96x96/animations</Path>
             <Path fileType="data">/usr/share/icons/hicolor/96x96/apps</Path>
@@ -332,6 +620,30 @@
             <Path fileType="data">/usr/share/icons/hicolor/96x96/stock/object</Path>
             <Path fileType="data">/usr/share/icons/hicolor/96x96/stock/table</Path>
             <Path fileType="data">/usr/share/icons/hicolor/96x96/stock/text</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/actions</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/animations</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/apps</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/categories</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/devices</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/emblems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/emotes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/filesystems</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/intl</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/mimetypes</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/places</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/status</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/stock/chart</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/stock/code</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/stock/data</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/stock/form</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/stock/image</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/stock/io</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/stock/media</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/stock/navigation</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/stock/net</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/stock/object</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/stock/table</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96@2/stock/text</Path>
             <Path fileType="data">/usr/share/icons/hicolor/index.theme</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/actions</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/animations</Path>
@@ -358,15 +670,16 @@
             <Path fileType="data">/usr/share/icons/hicolor/scalable/stock/table</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/stock/text</Path>
             <Path fileType="data">/usr/share/icons/hicolor/symbolic/apps</Path>
+            <Path fileType="data">/usr/share/pkgconfig/default-icon-theme.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2017-11-29</Date>
-            <Version>0.17</Version>
+        <Update release="8">
+            <Date>2024-11-06</Date>
+            <Version>0.18</Version>
             <Comment>Packaging update</Comment>
-            <Name>Ikey Doherty</Name>
-            <Email>ikey@solus-project.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
[Changelog](https://gitlab.freedesktop.org/xdg/default-icon-theme/-/raw/v0.18/NEWS?ref_type=tags)

**Test Plan**

- install use system as normal

**Checklist**

- [x] Package was built and tested against unstable
