### PR TITLE
fb2converter: Update to 1.76.1

### DIFF
--- a/packages/f/fb2converter/package.yml
+++ b/packages/f/fb2converter/package.yml
@@ -1,8 +1,8 @@
 name       : fb2converter
-version    : 1.76.0
-release    : 28
+version    : 1.76.1
+release    : 29
 source     :
-    - git|https://github.com/rupor-github/fb2converter.git : v1.76.0
+    - git|https://github.com/rupor-github/fb2converter.git : v1.76.1
 homepage   : https://github.com/rupor-github/fb2converter
 license    : GPL-3.0-only
 component  : office.viewers

--- a/packages/f/fb2converter/pspec_x86_64.xml
+++ b/packages/f/fb2converter/pspec_x86_64.xml
@@ -26,9 +26,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2024-10-31</Date>
-            <Version>1.76.0</Version>
+        <Update release="29">
+            <Date>2024-11-13</Date>
+            <Version>1.76.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- [changelog](https://github.com/rupor-github/fb2converter/compare/v1.76.0...v1.76.1)

**Test Plan**
- fb2c convert --to epub in.fb2

**Checklist**
- [X] Package was built and tested against unstable
