### PR TITLE
glibc: Update to latest and bump kernel baseline

### DIFF
--- a/packages/g/glibc/package.yml
+++ b/packages/g/glibc/package.yml
@@ -1,9 +1,9 @@
 name       : glibc
 version    : '2.40'
-release    : 127
+release    : 128
 source     :
     # release/2.40/master
-    - git|git://sourceware.org/git/glibc.git : 5c06c6e0b5078ffb0aa0c09bac79f086145e0897
+    - git|git://sourceware.org/git/glibc.git : 091dd12831792cef16eee24fe240c73a25b47a1d
 homepage   : https://www.gnu.org/software/libc/
 license    : GPL-3.0-or-later
 summary    :
@@ -68,19 +68,17 @@ setup      : |
     %patch -p1 -i $pkgfiles/0001-Compress-charmaps-with-zstd.patch
 
     mkdir glibc-build
-    pushd glibc-build
+    cd glibc-build
 
     extra_conf_args=""
     if [[ ! -z "${EMUL32BUILD}" ]]; then
-        mkdir b32
-        pushd b32
+        mkdir b32 && cd b32
         export CC="gcc -m32"
         export CXX="g++ -m32"
         export BUILDHOST="i686-pc-linux-gnu"
         export CFLAGS="-O3 -g2 -mtune=generic -march=i686 -mstackrealign"
     else
-        mkdir b64
-        pushd b64
+        mkdir b64 && cd b64
         export CC="gcc"
         export CXX="g++"
         export BUILDHOST="x86_64-solus-linux"
@@ -112,7 +110,7 @@ setup      : |
            --disable-build-nscd \
            --disable-nscd \
            --enable-bind-now \
-           --enable-kernel=5.10 \
+           --enable-kernel=5.15 \
            --enable-stack-protector=strong \
            --enable-systemtap \
            --prefix=/usr \
@@ -122,21 +120,19 @@ setup      : |
            --libdir=%libdir% \
            --with-pkgversion='Solus' \
            $extra_conf_args
-    popd
-    popd
 build      : |
-    pushd glibc-build
+    cd glibc-build
     export LANGUAGE="C"
     export LC_ALL="C"
     export LANG="C"
 
     if [[ "${EMUL32BUILD}" ]]; then
-        pushd b32
+        cd b32
         export CC="gcc -m32"
         export CXX="g++ -m32"
         export CFLAGS="-O3 -g2 mtune=generic -march=i686 -Wl,-z,max-page-size=0x1000"
     else
-        pushd b64
+        cd b64
         export CC="gcc"
         export CXX="g++"
         if [[ ! -z "${AVX2BUILD}" ]]; then
@@ -152,17 +148,14 @@ build      : |
     if [[ -z "${AVX2BUILD}" ]]; then
         %make bench-build
     fi
-
-    popd
-    popd
 install    : |
-    pushd glibc-build
+    cd glibc-build
 
     if [[ ! -z "${EMUL32BUILD}" ]]; then
-        pushd b32
+        cd b32
         %make_install install_root=$installdir
     else
-        pushd b64
+        cd b64
         %make_install install_root=$installdir
 
         if [[ -z "${AVX2BUILD}" ]]; then

--- a/packages/g/glibc/pspec_x86_64.xml
+++ b/packages/g/glibc/pspec_x86_64.xml
@@ -7015,7 +7015,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="127">glibc</Dependency>
+            <Dependency release="128">glibc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib32/ld-linux.so.2</Path>
@@ -7326,8 +7326,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="127">glibc-devel</Dependency>
-            <Dependency release="127">glibc-32bit</Dependency>
+            <Dependency release="128">glibc-32bit</Dependency>
+            <Dependency release="128">glibc-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libBrokenLocale.a</Path>
@@ -7783,7 +7783,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="127">glibc</Dependency>
+            <Dependency release="128">glibc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/a.out.h</Path>
@@ -8284,8 +8284,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="127">
-            <Date>2024-10-18</Date>
+        <Update release="128">
+            <Date>2024-12-06</Date>
             <Version>2.40</Version>
             <Comment>Packaging update</Comment>
             <Name>Reilly Brogan</Name>


### PR DESCRIPTION
**Summary**
- Updated to latest 2.40 stable
- Cleaned up recipe a bit
- Bumped kernel baseline to v5.15

For post-sync