### PR TITLE
amdgpu_top: Update to v0.10.1

### DIFF
--- a/packages/a/amdgpu_top/MAINTAINERS.md
+++ b/packages/a/amdgpu_top/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Muhammad Alfi Syahrin
+  - Matrix: @alfisya:matrix.org
+  - Email: malfisya.dev@hotmail.com

--- a/packages/a/amdgpu_top/package.yml
+++ b/packages/a/amdgpu_top/package.yml
@@ -1,8 +1,8 @@
 name       : amdgpu_top
-version    : 0.10.0
-release    : 21
+version    : 0.10.1
+release    : 22
 source     :
-    - https://github.com/Umio-Yasuno/amdgpu_top/archive/refs/tags/v0.10.0.tar.gz : 116020dcd15d0390ed55a0dffea6e110e658926d6bfa444bf1c23edc2cb794ad
+    - https://github.com/Umio-Yasuno/amdgpu_top/archive/refs/tags/v0.10.1.tar.gz : 99f76632866694f2fa24f2b6e7b687d34b901fdcba28762cccd8f0a876c11765
 homepage   : https://github.com/Umio-Yasuno/amdgpu_top
 license    : MIT
 component  : system.utils

--- a/packages/a/amdgpu_top/pspec_x86_64.xml
+++ b/packages/a/amdgpu_top/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>amdgpu_top</Name>
         <Homepage>https://github.com/Umio-Yasuno/amdgpu_top</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -27,12 +27,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2024-12-01</Date>
-            <Version>0.10.0</Version>
+        <Update release="22">
+            <Date>2024-12-17</Date>
+            <Version>0.10.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Update `libdrm_amdgpu_sys`
  - Fix `CHIP_CLASS` check for GFX12
- Include `CHIP_GFX1103_R1X` (Hawk Point1) in `has_npu` condition
- Add description of `--xdna` option
- Full changelog can be found [here](https://github.com/Umio-Yasuno/amdgpu_top/releases/tag/v0.10.1)

**Test Plan**

<!-- Short description of how the package was tested -->
Run the TUI and GUI app

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
