### PR TITLE
binutils: Update to latest and update configs

### DIFF
--- a/packages/b/binutils/abi_used_libs
+++ b/packages/b/binutils/abi_used_libs
@@ -1,7 +1,9 @@
 UNKNOWN
 ld-linux-x86-64.so.2
+libblake3.so.0
 libc.so.6
 libgcc_s.so.1
+libjansson.so.4
 libstdc++.so.6
 libz.so.1
 libzstd.so.1

--- a/packages/b/binutils/abi_used_symbols
+++ b/packages/b/binutils/abi_used_symbols
@@ -1,6 +1,9 @@
 UNKNOWN:_ZTVN10__cxxabiv117__class_type_infoE
 UNKNOWN:_ZTVN10__cxxabiv120__si_class_type_infoE
 ld-linux-x86-64.so.2:__tls_get_addr
+libblake3.so.0:blake3_hasher_finalize
+libblake3.so.0:blake3_hasher_init
+libblake3.so.0:blake3_hasher_update
 libc.so.6:__asprintf_chk
 libc.so.6:__assert_fail
 libc.so.6:__ctype_b_loc
@@ -288,6 +291,8 @@ libc.so.6:waitpid
 libc.so.6:write
 libgcc_s.so.1:_Unwind_Resume
 libgcc_s.so.1:__gcc_personality_v0
+libjansson.so.4:json_delete
+libjansson.so.4:json_loads
 libstdc++.so.6:_ZNKSt13runtime_error4whatEv
 libstdc++.so.6:_ZNKSt5ctypeIcE13_M_widen_initEv
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEcm

--- a/packages/b/binutils/files/0001-Proper-stateless.patch
+++ b/packages/b/binutils/files/0001-Proper-stateless.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Reilly Brogan <reilly@reillybrogan.com>
+Date: Fri, 13 Dec 2024 12:42:26 -0600
+Subject: [PATCH] Proper stateless
+
+---
+ gprofng/src/Settings.cc | 21 +++++++++++++++------
+ 1 file changed, 15 insertions(+), 6 deletions(-)
+
+diff --git a/gprofng/src/Settings.cc b/gprofng/src/Settings.cc
+index 6d1d357a17..d62c5fdacb 100644
+--- a/gprofng/src/Settings.cc
++++ b/gprofng/src/Settings.cc
+@@ -413,13 +413,22 @@ Settings::read_rc (bool ipc_or_rdt_mode)
+   rc_path = dbe_sprintf (NTXT ("%s/gprofng.rc"), sysconfdir);
+   if (access (rc_path, R_OK | F_OK) != 0)
+     {
+-      StringBuilder sb;
+-      sb.sprintf (GTXT ("Warning: Default gprofng.rc file (%s) missing; configuration error "), rc_path);
+-      Emsg *m = new Emsg (CMSG_COMMENT, sb);
+-      app->get_comments_queue ()->append (m);
++      free (rc_path);
++      // Read vendor file
++      const char *vendordir = getenv("GPROFNG_VENDORDIR");
++      if (vendordir == NULL)
++        vendordir = "/usr/share/defaults/gprofng";
++      rc_path = dbe_sprintf (NTXT ("%s/gprofng.rc"), vendordir);
++      if (access (rc_path, R_OK | F_OK) != 0)
++        {
++          StringBuilder sb;
++          sb.sprintf (GTXT ("Warning: Default gprofng.rc file (%s) missing; configuration error "), rc_path);
++          Emsg *m = new Emsg (CMSG_COMMENT, sb);
++          app->get_comments_queue ()->append (m);
++        }
++      else
++        set_rc (rc_path, false, app->get_comments_queue (), override);
+     }
+-  else
+-    set_rc (rc_path, false, app->get_comments_queue (), override);
+   free (rc_path);
+   is_loexpand_default = true;
+   if (str_printmode == NULL)

