### PR TITLE
github-cli: Update to v2.63.2

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.63.1
-release    : 62
+version    : 2.63.2
+release    : 63
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.63.1.tar.gz : b9a90118dfb46204dbcc0d09c2073d48f35b6f640b4db33fbaa24892fed56c8d
+    - https://github.com/cli/cli/archive/refs/tags/v2.63.2.tar.gz : 2578a8b1f00cb292a8094793515743f2a86e02b8d0b18d6b95959ddbeebd6b8d
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>github-cli</Name>
         <Homepage>https://cli.github.com</Homepage>
         <Packager>
-            <Name>Hans K</Name>
-            <Email>hans@communitycomputing.net</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -225,12 +225,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="62">
-            <Date>2024-12-04</Date>
-            <Version>2.63.1</Version>
+        <Update release="63">
+            <Date>2024-12-12</Date>
+            <Version>2.63.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Hans K</Name>
-            <Email>hans@communitycomputing.net</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Use consistent slice ordering in run download tests
- Fix bug when fetching bundles from OCI registry
- Use safepaths for run download
- Error for mutually exclusive json and watch flags

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
