### PR TITLE
github-cli: Update to v2.63.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.62.0
-release    : 60
+version    : 2.63.0
+release    : 61
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.62.0.tar.gz : 8b0d44a7fccd0c768d5ef7c3fbd274851b5752084e47761f146852de6539193e
+    - https://github.com/cli/cli/archive/refs/tags/v2.63.0.tar.gz : c5309db9707c9e64ebe264e1e2d0f893ecead9056d680b39a565aaa5513d2947
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -225,9 +225,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="60">
-            <Date>2024-11-19</Date>
-            <Version>2.62.0</Version>
+        <Update release="61">
+            <Date>2024-12-03</Date>
+            <Version>2.63.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Support bare repo creation
- Refactor the `getAttestations` functions
- Added a section on manual verification of the releases
- Adding option to return `baseRefOid` in `pr view`
- Update verification results printing
- Fix some multiline command documentation to use `heredoc` strings
- Print friendly error when `release create` fails due to missing `workflow` OAuth scope

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
