### PR TITLE
sysstat: Update to v12.7.6

### DIFF
--- a/packages/s/sysstat/abi_used_symbols
+++ b/packages/s/sysstat/abi_used_symbols
@@ -76,6 +76,7 @@ libc.so.6:scandir
 libc.so.6:setbuf
 libc.so.6:setlocale
 libc.so.6:sigaction
+libc.so.6:snprintf
 libc.so.6:stat
 libc.so.6:statvfs
 libc.so.6:stderr
@@ -104,6 +105,7 @@ libc.so.6:time
 libc.so.6:tzname
 libc.so.6:tzset
 libc.so.6:uname
+libc.so.6:wait
 libc.so.6:write
 libsensors.so.5:sensors_cleanup
 libsensors.so.5:sensors_get_all_subfeatures

--- a/packages/s/sysstat/monitoring.yml
+++ b/packages/s/sysstat/monitoring.yml
@@ -1,0 +1,9 @@
+releases:
+  id: 4931
+  rss: https://github.com/sysstat/sysstat/tags.atom
+security:
+  cpe:
+    - vendor: redhat
+      product: sysstat
+    - vendor: sysstat_project
+      product: sysstat

--- a/packages/s/sysstat/package.yml
+++ b/packages/s/sysstat/package.yml
@@ -1,9 +1,9 @@
 name       : sysstat
-version    : 12.6.1
-release    : 21
+version    : 12.7.6
+release    : 22
 source     :
-    - https://github.com/sysstat/sysstat/archive/v12.6.1.tar.gz : e50a3ebe03296ad87bc76e4f9d0e3c264ba2d4bb6c5c0a96dcbb5655a444e190
-homepage   : http://sebastien.godard.pagesperso-orange.fr/
+    - https://github.com/sysstat/sysstat/archive/refs/tags/v12.7.6.tar.gz : dc77a08871f8e8813448ea31048833d4acbab7276dd9a456cd2526c008bd5301
+homepage   : https://sysstat.github.io/
 license    : GPL-2.0-or-later
 component  : system.utils
 summary    : System performance tools for the Linux operating system

--- a/packages/s/sysstat/pspec_x86_64.xml
+++ b/packages/s/sysstat/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>sysstat</Name>
-        <Homepage>http://sebastien.godard.pagesperso-orange.fr/</Homepage>
+        <Homepage>https://sysstat.github.io/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -19,7 +19,7 @@ The mpstat command reports global and per-processor statistics.
 The pidstat command reports statistics for Linux tasks (processes).
 The cifsiostat command reports I/O statistics for CIFS file systems.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>sysstat</Name>
@@ -51,13 +51,16 @@ The cifsiostat command reports I/O statistics for CIFS file systems.
             <Path fileType="library">/usr/lib64/sa/sadc</Path>
             <Path fileType="library">/usr/lib64/systemd/system/sysstat-collect.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/sysstat-collect.timer</Path>
+            <Path fileType="library">/usr/lib64/systemd/system/sysstat-rotate.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/system/sysstat-rotate.timer</Path>
             <Path fileType="library">/usr/lib64/systemd/system/sysstat-summary.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/sysstat-summary.timer</Path>
             <Path fileType="library">/usr/lib64/systemd/system/sysstat.service</Path>
             <Path fileType="library">/usr/lib64/tmpfiles.d/sysstat.conf</Path>
             <Path fileType="data">/usr/share/defaults/etc/profile.d/60-colorsysstat.sh</Path>
-            <Path fileType="doc">/usr/share/doc/sysstat-12.6.1/sysstat-12.6.1.lsm</Path>
+            <Path fileType="doc">/usr/share/doc/sysstat-12.7.6</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/sysstat.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/be/LC_MESSAGES/sysstat.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/sysstat.mo</Path>
             <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/sysstat.mo</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/sysstat.mo</Path>
@@ -73,6 +76,7 @@ The cifsiostat command reports I/O statistics for CIFS file systems.
             <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/sysstat.mo</Path>
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/sysstat.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/sysstat.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/sysstat.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ko/LC_MESSAGES/sysstat.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ky/LC_MESSAGES/sysstat.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lv/LC_MESSAGES/sysstat.mo</Path>
@@ -107,12 +111,12 @@ The cifsiostat command reports I/O statistics for CIFS file systems.
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2022-12-09</Date>
-            <Version>12.6.1</Version>
+        <Update release="22">
+            <Date>2024-12-09</Date>
+            <Version>12.7.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Too many changes from 12.6.1 to 12.7.6 to list here
- Refer to full changelog [here](https://github.com/sysstat/sysstat/blob/master/CHANGES)

**Security**

- CVE-2023-33204

**Test Plan**

- Try a few commands `sar` `iostat`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
