### PR TITLE
waybar: Update to v0.11.0

### DIFF
--- a/packages/w/waybar/abi_used_symbols
+++ b/packages/w/waybar/abi_used_symbols
@@ -51,7 +51,6 @@ libc.so.6:feof
 libc.so.6:fgets
 libc.so.6:fork
 libc.so.6:freelocale
-libc.so.6:getaddrinfo
 libc.so.6:getenv
 libc.so.6:getloadavg
 libc.so.6:getpid
@@ -61,7 +60,6 @@ libc.so.6:inotify_add_watch
 libc.so.6:inotify_init
 libc.so.6:inotify_init1
 libc.so.6:inotify_rm_watch
-libc.so.6:islower
 libc.so.6:kill
 libc.so.6:killpg
 libc.so.6:memchr
@@ -219,10 +217,17 @@ libgiomm-2.4.so.1:_ZN3Gio11Application4holdEv
 libgiomm-2.4.so.1:_ZN3Gio11Application4quitEv
 libgiomm-2.4.so.1:_ZN3Gio11Cancellable6createEv
 libgiomm-2.4.so.1:_ZN3Gio11FileMonitor14signal_changedEv
+libgiomm-2.4.so.1:_ZN3Gio12OutputStream5flushEv
 libgiomm-2.4.so.1:_ZN3Gio13AsyncInitable16init_async_vfuncERKN4sigc4slotIvRN4Glib6RefPtrINS_11AsyncResultEEENS1_3nilES8_S8_S8_S8_S8_EERKNS4_INS_11CancellableEEEi
 libgiomm-2.4.so.1:_ZN3Gio13AsyncInitable17init_finish_vfuncERKN4Glib6RefPtrINS_11AsyncResultEEE
 libgiomm-2.4.so.1:_ZN3Gio14DesktopAppInfo20create_from_filenameERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
 libgiomm-2.4.so.1:_ZN3Gio14DesktopAppInfo6createERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+libgiomm-2.4.so.1:_ZN3Gio15DataInputStream6createERKN4Glib6RefPtrINS_11InputStreamEEE
+libgiomm-2.4.so.1:_ZN3Gio15DataInputStream9read_lineERNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+libgiomm-2.4.so.1:_ZN3Gio15UnixInputStream6createEib
+libgiomm-2.4.so.1:_ZN3Gio16DataOutputStream10put_stringENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+libgiomm-2.4.so.1:_ZN3Gio16DataOutputStream6createERKN4Glib6RefPtrINS_12OutputStreamEEE
+libgiomm-2.4.so.1:_ZN3Gio16UnixOutputStream6createEib
 libgiomm-2.4.so.1:_ZN3Gio4DBus10Connection10get_finishERKN4Glib6RefPtrINS_11AsyncResultEEE
 libgiomm-2.4.so.1:_ZN3Gio4DBus10Connection16signal_subscribeERKN4sigc4slotIvRKN4Glib6RefPtrIS1_EERKNS4_7ustringESB_SB_SB_RKNS4_20VariantContainerBaseENS2_3nilEEESB_SB_SB_SB_SB_NS0_11SignalFlagsE
 libgiomm-2.4.so.1:_ZN3Gio4DBus10Connection18signal_unsubscribeEj
@@ -437,9 +442,6 @@ libglibmm-2.4.so.1:_ZNK4Glib10ObjectBase11unreferenceEv
 libglibmm-2.4.so.1:_ZNK4Glib10ObjectBase9referenceEv
 libglibmm-2.4.so.1:_ZNK4Glib11VariantBase10is_of_typeERKNS_11VariantTypeE
 libglibmm-2.4.so.1:_ZNK4Glib11VariantBase14is_castable_toERKNS_11VariantTypeE
-libglibmm-2.4.so.1:_ZNK4Glib11VariantBase15get_type_stringB5cxx11Ev
-libglibmm-2.4.so.1:_ZNK4Glib11VariantBase5printEb
-libglibmm-2.4.so.1:_ZNK4Glib11VariantBase8get_sizeEv
 libglibmm-2.4.so.1:_ZNK4Glib11VariantBase9gobj_copyEv
 libglibmm-2.4.so.1:_ZNK4Glib11VariantBasecvbEv
 libglibmm-2.4.so.1:_ZNK4Glib15ValueBase_Boxed9get_boxedEv
