### PR TITLE
prusa-slicer: Deprecate

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2776,5 +2776,7 @@
 		<Package>pandoc-include-code</Package>
 		<Package>pandoc-include-code-devel</Package>
 		<Package>pandoc-include-code-dbginfo</Package>
+		<Package>prusa-slicer</Package>
+		<Package>prusa-slicer-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3725,6 +3725,9 @@
 		<Package>pandoc-include-code-devel</Package>
 		<Package>pandoc-include-code-dbginfo</Package>
 
+		<!-- Gnarly to package, upstream now recommends Flatpak -->
+		<Package>prusa-slicer</Package>
+		<Package>prusa-slicer-dbginfo</Package>
 	</Obsoletes>
 </PISI>
 


### PR DESCRIPTION
**Summary**

This package is being deprecated for a few reasons

- It is tricky to package, breaking often, and does not have a consistent maintainer
- Currently does not build
- As of release 2.9.0, upstream considers Flatpak to be the only supported way to install on linux
- [Upstream release notes here](https://github.com/prusa3d/PrusaSlicer/releases/tag/version_2.9.0)

Resolves https://github.com/getsolus/packages/issues/4645
