### PR TITLE
pingus: Fix music

### DIFF
--- a/packages/l/libmikmod/abi_symbols
+++ b/packages/l/libmikmod/abi_symbols
@@ -108,7 +108,6 @@ libmikmod.so.3:drv_aiff
 libmikmod.so.3:drv_aix
 libmikmod.so.3:drv_alsa
 libmikmod.so.3:drv_dart
-libmikmod.so.3:drv_dc
 libmikmod.so.3:drv_ds
 libmikmod.so.3:drv_esd
 libmikmod.so.3:drv_gp32
@@ -117,7 +116,6 @@ libmikmod.so.3:drv_mac
 libmikmod.so.3:drv_nas
 libmikmod.so.3:drv_nos
 libmikmod.so.3:drv_openal
-libmikmod.so.3:drv_os2
 libmikmod.so.3:drv_osles
 libmikmod.so.3:drv_oss
 libmikmod.so.3:drv_osx
@@ -126,7 +124,6 @@ libmikmod.so.3:drv_psp
 libmikmod.so.3:drv_pulseaudio
 libmikmod.so.3:drv_raw
 libmikmod.so.3:drv_sam9407
-libmikmod.so.3:drv_sb
 libmikmod.so.3:drv_sdl
 libmikmod.so.3:drv_sgi
 libmikmod.so.3:drv_sndio
@@ -135,7 +132,6 @@ libmikmod.so.3:drv_sun
 libmikmod.so.3:drv_ultra
 libmikmod.so.3:drv_wav
 libmikmod.so.3:drv_win
-libmikmod.so.3:drv_wss
 libmikmod.so.3:drv_xaudio2
 libmikmod.so.3:load_669
 libmikmod.so.3:load_amf

--- a/packages/l/libmikmod/abi_used_libs
+++ b/packages/l/libmikmod/abi_used_libs
@@ -1,4 +1,3 @@
-libSDL2-2.0.so.0
 libc.so.6
 libm.so.6
 libpulse-simple.so.0

--- a/packages/l/libmikmod/abi_used_symbols
+++ b/packages/l/libmikmod/abi_used_symbols
@@ -1,11 +1,3 @@
-libSDL2-2.0.so.0:SDL_CloseAudio
-libSDL2-2.0.so.0:SDL_Init
-libSDL2-2.0.so.0:SDL_LockAudio
-libSDL2-2.0.so.0:SDL_OpenAudio
-libSDL2-2.0.so.0:SDL_PauseAudio
-libSDL2-2.0.so.0:SDL_QuitSubSystem
-libSDL2-2.0.so.0:SDL_UnlockAudio
-libSDL2-2.0.so.0:SDL_WasInit
 libc.so.6:__errno_location
 libc.so.6:__memset_chk
 libc.so.6:__snprintf_chk

--- a/packages/l/libmikmod/files/man.patch
+++ b/packages/l/libmikmod/files/man.patch
@@ -1,0 +1,11 @@
+diff -u -r libmikmod-3.3.11.1/docs/CMakeLists.txt libmikmod-3.3.11.1-man/docs/CMakeLists.txt
+--- libmikmod-3.3.11.1/docs/CMakeLists.txt	2014-07-10 07:37:00.000000000 +0000
++++ libmikmod-3.3.11.1-man/docs/CMakeLists.txt	2020-01-11 18:54:48.154853499 +0000
+@@ -20,5 +20,7 @@
+   COMMENT "Creating HTML file ${html_out}"
+   VERBATIM)
+ 
++configure_file(libmikmod-config.1.in libmikmod-config.1 @ONLY)
++
+ add_custom_target(info ALL DEPENDS ${info_out} ${html_out})
+ ENDIF(ENABLE_DOC)

--- a/packages/l/libmikmod/monitoring.yml
+++ b/packages/l/libmikmod/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 1659
+  rss: ~
+security:
+  cpe:
+  - vendor: raphael_assenat
+    product: libmikmod

--- a/packages/l/libmikmod/package.yml
+++ b/packages/l/libmikmod/package.yml
@@ -1,6 +1,6 @@
 name       : libmikmod
 version    : 3.3.11.1
-release    : 12
+release    : 13
 source     :
     - https://sourceforge.net/projects/mikmod/files/libmikmod/3.3.11.1/libmikmod-3.3.11.1.tar.gz : ad9d64dfc8f83684876419ea7cd4ff4a41d8bcd8c23ef37ecb3a200a16b46d19
 homepage   : https://mikmod.sourceforge.net
