### PR TITLE
libsoup3: Update to v3.6.1

### DIFF
--- a/packages/l/libsoup3/abi_symbols
+++ b/packages/l/libsoup3/abi_symbols
@@ -7,6 +7,7 @@ libsoup-3.0.so.0:_SOUP_METHOD_LOCK
 libsoup-3.0.so.0:_SOUP_METHOD_MKCOL
 libsoup-3.0.so.0:_SOUP_METHOD_MOVE
 libsoup-3.0.so.0:_SOUP_METHOD_OPTIONS
+libsoup-3.0.so.0:_SOUP_METHOD_PATCH
 libsoup-3.0.so.0:_SOUP_METHOD_POST
 libsoup-3.0.so.0:_SOUP_METHOD_PROPFIND
 libsoup-3.0.so.0:_SOUP_METHOD_PROPPATCH
@@ -441,6 +442,7 @@ libsoup-3.0.so.0:soup_websocket_connection_get_connection_type
 libsoup-3.0.so.0:soup_websocket_connection_get_extensions
 libsoup-3.0.so.0:soup_websocket_connection_get_io_stream
 libsoup-3.0.so.0:soup_websocket_connection_get_keepalive_interval
+libsoup-3.0.so.0:soup_websocket_connection_get_keepalive_pong_timeout
 libsoup-3.0.so.0:soup_websocket_connection_get_max_incoming_payload_size
 libsoup-3.0.so.0:soup_websocket_connection_get_origin
 libsoup-3.0.so.0:soup_websocket_connection_get_protocol
@@ -452,6 +454,7 @@ libsoup-3.0.so.0:soup_websocket_connection_send_binary
 libsoup-3.0.so.0:soup_websocket_connection_send_message
 libsoup-3.0.so.0:soup_websocket_connection_send_text
 libsoup-3.0.so.0:soup_websocket_connection_set_keepalive_interval
+libsoup-3.0.so.0:soup_websocket_connection_set_keepalive_pong_timeout
 libsoup-3.0.so.0:soup_websocket_connection_set_max_incoming_payload_size
 libsoup-3.0.so.0:soup_websocket_connection_type_get_type
 libsoup-3.0.so.0:soup_websocket_data_type_get_type

--- a/packages/l/libsoup3/abi_symbols32
+++ b/packages/l/libsoup3/abi_symbols32
@@ -7,6 +7,7 @@ libsoup-3.0.so.0:_SOUP_METHOD_LOCK
 libsoup-3.0.so.0:_SOUP_METHOD_MKCOL
 libsoup-3.0.so.0:_SOUP_METHOD_MOVE
 libsoup-3.0.so.0:_SOUP_METHOD_OPTIONS
+libsoup-3.0.so.0:_SOUP_METHOD_PATCH
 libsoup-3.0.so.0:_SOUP_METHOD_POST
 libsoup-3.0.so.0:_SOUP_METHOD_PROPFIND
 libsoup-3.0.so.0:_SOUP_METHOD_PROPPATCH
@@ -441,6 +442,7 @@ libsoup-3.0.so.0:soup_websocket_connection_get_connection_type
 libsoup-3.0.so.0:soup_websocket_connection_get_extensions
 libsoup-3.0.so.0:soup_websocket_connection_get_io_stream
 libsoup-3.0.so.0:soup_websocket_connection_get_keepalive_interval
+libsoup-3.0.so.0:soup_websocket_connection_get_keepalive_pong_timeout
 libsoup-3.0.so.0:soup_websocket_connection_get_max_incoming_payload_size
 libsoup-3.0.so.0:soup_websocket_connection_get_origin
 libsoup-3.0.so.0:soup_websocket_connection_get_protocol
@@ -452,6 +454,7 @@ libsoup-3.0.so.0:soup_websocket_connection_send_binary
 libsoup-3.0.so.0:soup_websocket_connection_send_message
 libsoup-3.0.so.0:soup_websocket_connection_send_text
 libsoup-3.0.so.0:soup_websocket_connection_set_keepalive_interval
+libsoup-3.0.so.0:soup_websocket_connection_set_keepalive_pong_timeout
 libsoup-3.0.so.0:soup_websocket_connection_set_max_incoming_payload_size
 libsoup-3.0.so.0:soup_websocket_connection_type_get_type
 libsoup-3.0.so.0:soup_websocket_data_type_get_type

--- a/packages/l/libsoup3/abi_used_symbols
+++ b/packages/l/libsoup3/abi_used_symbols
@@ -23,7 +23,6 @@ libc.so.6:memset
 libc.so.6:qsort
 libc.so.6:strchr
 libc.so.6:strcmp
