### PR TITLE
[NFC] repo-wide: Add monitoring.yml to packages

### DIFF
--- a/packages/a/appstream-data/monitoring.yml
+++ b/packages/a/appstream-data/monitoring.yml
@@ -1,0 +1,7 @@
+# This package will never benefit from a monitoring.yml please do not attempt to edit any of the fields.
+# https://github.com/getsolus/packages/issues/4533
+releases:
+  id: ~
+  rss: ~
+security:
+  cpe: ~

--- a/packages/f/ffmpeg-chromium-opera/monitoring.yml
+++ b/packages/f/ffmpeg-chromium-opera/monitoring.yml
@@ -1,0 +1,7 @@
+# This package will never benefit from a monitoring.yml please do not attempt to edit any of the fields.
+# https://github.com/getsolus/packages/issues/4533
+releases:
+  id: ~
+  rss: ~
+security:
+  cpe: ~

--- a/packages/f/ffmpeg-chromium-vivaldi-stable/monitoring.yml
+++ b/packages/f/ffmpeg-chromium-vivaldi-stable/monitoring.yml
@@ -1,0 +1,7 @@
+# This package will never benefit from a monitoring.yml please do not attempt to edit any of the fields.
+# https://github.com/getsolus/packages/issues/4533
+releases:
+  id: ~
+  rss: ~
+security:
+  cpe: ~

--- a/packages/f/ffmpeg-chromium/monitoring.yml
+++ b/packages/f/ffmpeg-chromium/monitoring.yml
@@ -1,0 +1,7 @@
+# This package will never benefit from a monitoring.yml please do not attempt to edit any of the fields.
+# https://github.com/getsolus/packages/issues/4533
+releases:
+  id: ~
+  rss: ~
+security:
+  cpe: ~


### PR DESCRIPTION
**Summary**

Add monitoring.yml to
- appstream-data
- ffmpeg-chromium
- ffmpeg-chromium-opera
- ffmpeg-chromium-vivaldi-stable

Note these fields are intentionally blank see issue:
Resolves https://github.com/getsolus/packages/issues/4533

**Test Plan**

N/A

**Checklist**

N/A

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
