### PR TITLE
xfce4-taskmanager: Update to v1.5.7

### DIFF
--- a/packages/x/xfce4-taskmanager/abi_used_libs
+++ b/packages/x/xfce4-taskmanager/abi_used_libs
@@ -1,9 +1,9 @@
 libX11.so.6
 libXmu.so.6
 libc.so.6
+libcairo-gobject.so.2
 libcairo.so.2
 libgdk-3.so.0
-libgdk_pixbuf-2.0.so.0
 libgio-2.0.so.0
 libglib-2.0.so.0
 libgobject-2.0.so.0

--- a/packages/x/xfce4-taskmanager/abi_used_symbols
+++ b/packages/x/xfce4-taskmanager/abi_used_symbols
@@ -28,6 +28,7 @@ libc.so.6:setpriority
 libc.so.6:stderr
 libc.so.6:strlen
 libc.so.6:sysconf
+libcairo-gobject.so.2:cairo_gobject_surface_get_type
 libcairo.so.2:cairo_create
 libcairo.so.2:cairo_destroy
 libcairo.so.2:cairo_fill_preserve
@@ -47,14 +48,17 @@ libcairo.so.2:cairo_set_source_surface
 libcairo.so.2:cairo_stroke
 libcairo.so.2:cairo_surface_destroy
 libcairo.so.2:cairo_translate
+libgdk-3.so.0:gdk_cairo_surface_create_from_pixbuf
 libgdk-3.so.0:gdk_display_get_default
+libgdk-3.so.0:gdk_display_get_monitor
 libgdk-3.so.0:gdk_event_get_scroll_deltas
 libgdk-3.so.0:gdk_event_get_scroll_direction
+libgdk-3.so.0:gdk_monitor_get_scale_factor
+libgdk-3.so.0:gdk_rgba_free
 libgdk-3.so.0:gdk_screen_get_default
 libgdk-3.so.0:gdk_window_get_type
 libgdk-3.so.0:gdk_window_invalidate_rect
 libgdk-3.so.0:gdk_x11_display_get_type
-libgdk_pixbuf-2.0.so.0:gdk_pixbuf_get_type
 libgio-2.0.so.0:g_application_activate
 libgio-2.0.so.0:g_application_get_is_remote
 libgio-2.0.so.0:g_application_new
@@ -249,6 +253,7 @@ libgtk-3.so.0:gtk_message_dialog_format_secondary_text
 libgtk-3.so.0:gtk_message_dialog_new
 libgtk-3.so.0:gtk_scrolled_window_get_vadjustment
 libgtk-3.so.0:gtk_scrolled_window_get_vscrollbar
+libgtk-3.so.0:gtk_settings_get_default
 libgtk-3.so.0:gtk_show_about_dialog
 libgtk-3.so.0:gtk_status_icon_get_visible
 libgtk-3.so.0:gtk_status_icon_new_from_icon_name
@@ -258,6 +263,9 @@ libgtk-3.so.0:gtk_status_icon_set_visible
 libgtk-3.so.0:gtk_style_context_add_class
 libgtk-3.so.0:gtk_style_context_add_provider
 libgtk-3.so.0:gtk_style_context_add_provider_for_screen
+libgtk-3.so.0:gtk_style_context_get
+libgtk-3.so.0:gtk_style_context_has_class
+libgtk-3.so.0:gtk_style_context_remove_class
 libgtk-3.so.0:gtk_toggle_button_get_active
 libgtk-3.so.0:gtk_toggle_button_set_active
 libgtk-3.so.0:gtk_tooltip_set_text
@@ -332,6 +340,7 @@ libgtk-3.so.0:gtk_widget_destroy
 libgtk-3.so.0:gtk_widget_get_allocated_height
 libgtk-3.so.0:gtk_widget_get_allocated_width
 libgtk-3.so.0:gtk_widget_get_style_context
+libgtk-3.so.0:gtk_widget_get_toplevel
 libgtk-3.so.0:gtk_widget_get_type
 libgtk-3.so.0:gtk_widget_get_visible
 libgtk-3.so.0:gtk_widget_get_window
@@ -361,6 +370,7 @@ libwnck-3.so.0:wnck_application_get_pid
 libwnck-3.so.0:wnck_application_get_windows
 libwnck-3.so.0:wnck_screen_get_default
 libwnck-3.so.0:wnck_screen_get_windows
+libwnck-3.so.0:wnck_set_default_mini_icon_size
 libwnck-3.so.0:wnck_window_get_application
 libwnck-3.so.0:wnck_window_get_pid
 libwnck-3.so.0:wnck_window_get_window_type