-libc.so.6:strcpy
 libc.so.6:strcspn
 libc.so.6:strlen
 libc.so.6:strncmp
@@ -150,7 +149,6 @@ libgio-2.0.so.0:g_socket_shutdown
 libgio-2.0.so.0:g_task_attach_source
 libgio-2.0.so.0:g_task_get_cancellable
 libgio-2.0.so.0:g_task_get_context
-libgio-2.0.so.0:g_task_get_name
 libgio-2.0.so.0:g_task_get_priority
 libgio-2.0.so.0:g_task_get_source_object
 libgio-2.0.so.0:g_task_get_task_data
@@ -169,7 +167,6 @@ libgio-2.0.so.0:g_task_return_pointer
 libgio-2.0.so.0:g_task_run_in_thread
 libgio-2.0.so.0:g_task_set_priority
 libgio-2.0.so.0:g_task_set_source_tag
-libgio-2.0.so.0:g_task_set_static_name
 libgio-2.0.so.0:g_task_set_task_data
 libgio-2.0.so.0:g_tls_authentication_mode_get_type
 libgio-2.0.so.0:g_tls_backend_get_client_connection_type
@@ -350,7 +347,9 @@ libglib-2.0.so.0:g_mutex_init
 libglib-2.0.so.0:g_mutex_lock
 libglib-2.0.so.0:g_mutex_unlock
 libglib-2.0.so.0:g_once_init_enter
+libglib-2.0.so.0:g_once_init_enter_pointer
 libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_prefix_error
 libglib-2.0.so.0:g_propagate_error
 libglib-2.0.so.0:g_ptr_array_add
@@ -428,8 +427,8 @@ libglib-2.0.so.0:g_strdupv
 libglib-2.0.so.0:g_strfreev
 libglib-2.0.so.0:g_string_append_len
 libglib-2.0.so.0:g_string_append_printf
+libglib-2.0.so.0:g_string_assign
 libglib-2.0.so.0:g_string_free
-libglib-2.0.so.0:g_string_free_and_steal
 libglib-2.0.so.0:g_string_free_to_bytes
 libglib-2.0.so.0:g_string_insert_c
 libglib-2.0.so.0:g_string_insert_len

--- a/packages/l/libsoup3/abi_used_symbols32
+++ b/packages/l/libsoup3/abi_used_symbols32
@@ -23,7 +23,6 @@ libc.so.6:memset
 libc.so.6:qsort
 libc.so.6:strchr
 libc.so.6:strcmp
-libc.so.6:strcpy
 libc.so.6:strcspn
 libc.so.6:strlen
 libc.so.6:strncmp
@@ -150,7 +149,6 @@ libgio-2.0.so.0:g_socket_shutdown
 libgio-2.0.so.0:g_task_attach_source
 libgio-2.0.so.0:g_task_get_cancellable
 libgio-2.0.so.0:g_task_get_context
-libgio-2.0.so.0:g_task_get_name
 libgio-2.0.so.0:g_task_get_priority
 libgio-2.0.so.0:g_task_get_source_object
 libgio-2.0.so.0:g_task_get_task_data
@@ -169,7 +167,6 @@ libgio-2.0.so.0:g_task_return_pointer
 libgio-2.0.so.0:g_task_run_in_thread
 libgio-2.0.so.0:g_task_set_priority
 libgio-2.0.so.0:g_task_set_source_tag
-libgio-2.0.so.0:g_task_set_static_name
 libgio-2.0.so.0:g_task_set_task_data
 libgio-2.0.so.0:g_tls_authentication_mode_get_type
 libgio-2.0.so.0:g_tls_backend_get_client_connection_type
@@ -350,7 +347,9 @@ libglib-2.0.so.0:g_mutex_init
 libglib-2.0.so.0:g_mutex_lock
 libglib-2.0.so.0:g_mutex_unlock
 libglib-2.0.so.0:g_once_init_enter
+libglib-2.0.so.0:g_once_init_enter_pointer
 libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_prefix_error
 libglib-2.0.so.0:g_propagate_error
 libglib-2.0.so.0:g_ptr_array_add
@@ -428,8 +427,8 @@ libglib-2.0.so.0:g_strdupv
 libglib-2.0.so.0:g_strfreev
 libglib-2.0.so.0:g_string_append_len
 libglib-2.0.so.0:g_string_append_printf
+libglib-2.0.so.0:g_string_assign
 libglib-2.0.so.0:g_string_free
-libglib-2.0.so.0:g_string_free_and_steal
 libglib-2.0.so.0:g_string_free_to_bytes
 libglib-2.0.so.0:g_string_insert_c
 libglib-2.0.so.0:g_string_insert_len

