### PR TITLE
watchexec: Update to v2.2.0

### DIFF
--- a/packages/w/watchexec/abi_used_symbols
+++ b/packages/w/watchexec/abi_used_symbols
@@ -40,7 +40,6 @@ libc.so.6:geteuid
 libc.so.6:getpeername
 libc.so.6:getpid
 libc.so.6:getpwnam
-libc.so.6:getpwuid
 libc.so.6:getpwuid_r
 libc.so.6:getsockname
 libc.so.6:getsockopt
@@ -69,6 +68,7 @@ libc.so.6:nanosleep
 libc.so.6:open
 libc.so.6:open64
 libc.so.6:opendir
+libc.so.6:pause
 libc.so.6:pipe2
 libc.so.6:poll
 libc.so.6:posix_memalign
@@ -89,7 +89,6 @@ libc.so.6:pthread_attr_setstacksize
 libc.so.6:pthread_create
 libc.so.6:pthread_detach
 libc.so.6:pthread_getattr_np
-libc.so.6:pthread_getspecific
 libc.so.6:pthread_join
 libc.so.6:pthread_key_create
 libc.so.6:pthread_key_delete
@@ -150,8 +149,6 @@ libgcc_s.so.1:_Unwind_SetIP
 libm.so.6:ceil
 libm.so.6:floor
 libm.so.6:floorf
-libm.so.6:fmod
 libm.so.6:logf
 libm.so.6:pow
 libm.so.6:round
-libm.so.6:trunc

--- a/packages/w/watchexec/package.yml
+++ b/packages/w/watchexec/package.yml
@@ -1,8 +1,8 @@
 name       : watchexec
-version    : 2.1.2
-release    : 1
+version    : 2.2.0
+release    : 2
 source     :
-    - https://github.com/watchexec/watchexec/archive/refs/tags/v2.1.2.tar.gz : 500b886038ccd553559fe19914e1a502728cfeb8ee9d81f3db448b05e5a890ec
+    - https://github.com/watchexec/watchexec/archive/refs/tags/v2.2.0.tar.gz : 372def49d02a53864ede5fd821feb6f8de96bbbde8a94dbcd1b77aeed01d4a7b
 homepage   : https://watchexec.github.io
 license    : Apache-2.0
 component  : system.utils

--- a/packages/w/watchexec/pspec_x86_64.xml
+++ b/packages/w/watchexec/pspec_x86_64.xml
@@ -28,9 +28,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-08-21</Date>
-            <Version>2.1.2</Version>
+        <Update release="2">
+            <Date>2024-11-19</Date>
+            <Version>2.2.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Ian M. Jones</Name>
             <Email>ian@ianmjones.com</Email>


### PR DESCRIPTION
**Summary**

Changelog: https://github.com/watchexec/watchexec/releases/tag/v2.2.0

**Test Plan**

* Built and installed package locally.
* Ran within a few projects to run tests.

**Checklist**

- [x] Package was built and tested against unstable
