### PR TITLE
rymdport: Update to v3.7.0

### DIFF
--- a/packages/r/rymdport/package.yml
+++ b/packages/r/rymdport/package.yml
@@ -1,8 +1,8 @@
 name       : rymdport
-version    : 3.6.0
-release    : 11
+version    : 3.7.0
+release    : 12
 source     :
-    - https://github.com/Jacalz/rymdport/releases/download/v3.6.0/rymdport-v3.6.0-vendored.tar.xz : 2c608378b1ed6a4cbd6d01a297fc2e0772f873a95e5f3601027375ab99799762
+    - https://github.com/Jacalz/rymdport/releases/download/v3.7.0/rymdport-v3.7.0-vendored.tar.xz : 762abccd3db0fdaeedc81039022a17812059b69e63d745a51ce3f550a6db134a
 license    : GPL-3.0-or-later
 homepage   : https://rymdport.github.io/
 component  : network.clients

--- a/packages/r/rymdport/pspec_x86_64.xml
+++ b/packages/r/rymdport/pspec_x86_64.xml
@@ -35,9 +35,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2024-04-14</Date>
-            <Version>3.6.0</Version>
+        <Update release="12">
+            <Date>2024-12-20</Date>
+            <Version>3.7.0</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- The received text is now read-only.
- Received items are now not shown until after the download starts.
- Fixed a bug where the folder icon did not display until the receive completed.
- Cleaned up and optimized various code paths.
- Bump to Go 1.21 as lowest supported compiler version.
- Updated fyne to v2.5.3.
- Updated many other dependencies for various fixes and improvements.

**Test Plan**

- Send a file across local network

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
