### PR TITLE
libheif: Update to v1.19.5

### DIFF
--- a/packages/l/libheif/package.yml
+++ b/packages/l/libheif/package.yml
@@ -1,8 +1,8 @@
 name       : libheif
-version    : 1.19.3
-release    : 44
+version    : 1.19.5
+release    : 45
 source     :
-    - https://github.com/strukturag/libheif/releases/download/v1.19.3/libheif-1.19.3.tar.gz : 1e6d3bb5216888a78fbbf5fd958cd3cf3b941aceb002d2a8d635f85cc59a8599
+    - https://github.com/strukturag/libheif/releases/download/v1.19.5/libheif-1.19.5.tar.gz : d3cf0a76076115a070f9bc87cf5259b333a1f05806500045338798486d0afbaf
 license    : LGPL-3.0-or-later
 homepage   : https://github.com/strukturag/libheif
 component  : multimedia.codecs

--- a/packages/l/libheif/pspec_x86_64.xml
+++ b/packages/l/libheif/pspec_x86_64.xml
@@ -30,7 +30,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
             <Path fileType="library">/usr/lib64/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-heif.so</Path>
             <Path fileType="library">/usr/lib64/libheif</Path>
             <Path fileType="library">/usr/lib64/libheif.so.1</Path>
-            <Path fileType="library">/usr/lib64/libheif.so.1.19.3</Path>
+            <Path fileType="library">/usr/lib64/libheif.so.1.19.5</Path>
             <Path fileType="man">/usr/share/man/man1/heif-dec.1</Path>
             <Path fileType="man">/usr/share/man/man1/heif-enc.1</Path>
             <Path fileType="man">/usr/share/man/man1/heif-info.1</Path>
@@ -46,7 +46,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="44">libheif</Dependency>
+            <Dependency release="45">libheif</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libheif/heif.h</Path>
@@ -64,9 +64,9 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
         </Files>
     </Package>
     <History>
-        <Update release="44">
-            <Date>2024-11-11</Date>
-            <Version>1.19.3</Version>
+        <Update release="45">
+            <Date>2024-11-19</Date>
+            <Version>1.19.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- fix crash when encoding tiled `unci` images
- fix crash in `heif_context_encode_grid()`
- fix querying the preferred colorspace for monochrome AVIF files
- error when using a chroma format or bit depth that is not supported by the Kvazaar plugin
- output proper error message when memory allocation failed and use user-defined security limits
- heif-dec: do not show progress when option `--quiet` it given
- fix `heif_image_handle_is_premultiplied_alpha()`

**Test Plan**

Encode and decode a bunch of image files

**Checklist**

- [x] Package was built and tested against unstable
