### PR TITLE
github-cli: Update to v2.61.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.60.0
-release    : 58
+version    : 2.61.0
+release    : 59
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.60.0.tar.gz : 1936a80a668caef437b2f409eaa10e48613a3502db7da9eea011b163769218a7
+    - https://github.com/cli/cli/archive/refs/tags/v2.61.0.tar.gz : bf134281db2b65827426e3ad186de55cb04d0f92051ca2e6bd8a7d47aabe5b18
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -225,9 +225,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="58">
-            <Date>2024-10-24</Date>
-            <Version>2.60.0</Version>
+        <Update release="59">
+            <Date>2024-11-09</Date>
+            <Version>2.61.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- `gh repo edit` command has been enhanced to inform users about consequences of changing visibility and ensure users are intentional before making irreversible changes
  1. Interactive `gh repo edit` visibility change requires confirmation when changing from `public`, `private`, or `internal`
  2. Non-interactive `gh repo edit --visibility` change requires new `--accept-visibility-change-consequences` flag to confirm
  3. New content to inform users of consequences
- `gh attestation verify` should only verify provenance attestations by default
- Fix verbiage for deleting workflow runs
- Simplify Sigstore verification result handling in `gh attestation verify`
- Print empty array for `gh cache list` when `--json` is provided
- Create the automatic key when specified with `-i`
- fix: `gh pr create -w` ignore template flag

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh staus` (I typo'd the first time), `gh status`, `gh pr list`, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
