### PR TITLE
lenovo-legion-linux: Add at v0.0.18

### DIFF
--- a/packages/l/lenovo-legion-linux/MAINTAINERS.md
+++ b/packages/l/lenovo-legion-linux/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Gavin Zhao
+  - Email: me@gzgz.dev
+  - Matrix: @gzgavinzhao:matrix.org

--- a/packages/l/lenovo-legion-linux/package.yml
+++ b/packages/l/lenovo-legion-linux/package.yml
@@ -1,0 +1,76 @@
+name       : lenovo-legion-linux
+version    : 0.0.19
+release    : 1
+source     :
+    - https://github.com/johnfanv2/LenovoLegionLinux/archive/refs/tags/v0.0.19.tar.gz : 6bc6c00d5edcc18e347397b65527480e857f365dac5eafa365a4431ae7da2d4f
+homepage   : https://github.com/johnfanv2/LenovoLegionLinux
+license    : GPL-2.0-or-later
+component  :
+    - kernel.drivers
+    - current : kernel.drivers
+summary    :
+    - Driver and tools for controlling Lenovo Legion laptops
+    - current : lenovo-legion-linux kernel modules for the linux-current kernel
+    - lts : lenovo-legion-linux kernel modules for the linux-lts kernel
+description: |
+    Lenovo Legion Linux (LLL) brings additional drivers and tools for Lenovo Legion series laptops to Linux. It allows you to control features like the fan curve, power mode, power limits, rapid charging, and more.
+builddeps  :
+    - pkgconfig(inih)
+    - linux-current
+    - linux-current-headers
+    - linux-lts
+    - linux-lts-headers
+    - python-build
+    - python-installer
+    - python-wheel
+patterns   :
+    - current :
+        - /lib64/modules/*.current/**
+        - /usr/lib64/modules/*.current/**
+    - lts :
+        - /lib64/modules/*.lts/**
+        - /usr/lib64/modules/*.lts/**
+permanent  :
+    - /lib64/modules
+    - /usr/lib64/modules
+rundeps    :
+    - current :
+        - lenovo-legion-linux
+    - lts :
+        - lenovo-legion-linux
+    - python-qt6
+    - pyyaml
+setup      : |
+    sed -i 's|version = _VERSION|verison = %version%|' python/legion_linux/setup.cfg
+
+    # Prep build dirs for each kernel version
+    pushd ../
+    for KVER in %kernel_version_lts% %kernel_version_current%
+    do
+        cp -ra "LenovoLegionLinux-%version%" ${KVER}-build
+    done
+    popd
+build      : |
+    for KVER in %kernel_version_lts% %kernel_version_current%
+    do
+    pushd ${KVER}-build
+
+    %make -C kernel_module KERNELVERSION=$KVER KSRC=%libdir%/modules/$KVER/build
+
+    popd
+    done
+install    : |
+    for KVER in %kernel_version_lts% %kernel_version_current%
+    do
+    pushd ${KVER}-build
+
+    install -Dm00644 kernel_module/legion-laptop.ko -t $installdir/%libdir%/modules/$KVER/kernel/drivers/platform/x86/
+
+    popd
+    done
+
+    pushd LenovoLegionLinux-*/python/legion_linux
+        %python3_install
+    popd
+
+    find "$installdir" -name '*.ko' -exec strip --strip-debug {} \; -exec zstd {} \; -exec rm -v {} \;

