### PR TITLE
gpxsee: Update to 13.32

### DIFF
--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.31'
-release    : 49
+version    : '13.32'
+release    : 50
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.31.tar.gz : de7ec329e9ed1567a8448b25541e2bba359d93dd92a704595b0d87209d039c9e
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.32.tar.gz : 38b38ac7e502bc09c6ebd81b53f38f22752c74ec771dd49fe2d87eba72596e1c
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop
@@ -10,7 +10,6 @@ summary    : a Qt-based GPS log file viewer and analyzer that supports all commo
 description: |
     a Qt-based GPS log file viewer and analyzer that supports all common GPS log file formats.
 clang      : yes
-optimize   : thin-lto
 builddeps  :
     - pkgconfig(Qt6Positioning)
     - pkgconfig(Qt6SerialPort)

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -172,9 +172,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="49">
-            <Date>2024-11-24</Date>
-            <Version>13.31</Version>
+        <Update release="50">
+            <Date>2024-11-30</Date>
+            <Version>13.32</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Improved Mapsforge maps rendering performance.
- Improved Mapsforge map render theme.

**Test Plan**
- open map, zoom and pan

**Checklist**
- [X] Package was built and tested against unstable
