### PR TITLE
Update maturin and orjson

### DIFF
--- a/packages/py/python-maturin/abi_used_libs
+++ b/packages/py/python-maturin/abi_used_libs
@@ -3,5 +3,6 @@ libbz2.so.1.0
 libc.so.6
 libcrypto.so.3
 libgcc_s.so.1
+liblzma.so.5
 libm.so.6
 libssl.so.3

--- a/packages/py/python-maturin/abi_used_symbols
+++ b/packages/py/python-maturin/abi_used_symbols
@@ -29,6 +29,7 @@ libc.so.6:environ
 libc.so.6:execvp
 libc.so.6:exit
 libc.so.6:fchmod
+libc.so.6:fchown
 libc.so.6:fcntl
 libc.so.6:fdatasync
 libc.so.6:fdopendir
@@ -37,6 +38,8 @@ libc.so.6:free
 libc.so.6:freeaddrinfo
 libc.so.6:fstat64
 libc.so.6:fstatat64
+libc.so.6:ftruncate64
+libc.so.6:futimes
 libc.so.6:gai_strerror
 libc.so.6:getaddrinfo
 libc.so.6:getauxval
@@ -51,8 +54,11 @@ libc.so.6:getuid
 libc.so.6:gnu_get_libc_version
 libc.so.6:ioctl
 libc.so.6:isatty
+libc.so.6:lchown
+libc.so.6:linkat
 libc.so.6:lseek64
 libc.so.6:lstat64
+libc.so.6:lutimes
 libc.so.6:malloc
 libc.so.6:memcmp
 libc.so.6:memcpy
@@ -133,6 +139,8 @@ libc.so.6:tcsetattr
 libc.so.6:uname
 libc.so.6:unlink
 libc.so.6:unlinkat
+libc.so.6:utimensat
+libc.so.6:utimes
 libc.so.6:waitid
 libc.so.6:waitpid
 libc.so.6:write
@@ -182,6 +190,9 @@ libgcc_s.so.1:_Unwind_RaiseException
 libgcc_s.so.1:_Unwind_Resume
 libgcc_s.so.1:_Unwind_SetGR
 libgcc_s.so.1:_Unwind_SetIP
+liblzma.so.5:lzma_code
+liblzma.so.5:lzma_end
+liblzma.so.5:lzma_stream_decoder
 libm.so.6:ceil
 libm.so.6:fmod
 libm.so.6:log

--- a/packages/py/python-maturin/package.yml
+++ b/packages/py/python-maturin/package.yml
@@ -1,8 +1,8 @@
 name       : python-maturin
-version    : 1.7.7
-release    : 51
+version    : 1.8.0
+release    : 52
 source     :
-    - https://github.com/PyO3/maturin/archive/refs/tags/v1.7.7.tar.gz : 791e471100076a555a53a1a76642b6cf1a7774f07cadefadd524d31cb8ae499d
+    - https://github.com/PyO3/maturin/archive/refs/tags/v1.8.0.tar.gz : 481c6b354ef06d5eb5c52a7ab8bc01463927a291dabea2bf3257d56edd827f16
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-maturin/pspec_x86_64.xml
+++ b/packages/py/python-maturin/pspec_x86_64.xml
@@ -22,12 +22,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/maturin</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.7-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.7-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.7-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.7-py3.11.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.7-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.7.7-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.8.0-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.8.0-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.8.0-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.8.0-py3.11.egg-info/not-zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.8.0-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.8.0-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/__pycache__/__init__.cpython-311.pyc</Path>
@@ -35,9 +35,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="51">
-            <Date>2024-12-02</Date>
-            <Version>1.7.7</Version>
+        <Update release="52">
+            <Date>2024-12-25</Date>
+            <Version>1.8.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>

--- a/packages/py/python-orjson/package.yml
+++ b/packages/py/python-orjson/package.yml
@@ -1,8 +1,8 @@
 name       : python-orjson
-version    : 3.10.11
-release    : 45
+version    : 3.10.13
+release    : 46
 source     :
-    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.11.tar.gz : e35b6d730de6384d5b2dab5fd23f0d76fae8bbc8c353c2f78210aa5fa4beb3ef
+    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.13.tar.gz : eb9bfb14ab8f68d9d9492d4817ae497788a15fd7da72e14dfabc289c3bb088ec
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-orjson/pspec_x86_64.xml
+++ b/packages/py/python-orjson/pspec_x86_64.xml
@@ -21,11 +21,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.11.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.11.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.11.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.11.dist-info/licenses/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.11.dist-info/licenses/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.13.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.13.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.13.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.13.dist-info/licenses/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.13.dist-info/licenses/LICENSE-MIT</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
@@ -35,9 +35,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="45">
-            <Date>2024-11-02</Date>
-            <Version>3.10.11</Version>
+        <Update release="46">
+            <Date>2024-12-29</Date>
+            <Version>3.10.13</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

This updates `python-maturin` and `python-orjson` to their latest versions. The latter is necessary for compatibility with maturin 1.8.0

**Test Plan**
- Succesfully built `python-orjson`
- Ran some examples from the orjson README

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
