### PR TITLE
pcsx2: remove png++ as dependency

### DIFF
--- a/packages/p/pcsx2/abi_used_symbols
+++ b/packages/p/pcsx2/abi_used_symbols
@@ -604,6 +604,7 @@ libQt6Gui.so.6:_ZNK11QTextCursor5atEndEv
 libQt6Gui.so.6:_ZNK12QFontMetrics10elidedTextERK7QStringN2Qt13TextElideModeEii
 libQt6Gui.so.6:_ZNK12QFontMetrics16averageCharWidthEv
 libQt6Gui.so.6:_ZNK12QFontMetrics6heightEv
+libQt6Gui.so.6:_ZNK12QPaintDevice16devicePixelRatioEv
 libQt6Gui.so.6:_ZNK13QStandardItem3rowEv
 libQt6Gui.so.6:_ZNK13QStandardItem6columnEv
 libQt6Gui.so.6:_ZNK13QTextDocument11toPlainTextEv

--- a/packages/p/pcsx2/monitoring.yml
+++ b/packages/p/pcsx2/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 12288
+  rss: https://github.com/PCSX2/pcsx2/releases.atom
+# No known CPE, checked 2024-11-12
+security:
+  cpe: ~

--- a/packages/p/pcsx2/package.yml
+++ b/packages/p/pcsx2/package.yml
@@ -1,6 +1,6 @@
 name       : pcsx2
 version    : 2.0.2
-release    : 24
+release    : 25
 source     :
     - git|https://github.com/PCSX2/pcsx2.git : 2f46e5a8406e4832ba60c5ab1ba2fd16a074ab1f
     - git|https://github.com/ianlancetaylor/libbacktrace.git : 86885d14049fab06ef8a33aac51664230ca09200
@@ -53,7 +53,6 @@ builddeps  :
     - glibc-devel
     - libaio-devel
     - p7zip
-    - png++
     - zstd
 setup      : |
     # Build libbacktrace

--- a/packages/p/pcsx2/pspec_x86_64.xml
+++ b/packages/p/pcsx2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pcsx2</Name>
         <Homepage>https://pcsx2.net</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>GPL-3.0-or-later</License>
@@ -120,12 +120,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2024-10-01</Date>
+        <Update release="25">
+            <Date>2024-11-12</Date>
             <Version>2.0.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Remove png++ as dependency.
- Part of https://github.com/getsolus/packages/issues/3885

**Test Plan**
- Checked it still build and started up as expected.

**Checklist**

- [X] Package was built and tested against unstable
