### PR TITLE
tmux: Update to v3.5a

### DIFF
--- a/packages/t/tmux/monitoring.yml
+++ b/packages/t/tmux/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 4980
+  rss: https://github.com/tmux/tmux/tags.atom
+security:
+  cpe:
+    - vendor: tmux_project
+      product: tmux

--- a/packages/t/tmux/package.yml
+++ b/packages/t/tmux/package.yml
@@ -1,8 +1,8 @@
 name       : tmux
-version    : '3.5'
-release    : 23
+version    : '3.5a'
+release    : 24
 source     :
-    - https://github.com/tmux/tmux/archive/refs/tags/3.5.tar.gz : 74460f85bd81d73661356f777cdada121033ba8b0bc9119991d9fb0b5381c35e
+    - https://github.com/tmux/tmux/archive/refs/tags/3.5a.tar.gz : 49e68b41dec0bf408990160ee12fa29b06dee8f74c1f0b4b71c9d2a1477dd910
 homepage   : https://github.com/tmux/tmux/wiki
 license    : 0BSD
 component  : system.utils

--- a/packages/t/tmux/pspec_x86_64.xml
+++ b/packages/t/tmux/pspec_x86_64.xml
@@ -30,9 +30,9 @@ simple, modern, BSD-licensed alternative to programs such as GNU screen.
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2024-09-27</Date>
-            <Version>3.5</Version>
+        <Update release="24">
+            <Date>2024-11-11</Date>
+            <Version>3.5a</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Do not translate BSpace as Unicode with extended keys.
- Fix so that keys with Shift are represented correctly with extended keys.
- Revert to using /bin/sh for #() and run-shell and if-shell; the change to use default-shell only applies now to popups.
- Fix grey colour without a number suffix in styles.

**Test Plan**

- Use a new tmux session for a bit

**Checklist**

- [x] Package was built and tested against unstable
