### PR TITLE
budgie-backgrounds: Update to v3.0

### DIFF
--- a/packages/b/budgie-backgrounds/package.yml
+++ b/packages/b/budgie-backgrounds/package.yml
@@ -1,8 +1,8 @@
 name       : budgie-backgrounds
-version    : '2.0'
-release    : 3
+version    : '3.0'
+release    : 4
 source     :
-    - https://github.com/BuddiesOfBudgie/budgie-backgrounds/releases/download/v2.0/budgie-backgrounds-v2.0.tar.xz : 429664bb3e2dc46858a53cf853ef88ff49bf77a449fee46bf323cfeeeaeb0dcb
+    - https://github.com/BuddiesOfBudgie/budgie-backgrounds/releases/download/v3.0/budgie-backgrounds-v3.0.tar.xz : 536e966bb20873ffd8e5921fb046fb6ac978fca5e26772df54959d3122d9a482
 homepage   : https://buddiesofbudgie.org/
 license    : CC0-1.0
 component  : desktop.budgie

--- a/packages/b/budgie-backgrounds/pspec_x86_64.xml
+++ b/packages/b/budgie-backgrounds/pspec_x86_64.xml
@@ -21,41 +21,30 @@
         <PartOf>desktop.budgie</PartOf>
         <Files>
             <Path fileType="data">/usr/share/backgrounds/budgie/abstract-spiral.jpg</Path>
-            <Path fileType="data">/usr/share/backgrounds/budgie/accelerated-green.jpg</Path>
-            <Path fileType="data">/usr/share/backgrounds/budgie/apollo-11-earth.jpg</Path>
             <Path fileType="data">/usr/share/backgrounds/budgie/beacon-street-sunset.jpg</Path>
             <Path fileType="data">/usr/share/backgrounds/budgie/blue-periwinkle.jpg</Path>
             <Path fileType="data">/usr/share/backgrounds/budgie/canyon-wren.jpg</Path>
             <Path fileType="data">/usr/share/backgrounds/budgie/casa-mila.jpg</Path>
-            <Path fileType="data">/usr/share/backgrounds/budgie/dragonfly-on-lavender.jpg</Path>
             <Path fileType="data">/usr/share/backgrounds/budgie/extreme-desert-hike.jpg</Path>
-            <Path fileType="data">/usr/share/backgrounds/budgie/geo-forest.jpg</Path>
             <Path fileType="data">/usr/share/backgrounds/budgie/high-trestle-trail.jpg</Path>
-            <Path fileType="data">/usr/share/backgrounds/budgie/kitten-on-lawn.jpg</Path>
             <Path fileType="data">/usr/share/backgrounds/budgie/lake-sherburne.jpg</Path>
-            <Path fileType="data">/usr/share/backgrounds/budgie/motherboard-circuits.jpg</Path>
             <Path fileType="data">/usr/share/backgrounds/budgie/oakland-zoo-otters.jpg</Path>
             <Path fileType="data">/usr/share/backgrounds/budgie/ocean-waves.jpg</Path>
-            <Path fileType="data">/usr/share/backgrounds/budgie/orange-hallway.jpg</Path>
             <Path fileType="data">/usr/share/backgrounds/budgie/perched-osprey.jpg</Path>
             <Path fileType="data">/usr/share/backgrounds/budgie/piazza-gae-aulenti.jpg</Path>
             <Path fileType="data">/usr/share/backgrounds/budgie/roman-colosseum.jpg</Path>
             <Path fileType="data">/usr/share/backgrounds/budgie/saturnian-profile.jpg</Path>
             <Path fileType="data">/usr/share/backgrounds/budgie/singaporean-cityscape.jpg</Path>
-            <Path fileType="data">/usr/share/backgrounds/budgie/solaris-grapes.jpg</Path>
             <Path fileType="data">/usr/share/backgrounds/budgie/tea-gardens.jpg</Path>
-            <Path fileType="data">/usr/share/backgrounds/budgie/ufo-galaxy.jpg</Path>
-            <Path fileType="data">/usr/share/backgrounds/budgie/valley-coral.jpg</Path>
             <Path fileType="data">/usr/share/backgrounds/budgie/valley-midnight.jpg</Path>
             <Path fileType="data">/usr/share/backgrounds/budgie/waves-midnight.jpg</Path>
-            <Path fileType="data">/usr/share/backgrounds/budgie/waves-slate.jpg</Path>
             <Path fileType="data">/usr/share/gnome-background-properties/budgie-backgrounds.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2023-12-23</Date>
-            <Version>2.0</Version>
+        <Update release="4">
+            <Date>2024-12-17</Date>
+            <Version>3.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
             <Email>malfisya.dev@hotmail.com</Email>


### PR DESCRIPTION
**Summary**

We have removed about half of the backgrounds in the set to keep things lightweight. The following have been removed:
- accelerated-green
- apollo-11-earth
- dragonfly-on-lavender
- geo-forest
- kitten-on-lawn
- motherboard-circuits
- orange-hallway
- solaris-grapes
- ufo-galaxy
- valley-coral
- waves-slate Additionally, ocean-waves has been cropped to the standard 3840x2160.

Additionally, ocean-waves has been cropped to the standard 3840x2160.

**Test Plan**

<!-- Short description of how the package was tested -->
Install package and verify removed background is gone

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
