### PR TITLE
libgtksourceview5: Update to v5.14.2

### DIFF
--- a/packages/l/libgtksourceview5/abi_used_symbols
+++ b/packages/l/libgtksourceview5/abi_used_symbols
@@ -909,6 +909,7 @@ libgtk-4.so.1:gtk_widget_class_set_activate_signal
 libgtk-4.so.1:gtk_widget_class_set_css_name
 libgtk-4.so.1:gtk_widget_class_set_layout_manager_type
 libgtk-4.so.1:gtk_widget_class_set_template_from_resource
+libgtk-4.so.1:gtk_widget_compute_point
 libgtk-4.so.1:gtk_widget_create_pango_layout
 libgtk-4.so.1:gtk_widget_error_bell
 libgtk-4.so.1:gtk_widget_get_allocation

--- a/packages/l/libgtksourceview5/package.yml
+++ b/packages/l/libgtksourceview5/package.yml
@@ -1,9 +1,9 @@
 name       : libgtksourceview5
-version    : 5.14.1
-release    : 10
+version    : 5.14.2
+release    : 11
 source     :
-    - https://download.gnome.org/sources/gtksourceview/5.14/gtksourceview-5.14.1.tar.xz : 009862e87b929da5a724ece079f01f8cee29e74797a1ecac349f58c15a3cbc58
-homepage   : https://wiki.gnome.org/Projects/GtkSourceView
+    - https://download.gnome.org/sources/gtksourceview/5.14/gtksourceview-5.14.2.tar.xz : 1a6d387a68075f8aefd4e752cf487177c4a6823b14ff8a434986858aeaef6264
+homepage   : https://gitlab.gnome.org/GNOME/gtksourceview
 license    : LGPL-2.1-or-later
 component  : desktop.gnome.core
 summary    : A text widget adding syntax highlighting and more to GNOME

--- a/packages/l/libgtksourceview5/pspec_x86_64.xml
+++ b/packages/l/libgtksourceview5/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>libgtksourceview5</Name>
-        <Homepage>https://wiki.gnome.org/Projects/GtkSourceView</Homepage>
+        <Homepage>https://gitlab.gnome.org/GNOME/gtksourceview</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>desktop.gnome.core</PartOf>
@@ -330,7 +330,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">libgtksourceview5</Dependency>
+            <Dependency release="11">libgtksourceview5</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gtksourceview-5/gtksourceview/completion-providers/snippets/gtksourcecompletionsnippets.h</Path>
@@ -394,12 +394,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2024-10-19</Date>
-            <Version>5.14.1</Version>
+        <Update release="11">
+            <Date>2024-11-22</Date>
+            <Version>5.14.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
* Ignore various libxml2 deprecations
* Fix some incorrect GI annotations
* Fix extraneous dismissal of hover providers in some cases
* Add missing 5_14 version macros



**Test Plan**
- Checked it build correctly.

**Checklist**

- [X] Package was built and tested against unstable
