### PR TITLE
vkd3d: Update to v1.14

### DIFF
--- a/packages/v/vkd3d/abi_symbols
+++ b/packages/v/vkd3d/abi_symbols
@@ -31,6 +31,7 @@ libvkd3d-utils.so.1:D3D12SerializeRootSignature
 libvkd3d-utils.so.1:D3D12SerializeVersionedRootSignature
 libvkd3d-utils.so.1:D3DCompile
 libvkd3d-utils.so.1:D3DCompile2
+libvkd3d-utils.so.1:D3DCompile2VKD3D
 libvkd3d-utils.so.1:D3DCreateBlob
 libvkd3d-utils.so.1:D3DDisassemble
 libvkd3d-utils.so.1:D3DGetBlobPart

--- a/packages/v/vkd3d/abi_symbols32
+++ b/packages/v/vkd3d/abi_symbols32
@@ -31,6 +31,7 @@ libvkd3d-utils.so.1:D3D12SerializeRootSignature
 libvkd3d-utils.so.1:D3D12SerializeVersionedRootSignature
 libvkd3d-utils.so.1:D3DCompile
 libvkd3d-utils.so.1:D3DCompile2
+libvkd3d-utils.so.1:D3DCompile2VKD3D
 libvkd3d-utils.so.1:D3DCreateBlob
 libvkd3d-utils.so.1:D3DDisassemble
 libvkd3d-utils.so.1:D3DGetBlobPart

--- a/packages/v/vkd3d/abi_used_libs
+++ b/packages/v/vkd3d/abi_used_libs
@@ -1,2 +1,3 @@
 libc.so.6
 libm.so.6
+libncursesw.so.6

--- a/packages/v/vkd3d/abi_used_symbols
+++ b/packages/v/vkd3d/abi_used_symbols
@@ -1,4 +1,3 @@
-libc.so.6:__assert_fail
 libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
@@ -15,7 +14,6 @@ libc.so.6:__stack_chk_fail
 libc.so.6:__strcat_chk
 libc.so.6:__vfprintf_chk
 libc.so.6:__vsnprintf_chk
-libc.so.6:abort
 libc.so.6:calloc
 libc.so.6:clearerr
 libc.so.6:dlclose
@@ -88,3 +86,7 @@ libm.so.6:log2f
 libm.so.6:modff
 libm.so.6:sqrt
 libm.so.6:sqrtf
+libncursesw.so.6:cur_term
+libncursesw.so.6:del_curterm
+libncursesw.so.6:setupterm
+libncursesw.so.6:tigetstr

--- a/packages/v/vkd3d/abi_used_symbols32
+++ b/packages/v/vkd3d/abi_used_symbols32
@@ -1,4 +1,3 @@
-libc.so.6:__assert_fail
 libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
@@ -13,7 +12,6 @@ libc.so.6:__stack_chk_fail
 libc.so.6:__strcat_chk
 libc.so.6:__vfprintf_chk
 libc.so.6:__vsnprintf_chk
-libc.so.6:abort
 libc.so.6:calloc
 libc.so.6:clearerr
 libc.so.6:dlclose

--- a/packages/v/vkd3d/monitoring.yml
+++ b/packages/v/vkd3d/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 230555
+  rss: https://gitlab.winehq.org/wine/vkd3d/-/tags?format=atom
+# No known CPE, checked 2024-12-09
+security:
+  cpe: ~

--- a/packages/v/vkd3d/package.yml
+++ b/packages/v/vkd3d/package.yml
@@ -1,8 +1,8 @@
 name       : vkd3d
-version    : '1.11'
-release    : 10
+version    : '1.14'
+release    : 11
 source     :
-    - https://gitlab.winehq.org/wine/vkd3d/-/releases/vkd3d-1.11/downloads/vkd3d-1.11.tar.xz : 4912271f1be49ab1ca9b59fc4faa9c4de8a873b4cebe11e7f422d61ae13e7410
+    - https://dl.winehq.org/vkd3d/source/vkd3d-1.14.tar.xz : c94015d59ebe8ae72c4d802af5ca1517d9744548842a4e776534612a8d905485
 homepage   : https://gitlab.winehq.org/wine/vkd3d
 license    : LGPL-2.1-or-later
 component  : programming.library
