### PR TITLE
blueprint-compiler: Update to v0.14.0

### DIFF
--- a/packages/b/blueprint-compiler/package.yml
+++ b/packages/b/blueprint-compiler/package.yml
@@ -1,8 +1,8 @@
 name       : blueprint-compiler
-version    : 0.12.0
-release    : 6
+version    : 0.14.0
+release    : 7
 source     :
-    - https://gitlab.gnome.org/jwestman/blueprint-compiler/-/archive/v0.12.0/blueprint-compiler-v0.12.0.tar.bz2 : 0f762e8a0dfef9aa46b4bddf8ed4bbc09b5d2fa2baff5dec109ccc513c6e9e00
+    - https://gitlab.gnome.org/jwestman/blueprint-compiler/-/archive/v0.12.0/blueprint-compiler-v0.14.0.tar.bz2 : c9c5ce2ff94873fa4d59b71860b1bc08f7ab395c23284a0c0db1732cd15c8461
 license    : GPL-3.0-or-later
 homepage   : https://jwestman.pages.gitlab.gnome.org/blueprint-compiler/
 component  : programming.tools

--- a/packages/b/blueprint-compiler/pspec_x86_64.xml
+++ b/packages/b/blueprint-compiler/pspec_x86_64.xml
@@ -125,9 +125,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2024-06-09</Date>
-            <Version>0.12.0</Version>
+        <Update release="7">
+            <Date>2024-11-06</Date>
+            <Version>0.14.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Release notes available [here](https://gitlab.gnome.org/jwestman/blueprint-compiler/-/releases/v0.14.0)

**Test Plan**

Built and used Gradience

**Checklist**

- [x] Package was built and tested against unstable
