### PR TITLE
wesnoth: Update to v1.18.3

### DIFF
--- a/packages/w/wesnoth/MAINTAINERS.md
+++ b/packages/w/wesnoth/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Muhammad Alfi Syahrin
+  - Matrix: @alfisya:matrix.org
+  - Email: malfisya.dev@hotmail.com

--- a/packages/w/wesnoth/abi_used_libs
+++ b/packages/w/wesnoth/abi_used_libs
@@ -2,7 +2,7 @@ UNKNOWN
 libSDL2-2.0.so.0
 libSDL2_image-2.0.so.0
 libSDL2_mixer-2.0.so.0
-libboost_coroutine.so.1.83.0
+libboost_context.so.1.83.0
 libboost_filesystem.so.1.83.0
 libboost_iostreams.so.1.83.0
 libboost_locale.so.1.83.0

--- a/packages/w/wesnoth/abi_used_symbols
+++ b/packages/w/wesnoth/abi_used_symbols
@@ -164,13 +164,10 @@ libSDL2_mixer-2.0.so.0:Mix_ResumeMusic
 libSDL2_mixer-2.0.so.0:Mix_SetDistance
 libSDL2_mixer-2.0.so.0:Mix_Volume
 libSDL2_mixer-2.0.so.0:Mix_VolumeMusic
-libboost_coroutine.so.1.83.0:_ZN5boost10coroutines12stack_traits12default_sizeEv
-libboost_coroutine.so.1.83.0:_ZN5boost10coroutines12stack_traits12is_unboundedEv
-libboost_coroutine.so.1.83.0:_ZN5boost10coroutines12stack_traits12maximum_sizeEv
-libboost_coroutine.so.1.83.0:_ZN5boost10coroutines12stack_traits12minimum_sizeEv
-libboost_coroutine.so.1.83.0:_ZN5boost10coroutines6detail17coroutine_context4jumpERS2_Pv
-libboost_coroutine.so.1.83.0:_ZN5boost10coroutines6detail17coroutine_contextC1EPFvNS_7context6detail10transfer_tEERKNS1_12preallocatedE
-libboost_coroutine.so.1.83.0:_ZN5boost10coroutines6detail17coroutine_contextC1Ev
+libboost_context.so.1.83.0:_ZN5boost7context12stack_traits12default_sizeEv
+libboost_context.so.1.83.0:jump_fcontext
+libboost_context.so.1.83.0:make_fcontext
+libboost_context.so.1.83.0:ontop_fcontext
 libboost_filesystem.so.1.83.0:_ZN5boost10filesystem6detail11dir_itr_impD1Ev
 libboost_filesystem.so.1.83.0:_ZN5boost10filesystem6detail11dir_itr_impdlEPv
 libboost_filesystem.so.1.83.0:_ZN5boost10filesystem6detail12current_pathEPNS_6system10error_codeE
@@ -1063,6 +1060,7 @@ libstdc++.so.6:_ZTv0_n24_NSt14basic_ifstreamIcSt11char_traitsIcEED0Ev
 libstdc++.so.6:_ZTv0_n24_NSt14basic_ifstreamIcSt11char_traitsIcEED1Ev
 libstdc++.so.6:_ZdaPv
 libstdc++.so.6:_ZdlPv
+libstdc++.so.6:_ZdlPvm
 libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
 libstdc++.so.6:_ZnwmRKSt9nothrow_t

--- a/packages/w/wesnoth/package.yml
+++ b/packages/w/wesnoth/package.yml
@@ -1,8 +1,8 @@
 name       : wesnoth
-version    : 1.18.2
-release    : 33
+version    : 1.18.3
+release    : 34
 source     :
-    - https://github.com/wesnoth/wesnoth/archive/refs/tags/1.18.2.tar.gz : 59baaf3fb9d62d92702b343f9092da12c3455e95a6ff4782338b97a7b6285935
+    - https://github.com/wesnoth/wesnoth/archive/refs/tags/1.18.3.tar.gz : 62405b80fba37caa312c67a27f8b123ef52f6ded0d65c912c869663a411bd737
 homepage   : https://www.wesnoth.org/
 license    : GPL-2.0-or-later
 component  : games.strategy

--- a/packages/w/wesnoth/pspec_x86_64.xml
+++ b/packages/w/wesnoth/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>wesnoth</Name>
         <Homepage>https://www.wesnoth.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>games.strategy</PartOf>
