### PR TITLE
kvirc: Update to v5.2.6

### DIFF
--- a/packages/k/kvirc/abi_used_symbols
+++ b/packages/k/kvirc/abi_used_symbols
@@ -149,6 +149,7 @@ libQt6Core.so.6:_Z20qt_qFindChild_helperPK7QObject14QAnyStringViewRK11QMetaObjec
 libQt6Core.so.6:_Z23qt_qFindChildren_helperPK7QObject14QAnyStringViewRK11QMetaObjectP5QListIPvE6QFlagsIN2Qt15FindChildOptionEE
 libQt6Core.so.6:_Z26qt_QMetaEnum_debugOperatorR6QDebugxPK11QMetaObjectPKc
 libQt6Core.so.6:_Z5qHash11QStringViewm
+libQt6Core.so.6:_Z5qHash13QLatin1Stringm
 libQt6Core.so.6:_Z5qHash14QByteArrayViewm
 libQt6Core.so.6:_Z8qstrncpyPcPKcm
 libQt6Core.so.6:_Z9qBadAllocv
@@ -364,10 +365,10 @@ libQt6Core.so.6:_ZN6QEventC1ENS_4TypeE
 libQt6Core.so.6:_ZN6QEventC2ENS_4TypeE
 libQt6Core.so.6:_ZN6QEventD1Ev
 libQt6Core.so.6:_ZN6QEventD2Ev
-libQt6Core.so.6:_ZN6QTimer10singleShotEiPK7QObjectPKc
+libQt6Core.so.6:_ZN6QTimer10singleShotENSt6chrono8durationIlSt5ratioILl1ELl1000000000EEEEN2Qt9TimerTypeEPK7QObjectPKc
 libQt6Core.so.6:_ZN6QTimer11setIntervalEi
 libQt6Core.so.6:_ZN6QTimer13setSingleShotEb
-libQt6Core.so.6:_ZN6QTimer14singleShotImplEiN2Qt9TimerTypeEPK7QObjectPN9QtPrivate15QSlotObjectBaseE
+libQt6Core.so.6:_ZN6QTimer14singleShotImplENSt6chrono8durationIlSt5ratioILl1ELl1000000000EEEEN2Qt9TimerTypeEPK7QObjectPN9QtPrivate15QSlotObjectBaseE
 libQt6Core.so.6:_ZN6QTimer4stopEv
 libQt6Core.so.6:_ZN6QTimer5startEi
 libQt6Core.so.6:_ZN6QTimer5startEv
@@ -550,9 +551,11 @@ libQt6Core.so.6:_ZN9QSaveFile6commitEv
 libQt6Core.so.6:_ZN9QSaveFileC1ERK7QString
 libQt6Core.so.6:_ZN9QSaveFileD1Ev
 libQt6Core.so.6:_ZN9QtPrivate10startsWithE14QByteArrayViewS0_
+libQt6Core.so.6:_ZN9QtPrivate11lastIndexOfE11QStringViewxDsN2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZN9QtPrivate12argToQStringE11QStringViewmPPKNS_7ArgBaseE
 libQt6Core.so.6:_ZN9QtPrivate12equalStringsE11QStringView13QLatin1String
 libQt6Core.so.6:_ZN9QtPrivate12equalStringsE11QStringViewS0_
+libQt6Core.so.6:_ZN9QtPrivate12qustrcasechrE11QStringViewDs
 libQt6Core.so.6:_ZN9QtPrivate13findByteArrayE14QByteArrayViewxS0_
 libQt6Core.so.6:_ZN9QtPrivate14compareStringsE11QStringViewS0_N2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZN9QtPrivate16QStringList_joinEPK5QListI7QStringEPK5QCharx
