### PR TITLE
scrcpy: Update to v3.0

### DIFF
--- a/packages/s/scrcpy/abi_used_symbols
+++ b/packages/s/scrcpy/abi_used_symbols
@@ -41,7 +41,6 @@ libSDL2-2.0.so.0:SDL_HideWindow
 libSDL2-2.0.so.0:SDL_Init
 libSDL2-2.0.so.0:SDL_IsGameController
 libSDL2-2.0.so.0:SDL_JoystickInstanceID
-libSDL2-2.0.so.0:SDL_LockAudioDevice
 libSDL2-2.0.so.0:SDL_LockMutex
 libSDL2-2.0.so.0:SDL_LogDebug
 libSDL2-2.0.so.0:SDL_LogError
@@ -77,7 +76,6 @@ libSDL2-2.0.so.0:SDL_SetWindowSize
 libSDL2-2.0.so.0:SDL_SetYUVConversionMode
 libSDL2-2.0.so.0:SDL_ShowWindow
 libSDL2-2.0.so.0:SDL_ThreadID
-libSDL2-2.0.so.0:SDL_UnlockAudioDevice
 libSDL2-2.0.so.0:SDL_UnlockMutex
 libSDL2-2.0.so.0:SDL_UpdateYUVTexture
 libSDL2-2.0.so.0:SDL_WaitEvent

--- a/packages/s/scrcpy/package.yml
+++ b/packages/s/scrcpy/package.yml
@@ -1,9 +1,9 @@
 name       : scrcpy
-version    : '2.7'
-release    : 29
+version    : '3.0'
+release    : 30
 source     :
-    - https://github.com/Genymobile/scrcpy/archive/v2.7.tar.gz : 3ceea215f6eccb59535f68a16db6db2b05a8a1c91bdcb4a6e222d3093a9daf8c
-    - https://github.com/Genymobile/scrcpy/releases/download/v2.7/scrcpy-server-v2.7 : a23c5659f36c260f105c022d27bcb3eafffa26070e7baa9eda66d01377a1adba
+    - https://github.com/Genymobile/scrcpy/archive/v3.0.tar.gz : 6ad2306dcdf17a8c927691d1004ec632a694069187ded73d30113a5db780fc43
+    - https://github.com/Genymobile/scrcpy/releases/download/v3.0/scrcpy-server-v3.0 : 800044c62a94d5fc16f5ab9c86d45b1050eae3eb436514d1b0d2fe2646b894ea
 homepage   : https://github.com/Genymobile/scrcpy
 license    : Apache-2.0
 component  : network.util

--- a/packages/s/scrcpy/pspec_x86_64.xml
+++ b/packages/s/scrcpy/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>scrcpy</Name>
         <Homepage>https://github.com/Genymobile/scrcpy</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>network.util</PartOf>
@@ -31,12 +31,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="29">
-            <Date>2024-11-15</Date>
-            <Version>2.7</Version>
+        <Update release="30">
+            <Date>2024-11-25</Date>
+            <Version>3.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Highlighted changes:
- Virtual display
- On-device OpenGL filters
- Screen off timeout

Full release notes available [here](https://github.com/Genymobile/scrcpy/releases/tag/v3.0)

**Test Plan**
- Mirrored my phone's display and controlled it using mouse and keyboard
- Tried the new virtual display functionality

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
