### PR TITLE
libheif: Update to v1.19.3

### DIFF
--- a/packages/l/libheif/package.yml
+++ b/packages/l/libheif/package.yml
@@ -1,8 +1,8 @@
 name       : libheif
-version    : 1.19.1
-release    : 43
+version    : 1.19.3
+release    : 44
 source     :
-    - https://github.com/strukturag/libheif/releases/download/v1.19.1/libheif-1.19.1.tar.gz : 994913eb2a29c00c146d6f3d61e07d9ff0d8e9eccb0624d87e4be8b108c74e4b
+    - https://github.com/strukturag/libheif/releases/download/v1.19.3/libheif-1.19.3.tar.gz : 1e6d3bb5216888a78fbbf5fd958cd3cf3b941aceb002d2a8d635f85cc59a8599
 license    : LGPL-3.0-or-later
 homepage   : https://github.com/strukturag/libheif
 component  : multimedia.codecs

--- a/packages/l/libheif/pspec_x86_64.xml
+++ b/packages/l/libheif/pspec_x86_64.xml
@@ -30,7 +30,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
             <Path fileType="library">/usr/lib64/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-heif.so</Path>
             <Path fileType="library">/usr/lib64/libheif</Path>
             <Path fileType="library">/usr/lib64/libheif.so.1</Path>
-            <Path fileType="library">/usr/lib64/libheif.so.1.19.1</Path>
+            <Path fileType="library">/usr/lib64/libheif.so.1.19.3</Path>
             <Path fileType="man">/usr/share/man/man1/heif-dec.1</Path>
             <Path fileType="man">/usr/share/man/man1/heif-enc.1</Path>
             <Path fileType="man">/usr/share/man/man1/heif-info.1</Path>
@@ -46,7 +46,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="43">libheif</Dependency>
+            <Dependency release="44">libheif</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libheif/heif.h</Path>
@@ -64,9 +64,9 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
         </Files>
     </Package>
     <History>
-        <Update release="43">
-            <Date>2024-11-02</Date>
-            <Version>1.19.1</Version>
+        <Update release="44">
+            <Date>2024-11-11</Date>
+            <Version>1.19.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- fix running the unit tests from the build directory when building with plugins
- switch to catch2 testing framework
- fixes a race condition that may lead to some image tiles not being included in the output image
- fix a potential crash when querying overlay image information

**Test Plan**

Encoded and decoded a bunch of image files

**Checklist**

- [x] Package was built and tested against unstable