@@ -574,6 +577,7 @@ libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperIiE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperItE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperIxE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate8endsWithE14QByteArrayViewS0_
+libQt6Core.so.6:_ZN9QtPrivate8qustrchrE11QStringViewDs
 libQt6Core.so.6:_ZNK10QByteArray11toStdStringB5cxx11Ev
 libQt6Core.so.6:_ZNK10QByteArray13leftJustifiedExcb
 libQt6Core.so.6:_ZNK10QByteArray5splitEc
@@ -585,7 +589,6 @@ libQt6Core.so.6:_ZNK10QJsonValue8toObjectEv
 libQt6Core.so.6:_ZNK10QJsonValue8toStringEv
 libQt6Core.so.6:_ZNK11QDataStream26isDeviceTransactionStartedEv
 libQt6Core.so.6:_ZNK11QDataStream5atEndEv
-libQt6Core.so.6:_ZNK11QDataStream6statusEv
 libQt6Core.so.6:_ZNK11QFileDevice12isSequentialEv
 libQt6Core.so.6:_ZNK11QFileDevice3posEv
 libQt6Core.so.6:_ZNK11QFileDevice5atEndEv
@@ -691,7 +694,6 @@ libQt6Core.so.6:_ZNK7QObject8propertyEPKc
 libQt6Core.so.6:_ZNK7QString10startsWithE13QLatin1StringN2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString10startsWithE5QCharN2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString10startsWithERKS_N2Qt15CaseSensitivityE
-libQt6Core.so.6:_ZNK7QString11lastIndexOfE5QCharxN2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString11lastIndexOfERKS_xN2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString13toHtmlEscapedEv
 libQt6Core.so.6:_ZNK7QString3argE5QChariS0_
@@ -707,7 +709,6 @@ libQt6Core.so.6:_ZNK7QString5splitERKS_6QFlagsIN2Qt18SplitBehaviorFlagsEENS3_15C
 libQt6Core.so.6:_ZNK7QString5utf16Ev
 libQt6Core.so.6:_ZNK7QString7compareERKS_N2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString7indexOfE13QLatin1StringxN2Qt15CaseSensitivityE
-libQt6Core.so.6:_ZNK7QString7indexOfE5QCharxN2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString7indexOfERK18QRegularExpressionxP23QRegularExpressionMatch
 libQt6Core.so.6:_ZNK7QString7indexOfERKS_xN2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString7sectionERKS_xx6QFlagsINS_11SectionFlagEE
@@ -1275,10 +1276,13 @@ libQt6Gui.so.6:_ZrsR11QDataStreamR5QIcon
 libQt6Gui.so.6:_ZrsR11QDataStreamR6QBrush
 libQt6Gui.so.6:_ZrsR11QDataStreamR6QColor
 libQt6Gui.so.6:_ZrsR11QDataStreamR7QPixmap
-libQt6Multimedia.so.6:_ZN12QSoundEffect4playEv
-libQt6Multimedia.so.6:_ZN12QSoundEffect9setSourceERK4QUrl
-libQt6Multimedia.so.6:_ZN12QSoundEffectC1EP7QObject
-libQt6Multimedia.so.6:_ZN12QSoundEffectD1Ev
+libQt6Multimedia.so.6:_ZN12QAudioOutputC1EP7QObject
+libQt6Multimedia.so.6:_ZN12QMediaPlayer14setAudioOutputEP12QAudioOutput
+libQt6Multimedia.so.6:_ZN12QMediaPlayer4playEv
+libQt6Multimedia.so.6:_ZN12QMediaPlayer4stopEv
+libQt6Multimedia.so.6:_ZN12QMediaPlayer9setSourceERK4QUrl
+libQt6Multimedia.so.6:_ZN12QMediaPlayerC1EP7QObject
+libQt6Multimedia.so.6:_ZNK12QMediaPlayer9isPlayingEv
 libQt6Network.so.6:_Z43qRegisterNormalizedMetaType_QList_QSslErrorRK10QByteArray
 libQt6Network.so.6:_Z56qRegisterNormalizedMetaType_QAbstractSocket__SocketErrorRK10QByteArray
 libQt6Network.so.6:_Z56qRegisterNormalizedMetaType_QAbstractSocket__SocketStateRK10QByteArray
