### PR TITLE
whois: Update to v5.5.23

### DIFF
--- a/packages/w/whois/monitoring.yml
+++ b/packages/w/whois/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 5128
+  rss: https://github.com/rfc1036/whois/tags.atom
+# No known CPE, checked 2024-11-07
+security:
+  cpe: ~

--- a/packages/w/whois/package.yml
+++ b/packages/w/whois/package.yml
@@ -1,8 +1,8 @@
 name       : whois
-version    : 5.5.19
-release    : 24
+version    : 5.5.23
+release    : 25
 source     :
-    - https://github.com/rfc1036/whois/archive/refs/tags/v5.5.19.tar.gz : 58602ce405a0d1f62fc99cd9e9e8cb3fb1ce05451a45a8d5b532bab5120d070e
+    - https://github.com/rfc1036/whois/archive/refs/tags/v5.5.23.tar.gz : dcfc08f3362c74ec8ae30691941909ebccf0cb3d27da04236f7e2790dbc7757c
 homepage   : https://github.com/rfc1036/whois
 license    : GPL-2.0-or-later
 component  : network.clients

--- a/packages/w/whois/pspec_x86_64.xml
+++ b/packages/w/whois/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>whois</Name>
         <Homepage>https://github.com/rfc1036/whois</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>network.clients</PartOf>
@@ -47,12 +47,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2023-10-31</Date>
-            <Version>5.5.19</Version>
+        <Update release="25">
+            <Date>2024-11-07</Date>
+            <Version>5.5.23</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- 5.5.23
  - Updated the .sc, (.xn--yfro4i67o, Singapore) and (.xn--clchc0ea0b2g2a9gcd, Singapore) TLD servers.
- 5.5.22
  - Fixed a segmentation fault with --no-recursion.
  - Updated the .bm and .vi TLD servers.
  - Removed 4 new gTLDs which are no longer active.
- 5.5.21
  - Updated the .cv and .sd TLD servers.
  - Remove 4 new gTLDs which are no longer active. -5.5.20
  - Added the .gn TLD server.
  - Removed 6 new gTLDs which are no longer active.
  - Enabled getopt_long(3) support on Solaris.

**Test Plan**

- Do some whois lookups

**Checklist**

- [x] Package was built and tested against unstable
