### PR TITLE
go-task: Update to v3.40.1

### DIFF
--- a/packages/g/go-task/package.yml
+++ b/packages/g/go-task/package.yml
@@ -1,8 +1,8 @@
 name       : go-task
-version    : 3.40.0
-release    : 20
+version    : 3.40.1
+release    : 21
 source     :
-    - https://github.com/go-task/task/archive/refs/tags/v3.40.0.tar.gz : e5ef4dc1837ca35f05cb5065aca3ea3de30e363c2ded389b6b1c0896cf1770f3
+    - https://github.com/go-task/task/archive/refs/tags/v3.40.1.tar.gz : e80cdfa2afefa69238e5078960d50a8e703de1043740b277946629ca5f3bde85
 license    : MIT
 component  : programming.tools
 networking : yes

--- a/packages/g/go-task/pspec_x86_64.xml
+++ b/packages/g/go-task/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>go-task</Name>
         <Homepage>https://taskfile.dev/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.tools</PartOf>
@@ -27,12 +27,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2024-11-21</Date>
-            <Version>3.40.0</Version>
+        <Update release="21">
+            <Date>2024-12-18</Date>
+            <Version>3.40.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Fixed a security issue in git-urls by switching to the maintained fork `chainguard-dev/git-urls`.
- Added missing `platforms` property to `cmds` that use `for`.
- Added misspell linter to check for misspelled English words.

**Test Plan**

<!-- Short description of how the package was tested -->
Use `go-task` in various packaging workflow

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged (Write an appropriate message in the Summary section)
