### PR TITLE
wlopm: Fix install location

### DIFF
--- a/packages/w/wlopm/package.yml
+++ b/packages/w/wlopm/package.yml
@@ -1,6 +1,6 @@
 name       : wlopm
 version    : 0.1.0
-release    : 1
+release    : 2
 source     :
     - https://git.iohub.dev/dany/wlopm/archive/v0.1.0.tar.gz : e3d69112fbabb1df0bbcd8b8c36a881d4ad9804b40d0f0d43b4e992f5be477ed
 homepage   : https://git.iohub.dev/dany/wlopm
@@ -13,6 +13,6 @@ builddeps  :
     - pkgconfig(wayland-protocols)
     - pkgconfig(wayland-server)
 build      : |
-    %make
+    %make PREFIX=/usr
 install    : |
-    %make_install
+    %make_install PREFIX=/usr

--- a/packages/w/wlopm/pspec_x86_64.xml
+++ b/packages/w/wlopm/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>wlopm</Name>
         <Homepage>https://git.iohub.dev/dany/wlopm</Homepage>
         <Packager>
-            <Name>Facundo Ciruzzi</Name>
-            <Email>ciruzzifacundo@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0</License>
         <PartOf>desktop</PartOf>
@@ -20,17 +20,17 @@
 </Description>
         <PartOf>desktop</PartOf>
         <Files>
-            <Path fileType="data">/usr/local/bin/wlopm</Path>
-            <Path fileType="data">/usr/local/share/man/man1/wlopm.1</Path>
+            <Path fileType="executable">/usr/bin/wlopm</Path>
+            <Path fileType="man">/usr/share/man/man1/wlopm.1</Path>
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-03-10</Date>
+        <Update release="2">
+            <Date>2024-12-31</Date>
             <Version>0.1.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Facundo Ciruzzi</Name>
-            <Email>ciruzzifacundo@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Install to /usr and not /usr/local

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Restart Budgie and see that `swayidle` automatically starts, and that the `wlopm` binary is found in the path.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
