### PR TITLE
onefetch: Update to v2.23.1

### DIFF
--- a/packages/o/onefetch/abi_used_symbols
+++ b/packages/o/onefetch/abi_used_symbols
@@ -5,6 +5,7 @@ libc.so.6:__stack_chk_fail
 libc.so.6:__xpg_strerror_r
 libc.so.6:_exit
 libc.so.6:abort
+libc.so.6:aligned_alloc
 libc.so.6:bcmp
 libc.so.6:calloc
 libc.so.6:chdir
@@ -130,15 +131,12 @@ libgcc_s.so.1:_Unwind_SetGR
 libgcc_s.so.1:_Unwind_SetIP
 libm.so.6:ceil
 libm.so.6:ceilf
-libm.so.6:exp2f
 libm.so.6:expf
 libm.so.6:floorf
 libm.so.6:fmod
-libm.so.6:powf
 libm.so.6:round
 libm.so.6:roundf
 libm.so.6:sinf
-libm.so.6:truncf
 libzstd.so.1:ZSTD_DCtx_loadDictionary
 libzstd.so.1:ZSTD_DCtx_reset
 libzstd.so.1:ZSTD_DStreamInSize

--- a/packages/o/onefetch/package.yml
+++ b/packages/o/onefetch/package.yml
@@ -1,8 +1,8 @@
 name       : onefetch
-version    : 2.22.0
-release    : 10
+version    : 2.23.1
+release    : 11
 source     :
-    - https://github.com/o2sh/onefetch/archive/refs/tags/2.22.0.tar.gz : 1741516c628bb70b432285aa78439c4acfeb5df19e48b8d85dba5f71336e190b
+    - https://github.com/o2sh/onefetch/archive/refs/tags/2.23.1.tar.gz : 72e87f6a62682ad88aa07b02815ee1e2863fe45e04df3bba49026bf3edd10537
 homepage   : https://onefetch.dev
 license    : MIT
 component  : system.utils

--- a/packages/o/onefetch/pspec_x86_64.xml
+++ b/packages/o/onefetch/pspec_x86_64.xml
@@ -25,9 +25,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2024-11-13</Date>
-            <Version>2.22.0</Version>
+        <Update release="11">
+            <Date>2025-01-01</Date>
+            <Version>2.23.1</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Add language support for OpenSCAD
- Add language support for Modelica
- Add language support for ATS
- Add language support for CUDA
- Add missing nerd fonts icons for some language

**Test Plan**

- Run on packages repo

![Screenshot_20250101_163932](https://github.com/user-attachments/assets/5e54a765-5367-4f59-bffd-6d66d052d868)


**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
