### PR TITLE
scrcpy: Update to v3.0.2

### DIFF
--- a/packages/s/scrcpy/package.yml
+++ b/packages/s/scrcpy/package.yml
@@ -1,9 +1,9 @@
 name       : scrcpy
-version    : '3.0'
-release    : 30
+version    : 3.0.2
+release    : 31
 source     :
-    - https://github.com/Genymobile/scrcpy/archive/v3.0.tar.gz : 6ad2306dcdf17a8c927691d1004ec632a694069187ded73d30113a5db780fc43
-    - https://github.com/Genymobile/scrcpy/releases/download/v3.0/scrcpy-server-v3.0 : 800044c62a94d5fc16f5ab9c86d45b1050eae3eb436514d1b0d2fe2646b894ea
+    - https://github.com/Genymobile/scrcpy/archive/v3.0.2.tar.gz : 5ab92d091f308679fe81851666acec1b161e6810ac73eb9bade705ade285e109
+    - https://github.com/Genymobile/scrcpy/releases/download/v3.0.2/scrcpy-server-v3.0.2 : e19fe024bfa3367809494407ad6ca809a6f6e77dac95e99f85ba75144e0ba35d
 homepage   : https://github.com/Genymobile/scrcpy
 license    : Apache-2.0
 component  : network.util

--- a/packages/s/scrcpy/pspec_x86_64.xml
+++ b/packages/s/scrcpy/pspec_x86_64.xml
@@ -31,9 +31,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="30">
-            <Date>2024-11-25</Date>
-            <Version>3.0</Version>
+        <Update release="31">
+            <Date>2024-12-05</Date>
+            <Version>3.0.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Set main display power for virtual display
- Rollback to old --turn-screen-off method for Android 15
- Do not reset TCP/IP connections
- Fix NullPointerException on certain devices
- Fix camera capture failure without retry
- Accept control events without display

Full release notes:
- [3.0.1](https://github.com/Genymobile/scrcpy/releases/tag/v3.0.1)
- [3.0.2](https://github.com/Genymobile/scrcpy/releases/tag/v3.0.2)

**Test Plan**

Mirrored my phone display and controlled it using mouse and keyboard

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