@@ -2769,6 +2769,7 @@
             <Path fileType="data">/usr/share/wesnoth/data/campaigns/Under_the_Burning_Suns/images/halo/eloh-halo-back.png</Path>
             <Path fileType="data">/usr/share/wesnoth/data/campaigns/Under_the_Burning_Suns/images/halo/eloh-halo-bottom.png</Path>
             <Path fileType="data">/usr/share/wesnoth/data/campaigns/Under_the_Burning_Suns/images/items/burial2.png</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/campaigns/Under_the_Burning_Suns/images/items/cold-sword.png</Path>
             <Path fileType="data">/usr/share/wesnoth/data/campaigns/Under_the_Burning_Suns/images/items/kaleh-dead.png</Path>
             <Path fileType="data">/usr/share/wesnoth/data/campaigns/Under_the_Burning_Suns/images/items/magiccircle-n.png</Path>
             <Path fileType="data">/usr/share/wesnoth/data/campaigns/Under_the_Burning_Suns/images/items/magiccircle-ne.png</Path>
@@ -4266,7 +4267,7 @@
             <Path fileType="data">/usr/share/wesnoth/data/core/images/maps/l10n/sr@ijekavian/wesnoth--overlay.webp</Path>
             <Path fileType="data">/usr/share/wesnoth/data/core/images/maps/l10n/sr@ijekavianlatin/wesnoth--overlay.webp</Path>
             <Path fileType="data">/usr/share/wesnoth/data/core/images/maps/l10n/sr@latin/wesnoth--overlay.webp</Path>
-            <Path fileType="data">/usr/share/wesnoth/data/core/images/maps/l10n/tr/titlescreen--overlay.png</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/core/images/maps/l10n/tr/titlescreen--overlay.webp</Path>
             <Path fileType="data">/usr/share/wesnoth/data/core/images/maps/l10n/zh_CN/titlescreen--overlay.webp</Path>
             <Path fileType="data">/usr/share/wesnoth/data/core/images/maps/l10n/zh_CN/wesnoth--overlay.webp</Path>
             <Path fileType="data">/usr/share/wesnoth/data/core/images/maps/titlescreen.webp</Path>
@@ -18570,6 +18571,7 @@
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/prestart_settings.cfg</Path>
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/put_to_recall_and_modify.cfg</Path>
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/shroud.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/terrain_with_location_filter.cfg</Path>
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/test_end_turn.cfg</Path>
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/test_grunt_tod_damage.cfg</Path>
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/test_modify_unit.cfg</Path>
@@ -18622,6 +18624,9 @@
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/ScenarioWML/unknown_scenario_warning.cfg</Path>
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/ScenarioWML/xp_mod.cfg</Path>
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/TerrainWML/test_terrain_mask.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/ability_cycle_filter_self_recursion_by_id.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/ability_cycle_recursion_by_id.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/adjacent_abilities_recursion_by_id.cfg</Path>
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_add.cfg</Path>
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_add_divide.cfg</Path>
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_add_multiply.cfg</Path>
@@ -18691,9 +18696,97 @@
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/berserk/berserk_wfl_other.cfg</Path>
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/berserk/berserk_wfl_self.cfg</Path>
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/berserk/berserk_zero.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_add.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_add_divide.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_add_multiply.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_add_sub.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_affect_allies.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_affect_enemies.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_affect_everybody.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_affect_self_no.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_divide.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_multiply.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_multiply_divide.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_negative_value.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_no_value.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_overwrite_specials_both_sides.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_overwrite_specials_mixed.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_overwrite_specials_one_side.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_overwrite_specials_two_both_sides.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_overwrite_specials_two_one_side.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_sub.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_sub_divide.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_sub_multiply.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_two_cumulative_mixed_same_id.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_two_cumulative_mixed_unique_id.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_two_cumulative_no_same_id.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_two_cumulative_no_unique_id.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_two_cumulative_yes_same_id.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_two_cumulative_yes_unique_id.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_wfl_other.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_wfl_self.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_add.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_add_divide.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_add_multiply.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_add_sub.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_affect_allies.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_affect_enemies.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_affect_everybody.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_affect_self_no.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_divide.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_high_fraction.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_low_fraction.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_multiply.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_multiply_divide.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_multiply_fraction.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_negative_value.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_no_value.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_overwrite_specials_both_sides.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_overwrite_specials_mixed.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_overwrite_specials_one_side.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_overwrite_specials_two_both_sides.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_overwrite_specials_two_one_side.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_sub.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_sub_divide.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_sub_multiply.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_two_cumulative_mixed_same_id.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_two_cumulative_mixed_unique_id.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_two_cumulative_no_same_id.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_two_cumulative_no_unique_id.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_two_cumulative_yes_same_id.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_two_cumulative_yes_unique_id.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_wfl_other.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_wfl_self.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_zero.cfg</Path>
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_recalculation_mid_attack.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_arcane.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_blade.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_cold.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_fire.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_impact.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_pierce.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_three.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_two.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_apply_to_attacker_filter_attacker_defender.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_apply_to_both_filter_self_opponent.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_both_same_alternative_best.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_both_same_replacement_best.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_both_separate_alternative_best.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_both_separate_replacement_best.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_many.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_arcane.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_blade.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_cold.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_fire.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_impact.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_pierce.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_three.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_two.cfg</Path>
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/feeding.cfg</Path>
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/firststrike_and_laststrike.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/four_cycle_recursion_branching.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/four_cycle_recursion_by_id.cfg</Path>
+            <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/four_cycle_recursion_by_tagname.cfg</Path>
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heals/heal.cfg</Path>
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heals/heal_add.cfg</Path>
             <Path fileType="data">/usr/share/wesnoth/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heals/heal_add_divide.cfg</Path>