@@ -11,10 +11,10 @@ description: |
     Vkd3d is a 3D graphics library built on top of Vulkan. It has an API very similar, but not identical, to Direct3D 12.
 emul32     : yes
 builddeps  :
+    - pkgconfig32(ncursesw)
     - pkgconfig32(vulkan)
     - pkgconfig32(x11)
     - pkgconfig32(xcb)
-    - pkgconfig32(xcb-icccm)
     - pkgconfig32(xcb-keysyms)
     - pkgconfig32(xcb-util)
     - spirv-headers

--- a/packages/v/vkd3d/pspec_x86_64.xml
+++ b/packages/v/vkd3d/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>vkd3d</Name>
         <Homepage>https://gitlab.winehq.org/wine/vkd3d</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>programming.library</PartOf>
@@ -23,11 +23,11 @@
             <Path fileType="executable">/usr/bin/vkd3d-compiler</Path>
             <Path fileType="executable">/usr/bin/vkd3d-dxbc</Path>
             <Path fileType="library">/usr/lib64/libvkd3d-shader.so.1</Path>
-            <Path fileType="library">/usr/lib64/libvkd3d-shader.so.1.9.0</Path>
+            <Path fileType="library">/usr/lib64/libvkd3d-shader.so.1.12.0</Path>
             <Path fileType="library">/usr/lib64/libvkd3d-utils.so.1</Path>
-            <Path fileType="library">/usr/lib64/libvkd3d-utils.so.1.5.0</Path>
+            <Path fileType="library">/usr/lib64/libvkd3d-utils.so.1.6.0</Path>
             <Path fileType="library">/usr/lib64/libvkd3d.so.1</Path>
-            <Path fileType="library">/usr/lib64/libvkd3d.so.1.11.0</Path>
+            <Path fileType="library">/usr/lib64/libvkd3d.so.1.14.0</Path>
         </Files>
     </Package>
     <Package>
@@ -37,15 +37,15 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">vkd3d</Dependency>
+            <Dependency release="11">vkd3d</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libvkd3d-shader.so.1</Path>
-            <Path fileType="library">/usr/lib32/libvkd3d-shader.so.1.9.0</Path>
+            <Path fileType="library">/usr/lib32/libvkd3d-shader.so.1.12.0</Path>
             <Path fileType="library">/usr/lib32/libvkd3d-utils.so.1</Path>
-            <Path fileType="library">/usr/lib32/libvkd3d-utils.so.1.5.0</Path>
+            <Path fileType="library">/usr/lib32/libvkd3d-utils.so.1.6.0</Path>
             <Path fileType="library">/usr/lib32/libvkd3d.so.1</Path>
-            <Path fileType="library">/usr/lib32/libvkd3d.so.1.11.0</Path>
+            <Path fileType="library">/usr/lib32/libvkd3d.so.1.14.0</Path>
         </Files>
     </Package>
     <Package>
@@ -55,8 +55,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">vkd3d-devel</Dependency>
-            <Dependency release="10">vkd3d-32bit</Dependency>
+            <Dependency release="11">vkd3d-32bit</Dependency>
+            <Dependency release="11">vkd3d-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libvkd3d-shader.so</Path>
@@ -74,7 +74,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">vkd3d</Dependency>
+            <Dependency release="11">vkd3d</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/vkd3d/vkd3d.h</Path>
@@ -101,12 +101,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2024-07-24</Date>
-            <Version>1.11</Version>
+        <Update release="11">
+            <Date>2024-12-09</Date>
+            <Version>1.14</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- [1.14](https://gitlab.winehq.org/wine/vkd3d/-/releases/vkd3d-1.14)
- [1.13](https://gitlab.winehq.org/wine/vkd3d/-/releases/vkd3d-1.13)
- [1.12](https://gitlab.winehq.org/wine/vkd3d/-/releases/vkd3d-1.12)

Part of https://github.com/getsolus/packages/issues/4143

**Test Plan**

- Rebuilt wine without issue

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
