### PR TITLE
qutebrowser: Update to v3.4.0

### DIFF
--- a/packages/q/qutebrowser/package.yml
+++ b/packages/q/qutebrowser/package.yml
@@ -1,8 +1,8 @@
 name       : qutebrowser
-version    : 3.3.1
-release    : 47
+version    : 3.4.0
+release    : 48
 source     :
-    - https://github.com/qutebrowser/qutebrowser/releases/download/v3.3.1/qutebrowser-3.3.1.tar.gz : aadb64accc730bc9a15ce341c9a0580b1f36383ed4874f54d31ce1dabe94e17a
+    - https://github.com/qutebrowser/qutebrowser/releases/download/v3.4.0/qutebrowser-3.4.0.tar.gz : 814124c0ed337430e613a1da366d5e38904cb2049afb1505971456ca5ca6223e
 homepage   : https://qutebrowser.org
 license    : GPL-3.0-or-later
 component  : network.web.browser

--- a/packages/q/qutebrowser/pspec_x86_64.xml
+++ b/packages/q/qutebrowser/pspec_x86_64.xml
@@ -21,13 +21,13 @@
         <PartOf>network.web.browser</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/qutebrowser</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.3.1-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.3.1-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.3.1-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.3.1-py3.11.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.3.1-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.3.1-py3.11.egg-info/top_level.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.3.1-py3.11.egg-info/zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.4.0-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.4.0-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.4.0-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.4.0-py3.11.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.4.0-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.4.0-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser-3.4.0-py3.11.egg-info/zip-safe</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
@@ -430,6 +430,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/javascript/greasemonkey_wrapper.js</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/javascript/history.js</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/javascript/pac_utils.js</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/javascript/pdfjs_polyfills.js</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/javascript/position_caret.js</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/javascript/quirks/array_at.user.js</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/qutebrowser/javascript/quirks/discord.user.js</Path>
@@ -771,9 +772,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="47">
-            <Date>2024-10-13</Date>
-            <Version>3.3.1</Version>
+        <Update release="48">
+            <Date>2024-12-17</Date>
+            <Version>3.4.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/qutebrowser/qutebrowser/blob/main/doc/changelog.asciidoc#v340-2024-12-14).

**Test Plan**
- Read the change notes in the browser.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
