### PR TITLE
audacity: Update to 3.7.1

### DIFF
--- a/packages/a/audacity/abi_symbols
+++ b/packages/a/audacity/abi_symbols
@@ -16126,7 +16126,6 @@ lib-wave-track.so:_ZN18WaveTrackUtilities16AllClipsIterator4PushESt6vectorISt10s
 lib-wave-track.so:_ZN18WaveTrackUtilities16AllClipsIteratorC1ER9WaveTrack
 lib-wave-track.so:_ZN18WaveTrackUtilities16AllClipsIteratorC2ER9WaveTrack
 lib-wave-track.so:_ZN18WaveTrackUtilities16AllClipsIteratorppEv
-lib-wave-track.so:_ZN18WaveTrackUtilities20GetClipsIntersectingERK9WaveTrackdd
 lib-wave-track.so:_ZN18WaveTrackUtilities21ExpandClipTillNextOneERK9WaveTrackR8WaveClip
 lib-wave-track.so:_ZN18WaveTrackUtilities23GetSequenceSamplesCountERK9WaveTrack
 lib-wave-track.so:_ZN18WaveTrackUtilities7ReverseER9WaveTrack11sampleCountS2_RKSt8functionIFbdEE
@@ -16514,6 +16513,7 @@ lib-wave-track.so:_ZNK9WaveTrack21GetVisibleSampleCountEv
 lib-wave-track.so:_ZNK9WaveTrack21WidestEffectiveFormatEv
 lib-wave-track.so:_ZNK9WaveTrack22FormatConsistencyCheckEv
 lib-wave-track.so:_ZNK9WaveTrack23DuplicateWithOtherTempoEd
+lib-wave-track.so:_ZNK9WaveTrack26GetSortedClipsIntersectingEdd
 lib-wave-track.so:_ZNK9WaveTrack4CopyEddb
 lib-wave-track.so:_ZNK9WaveTrack5CloneEb
 lib-wave-track.so:_ZNK9WaveTrack5DoGetEmmPKPc12sampleFormat11sampleCountmb10FillFormatbPS4_

--- a/packages/a/audacity/package.yml
+++ b/packages/a/audacity/package.yml
@@ -1,8 +1,8 @@
 name       : audacity
-version    : 3.7.0
-release    : 40
+version    : 3.7.1
+release    : 41
 source     :
-    - https://github.com/audacity/audacity/releases/download/Audacity-3.7.0/audacity-sources-3.7.0.tar.gz : fefe75f375a7e63c436eefe7258e0817bb17abf433252df7fa2667813031eb70
+    - https://github.com/audacity/audacity/releases/download/Audacity-3.7.1/audacity-sources-3.7.1.tar.gz : 5f89397a60dee54e5a6b05c9947ebce6e1566815050b01c534c52d44353ceb80
 homepage   : https://www.audacityteam.org/
 license    :
     - CC-BY-SA-3.0

--- a/packages/a/audacity/pspec_x86_64.xml
+++ b/packages/a/audacity/pspec_x86_64.xml
@@ -256,9 +256,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="40">
-            <Date>2024-12-07</Date>
-            <Version>3.7.0</Version>
+        <Update release="41">
+            <Date>2024-12-12</Date>
+            <Version>3.7.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**

- Effects can be applied to time-stretched clips.
- Moving or renaming the installation directory no longer re-enables disabled modules.
- Opening the "Adjust Playback Speed" dialog doesn't crash Audacity anymore.

**Test Plan**
- Installed and checked settings.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
