### PR TITLE
apr: Update to v1.7.5

### DIFF
--- a/packages/a/apr/abi_used_symbols
+++ b/packages/a/apr/abi_used_symbols
@@ -5,6 +5,7 @@ libc.so.6:__ctype_toupper_loc
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__h_errno_location
+libc.so.6:__isoc23_strtol
 libc.so.6:__memcpy_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:_exit
@@ -32,6 +33,7 @@ libc.so.6:execv
 libc.so.6:execve
 libc.so.6:execvp
 libc.so.6:exit
+libc.so.6:fchmod
 libc.so.6:fchown
 libc.so.6:fcntl
 libc.so.6:fdatasync
@@ -190,7 +192,6 @@ libc.so.6:strftime
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strrchr
-libc.so.6:strtol
 libc.so.6:unlink
 libc.so.6:unsetenv
 libc.so.6:utimes

--- a/packages/a/apr/monitoring.yml
+++ b/packages/a/apr/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 95
+  rss: ~
+security:
+  cpe:
+    - vendor: apache
+      product: portable_runtime

--- a/packages/a/apr/package.yml
+++ b/packages/a/apr/package.yml
@@ -1,8 +1,8 @@
 name       : apr
-version    : 1.7.4
-release    : 10
+version    : 1.7.5
+release    : 11
 source     :
-    - https://www.apache.org/dist/apr/apr-1.7.4.tar.bz2 : fc648de983f3a2a6c9e78dea1f180639bd2fad6c06d556d4367a701fe5c35577
+    - https://www.apache.org/dist/apr/apr-1.7.5.tar.bz2 : cd0f5d52b9ab1704c72160c5ee3ed5d3d4ca2df4a7f8ab564e3cb352b67232f2
 homepage   : https://apr.apache.org/
 license    : Apache-2.0
 component  : programming

--- a/packages/a/apr/pspec_x86_64.xml
+++ b/packages/a/apr/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>apr</Name>
         <Homepage>https://apr.apache.org/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">The Apache Portable Runtime (APR) library provides an abstraction of operating-system level services</Summary>
         <Description xml:lang="en">The Apache Portable Runtime (APR) library provides an abstraction of operating-system level services such as file and network I/O, memory management, and so on.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>apr</Name>
@@ -23,7 +23,7 @@
             <Path fileType="executable">/usr/bin/apr-1-config</Path>
             <Path fileType="library">/usr/lib64/apr.exp</Path>
             <Path fileType="library">/usr/lib64/libapr-1.so.0</Path>
-            <Path fileType="library">/usr/lib64/libapr-1.so.0.7.4</Path>
+            <Path fileType="library">/usr/lib64/libapr-1.so.0.7.5</Path>
             <Path fileType="data">/usr/share/build-1/apr_rules.mk</Path>
             <Path fileType="data">/usr/share/build-1/libtool</Path>
             <Path fileType="data">/usr/share/build-1/make_exports.awk</Path>
@@ -38,7 +38,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">apr</Dependency>
+            <Dependency release="11">apr</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/apr-1/apr.h</Path>
@@ -87,12 +87,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2023-05-06</Date>
-            <Version>1.7.4</Version>
+        <Update release="11">
+            <Date>2024-11-08</Date>
+            <Version>1.7.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Unix: Implement apr_shm_perms_set() for the "POSIX shm_open()" and "classic mmap" shared memory implementations.
- Fix missing ';' for XML/HTML hex entities from apr_escape_entity().
- Fix crash in apr_pool_create() with --enable-pool-debug=all|owner.
- Improve platform detection by updating config.guess and config.sub.
- Full release notes [here](https://dlcdn.apache.org//apr/CHANGES-APR-1.7)

**Security**
Includes fixes for:
- CVE-2023-49582

**Test Plan**

- Try running a few revdeps: kdevelop, svn

**Checklist**

- [x] Package was built and tested against unstable
