### PR TITLE
bdwgc: Update to v8.2.8 and add monitoring.yml

### DIFF
--- a/packages/b/bdwgc/abi_used_symbols
+++ b/packages/b/bdwgc/abi_used_symbols
@@ -3,6 +3,8 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoul
 libc.so.6:__longjmp_chk
 libc.so.6:__memcpy_chk
 libc.so.6:__memset_chk
@@ -93,8 +95,6 @@ libc.so.6:strcmp
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strncpy
-libc.so.6:strtol
-libc.so.6:strtoul
 libc.so.6:uname
 libc.so.6:usleep
 libc.so.6:write

--- a/packages/b/bdwgc/abi_used_symbols32
+++ b/packages/b/bdwgc/abi_used_symbols32
@@ -3,6 +3,8 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoul
 libc.so.6:__longjmp_chk
 libc.so.6:__memcpy_chk
 libc.so.6:__memset_chk
@@ -93,8 +95,6 @@ libc.so.6:strcmp
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strncpy
-libc.so.6:strtol
-libc.so.6:strtoul
 libc.so.6:uname
 libc.so.6:usleep
 libc.so.6:write

--- a/packages/b/bdwgc/monitoring.yml
+++ b/packages/b/bdwgc/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 17108
+  rss: https://github.com/ivmai/bdwgc/releases.atom
+security:
+  cpe:
+    - vendor: bdwgc_project
+      product: bdwgc

--- a/packages/b/bdwgc/package.yml
+++ b/packages/b/bdwgc/package.yml
@@ -1,8 +1,8 @@
 name       : bdwgc
-version    : 8.2.4
-release    : 19
+version    : 8.2.8
+release    : 20
 source     :
-    - https://github.com/ivmai/bdwgc/archive/v8.2.4.tar.gz : 18e63ab1428bd52e691da107a6a56651c161210b11fbe22e2aa3c31f7fa00ca5
+    - https://github.com/ivmai/bdwgc/archive/v8.2.8.tar.gz : f8f85e2ad675375df37916826c70f80630b7cc4d3ae33c4447a72640641d224f
 homepage   : https://www.hboehm.info/gc/
 license    :
     - GPL-2.0-only

--- a/packages/b/bdwgc/pspec_x86_64.xml
+++ b/packages/b/bdwgc/pspec_x86_64.xml
@@ -12,7 +12,7 @@
         <Summary xml:lang="en">Boehm-Demers-Weiser Garbage Collector</Summary>
         <Description xml:lang="en">The Boehm-Demers-Weiser conservative garbage collector can be used as a garbage colecting replacement for C malloc or C++ new. It allows you to allocate memory basically as you normally would, without explicitly deallocating memory that is no longer useful. The collector automatically recycles memory when it determines that it can no longer be otherwise accessed.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>bdwgc</Name>
@@ -22,9 +22,9 @@
         <PartOf>programming.tools</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libcord.so.1</Path>
-            <Path fileType="library">/usr/lib64/libcord.so.1.5.0</Path>
+            <Path fileType="library">/usr/lib64/libcord.so.1.5.1</Path>
             <Path fileType="library">/usr/lib64/libgc.so.1</Path>
-            <Path fileType="library">/usr/lib64/libgc.so.1.5.2</Path>
+            <Path fileType="library">/usr/lib64/libgc.so.1.5.4</Path>
             <Path fileType="library">/usr/lib64/libgccpp.so.1</Path>
             <Path fileType="library">/usr/lib64/libgccpp.so.1.5.0</Path>
             <Path fileType="library">/usr/lib64/libgctba.so.1</Path>
@@ -72,13 +72,13 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="18">bdwgc</Dependency>
+            <Dependency release="20">bdwgc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libcord.so.1</Path>
-            <Path fileType="library">/usr/lib32/libcord.so.1.5.0</Path>
+            <Path fileType="library">/usr/lib32/libcord.so.1.5.1</Path>
             <Path fileType="library">/usr/lib32/libgc.so.1</Path>
-            <Path fileType="library">/usr/lib32/libgc.so.1.5.2</Path>
+            <Path fileType="library">/usr/lib32/libgc.so.1.5.4</Path>
             <Path fileType="library">/usr/lib32/libgccpp.so.1</Path>
             <Path fileType="library">/usr/lib32/libgccpp.so.1.5.0</Path>
             <Path fileType="library">/usr/lib32/libgctba.so.1</Path>
@@ -92,8 +92,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="18">bdwgc-devel</Dependency>
-            <Dependency release="18">bdwgc-32bit</Dependency>
+            <Dependency release="20">bdwgc-32bit</Dependency>
+            <Dependency release="20">bdwgc-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libcord.so</Path>
@@ -110,7 +110,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="18">bdwgc</Dependency>
+            <Dependency release="20">bdwgc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gc.h</Path>
@@ -142,9 +142,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2023-10-05</Date>
-            <Version>8.2.4</Version>
+        <Update release="20">
+            <Date>2024-11-27</Date>
+            <Version>8.2.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Release notes:
- [8.2.8](https://github.com/ivmai/bdwgc/releases/tag/v8.2.8)
- [8.2.6](https://github.com/ivmai/bdwgc/releases/tag/v8.2.6)

**Test Plan**
- Built and used `crystal`
- Used `inkscape`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
