### PR TITLE
noto-sans-ttf: Update to v2025.01.01

### DIFF
--- a/packages/n/noto-sans-ttf/package.yml
+++ b/packages/n/noto-sans-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : noto-sans-ttf
-version    : 2024.12.01
-release    : 36
+version    : 2025.01.01
+release    : 37
 source     :
-    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-2024.12.01.tar.gz : 106ef938580a210e4fe84f890275863b2e463997a8ed510cf41d2b16ec9b95d3
+    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-2025.01.01.tar.gz : 0224f98c86e1deaa1b2b8b4aaa3e9c63667c020474bb25dd9e5ebe4cd662ad03
     - https://github.com/googlefonts/noto-emoji/archive/refs/tags/v2.047.tar.gz : 2cfaf5a427eb26334cdb30d98e4a0c005b660504a339249dc54373e566f09b50
 homepage   : https://fonts.google.com/noto
 extract    : no

--- a/packages/n/noto-sans-ttf/pspec_x86_64.xml
+++ b/packages/n/noto-sans-ttf/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>noto-sans-ttf</Name>
         <Homepage>https://fonts.google.com/noto</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>OFL-1.1</License>
         <PartOf>desktop.font</PartOf>
@@ -1537,12 +1537,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2024-12-03</Date>
-            <Version>2024.12.01</Version>
+        <Update release="37">
+            <Date>2025-01-02</Date>
+            <Version>2025.01.01</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

No summarized changelog available

Full commit log available [here](https://github.com/notofonts/notofonts.github.io/compare/noto-monthly-release-2024.12.01...noto-monthly-release-2025.01.01)

**Test Plan**
- Wrote some text in LibreOffice Writer
- Confirmed Noto as system font looked okay

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
