### PR TITLE
putty: update to 0.82

### DIFF
--- a/packages/p/putty/abi_used_symbols
+++ b/packages/p/putty/abi_used_symbols
@@ -38,7 +38,6 @@ libc.so.6:__isoc23_sscanf
 libc.so.6:__isoc23_strtol
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
-libc.so.6:__memcpy_chk
 libc.so.6:__memset_chk
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
@@ -180,6 +179,7 @@ libc.so.6:setresuid
 libc.so.6:setsid
 libc.so.6:setsockopt
 libc.so.6:setutxent
+libc.so.6:setvbuf
 libc.so.6:shutdown
 libc.so.6:sigaction
 libc.so.6:sigaddset
@@ -231,6 +231,7 @@ libc.so.6:utime
 libc.so.6:utimes
 libc.so.6:waitpid
 libc.so.6:wcrtomb
+libc.so.6:wcslen
 libc.so.6:wcsncmp
 libc.so.6:write
 libcairo.so.2:cairo_clip

--- a/packages/p/putty/package.yml
+++ b/packages/p/putty/package.yml
@@ -1,8 +1,8 @@
 name       : putty
-version    : '0.81'
-release    : 14
+version    : '0.82'
+release    : 15
 source     :
-    - https://the.earth.li/~sgtatham/putty/0.81/putty-0.81.tar.gz : cb8b00a94f453494e345a3df281d7a3ed26bb0dd7e36264f145206f8857639fe
+    - https://the.earth.li/~sgtatham/putty/latest/putty-0.82.tar.gz : 195621638bb6b33784b4e96cdc296f332991b5244968dc623521c3703097b5d9
 license    : MIT
 component  : network.remote
 homepage   : https://www.chiark.greenend.org.uk/~sgtatham/putty

--- a/packages/p/putty/pspec_x86_64.xml
+++ b/packages/p/putty/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>putty</Name>
         <Homepage>https://www.chiark.greenend.org.uk/~sgtatham/putty</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>network.remote</PartOf>
@@ -43,12 +43,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2024-09-14</Date>
-            <Version>0.81</Version>
+        <Update release="15">
+            <Date>2024-12-20</Date>
+            <Version>0.82</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Major refactoring of Unicode handling to allow the use of 'foreign' Unicode characters, i.e. outside the system's configured default character set / code page. Not yet complete, but the following things work:
- Windows console: usernames and passwords entered interactively into PSCP, PSFTP and Plink can use foreign characters.
- Windows command line: usernames, remote commands, and filenames entered via command-line options can use foreign characters.
- PuTTY's own terminal (on Windows and Unix): even if it's not configured into UTF-8 mode for the main session, interactive usernames and passwords can use foreign characters.
- Unicode version update: all character analysis is updated to Unicode 16.0.0.
- Unicode terminal rendering: national and regional flags are now understood by PuTTY's terminal emulator. (However, correct display of those flags will depend on fonts and operating system.)
- The Event Log mentions the local address and port number of the outgoing connection socket.
- Bracketed paste mode can now be turned off in the Terminal > Features panel.
- Unix Pageant: new --foreground mode for running as a subprocess.
- Bug fix: the 'border width' configuration option is now honoured even when the window is maximised.
- Bug fix: SHA-2 based RSA signatures are now sent with correct zero padding.
- Bug fix: terminal wrap mishandling caused occasional incorrect redraws in curses-based applications.
- Bug fix: Alt + function key in "Xterm 216+" mode sent a spurious extra escape character.

**Test Plan**
- Connnected to blinkenshell

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section -->
