### PR TITLE
tealdeer: Update to v1.7.1

### DIFF
--- a/packages/t/tealdeer/monitoring.yml
+++ b/packages/t/tealdeer/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 84521
+  rss: https://github.com/tealdeer-rs/tealdeer/releases.atom
+# No known CPE, checked 2024-11-14
+security:
+  cpe: ~

--- a/packages/t/tealdeer/package.yml
+++ b/packages/t/tealdeer/package.yml
@@ -1,8 +1,8 @@
 name       : tealdeer
-version    : 1.7.0
-release    : 12
+version    : 1.7.1
+release    : 13
 source     :
-    - https://github.com/tealdeer-rs/tealdeer/archive/refs/tags/v1.7.0.tar.gz : 940fe96a44571f395ac8349e5cba7ddb9231ce526bee07a9eb68f02c32f7da7b
+    - https://github.com/tealdeer-rs/tealdeer/archive/refs/tags/v1.7.1.tar.gz : 2b10e141774d2a50d25a1d3ca3d911dedc0e1313366ce0a364068c7a686300d8
 license    : MIT
 component  : system.utils
 homepage   : https://tldr.sh/

--- a/packages/t/tealdeer/pspec_x86_64.xml
+++ b/packages/t/tealdeer/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2024-10-03</Date>
-            <Version>1.7.0</Version>
+        <Update release="13">
+            <Date>2024-11-14</Date>
+            <Version>1.7.1</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- This patch release updates the yansi dependency to version 1, so that the previous versions of yansi can be removed from the package sets of Linux distributions. This change should not impact the behavior of tealdeer.

**Test Plan**

- Use tldr to look up a random command

**Checklist**

- [x] Package was built and tested against unstable