@@ -19826,6 +19919,12 @@
             <Path fileType="data">/usr/share/wesnoth/images/icons/action/editor-draw-terrain-codes_30-active.png</Path>
             <Path fileType="data">/usr/share/wesnoth/images/icons/action/editor-draw-terrain-codes_30-pressed.png</Path>
             <Path fileType="data">/usr/share/wesnoth/images/icons/action/editor-draw-terrain-codes_30.png</Path>
+            <Path fileType="data">/usr/share/wesnoth/images/icons/action/editor-help-text-shown_25-active.png</Path>
+            <Path fileType="data">/usr/share/wesnoth/images/icons/action/editor-help-text-shown_25-pressed.png</Path>
+            <Path fileType="data">/usr/share/wesnoth/images/icons/action/editor-help-text-shown_25.png</Path>
+            <Path fileType="data">/usr/share/wesnoth/images/icons/action/editor-help-text-shown_30-active.png</Path>
+            <Path fileType="data">/usr/share/wesnoth/images/icons/action/editor-help-text-shown_30-pressed.png</Path>
+            <Path fileType="data">/usr/share/wesnoth/images/icons/action/editor-help-text-shown_30.png</Path>
             <Path fileType="data">/usr/share/wesnoth/images/icons/action/editor-map-flip_25-active.png</Path>
             <Path fileType="data">/usr/share/wesnoth/images/icons/action/editor-map-flip_25-pressed.png</Path>
             <Path fileType="data">/usr/share/wesnoth/images/icons/action/editor-map-flip_25.png</Path>
@@ -22415,12 +22514,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2024-09-15</Date>
-            <Version>1.18.2</Version>
+        <Update release="34">
+            <Date>2025-01-02</Date>
+            <Version>1.18.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Campaigns
  - Eastern Invasion
    - S04c: achievement now only triggers when escaping with all knights alive
    - S11/S99: flying units can no longer enter prison cells via the river
    - S12: fixed Dra-Nak (if present) having incorrect traits and portraits
    - S17b: AI is now more forced to recruit only higher-level units when gold reserves get too high
    - S99: prisoners now escape if their jailers are killed
  - Under the Burnings Suns
    - S04: added sprite for the Cold Dagger item
- Editor: Added Show Tool Information toggle option in the menus and toolbar to allow hiding the informational tooltip on the edge of the screen that shows the current editor tool's usage and palette information
- Translations: Updated Arabic, Bengali, British English, Chinese (Simplified), Czech, Finnish, French, German, Hungarian, Italian, Japanese, Turkish, Ukrainian
- User interface: Help button in the leaderchoosing window works on all languages
- WML Engine: Fix crash when weapon specials' filters lead to infinite recursion
- Miscellaneous and Bug Fixes: Search filter should now be case-insensitive for more than just ASCII characters

**Test Plan**

<!-- Short description of how the package was tested -->
Play tutorial

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
