### PR TITLE
python-waitress: Update to v3.0.2

### DIFF
--- a/packages/py/python-waitress/package.yml
+++ b/packages/py/python-waitress/package.yml
@@ -1,8 +1,8 @@
 name       : python-waitress
-version    : 3.0.1
-release    : 10
+version    : 3.0.2
+release    : 11
 source     :
-    - https://github.com/Pylons/waitress/archive/refs/tags/v3.0.1.tar.gz : 724e4870e41ed9d4cd8b1d3330ff460789ae7e86910b4ace47b1b5bbe0fd0c0c
+    - https://github.com/Pylons/waitress/archive/refs/tags/v3.0.2.tar.gz : 4c5583cee40bee842b48443ed899b5d445947c5d88fe170d31c3becab09710c3
 homepage   : https://docs.pylonsproject.org/projects/waitress/en/latest/
 license    : ZPL-2.1
 component  : programming.python

--- a/packages/py/python-waitress/pspec_x86_64.xml
+++ b/packages/py/python-waitress/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-waitress</Name>
         <Homepage>https://docs.pylonsproject.org/projects/waitress/en/latest/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>ZPL-2.1</License>
         <PartOf>programming.python</PartOf>
@@ -21,12 +21,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/waitress-serve</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/waitress-3.0.1-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/waitress-3.0.1-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/waitress-3.0.1-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/waitress-3.0.1-py3.11.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/waitress-3.0.1-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/waitress-3.0.1-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/waitress-3.0.2-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/waitress-3.0.2-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/waitress-3.0.2-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/waitress-3.0.2-py3.11.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/waitress-3.0.2-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/waitress-3.0.2-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/waitress/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/waitress/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/waitress/__pycache__/__init__.cpython-311.pyc</Path>
@@ -62,12 +62,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2024-11-10</Date>
-            <Version>3.0.1</Version>
+        <Update release="11">
+            <Date>2024-11-16</Date>
+            <Version>3.0.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
When using Waitress to process trusted proxy headers, Waitress will now update the headers to drop any untrusted values, thereby making sure that WSGI apps only get trusted and validated values that Waitress itself used to update the environ

Full release notes available [here](https://github.com/Pylons/waitress/releases/tag/v3.0.2)

**Test Plan**
- Shared a file with `onionshare-cli`
- Used `anki` online functionalities (though I'm unsure what part exactly uses the waitress)

**Checklist**

- [x] Package was built and tested against unstable