@@ -1851,6 +1855,7 @@ libQt6Widgets.so.6:_ZN13QItemDelegate11qt_metacastEPKc
 libQt6Widgets.so.6:_ZN13QItemDelegate16staticMetaObjectE
 libQt6Widgets.so.6:_ZN13QItemDelegateC2EP7QObject
 libQt6Widgets.so.6:_ZN13QItemDelegateD2Ev
+libQt6Widgets.so.6:_ZN13QStyleFactory4keysEv
 libQt6Widgets.so.6:_ZN13QStyleFactory6createERK7QString
 libQt6Widgets.so.6:_ZN13QWidgetAction16setDefaultWidgetEP7QWidget
 libQt6Widgets.so.6:_ZN13QWidgetActionC1EP7QObject
@@ -2319,6 +2324,7 @@ libQt6Widgets.so.6:_ZN9QComboBox11setMaxCountEi
 libQt6Widgets.so.6:_ZN9QComboBox12focusInEventEP11QFocusEvent
 libQt6Widgets.so.6:_ZN9QComboBox13focusOutEventEP11QFocusEvent
 libQt6Widgets.so.6:_ZN9QComboBox13keyPressEventEP9QKeyEvent
+libQt6Widgets.so.6:_ZN9QComboBox14setCurrentTextERK7QString
 libQt6Widgets.so.6:_ZN9QComboBox15keyReleaseEventEP9QKeyEvent
 libQt6Widgets.so.6:_ZN9QComboBox15mousePressEventEP11QMouseEvent
 libQt6Widgets.so.6:_ZN9QComboBox15setCurrentIndexEi
@@ -3161,6 +3167,7 @@ libperl.so:perl_parse
 libphonon4qt6.so.4:_ZN6Phonon11MediaObject16setCurrentSourceERKNS_11MediaSourceE
 libphonon4qt6.so.4:_ZN6Phonon11MediaObject17setTransitionTimeEi
 libphonon4qt6.so.4:_ZN6Phonon11MediaObject4playEv
+libphonon4qt6.so.4:_ZN6Phonon11MediaObject4stopEv
 libphonon4qt6.so.4:_ZN6Phonon11MediaSourceC1ERK4QUrl
 libphonon4qt6.so.4:_ZN6Phonon11MediaSourceD1Ev
 libphonon4qt6.so.4:_ZN6Phonon12createPlayerENS_8CategoryERKNS_11MediaSourceE
@@ -3229,7 +3236,6 @@ libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt28_Rb_tree_rebalance_for_erasePSt18_Rb_tree_node_baseRS_
 libstdc++.so.6:_ZSt28__throw_bad_array_new_lengthv
 libstdc++.so.6:_ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_
-libstdc++.so.6:_ZSt9terminatev
 libstdc++.so.6:_ZTISt12bad_weak_ptr
 libstdc++.so.6:_ZTISt9exception
 libstdc++.so.6:_ZTVN10__cxxabiv117__class_type_infoE
@@ -3244,6 +3250,7 @@ libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
 libstdc++.so.6:__cxa_allocate_exception
 libstdc++.so.6:__cxa_begin_catch
+libstdc++.so.6:__cxa_call_terminate
 libstdc++.so.6:__cxa_end_catch
 libstdc++.so.6:__cxa_free_exception
 libstdc++.so.6:__cxa_get_exception_ptr

--- a/packages/k/kvirc/files/0001-Force-app_id-to-be-set-in-more-places.patch
+++ b/packages/k/kvirc/files/0001-Force-app_id-to-be-set-in-more-places.patch
@@ -37,9 +37,9 @@ index 60d07d179..46ea0ff2e 100644
  #endif
 -	// set name of the app desktop file; used by wayland to load the window icon
 -	QGuiApplication::setDesktopFileName("net.kvirc.KVIrc" KVIRC_VERSION_MAJOR);
