### PR TITLE
keepass: Update to v2.57.1

### DIFF
--- a/packages/k/keepass/package.yml
+++ b/packages/k/keepass/package.yml
@@ -1,8 +1,8 @@
 name       : keepass
-version    : '2.57'
-release    : 43
+version    : 2.57.1
+release    : 44
 source     :
-    - https://sourceforge.net/projects/keepass/files/KeePass%202.x/2.57/KeePass-2.57-Source.zip : 7a6278421848694a301b848053344aea151e9dd73f1fa247d3d26cd898bd3d0d
+    - https://sourceforge.net/projects/keepass/files/KeePass%202.x/2.57.1/KeePass-2.57.1-Source.zip : f7b657d44ce132fe01dd86771e852a9464c432c427ddc98d1abfaebd2e802986
 homepage   : https://keepass.info/
 license    : GPL-2.0-or-later
 component  : security

--- a/packages/k/keepass/pspec_x86_64.xml
+++ b/packages/k/keepass/pspec_x86_64.xml
@@ -43,9 +43,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="43">
-            <Date>2024-06-09</Date>
-            <Version>2.57</Version>
+        <Update release="44">
+            <Date>2024-11-27</Date>
+            <Version>2.57.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Release notes available [here](https://keepass.info/news/n240601_2.57.html#v1)

**Test Plan**

Opened my password database, added an entry, let it perform Auto-Type

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
