### PR TITLE
snapd: Update confinement warning with a date

### DIFF
--- a/packages/s/snapd/files/wrapper.sh
+++ b/packages/s/snapd/files/wrapper.sh
@@ -36,9 +36,11 @@ if [[ "${CONFINEMENT}" != "strict" ]] && [[ "${DISABLE_CONFINEMENT_WARNING:-n}" 
           --urgency normal \
           --icon dialog-warning \
           "Snap has ${CONFINEMENT} confinement" \
+          "Snaps will stop working in early January 2025." \
           "See ${URL} for details."
   else
       echo -e "${YELLOW}WARNING:${NC} snap is running with ${CONFINEMENT} confinement." \
+        "Snaps will stop working in early January 2025." \
         "See ${URL} for details"
   fi
 fi

--- a/packages/s/snapd/package.yml
+++ b/packages/s/snapd/package.yml
@@ -1,7 +1,7 @@
 name       : snapd
 version    : 2.63
 homepage   : https://snapcraft.io/
-release    : 82
+release    : 83
 source     :
     - https://github.com/snapcore/snapd/releases/download/2.63/snapd_2.63.vendor.tar.xz : 2f0083d2c4e087c29f48cd1abb8a92eb2e63cf04cd433256c86fac05d0b28cab
 license    : GPL-3.0-only

--- a/packages/s/snapd/pspec_x86_64.xml
+++ b/packages/s/snapd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>snapd</Name>
         <Homepage>https://snapcraft.io/</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <PartOf>desktop</PartOf>
@@ -77,12 +77,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="82">
-            <Date>2024-07-10</Date>
+        <Update release="83">
+            <Date>2024-12-20</Date>
             <Version>2.63</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Add a sentence to the warning which runs for every snap, telling users that snaps will stop working soon.
- Part of https://github.com/getsolus/packages/issues/325
- See also https://github.com/getsolus/help-center-docs/pull/589

Sync Message:

The warning that pops up whenever you run a snap has been changed to include the sentence **"Snaps will stop working in early January 2025."** This is part of a process we started back in July to remove snap support from Solus; we wrote about our reasons for this in a [blog post](https://getsol.us/2024/07/15/dropping-apparmor-kernel-patches/). The Help Center has [a page](https://help.getsol.us/docs/user/software/third-party/snap/) with more details about the warning and what you can do if you have snaps installed. Most users will not have snaps installed, as Solus has usually recommended that third-party apps be installed from the Third Party section of the Solus Software Center or as Flatpaks.

**Test Plan**

- Run a CLI snap, see changed warning
- Graphical warning untested

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section -->
