### PR TITLE
mdbook: Update to 0.4.41

### DIFF
--- a/packages/m/mdbook/abi_used_symbols
+++ b/packages/m/mdbook/abi_used_symbols
@@ -1,5 +1,4 @@
 ld-linux-x86-64.so.2:__tls_get_addr
-libc.so.6:__environ
 libc.so.6:__errno_location
 libc.so.6:__libc_start_main
 libc.so.6:__register_atfork
@@ -65,6 +64,7 @@ libc.so.6:open
 libc.so.6:open64
 libc.so.6:openat64
 libc.so.6:opendir
+libc.so.6:pause
 libc.so.6:pipe2
 libc.so.6:poll
 libc.so.6:posix_memalign
@@ -85,7 +85,6 @@ libc.so.6:pthread_attr_setstacksize
 libc.so.6:pthread_create
 libc.so.6:pthread_detach
 libc.so.6:pthread_getattr_np
-libc.so.6:pthread_getspecific
 libc.so.6:pthread_join
 libc.so.6:pthread_key_create
 libc.so.6:pthread_key_delete
@@ -142,6 +141,5 @@ libgcc_s.so.1:_Unwind_RaiseException
 libgcc_s.so.1:_Unwind_Resume
 libgcc_s.so.1:_Unwind_SetGR
 libgcc_s.so.1:_Unwind_SetIP
-libm.so.6:ceil
 libm.so.6:fmod
 libm.so.6:pow

--- a/packages/m/mdbook/package.yml
+++ b/packages/m/mdbook/package.yml
@@ -1,8 +1,8 @@
 name       : mdbook
-version    : 0.4.40
-release    : 36
+version    : 0.4.41
+release    : 37
 source     :
-    - https://github.com/rust-lang/mdBook/archive/refs/tags/v0.4.40.tar.gz : 550da7ff02ef62c60db6e813b6dbae65b9ed3d491186ea74929536feaceea94b
+    - https://github.com/rust-lang/mdBook/archive/refs/tags/v0.4.41.tar.gz : 9a38dbb6c28d5d58c34644074e113b0b80cea89e39bba70a126ee69a2e5f477c
 homepage   : https://github.com/rust-lang/mdBook
 license    : MPL-2.0
 component  : programming.tools

--- a/packages/m/mdbook/pspec_x86_64.xml
+++ b/packages/m/mdbook/pspec_x86_64.xml
@@ -24,9 +24,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2024-05-17</Date>
-            <Version>0.4.40</Version>
+        <Update release="37">
+            <Date>2024-11-06</Date>
+            <Version>0.4.41</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Added preliminary support for Rust 2024 edition.
- Added a full example of the remove-emphasis preprocessor.
- Adjusted styling of clipboard/play icons.
- Updated to handlebars v6.
- Attr and section rules now have specific code highlighting.
- The sidebar is now loaded from a common file, significantly reducing the book size when there are many chapters.

**Test Plan**

- Built a test site locally

**Checklist**

- [x] Package was built and tested against unstable
