### PR TITLE
mdbook: Update to v0.4.43

### DIFF
--- a/packages/m/mdbook/package.yml
+++ b/packages/m/mdbook/package.yml
@@ -1,8 +1,8 @@
 name       : mdbook
-version    : 0.4.42
-release    : 38
+version    : 0.4.43
+release    : 39
 source     :
-    - https://github.com/rust-lang/mdBook/archive/refs/tags/v0.4.42.tar.gz : cf1c7c293fd1ad3d51fe13cd385303df8b30004ba5edcc35dd8dbd23d670d528
+    - https://github.com/rust-lang/mdBook/archive/refs/tags/v0.4.43.tar.gz : 7213c006d78dafa0d7a893bdb8fd3814bbf4d6794ffb97822038185364b73f77
 homepage   : https://github.com/rust-lang/mdBook
 license    : MPL-2.0
 component  : programming.tools

--- a/packages/m/mdbook/pspec_x86_64.xml
+++ b/packages/m/mdbook/pspec_x86_64.xml
@@ -24,9 +24,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="38">
-            <Date>2024-11-07</Date>
-            <Version>0.4.42</Version>
+        <Update release="39">
+            <Date>2024-11-25</Date>
+            <Version>0.4.43</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Fixed setting the title in mdbook init when no git user is configured
- The Rust 2024 edition no longer needs -Zunstable-options

**Test Plan**

- `init` and `serve` a local test site

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
