### PR TITLE
yubico-authenticator: Add appstream metainfo

### DIFF
--- a/packages/y/yubico-authenticator/files/com.yubico.yubioath.appdata.xml
+++ b/packages/y/yubico-authenticator/files/com.yubico.yubioath.appdata.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.yubico.yubioath</id>
+  <launchable type="desktop-id">com.yubico.yubioath.desktop</launchable>
+
+  <metadata_license>MIT</metadata_license>
+  <project_license>BSD-2-Clause</project_license>
+
+  <name>Yubico Authenticator</name>
+  <summary>Graphical interface for displaying OATH codes with a YubiKey</summary>
+  <url type="homepage">https://www.yubico.com/products/yubico-authenticator/yubico-authenticator-desktop-beta/</url>
+  <url type="contact">https://support.yubico.com/support/tickets/new</url>
+  <content_rating type="oars-1.1"/>
+
+  <developer_name>Yubico</developer_name>
+
+  <description>
+    <p>Generating Open Authentication (OATH) time-based TOTP and event-based HOTP one-time password codes, with the help of a YubiKey that protects the shared secrets.</p>
+    <p>Features:</p>
+    <ul>
+      <li>Add a credential by scanning a QR code on the screen</li>
+      <li>Favorite your most used credentials for easy access</li>
+      <li>Keep your secret seeds safe by storing them on a YubiKey</li>
+      <li>Require a touch on YubiKey to generate the code</li>
+      <li>Protect your credentials with a device password</li>
+      <li>Connect an external smart card reader and use the YubiKey over NFC</li>
+    </ul>
+  </description>
+
+  <screenshots>
+    <screenshot type="default">
+      <image type="source" width="830" height="323">https://raw.githubusercontent.com/Yubico/yubioath-flutter/main/splash.png</image>
+      <caption>Official splash image</caption>
+    </screenshot>
+    ​<screenshot>
+      <image type="source" width="400" height="724">https://i.imgur.com/CMk0Oyc.png</image>
+      <caption>Main window (with e-mail addresses censored)</caption>
+    </screenshot>
+  </screenshots>
+
+</component>

--- a/packages/y/yubico-authenticator/package.yml
+++ b/packages/y/yubico-authenticator/package.yml
@@ -1,6 +1,6 @@
 name       : yubico-authenticator
 version    : 7.1.1
-release    : 9
+release    : 10
 source     :
     - https://github.com/Yubico/yubioath-flutter/archive/refs/tags/7.1.1.tar.gz : 23b6a66512588a488ff63d0e6e349e1b6674e964c58bdac68c0b41b919f2fd52
     - https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.24.4-stable.tar.xz#flutter.tar.xz : 2ce78d4a51f063efa7f04666ae010d026d119eea6bdea7e08b736840fe88ddb4
@@ -30,14 +30,14 @@ builddeps  :
     - python-poetry
     - swig
 rundeps    :
-    - yubikey-manager
-    - pcsc-lite
-    - python-pillow
-    - python-zxing-cpp
-    - python-mss
     # pip told me that these deps are required, I don't know why...
     - numpy
+    - pcsc-lite
     - python-keyring
+    - python-mss
+    - python-pillow
+    - python-zxing-cpp
+    - yubikey-manager
 environment: |
     # Let Poetry use our system environment, so that if it starts installing
     # packages (which would fail due to insufficient privileges), we know
@@ -71,12 +71,13 @@ install    : |
     install -dm00755 $installdir/usr/share
     mv build/linux/x64/release/bundle $installdir/$YUBIOATH_DIR/
 
-    # Desktop and icon
+    # Desktop, icon and appstream metainfo
     sed -i 's|\(Exec="\)@EXEC_PATH|\1/usr/share/yubioath-desktop|' $installdir/$YUBIOATH_DIR/linux_support/com.yubico.authenticator.desktop
     sed -i 's|\(Icon=\)@EXEC_PATH/linux_support/|\1|' $installdir/$YUBIOATH_DIR/linux_support/com.yubico.authenticator.desktop
-    install -dm00755 $installdir/usr/share/applications/ $installdir/usr/share/pixmaps/
-    ln -s $YUBIOATH_DIR/linux_support/com.yubico.authenticator.desktop $installdir/usr/share/applications/com.yubico.authenticator.desktop
-    ln -s $YUBIOATH_DIR/linux_support/com.yubico.yubioath.png $installdir/usr/share/pixmaps/com.yubico.yubioath.png
+    # appstream builder cannot handle sysmlink, do install instead
+    install -Dm00644 $installdir/$YUBIOATH_DIR/linux_support/com.yubico.authenticator.desktop $installdir/usr/share/applications/com.yubico.yubioath.desktop
+    install -Dm00644 $installdir/$YUBIOATH_DIR/linux_support/com.yubico.yubioath.png $installdir/usr/share/icons/hicolor/128x128/apps/com.yubico.yubioath.png
+    install -Dm00644 $pkgfiles/com.yubico.yubioath.appdata.xml -t $installdir/usr/share/metainfo/
 
     # Binary
     install -dm00755 $installdir/usr/bin

--- a/packages/y/yubico-authenticator/pspec_x86_64.xml
+++ b/packages/y/yubico-authenticator/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>yubico-authenticator</Name>
         <Homepage>https://www.yubico.com/products/yubico-authenticator/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>security</PartOf>
@@ -29,8 +29,9 @@ The Yubico Authenticator securely generates a code used to verify your identity 
         <PartOf>security</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/authenticator</Path>
-            <Path fileType="data">/usr/share/applications/com.yubico.authenticator.desktop</Path>
-            <Path fileType="data">/usr/share/pixmaps/com.yubico.yubioath.png</Path>
+            <Path fileType="data">/usr/share/applications/com.yubico.yubioath.desktop</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/com.yubico.yubioath.png</Path>
+            <Path fileType="data">/usr/share/metainfo/com.yubico.yubioath.appdata.xml</Path>
             <Path fileType="data">/usr/share/yubioath-desktop/authenticator</Path>
             <Path fileType="data">/usr/share/yubioath-desktop/data/flutter_assets/AssetManifest.bin</Path>
             <Path fileType="data">/usr/share/yubioath-desktop/data/flutter_assets/AssetManifest.json</Path>
@@ -131,12 +132,12 @@ The Yubico Authenticator securely generates a code used to verify your identity 
         </Replaces>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2024-11-06</Date>
+        <Update release="10">
+            <Date>2024-11-13</Date>
             <Version>7.1.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add appstream metainfo (Part of getsolus/packages#1389)

**Test Plan**

<!-- Short description of how the package was tested -->
Run `appstream-builder --packages-dir=. --include-failed -v`

**Checklist**

- [x] Package was built and tested against unstable
