### PR TITLE
wine: Update to v9.22

### DIFF
--- a/packages/w/wine/abi_symbols
+++ b/packages/w/wine/abi_symbols
@@ -228,6 +228,7 @@ ntdll.so:NtSetInformationToken
 ntdll.so:NtSetInformationVirtualMemory
 ntdll.so:NtSetIntervalProfile
 ntdll.so:NtSetIoCompletion
+ntdll.so:NtSetIoCompletionEx
 ntdll.so:NtSetLdtEntries
 ntdll.so:NtSetSecurityObject
 ntdll.so:NtSetSystemInformation
@@ -524,6 +525,8 @@ win32u.so:NtUserAttachThreadInput
 win32u.so:NtUserBeginPaint
 win32u.so:NtUserBuildHimcList
 win32u.so:NtUserBuildHwndList
+win32u.so:NtUserBuildNameList
+win32u.so:NtUserBuildPropList
 win32u.so:NtUserCallHwnd
 win32u.so:NtUserCallHwndParam
 win32u.so:NtUserCallMsgFilter
@@ -667,6 +670,7 @@ win32u.so:NtUserPostThreadMessage
 win32u.so:NtUserPrintWindow
 win32u.so:NtUserQueryDisplayConfig
 win32u.so:NtUserQueryInputContext
+win32u.so:NtUserQueryWindow
 win32u.so:NtUserRealChildWindowFromPoint
 win32u.so:NtUserRedrawWindow
 win32u.so:NtUserRegisterClassExWOW

--- a/packages/w/wine/abi_symbols32
+++ b/packages/w/wine/abi_symbols32
@@ -217,6 +217,7 @@ ntdll.so:NtSetInformationToken
 ntdll.so:NtSetInformationVirtualMemory
 ntdll.so:NtSetIntervalProfile
 ntdll.so:NtSetIoCompletion
+ntdll.so:NtSetIoCompletionEx
 ntdll.so:NtSetLdtEntries
 ntdll.so:NtSetSecurityObject
 ntdll.so:NtSetSystemInformation
@@ -513,6 +514,8 @@ win32u.so:NtUserAttachThreadInput
 win32u.so:NtUserBeginPaint
 win32u.so:NtUserBuildHimcList
 win32u.so:NtUserBuildHwndList
+win32u.so:NtUserBuildNameList
+win32u.so:NtUserBuildPropList
 win32u.so:NtUserCallHwnd
 win32u.so:NtUserCallHwndParam
 win32u.so:NtUserCallMsgFilter
@@ -656,6 +659,7 @@ win32u.so:NtUserPostThreadMessage
 win32u.so:NtUserPrintWindow
 win32u.so:NtUserQueryDisplayConfig
 win32u.so:NtUserQueryInputContext
+win32u.so:NtUserQueryWindow
 win32u.so:NtUserRealChildWindowFromPoint
 win32u.so:NtUserRedrawWindow
 win32u.so:NtUserRegisterClassExWOW

--- a/packages/w/wine/abi_used_symbols
+++ b/packages/w/wine/abi_used_symbols
@@ -889,6 +889,7 @@ libm.so.6:hypot
 libm.so.6:log
 libm.so.6:pow
 libm.so.6:round
+libm.so.6:roundf
 libm.so.6:sin
 libm.so.6:sincos
 libm.so.6:sqrt

--- a/packages/w/wine/abi_used_symbols32
+++ b/packages/w/wine/abi_used_symbols32
@@ -808,6 +808,7 @@ libm.so.6:hypot
 libm.so.6:log
 libm.so.6:pow
 libm.so.6:round
+libm.so.6:roundf
 libm.so.6:sin
 libm.so.6:sincos
 libm.so.6:sqrt

--- a/packages/w/wine/package.yml
+++ b/packages/w/wine/package.yml
@@ -1,8 +1,8 @@
 name       : wine
-version    : '9.21'
-release    : 189
+version    : '9.22'
+release    : 190
 source     :
-    - https://dl.winehq.org/wine/source/9.x/wine-9.21.tar.xz : 4442b47ffd9b2ea457100e36ed5fd4e6f4d829d9db79a25e605175a988ca2fff
+    - https://dl.winehq.org/wine/source/9.x/wine-9.22.tar.xz : e150d29742aa54f768ef3e976ed861aaa4f9f48542e409bea902d0f49b359683
 license    : LGPL-2.1-or-later
 component  : virt
 homepage   : https://www.winehq.org/
@@ -77,16 +77,14 @@ setup      : |
     # Get 64-bit done first.
     mkdir wine64 && pushd wine64
     ../configure %CONFOPTS% \
-        --enable-win64 \
-        --with-x
+        --enable-win64
     popd
 
     # 32-bit now
     mkdir wine32 && pushd wine32
     PKG_CONFIG_PATH=/usr/lib32/pkgconfig:/usr/share/pkgconfig:/usr/lib64/pkgconfig ../configure %CONFOPTS% \
         --with-wine64=../wine64 \
-        --libdir=/usr/lib32 \
-        --with-x
+        --libdir=/usr/lib32
     popd
 build      : |
     %make -C wine64

--- a/packages/w/wine/pspec_x86_64.xml
+++ b/packages/w/wine/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>wine</Name>
         <Homepage>https://www.winehq.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>virt</PartOf>
@@ -320,6 +320,7 @@
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/iccvid.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/icinfo.exe</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/icmp.dll</Path>
+            <Path fileType="library">/usr/lib64/wine/x86_64-windows/icmui.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/ieframe.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/ieproxy.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/iertutil.dll</Path>
@@ -1003,7 +1004,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="189">wine</Dependency>
+            <Dependency release="190">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/wine</Path>
@@ -1288,6 +1289,7 @@
             <Path fileType="library">/usr/lib32/wine/i386-windows/iccvid.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/icinfo.exe</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/icmp.dll</Path>
+            <Path fileType="library">/usr/lib32/wine/i386-windows/icmui.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/ieframe.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/ieproxy.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/iertutil.dll</Path>
@@ -1854,7 +1856,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="189">wine</Dependency>
+            <Dependency release="190">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wine/debug.h</Path>
@@ -2324,6 +2326,8 @@
             <Path fileType="header">/usr/include/wine/windows/dxva.h</Path>
             <Path fileType="header">/usr/include/wine/windows/dxva2api.h</Path>
             <Path fileType="header">/usr/include/wine/windows/dxva2api.idl</Path>
+            <Path fileType="header">/usr/include/wine/windows/dxvahd.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/dxvahd.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/dyngraph.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/endpointvolume.h</Path>
             <Path fileType="header">/usr/include/wine/windows/endpointvolume.idl</Path>
@@ -3197,12 +3201,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="189">
-            <Date>2024-11-15</Date>
-            <Version>9.21</Version>
+        <Update release="190">
+            <Date>2024-11-24</Date>
+            <Version>9.22</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Highlighted changes:
- Support for display mode virtualization
- Locale data updated to Unicode CLDR 46
- More support for network sessions in DirectPlay
- Wayland driver enabled in default configuration
- Various bug fixes

Full release notes available [here](https://gitlab.winehq.org/wine/wine/-/releases/wine-9.22)

**Test Plan**
- Ran `winemine`, `winecfg`, `wineconsole`, `winefile`
- Played Age of Empires I Trial

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
