### PR TITLE
mu: Update to 1.12.8

### DIFF
--- a/packages/m/mu/abi_used_symbols
+++ b/packages/m/mu/abi_used_symbols
@@ -7,7 +7,6 @@ libc.so.6:__isoc23_strtoll
 libc.so.6:__isoc23_strtoull
 libc.so.6:__libc_single_threaded
 libc.so.6:__libc_start_main
-libc.so.6:__memcpy_chk
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
@@ -46,14 +45,12 @@ libc.so.6:memset
 libc.so.6:mkdir
 libc.so.6:nanosleep
 libc.so.6:opendir
-libc.so.6:pthread_cond_clockwait
 libc.so.6:pthread_mutex_lock
 libc.so.6:pthread_mutex_unlock
 libc.so.6:puts
 libc.so.6:raise
 libc.so.6:readdir64
 libc.so.6:rename
-libc.so.6:sched_yield
 libc.so.6:setlocale
 libc.so.6:setsid
 libc.so.6:sigaction
@@ -374,9 +371,6 @@ libstdc++.so.6:_ZNSt15basic_streambufIcSt11char_traitsIcEEaSERKS2_
 libstdc++.so.6:_ZNSt16invalid_argumentC1EPKc
 libstdc++.so.6:_ZNSt16invalid_argumentC1ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
 libstdc++.so.6:_ZNSt16invalid_argumentD1Ev
-libstdc++.so.6:_ZNSt18condition_variable10notify_oneEv
-libstdc++.so.6:_ZNSt18condition_variableC1Ev
-libstdc++.so.6:_ZNSt18condition_variableD1Ev
 libstdc++.so.6:_ZNSt3_V215system_categoryEv
 libstdc++.so.6:_ZNSt3_V216generic_categoryEv
 libstdc++.so.6:_ZNSt5ctypeIcE2idE
@@ -390,7 +384,6 @@ libstdc++.so.6:_ZNSt6localeC1Ev
 libstdc++.so.6:_ZNSt6localeD1Ev
 libstdc++.so.6:_ZNSt6localeaSERKS_
 libstdc++.so.6:_ZNSt6thread15_M_start_threadESt10unique_ptrINS_6_StateESt14default_deleteIS1_EEPFvvE
-libstdc++.so.6:_ZNSt6thread20hardware_concurrencyEv
 libstdc++.so.6:_ZNSt6thread4joinEv
 libstdc++.so.6:_ZNSt6thread6_StateD2Ev
 libstdc++.so.6:_ZNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE14__xfer_bufptrsD1Ev

--- a/packages/m/mu/monitoring.yml
+++ b/packages/m/mu/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 376028
+  rss: https://github.com/djcb/mu/releases.atom
+# No known CPE, checked 2024-12-29
+security:
+  cpe: ~

--- a/packages/m/mu/package.yml
+++ b/packages/m/mu/package.yml
@@ -1,8 +1,8 @@
 name       : mu
-version    : 1.12.7
-release    : 28
+version    : 1.12.8
+release    : 29
 source     :
-    - https://github.com/djcb/mu/releases/download/v1.12.7/mu-1.12.7.tar.xz : d916ba9b8ada90996b37eedf7f5fc70c35eb77f47fd933a502fbe0dccf2a6529
+    - https://github.com/djcb/mu/releases/download/v1.12.8/mu-1.12.8.tar.xz : 6c7d43e95ad228990defe5dfd61101aa7a7217d631add303cce1fb29f7a204d0
 license    : GPL-3.0-only
 homepage   : https://www.djcbsoftware.nl/code/mu/
 component  : editor
@@ -18,7 +18,7 @@ builddeps  :
     - pkgconfig(xapian-core)
     - emacs
 setup      : |
-    %meson_configure -Dxapian-single-threaded=false
+    %meson_configure
 build      : |
     %ninja_build
     emacs --batch --eval '(byte-recompile-directory "mu4e")'

--- a/packages/m/mu/pspec_x86_64.xml
+++ b/packages/m/mu/pspec_x86_64.xml
@@ -108,9 +108,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2024-10-28</Date>
-            <Version>1.12.7</Version>
+        <Update release="29">
+            <Date>2024-12-21</Date>
+            <Version>1.12.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- documentation improvements
- removal of the old threading option and cleanup
- 'lazy' indexing is even lazier (faster)
- make References:/In-reply-to: headers searchable
- add new combination-field "related:" to search by msgid: or references:
- new command 'mu4e-view-jump-to-mime-part', to jump to some mime part by number
- new variable mu4e-trash-without-flag, if set to non-nil, "trashing" a message will not add the "T" flag

**Test Plan**
- index, search and view message

**Checklist**
- [X] Package was built and tested against unstable