--- a/packages/b/binutils/files/0001-Use-BLAKE3-for-build-id-hashing.patch
+++ b/packages/b/binutils/files/0001-Use-BLAKE3-for-build-id-hashing.patch
@@ -1,0 +1,358 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Reilly Brogan <reilly@reillybrogan.com>
+Date: Sun, 15 Dec 2024 17:00:00 -0600
+Subject: [PATCH] Use BLAKE3 for build-id hashing
+
+---
+ ld/Makefile.am  |   6 +--
+ ld/Makefile.in  |   8 ++--
+ ld/config.in    |   3 ++
+ ld/configure    | 124 ++++++++++++++++++++++++++++++++++++++++++++++++
+ ld/configure.ac |  12 +++++
+ ld/ldbuildid.c  |  25 ++++++++++
+ 6 files changed, 172 insertions(+), 6 deletions(-)
+
+diff --git a/ld/Makefile.am b/ld/Makefile.am
+index 6a9833e577..7d3b7a4a11 100644
+--- a/ld/Makefile.am
++++ b/ld/Makefile.am
+@@ -45,7 +45,7 @@ ELF_CFLAGS=-DELF_LIST_OPTIONS=@elf_list_options@ \
+ 	   -DELF_PLT_UNWIND_LIST_OPTIONS=@elf_plt_unwind_list_options@
+ WARN_CFLAGS = @WARN_CFLAGS@
+ NO_WERROR = @NO_WERROR@
+-AM_CFLAGS = $(WARN_CFLAGS) $(ELF_CFLAGS) $(JANSSON_CFLAGS) $(ZSTD_CFLAGS)
++AM_CFLAGS = $(WARN_CFLAGS) $(ELF_CFLAGS) $(JANSSON_CFLAGS) $(ZSTD_CFLAGS) $(BLAKE3_CFLAGS)
+ 
+ # We put the scripts in the directory $(scriptdir)/ldscripts.
+ # We can't put the scripts in $(datadir) because the SEARCH_DIR
+@@ -660,7 +660,7 @@ ld_new_SOURCES = ldgram.y ldlex-wrapper.c lexsup.c ldlang.c mri.c ldctor.c ldmai
+ ld_new_DEPENDENCIES = $(EMULATION_OFILES) $(EMUL_EXTRA_OFILES) \
+ 		      $(BFDLIB) $(LIBCTF) $(LIBIBERTY) $(LIBINTL_DEP)
+ ld_new_LDADD = $(EMULATION_OFILES) $(EMUL_EXTRA_OFILES) $(BFDLIB) $(LIBCTF) \
+-	       $(LIBIBERTY) $(LIBINTL) $(ZLIB) $(ZSTD_LIBS) $(JANSSON_LIBS)
++	       $(LIBIBERTY) $(LIBINTL) $(ZLIB) $(ZSTD_LIBS) $(JANSSON_LIBS) $(BLAKE3_LIBS)
+ 
+ # Dependency tracking for the generated emulation files.
+ EXTRA_ld_new_SOURCES += $(ALL_EMULATION_SOURCES) $(ALL_64_EMULATION_SOURCES)
+@@ -687,7 +687,7 @@ check-DEJAGNU: site.exp
+ 		CXXFLAGS_FOR_TARGET="$(filter-out -ffile-prefix-map=%,$(CXXFLAGS_FOR_TARGET))" \
+ 		OFILES="$(OFILES)" BFDLIB="$(TESTBFDLIB)" CTFLIB="$(TESTCTFLIB) $(ZLIB)" \
+ 		SFRAMELIB="$(TESTSFRAMELIB)" \
+-		JANSSON_LIBS="$(JANSSON_LIBS)" ZSTD_LIBS="$(ZSTD_LIBS)" \
++		JANSSON_LIBS="$(JANSSON_LIBS)" ZSTD_LIBS="$(ZSTD_LIBS)" BLAKE3_LIBS="$(BLAKE3_LIBS)" \
+ 		LIBIBERTY="$(LIBIBERTY) $(LIBINTL)" LIBS="$(LIBS)" \
+ 		DO_COMPARE="`echo '$(do_compare)' | sed -e 's,\\$$,,g'`" \
+ 		$(RUNTESTFLAGS); \
+diff --git a/ld/Makefile.in b/ld/Makefile.in
+index 8639e782cd..652a4dd1ea 100644
+--- a/ld/Makefile.in
++++ b/ld/Makefile.in
+@@ -375,6 +375,8 @@ AUTOCONF = @AUTOCONF@
+ AUTOHEADER = @AUTOHEADER@
+ AUTOMAKE = @AUTOMAKE@
+ AWK = @AWK@
++BLAKE3_CFLAGS = @BLAKE3_CFLAGS@
++BLAKE3_LIBS = @BLAKE3_LIBS@
+ CATALOGS = @CATALOGS@
+ CATOBJEXT = @CATOBJEXT@
+ CC = @CC@
+@@ -578,7 +580,7 @@ ELF_CFLAGS = -DELF_LIST_OPTIONS=@elf_list_options@ \
+ 	   -DELF_SHLIB_LIST_OPTIONS=@elf_shlib_list_options@ \
+ 	   -DELF_PLT_UNWIND_LIST_OPTIONS=@elf_plt_unwind_list_options@
+ 
+-AM_CFLAGS = $(WARN_CFLAGS) $(ELF_CFLAGS) $(JANSSON_CFLAGS) $(ZSTD_CFLAGS)
++AM_CFLAGS = $(WARN_CFLAGS) $(ELF_CFLAGS) $(JANSSON_CFLAGS) $(ZSTD_CFLAGS) $(BLAKE3_CFLAGS)
+ 
+ # We put the scripts in the directory $(scriptdir)/ldscripts.
+ # We can't put the scripts in $(datadir) because the SEARCH_DIR
+@@ -1039,7 +1041,7 @@ ld_new_DEPENDENCIES = $(EMULATION_OFILES) $(EMUL_EXTRA_OFILES) \
+ 		      $(BFDLIB) $(LIBCTF) $(LIBIBERTY) $(LIBINTL_DEP)
+ 
+ ld_new_LDADD = $(EMULATION_OFILES) $(EMUL_EXTRA_OFILES) $(BFDLIB) $(LIBCTF) \
+-	       $(LIBIBERTY) $(LIBINTL) $(ZLIB) $(ZSTD_LIBS) $(JANSSON_LIBS)
++	       $(LIBIBERTY) $(LIBINTL) $(ZLIB) $(ZSTD_LIBS) $(JANSSON_LIBS) $(BLAKE3_LIBS)
+ 
+ #
+ #
+@@ -2399,7 +2401,7 @@ check-DEJAGNU: site.exp
+ 		CXXFLAGS_FOR_TARGET="$(filter-out -ffile-prefix-map=%,$(CXXFLAGS_FOR_TARGET))" \
+ 		OFILES="$(OFILES)" BFDLIB="$(TESTBFDLIB)" CTFLIB="$(TESTCTFLIB) $(ZLIB)" \
+ 		SFRAMELIB="$(TESTSFRAMELIB)" \
+-		JANSSON_LIBS="$(JANSSON_LIBS)" ZSTD_LIBS="$(ZSTD_LIBS)" \
++		JANSSON_LIBS="$(JANSSON_LIBS)" ZSTD_LIBS="$(ZSTD_LIBS)" BLAKE3_LIBS="$(BLAKE3_LIBS)" \
+ 		LIBIBERTY="$(LIBIBERTY) $(LIBINTL)" LIBS="$(LIBS)" \
+ 		DO_COMPARE="`echo '$(do_compare)' | sed -e 's,\\$$,,g'`" \
+ 		$(RUNTESTFLAGS); \
+diff --git a/ld/config.in b/ld/config.in
+index f7c9da3d02..c736f614a5 100644
+--- a/ld/config.in
++++ b/ld/config.in
+@@ -80,6 +80,9 @@
+ /* Define to choose default GOT handling scheme */
+ #undef GOT_HANDLING_DEFAULT
+ 
++/* Define to 1 if blake3 is available. */
++#undef HAVE_BLAKE3
++
+ /* Define to 1 if you have the Mac OS X function
+    CFLocaleCopyPreferredLanguages in the CoreFoundation framework. */
+ #undef HAVE_CFLOCALECOPYPREFERREDLANGUAGES
+diff --git a/ld/configure b/ld/configure
+index cb3bcae4d3..2c66874623 100755
+--- a/ld/configure
++++ b/ld/configure
+@@ -651,6 +651,8 @@ ZSTD_LIBS
+ ZSTD_CFLAGS
+ zlibinc
+ zlibdir
++BLAKE3_LIBS
++BLAKE3_CFLAGS
+ NATIVE_LIB_DIRS
+ HDEFINES
+ do_compare
+@@ -872,6 +874,7 @@ with_libiconv_prefix
+ with_libiconv_type
+ with_libintl_prefix
+ with_libintl_type
++with_blake3
+ with_system_zlib
+ with_zstd
+ '
+@@ -895,6 +898,8 @@ JANSSON_CFLAGS
+ JANSSON_LIBS
+ YACC
+ YFLAGS
++BLAKE3_CFLAGS
++BLAKE3_LIBS
+ ZSTD_CFLAGS
+ ZSTD_LIBS'
+ 
+@@ -1589,6 +1594,8 @@ Optional Packages:
+   --with-libintl-prefix[=DIR]  search for libintl in DIR/include and DIR/lib
+   --without-libintl-prefix     don't search for libintl in includedir and libdir
+   --with-libintl-type=TYPE     type of library to search for (auto/static/shared)
++  --with-blake3           Enable blake3 for build-id hashing instead of
++                          md5/sha1 (auto/yes/no)
+   --with-system-zlib      use installed libz
+   --with-zstd             support zstd compressed debug sections
+                           (default=auto)
+@@ -1620,6 +1627,9 @@ Some influential environment variables:
+   YFLAGS      The list of arguments that will be passed by default to $YACC.
+               This script will default YFLAGS to the empty string to avoid a
+               default value of `-d' given by some make applications.
++  BLAKE3_CFLAGS
++              C compiler flags for BLAKE3, overriding pkg-config
++  BLAKE3_LIBS linker flags for BLAKE3, overriding pkg-config
+   ZSTD_CFLAGS C compiler flags for ZSTD, overriding pkg-config
+   ZSTD_LIBS   linker flags for ZSTD, overriding pkg-config
+ 
+@@ -19086,6 +19096,120 @@ $as_echo "#define HAVE_DECL_GETOPT 1" >>confdefs.h
+ 
+ fi
+ 
++# Support for the blake3.
++
++# Check whether --with-blake3 was given.
++if test "${with_blake3+set}" = set; then :
++  withval=$with_blake3;
++else
++  with_blake3=auto
++fi
++
++
++if test "$with_blake3" != no; then :
++
++pkg_failed=no
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for libblake3" >&5
++$as_echo_n "checking for libblake3... " >&6; }
++
++if test -n "$BLAKE3_CFLAGS"; then
++    pkg_cv_BLAKE3_CFLAGS="$BLAKE3_CFLAGS"
++ elif test -n "$PKG_CONFIG"; then
++    if test -n "$PKG_CONFIG" && \
++    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libblake3\""; } >&5
++  ($PKG_CONFIG --exists --print-errors "libblake3") 2>&5
++  ac_status=$?
++  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; then
++  pkg_cv_BLAKE3_CFLAGS=`$PKG_CONFIG --cflags "libblake3" 2>/dev/null`
++		      test "x$?" != "x0" && pkg_failed=yes
++else
++  pkg_failed=yes
++fi
++ else
++    pkg_failed=untried
++fi
++if test -n "$BLAKE3_LIBS"; then
++    pkg_cv_BLAKE3_LIBS="$BLAKE3_LIBS"
++ elif test -n "$PKG_CONFIG"; then
++    if test -n "$PKG_CONFIG" && \
++    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libblake3\""; } >&5
++  ($PKG_CONFIG --exists --print-errors "libblake3") 2>&5
++  ac_status=$?
++  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; then
++  pkg_cv_BLAKE3_LIBS=`$PKG_CONFIG --libs "libblake3" 2>/dev/null`
++		      test "x$?" != "x0" && pkg_failed=yes
++else
++  pkg_failed=yes
++fi
++ else
++    pkg_failed=untried
++fi
++
++if test $pkg_failed = no; then
++  pkg_save_LDFLAGS="$LDFLAGS"
++  LDFLAGS="$LDFLAGS $pkg_cv_BLAKE3_LIBS"
++  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++int
++main ()
++{
++
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_link "$LINENO"; then :
++
++else
++  pkg_failed=yes
++fi
++rm -f core conftest.err conftest.$ac_objext \
++    conftest$ac_exeext conftest.$ac_ext
++  LDFLAGS=$pkg_save_LDFLAGS
++fi
++
++
++
++if test $pkg_failed = yes; then
++        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
++$as_echo "no" >&6; }
++
++if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
++        _pkg_short_errors_supported=yes
++else
++        _pkg_short_errors_supported=no
++fi
++        if test $_pkg_short_errors_supported = yes; then
++	        BLAKE3_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libblake3" 2>&1`
++        else
++	        BLAKE3_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libblake3" 2>&1`
++        fi
++	# Put the nasty error message in config.log where it belongs
++	echo "$BLAKE3_PKG_ERRORS" >&5
++
++	if test "$with_blake3" = yes; then :
++  as_fn_error $? "--with-blake3 was given, but blake3 is missing or unusable." "$LINENO" 5
++fi
++elif test $pkg_failed = untried; then
++        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
++$as_echo "no" >&6; }
++	if test "$with_blake3" = yes; then :
++  as_fn_error $? "--with-blake3 was given, but blake3 is missing or unusable." "$LINENO" 5
++fi
++else
++	BLAKE3_CFLAGS=$pkg_cv_BLAKE3_CFLAGS
++	BLAKE3_LIBS=$pkg_cv_BLAKE3_LIBS
++        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
++$as_echo "yes" >&6; }
++
++$as_echo "#define HAVE_BLAKE3 1" >>confdefs.h
++
++fi
++fi
++
+ # Link in zlib/zstd if we can.  This allows us to read and write
+ # compressed debug sections.
+ 
+diff --git a/ld/configure.ac b/ld/configure.ac
+index bdf51a062f..ae0c7ad1e7 100644
+--- a/ld/configure.ac
++++ b/ld/configure.ac
+@@ -424,6 +424,18 @@ if test $ld_cv_decl_getopt_unistd_h = yes; then
+ 	    [Is the prototype for getopt in <unistd.h> in the expected format?])
+ fi
+ 
++# Support for the blake3.
++AC_ARG_WITH([blake3],
++	    AS_HELP_STRING([--with-blake3], [Enable blake3 for build-id hashing instead of md5/sha1 (auto/yes/no)]),
++	    [],
++	    [with_blake3=auto])
++
++AS_IF([test "$with_blake3" != no],
++  [PKG_CHECK_MODULES(BLAKE3, libblake3,
++    [AC_DEFINE([HAVE_BLAKE3], [1], [Define to 1 if blake3 is available.])],
++    [AS_IF([test "$with_blake3" = yes],
++      [AC_MSG_ERROR([--with-blake3 was given, but blake3 is missing or unusable.])])])])
++
+ # Link in zlib/zstd if we can.  This allows us to read and write
+ # compressed debug sections.
+ AM_ZLIB
+diff --git a/ld/ldbuildid.c b/ld/ldbuildid.c
+index 5ba9e503c7..6aa5f0b2d4 100644
+--- a/ld/ldbuildid.c
++++ b/ld/ldbuildid.c
+@@ -23,6 +23,9 @@
+ #include "safe-ctype.h"
+ #include "md5.h"
+ #include "sha1.h"
++#ifdef HAVE_BLAKE3
++#include <blake3.h>
++#endif
+ #include "ldbuildid.h"
+ #ifdef __MINGW32__
+ #include <windows.h>
+@@ -93,6 +96,14 @@ read_hex (const char xdigit)
+   return 0;
+ }
+ 
++#ifdef HAVE_BLAKE3
++static void
++blake3_process_bytes(const void* buffer, size_t size, void* state)
++{
++  blake3_hasher_update ((blake3_hasher*) state, buffer, size);
++}
++#endif
++
+ bool
+ generate_build_id (bfd *abfd,
+ 		   const char *style,
+@@ -102,15 +113,28 @@ generate_build_id (bfd *abfd,
+ {
+   if (streq (style, "md5"))
+     {
++#ifdef HAVE_BLAKE3
++      blake3_hasher hasher;
++      blake3_hasher_init(&hasher);
++      (*checksum_contents) (abfd, &blake3_process_bytes, &hasher);
++      blake3_hasher_finalize(&hasher, id_bits, 16);
++#else
+       struct md5_ctx ctx;
+ 
+       md5_init_ctx (&ctx);
+       if (!(*checksum_contents) (abfd, (sum_fn) &md5_process_bytes, &ctx))
+ 	return false;
+       md5_finish_ctx (&ctx, id_bits);
++#endif
+     }
+   else if (streq (style, "sha1"))
+     {
++#ifdef HAVE_BLAKE3
++      blake3_hasher hasher;
++      blake3_hasher_init(&hasher);
++      (*checksum_contents) (abfd, &blake3_process_bytes, &hasher);
++      blake3_hasher_finalize(&hasher, id_bits, 20);
++#else
+       struct sha1_ctx ctx;
+ 
+       sha1_init_ctx (&ctx);
+@@ -118,6 +142,7 @@ generate_build_id (bfd *abfd,
+ 				 &ctx))
+ 	return false;
+       sha1_finish_ctx (&ctx, id_bits);
++#endif
+     }
+   else if (streq (style, "uuid"))
+     {

--- a/packages/b/binutils/files/series
+++ b/packages/b/binutils/files/series
@@ -1,3 +1,5 @@
+0001-Proper-stateless.patch
 ld-as-needed.patch
 binutils-testsuite-fixes.patch
 Relink-also-libopcodes-and-libgprofng-to-newly-built-libiberty.a.patch
+0001-Use-BLAKE3-for-build-id-hashing.patch

--- a/packages/b/binutils/package.yml
+++ b/packages/b/binutils/package.yml
@@ -1,10 +1,10 @@
 name       : binutils
 version    : 2.43.1
-release    : 75
+release    : 76
 source     :
     # - https://ftp.gnu.org/gnu/binutils/binutils-2.43.tar.xz : f6e4d41fd5fc778b06b7891457b3620da5ecea1006c6a4a41ae998109f85a800
     # Stable 2.43 series
-    - git|https://sourceware.org/git/binutils-gdb.git : cd3e2b58f2c42197737e5f24943a74c394d04b05
+    - git|https://sourceware.org/git/binutils-gdb.git : 46873460b6aa66726095ea86fb612fb6ac0a2ebc
 homepage   : https://www.gnu.org/software/binutils
 license    : GPL-3.0-or-later
 component  :
@@ -18,12 +18,16 @@ summary    :
 description: |
     The Binutils package contains a linker, an assembler, and other tools for handling object files.
 patterns   :
-    - /usr/include
-    - /usr/lib64/*.a
-    - gold : /usr/bin/ld.gold
     - libs : /usr/lib64/lib*.so*
+    - gold :
+        - /usr/bin/ld.gold
+        - /usr/share/locale/*/LC_MESSAGES/gold.mo
+    - main :
+        - /usr/lib64/libgprofng.so*
 mancompress: yes
 builddeps  :
+    - pkgconfig(jansson)
+    - pkgconfig(libblake3)
     - pkgconfig(libzstd)
     - dejagnu
 rundeps    :
@@ -44,20 +48,31 @@ setup      : |
                  --libdir=%libdir% \
                  --with-lib-path="/usr/lib64:/lib64:/usr/lib32:/lib32" \
                  --enable-64-bit-bfd \
+                 --enable-compressed-debug-sections=all \
+                 --enable-default-compressed-debug-sections-algorithm=zstd \
+                 --enable-default-execstack=no \
+                 --enable-default-hash-style=gnu \
                  --enable-deterministic-archives \
                  --enable-gold \
+                 --enable-jansson \
                  --enable-ld=default \
                  --enable-lto \
                  --enable-multilib \
+                 --enable-new-dtags \
                  --enable-pgo-build=lto \
                  --enable-plugins \
+                 --enable-relro=yes \
                  --enable-secureplt \
                  --enable-shared \
                  --enable-threads \
+                 --enable-warn-execstack=yes \
                  --disable-gdb \
                  --disable-gdbserver \
+                 --disable-rpath \
                  --disable-static \
                  --disable-werror \
+                 --with-blake3=yes \
+                 --with-zstd=yes \
                  --build=$buildArch \
                  --target=$buildArch
 build      : |
@@ -67,6 +82,11 @@ install    : |
 
     install -m 00644 include/libiberty.h $installdir/usr/include/.
     install -m 00644 build/libiberty/libiberty.a $installdir/%libdir%/.
+
+    # Better stateless
+    install -dm00755 $installdir/usr/share/defaults/gprofng
+    mv $installdir/usr/etc/gprofng.rc $installdir/usr/share/defaults/gprofng
+    rmdir -v $installdir/usr/etc
 check      : |
     unset LDFLAGS
-    %make -k check -C build || :
+    %make -k check-gas check-binutils check-ld -C build || :

--- a/packages/b/binutils/pspec_x86_64.xml
+++ b/packages/b/binutils/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>binutils</Name>
         <Homepage>https://www.gnu.org/software/binutils</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Reilly Brogan</Name>
+            <Email>solus@reillybrogan.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.devel</PartOf>
@@ -20,7 +20,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="75">binutils-libs</Dependency>
+            <Dependency release="76">binutils-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/addr2line</Path>
@@ -46,22 +46,6 @@
             <Path fileType="executable">/usr/bin/size</Path>
             <Path fileType="executable">/usr/bin/strings</Path>
             <Path fileType="executable">/usr/bin/strip</Path>
-            <Path fileType="data">/usr/etc/gprofng.rc</Path>
-            <Path fileType="header">/usr/include/ansidecl.h</Path>
-            <Path fileType="header">/usr/include/bfd.h</Path>
-            <Path fileType="header">/usr/include/bfdlink.h</Path>
-            <Path fileType="header">/usr/include/collectorAPI.h</Path>
-            <Path fileType="header">/usr/include/ctf-api.h</Path>
-            <Path fileType="header">/usr/include/ctf.h</Path>
-            <Path fileType="header">/usr/include/diagnostics.h</Path>
-            <Path fileType="header">/usr/include/dis-asm.h</Path>
-            <Path fileType="header">/usr/include/libcollector.h</Path>
-            <Path fileType="header">/usr/include/libfcollector.h</Path>
-            <Path fileType="header">/usr/include/libiberty.h</Path>
-            <Path fileType="header">/usr/include/plugin-api.h</Path>
-            <Path fileType="header">/usr/include/sframe-api.h</Path>
-            <Path fileType="header">/usr/include/sframe.h</Path>
-            <Path fileType="header">/usr/include/symcat.h</Path>
             <Path fileType="library">/usr/lib/ldscripts/elf32_x86_64.x</Path>
             <Path fileType="library">/usr/lib/ldscripts/elf32_x86_64.xbn</Path>
             <Path fileType="library">/usr/lib/ldscripts/elf32_x86_64.xc</Path>
@@ -193,7 +177,10 @@
             <Path fileType="library">/usr/lib64/gprofng/libgp-heap.so</Path>
             <Path fileType="library">/usr/lib64/gprofng/libgp-iotrace.so</Path>
             <Path fileType="library">/usr/lib64/gprofng/libgp-sync.so</Path>
-            <Path fileType="library">/usr/lib64/libiberty.a</Path>
+            <Path fileType="library">/usr/lib64/libgprofng.so</Path>
+            <Path fileType="library">/usr/lib64/libgprofng.so.0</Path>
+            <Path fileType="library">/usr/lib64/libgprofng.so.0.0.0</Path>
+            <Path fileType="data">/usr/share/defaults/gprofng/gprofng.rc</Path>
             <Path fileType="info">/usr/share/info/as.info.gz</Path>
             <Path fileType="info">/usr/share/info/bfd.info.gz</Path>
             <Path fileType="info">/usr/share/info/binutils.info.gz</Path>
@@ -219,21 +206,18 @@
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/bfd.mo</Path>
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/binutils.mo</Path>
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/gas.mo</Path>
-            <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/gold.mo</Path>
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/gprof.mo</Path>
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/ld.mo</Path>
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/opcodes.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fi/LC_MESSAGES/bfd.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fi/LC_MESSAGES/binutils.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fi/LC_MESSAGES/gas.mo</Path>
-            <Path fileType="localedata">/usr/share/locale/fi/LC_MESSAGES/gold.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fi/LC_MESSAGES/gprof.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fi/LC_MESSAGES/ld.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fi/LC_MESSAGES/opcodes.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/bfd.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/binutils.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/gas.mo</Path>
-            <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/gold.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/gprof.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/ld.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/opcodes.mo</Path>
@@ -246,19 +230,16 @@
             <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/bfd.mo</Path>
             <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/binutils.mo</Path>
             <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/gas.mo</Path>
-            <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/gold.mo</Path>
             <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/gprof.mo</Path>
             <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/ld.mo</Path>
             <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/opcodes.mo</Path>
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/binutils.mo</Path>
-            <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/gold.mo</Path>
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/gprof.mo</Path>
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/ld.mo</Path>
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/opcodes.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/bfd.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/binutils.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/gas.mo</Path>
-            <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/gold.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/gprof.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/ld.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/bfd.mo</Path>
@@ -275,7 +256,6 @@
             <Path fileType="localedata">/usr/share/locale/ro/LC_MESSAGES/bfd.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ro/LC_MESSAGES/binutils.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ro/LC_MESSAGES/gas.mo</Path>
-            <Path fileType="localedata">/usr/share/locale/ro/LC_MESSAGES/gold.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ro/LC_MESSAGES/gprof.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ro/LC_MESSAGES/ld.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ro/LC_MESSAGES/opcodes.mo</Path>
@@ -291,14 +271,12 @@
             <Path fileType="localedata">/usr/share/locale/sk/LC_MESSAGES/binutils.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sr/LC_MESSAGES/bfd.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sr/LC_MESSAGES/binutils.mo</Path>
-            <Path fileType="localedata">/usr/share/locale/sr/LC_MESSAGES/gold.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sr/LC_MESSAGES/gprof.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sr/LC_MESSAGES/ld.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sr/LC_MESSAGES/opcodes.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/bfd.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/binutils.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/gas.mo</Path>
-            <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/gold.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/gprof.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/ld.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/opcodes.mo</Path>
@@ -311,20 +289,17 @@
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/bfd.mo</Path>
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/binutils.mo</Path>
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/gas.mo</Path>
-            <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/gold.mo</Path>
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/gprof.mo</Path>
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/ld.mo</Path>
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/opcodes.mo</Path>
             <Path fileType="localedata">/usr/share/locale/vi/LC_MESSAGES/bfd.mo</Path>
             <Path fileType="localedata">/usr/share/locale/vi/LC_MESSAGES/binutils.mo</Path>
-            <Path fileType="localedata">/usr/share/locale/vi/LC_MESSAGES/gold.mo</Path>
             <Path fileType="localedata">/usr/share/locale/vi/LC_MESSAGES/gprof.mo</Path>
             <Path fileType="localedata">/usr/share/locale/vi/LC_MESSAGES/ld.mo</Path>
             <Path fileType="localedata">/usr/share/locale/vi/LC_MESSAGES/opcodes.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/bfd.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/binutils.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/gas.mo</Path>
-            <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/gold.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/ld.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/opcodes.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/binutils.mo</Path>
@@ -356,16 +331,56 @@
         </Files>
     </Package>
     <Package>
+        <Name>binutils-devel</Name>
+        <Summary xml:lang="en">Development files for binutils</Summary>
+        <Description xml:lang="en">The Binutils package contains a linker, an assembler, and other tools for handling object files.
+</Description>
+        <PartOf>programming.devel</PartOf>
+        <RuntimeDependencies>
+            <Dependency release="76">binutils</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="header">/usr/include/ansidecl.h</Path>
+            <Path fileType="header">/usr/include/bfd.h</Path>
+            <Path fileType="header">/usr/include/bfdlink.h</Path>
+            <Path fileType="header">/usr/include/collectorAPI.h</Path>
+            <Path fileType="header">/usr/include/ctf-api.h</Path>
+            <Path fileType="header">/usr/include/ctf.h</Path>
+            <Path fileType="header">/usr/include/diagnostics.h</Path>
+            <Path fileType="header">/usr/include/dis-asm.h</Path>
+            <Path fileType="header">/usr/include/libcollector.h</Path>
+            <Path fileType="header">/usr/include/libfcollector.h</Path>
+            <Path fileType="header">/usr/include/libiberty.h</Path>
+            <Path fileType="header">/usr/include/plugin-api.h</Path>
+            <Path fileType="header">/usr/include/sframe-api.h</Path>
+            <Path fileType="header">/usr/include/sframe.h</Path>
+            <Path fileType="header">/usr/include/symcat.h</Path>
+            <Path fileType="library">/usr/lib64/libiberty.a</Path>
+        </Files>
+    </Package>
+    <Package>
         <Name>binutils-gold</Name>
         <Summary xml:lang="en">binutils gold linker</Summary>
         <Description xml:lang="en">The Binutils package contains a linker, an assembler, and other tools for handling object files.
 </Description>
         <PartOf>programming.tools</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="75">binutils</Dependency>
+            <Dependency releaseFrom="76">binutils</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/ld.gold</Path>
+            <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/gold.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/fi/LC_MESSAGES/gold.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/gold.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/gold.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/gold.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/gold.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ro/LC_MESSAGES/gold.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sr/LC_MESSAGES/gold.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/gold.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/gold.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/vi/LC_MESSAGES/gold.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/gold.mo</Path>
         </Files>
     </Package>
     <Package>
@@ -383,9 +398,6 @@
             <Path fileType="library">/usr/lib64/libctf.so</Path>
             <Path fileType="library">/usr/lib64/libctf.so.0</Path>
             <Path fileType="library">/usr/lib64/libctf.so.0.0.0</Path>
-            <Path fileType="library">/usr/lib64/libgprofng.so</Path>
-            <Path fileType="library">/usr/lib64/libgprofng.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgprofng.so.0.0.0</Path>
             <Path fileType="library">/usr/lib64/libopcodes-2.43.1.so</Path>
             <Path fileType="library">/usr/lib64/libopcodes.so</Path>
             <Path fileType="library">/usr/lib64/libsframe.so</Path>
@@ -394,12 +406,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="75">
-            <Date>2024-09-08</Date>
+        <Update release="76">
+            <Date>2024-12-15</Date>
             <Version>2.43.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Reilly Brogan</Name>
+            <Email>solus@reillybrogan.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/b/blake3/package.yml
+++ b/packages/b/blake3/package.yml
@@ -1,16 +1,18 @@
 name       : blake3
 version    : 1.5.5
-release    : 5
+release    : 6
 source     :
     - https://github.com/BLAKE3-team/BLAKE3/archive/refs/tags/1.5.5.tar.gz : 6feba0750efc1a99a79fb9a495e2628b5cd1603e15f56a06b1d6cb13ac55c618
 homepage   : https://github.com/BLAKE3-team/BLAKE3
 license    : Apache-2.0
-component  : system.utils
+component  :
+    - system.devel
+    - ^b3sum : system.utils
 summary    :
-    - A very fast cryptographic hash
+    - A very fast cryptographic hash algorithm
     - ^b3sum : Command line implementation of the BLAKE3 hash function
 description:
-    - A very fast cryptographic hash
+    - A very fast cryptographic hash algorithm
     - ^b3sum : Command line implementation of the BLAKE3 hash function
 networking : yes
 builddeps  :

--- a/packages/b/blake3/pspec_x86_64.xml
+++ b/packages/b/blake3/pspec_x86_64.xml
@@ -7,16 +7,16 @@
             <Email>solus@reillybrogan.com</Email>
         </Packager>
         <License>Apache-2.0</License>
-        <PartOf>system.utils</PartOf>
-        <Summary xml:lang="en">A very fast cryptographic hash</Summary>
-        <Description xml:lang="en">A very fast cryptographic hash</Description>
+        <PartOf>system.devel</PartOf>
+        <Summary xml:lang="en">A very fast cryptographic hash algorithm</Summary>
+        <Description xml:lang="en">A very fast cryptographic hash algorithm</Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>blake3</Name>
-        <Summary xml:lang="en">A very fast cryptographic hash</Summary>
-        <Description xml:lang="en">A very fast cryptographic hash</Description>
-        <PartOf>system.utils</PartOf>
+        <Summary xml:lang="en">A very fast cryptographic hash algorithm</Summary>
+        <Description xml:lang="en">A very fast cryptographic hash algorithm</Description>
+        <PartOf>system.devel</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libblake3.so.0</Path>
             <Path fileType="library">/usr/lib64/libblake3.so.1.5.5</Path>
@@ -26,6 +26,7 @@
         <Name>b3sum</Name>
         <Summary xml:lang="en">Command line implementation of the BLAKE3 hash function</Summary>
         <Description xml:lang="en">Command line implementation of the BLAKE3 hash function</Description>
+        <PartOf>system.utils</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/b3sum</Path>
         </Files>
@@ -33,10 +34,10 @@
     <Package>
         <Name>blake3-devel</Name>
         <Summary xml:lang="en">Development files for blake3</Summary>
-        <Description xml:lang="en">A very fast cryptographic hash</Description>
+        <Description xml:lang="en">A very fast cryptographic hash algorithm</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="5">blake3</Dependency>
+            <Dependency release="6">blake3</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/blake3.h</Path>
@@ -49,8 +50,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2024-12-13</Date>
+        <Update release="6">
+            <Date>2024-12-16</Date>
             <Version>1.5.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Reilly Brogan</Name>

--- a/packages/b/bpftrace/package.yml
+++ b/packages/b/bpftrace/package.yml
@@ -14,6 +14,7 @@ builddeps  :
     - pkgconfig(libbpf)
     - pkgconfig(libedit)
     - pkgconfig(libpcap)
+    - binutils-devel
     - cereal
     - clang-devel
     - pahole

--- a/packages/g/gammaray/package.yml
+++ b/packages/g/gammaray/package.yml
@@ -35,6 +35,7 @@ builddeps  :
     - pkgconfig(Qt6Svg)
     - pkgconfig(Qt6WaylandCompositor)
     - pkgconfig(Qt6WebEngineWidgets)
+    - binutils-devel
     - kf6-syntax-highlighting-devel
 rundeps    :
     - lldb

--- a/packages/l/linux-tools/package.yml
+++ b/packages/l/linux-tools/package.yml
@@ -66,6 +66,7 @@ builddeps  :
     - pkgconfig(python3)
     - pkgconfig(slang)
     - asciidoc
+    - binutils-devel
     - clang
     - llvm-devel
     - python-docutils


### PR DESCRIPTION
Changes:
- Link against jansson to enable ELF_PACKAGE_METADATA
- Default to compressing debug symbols and set default compression algorithm to zstd
- Use BLAKE3 for hashing when using the --build-id=md5 or --build-id=sha1 flags
- Switch to RUNPATH over RPATH
- Add `--with-zstd` flag so the build fails if somehow it can't use zstd (really important now)
- Fix gprofng stateless
- Move gprofng shared libs back into main binutils package
- Split out the devel files to -devel
