### PR TITLE
shotcut: Update to v24.11.17

### DIFF
--- a/packages/s/shotcut/abi_used_symbols
+++ b/packages/s/shotcut/abi_used_symbols
@@ -484,7 +484,6 @@ libQt6Core.so.6:_ZN7QString6insertEx5QChar
 libQt6Core.so.6:_ZN7QString6insertExPK5QCharx
 libQt6Core.so.6:_ZN7QString6numberEdci
 libQt6Core.so.6:_ZN7QString6numberEii
-libQt6Core.so.6:_ZN7QString6numberEji
 libQt6Core.so.6:_ZN7QString6numberExi
 libQt6Core.so.6:_ZN7QString6removeERKS_N2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZN7QString6removeExx

--- a/packages/s/shotcut/package.yml
+++ b/packages/s/shotcut/package.yml
@@ -1,8 +1,8 @@
 name       : shotcut
-version    : 24.10.29
-release    : 41
+version    : 24.11.17
+release    : 42
 source     :
-    - https://github.com/mltframework/shotcut/archive/refs/tags/v24.10.29.tar.gz : 8635486cfb0e8e0d50e264e97a3ab4c57b2901742b188aed3ee91ac0371b3250
+    - https://github.com/mltframework/shotcut/archive/refs/tags/v24.11.17.tar.gz : cb6a3a819b3ae56325406665273347328ae973250c02a832fce609ee6c0f6b13
 homepage   : https://www.shotcut.org/
 license    : GPL-3.0-or-later
 component  : multimedia.video

--- a/packages/s/shotcut/pspec_x86_64.xml
+++ b/packages/s/shotcut/pspec_x86_64.xml
@@ -964,9 +964,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="41">
-            <Date>2024-11-11</Date>
-            <Version>24.10.29</Version>
+        <Update release="42">
+            <Date>2024-11-19</Date>
+            <Version>24.11.17</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Fixed Convert stopped converting variable frame rate to constant (broke in v24.10).
- Fixed filter in and out points when you resize transition by moving a clip (broke in v24.10).
- Fixed Reframe loses its keyframes in Export (broke in v24.10).
- Fixed moving a clip immediately after a transition beyond another clip stopped working (broke in v24.10).
- Fixed Settings > Time Format > Timecode (Non-Drop Frame) for other non-integer frame rates such as 23.98 fps.
- Fixed using Export > From > Marker with subtitles creates a bad output (broke in v24.08).
- Fixed a video transition between sources with alpha channel is more translucent than expected.
- Fixed a crash adding MLT XML As a Clip to a Timeline with a higher frame rate.
- Fixed View > Resources > Convert negatively affects color if input is not HDR.
- Fixed Export > Video > Aspect ratio immediately after you toggle Use hardware encoder.
- Fixed possible crash dragging a MLT XML file to Playlist of a new project/session.
- Fixed changing Properties > Audio > Track > All to something else not working.

**Test Plan**

- Ran shotcut

**Checklist**

- [x] Package was built and tested against unstable
