### PR TITLE
github-cli: Update to v2.62.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.61.0
-release    : 59
+version    : 2.62.0
+release    : 60
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.61.0.tar.gz : bf134281db2b65827426e3ad186de55cb04d0f92051ca2e6bd8a7d47aabe5b18
+    - https://github.com/cli/cli/archive/refs/tags/v2.62.0.tar.gz : 8b0d44a7fccd0c768d5ef7c3fbd274851b5752084e47761f146852de6539193e
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -225,9 +225,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="59">
-            <Date>2024-11-09</Date>
-            <Version>2.61.0</Version>
+        <Update release="60">
+            <Date>2024-11-19</Date>
+            <Version>2.62.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Update monotonic verification logic and testing
- Check extension for latest version when executed
- Shorten extension release checking from 3s to 1s
- Mention GitHub CLI team on discussion issues

**Security**
Includes fixes for:
- CVE-2024-52308

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
