### PR TITLE
scrcpy: Update to v3.1

### DIFF
--- a/packages/s/scrcpy/package.yml
+++ b/packages/s/scrcpy/package.yml
@@ -1,9 +1,9 @@
 name       : scrcpy
-version    : 3.0.2
-release    : 31
+version    : '3.1'
+release    : 32
 source     :
-    - https://github.com/Genymobile/scrcpy/archive/v3.0.2.tar.gz : 5ab92d091f308679fe81851666acec1b161e6810ac73eb9bade705ade285e109
-    - https://github.com/Genymobile/scrcpy/releases/download/v3.0.2/scrcpy-server-v3.0.2 : e19fe024bfa3367809494407ad6ca809a6f6e77dac95e99f85ba75144e0ba35d
+    - https://github.com/Genymobile/scrcpy/archive/v3.1.tar.gz : beaa5050a3c45faa77cedc70ad13d88ef26b74d29d52f512b7708671e037d24d
+    - https://github.com/Genymobile/scrcpy/releases/download/v3.1/scrcpy-server-v3.1 : 958f0944a62f23b1f33a16e9eb14844c1a04b882ca175a738c16d23cb22b86c0
 homepage   : https://github.com/Genymobile/scrcpy
 license    : Apache-2.0
 component  : network.util

--- a/packages/s/scrcpy/pspec_x86_64.xml
+++ b/packages/s/scrcpy/pspec_x86_64.xml
@@ -31,9 +31,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2024-12-05</Date>
-            <Version>3.0.2</Version>
+        <Update release="32">
+            <Date>2024-12-10</Date>
+            <Version>3.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Highlighted changes:
- Keep virtual display content on close
- Improved gamepad support
- Fix unclickable elements
- Fix "turn screen off" on some devices
- AV1 decoder

Full release notes available [here](https://github.com/Genymobile/scrcpy/releases/tag/v3.1)

**Test Plan**

Mirrored my phone's display and controlled it with mouse and keyboard

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