--- a/packages/l/lenovo-legion-linux/pspec_x86_64.xml
+++ b/packages/l/lenovo-legion-linux/pspec_x86_64.xml
@@ -1,0 +1,93 @@
+<PISI>
+    <Source>
+        <Name>lenovo-legion-linux</Name>
+        <Homepage>https://github.com/johnfanv2/LenovoLegionLinux</Homepage>
+        <Packager>
+            <Name>Gavin Zhao</Name>
+            <Email>me@gzgz.dev</Email>
+        </Packager>
+        <License>GPL-2.0-or-later</License>
+        <PartOf>kernel.drivers</PartOf>
+        <Summary xml:lang="en">Driver and tools for controlling Lenovo Legion laptops</Summary>
+        <Description xml:lang="en">Lenovo Legion Linux (LLL) brings additional drivers and tools for Lenovo Legion series laptops to Linux. It allows you to control features like the fan curve, power mode, power limits, rapid charging, and more.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>lenovo-legion-linux</Name>
+        <Summary xml:lang="en">Driver and tools for controlling Lenovo Legion laptops</Summary>
+        <Description xml:lang="en">Lenovo Legion Linux (LLL) brings additional drivers and tools for Lenovo Legion series laptops to Linux. It allows you to control features like the fan curve, power mode, power limits, rapid charging, and more.
+</Description>
+        <PartOf>kernel.drivers</PartOf>
+        <Files>
+            <Path fileType="executable">/usr/bin/legion_cli</Path>
+            <Path fileType="executable">/usr/bin/legion_gui</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/legion_linux-0.0.0-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/legion_linux-0.0.0-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/legion_linux-0.0.0-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/legion_linux-0.0.0-py3.11.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/legion_linux-0.0.0-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/legion_linux-0.0.0-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/legion_linux/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/legion_linux/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/legion_linux/__pycache__/legion.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/legion_linux/__pycache__/legion_cli.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/legion_linux/__pycache__/legion_gui.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/legion_linux/legion.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/legion_linux/legion_cli.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/legion_linux/legion_gui.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/legion_linux/legion_logo.png</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/legion_linux/legion_logo_dark.png</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/legion_linux/legion_logo_light.png</Path>
+            <Path fileType="data">/usr/share/applications/legion_gui.desktop</Path>
+            <Path fileType="data">/usr/share/legion_linux/balanced-ac.yaml</Path>
+            <Path fileType="data">/usr/share/legion_linux/balanced-battery.yaml</Path>
+            <Path fileType="data">/usr/share/legion_linux/balanced-performance-ac.yaml</Path>
+            <Path fileType="data">/usr/share/legion_linux/balanced-performance-battery.yaml</Path>
+            <Path fileType="data">/usr/share/legion_linux/legiond.ini</Path>
+            <Path fileType="data">/usr/share/legion_linux/performance-ac.yaml</Path>
+            <Path fileType="data">/usr/share/legion_linux/performance-battery.yaml</Path>
+            <Path fileType="data">/usr/share/legion_linux/quiet-ac.yaml</Path>
+            <Path fileType="data">/usr/share/legion_linux/quiet-battery.yaml</Path>
+            <Path fileType="data">/usr/share/pixmaps/legion_logo.png</Path>
+            <Path fileType="data">/usr/share/pixmaps/legion_logo_dark.png</Path>
+            <Path fileType="data">/usr/share/pixmaps/legion_logo_light.png</Path>
+            <Path fileType="data">/usr/share/polkit-1/actions/legion_cli.policy</Path>
+            <Path fileType="data">/usr/share/polkit-1/actions/legion_gui.policy</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>lenovo-legion-linux-current</Name>
+        <Summary xml:lang="en">lenovo-legion-linux kernel modules for the linux-current kernel</Summary>
+        <Description xml:lang="en">Lenovo Legion Linux (LLL) brings additional drivers and tools for Lenovo Legion series laptops to Linux. It allows you to control features like the fan curve, power mode, power limits, rapid charging, and more.
+</Description>
+        <PartOf>kernel.drivers</PartOf>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="1">lenovo-legion-linux</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="library">/usr/lib64/modules/6.11.10-310.current/kernel/drivers/platform/x86/legion-laptop.ko.zst</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>lenovo-legion-linux-lts</Name>
+        <Summary xml:lang="en">lenovo-legion-linux kernel modules for the linux-lts kernel</Summary>
+        <Description xml:lang="en">Lenovo Legion Linux (LLL) brings additional drivers and tools for Lenovo Legion series laptops to Linux. It allows you to control features like the fan curve, power mode, power limits, rapid charging, and more.
+</Description>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="1">lenovo-legion-linux</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="library">/usr/lib64/modules/6.6.63-261.lts/kernel/drivers/platform/x86/legion-laptop.ko.zst</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2024-12-17</Date>
+            <Version>0.0.19</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Gavin Zhao</Name>
+            <Email>me@gzgz.dev</Email>
+        </Update>
+    </History>
+</PISI>

--- a/packages/l/linux-current/REBUILDS.md
+++ b/packages/l/linux-current/REBUILDS.md
@@ -2,6 +2,7 @@ This is a list of things to rebuild after this, in the right order:
 
 * bbswitch
 * broadcom-sta
+* lenovo-legion-linux
 * nvidia-470-glx-driver
 * nvidia-glx-driver
 * nvidia-beta-driver

--- a/packages/l/linux-current/autopush.yml
+++ b/packages/l/linux-current/autopush.yml
@@ -9,6 +9,7 @@ tiers:
   dirs:
   - bbswitch
   - broadcom-sta
+  - lenovo-legion-linux
   - nvidia-470-glx-driver
   - nvidia-beta-driver
   - nvidia-developer-driver

--- a/packages/l/linux-lts/autopush.yml
+++ b/packages/l/linux-lts/autopush.yml
@@ -9,6 +9,7 @@ tiers:
   dirs:
   - bbswitch
   - broadcom-sta
+  - lenovo-legion-linux
   - nvidia-390-glx-driver
   - nvidia-470-glx-driver
   - nvidia-beta-driver


### PR DESCRIPTION
Fixes #2590.

**Summary**

Added `lenovo-legion-linux`, providing drivers and tools to control hardware features for Lenovo Legion laptops such as power profile modes, fan speed, battery conservation/quick charge mode, and more.

**Test Plan**

Ran both the CLI and GUI. Verified switching power mode in Power Profiles Daemon works.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
