### PR TITLE
freetype2: Update to v2.13.3 and add monitoring.yml

### DIFF
--- a/packages/f/freetype2/monitoring.yml
+++ b/packages/f/freetype2/monitoring.yml
@@ -1,0 +1,7 @@
+releases:
+  id: 854
+  rss: https://sourceforge.net/projects/freetype/rss?path=/freetype2
+security:
+  cpe:
+    - vendor: freetype
+      product: freetype

--- a/packages/f/freetype2/package.yml
+++ b/packages/f/freetype2/package.yml
@@ -1,8 +1,8 @@
 name       : freetype2
-version    : 2.13.2
-release    : 36
+version    : 2.13.3
+release    : 37
 source     :
-    - https://download.savannah.gnu.org/releases/freetype/freetype-2.13.2.tar.xz : 12991c4e55c506dd7f9b765933e62fd2be2e06d421505d7950a132e4f1bb484d
+    - https://download.savannah.gnu.org/releases/freetype/freetype-2.13.3.tar.xz : 0550350666d427c74daeb85d5ac7bb353acba5f76956395995311a9c6f063289
 homepage   : https://freetype.org/
 license    : GPL-2.0-or-later
 component  :
@@ -33,20 +33,20 @@ rundeps    :
         - glibc-32bit
         - libpng-32bit
         - zlib-32bit
-    - devel :
-        - brotli-devel
-        - bzip2-devel
-        - freetype2
-        - zlib-devel
-        - libpng-devel
-        - harfbuzz-devel
     - 32bit-devel :
         - brotli-32bit-devel
         - bzip2-32bit-devel
         - freetype2-32bit
-        - zlib-32bit-devel
-        - libpng-32bit-devel
         - harfbuzz-32bit-devel
+        - libpng-32bit-devel
+        - zlib-32bit-devel
+    - devel :
+        - brotli-devel
+        - bzip2-devel
+        - freetype2
+        - harfbuzz-devel
+        - libpng-devel
+        - zlib-devel
 emul32     : yes
 optimize   : speed
 setup      : |

--- a/packages/f/freetype2/pspec_x86_64.xml
+++ b/packages/f/freetype2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>freetype2</Name>
         <Homepage>https://freetype.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.library</PartOf>
@@ -21,7 +21,7 @@
         <PartOf>desktop.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libfreetype.so.6</Path>
-            <Path fileType="library">/usr/lib64/libfreetype.so.6.20.1</Path>
+            <Path fileType="library">/usr/lib64/libfreetype.so.6.20.2</Path>
         </Files>
     </Package>
     <Package>
@@ -31,11 +31,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="36">freetype2</Dependency>
+            <Dependency release="37">freetype2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libfreetype.so.6</Path>
-            <Path fileType="library">/usr/lib32/libfreetype.so.6.20.1</Path>
+            <Path fileType="library">/usr/lib32/libfreetype.so.6.20.2</Path>
         </Files>
     </Package>
     <Package>
@@ -45,8 +45,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="36">freetype2-devel</Dependency>
-            <Dependency release="36">freetype2-32bit</Dependency>
+            <Dependency release="37">freetype2-devel</Dependency>
+            <Dependency release="37">freetype2-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libfreetype.so</Path>
@@ -60,7 +60,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="36">freetype2</Dependency>
+            <Dependency release="37">freetype2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/freetype-config</Path>
@@ -125,12 +125,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2024-04-26</Date>
-            <Version>2.13.2</Version>
+        <Update release="37">
+            <Date>2024-12-19</Date>
+            <Version>2.13.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Some fields in the `FT_Outline` structure have been changed from signed  to unsigned type
- Rare double-free crashes in the cache subsystem have been fixed
- Excessive stack allocation in the autohinter has been fixed
- The B/W rasterizer has received a major upkeep that results in large performance improvements
- If the new configuration option `TT_CONFIG_OPTION_GPOS_KERNING` is defined, `FT_Get_Kerning` understands rudimentary GPOS kerning
- The internal structures `PS_DesignMap` and `PS_Blend` related to parsing of old Multiple Masters fonts have been removed

Full release notes available [here](https://sourceforge.net/projects/freetype/files/freetype2/2.13.3/)

**Test Plan**
- Rebooted
- Confirmed fonts looked okay Firefox, LibreOffice, gnome-terminal, Element, various other apps

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section -->
