### PR TITLE
wine: Update to v10.0-rc1

### DIFF
--- a/packages/w/wine/abi_libs
+++ b/packages/w/wine/abi_libs
@@ -21,6 +21,7 @@ secur32.so
 win32u.so
 wine64
 winealsa.so
+winebth.so
 winebus.so
 winedmo.so
 winegstreamer.so

--- a/packages/w/wine/abi_libs32
+++ b/packages/w/wine/abi_libs32
@@ -20,6 +20,7 @@ secur32.so
 win32u.so
 wine
 winealsa.so
+winebth.so
 winebus.so
 winegstreamer.so
 wineps.so

--- a/packages/w/wine/abi_symbols
+++ b/packages/w/wine/abi_symbols
@@ -53,6 +53,7 @@ ntdll.so:NtCompareTokens
 ntdll.so:NtCompleteConnectPort
 ntdll.so:NtConnectPort
 ntdll.so:NtContinue
+ntdll.so:NtContinueEx
 ntdll.so:NtCreateDebugObject
 ntdll.so:NtCreateDirectoryObject
 ntdll.so:NtCreateEvent
@@ -94,6 +95,7 @@ ntdll.so:NtEnumerateValueKey
 ntdll.so:NtFilterToken
 ntdll.so:NtFindAtom
 ntdll.so:NtFlushBuffersFile
+ntdll.so:NtFlushBuffersFileEx
 ntdll.so:NtFlushInstructionCache
 ntdll.so:NtFlushKey
 ntdll.so:NtFlushProcessWriteBuffers
@@ -775,6 +777,7 @@ wine64:_start
 wine64:wine_main_preload_info
 winealsa.so:__wine_unix_call_funcs
 winealsa.so:__wine_unix_call_wow64_funcs
+winebth.so:__wine_unix_call_funcs
 winebus.so:__wine_unix_call_funcs
 winedmo.so:__wine_unix_call_funcs
 winedmo.so:__wine_unix_call_wow64_funcs

--- a/packages/w/wine/abi_symbols32
+++ b/packages/w/wine/abi_symbols32
@@ -42,6 +42,7 @@ ntdll.so:NtCompareTokens
 ntdll.so:NtCompleteConnectPort
 ntdll.so:NtConnectPort
 ntdll.so:NtContinue
+ntdll.so:NtContinueEx
 ntdll.so:NtCreateDebugObject
 ntdll.so:NtCreateDirectoryObject
 ntdll.so:NtCreateEvent
@@ -83,6 +84,7 @@ ntdll.so:NtEnumerateValueKey
 ntdll.so:NtFilterToken
 ntdll.so:NtFindAtom
 ntdll.so:NtFlushBuffersFile
+ntdll.so:NtFlushBuffersFileEx
 ntdll.so:NtFlushInstructionCache
 ntdll.so:NtFlushKey
 ntdll.so:NtFlushProcessWriteBuffers
@@ -764,6 +766,7 @@ wine:_fp_hw
 wine:_start
 wine:wine_main_preload_info
 winealsa.so:__wine_unix_call_funcs
+winebth.so:__wine_unix_call_funcs
 winebus.so:__wine_unix_call_funcs
 winegstreamer.so:__wine_unix_call_funcs
 wineps.so:__wine_unix_call_funcs

--- a/packages/w/wine/abi_used_symbols
+++ b/packages/w/wine/abi_used_symbols
@@ -576,6 +576,7 @@ libc.so.6:rename
 libc.so.6:res_query
 libc.so.6:rmdir
 libc.so.6:sched_getaffinity
+libc.so.6:sched_getcpu
 libc.so.6:sched_setaffinity
 libc.so.6:sched_yield
 libc.so.6:select

--- a/packages/w/wine/abi_used_symbols32
+++ b/packages/w/wine/abi_used_symbols32
@@ -511,6 +511,7 @@ libc.so.6:recv
 libc.so.6:rename
 libc.so.6:res_query
 libc.so.6:rmdir
+libc.so.6:sched_getcpu
 libc.so.6:sched_yield
 libc.so.6:send
 libc.so.6:sendto

--- a/packages/w/wine/package.yml
+++ b/packages/w/wine/package.yml
@@ -1,8 +1,8 @@
 name       : wine
-version    : '9.22'
-release    : 190
+version    : 10.0_rc1
+release    : 191
 source     :
-    - https://dl.winehq.org/wine/source/9.x/wine-9.22.tar.xz : e150d29742aa54f768ef3e976ed861aaa4f9f48542e409bea902d0f49b359683
+    - https://dl.winehq.org/wine/source/10.0/wine-10.0-rc1.tar.xz : 754b9abafe74baffe9b1ce6b2eeb777865c72c7f70c9c5baee951bde8ce287c1
 license    : LGPL-2.1-or-later
 component  : virt
 homepage   : https://www.winehq.org/