--- a/packages/l/libsoup3/package.yml
+++ b/packages/l/libsoup3/package.yml
@@ -1,10 +1,10 @@
 name       : libsoup3
-version    : 3.4.4
-release    : 10
+version    : 3.6.1
+release    : 11
 source     :
-    - https://download.gnome.org/sources/libsoup/3.4/libsoup-3.4.4.tar.xz : 291c67725f36ed90ea43efff25064b69c5a2d1981488477c05c481a3b4b0c5aa
-homepage   : https://wiki.gnome.org/Projects/libsoup
-license    : LGPL-2.1-only
+    - https://download.gnome.org/sources/libsoup/3.6/libsoup-3.6.1.tar.xz : ceb1f1aa2bdd73b2cd8159d3998c96c55ef097ef15e4b4f36029209fa18af838
+homepage   : https://gitlab.gnome.org/GNOME/libsoup
+license    : LGPL-2.0-only
 component  : desktop.gnome.core
 emul32     : yes
 summary    : GNOME HTTP client/server library

--- a/packages/l/libsoup3/pspec_x86_64.xml
+++ b/packages/l/libsoup3/pspec_x86_64.xml
@@ -1,12 +1,12 @@
 <PISI>
     <Source>
         <Name>libsoup3</Name>
-        <Homepage>https://wiki.gnome.org/Projects/libsoup</Homepage>
+        <Homepage>https://gitlab.gnome.org/GNOME/libsoup</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
-        <License>LGPL-2.1-only</License>
+        <License>LGPL-2.0-only</License>
         <PartOf>desktop.gnome.core</PartOf>
         <Summary xml:lang="en">GNOME HTTP client/server library</Summary>
         <Description xml:lang="en">The libsoup is HTTP client/server library for GNOME. It uses GObject and the GLib main loop to integrate with GNOME applications and it also has asynchronous API for use in threaded applications.
@@ -23,7 +23,6 @@
             <Path fileType="library">/usr/lib64/girepository-1.0/Soup-3.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libsoup-3.0.so.0</Path>
             <Path fileType="library">/usr/lib64/libsoup-3.0.so.0.7.1</Path>
-            <Path fileType="data">/usr/share/gir-1.0/Soup-3.0.gir</Path>
             <Path fileType="localedata">/usr/share/locale/ab/LC_MESSAGES/libsoup-3.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/an/LC_MESSAGES/libsoup-3.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/as/LC_MESSAGES/libsoup-3.0.mo</Path>
@@ -57,6 +56,7 @@
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/libsoup-3.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/libsoup-3.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/libsoup-3.0.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/kab/LC_MESSAGES/libsoup-3.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/kn/LC_MESSAGES/libsoup-3.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ko/LC_MESSAGES/libsoup-3.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lt/LC_MESSAGES/libsoup-3.0.mo</Path>
@@ -101,7 +101,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">libsoup3</Dependency>
+            <Dependency release="11">libsoup3</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libsoup-3.0.so.0</Path>
@@ -115,8 +115,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">libsoup3-devel</Dependency>
-            <Dependency release="10">libsoup3-32bit</Dependency>
+            <Dependency release="11">libsoup3-devel</Dependency>
+            <Dependency release="11">libsoup3-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libsoup-3.0.so</Path>
@@ -130,7 +130,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">libsoup3</Dependency>
+            <Dependency release="11">libsoup3</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libsoup-3.0/libsoup/soup-auth-domain-basic.h</Path>
@@ -177,17 +177,18 @@
             <Path fileType="header">/usr/include/libsoup-3.0/libsoup/soup.h</Path>
             <Path fileType="library">/usr/lib64/libsoup-3.0.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/libsoup-3.0.pc</Path>
+            <Path fileType="data">/usr/share/gir-1.0/Soup-3.0.gir</Path>
             <Path fileType="data">/usr/share/vala/vapi/libsoup-3.0.deps</Path>
             <Path fileType="data">/usr/share/vala/vapi/libsoup-3.0.vapi</Path>
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2023-11-11</Date>
-            <Version>3.4.4</Version>
+        <Update release="11">
+            <Date>2024-11-30</Date>
+            <Version>3.6.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
* Fix `soup_uri_copy()` reading port as a long instead of an int
* Fix possible NULL deref in `soup_uri_decode_data_uri()`
* Fix possible overflow in `SoupContentSniffer`
* Fix assertion in `soup_uri_decode_data_uri()` on URLs with a path starting with `//`
* headers: Be more robust against invalid input when parsing params
* websocket: Fix possibility of being stuck in a read loop

**Test Plan**
- Installed, loaded homebank that is dependent on this.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
