### PR TITLE
wine: Update to v10.0-rc2

### DIFF
--- a/packages/w/wine/package.yml
+++ b/packages/w/wine/package.yml
@@ -1,8 +1,8 @@
 name       : wine
-version    : 10.0_rc1
-release    : 191
+version    : 10.0_rc2
+release    : 192
 source     :
-    - https://dl.winehq.org/wine/source/10.0/wine-10.0-rc1.tar.xz : 754b9abafe74baffe9b1ce6b2eeb777865c72c7f70c9c5baee951bde8ce287c1
+    - https://dl.winehq.org/wine/source/10.0/wine-10.0-rc2.tar.xz : ccad4ff0cc9f691b4ef18be0e1e9989183a4784422993785764af78d89ad5ab7
 license    : LGPL-2.1-or-later
 component  : virt
 homepage   : https://www.winehq.org/

--- a/packages/w/wine/pspec_x86_64.xml
+++ b/packages/w/wine/pspec_x86_64.xml
@@ -1007,7 +1007,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="191">wine</Dependency>
+            <Dependency release="192">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/wine</Path>
@@ -1862,7 +1862,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="191">wine</Dependency>
+            <Dependency release="192">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wine/debug.h</Path>
@@ -3209,9 +3209,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="191">
-            <Date>2024-12-06</Date>
-            <Version>10.0_rc1</Version>
+        <Update release="192">
+            <Date>2024-12-15</Date>
+            <Version>10.0_rc2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Bugfix update

Full release notes available [here](https://gitlab.winehq.org/wine/wine/-/releases/wine-10.0-rc2)

**Test Plan**
- Ran `winemine`, `winecfg`, `wineconsole`, `winefile`
- Played Age of Empires I Trial

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
