### PR TITLE
noto-sans-ttf: Update to v2024.12.01 and fix color emojis

### DIFF
--- a/packages/n/noto-sans-ttf/package.yml
+++ b/packages/n/noto-sans-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : noto-sans-ttf
-version    : 2024.11.01
-release    : 34
+version    : 2024.12.01
+release    : 35
 source     :
-    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-2024.11.01.tar.gz : f2cfbc9c3b7794819fc12f0b95b6637727e875934f6ee6110b1f4c12ce7114eb
+    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-2024.12.01.tar.gz : 106ef938580a210e4fe84f890275863b2e463997a8ed510cf41d2b16ec9b95d3
     - https://github.com/googlefonts/noto-emoji/archive/refs/tags/v2.047.tar.gz : 2cfaf5a427eb26334cdb30d98e4a0c005b660504a339249dc54373e566f09b50
 homepage   : https://fonts.google.com/noto
 extract    : no
@@ -24,7 +24,7 @@ install    : |
     install -Ddm00755 $installdir/usr/share/fonts/truetype/noto-sans-ttf
 
     # Install emoji
-    install -Dm00644 noto-emoji*/fonts/NotoColorEmoji.ttf $installdir/usr/share/fonts/truetype/noto-sans-ttf
+    install -m00644 noto-emoji*/fonts/{Noto-COLRv1,NotoColorEmoji}.ttf $installdir/usr/share/fonts/truetype/noto-sans-ttf
 
     # Install fonts
     pushd notofonts*/fonts

--- a/packages/n/noto-sans-ttf/pspec_x86_64.xml
+++ b/packages/n/noto-sans-ttf/pspec_x86_64.xml
@@ -21,6 +21,7 @@
         <PartOf>desktop.font</PartOf>
         <Files>
             <Path fileType="data">/usr/share/fontconfig/conf.avail/66-noto-color-emoji.conf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/Noto-COLRv1.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoColorEmoji.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoFangsongKSSRotated-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoFangsongKSSVertical-Regular.ttf</Path>
@@ -1538,9 +1539,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="34">
-            <Date>2024-11-02</Date>
-            <Version>2024.11.01</Version>
+        <Update release="35">
+            <Date>2024-12-02</Date>
+            <Version>2024.12.01</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Fix color emojis by also including COLRv1 font variant.

Resolves https://github.com/getsolus/packages/issues/4181

Full commit log available [here](https://github.com/notofonts/notofonts.github.io/compare/noto-monthly-release-2024.11.01...noto-monthly-release-2024.12.01)

**Test Plan**
- Confirmed system looks okay with Noto system font
- Posted coloured emojis in Steam chat window

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
