### PR TITLE
font-firacode-nerd: Update to v3.3.0 and add monitoring.yml

### DIFF
--- a/packages/f/font-firacode-nerd/monitoring.yml
+++ b/packages/f/font-firacode-nerd/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 227412
+  rss: https://github.com/ryanoasis/nerd-fonts/releases.atom
+# No known CPE, checked 2024-11-27
+security:
+  cpe: ~

--- a/packages/f/font-firacode-nerd/package.yml
+++ b/packages/f/font-firacode-nerd/package.yml
@@ -1,8 +1,8 @@
 name       : font-firacode-nerd
-version    : 3.0.2
-release    : 3
+version    : 3.3.0
+release    : 4
 source     :
-    - https://github.com/ryanoasis/nerd-fonts/releases/download/v3.0.2/FiraCode.tar.xz : 76c1d691cea44b0cae4d6add56bb3ef52b83cedebb1c5f519b62d068f8586b93
+    - https://github.com/ryanoasis/nerd-fonts/releases/download/v3.3.0/FiraCode.tar.xz : 7c64c44d7e530b25faf23904e135e9d1ff0339a92ee64e35e7da9116aa48af67
 homepage   : https://www.nerdfonts.com/
 license    : MIT
 component  : desktop.font

--- a/packages/f/font-firacode-nerd/pspec_x86_64.xml
+++ b/packages/f/font-firacode-nerd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>font-firacode-nerd</Name>
         <Homepage>https://www.nerdfonts.com/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>desktop.font</PartOf>
@@ -42,12 +42,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-07-05</Date>
-            <Version>3.0.2</Version>
+        <Update release="4">
+            <Date>2024-11-27</Date>
+            <Version>3.3.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Release notes:
- [3.3.0](https://github.com/ryanoasis/nerd-fonts/releases/tag/v3.3.0)
- [3.2.1](https://github.com/ryanoasis/nerd-fonts/releases/tag/v3.2.1)
- [3.2.0](https://github.com/ryanoasis/nerd-fonts/releases/tag/v3.2.0)
- [3.1.1](https://github.com/ryanoasis/nerd-fonts/releases/tag/v3.1.1)
- [3.1.0](https://github.com/ryanoasis/nerd-fonts/releases/tag/v3.1.0)

**Test Plan**

Used "Fira Code Nerd Font" as my terminal font

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
