### PR TITLE
virtualbox: KVM fix

### DIFF
--- a/packages/v/virtualbox/files/virtualbox.conf
+++ b/packages/v/virtualbox/files/virtualbox.conf
@@ -1,0 +1,2 @@
+# With kernel 6.12 kvm is enabled by default and this breaks virtualbox.
+options kvm enable_virt_at_load=0

--- a/packages/v/virtualbox/package.yml
+++ b/packages/v/virtualbox/package.yml
@@ -1,6 +1,6 @@
 name       : virtualbox
 version    : 7.1.4
-release    : 341
+release    : 342
 source     :
     - https://download.virtualbox.org/virtualbox/7.1.4/VirtualBox-7.1.4.tar.bz2 : 872e7a42b41f8558abbf887f1bdc7aac932bb88b2764d07cbce270cab57e3b5e
     - https://download.virtualbox.org/virtualbox/7.1.4/VBoxGuestAdditions_7.1.4.iso : 80c91d35742f68217cf47b13e5b50d53f54c22c485bacce41ad7fdc321649e61
@@ -263,6 +263,9 @@ install    : |
 
     # Install Guest Additons ISO
     install -Dm00644 $sources/VBoxGuestAdditions_*.iso $installdir/usr/share/virtualbox/VBoxGuestAdditions.iso
+
+    # Disable KVM
+    install -Dm00644 $pkgfiles/virtualbox.conf $installdir/usr/lib/modprobe.d/virtualbox.conf
 
     # Usr-merge
     install -dm00755 $installdir/lib64

--- a/packages/v/virtualbox/pspec_x86_64.xml
+++ b/packages/v/virtualbox/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>virtualbox</Name>
         <Homepage>https://www.virtualbox.org</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>virt</PartOf>
@@ -24,7 +24,7 @@ Installation Guide: https://help.getsol.us/docs/user/software/virtualization/vir
 </Description>
         <PartOf>virt</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="341">virtualbox-common</Dependency>
+            <Dependency releaseFrom="342">virtualbox-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.6.66-262.lts/extra/vboxdrv.ko.zst</Path>
@@ -54,6 +54,7 @@ Installation Guide: https://help.getsol.us/docs/user/software/virtualization/vir
             <Path fileType="executable">/usr/bin/VBoxSDL</Path>
             <Path fileType="executable">/usr/bin/VBoxVRDP</Path>
             <Path fileType="executable">/usr/bin/VirtualBox</Path>
+            <Path fileType="library">/usr/lib/modprobe.d/virtualbox.conf</Path>
             <Path fileType="library">/usr/lib64/systemd/system/multi-user.target.wants/vboxdrv.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/vboxdrv.service</Path>
             <Path fileType="library">/usr/lib64/sysusers.d/virtualbox.conf</Path>
@@ -305,7 +306,7 @@ Installation Guide: https://help.getsol.us/docs/user/software/virtualization/vir
 </Description>
         <PartOf>virt</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="341">virtualbox-common</Dependency>
+            <Dependency releaseFrom="342">virtualbox-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.12.5-311.current/extra/vboxdrv.ko.zst</Path>
@@ -325,8 +326,8 @@ Installation Guide: https://help.getsol.us/docs/user/software/virtualization/vir
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="341">virtualbox</Dependency>
-            <Dependency releaseFrom="341">virtualbox-common</Dependency>
+            <Dependency release="342">virtualbox</Dependency>
+            <Dependency releaseFrom="342">virtualbox-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib/python3.11/site-packages/vboxapi-1-py3.11.egg-info/PKG-INFO</Path>
@@ -617,7 +618,7 @@ Installation Guide: https://help.getsol.us/docs/user/software/virtualization/vir
 </Description>
         <PartOf>virt</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="341">virtualbox-guest-common</Dependency>
+            <Dependency releaseFrom="342">virtualbox-guest-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.6.66-262.lts/misc/vboxguest.ko.zst</Path>
@@ -672,7 +673,7 @@ Installation Guide: https://help.getsol.us/docs/user/software/virtualization/vir
 </Description>
         <PartOf>virt</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="341">virtualbox-guest-common</Dependency>
+            <Dependency releaseFrom="342">virtualbox-guest-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.12.5-311.current/misc/vboxguest.ko.zst</Path>
@@ -684,12 +685,12 @@ Installation Guide: https://help.getsol.us/docs/user/software/virtualization/vir
         </Files>
     </Package>
     <History>
-        <Update release="341">
-            <Date>2024-12-18</Date>
+        <Update release="342">
+            <Date>2024-12-21</Date>
             <Version>7.1.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

"In kernel 6.12, KVM initializes virtualization on module loading by default. This prevents VirtualBox VMs from starting."

https://www.virtualbox.org/wiki/Changelog

**Test Plan**

See that VirtualBox VMs now start.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
