### PR TITLE
cemu: Update to 2.4

### DIFF
--- a/packages/c/cemu/abi_used_symbols
+++ b/packages/c/cemu/abi_used_symbols
@@ -353,6 +353,7 @@ libcrypto.so.3:EC_POINT_new
 libcrypto.so.3:EC_POINT_set_affine_coordinates
 libcrypto.so.3:EVP_DigestFinal_ex
 libcrypto.so.3:EVP_DigestInit
+libcrypto.so.3:EVP_DigestInit_ex
 libcrypto.so.3:EVP_DigestUpdate
 libcrypto.so.3:EVP_MD_CTX_free
 libcrypto.so.3:EVP_MD_CTX_new
@@ -361,11 +362,7 @@ libcrypto.so.3:EVP_PKEY_new
 libcrypto.so.3:EVP_sha1
 libcrypto.so.3:EVP_sha256
 libcrypto.so.3:HMAC
-libcrypto.so.3:OPENSSL_cleanse
 libcrypto.so.3:SHA1
-libcrypto.so.3:SHA1_Final
-libcrypto.so.3:SHA1_Init
-libcrypto.so.3:SHA1_Update
 libcrypto.so.3:SHA256
 libcrypto.so.3:X509_STORE_CTX_get_error
 libcrypto.so.3:X509_STORE_CTX_set_error
@@ -857,6 +854,7 @@ libusb-1.0.so.0:libusb_kernel_driver_active
 libusb-1.0.so.0:libusb_open
 libusb-1.0.so.0:libusb_release_interface
 libusb-1.0.so.0:libusb_set_configuration
+libusb-1.0.so.0:libusb_strerror
 libwayland-client.so.0:wl_display_roundtrip
 libwayland-client.so.0:wl_proxy_add_listener
 libwayland-client.so.0:wl_proxy_get_version

--- a/packages/c/cemu/monitoring.yml
+++ b/packages/c/cemu/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 328492
+  rss: https://github.com/cemu-project/Cemu/tags.atom
+# No known CPE, checked 2024-11-25
+security:
+  cpe: ~

--- a/packages/c/cemu/package.yml
+++ b/packages/c/cemu/package.yml
@@ -1,8 +1,8 @@
 name       : cemu
-version    : '2.1'
-release    : 11
+version    : '2.4'
+release    : 12
 source     :
-    - git|https://github.com/cemu-project/Cemu : v2.1
+    - git|https://github.com/cemu-project/Cemu : v2.4
 homepage   : https://cemu.info/
 license    : MPL-2.0
 component  : games.emulator

--- a/packages/c/cemu/pspec_x86_64.xml
+++ b/packages/c/cemu/pspec_x86_64.xml
@@ -286,9 +286,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2024-09-10</Date>
-            <Version>2.1</Version>
+        <Update release="12">
+            <Date>2024-11-25</Date>
+            <Version>2.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Marcus Mellor</Name>
             <Email>infinitymdm@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Update to 2.4, the latest release. Improvements include reduced input latency, proper proxy server handling, and lots of bugfixes.

Enhancements:
- Vulkan: Reduced input latency
- SpotPass now respects proxy_server option in settings.xml
- More accurate error dialog emulation

Bugfixes:
- Fix corruption bug when reading .app, .wud, and .wux files
- Fix unskippable error dialogs in some games
- Fix a race condition which could cause polygon corruption
- Amiibo now work in MK8
- Various crash fixes

**Test Plan**

Launch a title and make sure things generally look ok. Test out some graphics packs. Save and load a few times.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
