### PR TITLE
snapd: bugfix: Fix formatting error and change to critical

### DIFF
--- a/packages/s/snapd/files/wrapper.sh
+++ b/packages/s/snapd/files/wrapper.sh
@@ -29,15 +29,19 @@ fi
 
 if [[ "${CONFINEMENT}" != "strict" ]] && [[ "${DISABLE_CONFINEMENT_WARNING:-n}" != "y" ]]
   then
-  if [[ -n "${BAMF_DESKTOP_FILE_HINT+x}" ]] && [[ -n "${GIO_LAUNCHED_DESKTOP_FILE+x}" ]]
+
+  if [[ -n "${BAMF_DESKTOP_FILE_HINT+x}" ]]
   then
+  # Ensure the notify-send meets the freedesktop standards
+  # https://specifications.freedesktop.org/notification-spec/latest/
+  # Keep it short and test on all DEs
+  # Also, we can't use any HTML tags, they are only optionally supported
       notify-send \
           --app-name Snap \
-          --urgency normal \
+          --urgency critical \
           --icon dialog-warning \
           "Snap has ${CONFINEMENT} confinement" \
-          "Snaps will stop working in early January 2025." \
-          "See ${URL} for details."
+          "Snaps will stop working in Jan. 2025. See ${URL}"
   else
       echo -e "${YELLOW}WARNING:${NC} snap is running with ${CONFINEMENT} confinement." \
         "Snaps will stop working in early January 2025." \

--- a/packages/s/snapd/package.yml
+++ b/packages/s/snapd/package.yml
@@ -1,7 +1,7 @@
 name       : snapd
 version    : 2.63
 homepage   : https://snapcraft.io/
-release    : 83
+release    : 84
 source     :
     - https://github.com/snapcore/snapd/releases/download/2.63/snapd_2.63.vendor.tar.xz : 2f0083d2c4e087c29f48cd1abb8a92eb2e63cf04cd433256c86fac05d0b28cab
 license    : GPL-3.0-only

--- a/packages/s/snapd/pspec_x86_64.xml
+++ b/packages/s/snapd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>snapd</Name>
         <Homepage>https://snapcraft.io/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <PartOf>desktop</PartOf>
@@ -77,12 +77,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="83">
-            <Date>2024-12-20</Date>
+        <Update release="84">
+            <Date>2024-12-31</Date>
             <Version>2.63</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Fix text to be two lines not three per spec
Change urgency to critical so users must manually dismiss the notification to give them time to copy the link

Resolves #4636

**Test Plan**

Ran the Spotify and Termius snaps from command line and App menu
Verified the correct warning appeared

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
