### PR TITLE
Taskfile: Use `~` for null in monitoring template

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -298,8 +298,10 @@ tasks:
     cmds:
       - touch monitoring.yml
       - yq --inplace '
-          .releases.id line_comment = "# Check https://release-monitoring.org/" |
-          .releases.rss line_comment = "# For example https://github.com/PyO3/maturin/releases.atom" |
+          . head_comment="Remove all comments before submitting, except CPE check date if none found" |
+          .releases.id line_comment = "Check https://release-monitoring.org/" |
+          .releases.rss line_comment = "For example https://github.com/PyO3/maturin/releases.atom" |
+          .releases.[] = ~ |
           (.security | key) head_comment = "{{ .COMMENT }}" |
           .security.cpe = ~
         '  monitoring.yml


### PR DESCRIPTION
**Summary**

Use `~` instead of `null` for the default null values in the monitoring.yml template

Also add a head comment about removing all comments before submitting

Part of https://github.com/getsolus/packages/issues/4425

Old template:
```yaml
releases:
  id: null # Check https://release-monitoring.org/
  rss: null # For example https://github.com/PyO3/maturin/releases.atom
# No known CPE, checked 2024-11-22
security:
  cpe: ~
```


New template:
```yaml
# Remove all comments before submitting, except CPE check date if none found
releases:
  id: ~ # Check https://release-monitoring.org/
  rss: ~ # For example https://github.com/PyO3/maturin/releases.atom
# No known CPE, checked 2024-11-22
security:
  cpe: ~
```
