### PR TITLE
acpica-unix: Update to v20240927

### DIFF
--- a/packages/a/acpica-unix/monitoring.yml
+++ b/packages/a/acpica-unix/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 18
+  rss: https://github.com/acpica/acpica/releases.atom
+# No known CPE, checked 2024-11-11
+security:
+  cpe: ~

--- a/packages/a/acpica-unix/package.yml
+++ b/packages/a/acpica-unix/package.yml
@@ -1,8 +1,8 @@
 name       : acpica-unix
-version    : '20240827'
-release    : 9
+version    : '20240927'
+release    : 10
 source     :
-    - https://github.com/acpica/acpica/archive/refs/tags/version-20240827.tar.gz : fe5b043d83521d489246c8e8f9a32aed24f9dfddf3e676453fe5d3bd0316a740
+    - https://github.com/acpica/acpica/archive/refs/tags/R09_27_24.tar.gz : cc167c0825c3807f9812f892e77ec918b7f62c3faeaf9a2e3664de7639b00b6b
 license    : GPL-2.0-or-later
 homepage   : https://www.intel.com/content/www/us/en/developer/topic-technology/open/acpica/overview.html
 component  : programming.tools

--- a/packages/a/acpica-unix/pspec_x86_64.xml
+++ b/packages/a/acpica-unix/pspec_x86_64.xml
@@ -31,9 +31,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2024-08-31</Date>
-            <Version>20240827</Version>
+        <Update release="10">
+            <Date>2024-11-11</Date>
+            <Version>20240927</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Fix the acpixf.h file which caused issues for the last release (before this) 20240827
- Fix the pointer offset for the SLIC table
- Verify the local environment and GitHub commits are all in sync which was a problem with the second from last release (before this)20240322 (aka 20240323 date issue)

**Test Plan**

- Run some `acpi*` commands

**Checklist**

- [x] Package was built and tested against unstable
