### PR TITLE
zotero: Update to 7.0.10

### DIFF
--- a/packages/z/zotero/package.yml
+++ b/packages/z/zotero/package.yml
@@ -1,8 +1,8 @@
 name       : zotero
-version    : 7.0.9
-release    : 22
+version    : 7.0.10
+release    : 23
 source     :
-    - https://download.zotero.org/client/release/7.0.9/Zotero-7.0.9_linux-x86_64.tar.bz2 : f6c9ac3ab2248c37d2723cbaacc7f5d5b895d5dad684408f0e6b4b374443f810
+    - https://download.zotero.org/client/release/7.0.10/Zotero-7.0.10_linux-x86_64.tar.bz2 : b742c0a5a535ded4ffd789ef4699d66701725a226af967d936057284d6b231cb
 homepage   : https://www.zotero.org/
 license    : AGPL-3.0-or-later
 component  : office.scientific

--- a/packages/z/zotero/pspec_x86_64.xml
+++ b/packages/z/zotero/pspec_x86_64.xml
@@ -124,9 +124,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2024-10-31</Date>
-            <Version>7.0.9</Version>
+        <Update release="23">
+            <Date>2024-11-30</Date>
+            <Version>7.0.10</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Import Calibre and KOReader EPUB annotations
- Import notes from Mendeley “Notebook” feature
- Wrap all long fields in the Info pane
- Increased width of search bar
- Added option to prevent note, text, and image annotation tools from automatically turning off after reader use
- Added basic image zoom feature for EPUBs to the reader
- Select next duplicate set when using up/down-arrow in Duplicate Items view
- Added File, Edit, and Window menus to note editor window
- Improved detection of creators in some Atom feeds
- Updated ISBN detection to handle new ISBN ranges
- Make side navigation bar (including Locate menu) keyboard accessible
- Bugfixes
- [changelog](https://www.zotero.org/support/changelog#changes_in_7010_november_26_2024)

**Test Plan**
- export bibliography

**Checklist**
- [X] Package was built and tested against unstable