+
  	setWindowTitle(KVI_DEFAULT_FRAME_CAPTION);
- 
- 	m_pSplitter = new QSplitter(Qt::Horizontal, this);
+
 diff --git a/src/kvirc/ui/KviWindow.cpp b/src/kvirc/ui/KviWindow.cpp
 index 3224d7e78..c72caacc6 100644
 --- a/src/kvirc/ui/KviWindow.cpp

--- a/packages/k/kvirc/package.yml
+++ b/packages/k/kvirc/package.yml
@@ -1,8 +1,8 @@
 name       : kvirc
-version    : 5.2.4
-release    : 16
+version    : 5.2.6
+release    : 17
 source     :
-    - https://github.com/kvirc/KVIrc/archive/5.2.4.tar.gz : 99bb33d9bd42060dc3dcd8783db036bebd9a23f29c4cef99facf0e0d5cd12d6b
+    - https://github.com/kvirc/KVIrc/archive/refs/tags/5.2.6.tar.gz : e8de989b5df8d9286da3e26146682a349fe496864dc2e7d7eae8dc27167fdd25
 homepage   : http://www.kvirc.net/
 license    : GPL-2.0-or-later
 component  : network.irc

--- a/packages/k/kvirc/pspec_x86_64.xml
+++ b/packages/k/kvirc/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>kvirc</Name>
         <Homepage>http://www.kvirc.net/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>network.irc</PartOf>
@@ -97,7 +97,7 @@
             <Path fileType="library">/usr/lib/kvirc/5.2/modules/libkviwindow.so</Path>
             <Path fileType="library">/usr/lib/libkvilib.so</Path>
             <Path fileType="library">/usr/lib/libkvilib.so.5</Path>
-            <Path fileType="library">/usr/lib/libkvilib.so.5.2.4</Path>
+            <Path fileType="library">/usr/lib/libkvilib.so.5.2.6</Path>
             <Path fileType="data">/usr/share/applications/net.kvirc.KVIrc5.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/kvirc.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/128x128/mimetypes/application-x-kva.png</Path>
@@ -864,7 +864,7 @@
             <Path fileType="data">/usr/share/kvirc/5.2/help/en/doc_widget_alphabetic_z.html</Path>
             <Path fileType="data">/usr/share/kvirc/5.2/help/en/doc_widget_index_all.html</Path>
             <Path fileType="data">/usr/share/kvirc/5.2/help/en/doc_window_naming_conventions.html</Path>
-            <Path fileType="data">/usr/share/kvirc/5.2/help/en/documentation.5.2.4.tag</Path>
+            <Path fileType="data">/usr/share/kvirc/5.2/help/en/documentation.5.2.6.tag</Path>
             <Path fileType="data">/usr/share/kvirc/5.2/help/en/event_onaccelkeypressed.html</Path>
             <Path fileType="data">/usr/share/kvirc/5.2/help/en/event_onaccount.html</Path>
             <Path fileType="data">/usr/share/kvirc/5.2/help/en/event_onaction.html</Path>
@@ -2375,12 +2375,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2024-07-11</Date>
-            <Version>5.2.4</Version>
+        <Update release="17">
+            <Date>2024-12-05</Date>
+            <Version>5.2.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

<!-- Info on what this pull request updates/changes/etc -->
- A few bugs were fixed, including potential app crashes.
- Updated sound effects to use newer Qt library, cleaned up older audio backends (ESD, aRts), made Qt be preferred over Phonon, which is also becoming outdated.
- Full release notes can read [here](https://github.com/kvirc/KVIrc/releases/tag/5.2.6)

**Test Plan**

<!-- Short description of how the package was tested -->
Launch the app and join a room

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
