### PR TITLE
ncdu: Update to 2.7

### DIFF
--- a/packages/n/ncdu/abi_used_symbols
+++ b/packages/n/ncdu/abi_used_symbols
@@ -24,7 +24,10 @@ libc.so.6:fstatfs
 libc.so.6:getauxval
 libc.so.6:getcontext
 libc.so.6:getenv
+libc.so.6:getpwnam
+libc.so.6:getpwuid
 libc.so.6:getrlimit64
+libc.so.6:getuid
 libc.so.6:isatty
 libc.so.6:localeconv
 libc.so.6:localtime
@@ -85,7 +88,14 @@ libncursesw.so.6:set_term
 libncursesw.so.6:start_color
 libncursesw.so.6:stdscr
 libncursesw.so.6:use_default_colors
+libzstd.so.1:ZSTD_CCtx_setParameter
 libzstd.so.1:ZSTD_compress
+libzstd.so.1:ZSTD_compressStream2
+libzstd.so.1:ZSTD_createCStream
+libzstd.so.1:ZSTD_createDStream
 libzstd.so.1:ZSTD_decompress
+libzstd.so.1:ZSTD_decompressStream
+libzstd.so.1:ZSTD_freeCStream
+libzstd.so.1:ZSTD_freeDStream
 libzstd.so.1:ZSTD_getFrameContentSize
 libzstd.so.1:ZSTD_isError

--- a/packages/n/ncdu/monitoring.yml
+++ b/packages/n/ncdu/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 6045
+  rss: https://dev.yorhel.nl/feed.atom
+# No known CPE, checked 2024-11-24
+security:
+  cpe: ~

--- a/packages/n/ncdu/package.yml
+++ b/packages/n/ncdu/package.yml
@@ -1,8 +1,8 @@
 name       : ncdu
-version    : '2.6'
-release    : 23
+version    : '2.7'
+release    : 24
 source     :
-    - https://dev.yorhel.nl/download/ncdu-2.6.tar.gz : 3f471ebd38b56e60dab80c27e3af1d826666957f02d9e8419b149daaf7ade505
+    - https://dev.yorhel.nl/download/ncdu-2.7.tar.gz : b218cc14a2bb9852cf951db4e21aec8980e7a8c3aca097e3aa3417f20eb93000
 homepage   : https://dev.yorhel.nl/ncdu
 license    : MIT
 component  : system.utils

--- a/packages/n/ncdu/pspec_x86_64.xml
+++ b/packages/n/ncdu/pspec_x86_64.xml
@@ -25,9 +25,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2024-09-28</Date>
-            <Version>2.6</Version>
+        <Update release="24">
+            <Date>2024-11-24</Date>
+            <Version>2.7</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Support transparent reading/writing of zstandard-compressed JSON
- Add --compress and --export-block-size options
- Perform tilde expansion on paths in the config file
- Fix JSON import of escaped UTF-16 surrogate pairs
- Fix incorrect field in root item when exporting to the binary format
- [changelog](https://dev.yorhel.nl/ncdu/changes2)

**Test Plan**
- ncdu

**Checklist**
- [X] Package was built and tested against unstable
