### PR TITLE
lutris: Update to v0.5.18 and add monitoring.yml

### DIFF
--- a/packages/l/lutris/monitoring.yml
+++ b/packages/l/lutris/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 12270
+  rss: https://github.com/lutris/lutris/releases.atom
+# No known CPE, checked 2024-12-02
+security:
+  cpe: ~

--- a/packages/l/lutris/package.yml
+++ b/packages/l/lutris/package.yml
@@ -1,8 +1,8 @@
 name       : lutris
-version    : 0.5.17
-release    : 78
+version    : 0.5.18
+release    : 79
 source     :
-    - https://github.com/lutris/lutris/archive/refs/tags/v0.5.17.tar.gz : e913d0c70bcb8c29839fcc2368f0b672bc1e70d1bc2bc18e6fd50ac785261aa8
+    - https://github.com/lutris/lutris/archive/refs/tags/v0.5.18.tar.gz : b9d4ad052d1c750910940d5cc7c583967c0c65c1584b7f4a1abaf46e40c3d8d1
 license    : GPL-3.0-or-later
 component  : games
 homepage   : https://lutris.net/

--- a/packages/l/lutris/pspec_x86_64.xml
+++ b/packages/l/lutris/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>lutris</Name>
         <Homepage>https://lutris.net/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>games</PartOf>
@@ -34,6 +34,8 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/__pycache__/optional_settings.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/__pycache__/runner_interpreter.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/__pycache__/runtime.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/__pycache__/search.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/__pycache__/search_predicate.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/__pycache__/settings.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/__pycache__/startup.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/__pycache__/style_manager.cpython-311.pyc</Path>
@@ -45,12 +47,14 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/database/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/database/__pycache__/categories.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/database/__pycache__/games.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/database/__pycache__/saved_searches.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/database/__pycache__/schema.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/database/__pycache__/services.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/database/__pycache__/sources.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/database/__pycache__/sql.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/database/categories.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/database/games.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/database/saved_searches.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/database/schema.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/database/services.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/database/sources.py</Path>
@@ -77,6 +81,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/__pycache__/edit_category_games.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/__pycache__/edit_game.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/__pycache__/edit_game_categories.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/__pycache__/edit_saved_search.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/__pycache__/game_common.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/__pycache__/preferences_box.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/__pycache__/preferences_dialog.cpython-311.pyc</Path>
@@ -94,6 +99,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/edit_category_games.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/edit_game.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/edit_game_categories.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/edit_saved_search.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/game_common.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/preferences_box.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/preferences_dialog.py</Path>
@@ -112,6 +118,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/dialogs/__pycache__/game_import.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/dialogs/__pycache__/issue.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/dialogs/__pycache__/log.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/dialogs/__pycache__/move_game.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/dialogs/__pycache__/runner_install.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/dialogs/__pycache__/uninstall_dialog.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/dialogs/__pycache__/webconnect_dialog.cpython-311.pyc</Path>
@@ -121,6 +128,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/dialogs/game_import.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/dialogs/issue.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/dialogs/log.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/dialogs/move_game.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/dialogs/runner_install.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/dialogs/uninstall_dialog.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/dialogs/webconnect_dialog.py</Path>
@@ -230,6 +238,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/runners/__pycache__/cemu.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/runners/__pycache__/dolphin.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/runners/__pycache__/dosbox.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/runners/__pycache__/duckstation.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/runners/__pycache__/easyrpg.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/runners/__pycache__/flatpak.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/runners/__pycache__/fsuae.cpython-311.pyc</Path>
@@ -271,6 +280,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/runners/commands/wine.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/runners/dolphin.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/runners/dosbox.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/runners/duckstation.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/runners/easyrpg.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/runners/flatpak.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/runners/fsuae.py</Path>
@@ -313,6 +323,8 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/scanners/lutris.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/scanners/retroarch.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/scanners/tosec.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/search.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/search_predicate.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/services/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/services/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/services/__pycache__/amazon.cpython-311.pyc</Path>
@@ -327,7 +339,6 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/services/__pycache__/itchio.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/services/__pycache__/lutris.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/services/__pycache__/mame.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/services/__pycache__/origin.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/services/__pycache__/scummvm.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/services/__pycache__/service_game.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/services/__pycache__/service_media.cpython-311.pyc</Path>
@@ -347,7 +358,6 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/services/itchio.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/services/lutris.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/services/mame.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/services/origin.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/services/scummvm.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/services/service_game.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/services/service_media.py</Path>
@@ -361,6 +371,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/sysoptions.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/__pycache__/busy.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/__pycache__/cookies.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/__pycache__/datapath.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/__pycache__/display.cpython-311.pyc</Path>
@@ -395,6 +406,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/__pycache__/system.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/__pycache__/test_config.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/__pycache__/timer.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/__pycache__/tokenization.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/__pycache__/urlhandler.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/__pycache__/xdgshortcuts.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/__pycache__/yaml.cpython-311.pyc</Path>
@@ -410,6 +422,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/battlenet/__pycache__/product_db_pb2.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/battlenet/definitions.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/battlenet/product_db_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/busy.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/cookies.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/datapath.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/discord/__init__.py</Path>
@@ -504,6 +517,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/system.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/test_config.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/timer.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/tokenization.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/ubisoft/__pycache__/client.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/ubisoft/__pycache__/consts.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/ubisoft/__pycache__/helpers.cpython-311.pyc</Path>
@@ -613,12 +627,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="78">
-            <Date>2024-04-11</Date>
-            <Version>0.5.17</Version>
+        <Update release="79">
+            <Date>2024-12-02</Date>
+            <Version>0.5.18</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Lutris downloads the latest GE-Proton build for Wine if any Wine version is installed
- Use dark theme by default
- Display cover-art rather than banners by default
- Add 'Uncategorized' view to sidebar
- Preference options that do not work on Wayland will be hidden when on Wayland
- Game searches can now use fancy tags like 'installed:yes' or 'source:gog', with explanatory tool-tip
- A new filter button on the search box can build many of these fancy tags for you
- Runner searches can use 'installed:yes' as well, but no other fancy searches or anything
- Updated the Flathub and Amazon source to new APIs, restoring integration
- Itch.io source integration will load a collection named 'Lutris' if present
- GOG and Itch.io sources can now offer Linux and Windows installers for the same game
- Added support for the 'foot' terminal
- Support for DirectX 8 in DXVK v2.4
- Support for Ayatana Application Indicators
- Additional options for Ruffle runner
- Updated download links for the Atari800 and MicroM8 runners
- No longer re-download cached installation files even when some are missing
- Lutris log is included in the 'System' tab of the Preferences window
- Improved error reporting, with the Lutris log included in the error details
- Add Duckstation runner

**Test Plan**

Installed and played GTA II

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
