### PR TITLE
Update python3-pylast stack, and fix python-trove-classifiers issue

### DIFF
--- a/packages/py/python-hatchling/package.yml
+++ b/packages/py/python-hatchling/package.yml
@@ -1,8 +1,8 @@
 name       : python-hatchling
-version    : 1.25.0
-release    : 8
+version    : 1.26.3
+release    : 9
 source     :
-    - https://files.pythonhosted.org/packages/source/h/hatchling/hatchling-1.25.0.tar.gz : 7064631a512610b52250a4d3ff1bd81551d6d1431c4eb7b72e734df6c74f4262
+    - https://files.pythonhosted.org/packages/source/h/hatchling/hatchling-1.26.3.tar.gz : b672a9c36a601a06c4e88a1abb1330639ee8e721e0535a37536e546a667efc7a
 homepage   : https://github.com/pypa/hatch
 license    : MIT
 component  : programming.python

--- a/packages/py/python-hatchling/pspec_x86_64.xml
+++ b/packages/py/python-hatchling/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-hatchling</Name>
         <Homepage>https://github.com/pypa/hatch</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -21,11 +21,11 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/hatchling</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling-1.25.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling-1.25.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling-1.25.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling-1.25.0.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling-1.25.0.dist-info/licenses/LICENSE.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling-1.26.3.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling-1.26.3.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling-1.26.3.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling-1.26.3.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling-1.26.3.dist-info/licenses/LICENSE.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/__about__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/__main__.py</Path>
@@ -112,6 +112,9 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/cli/dep/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/cli/dep/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/cli/dep/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/cli/dep/__pycache__/core.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/cli/dep/__pycache__/core.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/cli/dep/core.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/cli/metadata/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/cli/metadata/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/cli/metadata/__pycache__/__init__.cpython-311.pyc</Path>
@@ -127,11 +130,8 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/licenses/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/licenses/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/licenses/__pycache__/__init__.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/licenses/__pycache__/parse.cpython-311.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/licenses/__pycache__/parse.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/licenses/__pycache__/supported.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/licenses/__pycache__/supported.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/licenses/parse.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/licenses/supported.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/metadata/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/hatchling/metadata/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
@@ -231,12 +231,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2024-09-02</Date>
-            <Version>1.25.0</Version>
+        <Update release="9">
+            <Date>2024-11-29</Date>
+            <Version>1.26.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/py/python-packaging/package.yml
+++ b/packages/py/python-packaging/package.yml
@@ -1,8 +1,8 @@
 name       : python-packaging
-version    : '24.1'
-release    : 22
+version    : '24.2'
+release    : 23
 source     :
-    - https://pypi.debian.net/packaging/packaging-24.1.tar.gz : 026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002
+    - https://pypi.debian.net/packaging/packaging-24.2.tar.gz : c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f
 homepage   : https://packaging.pypa.io/
 license    : Apache-2.0
 component  : programming.python

--- a/packages/py/python-packaging/pspec_x86_64.xml
+++ b/packages/py/python-packaging/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-packaging</Name>
         <Homepage>https://packaging.pypa.io/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -20,12 +20,12 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/packaging-24.1.dist-info/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/packaging-24.1.dist-info/LICENSE.APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/packaging-24.1.dist-info/LICENSE.BSD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/packaging-24.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/packaging-24.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/packaging-24.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/packaging-24.2.dist-info/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/packaging-24.2.dist-info/LICENSE.APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/packaging-24.2.dist-info/LICENSE.BSD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/packaging-24.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/packaging-24.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/packaging-24.2.dist-info/WHEEL</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/packaging/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/packaging/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/packaging/__pycache__/__init__.cpython-311.pyc</Path>
@@ -61,6 +61,12 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/packaging/_parser.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/packaging/_structures.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/packaging/_tokenizer.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/packaging/licenses/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/packaging/licenses/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/packaging/licenses/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/packaging/licenses/__pycache__/_spdx.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/packaging/licenses/__pycache__/_spdx.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/packaging/licenses/_spdx.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/packaging/markers.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/packaging/metadata.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/packaging/py.typed</Path>
@@ -72,12 +78,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2024-09-18</Date>
-            <Version>24.1</Version>
+        <Update release="23">
+            <Date>2024-11-29</Date>
+            <Version>24.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/py/python-trove-classifiers/package.yml
+++ b/packages/py/python-trove-classifiers/package.yml
@@ -1,8 +1,8 @@
 name       : python-trove-classifiers
-version    : 2023.7.6
-release    : 3
+version    : 2024.10.21.16
+release    : 4
 source     :