@@ -14,11 +14,19 @@ description: |
 builddeps  :
     - pkgconfig(alsa)
     - pkgconfig(libpulse)
-    - pkgconfig(sdl)
-    - pkgconfig(sdl2)
 setup      : |
-    %configure_no_runstatedir --enable-alsa --enable-sdl --disable-static
+    %patch -p1 -i $pkgfiles/man.patch
+
+    %cmake_ninja -DENABLE_STATIC=OFF \
+                 -DENABLE_DL=1
 build      : |
-    %make
+    %ninja_build
 install    : |
-    %make_install
+    %ninja_install
+
+    install -Dm00644 libmikmod.m4 -t $installdir/usr/share/aclocal
+    install -Dm00644 solusBuildDir/docs/libmikmod-config.1 -t $installdir/usr/share/man/man1
+patterns   :
+    - devel :
+        - /usr/bin/libmikmod-config
+        - /usr/share/man/man1

--- a/packages/l/libmikmod/pspec_x86_64.xml
+++ b/packages/l/libmikmod/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libmikmod</Name>
         <Homepage>https://mikmod.sourceforge.net</Homepage>
         <Packager>
-            <Name>Domen Skamlic</Name>
-            <Email>domen@skamlic.com</Email>
+            <Name>Reilly Brogan</Name>
+            <Email>solus@reillybrogan.com</Email>
         </Packager>
         <License>LGPL-2.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -21,11 +21,8 @@
 </Description>
         <PartOf>programming.library</PartOf>
         <Files>
-            <Path fileType="executable">/usr/bin/libmikmod-config</Path>
-            <Path fileType="library">/usr/lib64/libmikmod.so.3</Path>
-            <Path fileType="library">/usr/lib64/libmikmod.so.3.3.0</Path>
-            <Path fileType="info">/usr/share/info/mikmod.info</Path>
-            <Path fileType="man">/usr/share/man/man1/libmikmod-config.1</Path>
+            <Path fileType="library">/usr/lib/libmikmod.so.3</Path>
+            <Path fileType="library">/usr/lib/libmikmod.so.3.3.0</Path>
         </Files>
     </Package>
     <Package>
@@ -35,22 +32,24 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="12">libmikmod</Dependency>
+            <Dependency release="13">libmikmod</Dependency>
         </RuntimeDependencies>
         <Files>
+            <Path fileType="executable">/usr/bin/libmikmod-config</Path>
             <Path fileType="header">/usr/include/mikmod.h</Path>
-            <Path fileType="library">/usr/lib64/libmikmod.so</Path>
-            <Path fileType="data">/usr/lib64/pkgconfig/libmikmod.pc</Path>
+            <Path fileType="library">/usr/lib/libmikmod.so</Path>
+            <Path fileType="data">/usr/lib/pkgconfig/libmikmod.pc</Path>
             <Path fileType="data">/usr/share/aclocal/libmikmod.m4</Path>
+            <Path fileType="man">/usr/share/man/man1/libmikmod-config.1</Path>
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2024-07-07</Date>
+        <Update release="13">
+            <Date>2024-12-19</Date>
             <Version>3.3.11.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Domen Skamlic</Name>
-            <Email>domen@skamlic.com</Email>
+            <Name>Reilly Brogan</Name>
+            <Email>solus@reillybrogan.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/p/pingus/MAINTAINERS.md
+++ b/packages/p/pingus/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Muhammad Alfi Syahrin
+  - Matrix: @alfisya:matrix.org
+  - Email: malfisya.dev@hotmail.com

--- a/packages/p/pingus/abi_used_symbols
+++ b/packages/p/pingus/abi_used_symbols
@@ -169,6 +169,7 @@ libstdc++.so.6:_ZNSo9_M_insertIbEERSoT_
 libstdc++.so.6:_ZNSo9_M_insertIdEERSoT_
 libstdc++.so.6:_ZNSo9_M_insertIlEERSoT_
 libstdc++.so.6:_ZNSo9_M_insertImEERSoT_
+libstdc++.so.6:_ZNSoC2Ev
 libstdc++.so.6:_ZNSolsEi
 libstdc++.so.6:_ZNSt11range_errorC1EPKc
 libstdc++.so.6:_ZNSt11range_errorD1Ev
