### PR TITLE
warzone2100: Update to v4.5.4

### DIFF
--- a/packages/w/warzone2100/abi_used_symbols
+++ b/packages/w/warzone2100/abi_used_symbols
@@ -694,6 +694,7 @@ libstdc++.so.6:_ZNSt16invalid_argumentD1Ev
 libstdc++.so.6:_ZNSt28__atomic_futex_unsigned_base19_M_futex_notify_allEPj
 libstdc++.so.6:_ZNSt28__atomic_futex_unsigned_base19_M_futex_wait_untilEPjjbNSt6chrono8durationIlSt5ratioILl1ELl1EEEENS2_IlS3_ILl1ELl1000000000EEEE
 libstdc++.so.6:_ZNSt3_V214error_categoryD2Ev
+libstdc++.so.6:_ZNSt3_V215system_categoryEv
 libstdc++.so.6:_ZNSt3_V216generic_categoryEv
 libstdc++.so.6:_ZNSt6chrono3_V212steady_clock3nowEv
 libstdc++.so.6:_ZNSt6chrono3_V212system_clock3nowEv

--- a/packages/w/warzone2100/monitoring.yml
+++ b/packages/w/warzone2100/monitoring.yml
@@ -2,5 +2,5 @@ releases:
   id: 5118
   rss: https://github.com/Warzone2100/warzone2100/releases.atom
 security:
-  # No known CPE, last checked 2024-01-30
+  # No known CPE, last checked 2024-11-07
   cpe: ~

--- a/packages/w/warzone2100/package.yml
+++ b/packages/w/warzone2100/package.yml
@@ -1,8 +1,8 @@
 name       : warzone2100
-version    : 4.5.3
-release    : 33
+version    : 4.5.4
+release    : 34
 source     :
-    - https://downloads.sourceforge.net/project/warzone2100/releases/4.5.3/warzone2100_src.tar.xz : eed49f2e456d87d9db192c27d6e356785ac7c7969cfa368edc693d05bfa12c89
+    - https://github.com/Warzone2100/warzone2100/releases/download/4.5.4/warzone2100_src.tar.xz : bfb39d9f9509c0dc5dafa3e6f79f5582d76414962937a7bd7f7d1b557a88afc2
 license    :
     - BSD-3-Clause
     - CC0-1.0

--- a/packages/w/warzone2100/pspec_x86_64.xml
+++ b/packages/w/warzone2100/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>warzone2100</Name>
         <Homepage>https://wz2100.net</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>CC0-1.0</License>
@@ -142,12 +142,12 @@ The game offers campaign, multi-player, and single-player skirmish modes. An ext
         </Files>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2024-10-04</Date>
-            <Version>4.5.3</Version>
+        <Update release="34">
+            <Date>2024-11-07</Date>
+            <Version>4.5.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Add: In-game options button
- Fix: Transporter timer capacity label area should be clickable
- Fix: Do not remove vision from transporters when loading saves
- Fix: Various potential crashes
- Change: Improve high-quality terrain water
- Fix: Loading high-quality terrain water diffuse textures
- Add: Initial support for admins changing settings via UI
- Add: Host auto-kick on sustained desync
- Fix: Refactor socket operations error code return
- Fix: Add campaign HQs to MP stats
- Fix: Display and log connection state on joining screen timeout
- Fix: Only play "Player is exiting" audio when player slot drops, ignore spectators
- Add: Research field for Stats object
- Change: Plasmite Flamer boost

**Packaging**

- Switch to GitHub source, project homepage does not mention SourceForge

**Test Plan**

- Play the tutorial for a bit

**Checklist**

- [x] Package was built and tested against unstable
