### PR TITLE
weechat: Update to v4.4.4

### DIFF
--- a/packages/w/weechat/package.yml
+++ b/packages/w/weechat/package.yml
@@ -1,8 +1,8 @@
 name       : weechat
-version    : 4.4.3
-release    : 87
+version    : 4.4.4
+release    : 88
 source     :
-    - https://github.com/weechat/weechat/archive/refs/tags/v4.4.3.tar.gz : c59b04405584fb76adb04c731b0dcde0c1add371cd050c83e7360b9f220cea72
+    - https://github.com/weechat/weechat/archive/refs/tags/v4.4.4.tar.gz : 81d6f24ff92c6ac34d73265b4f172ff8d51c728046e8a8603d42c23b7adccf3c
 homepage   : https://weechat.org
 license    : GPL-3.0-or-later
 summary    : WeeChat is a fast, light and extensible chat client.

--- a/packages/w/weechat/pspec_x86_64.xml
+++ b/packages/w/weechat/pspec_x86_64.xml
@@ -72,7 +72,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="87">weechat</Dependency>
+            <Dependency release="88">weechat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/weechat/weechat-plugin.h</Path>
@@ -80,9 +80,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="87">
-            <Date>2024-11-01</Date>
-            <Version>4.4.3</Version>
+        <Update release="88">
+            <Date>2024-12-03</Date>
+            <Version>4.4.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- script: fix crash on /script buffer when a filter is set
- core: fix too many sorts of hotlist when buffers are moved
- relay, xfer: fix letters with actions displayed on top of buffer
- perl: fix crash when unloading Perl scripts with Perl 5.38

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Connect to Libera, send and receive messages.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
