### PR TITLE
calibre: Remove unused appstream files & restore desktop files

### DIFF
--- a/packages/c/calibre/abi_used_symbols
+++ b/packages/c/calibre/abi_used_symbols
@@ -1211,8 +1211,10 @@ libstdc++.so.6:_ZTVSt15basic_streambufIcSt11char_traitsIcEE
 libstdc++.so.6:_ZTVSt9bad_alloc
 libstdc++.so.6:_ZTVSt9exception
 libstdc++.so.6:_ZdaPv
+libstdc++.so.6:_ZdaPvm
 libstdc++.so.6:_ZdlPv
 libstdc++.so.6:_ZdlPvRKSt9nothrow_t
+libstdc++.so.6:_ZdlPvm
 libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
 libstdc++.so.6:_ZnwmRKSt9nothrow_t

--- a/packages/c/calibre/package.yml
+++ b/packages/c/calibre/package.yml
@@ -1,6 +1,6 @@
 name       : calibre
 version    : 7.22.0
-release    : 206
+release    : 207
 source     :
     - https://download.calibre-ebook.com/7.22.0/calibre-7.22.0.tar.xz : 4660ad7bab6893417fb6ce5c69c005064b0d61f9cbca5638242993c9bfba2149
 homepage   : https://calibre-ebook.com/
@@ -116,7 +116,6 @@ install    : |
 
     # Remove MimeTypes from .desktop as it creates unwanted associations
     sed -e "/MimeType/d" -i  $installdir/usr/share/applications/calibre*.desktop
-    rm -rfv $installdir/usr/share/applications/calibre-{ebook-*,lrfviewer}.desktop
     chmod -R 00755 $installdir/usr/share/applications/calibre-gui.desktop
     install -Dm00644 $workdir/resources/calibre-mimetypes.xml $installdir/usr/share/mime/packages/calibre-mimetypes.xml
 
@@ -125,6 +124,9 @@ install    : |
 
     # Remove unneeded files
     rm $installdir/usr/share/calibre/*portable*
+
+    # We can only include one, remove other appstream metainfo files
+    rm -rfv $installdir/usr/share/metainfo/calibre-ebook-*.metainfo.xml
 check      : |
     # excluded tests for optional or missing packages like:
     # python-py7zr python-pychm python-pycryptodome python-pykakasi python-sgmllib3k python-unrardll piper is not yet packaged

--- a/packages/c/calibre/pspec_x86_64.xml
+++ b/packages/c/calibre/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>calibre</Name>
         <Homepage>https://calibre-ebook.com/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <PartOf>office.viewers</PartOf>
@@ -3016,7 +3016,10 @@
             <Path fileType="library">/usr/lib/calibre/tinycss/version.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/__pycache__/init_calibre.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/init_calibre.py</Path>
+            <Path fileType="data">/usr/share/applications/calibre-ebook-edit.desktop</Path>
+            <Path fileType="data">/usr/share/applications/calibre-ebook-viewer.desktop</Path>
             <Path fileType="data">/usr/share/applications/calibre-gui.desktop</Path>
+            <Path fileType="data">/usr/share/applications/calibre-lrfviewer.desktop</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/calibre</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/calibre-debug</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/calibre-server</Path>
@@ -3502,20 +3505,18 @@
             <Path fileType="data">/usr/share/icons/hicolor/64x64/mimetypes/gnome-mime-application-x-topaz-ebook.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/64x64/mimetypes/gnome-mime-text-lrs.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/64x64/mimetypes/text-lrs.png</Path>
-            <Path fileType="data">/usr/share/metainfo/calibre-ebook-edit.metainfo.xml</Path>
-            <Path fileType="data">/usr/share/metainfo/calibre-ebook-viewer.metainfo.xml</Path>
             <Path fileType="data">/usr/share/metainfo/calibre-gui.metainfo.xml</Path>
             <Path fileType="data">/usr/share/mime/packages/calibre-mimetypes.xml</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_calibre</Path>
         </Files>
     </Package>
     <History>
-        <Update release="206">
-            <Date>2024-12-02</Date>
+        <Update release="207">
+            <Date>2024-12-17</Date>
             <Version>7.22.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- We can only include one appstream metainfo per package,  remove the other files
- There is not much justification deleting additional desktop files, restore them

Resolves getsolus/packages#1364

**Test Plan**

<!-- Short description of how the package was tested -->
- Verify the appstream generation with `appstream-builder --packages-dir=. --include-failed -v`
- Test the package in Plasma VM

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
