### PR TITLE
diffoscope: Update to v284

### DIFF
--- a/packages/d/diffoscope/package.yml
+++ b/packages/d/diffoscope/package.yml
@@ -1,8 +1,8 @@
 name       : diffoscope
-version    : '277'
-release    : 9
+version    : '284'
+release    : 10
 source     :
-    - https://diffoscope.org/archive/diffoscope-277.tar.bz2 : 6435bd133a101b96f4766c9d2a2f39d2b75fd1af1458a163ae4fada3180189c6
+    - https://diffoscope.org/archive/diffoscope-284.tar.bz2 : 7b7d09205a11c4f737f845422e86946c74997751231cca59ff693ab9883db4f8
 homepage   : https://diffoscope.org/
 license    : GPL-3.0-or-later
 component  : programming.python

--- a/packages/d/diffoscope/pspec_x86_64.xml
+++ b/packages/d/diffoscope/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>diffoscope</Name>
         <Homepage>https://diffoscope.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>programming.python</PartOf>
@@ -21,12 +21,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/diffoscope</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope-277-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope-277-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope-277-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope-277-py3.11.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope-277-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope-277-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope-284-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope-284-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope-284-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope-284-py3.11.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope-284-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope-284-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope/__pycache__/changes.cpython-311.pyc</Path>
@@ -122,6 +122,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope/comparators/__pycache__/tar.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope/comparators/__pycache__/text.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope/comparators/__pycache__/uimage.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope/comparators/__pycache__/uki.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope/comparators/__pycache__/vmlinuz.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope/comparators/__pycache__/wasm.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope/comparators/__pycache__/xar.cpython-311.pyc</Path>
@@ -204,6 +205,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope/comparators/tar.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope/comparators/text.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope/comparators/uimage.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope/comparators/uki.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope/comparators/utils/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope/comparators/utils/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/diffoscope/comparators/utils/__pycache__/archive.cpython-311.pyc</Path>
@@ -283,12 +285,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2024-09-08</Date>
-            <Version>277</Version>
+        <Update release="10">
+            <Date>2024-12-17</Date>
+            <Version>284</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Full changelog can be found [here](https://salsa.debian.org/reproducible-builds/diffoscope/-/raw/284/debian/changelog?ref_type=tags)

**Test Plan**

<!-- Short description of how the package was tested -->
Compare two version  `qtractor-*.eopkg` files

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
