### PR TITLE
gpxsee: Update to 13.31

### DIFF
--- a/packages/g/gpxsee/abi_used_symbols
+++ b/packages/g/gpxsee/abi_used_symbols
@@ -793,7 +793,6 @@ libQt6Gui.so.6:_ZNK12QPainterPath14angleAtPercentEd
 libQt6Gui.so.6:_ZNK12QPainterPath14pointAtPercentEd
 libQt6Gui.so.6:_ZNK12QPainterPath6lengthEv
 libQt6Gui.so.6:_ZNK12QPainterPath7isEmptyEv
-libQt6Gui.so.6:_ZNK12QPainterPath8containsERK7QPointF
 libQt6Gui.so.6:_ZNK12QPainterPath9elementAtEi
 libQt6Gui.so.6:_ZNK19QPainterPathStroker12createStrokeERK12QPainterPath
 libQt6Gui.so.6:_ZNK4QPen5colorEv

--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.28'
-release    : 48
+version    : '13.31'
+release    : 49
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.28.tar.gz : 826b2d37d98675fdff07898f12d3db811e7a2902f51b99ef34b1076e90f6a29d
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.31.tar.gz : de7ec329e9ed1567a8448b25541e2bba359d93dd92a704595b0d87209d039c9e
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -172,9 +172,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="48">
-            <Date>2024-11-18</Date>
-            <Version>13.28</Version>
+        <Update release="49">
+            <Date>2024-11-24</Date>
+            <Version>13.31</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Improved Mapsforge maps rendering performance.
- Improved Mapsforge map render theme.
- Improved Mapsforge maps render engine.
- [changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

**Test Plan**
- open map, zoom, pan, etc

**Checklist**
- [X] Package was built and tested against unstable
