### PR TITLE
xfce4-weather-plugin: Update to v0.11.3

### DIFF
--- a/packages/x/xfce4-weather-plugin/abi_used_symbols
+++ b/packages/x/xfce4-weather-plugin/abi_used_symbols
@@ -127,6 +127,7 @@ libglib-2.0.so.0:g_utf8_strchr
 libglib-2.0.so.0:g_utf8_strlen
 libglib-2.0.so.0:g_utf8_strncpy
 libglib-2.0.so.0:g_utf8_validate
+libgobject-2.0.so.0:g_object_add_weak_pointer
 libgobject-2.0.so.0:g_object_get_data
 libgobject-2.0.so.0:g_object_new
 libgobject-2.0.so.0:g_object_set

--- a/packages/x/xfce4-weather-plugin/package.yml
+++ b/packages/x/xfce4-weather-plugin/package.yml
@@ -1,8 +1,8 @@
 name       : xfce4-weather-plugin
-version    : 0.11.2
-release    : 1
+version    : 0.11.3
+release    : 2
 source     :
-    - https://archive.xfce.org/src/panel-plugins/xfce4-weather-plugin/0.11/xfce4-weather-plugin-0.11.2.tar.bz2 : 65d40aff7863550858a9f9d2b6054f27c69a3e7e712991785987f9a73bba876b
+    - https://archive.xfce.org/src/panel-plugins/xfce4-weather-plugin/0.11/xfce4-weather-plugin-0.11.3.tar.bz2 : 002d1fe63906d2f3a012f3cb58cceff1dfbcc466759e36c76d3b03dd01c0dc57
 homepage   : https://docs.xfce.org/panel-plugins/xfce4-weather-plugin/start
 license    : GPL-2.0-or-later
 component  : desktop.xfce

--- a/packages/x/xfce4-weather-plugin/pspec_x86_64.xml
+++ b/packages/x/xfce4-weather-plugin/pspec_x86_64.xml
@@ -3,20 +3,20 @@
         <Name>xfce4-weather-plugin</Name>
         <Homepage>https://docs.xfce.org/panel-plugins/xfce4-weather-plugin/start</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.xfce</PartOf>
         <Summary xml:lang="en">Display information about your local weather in the panel</Summary>
-        <Description xml:lang="en">Originally written by Bob Schlärmann, this panel plugin shows information about your local weather in the panel, using forecast data provided by met.no
+        <Description xml:lang="en">Originally written by Bob Schl&#xe4;rmann, this panel plugin shows information about your local weather in the panel, using forecast data provided by met.no
 </Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>xfce4-weather-plugin</Name>
         <Summary xml:lang="en">Display information about your local weather in the panel</Summary>
-        <Description xml:lang="en">Originally written by Bob Schlärmann, this panel plugin shows information about your local weather in the panel, using forecast data provided by met.no
+        <Description xml:lang="en">Originally written by Bob Schl&#xe4;rmann, this panel plugin shows information about your local weather in the panel, using forecast data provided by met.no
 </Description>
         <PartOf>desktop.xfce</PartOf>
         <Files>
@@ -373,12 +373,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-03-19</Date>
-            <Version>0.11.2</Version>
+        <Update release="2">
+            <Date>2024-11-06</Date>
+            <Version>0.11.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Use subdomain for api.met.no
- Avoid calling libsoup callbacks when dialogs are destroyed
- weather-config: Fix memory leak on GtkBuilder
- icon: Apply translate logic to get_symbol_name
- weather-config: Fix memory management of source
- Translation updates

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Add the plugin to the panel, configure my location, see the current weather. Tis a bit warm, for this time of year.

**Checklist**

- [x] Package was built and tested against unstable
