### PR TITLE
wine: Update to v9.21

### DIFF
--- a/packages/w/wine/abi_symbols
+++ b/packages/w/wine/abi_symbols
@@ -565,6 +565,7 @@ win32u.so:NtUserDrawMenuBarTemp
 win32u.so:NtUserEmptyClipboard
 win32u.so:NtUserEnableMenuItem
 win32u.so:NtUserEnableMouseInPointer
+win32u.so:NtUserEnableMouseInPointerForThread
 win32u.so:NtUserEnableScrollBar
 win32u.so:NtUserEndDeferWindowPosEx
 win32u.so:NtUserEndMenu
@@ -671,6 +672,7 @@ win32u.so:NtUserRedrawWindow
 win32u.so:NtUserRegisterClassExWOW
 win32u.so:NtUserRegisterHotKey
 win32u.so:NtUserRegisterRawInputDevices
+win32u.so:NtUserRegisterTouchPadCapable
 win32u.so:NtUserReleaseDC
 win32u.so:NtUserRemoveClipboardFormatListener
 win32u.so:NtUserRemoveMenu

--- a/packages/w/wine/abi_symbols32
+++ b/packages/w/wine/abi_symbols32
@@ -250,6 +250,7 @@ ntdll.so:NtWaitForSingleObject
 ntdll.so:NtWow64AllocateVirtualMemory64
 ntdll.so:NtWow64GetNativeSystemInformation
 ntdll.so:NtWow64IsProcessorFeaturePresent
+ntdll.so:NtWow64QueryInformationProcess64
 ntdll.so:NtWow64ReadVirtualMemory64
 ntdll.so:NtWow64WriteVirtualMemory64
 ntdll.so:NtWriteFile
@@ -553,6 +554,7 @@ win32u.so:NtUserDrawMenuBarTemp
 win32u.so:NtUserEmptyClipboard
 win32u.so:NtUserEnableMenuItem
 win32u.so:NtUserEnableMouseInPointer
+win32u.so:NtUserEnableMouseInPointerForThread
 win32u.so:NtUserEnableScrollBar
 win32u.so:NtUserEndDeferWindowPosEx
 win32u.so:NtUserEndMenu
@@ -659,6 +661,7 @@ win32u.so:NtUserRedrawWindow
 win32u.so:NtUserRegisterClassExWOW
 win32u.so:NtUserRegisterHotKey
 win32u.so:NtUserRegisterRawInputDevices
+win32u.so:NtUserRegisterTouchPadCapable
 win32u.so:NtUserReleaseDC
 win32u.so:NtUserRemoveClipboardFormatListener
 win32u.so:NtUserRemoveMenu

--- a/packages/w/wine/abi_used_symbols
+++ b/packages/w/wine/abi_used_symbols
@@ -171,6 +171,7 @@ libX11.so.6:XMoveResizeWindow
 libX11.so.6:XNoOp
 libX11.so.6:XOpenDisplay
 libX11.so.6:XOpenIM
+libX11.so.6:XPutBackEvent
 libX11.so.6:XPutImage
 libX11.so.6:XQueryColor
 libX11.so.6:XQueryColors
@@ -632,7 +633,6 @@ libc.so.6:symlink
 libc.so.6:syscall
 libc.so.6:sysconf
 libc.so.6:sysinfo
-libc.so.6:system
 libc.so.6:tcgetattr
 libc.so.6:tcsetattr
 libc.so.6:time

--- a/packages/w/wine/abi_used_symbols32
+++ b/packages/w/wine/abi_used_symbols32
@@ -171,6 +171,7 @@ libX11.so.6:XMoveResizeWindow
 libX11.so.6:XNoOp
 libX11.so.6:XOpenDisplay
 libX11.so.6:XOpenIM
+libX11.so.6:XPutBackEvent
 libX11.so.6:XPutImage
 libX11.so.6:XQueryColor
 libX11.so.6:XQueryColors
@@ -553,7 +554,6 @@ libc.so.6:symlink
 libc.so.6:syscall
 libc.so.6:sysconf
 libc.so.6:sysinfo
-libc.so.6:system
 libc.so.6:times
 libc.so.6:umask
 libc.so.6:uname

--- a/packages/w/wine/package.yml
+++ b/packages/w/wine/package.yml
@@ -1,8 +1,8 @@
 name       : wine
-version    : '9.20'
-release    : 187
+version    : '9.21'
+release    : 188
 source     :
-    - https://dl.winehq.org/wine/source/9.x/wine-9.20.tar.xz : 95f2b45b1458125be7d9fccc94ca5f8cce0a5e4ae11d0d193cfb7dddb35e7a86
+    - https://dl.winehq.org/wine/source/9.x/wine-9.21.tar.xz : 4442b47ffd9b2ea457100e36ed5fd4e6f4d829d9db79a25e605175a988ca2fff
 license    : LGPL-2.1-or-later
 component  : virt
 homepage   : https://www.winehq.org/

