### PR TITLE
[NFC] zsh: fix sourcing of 10-xdg.sh

### DIFF
--- a/packages/z/zsh/files/zprofile
+++ b/packages/z/zsh/files/zprofile
@@ -11,8 +11,8 @@ fi
 
 # Source paths not included by systemctl necessary for XDG_DATA_DIRS
 
-if [ -f 10-xdg.sh ]; then
-    emulate sh -c 'source 10-xdg.sh'
+if [ -f /usr/share/defaults/etc/profile.d/10-xdg.sh ]; then
+    emulate sh -c 'source /usr/share/defaults/etc/profile.d/10-xdg.sh'
 fi
 
 # Source paths not included by systemctl necessary for flatpaks to be found in the app menu and run


### PR DESCRIPTION
**Summary**
Fix the sourcing of 10-xdh.sh to have the full path Without this zsh was failing to load the file

**Test Plan**

Verified the file is at the location now in the zprofile file
