### PR TITLE
adw-gtk3-theme: Update to v5.6

### DIFF
--- a/packages/a/adw-gtk3-theme/monitoring.yml
+++ b/packages/a/adw-gtk3-theme/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 301867
+  rss: https://github.com/lassekongo83/adw-gtk3/releases.atom
+# No known CPE, checked 2024-12-05
+security:
+  cpe: ~

--- a/packages/a/adw-gtk3-theme/package.yml
+++ b/packages/a/adw-gtk3-theme/package.yml
@@ -1,8 +1,8 @@
 name       : adw-gtk3-theme
-version    : '5.5'
-release    : 15
+version    : '5.6'
+release    : 16
 source     :
-    - https://github.com/lassekongo83/adw-gtk3/archive/refs/tags/v5.5.tar.gz : 02433c9ef67267776e0a4c822e28b6810063a68c1ecf2f17f0936a9c45a20b9b
+    - https://github.com/lassekongo83/adw-gtk3/archive/refs/tags/v5.6.tar.gz : e947de328a87678ae76f41061d94931523ee6015cb83bba8af7a5cd6375265b2
 license    : LGPL-2.1-only
 homepage   : https://github.com/lassekongo83/adw-gtk3
 component  : desktop.theme
@@ -10,8 +10,8 @@ summary    : An unofficial GTK3 port of libadwaita
 description: |
     An unofficial GTK3 port of libadwaita
 builddeps  :
-    - sassc
     - gnome-themes-extra
+    - sassc
 rundeps    :
     - gnome-themes-extra
 setup      : |

--- a/packages/a/adw-gtk3-theme/pspec_x86_64.xml
+++ b/packages/a/adw-gtk3-theme/pspec_x86_64.xml
@@ -145,9 +145,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2024-10-20</Date>
-            <Version>5.5</Version>
+        <Update release="16">
+            <Date>2024-12-05</Date>
+            <Version>5.6</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Remove legacy stuff
- Add link to accent-color-change shell script
- Add `monitoring.yml` (Part of https://github.com/getsolus/packages/issues/4121)

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Switch to the `adw-gtk3` theme in XFCE.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
