### PR TITLE
doctl: Update to v1.17.0

### DIFF
--- a/packages/d/doctl/monitoring.yml
+++ b/packages/d/doctl/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 235006
+  rss: https://github.com/digitalocean/doctl/releases.atom
+# No known CPE, checked 2024-11-11
+security:
+  cpe: ~

--- a/packages/d/doctl/package.yml
+++ b/packages/d/doctl/package.yml
@@ -1,8 +1,8 @@
 name       : doctl
-version    : 1.113.0
-release    : 4
+version    : 1.117.0
+release    : 5
 source     :
-    - https://github.com/digitalocean/doctl/archive/refs/tags/v1.113.0.tar.gz : 9a74e5d7ca65dab98afdabe74d69d3d3c71bca512ff3d5ad6039881af1b14f4c
+    - https://github.com/digitalocean/doctl/archive/refs/tags/v1.117.0.tar.gz : 2ff734465d45a95a1e31032ea607d05c2582ef28406d7f64142705339a58f3da
 homepage   : https://github.com/digitalocean/doctl/
 license    : Apache-2.0
 component  : network.client

--- a/packages/d/doctl/pspec_x86_64.xml
+++ b/packages/d/doctl/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-09-10</Date>
-            <Version>1.113.0</Version>
+        <Update release="5">
+            <Date>2024-11-11</Date>
+            <Version>1.117.0</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- [1.117.0](https://github.com/digitalocean/doctl/releases/tag/v1.117.0)
- [1.116.0](https://github.com/digitalocean/doctl/releases/tag/v1.116.0)
- [1.115.0](https://github.com/digitalocean/doctl/releases/tag/v1.115.0)
- [1.114.0](https://github.com/digitalocean/doctl/releases/tag/v1.114.0)

**Test Plan**

- Authorize doctl with a test API token

**Checklist**

- [x] Package was built and tested against unstable