@@ -40,6 +40,7 @@ builddeps  :
     - pkgconfig32(xxf86vm)
     - pkgconfig(libavcodec)
     - pkgconfig(libpcsclite)
+    - pkgconfig(netapi)
     - pkgconfig(sane-backends)
     - glibc-32bit-devel
     - libpth-32bit-devel

--- a/packages/w/wine/pspec_x86_64.xml
+++ b/packages/w/wine/pspec_x86_64.xml
@@ -69,6 +69,7 @@
             <Path fileType="library">/usr/lib64/wine/x86_64-unix/secur32.so</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-unix/win32u.so</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-unix/winealsa.so</Path>
+            <Path fileType="library">/usr/lib64/wine/x86_64-unix/winebth.so</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-unix/winebus.so</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-unix/winedmo.so</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-unix/winegstreamer.so</Path>
@@ -697,6 +698,7 @@
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/windows.media.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/windows.media.mediacontrol.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/windows.media.speech.dll</Path>
+            <Path fileType="library">/usr/lib64/wine/x86_64-windows/windows.networking.connectivity.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/windows.networking.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/windows.networking.hostname.dll</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/windows.perception.stub.dll</Path>
@@ -711,6 +713,7 @@
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/winealsa.drv</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/wineboot.exe</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/winebrowser.exe</Path>
+            <Path fileType="library">/usr/lib64/wine/x86_64-windows/winebth.sys</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/winebus.sys</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/winecfg.exe</Path>
             <Path fileType="library">/usr/lib64/wine/x86_64-windows/wineconsole.exe</Path>
@@ -1004,7 +1007,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="190">wine</Dependency>
+            <Dependency release="191">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/wine</Path>
@@ -1029,6 +1032,7 @@
             <Path fileType="library">/usr/lib32/wine/i386-unix/secur32.so</Path>
             <Path fileType="library">/usr/lib32/wine/i386-unix/win32u.so</Path>
             <Path fileType="library">/usr/lib32/wine/i386-unix/winealsa.so</Path>
+            <Path fileType="library">/usr/lib32/wine/i386-unix/winebth.so</Path>
             <Path fileType="library">/usr/lib32/wine/i386-unix/winebus.so</Path>
             <Path fileType="library">/usr/lib32/wine/i386-unix/winedmo.so</Path>
             <Path fileType="library">/usr/lib32/wine/i386-unix/winegstreamer.so</Path>
@@ -1708,6 +1712,7 @@
             <Path fileType="library">/usr/lib32/wine/i386-windows/windows.media.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/windows.media.mediacontrol.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/windows.media.speech.dll</Path>
+            <Path fileType="library">/usr/lib32/wine/i386-windows/windows.networking.connectivity.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/windows.networking.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/windows.networking.hostname.dll</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/windows.perception.stub.dll</Path>
@@ -1722,6 +1727,7 @@
             <Path fileType="library">/usr/lib32/wine/i386-windows/winealsa.drv</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/wineboot.exe</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/winebrowser.exe</Path>
+            <Path fileType="library">/usr/lib32/wine/i386-windows/winebth.sys</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/winebus.sys</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/winecfg.exe</Path>
             <Path fileType="library">/usr/lib32/wine/i386-windows/wineconsole.exe</Path>
@@ -1856,7 +1862,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="190">wine</Dependency>
+            <Dependency release="191">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wine/debug.h</Path>
@@ -2010,6 +2016,8 @@
             <Path fileType="header">/usr/include/wine/windows/bits5_0.idl</Path>
             <Path fileType="header">/usr/include/wine/windows/bitsmsg.h</Path>
             <Path fileType="header">/usr/include/wine/windows/bluetoothapis.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/bthdef.h</Path>
+            <Path fileType="header">/usr/include/wine/windows/bthioctl.h</Path>
             <Path fileType="header">/usr/include/wine/windows/bthsdpdef.h</Path>
             <Path fileType="header">/usr/include/wine/windows/cderr.h</Path>
             <Path fileType="header">/usr/include/wine/windows/cdosys.h</Path>
@@ -3201,9 +3209,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="190">
-            <Date>2024-11-24</Date>
-            <Version>9.22</Version>
+        <Update release="191">
+            <Date>2024-12-06</Date>
+            <Version>10.0_rc1</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Highlighted changes:
- Bundled vkd3d upgraded to version 1.14
- Mono engine updated to version 9.4.0
- Initial version of a Bluetooth driver
- UTF-8 support in the C runtime functions
- Support for split debug info using build ids
- Various bug fixes

Full release notes available [here](https://gitlab.winehq.org/wine/wine/-/releases/wine-10.0-rc1)

Packaging note: Add netapi build dep to enable Samba NetAPI support

**Test Plan**
- Ran `winemine`, `winecfg`, `wineconsole`, `winefile`
- Played Age of Empires I demo

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
