### PR TITLE
budgie-extras: Fix parsing of default commands

### DIFF
--- a/packages/b/budgie-extras/files/0001-budgie-hotcorners-Fix-formatting-of-defaults-file-JSON.patch
+++ b/packages/b/budgie-extras/files/0001-budgie-hotcorners-Fix-formatting-of-defaults-file-JSON.patch
@@ -1,0 +1,41 @@
+From 83061f56ff190be691e9b9401168311b0becf15e Mon Sep 17 00:00:00 2001
+From: Thomas Staudinger <Staudi.Kaos@gmail.com>
+Date: Tue, 24 Dec 2024 21:52:43 +0100
+Subject: [PATCH] budgie-hotcorners: Fix formatting of defaults file JSON
+
+Signed-off-by: Thomas Staudinger <Staudi.Kaos@gmail.com>
+---
+ budgie-hotcorners/misc/defaults.in | 26 +++++++++++++-------------
+ 1 file changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/budgie-hotcorners/misc/defaults.in b/budgie-hotcorners/misc/defaults.in
+index 57e03807..90bac834 100644
+--- a/budgie-hotcorners/misc/defaults.in
++++ b/budgie-hotcorners/misc/defaults.in
+@@ -1,13 +1,13 @@
+-{'command': '@bdesktopdir@/showdesktop/showdesktop', 'name': 'Show Desktop'}
+-{'command': '@libdir@/budgie-previews/previews_triggers hotcorners_all', 'name': 'Exposé all windows', 'gsettingsboolean': 'org.ubuntubudgie.budgie-wpreviews enable-previews'}
+-{'command': '@libdir@/budgie-previews/previews_triggers hotcorners_current', 'name': 'Exposé current application', 'gsettingsboolean': 'org.ubuntubudgie.budgie-wpreviews enable-previews'}
+-{'command': 'budgie-desktop-settings', 'name':'Budgie Desktop Settings'}
+-{'command': 'dbus-send --session --type="method_call" --dest=org.gnome.ScreenSaver /org/gnome/ScreenSaver org.gnome.ScreenSaver.Lock', 'name': 'Lock screen'}
+-{'command': '@libdir@/budgie-window-shuffler/togglegui', 'name': 'Toggle Shuffler GUI', 'gsettingsboolean': 'org.ubuntubudgie.windowshuffler runshufflergui'}
+-{'command': '@libdir@/budgie-window-shuffler/grid_all', 'name': 'All windows in grid'}
+-{'command': '@libdir@/budgie-window-shuffler/tile_active 0 0 2 2', 'name': 'Window to topleft'}
+-{'command': '@libdir@/budgie-window-shuffler/tile_active 1 0 2 2', 'name': 'Window to topright'}
+-{'command': '@libdir@/budgie-window-shuffler/tile_active 1 1 2 2', 'name': 'Window to bottomright'}
+-{'command': '@libdir@/budgie-window-shuffler/tile_active 0 1 2 2', 'name': 'Window to bottomleft'}
+-{'command': 'dbus-send --session --type="method_call" --dest=org.budgie_desktop.Panel /org/budgie_desktop/Raven org.budgie_desktop.Raven.ToggleAppletView', 'name': 'Toggle Raven - AppletView'}
+-{'command': 'dbus-send --session --type="method_call" --dest=org.budgie_desktop.Panel /org/budgie_desktop/Raven org.budgie_desktop.Raven.ToggleNotificationsView', 'name': 'Toggle Raven - Notifications'}
++{"command": "@bdesktopdir@/showdesktop/showdesktop", "name": "Show Desktop"}
++{"command": "@libdir@/budgie-previews/previews_triggers hotcorners_all", "name": "Exposé all windows", "gsettingsboolean": "org.ubuntubudgie.budgie-wpreviews enable-previews"}
++{"command": "@libdir@/budgie-previews/previews_triggers hotcorners_current", "name": "Exposé current application", "gsettingsboolean": "org.ubuntubudgie.budgie-wpreviews enable-previews"}
++{"command": "budgie-desktop-settings", "name":"Budgie Desktop Settings"}
++{"command": "dbus-send --session --type=\"method_call\" --dest=org.gnome.ScreenSaver /org/gnome/ScreenSaver org.gnome.ScreenSaver.Lock", "name": "Lock screen"}
++{"command": "@libdir@/budgie-window-shuffler/togglegui", "name": "Toggle Shuffler GUI", "gsettingsboolean": "org.ubuntubudgie.windowshuffler runshufflergui"}
++{"command": "@libdir@/budgie-window-shuffler/grid_all", "name": "All windows in grid"}
++{"command": "@libdir@/budgie-window-shuffler/tile_active 0 0 2 2", "name": "Window to topleft"}
++{"command": "@libdir@/budgie-window-shuffler/tile_active 1 0 2 2", "name": "Window to topright"}
++{"command": "@libdir@/budgie-window-shuffler/tile_active 1 1 2 2", "name": "Window to bottomright"}
++{"command": "@libdir@/budgie-window-shuffler/tile_active 0 1 2 2", "name": "Window to bottomleft"}
++{"command": "dbus-send --session --type=\"method_call\" --dest=org.budgie_desktop.Panel /org/budgie_desktop/Raven org.budgie_desktop.Raven.ToggleAppletView", "name": "Toggle Raven - AppletView"}
++{"command": "dbus-send --session --type=\"method_call\" --dest=org.budgie_desktop.Panel /org/budgie_desktop/Raven org.budgie_desktop.Raven.ToggleNotificationsView", "name": "Toggle Raven - Notifications"}

