### PR TITLE
hyprland: Update to 0.45.2

### DIFF
--- a/packages/h/hyprland/package.yml
+++ b/packages/h/hyprland/package.yml
@@ -1,8 +1,8 @@
 name       : hyprland
-version    : 0.45.1
-release    : 4
+version    : 0.45.2
+release    : 5
 source     :
-    - https://github.com/hyprwm/Hyprland/releases/download/v0.45.1/source-v0.45.1.tar.gz : cfde862579248f0ed8824731073d796ed8fee3df863665ce41305a002b15c2d8
+    - https://github.com/hyprwm/Hyprland/releases/download/v0.45.2/source-v0.45.2.tar.gz : d70231021f44980ef1c587e3adcb13471cface8ae580f0b503628b0391a716cb
 homepage   : https://hyprland.org/
 license    : BSD-3-Clause
 component  : desktop.hyprland

--- a/packages/h/hyprland/pspec_x86_64.xml
+++ b/packages/h/hyprland/pspec_x86_64.xml
@@ -48,7 +48,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="4">hyprland</Dependency>
+            <Dependency release="5">hyprland</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/hyprland/protocols/alpha-modifier-v1.hpp</Path>
@@ -268,9 +268,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-11-19</Date>
-            <Version>0.45.1</Version>
+        <Update release="5">
+            <Date>2024-12-08</Date>
+            <Version>0.45.2</Version>
             <Comment>Packaging update</Comment>
             <Name>GENEVEE Nicolas</Name>
             <Email>gnick@orange.fr</Email>


### PR DESCRIPTION
**Summary**

Bugfixes:

- internal: fix changeWindowZOrder reordering incorrectly
- xdg-shell: don't report invalid min/max sizes on unset

Full release notes:

- [0.45.2](https://github.com/hyprwm/Hyprland/releases/tag/v0.45.2)

by gNick

**Summary**

package file updated

**Test Plan**

tested on a VM and on my laptop

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
