### PR TITLE
font-ubuntu-sans-ttf: Add at 1.006

### DIFF
--- a/packages/f/font-ubuntu-sans-ttf/files/ubuntu-sans.metainfo.xml
+++ b/packages/f/font-ubuntu-sans-ttf/files/ubuntu-sans.metainfo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2024 Solus Developers <copyright@getsol.us> -->
+<component type="font">
+  <id>font-ubuntu-sans</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Ubuntu Sans Font Family</name>
+  <url type="homepage">https://github.com/canonical/Ubuntu-Sans-fonts</url>
+  <summary>The Ubuntu Font Family are a set of matching libre/open fonts</summary>
+</component>

--- a/packages/f/font-ubuntu-sans-ttf/monitoring.yml
+++ b/packages/f/font-ubuntu-sans-ttf/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 375586
+  rss: https://github.com/canonical/Ubuntu-Sans-fonts/releases.atom
+# No known CPE, checked 2024-11-20
+security:
+  cpe: ~

--- a/packages/f/font-ubuntu-sans-ttf/package.yml
+++ b/packages/f/font-ubuntu-sans-ttf/package.yml
@@ -1,0 +1,15 @@
+name       : font-ubuntu-sans-ttf
+version    : 1.006
+release    : 1
+source     :
+    - https://github.com/canonical/Ubuntu-Sans-fonts/archive/refs/tags/v1.006.tar.gz : ddd9e2b74767cf2b5b33d933ff8d579e806b0b26e9b7abf96ebfe9b3f6895a65
+homepage   : https://github.com/canonical/Ubuntu-Sans-fonts
+license    : Ubuntu-font-1.0
+component  : desktop.font
+summary    : Ubuntu Sans Font Family
+description: |
+    The Ubuntu Font Family are a set of matching libre/open fonts.
+install    : |
+     install -Dm00644 fonts/ttf/*.ttf -t $installdir/usr/share/fonts/truetype/ubuntu-sans/
+
+     install -Dm00644 $pkgfiles/ubuntu-sans.metainfo.xml -t $installdir/usr/share/metainfo/

--- a/packages/f/font-ubuntu-sans-ttf/pspec_x86_64.xml
+++ b/packages/f/font-ubuntu-sans-ttf/pspec_x86_64.xml
@@ -1,0 +1,67 @@
+<PISI>
+    <Source>
+        <Name>font-ubuntu-sans-ttf</Name>
+        <Homepage>https://github.com/canonical/Ubuntu-Sans-fonts</Homepage>
+        <Packager>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
+        </Packager>
+        <License>Ubuntu-font-1.0</License>
+        <PartOf>desktop.font</PartOf>
+        <Summary xml:lang="en">Ubuntu Sans Font Family</Summary>
+        <Description xml:lang="en">The Ubuntu Font Family are a set of matching libre/open fonts.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>font-ubuntu-sans-ttf</Name>
+        <Summary xml:lang="en">Ubuntu Sans Font Family</Summary>
+        <Description xml:lang="en">The Ubuntu Font Family are a set of matching libre/open fonts.
+</Description>
+        <PartOf>desktop.font</PartOf>
+        <Files>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSans-Bold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSans-BoldItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSans-ExtraBold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSans-ExtraBoldItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSans-ExtraLight.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSans-ExtraLightItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSans-Italic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSans-Light.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSans-LightItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSans-Medium.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSans-MediumItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSans-Regular.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSans-SemiBold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSans-SemiBoldItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSans-Thin.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSans-ThinItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSansCondensed-Bold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSansCondensed-BoldItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSansCondensed-ExtraBold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSansCondensed-ExtraBoldItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSansCondensed-ExtraLight.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSansCondensed-ExtraLightItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSansCondensed-Italic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSansCondensed-Light.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSansCondensed-LightItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSansCondensed-Medium.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSansCondensed-MediumItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSansCondensed-Regular.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSansCondensed-SemiBold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSansCondensed-SemiBoldItalic.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSansCondensed-Thin.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/ubuntu-sans/UbuntuSansCondensed-ThinItalic.ttf</Path>
+            <Path fileType="data">/usr/share/metainfo/ubuntu-sans.metainfo.xml</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2024-11-21</Date>
+            <Version>1.006</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**
- Add ubuntu-sans font
- resolves https://github.com/getsolus/packages/issues/4360


**Test Plan**

Install font, and view in kde font manager.

**Checklist**

- [x] Package was built and tested against unstable
