### PR TITLE
zsh-autosuggestions: Update to v0.7.1

### DIFF
--- a/packages/z/zsh-autosuggestions/package.yml
+++ b/packages/z/zsh-autosuggestions/package.yml
@@ -1,8 +1,8 @@
 name       : zsh-autosuggestions
-version    : 0.7.0
-release    : 6
+version    : 0.7.1
+release    : 7
 source     :
-    - https://github.com/zsh-users/zsh-autosuggestions/archive/v0.7.0.tar.gz : ccd97fe9d7250b634683c651ef8a2fe3513ea917d1b491e8696a2a352b714f08
+    - https://github.com/zsh-users/zsh-autosuggestions/archive/v0.7.1.tar.gz : 0df7affff21cd87ed298e6a3970ed08a1dd66a6efa676454ee5b091ad503badf
 homepage   : https://github.com/zsh-users/zsh-autosuggestions
 license    : MIT
 component  : system.utils

--- a/packages/z/zsh-autosuggestions/pspec_x86_64.xml
+++ b/packages/z/zsh-autosuggestions/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>zsh-autosuggestions</Name>
         <Homepage>https://github.com/zsh-users/zsh-autosuggestions</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -26,12 +26,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2023-10-10</Date>
-            <Version>0.7.0</Version>
+        <Update release="7">
+            <Date>2024-11-27</Date>
+            <Version>0.7.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Clear POSTDISPLAY instead of unsetting
- Always reset async file descriptor after consuming it
- Always use builtin `exec`
- Add `history-beginning-search-*-end` widgets to clear widget list

**Test Plan**

Used `zsh` with autosuggestions while packaging some stuff

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