@@ -532,6 +534,7 @@ libgtk-3.so.0:gtk_builder_new
 libgtk-3.so.0:gtk_menu_popup_at_pointer
 libgtk-3.so.0:gtk_style_context_to_string
 libgtk-3.so.0:gtk_widget_show_all
+libgtk-3.so.0:gtk_widget_translate_coordinates
 libgtk-layer-shell.so.0:gtk_layer_auto_exclusive_zone_enable
 libgtk-layer-shell.so.0:gtk_layer_init_for_window
 libgtk-layer-shell.so.0:gtk_layer_is_supported
@@ -669,6 +672,7 @@ libgtkmm-3.0.so.1:_ZN3Gtk6Widget20on_key_release_eventEP12_GdkEventKey
 libgtkmm-3.0.so.1:_ZN3Gtk6Widget20on_mnemonic_activateEb
 libgtkmm-3.0.so.1:_ZN3Gtk6Widget20signal_drag_data_getEv
 libgtkmm-3.0.so.1:_ZN3Gtk6Widget20signal_query_tooltipEv
+libgtkmm-3.0.so.1:_ZN3Gtk6Widget20signal_size_allocateEv
 libgtkmm-3.0.so.1:_ZN3Gtk6Widget21on_button_press_eventEP15_GdkEventButton
 libgtkmm-3.0.so.1:_ZN3Gtk6Widget21on_drag_data_receivedERKN4Glib6RefPtrIN3Gdk11DragContextEEEiiRKNS_13SelectionDataEjj
 libgtkmm-3.0.so.1:_ZN3Gtk6Widget21on_enter_notify_eventEP17_GdkEventCrossing
@@ -798,6 +802,9 @@ libjsoncpp.so.25:_ZN4Json15parseFromStreamERKNS_10CharReader7FactoryERSiPNS_5Val
 libjsoncpp.so.25:_ZN4Json17CharReaderBuilderC1Ev
 libjsoncpp.so.25:_ZN4Json17CharReaderBuilderD1Ev
 libjsoncpp.so.25:_ZN4Json17ValueIteratorBase9incrementEv
+libjsoncpp.so.25:_ZN4Json19StreamWriterBuilderC1Ev
+libjsoncpp.so.25:_ZN4Json19StreamWriterBuilderD1Ev
+libjsoncpp.so.25:_ZN4Json19StreamWriterBuilderixERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
 libjsoncpp.so.25:_ZN4Json5Value13nullSingletonEv
 libjsoncpp.so.25:_ZN4Json5Value3endEv
 libjsoncpp.so.25:_ZN4Json5Value4nullE
@@ -814,6 +821,7 @@ libjsoncpp.so.25:_ZN4Json5ValueC1ERKS0_
 libjsoncpp.so.25:_ZN4Json5ValueC1Eb
 libjsoncpp.so.25:_ZN4Json5ValueC1Ei
 libjsoncpp.so.25:_ZN4Json5ValueC1Ej
+libjsoncpp.so.25:_ZN4Json5ValueC1Em
 libjsoncpp.so.25:_ZN4Json5ValueD1Ev
 libjsoncpp.so.25:_ZN4Json5ValueaSEOS0_
 libjsoncpp.so.25:_ZN4Json5ValueaSERKS0_
@@ -822,10 +830,12 @@ libjsoncpp.so.25:_ZN4Json5ValueixERKNSt7__cxx1112basic_stringIcSt11char_traitsIc
 libjsoncpp.so.25:_ZN4Json5ValueixEi
 libjsoncpp.so.25:_ZN4Json5ValueixEj
 libjsoncpp.so.25:_ZN4JsonlsERSoRKNS_5ValueE
+libjsoncpp.so.25:_ZN4JsonrsERSiRNS_5ValueE
 libjsoncpp.so.25:_ZNK4Json17ValueIteratorBase3keyEv
 libjsoncpp.so.25:_ZNK4Json17ValueIteratorBase5derefEv
 libjsoncpp.so.25:_ZNK4Json17ValueIteratorBase5indexEv
 libjsoncpp.so.25:_ZNK4Json17ValueIteratorBase7isEqualERKS0_
+libjsoncpp.so.25:_ZNK4Json19StreamWriterBuilder15newStreamWriterEv
 libjsoncpp.so.25:_ZNK4Json5Value14getMemberNamesB5cxx11Ev
 libjsoncpp.so.25:_ZNK4Json5Value14toStyledStringB5cxx11Ev
 libjsoncpp.so.25:_ZNK4Json5Value15isConvertibleToENS_9ValueTypeE
