### PR TITLE
sof-firmware: Update to v2.11.3

### DIFF
--- a/packages/s/sof-firmware/files/sof-firmware.metainfo.xml
+++ b/packages/s/sof-firmware/files/sof-firmware.metainfo.xml
@@ -9,7 +9,7 @@
   <url type="homepage">https://github.com/thesofproject</url>
   <url type="help">https://thesofproject.github.io</url>
   <description>
-    <p>Sound Open Firmware. This package provides Firmware and topology binaries.</p>
+    <p>Sound Open Firmware. This package provides audio DSP firmware and topology binaries.</p>
   </description>
   <update_contact>releng@getsol.us</update_contact>
 </component>

--- a/packages/s/sof-firmware/monitoring.yml
+++ b/packages/s/sof-firmware/monitoring.yml
@@ -2,5 +2,5 @@ releases:
   id: 246473
   rss: https://github.com/thesofproject/sof-bin/releases.atom
 security:
-  # No known CPE, checked 2024-04-02
+  # No known CPE, checked 2024-12-29
   cpe: ~

--- a/packages/s/sof-firmware/package.yml
+++ b/packages/s/sof-firmware/package.yml
@@ -1,9 +1,9 @@
 name       : sof-firmware
 homepage   : https://github.com/thesofproject/sof-bin
-version    : '2.11'
-release    : 23
+version    : 2.11.3
+release    : 24
 source     :
-    - https://github.com/thesofproject/sof-bin/releases/download/v2024.09/sof-bin-2024.09.tar.gz : ea47d99f81359008d07618bca103cf78f82d84e940bfe941a28afe07c8cbc620
+    - https://github.com/thesofproject/sof-bin/releases/download/v2024.09.2/sof-bin-2024.09.2.tar.gz : 86e6841a55f1d6d1c91503a8482c1b475dbcadecdb6151bfa0ac0095d1d8a52a
 license    :
     - BSD-3-Clause
     - ISC

--- a/packages/s/sof-firmware/pspec_x86_64.xml
+++ b/packages/s/sof-firmware/pspec_x86_64.xml
@@ -37,6 +37,7 @@
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-arl-cs42l43-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-arl-cs42l43-l2-cs35l56-l3.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-arl-cs42l43-l2.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-arl-rt722-l0_rt1320-l2.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-2ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace1-2ch.tplg</Path>
@@ -53,17 +54,20 @@
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-imx8mp-wm8960.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l23.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l3-2ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l3.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt1318-l12-rt714-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt711-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt711-l0-rt1316-l23-rt714-l1.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt712-l2-rt1712-l3.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt713-l0-rt1318-l1-2ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt722-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0-cs35l56-l12.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0-cs35l56-l23.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-es83x6-ssp1-hdmi-ssp02.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-es83x6-ssp1.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-hdmi-ssp02.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-max98357a-rt5682-google-aec.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-max98357a-rt5682-ssp2-ssp0-2ch-pdm1-google-aec.tplg</Path>
@@ -113,6 +117,8 @@
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4/arl-s/intel-signed/sof-arl-s.ri</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4/arl-s/sof-arl-s.ri</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4/arl/community/sof-arl.ri</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4/arl/intel-signed/sof-arl.ri</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4/arl/sof-arl.ri</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4/ehl/community/sof-ehl.ri</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4/lnl/community/sof-lnl.ri</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4/lnl/intel-signed/sof-lnl.ri</Path>
@@ -373,6 +379,7 @@
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-mt8195-mt6359-rt1019-rt5682.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-rn-rt5682-max98360.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-rn-rt5682-rt1019.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-rpl-cs42l43-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-rpl-nocodec.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-rpl-rt1316-l12-rt714-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-rpl-rt711-4ch.tplg</Path>
@@ -506,6 +513,7 @@
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-arl-cs42l43-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-arl-cs42l43-l2-cs35l56-l3.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-arl-cs42l43-l2.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-arl-rt722-l0_rt1320-l2.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-2ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace1-2ch.tplg</Path>
@@ -522,17 +530,20 @@
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-imx8mp-wm8960.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l23.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l3-2ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l3.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt1318-l12-rt714-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt711-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt711-l0-rt1316-l23-rt714-l1.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt712-l2-rt1712-l3.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt713-l0-rt1318-l1-2ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt722-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0-cs35l56-l12.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0-cs35l56-l23.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-es83x6-ssp1-hdmi-ssp02.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-es83x6-ssp1.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-hdmi-ssp02.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-max98357a-rt5682-google-aec.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-max98357a-rt5682-ssp2-ssp0-2ch-pdm1-google-aec.tplg</Path>
@@ -582,6 +593,8 @@
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/arl-s/intel-signed/sof-arl-s.ri</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/arl-s/sof-arl-s.ri</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/arl/community/sof-arl.ri</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/arl/intel-signed/sof-arl.ri</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/arl/sof-arl.ri</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/ehl/community/sof-ehl.ri</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/lnl/community/sof-lnl.ri</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4/lnl/intel-signed/sof-lnl.ri</Path>
@@ -842,6 +855,7 @@
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-mt8195-mt6359-rt1019-rt5682.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-rn-rt5682-max98360.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-rn-rt5682-rt1019.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-rpl-cs42l43-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-rpl-nocodec.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-rpl-rt1316-l12-rt714-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-rpl-rt711-4ch.tplg</Path>
@@ -963,9 +977,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2024-10-24</Date>
-            <Version>2.11</Version>
+        <Update release="24">
+            <Date>2024-12-30</Date>
+            <Version>2.11.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Tracey Clark</Name>
             <Email>traceyc.dev@tlcnet.info</Email>


### PR DESCRIPTION
**Summary**

- The binary release includes latest versions of firmware, tool and DSP topologies for all Intel released platforms
- Bugfixes

Full release notes [here](https://github.com/thesofproject/sof-bin/releases)

**Solus**

Update package description

**Test Plan**

Verified firmware files were installed to correct paths.
Restarted pipewire.
    systemctl --user restart pipewire.service
Listened to music and triggered system sounds to verify that sound still works.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