@@ -245,7 +246,6 @@ libstdc++.so.6:_ZSt4cerr
 libstdc++.so.6:_ZSt4cout
 libstdc++.so.6:_ZSt7getlineIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EES4_
 libstdc++.so.6:_ZSt7nothrow
-libstdc++.so.6:_ZSt9terminatev
 libstdc++.so.6:_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
 libstdc++.so.6:_ZTISo
 libstdc++.so.6:_ZTISt11range_error
@@ -280,6 +280,7 @@ libstdc++.so.6:_Znwm
 libstdc++.so.6:_ZnwmRKSt9nothrow_t
 libstdc++.so.6:__cxa_allocate_exception
 libstdc++.so.6:__cxa_begin_catch
+libstdc++.so.6:__cxa_call_terminate
 libstdc++.so.6:__cxa_call_unexpected
 libstdc++.so.6:__cxa_end_catch
 libstdc++.so.6:__cxa_free_exception

--- a/packages/p/pingus/monitoring.yml
+++ b/packages/p/pingus/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 8592
+  rss: https://github.com/Pingus/pingus/tags.atom
+# No known CPE, checked 2024-12-19
+security:
+  cpe: ~

--- a/packages/p/pingus/package.yml
+++ b/packages/p/pingus/package.yml
@@ -1,6 +1,6 @@
 name       : pingus
 version    : 0.7.6
-release    : 10
+release    : 11
 source     :
     - https://github.com/Pingus/pingus/archive/v0.7.6.tar.gz : c4cd89e1d350d2472f32de5f6266ac9f3658a3620eace3f79efac45db4323b65
 homepage   : https://pingus.github.io/
@@ -18,6 +18,8 @@ builddeps  :
     - libboost-devel
     - libiconv-devel
     - scons
+rundeps    :
+    - libmikmod # dlopened by sdl1-mixer
 setup      : |
     # Fedora patch to fix error due to new standards
     # http://gcc.gnu.org/bugzilla/show_bug.cgi?id=51282

--- a/packages/p/pingus/pspec_x86_64.xml
+++ b/packages/p/pingus/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pingus</Name>
         <Homepage>https://pingus.github.io/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Reilly Brogan</Name>
+            <Email>solus@reillybrogan.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>games.strategy</PartOf>
@@ -1857,12 +1857,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2024-02-23</Date>
+        <Update release="11">
+            <Date>2024-12-19</Date>
             <Version>0.7.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Reilly Brogan</Name>
+            <Email>solus@reillybrogan.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/s/sdl1-mixer/abi_used_symbols
+++ b/packages/s/sdl1-mixer/abi_used_symbols
@@ -14,8 +14,11 @@ libSDL-1.2.so.0:SDL_ConvertAudio
 libSDL-1.2.so.0:SDL_Delay
 libSDL-1.2.so.0:SDL_Error
 libSDL-1.2.so.0:SDL_FreeRW
+libSDL-1.2.so.0:SDL_FreeWAV
 libSDL-1.2.so.0:SDL_GetError
 libSDL-1.2.so.0:SDL_GetTicks
+libSDL-1.2.so.0:SDL_LoadFunction
+libSDL-1.2.so.0:SDL_LoadObject
 libSDL-1.2.so.0:SDL_LoadWAV_RW
 libSDL-1.2.so.0:SDL_LockAudio
 libSDL-1.2.so.0:SDL_MixAudio
@@ -26,6 +29,7 @@ libSDL-1.2.so.0:SDL_ReadBE16
 libSDL-1.2.so.0:SDL_ReadBE32
 libSDL-1.2.so.0:SDL_ReadLE32
 libSDL-1.2.so.0:SDL_SetError
+libSDL-1.2.so.0:SDL_UnloadObject
 libSDL-1.2.so.0:SDL_UnlockAudio
 libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_toupper_loc

--- a/packages/s/sdl1-mixer/abi_used_symbols32
+++ b/packages/s/sdl1-mixer/abi_used_symbols32
@@ -14,6 +14,7 @@ libSDL-1.2.so.0:SDL_ConvertAudio
 libSDL-1.2.so.0:SDL_Delay
 libSDL-1.2.so.0:SDL_Error
 libSDL-1.2.so.0:SDL_FreeRW