@@ -846,6 +856,7 @@ libjsoncpp.so.25:_ZNK4Json5Value7asFloatEv
 libjsoncpp.so.25:_ZNK4Json5Value7isArrayEv
 libjsoncpp.so.25:_ZNK4Json5Value8asDoubleEv
 libjsoncpp.so.25:_ZNK4Json5Value8asStringB5cxx11Ev
+libjsoncpp.so.25:_ZNK4Json5Value8asUInt64Ev
 libjsoncpp.so.25:_ZNK4Json5Value8isDoubleEv
 libjsoncpp.so.25:_ZNK4Json5Value8isMemberEPKc
 libjsoncpp.so.25:_ZNK4Json5Value8isMemberERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
@@ -1225,6 +1236,7 @@ libstdc++.so.6:_Znwm
 libstdc++.so.6:_ZnwmRKSt9nothrow_t
 libstdc++.so.6:__cxa_allocate_exception
 libstdc++.so.6:__cxa_begin_catch
+libstdc++.so.6:__cxa_call_terminate
 libstdc++.so.6:__cxa_end_catch
 libstdc++.so.6:__cxa_free_exception
 libstdc++.so.6:__cxa_guard_abort

--- a/packages/w/waybar/package.yml
+++ b/packages/w/waybar/package.yml
@@ -1,8 +1,8 @@
 name       : waybar
-version    : 0.10.4
-release    : 15
+version    : 0.11.0
+release    : 16
 source     :
-    - https://github.com/Alexays/Waybar/archive/refs/tags/0.10.4.tar.gz : ad1ead64aec35bc589207ea1edce90e848620d578985967d44a850a66b5ef829
+    - https://github.com/Alexays/Waybar/archive/refs/tags/0.11.0.tar.gz : 6a0e9f0f7f2eff503951958cbb16dc39041c0b67e86c35154e8507677c61be9d
 license    : MIT
 homepage   : https://github.com/Alexays/Waybar
 component  : system.utils

--- a/packages/w/waybar/pspec_x86_64.xml
+++ b/packages/w/waybar/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>waybar</Name>
         <Homepage>https://github.com/Alexays/Waybar</Homepage>
         <Packager>
-            <Name>Facundo Ciruzzi</Name>
-            <Email>ciruzzifacundo@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -50,6 +50,9 @@
             <Path fileType="man">/usr/share/man/man5/waybar-mpd.5</Path>
             <Path fileType="man">/usr/share/man/man5/waybar-mpris.5</Path>
             <Path fileType="man">/usr/share/man/man5/waybar-network.5</Path>
+            <Path fileType="man">/usr/share/man/man5/waybar-niri-language.5</Path>
+            <Path fileType="man">/usr/share/man/man5/waybar-niri-window.5</Path>
+            <Path fileType="man">/usr/share/man/man5/waybar-niri-workspaces.5</Path>
             <Path fileType="man">/usr/share/man/man5/waybar-power-profiles-daemon.5</Path>
             <Path fileType="man">/usr/share/man/man5/waybar-privacy.5</Path>
             <Path fileType="man">/usr/share/man/man5/waybar-pulseaudio-slider.5</Path>
@@ -76,12 +79,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2024-07-18</Date>
-            <Version>0.10.4</Version>
+        <Update release="16">
+            <Date>2024-11-07</Date>
+            <Version>0.11.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Facundo Ciruzzi</Name>
-            <Email>ciruzzifacundo@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- bar: fix setVisible
- Walk up Symlink Chain
- group: fix revealer hover regression
- flake.lock: Update by
- Handle offline CPUs and CPU hotplug by
- fix: expand menu file before opening it
- Accept "default-node-changed" signals from wireplumber, even if only the node ID is changed
- fix crash caused by use bar instance after it is freed (use-after-free)
- fix: check format-source before use
- hyprland/backend: drop unnecessary getaddrinfo call
- taskbar: Send minimize geometry hints
- chore: update power_profiles_daemon.cpp
- flake.lock: Update by
- fix/upower: upower module selection with multiple devices
- feat: hidpi support for image module
- Add niri/workspaces, niri/window, niri/language

**Test Plan**

- WIP

**Checklist**

- [ ] Package was built and tested against unstable
