### PR TITLE
obs-cmd: Update to v0.18.0

### DIFF
--- a/packages/o/obs-cmd/files/fix-version.patch
+++ b/packages/o/obs-cmd/files/fix-version.patch
@@ -1,5 +1,5 @@
 diff --git a/Cargo.lock b/Cargo.lock
-index d92760a..91690cb 100644
+index d92760a..6dec3f6 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
 @@ -586,7 +586,7 @@ dependencies = [
@@ -7,19 +7,19 @@ index d92760a..91690cb 100644
  [[package]]
  name = "obs-cmd"
 -version = "0.17.8"
-+version = "0.17.9"
++version = "0.18.0"
  dependencies = [
   "clap",
   "obws",
 diff --git a/Cargo.toml b/Cargo.toml
-index 375a4c6..aed29e8 100644
+index 375a4c6..a3c2da1 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
 @@ -1,6 +1,6 @@
  [package]
  name = "obs-cmd"
 -version = "0.17.8"
-+version = "0.17.9"
++version = "0.18.0"
  edition = "2021"
  description = "A minimal command to control obs via obs-websocket"
  authors = ["Luigi Maselli <luigi@grigio.org>"]

--- a/packages/o/obs-cmd/package.yml
+++ b/packages/o/obs-cmd/package.yml
@@ -1,8 +1,8 @@
 name       : obs-cmd
-version    : 0.17.9
-release    : 3
+version    : 0.18.0
+release    : 4
 source     :
-    - https://github.com/grigio/obs-cmd/archive/refs/tags/v0.17.9.tar.gz : 790951c3b87a04d604ae7b1a35e7ca3482d00e2f246043c6aac9e10609122a34
+    - https://github.com/grigio/obs-cmd/archive/refs/tags/v0.18.0.tar.gz : 0812645f9a5c4a87f94389e114943e8b27a049d50a531daf4de2fe46325900a5
 homepage   : https://github.com/grigio/obs-cmd
 license    : MIT
 component  : system.utils

--- a/packages/o/obs-cmd/pspec_x86_64.xml
+++ b/packages/o/obs-cmd/pspec_x86_64.xml
@@ -24,9 +24,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-10-14</Date>
-            <Version>0.17.9</Version>
+        <Update release="4">
+            <Date>2024-11-19</Date>
+            <Version>0.18.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Ian M. Jones</Name>
             <Email>ian@ianmjones.com</Email>


### PR DESCRIPTION
**Summary**

Changelog: https://github.com/grigio/obs-cmd/releases/tag/v0.18.0

* Built and installed package locally.
* Ran a few manual commands.
* Ran a few scripted commands (via deckmaster).
* Checked version reported correctly.

**Checklist**

- [x] Package was built and tested against unstable
