### PR TITLE
python-maturin: Update to v1.7.7

### DIFF
--- a/packages/py/python-maturin/package.yml
+++ b/packages/py/python-maturin/package.yml
@@ -1,8 +1,8 @@
 name       : python-maturin
-version    : 1.7.6
-release    : 50
+version    : 1.7.7
+release    : 51
 source     :
-    - https://github.com/PyO3/maturin/archive/refs/tags/v1.7.6.tar.gz : 97fbd90108886776441eccbc44b92d5804cc6e8261fd8c03758c210c7f759320
+    - https://github.com/PyO3/maturin/archive/refs/tags/v1.7.7.tar.gz : 791e471100076a555a53a1a76642b6cf1a7774f07cadefadd524d31cb8ae499d
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-maturin/pspec_x86_64.xml
+++ b/packages/py/python-maturin/pspec_x86_64.xml
@@ -22,12 +22,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/maturin</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.6-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.6-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.6-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.6-py3.11.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.6-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.6-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.7-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.7-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.7-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.7-py3.11.egg-info/not-zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.7-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.7-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/__pycache__/__init__.cpython-311.pyc</Path>
@@ -35,9 +35,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="50">
-            <Date>2024-11-28</Date>
-            <Version>1.7.6</Version>
+        <Update release="51">
+            <Date>2024-12-02</Date>
+            <Version>1.7.7</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fix: remove extra indent in generated CI
- Upgrade cargo-xwin to unify rustls versions
- Normalize python source directory path
- Use different binding dirs for different uniffi modules
- Update minimal Python minor version for pyo3 0.23
- Limit minimal PyPy version based on bindings crate version
- Remove hard coded `pip show` in `fix_direct_url`

**Test Plan**

Rebuilt `python-orjson`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
