### PR TITLE
CI/config: Add ispc, ldc and llvm-bolt to allowlist

### DIFF
--- a/common/CI/config.yaml
+++ b/common/CI/config.yaml
@@ -13,10 +13,13 @@ static_libs:
     - ghc
     - glibc
     - golang
+    - ispc
+    - ldc
     - libboost
     - libnss
     - llvm
     - llvm-15
+    - llvm-bolt
     - ocaml
     - qt5-tools
     - qt6-base


### PR DESCRIPTION
**Summary**

Add ispc, ldc and llvm-bolt to the list of packages allowed to contain static libs.

**Test Plan**

N/A

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