--- a/packages/x/xfce4-taskmanager/files/org.xfce.taskmanager.metainfo.xml
+++ b/packages/x/xfce4-taskmanager/files/org.xfce.taskmanager.metainfo.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.xfce.taskmanager</id>
+
+  <name>Task Manager</name>
+  <summary>Easy to use task manager</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-or-later</project_license>
+
+  <description>
+    <p>
+      The xfce4-taskmanager component is an easy to use graphical task manager.
+    </p>
+    <ul>
+      <li>Support for Linux, OpenBSD, NetBSD, FreeBSD and OpenSolaris.</li>
+      <li>Monitors the CPU and memory usage.</li>
+      <li>Tree view columns can be reordered.</li>
+      <li>View processes as a tree.</li>
+      <li>Display process icons.</li>
+      <li> Customizable with some settings.</li>
+      <li>Filter process list on process names.</li>
+      <li>Support for Gtk+3.</li>
+    </ul>
+  </description>
+  <project_group>Xfce</project_group>
+
+  <launchable type="desktop-id">xfce4-taskmanager.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://docs.xfce.org/_media/apps/xfce4-taskmanager/xfce4-taskmanager-main-window.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://docs.xfce.org/_media/apps/xfce4-taskmanager/xfce4-taskmanager-preferences-general.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://docs.xfce.org/_media/apps/xfce4-taskmanager/xfce4-taskmanager-preferences-columns.png</image>
+    </screenshot>
+  </screenshots>
+</component>

--- a/packages/x/xfce4-taskmanager/package.yml
+++ b/packages/x/xfce4-taskmanager/package.yml
@@ -1,8 +1,8 @@
 name       : xfce4-taskmanager
-version    : 1.5.6
-release    : 1
+version    : 1.5.7
+release    : 2
 source     :
-    - https://archive.xfce.org/src/apps/xfce4-taskmanager/1.5/xfce4-taskmanager-1.5.6.tar.bz2 : 20979000761a41faed4f7f63f27bd18bb36fb27db4f7ecc8784a460701fb4abb
+    - https://archive.xfce.org/src/apps/xfce4-taskmanager/1.5/xfce4-taskmanager-1.5.7.tar.bz2 : 6736832f5a64533e536f4994280bd907da19666cda8d2f465c8a53bb581f68bb
 homepage   : https://docs.xfce.org/apps/xfce4-taskmanager/start
 license    : GPL-2.0-or-later
 component  : desktop.xfce
@@ -20,3 +20,5 @@ build      : |
     %make
 install    : |
     %make_install
+    # Install AppStream metainfo
+    install -Dm00644 $pkgfiles/org.xfce.taskmanager.metainfo.xml -t $installdir/usr/share/metainfo

--- a/packages/x/xfce4-taskmanager/pspec_x86_64.xml
+++ b/packages/x/xfce4-taskmanager/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xfce4-taskmanager</Name>
         <Homepage>https://docs.xfce.org/apps/xfce4-taskmanager/start</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.xfce</PartOf>
@@ -23,15 +23,13 @@
             <Path fileType="executable">/usr/bin/xfce4-taskmanager</Path>
             <Path fileType="data">/usr/share/applications/xfce4-taskmanager.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/org.xfce.taskmanager.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/16x16/actions/xc_crosshair.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/16x16/apps/org.xfce.taskmanager.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/24x24/actions/xc_crosshair.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/24x24/apps/org.xfce.taskmanager.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/org.xfce.taskmanager.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/org.xfce.taskmanager.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/org.xfce.taskmanager.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/96x96/apps/org.xfce.taskmanager.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xc_crosshair.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/xc_crosshair-symbolic.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/org.xfce.taskmanager.svg</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/xfce4-taskmanager.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ast/LC_MESSAGES/xfce4-taskmanager.mo</Path>
@@ -92,15 +90,16 @@
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/xfce4-taskmanager.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_HK/LC_MESSAGES/xfce4-taskmanager.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/xfce4-taskmanager.mo</Path>
+            <Path fileType="data">/usr/share/metainfo/org.xfce.taskmanager.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2023-12-16</Date>
-            <Version>1.5.6</Version>
+        <Update release="2">
+            <Date>2024-12-19</Date>
+            <Version>1.5.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Changes:
   - Update copyright year
   - build: Fix `-Wcast-align` warning from clang
   - Fix UBSan errors
   - settings-dialog: Fix `XtmRefreshRate` memory leak
   - Dark mode for process-statusbar
   - Dark mode for process-monitor
   - Allow multiple instances via command line option.
   - Fix blurry app icons when UI scale > 1
   - Use symbolic window picker icon in toolbar
   - Fix broken "show-legend" setting sync
   - Translation Updates: Catalan, Croatian, Estonian, Greek, Hebrew, Italian, Occitan (post  1500), Polish, Spanish, Swedish, Turkish
- Add appstream metainfo (Part of getsolus/packages#1389)

**Test Plan**

<!-- Short description of how the package was tested -->
Install and launch it in the XFCE VM

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section -->
