### PR TITLE
tailscale: Update to 1.78.3

### DIFF
--- a/packages/t/tailscale/package.yml
+++ b/packages/t/tailscale/package.yml
@@ -1,8 +1,8 @@
 name       : tailscale
-version    : 1.78.1
-release    : 29
+version    : 1.78.3
+release    : 30
 source     :
-    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.78.1.tar.gz : dbc25cc241bb233f183475f003d5508af7b45add1ca548b35a6a6fea91fb91af
+    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.78.3.tar.gz : bac059152e3fa8ab379ee5ec7a03940114e7ac65c6e1baea4f840f6fadd17d57
 homepage   : https://tailscale.com
 license    : BSD-3-Clause
 component  : network.clients

--- a/packages/t/tailscale/pspec_x86_64.xml
+++ b/packages/t/tailscale/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="29">
-            <Date>2024-12-07</Date>
-            <Version>1.78.1</Version>
+        <Update release="30">
+            <Date>2024-12-14</Date>
+            <Version>1.78.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- [changelog](https://tailscale.com/changelog#2024-12-13-client)

**Test Plan**
- tailscale netcheck

**Checklist**
- [X] Package was built and tested against unstable