--- a/packages/w/wine/pspec_x86_64.xml
+++ b/packages/w/wine/pspec_x86_64.xml
@@ -215,6 +215,7 @@
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/d3dx9_42.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/d3dx9_43.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/d3dxof.dll</Path>
+            <Path fileType="library">/usr/lib64/wine/x86_64-windows/dataexchange.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/davclnt.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/dbgeng.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/dbghelp.dll</Path>
@@ -321,6 +322,7 @@
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/icmp.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/ieframe.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/ieproxy.dll</Path>
+            <Path fileType="library">/usr/lib64/wine/x86_64-windows/iertutil.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/iexplore.exe</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/imaadp32.acm</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/imagehlp.dll</Path>
@@ -754,6 +756,7 @@
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/wmasf.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/wmi.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/wmic.exe</Path>
+            <Path fileType="library">/usr/lib64/wine/x86_64-windows/wmilib.sys</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/wmiutils.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/wmp.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/wmphoto.dll</Path>
@@ -1000,7 +1003,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="187">wine</Dependency>
+            <Dependency release="188">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/wine</Path>
@@ -1176,6 +1179,7 @@
             <Path fileType="library">/usr/lib32/wine/i386-windows/d3dx9_42.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/d3dx9_43.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/d3dxof.dll</Path>
+            <Path fileType="library">/usr/lib32/wine/i386-windows/dataexchange.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/davclnt.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/dbgeng.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/dbghelp.dll</Path>
@@ -1286,6 +1290,7 @@
             <Path fileType="library">/usr/lib32/wine/i386-windows/icmp.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/ieframe.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/ieproxy.dll</Path>
+            <Path fileType="library">/usr/lib32/wine/i386-windows/iertutil.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/iexplore.exe</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/ifsmgr.vxd</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/imaadp32.acm</Path>
@@ -1768,6 +1773,7 @@
             <Path fileType="library">/usr/lib32/wine/i386-windows/wmasf.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/wmi.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/wmic.exe</Path>
+            <Path fileType="library">/usr/lib32/wine/i386-windows/wmilib.sys</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/wmiutils.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/wmp.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/wmphoto.dll</Path>
@@ -1848,7 +1854,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="187">wine</Dependency>
+            <Dependency release="188">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wine/debug.h</Path>
@@ -2265,6 +2271,8 @@
             <Path fileType="header">/usr/include/wine/windows/dplobby.h</Path>
             <Path fileType="header">/usr/include/wine/windows/dplobby8.h</Path>
             <Path fileType="header">/usr/include/wine/windows/dpnathlp.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/dragdropinterop.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/dragdropinterop.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/driverspecs.h</Path>
             <Path fileType="header">/usr/include/wine/windows/drmexternals.h</Path>
             <Path fileType="header">/usr/include/wine/windows/drmexternals.idl</Path>
@@ -2717,10 +2725,14 @@
             <Path fileType="header">/usr/include/wine/windows/rpcsal.h</Path>
             <Path fileType="header">/usr/include/wine/windows/rstbas.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/rstchg.idl</Path>
+            <Path fileType="header">/usr/include/wine/windows/rstfnd.idl</Path>
+            <Path fileType="header">/usr/include/wine/windows/rstidn.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/rstinf.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/rstloc.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/rstnot.idl</Path>
+            <Path fileType="header">/usr/include/wine/windows/rstscr.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/rstupd.idl</Path>
+            <Path fileType="header">/usr/include/wine/windows/rstxsc.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/rtlsupportapi.h</Path>
             <Path fileType="header">/usr/include/wine/windows/rtutils.h</Path>
             <Path fileType="header">/usr/include/wine/windows/rtworkq.h</Path>
@@ -2885,6 +2897,7 @@
             <Path fileType="header">/usr/include/wine/windows/weakreference.h</Path>
             <Path fileType="header">/usr/include/wine/windows/weakreference.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/webservices.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/websocket.h</Path>
             <Path fileType="header">/usr/include/wine/windows/werapi.h</Path>
             <Path fileType="header">/usr/include/wine/windows/wfext.h</Path>
             <Path fileType="header">/usr/include/wine/windows/wia.h</Path>
@@ -2914,6 +2927,12 @@
             <Path fileType="header">/usr/include/wine/windows/windows.applicationmodel.background.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.applicationmodel.core.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.applicationmodel.core.idl</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.applicationmodel.datatransfer.dragdrop.core.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.applicationmodel.datatransfer.dragdrop.core.idl</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.applicationmodel.datatransfer.dragdrop.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.applicationmodel.datatransfer.dragdrop.idl</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.applicationmodel.datatransfer.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.applicationmodel.datatransfer.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.applicationmodel.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.applicationmodel.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.data.json.h</Path>
@@ -3009,6 +3028,8 @@
             <Path fileType="header">/usr/include/wine/windows/windows.security.credentials.ui.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.security.cryptography.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.security.cryptography.idl</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.security.enterprisedata.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/windows.security.enterprisedata.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.security.exchangeactivesyncprovisioning.h</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.security.exchangeactivesyncprovisioning.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/windows.security.isolation.h</Path>
@@ -3176,9 +3197,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="187">
-            <Date>2024-10-19</Date>
-            <Version>9.20</Version>
+        <Update release="188">
+            <Date>2024-11-09</Date>
+            <Version>9.21</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Highlighted changes:
- More support for network sessions in DirectPlay
- Header fixes for C++ compilation
- I/O completion fixes
- More formats supported in D3DX9
- Various bug fixes

Full release notes available [here](https://gitlab.winehq.org/wine/wine/-/releases/wine-9.21)

**Test Plan**
- Used `winemine`, `winecfg`, `wineconsole`, `winefile`
- Played Age of Empires I Trial

**Checklist**

- [x] Package was built and tested against unstable
