### PR TITLE
fb2converter: Update to 1.76.2

### DIFF
--- a/packages/f/fb2converter/monitoring.yml
+++ b/packages/f/fb2converter/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 376128
+  rss: https://github.com/rupor-github/fb2converter/tags.atom
+# No known CPE, checked 2024-12-29
+security:
+  cpe: ~

--- a/packages/f/fb2converter/package.yml
+++ b/packages/f/fb2converter/package.yml
@@ -1,8 +1,8 @@
 name       : fb2converter
-version    : 1.76.1
-release    : 29
+version    : 1.76.2
+release    : 30
 source     :
-    - git|https://github.com/rupor-github/fb2converter.git : v1.76.1
+    - git|https://github.com/rupor-github/fb2converter.git : v1.76.2
 homepage   : https://github.com/rupor-github/fb2converter
 license    : GPL-3.0-only
 component  : office.viewers

--- a/packages/f/fb2converter/pspec_x86_64.xml
+++ b/packages/f/fb2converter/pspec_x86_64.xml
@@ -26,9 +26,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="29">
-            <Date>2024-11-13</Date>
-            <Version>1.76.1</Version>
+        <Update release="30">
+            <Date>2024-12-29</Date>
+            <Version>1.76.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Adding new configuration document.transform.dialogue
- Updating to go1.23.4 and latest packages.
- Release not monitored, see https://archive.is/raGbr
- [changelog](https://github.com/rupor-github/fb2converter/compare/v1.76.1...v1.76.2)

**Test Plan**
- fb2c h

**Checklist**
- [X] Package was built and tested against unstable