--- a/packages/b/budgie-extras/files/series
+++ b/packages/b/budgie-extras/files/series
@@ -1,3 +1,4 @@
 0001-Replace-gnome-screensaver-with-budgie-screensaver.patch
 0001-hardcode-libexecdir.patch
 0001-fix-budgie-hotcorners-settingswindow.patch
+0001-budgie-hotcorners-Fix-formatting-of-defaults-file-JSON.patch

--- a/packages/b/budgie-extras/package.yml
+++ b/packages/b/budgie-extras/package.yml
@@ -1,6 +1,6 @@
 name       : budgie-extras
 version    : 1.8.0
-release    : 29
+release    : 30
 source     :
     - https://github.com/UbuntuBudgie/budgie-extras/releases/download/v1.8.0/budgie-extras-1.8.0.tar.xz : 7d72ed2d94b89e8f0a119c522acb34e6324ff6fa777bc9ed83e8caaf5101304a
 homepage   : https://github.com/UbuntuBudgie/budgie-extras

--- a/packages/b/budgie-extras/pspec_x86_64.xml
+++ b/packages/b/budgie-extras/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>budgie-extras</Name>
         <Homepage>https://github.com/UbuntuBudgie/budgie-extras</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop.budgie</PartOf>
@@ -46,7 +46,7 @@
         <Description xml:lang="en">The brightness controller applet allows controlling of the screen levels via xrandr (fallback) or via gnome-settings-daemon (if available).</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="29">budgie-extras</Dependency>
+            <Dependency releaseFrom="30">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-brightness-controller/brightnesscontroller.plugin</Path>
@@ -60,7 +60,7 @@
         <Description xml:lang="en">A count down applet with the following options; ring a bell, flash the (panel) icon, display a message window or run a (any) command.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="29">budgie-extras</Dependency>
+            <Dependency releaseFrom="30">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-countdown/CountDown.plugin</Path>
@@ -80,7 +80,7 @@
         <Description xml:lang="en">This on logon process manages keyboard shortcuts delivered via .bde files for various extras-plugins.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="29">budgie-extras</Dependency>
+            <Dependency releaseFrom="30">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/budgie-extras-daemon</Path>
@@ -104,8 +104,8 @@
         <Description xml:lang="en">The hotcorners applet allow user defined commands to be executed when the mouse cursor is pushed into a corner of the main desktop.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="29">budgie-previews</Dependency>
-            <Dependency releaseFrom="29">budgie-window-shuffler</Dependency>
+            <Dependency releaseFrom="30">budgie-previews</Dependency>
+            <Dependency releaseFrom="30">budgie-window-shuffler</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-hotcorners/HotCorners.plugin</Path>
@@ -130,7 +130,7 @@
         <Description xml:lang="en">The kangaroo applet allows for quick and easy browsing, across (possibly) many directory layers, without having to do a single mouse click.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="29">budgie-extras</Dependency>
+            <Dependency releaseFrom="30">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-kangaroo/BudgieKangaroo.plugin</Path>
@@ -144,7 +144,7 @@
         <Description xml:lang="en">Set previews to show an overview of windows in an expose like way.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="29">budgie-extras-daemon</Dependency>
+            <Dependency releaseFrom="30">budgie-extras-daemon</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-previews/previews_controls</Path>
@@ -177,7 +177,7 @@
         <Description xml:lang="en">The quicknote applet allows a user to record a text based note. The applet autosaves the text while writing and supports multiple undo and redo capabilities.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="29">budgie-extras</Dependency>
+            <Dependency releaseFrom="30">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-quicknote/QuickNoteApplet.plugin</Path>
@@ -192,7 +192,7 @@
         <Description xml:lang="en">Budgie Showtime is a digital desktop clock, showing time, and optionally, date. Text color of both can be set separately from the applet&apos;s menu.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="29">budgie-extras</Dependency>
+            <Dependency releaseFrom="30">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-showtime/ShowTime.plugin</Path>
@@ -208,7 +208,7 @@
         <Description xml:lang="en">Budgie TakeaBreak is a pomodoro like applet, to make sure to take regular breaks from working. Options from Budgie Settings include turning the screen upside down, dim the screen, lock screen or show a countdown message on break time. The applet can be accessed quickly from the panel to temporarily switch it off.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="29">budgie-extras</Dependency>
+            <Dependency releaseFrom="30">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-takeabreak/BudgieTakeaBreak.plugin</Path>
@@ -226,7 +226,7 @@
         <Description xml:lang="en">The visualspace applet shows as a stylish compact workspace on the budgie panel. Choosing windows in the applet popup moves to the workspace where the window is located and gives it focus. The number of Workspace can also be changed though the applet popup.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="29">budgie-extras</Dependency>
+            <Dependency releaseFrom="30">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-visualspace/VisualSpace.plugin</Path>
@@ -243,7 +243,7 @@
         <Description xml:lang="en">The weathershow applet displays daily and three hourly weather forecasts on both the desktop and a Popover.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="29">budgie-extras</Dependency>
+            <Dependency releaseFrom="30">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-weathershow/WeatherShow.plugin</Path>
@@ -328,7 +328,7 @@
         <Description xml:lang="en">The window shuffler is an easy to use windows tiling capability driven primarily through the keyboard to place and move window in a grid format.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="29">budgie-extras-daemon</Dependency>
+            <Dependency releaseFrom="30">budgie-extras-daemon</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-window-shuffler/ShufflerAPplet.plugin</Path>
@@ -406,12 +406,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="29">
-            <Date>2024-12-17</Date>
+        <Update release="30">
+            <Date>2024-12-24</Date>
             <Version>1.8.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fix parsing of default commands

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Restart Budgie Panel with the Hotcorners applet added, open the applet's settings, click on a corner, enable the command field, and open the dropdown box to see the populated list of default commands.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
