### PR TITLE
github-cli: Update to v2.63.1

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.63.0
-release    : 61
+version    : 2.63.1
+release    : 62
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.63.0.tar.gz : c5309db9707c9e64ebe264e1e2d0f893ecead9056d680b39a565aaa5513d2947
+    - https://github.com/cli/cli/archive/refs/tags/v2.63.1.tar.gz : b9a90118dfb46204dbcc0d09c2073d48f35b6f640b4db33fbaa24892fed56c8d
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>github-cli</Name>
         <Homepage>https://cli.github.com</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -225,12 +225,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="61">
-            <Date>2024-12-03</Date>
-            <Version>2.63.0</Version>
+        <Update release="62">
+            <Date>2024-12-04</Date>
+            <Version>2.63.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fix formatting in git/client_test.go comments for linter
- Bump github.com/gabriel-vasile/mimetype from 1.4.6 to 1.4.7
- Clarify which commands correspond to which DNF version under Linux install instructions
- When renaming an existing remote as part of remote creation in gh repo fork, log the change
- Fix PR checkout panic when base repo is not in remotes

**Security**
Includes fixes for:
- [CVE-2024-54132](https://github.com/cli/cli/security/advisories/GHSA-2m9h-r57g-45pj)

**Test Plan**
- Build `github-cli` from this PR and install it
- Execute a few `gh` commands and make sure it doesn't blow up

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