+libSDL-1.2.so.0:SDL_FreeWAV
 libSDL-1.2.so.0:SDL_GetError
 libSDL-1.2.so.0:SDL_GetTicks
 libSDL-1.2.so.0:SDL_LoadWAV_RW

--- a/packages/s/sdl1-mixer/monitoring.yml
+++ b/packages/s/sdl1-mixer/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 7989
+  rss: https://github.com/libsdl-org/SDL_mixer/releases.atom
+security:
+  # No known CPE, last checked 2024-12-18
+  cpe: ~

--- a/packages/s/sdl1-mixer/package.yml
+++ b/packages/s/sdl1-mixer/package.yml
@@ -1,8 +1,9 @@
 name       : sdl1-mixer
 version    : 1.2.12
-release    : 7
+release    : 8
 source     :
-    - https://www.libsdl.org/projects/SDL_mixer/release/SDL_mixer-1.2.12.tar.gz : 1644308279a975799049e4826af2cfc787cad2abb11aa14562e402521f86992a
+    # - https://www.libsdl.org/projects/SDL_mixer/release/SDL_mixer-1.2.12.tar.gz : 1644308279a975799049e4826af2cfc787cad2abb11aa14562e402521f86992a
+    - git|https://github.com/libsdl-org/SDL_mixer : ed76d39cda0735d26c14a3e4f4da996e420f6478 # SDL-1.2 bugfix branch
 homepage   : https://www.libsdl.org/
 license    : Zlib
 component  : multimedia.library
@@ -15,13 +16,19 @@ builddeps  :
     - pkgconfig32(libzstd)
     - pkgconfig32(sdl)
     - pkgconfig32(vorbisfile)
+    - pkgconfig(libmikmod)
 emul32     : yes
 optimize   : speed
 setup      : |
+    if [ ! -z "${EMUL32BUILD+set}" ]; then
+        EXTRA_ARGS="--enable-music-mod --enable-music-mod-shared"
+    fi
+
     %configure_no_runstatedir \
         --disable-music-flac-shared \
         --disable-music-ogg-shared \
-        --disable-static
+        --disable-static \
+        $EXTRA_ARGS
 build      : |
     %make
 install    : |

--- a/packages/s/sdl1-mixer/pspec_x86_64.xml
+++ b/packages/s/sdl1-mixer/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>sdl1-mixer</Name>
         <Homepage>https://www.libsdl.org/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Reilly Brogan</Name>
+            <Email>solus@reillybrogan.com</Email>
         </Packager>
         <License>Zlib</License>
         <PartOf>multimedia.library</PartOf>
@@ -21,7 +21,7 @@
         <PartOf>multimedia.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libSDL_mixer-1.2.so.0</Path>
-            <Path fileType="library">/usr/lib64/libSDL_mixer-1.2.so.0.12.0</Path>
+            <Path fileType="library">/usr/lib64/libSDL_mixer-1.2.so.0.12.1</Path>
         </Files>
     </Package>
     <Package>
@@ -31,11 +31,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="7">sdl1-mixer</Dependency>
+            <Dependency release="8">sdl1-mixer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libSDL_mixer-1.2.so.0</Path>
-            <Path fileType="library">/usr/lib32/libSDL_mixer-1.2.so.0.12.0</Path>
+            <Path fileType="library">/usr/lib32/libSDL_mixer-1.2.so.0.12.1</Path>
         </Files>
     </Package>
     <Package>
@@ -45,8 +45,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="7">sdl1-mixer-32bit</Dependency>
-            <Dependency release="7">sdl1-mixer-devel</Dependency>
+            <Dependency release="8">sdl1-mixer-32bit</Dependency>
+            <Dependency release="8">sdl1-mixer-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libSDL_mixer.so</Path>
@@ -60,7 +60,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="7">sdl1-mixer</Dependency>
+            <Dependency release="8">sdl1-mixer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/SDL/SDL_mixer.h</Path>
@@ -69,12 +69,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2024-06-03</Date>
+        <Update release="8">
+            <Date>2024-12-19</Date>
             <Version>1.2.12</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Reilly Brogan</Name>
+            <Email>solus@reillybrogan.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Use cmake build with libmikmod
- Use bugfix branch for sdl1-mixer and build with explicit mikmod support
- Add a direct rundep onto libmikmod from pingus

Pingus' music finally playing again after several years. Enjoy playing Pingus, now with music!

Closes getsolus/packages#1712

**Checklist**

- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section -->