### PR TITLE
onefetch: Update to v2.22.0

### DIFF
--- a/packages/o/onefetch/MAINTAINERS.md
+++ b/packages/o/onefetch/MAINTAINERS.md
@@ -1,4 +1,0 @@
-This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
-
-- Longwu Ou
-  - Email: xulongwu4@gmail.com

--- a/packages/o/onefetch/abi_used_symbols
+++ b/packages/o/onefetch/abi_used_symbols
@@ -1,7 +1,6 @@
 ld-linux-x86-64.so.2:__tls_get_addr
 libc.so.6:__errno_location
 libc.so.6:__libc_start_main
-libc.so.6:__memcpy_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__xpg_strerror_r
 libc.so.6:_exit
@@ -36,7 +35,6 @@ libc.so.6:gnu_get_libc_version
 libc.so.6:ioctl
 libc.so.6:isatty
 libc.so.6:kill
-libc.so.6:localtime_r
 libc.so.6:lseek64
 libc.so.6:lstat64
 libc.so.6:malloc
@@ -45,7 +43,6 @@ libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset
 libc.so.6:mkdir
-libc.so.6:mmap
 libc.so.6:mmap64
 libc.so.6:mprotect
 libc.so.6:munmap
@@ -53,6 +50,7 @@ libc.so.6:nanosleep
 libc.so.6:open
 libc.so.6:open64
 libc.so.6:opendir
+libc.so.6:pause
 libc.so.6:pipe2
 libc.so.6:poll
 libc.so.6:posix_memalign
@@ -73,7 +71,6 @@ libc.so.6:pthread_attr_setstacksize
 libc.so.6:pthread_create
 libc.so.6:pthread_detach
 libc.so.6:pthread_getattr_np
-libc.so.6:pthread_getspecific
 libc.so.6:pthread_join
 libc.so.6:pthread_key_create
 libc.so.6:pthread_key_delete
@@ -112,7 +109,6 @@ libc.so.6:syscall
 libc.so.6:sysconf
 libc.so.6:tcgetattr
 libc.so.6:tcsetattr
-libc.so.6:tzset
 libc.so.6:unlink
 libc.so.6:waitid
 libc.so.6:waitpid

--- a/packages/o/onefetch/package.yml
+++ b/packages/o/onefetch/package.yml
@@ -1,8 +1,8 @@
 name       : onefetch
-version    : 2.21.0
-release    : 9
+version    : 2.22.0
+release    : 10
 source     :
-    - https://github.com/o2sh/onefetch/archive/refs/tags/2.21.0.tar.gz : a035bc44ef0c04a330b409e08ee61ac8a66a56cb672f87a824d4c0349989eaf2
+    - https://github.com/o2sh/onefetch/archive/refs/tags/2.22.0.tar.gz : 1741516c628bb70b432285aa78439c4acfeb5df19e48b8d85dba5f71336e190b
 homepage   : https://onefetch.dev
 license    : MIT
 component  : system.utils

--- a/packages/o/onefetch/pspec_x86_64.xml
+++ b/packages/o/onefetch/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>onefetch</Name>
         <Homepage>https://onefetch.dev</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -25,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2024-07-14</Date>
-            <Version>2.21.0</Version>
+        <Update release="10">
+            <Date>2024-11-13</Date>
+            <Version>2.22.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Add support for nerd font glyphs in languages info
- Add nerdfont iconts to the preview
- Show future commit dates without panicking
- Full changelog [here](https://github.com/o2sh/onefetch/releases/tag/2.22.0)

**Test Plan**

- Run `onefetch` on the packages repository, learn we are a python project

**Checklist**

- [x] Package was built and tested against unstable
