### PR TITLE
gnome-online-accounts-gtk: Update to v3.50.4

### DIFF
--- a/packages/g/gnome-online-accounts-gtk/package.yml
+++ b/packages/g/gnome-online-accounts-gtk/package.yml
@@ -1,8 +1,8 @@
 name       : gnome-online-accounts-gtk
-version    : 3.50.2
-release    : 1
+version    : 3.50.4
+release    : 2
 source     :
-    - https://github.com/xapp-project/gnome-online-accounts-gtk/archive/refs/tags/3.50.2.tar.gz : 590663ceff05d1144d9977bc0bbd97f0b277366ba52ce0940dc5daf0bbda5210
+    - https://github.com/xapp-project/gnome-online-accounts-gtk/archive/refs/tags/3.50.4.tar.gz : 661192f5092cf722fb883d364f1f3555a4f2c00194e5c27f92e2ac0db65f1e93
 homepage   : https://github.com/xapp-project/gnome-online-accounts-gtk
 license    : GPL-3.0-or-later
 component  : desktop.gtk

--- a/packages/g/gnome-online-accounts-gtk/pspec_x86_64.xml
+++ b/packages/g/gnome-online-accounts-gtk/pspec_x86_64.xml
@@ -23,26 +23,54 @@
             <Path fileType="executable">/usr/bin/gnome-online-accounts-gtk</Path>
             <Path fileType="data">/usr/share/applications/gnome-online-accounts-gtk.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/gnome-online-accounts-gtk.svg</Path>
+            <Path fileType="localedata">/usr/share/locale/ast/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/be/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/br/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/cy/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/en_GB/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/et/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/eu/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fa/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fi/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/fr_CA/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/he/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/hu/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ia/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/is/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ko/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/mnw/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/nb/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/nl/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/oc/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pl/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/pt/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ro/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ru/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sk/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sl/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/tr/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/uz/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/vi/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/gnome-online-accounts-gtk.mo</Path>
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-05-01</Date>
-            <Version>3.50.2</Version>
+        <Update release="2">
+            <Date>2024-11-06</Date>
+            <Version>3.50.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Fix build with newer GTK4
- Translation updates

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Add my Google account.

**Checklist**

- [x] Package was built and tested against unstable
