### PR TITLE
egl-wayland: Update to v1.1.17

### DIFF
--- a/packages/e/egl-wayland/package.yml
+++ b/packages/e/egl-wayland/package.yml
@@ -1,8 +1,8 @@
 name       : egl-wayland
-version    : 1.1.16
-release    : 26
+version    : 1.1.17
+release    : 27
 source     :
-    - git|https://github.com/NVIDIA/egl-wayland.git : 0cd471dcfd46e6cb8b71eceddb20cc02eadabf61
+    - https://github.com/NVIDIA/egl-wayland/archive/refs/tags/1.1.17.tar.gz : 974351af2057a385e98f4a0d4a40adab4480b77f4b65449d1bd6137c758c25b7
 homepage   : https://github.com/NVIDIA/egl-wayland
 license    : MIT
 component  : programming.library

--- a/packages/e/egl-wayland/pspec_x86_64.xml
+++ b/packages/e/egl-wayland/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>egl-wayland</Name>
         <Homepage>https://github.com/NVIDIA/egl-wayland</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.library</PartOf>
@@ -32,7 +32,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="26">egl-wayland</Dependency>
+            <Dependency release="27">egl-wayland</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnvidia-egl-wayland.so.1</Path>
@@ -46,8 +46,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="26">egl-wayland-devel</Dependency>
-            <Dependency release="26">egl-wayland-32bit</Dependency>
+            <Dependency release="27">egl-wayland-32bit</Dependency>
+            <Dependency release="27">egl-wayland-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnvidia-egl-wayland.so</Path>
@@ -61,7 +61,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="26">egl-wayland</Dependency>
+            <Dependency release="27">egl-wayland</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libnvidia-egl-wayland.so</Path>
@@ -73,12 +73,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2024-10-22</Date>
-            <Version>1.1.16</Version>
+        <Update release="27">
+            <Date>2024-12-10</Date>
+            <Version>1.1.17</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Fixed issue causing spurious crashes in KDE
- Return EGL_BAD_ALLOC when multiple EGLSurfaces are created from one wl_surface

Full release notes available [here](https://github.com/NVIDIA/egl-wayland/releases/tag/1.1.17)

The remaining changes had already been patched in our package

**Test Plan**
- Logged into a GNOME Wayland session
- Ran `xeglgears`, `glxgears`, `vkcube`
- Launched a game from Steam

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