-    - https://files.pythonhosted.org/packages/source/t/trove-classifiers/trove-classifiers-2023.7.6.tar.gz : 8a8e168b51d20fed607043831d37632bb50919d1c80a64e0f1393744691a8b22
+    - https://files.pythonhosted.org/packages/source/t/trove-classifiers/trove_classifiers-2024.10.21.16.tar.gz : 17cbd055d67d5e9d9de63293a8732943fabc21574e4c7b74edf112b4928cf5f3
 homepage   : https://github.com/pypa/trove-classifiers
 license    : Apache-2.0
 component  : programming.python

--- a/packages/py/python-trove-classifiers/pspec_x86_64.xml
+++ b/packages/py/python-trove-classifiers/pspec_x86_64.xml
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/trove_classifiers-2023.7.6-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/trove_classifiers-2023.7.6-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/trove_classifiers-2023.7.6-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/trove_classifiers-2023.7.6-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/trove_classifiers-2024.10.21.16-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/trove_classifiers-2024.10.21.16-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/trove_classifiers-2024.10.21.16-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/trove_classifiers-2024.10.21.16-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/trove_classifiers/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/trove_classifiers/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/trove_classifiers/__pycache__/__init__.cpython-311.pyc</Path>
@@ -32,9 +32,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-02-27</Date>
-            <Version>2023.7.6</Version>
+        <Update release="4">
+            <Date>2024-11-29</Date>
+            <Version>2024.10.21.16</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>

--- a/packages/py/python3-pylast/monitoring.yml
+++ b/packages/py/python3-pylast/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 8146
+  rss: https://github.com/pylast/pylast/releases.atom
+# No known CPE, checked 2024-11-29
+security:
+  cpe: ~

--- a/packages/py/python3-pylast/package.yml
+++ b/packages/py/python3-pylast/package.yml
@@ -1,8 +1,8 @@
 name       : python3-pylast
-version    : 5.2.0
-release    : 12
+version    : 5.3.0
+release    : 13
 source     :
-    - https://pypi.io/packages/source/p/pylast/pylast-5.2.0.tar.gz : bb046804ef56a0c18072c750d61a282d47ac102a3b0b9c44a023eaf5b0934b0a
+    - https://pypi.io/packages/source/p/pylast/pylast-5.3.0.tar.gz : 637943b1b0e6045dd85ed7389db6071a1fea45cc7ff90dc6126fd509ca6fae2f
 homepage   : https://github.com/pylast/pylast
 license    : Apache-2.0
 component  : programming.python

--- a/packages/py/python3-pylast/pspec_x86_64.xml
+++ b/packages/py/python3-pylast/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python3-pylast</Name>
         <Homepage>https://github.com/pylast/pylast</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -20,23 +20,23 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pylast-5.2.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pylast-5.2.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pylast-5.2.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pylast-5.2.0.dist-info/licenses/COPYING</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pylast-5.2.0.dist-info/licenses/LICENSE.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pylast-5.3.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pylast-5.3.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pylast-5.3.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pylast-5.3.0.dist-info/licenses/COPYING</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pylast-5.3.0.dist-info/licenses/LICENSE.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pylast/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pylast/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pylast/__pycache__/__init__.cpython-311.pyc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2024-02-14</Date>
-            <Version>5.2.0</Version>
+        <Update release="13">
+            <Date>2024-11-29</Date>
+            <Version>5.3.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/y/yt-dlp/package.yml
+++ b/packages/y/yt-dlp/package.yml
@@ -1,6 +1,6 @@
 name       : yt-dlp
 version    : 2024.12.03
-release    : 231
+release    : 232
 source     :
     - https://github.com/yt-dlp/yt-dlp/archive/refs/tags/2024.12.03.tar.gz : 444165351fee6f1f7f248b82b8adfeefaecc0d6e0bb9a7dea64dd5758e899737
 license    : Unlicense
@@ -24,8 +24,6 @@ rundeps    :
     - python-websockets
     - python3
     - python3-pycryptodome
-setup      : |
-    sed -i "/Programming Language :: Python :: 3.13/d" pyproject.toml
 build      : |
     %make PREFIX=$installdir/usr yt-dlp.1 completion-bash completion-fish completion-zsh
     python3 -m build --wheel --no-isolation

--- a/packages/y/yt-dlp/pspec_x86_64.xml
+++ b/packages/y/yt-dlp/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>yt-dlp</Name>
         <Homepage>https://github.com/yt-dlp/yt-dlp</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>Unlicense</License>
         <PartOf>network.download</PartOf>
@@ -3285,12 +3285,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="231">
+        <Update release="232">
             <Date>2024-12-04</Date>
             <Version>2024.12.03</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Update the `python3-pylast` build stack, down from `python-packaging`, to fix an issue with `python-trove-classifiers` that also affected `yt-dlp`. This also introduces Python 3.13 support.

Update `python3-pylast` to 5.3.0.

Remove the workaround from `yt-dlp`.

**Test Plan**
- Successfully built all the packages in the stack without workaround
- Played some last.fm songs in `lollypop`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
