### PR TITLE
rinutils: Update to v0.10.3 and add monitoring.yml

### DIFF
--- a/packages/r/rinutils/monitoring.yml
+++ b/packages/r/rinutils/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 230526
+  rss: https://github.com/shlomif/rinutils/releases.atom
+# No known CPE, checked 2024-11-27
+security:
+  cpe: ~

--- a/packages/r/rinutils/package.yml
+++ b/packages/r/rinutils/package.yml
@@ -1,14 +1,14 @@
 name       : rinutils
-version    : 0.10.1
-release    : 3
+version    : 0.10.3
+release    : 4
 source     :
-    - https://github.com/shlomif/rinutils/releases/download/0.10.1/rinutils-0.10.1.tar.xz : 31ec258ce99de7bbbe79f3338ce73048dac45425045eb2bd0d6bd92d1b8b9afb
+    - https://github.com/shlomif/rinutils/releases/download/0.10.3/rinutils-0.10.3.tar.xz : f9e527d37a6cc8c7b8870ada63caa24f32ab0d29fd1116df3ebb686583030955
 license    : MIT
-homepage   : https://www.shlomifish.org/open-source/projects/
+homepage   : https://github.com/shlomif/rinutils
 component  : programming.library
 summary    : C11 / gnu11 utilities C library
 description: |
-    C11 / gnu11 utilities C library
+    A set of C headers containing macros and static functions that are expected to work on Unix-like systems and MS Windows that have been extracted from Shlomi Fish's projects
 patterns   :
     - /*
 setup      : |

--- a/packages/r/rinutils/pspec_x86_64.xml
+++ b/packages/r/rinutils/pspec_x86_64.xml
@@ -1,7 +1,7 @@
 <PISI>
     <Source>
         <Name>rinutils</Name>
-        <Homepage>https://www.shlomifish.org/open-source/projects/</Homepage>
+        <Homepage>https://github.com/shlomif/rinutils</Homepage>
         <Packager>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>
@@ -9,14 +9,14 @@
         <License>MIT</License>
         <PartOf>programming.library</PartOf>
         <Summary xml:lang="en">C11 / gnu11 utilities C library</Summary>
-        <Description xml:lang="en">C11 / gnu11 utilities C library
+        <Description xml:lang="en">A set of C headers containing macros and static functions that are expected to work on Unix-like systems and MS Windows that have been extracted from Shlomi Fish&apos;s projects
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>rinutils</Name>
         <Summary xml:lang="en">C11 / gnu11 utilities C library</Summary>
-        <Description xml:lang="en">C11 / gnu11 utilities C library
+        <Description xml:lang="en">A set of C headers containing macros and static functions that are expected to work on Unix-like systems and MS Windows that have been extracted from Shlomi Fish&apos;s projects
 </Description>
         <PartOf>programming.library</PartOf>
         <Files>
@@ -40,9 +40,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2022-11-13</Date>
-            <Version>0.10.1</Version>
+        <Update release="4">
+            <Date>2024-11-27</Date>
+            <Version>0.10.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fix absolute pkg-config libdir
- Exclude .ninja files from trailing space check
- Refactoring and minor build-fixes

**Test Plan**

Built `freecell-solver`, `black-hole-solver`, `fortune-mod`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
