### PR TITLE
tlp: Update to v1.7.0

### DIFF
--- a/packages/t/tlp/monitoring.yml
+++ b/packages/t/tlp/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 9269
+  rss: https://github.com/linrunner/TLP/tags.atom
+# No known CPE, checked 2024-12-09
+security:
+  cpe: ~

--- a/packages/t/tlp/package.yml
+++ b/packages/t/tlp/package.yml
@@ -1,8 +1,8 @@
 name       : tlp
-version    : 1.6.1
-release    : 20
+version    : 1.7.0
+release    : 21
 source     :
-    - https://github.com/linrunner/TLP/archive/refs/tags/1.6.1.tar.gz : f7d013691a92ffcf42ef1648565dbc24a33202046d3c8138dad1963a3169a0f5
+    - https://github.com/linrunner/TLP/archive/refs/tags/1.7.0.tar.gz : 547ff90bef0ea035f0ff6d7546d0d867690ebf60beec426885a884ee8d023e2e
 homepage   : https://linrunner.de/tlp/
 license    : GPL-2.0-only
 component  : system.utils
@@ -36,5 +36,5 @@ install    : |
     install -Ddm 00755 $installdir/%libdir%/systemd/system/multi-user.target.wants
     ln -sv ../tlp.service $installdir/%libdir%/systemd/system/multi-user.target.wants
 
-    mv $installdir/lib/systemd/system-sleep $installdir/usr/lib64/systemd
-    rm -rf $installdir/lib
+    mv $installdir/usr/lib/systemd/system-sleep $installdir/usr/lib64/systemd
+    rm -rf $installdir/usr/lib

--- a/packages/t/tlp/pspec_x86_64.xml
+++ b/packages/t/tlp/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>tlp</Name>
         <Homepage>https://linrunner.de/tlp/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>system.utils</PartOf>
@@ -37,7 +37,6 @@
             <Path fileType="executable">/usr/bin/tlp-stat</Path>
             <Path fileType="executable">/usr/bin/wifi</Path>
             <Path fileType="executable">/usr/bin/wwan</Path>
-            <Path fileType="library">/usr/lib/NetworkManager/dispatcher.d/99tlp-rdw-nm</Path>
             <Path fileType="library">/usr/lib64/systemd/system-sleep/tlp</Path>
             <Path fileType="library">/usr/lib64/systemd/system/multi-user.target.wants/tlp.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/tlp.service</Path>
@@ -48,11 +47,22 @@
             <Path fileType="executable">/usr/sbin/tlp</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/bluetooth</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/nfc</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/run-on-ac</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/run-on-bat</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/tlp</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/tlp-rdw</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/tlp-stat</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/wifi</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/wwan</Path>
+            <Path fileType="data">/usr/share/fish/vendor_completions.d/bluetooth.fish</Path>
+            <Path fileType="data">/usr/share/fish/vendor_completions.d/nfc.fish</Path>
+            <Path fileType="data">/usr/share/fish/vendor_completions.d/run-on-ac.fish</Path>
+            <Path fileType="data">/usr/share/fish/vendor_completions.d/run-on-bat.fish</Path>
+            <Path fileType="data">/usr/share/fish/vendor_completions.d/tlp-rdw.fish</Path>
+            <Path fileType="data">/usr/share/fish/vendor_completions.d/tlp-stat.fish</Path>
+            <Path fileType="data">/usr/share/fish/vendor_completions.d/tlp.fish</Path>
+            <Path fileType="data">/usr/share/fish/vendor_completions.d/wifi.fish</Path>
+            <Path fileType="data">/usr/share/fish/vendor_completions.d/wwan.fish</Path>
             <Path fileType="man">/usr/share/man/man1/bluetooth.1</Path>
             <Path fileType="man">/usr/share/man/man1/nfc.1</Path>
             <Path fileType="man">/usr/share/man/man1/run-on-ac.1</Path>
@@ -66,15 +76,17 @@
             <Path fileType="data">/usr/share/metainfo/de.linrunner.tlp.metainfo.xml</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/05-thinkpad</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/10-thinkpad-legacy</Path>
-            <Path fileType="data">/usr/share/tlp/bat.d/15-asus</Path>
+            <Path fileType="data">/usr/share/tlp/bat.d/15-lenovo</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/20-huawei</Path>
-            <Path fileType="data">/usr/share/tlp/bat.d/25-lenovo</Path>
+            <Path fileType="data">/usr/share/tlp/bat.d/25-msi</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/30-samsung</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/35-lg</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/36-lg-legacy</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/40-sony</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/45-system76</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/50-toshiba</Path>
+            <Path fileType="data">/usr/share/tlp/bat.d/60-macbook</Path>
+            <Path fileType="data">/usr/share/tlp/bat.d/89-asus</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/90-generic</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/TEMPLATE</Path>
             <Path fileType="data">/usr/share/tlp/defaults.conf</Path>
@@ -94,7 +106,6 @@
             <Path fileType="data">/usr/share/tlp/tlp-pcilist</Path>
             <Path fileType="data">/usr/share/tlp/tlp-readconfs</Path>
             <Path fileType="data">/usr/share/tlp/tlp-usblist</Path>
-            <Path fileType="data">/usr/share/tlp/tpacpi-bat</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_tlp</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_tlp-radio-device</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_tlp-rdw</Path>
@@ -103,12 +114,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2024-04-01</Date>
-            <Version>1.6.1</Version>
+        <Update release="21">
+            <Date>2024-12-09</Date>
+            <Version>1.7.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Add charge threshold support for Apple Silicon Macbooks (M*), MSI laptops
- Improve support for LG Gram laptops, ThinkPads with coreboot
- Laptop screen power saving with adaptive backlight modulation (ABM) for AMD Vega or newer GPUs
- Highlight (colorize) error, warning, notice and success messages
- Add option --version to all TLP commands
- Add Fish shell command completion
- Avoid error popups from NetworkManager when switching wifi/wwan

Resolves https://github.com/getsolus/packages/issues/4539

**Test Plan**

- enable tlp, look at `tlp-stat`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
