### PR TITLE
CI/config: Add qt6-base and qt6-declarative to allowlist

### DIFF
--- a/common/CI/config.yaml
+++ b/common/CI/config.yaml
@@ -19,6 +19,8 @@ static_libs:
     - llvm-15
     - ocaml
     - qt5-tools
+    - qt6-base
+    - qt6-declarative
     - rocm-llvm
     - rust
     - shadow


### PR DESCRIPTION
**Summary**

Adds qt6-base and qt6-declarative to the list of packages allowed to contain static libs.

**Test Plan**

N/A

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
