### PR TITLE
Update Drumstick and vmpk

### DIFF
--- a/packages/d/drumstick/abi_symbols
+++ b/packages/d/drumstick/abi_symbols
@@ -308,6 +308,7 @@ libdrumstick-alsa.so.2:_ZN9drumstick4ALSA11TimerStatusD0Ev
 libdrumstick-alsa.so.2:_ZN9drumstick4ALSA11TimerStatusD1Ev
 libdrumstick-alsa.so.2:_ZN9drumstick4ALSA11TimerStatusD2Ev
 libdrumstick-alsa.so.2:_ZN9drumstick4ALSA11TimerStatusaSERKS1_
+libdrumstick-alsa.so.2:_ZN9drumstick4ALSA11typeOfEventERKNS0_14SequencerEventE
 libdrumstick-alsa.so.2:_ZN9drumstick4ALSA12NoteOffEventC1Eiii
 libdrumstick-alsa.so.2:_ZN9drumstick4ALSA12NoteOffEventC2Eiii
 libdrumstick-alsa.so.2:_ZN9drumstick4ALSA12RemoveEvents10getChannelEv
@@ -738,6 +739,8 @@ libdrumstick-alsa.so.2:_ZN9drumstick4ALSA9TimerInfoD0Ev
 libdrumstick-alsa.so.2:_ZN9drumstick4ALSA9TimerInfoD1Ev
 libdrumstick-alsa.so.2:_ZN9drumstick4ALSA9TimerInfoD2Ev
 libdrumstick-alsa.so.2:_ZN9drumstick4ALSA9TimerInfoaSERKS1_
+libdrumstick-alsa.so.2:_ZN9drumstick4ALSAlsE6QDebugPKNS0_14SequencerEventE
+libdrumstick-alsa.so.2:_ZN9drumstick4ALSAlsE6QDebugRKNS0_14SequencerEventE
 libdrumstick-alsa.so.2:_ZNK9drumstick4ALSA10ClientInfo13getSizeOfInfoEv
 libdrumstick-alsa.so.2:_ZNK9drumstick4ALSA10ClientInfo8getPortsEv
 libdrumstick-alsa.so.2:_ZNK9drumstick4ALSA10MidiClient10metaObjectEv
@@ -1273,6 +1276,7 @@ libdrumstick-rt-fluidsynth.so:_ZN9drumstick2rt16FluidSynthEngine6benderEii
 libdrumstick-rt-fluidsynth.so:_ZN9drumstick2rt16FluidSynthEngine6noteOnEiii
 libdrumstick-rt-fluidsynth.so:_ZN9drumstick2rt16FluidSynthEngine7noteOffEiii
 libdrumstick-rt-fluidsynth.so:_ZN9drumstick2rt16FluidSynthEngine9QSTR_GAINE
+libdrumstick-rt-fluidsynth.so:_ZN9drumstick2rt16FluidSynthEngine9QSTR_JACKE
 libdrumstick-rt-fluidsynth.so:_ZN9drumstick2rt16FluidSynthEngine9getStatusEv
 libdrumstick-rt-fluidsynth.so:_ZN9drumstick2rt16FluidSynthEngineC1EP7QObject
 libdrumstick-rt-fluidsynth.so:_ZN9drumstick2rt16FluidSynthEngineC2EP7QObject

--- a/packages/d/drumstick/abi_used_symbols
+++ b/packages/d/drumstick/abi_used_symbols
@@ -51,6 +51,7 @@ libQt5Core.so.5:_ZN11QDataStreamrsERi
 libQt5Core.so.5:_ZN11QDataStreamrsERs
 libQt5Core.so.5:_ZN11QFileDevice4seekEx
 libQt5Core.so.5:_ZN11QFileDevice5closeEv
+libQt5Core.so.5:_ZN11QMetaMethod14fromSignalImplEPK11QMetaObjectPPv
 libQt5Core.so.5:_ZN11QMetaObject10ConnectionD1Ev
 libQt5Core.so.5:_ZN11QMetaObject12invokeMethodEP7QObjectPKcN2Qt14ConnectionTypeE22QGenericReturnArgument16QGenericArgumentS7_S7_S7_S7_S7_S7_S7_S7_S7_
 libQt5Core.so.5:_ZN11QMetaObject14normalizedTypeEPKc
@@ -85,9 +86,9 @@ libQt5Core.so.5:_ZN12QMapDataBase20freeNodeAndRebalanceEP12QMapNodeBase
 libQt5Core.so.5:_ZN12QMapDataBase8freeDataEPS_
 libQt5Core.so.5:_ZN12QMapDataBase8freeTreeEP12QMapNodeBasei
 libQt5Core.so.5:_ZN13QPluginLoader15staticInstancesEv
+libQt5Core.so.5:_ZN13QPluginLoader6unloadEv
 libQt5Core.so.5:_ZN13QPluginLoader8instanceEv
 libQt5Core.so.5:_ZN13QPluginLoaderC1ERK7QStringP7QObject
-libQt5Core.so.5:_ZN13QPluginLoaderD1Ev
 libQt5Core.so.5:_ZN14QReadWriteLock11lockForReadEv
 libQt5Core.so.5:_ZN14QReadWriteLock12lockForWriteEv
 libQt5Core.so.5:_ZN14QReadWriteLock6unlockEv
@@ -123,6 +124,8 @@ libQt5Core.so.5:_ZN16QCoreApplication9postEventEP7QObjectP6QEventi
 libQt5Core.so.5:_ZN16QCoreApplication9translateEPKcS1_S1_i
 libQt5Core.so.5:_ZN16QCoreApplicationC1ERiPPci
 libQt5Core.so.5:_ZN16QCoreApplicationD1Ev
+libQt5Core.so.5:_ZN16QDebugStateSaverC1ER6QDebug
+libQt5Core.so.5:_ZN16QDebugStateSaverD1Ev
 libQt5Core.so.5:_ZN18QAbstractItemModel10insertRowsEiiRK11QModelIndex
 libQt5Core.so.5:_ZN18QAbstractItemModel10removeRowsEiiRK11QModelIndex
 libQt5Core.so.5:_ZN18QAbstractItemModel11dataChangedERK11QModelIndexS2_RK7QVectorIiE
@@ -198,7 +201,6 @@ libQt5Core.so.5:_ZN6QEventD2Ev
 libQt5Core.so.5:_ZN6QMutex4lockEv
 libQt5Core.so.5:_ZN6QMutex6unlockEv
 libQt5Core.so.5:_ZN6QMutexD1Ev
-libQt5Core.so.5:_ZN7QLocaleC1ENS_8LanguageENS_7CountryE
 libQt5Core.so.5:_ZN7QLocaleC1Ev
 libQt5Core.so.5:_ZN7QLocaleD1Ev
 libQt5Core.so.5:_ZN7QObject10childEventEP11QChildEvent
@@ -327,6 +329,7 @@ libQt5Core.so.5:_ZNK10QTextCodec9toUnicodeERK10QByteArray
 libQt5Core.so.5:_ZNK11QDataStream5atEndEv
 libQt5Core.so.5:_ZNK11QDataStream6statusEv
 libQt5Core.so.5:_ZNK11QFileDevice6handleEv
+libQt5Core.so.5:_ZNK11QMetaObject10Connection18isConnected_helperEv
 libQt5Core.so.5:_ZNK11QMetaObject13indexOfMethodEPKc
 libQt5Core.so.5:_ZNK11QMetaObject15indexOfPropertyEPKc
 libQt5Core.so.5:_ZNK11QMetaObject2trEPKcS1_i
@@ -334,6 +337,7 @@ libQt5Core.so.5:_ZNK11QMetaObject4castEP7QObject
 libQt5Core.so.5:_ZNK11QMetaObject9classNameEv
 libQt5Core.so.5:_ZNK11QObjectData17dynamicMetaObjectEv
 libQt5Core.so.5:_ZNK12QMapNodeBase8nextNodeEv
+libQt5Core.so.5:_ZNK13QPluginLoader8fileNameEv
 libQt5Core.so.5:_ZNK14QMessageLogger5debugEv
 libQt5Core.so.5:_ZNK14QMessageLogger5fatalEPKcz
 libQt5Core.so.5:_ZNK14QMessageLogger7warningEPKcz
@@ -374,6 +378,7 @@ libQt5Core.so.5:_ZNK5QFile4sizeEv
 libQt5Core.so.5:_ZNK7QLocale4nameEv
 libQt5Core.so.5:_ZNK7QLocale8languageEv
 libQt5Core.so.5:_ZNK7QObject10objectNameEv
+libQt5Core.so.5:_ZNK7QObject17isSignalConnectedERK11QMetaMethod
 libQt5Core.so.5:_ZNK7QObject8propertyEPKc
 libQt5Core.so.5:_ZNK7QString10startsWithERKS_N2Qt15CaseSensitivityE
 libQt5Core.so.5:_ZNK7QString13leftJustifiedEi5QCharb
@@ -402,7 +407,6 @@ libQt5Core.so.5:_ZNK8QVariant5toIntEPb
 libQt5Core.so.5:_ZNK8QVariant6toBoolEv
 libQt5Core.so.5:_ZNK8QVariant6toUIntEPb
 libQt5Core.so.5:_ZNK8QVariant7convertEiPv
-libQt5Core.so.5:_ZNK8QVariant7toFloatEPb
 libQt5Core.so.5:_ZNK8QVariant8toDoubleEPb
 libQt5Core.so.5:_ZNK8QVariant8toStringEv
 libQt5Core.so.5:_ZNK8QVariant8userTypeEv
@@ -444,20 +448,16 @@ libQt5DBus.so.5:_ZN22QDBusAbstractInterface6doCallEN5QDBus8CallModeERK7QStringPK
 libQt5DBus.so.5:_ZNK12QDBusMessage12errorMessageEv
 libQt5DBus.so.5:_ZNK12QDBusMessage4typeEv
 libQt5Gui.so.5:_ZN10QTransformC1Ev
-libQt5Gui.so.5:_ZN10QValidator9setLocaleERK7QLocale
 libQt5Gui.so.5:_ZN11QTouchEvent10TouchPointC1ERKS0_
 libQt5Gui.so.5:_ZN11QTouchEvent10TouchPointD1Ev
 libQt5Gui.so.5:_ZN12QKeySequenceC1ENS_11StandardKeyE
 libQt5Gui.so.5:_ZN12QKeySequenceC1Eiiii
 libQt5Gui.so.5:_ZN12QKeySequenceD1Ev
 libQt5Gui.so.5:_ZN12QTouchDevice7devicesEv
-libQt5Gui.so.5:_ZN13QIntValidatorC1EiiP7QObject
 libQt5Gui.so.5:_ZN13QTextDocument18setUndoRedoEnabledEb
 libQt5Gui.so.5:_ZN15QGuiApplication18setDesktopFileNameERK7QString
 libQt5Gui.so.5:_ZN15QGuiApplication4fontEv
 libQt5Gui.so.5:_ZN15QGuiApplication7paletteEv
-libQt5Gui.so.5:_ZN16QDoubleValidator11setNotationENS_8NotationE
-libQt5Gui.so.5:_ZN16QDoubleValidatorC1EddiP7QObject
 libQt5Gui.so.5:_ZN4QPenC1ERK6QBrushdN2Qt8PenStyleENS3_11PenCapStyleENS3_12PenJoinStyleE
 libQt5Gui.so.5:_ZN4QPenD1Ev
 libQt5Gui.so.5:_ZN5QFont10fromStringERK7QString
@@ -679,6 +679,10 @@ libQt5Widgets.so.5:_ZN13QGraphicsView9fitInViewERK6QRectFN2Qt15AspectRatioModeE
 libQt5Widgets.so.5:_ZN13QGraphicsView9showEventEP10QShowEvent
 libQt5Widgets.so.5:_ZN13QGraphicsViewC2EP7QWidget
 libQt5Widgets.so.5:_ZN13QGraphicsViewD2Ev
+libQt5Widgets.so.5:_ZN14QDoubleSpinBox10setMaximumEd
+libQt5Widgets.so.5:_ZN14QDoubleSpinBox13setSingleStepEd
+libQt5Widgets.so.5:_ZN14QDoubleSpinBox8setValueEd
+libQt5Widgets.so.5:_ZN14QDoubleSpinBoxC1EP7QWidget
 libQt5Widgets.so.5:_ZN14QGraphicsScene10invalidateERK6QRectF6QFlagsINS_10SceneLayerEE
 libQt5Widgets.so.5:_ZN14QGraphicsScene10wheelEventEP24QGraphicsSceneWheelEvent
 libQt5Widgets.so.5:_ZN14QGraphicsScene11eventFilterEP7QObjectP6QEvent
@@ -895,11 +899,8 @@ libQt5Widgets.so.5:_ZN9QComboBox18setMaxVisibleItemsEi
 libQt5Widgets.so.5:_ZN9QComboBox19currentIndexChangedEi
 libQt5Widgets.so.5:_ZN9QComboBox5clearEv
 libQt5Widgets.so.5:_ZN9QComboBoxC1EP7QWidget
-libQt5Widgets.so.5:_ZN9QLineEdit12setValidatorEPK10QValidator
 libQt5Widgets.so.5:_ZN9QLineEdit5clearEv
 libQt5Widgets.so.5:_ZN9QLineEdit7setTextERK7QString
-libQt5Widgets.so.5:_ZN9QLineEdit8deselectEv
-libQt5Widgets.so.5:_ZN9QLineEdit9selectAllEv
 libQt5Widgets.so.5:_ZN9QLineEditC1EP7QWidget
 libQt5Widgets.so.5:_ZN9QShortcut16staticMetaObjectE
 libQt5Widgets.so.5:_ZN9QShortcut9activatedEv
@@ -918,6 +919,7 @@ libQt5Widgets.so.5:_ZNK13QGraphicsView10mapToSceneERK6QPoint
 libQt5Widgets.so.5:_ZNK13QGraphicsView12mapFromSceneERK6QRectF
 libQt5Widgets.so.5:_ZNK13QGraphicsView16inputMethodQueryEN2Qt16InputMethodQueryE
 libQt5Widgets.so.5:_ZNK13QGraphicsView9sceneRectEv
+libQt5Widgets.so.5:_ZNK14QDoubleSpinBox5valueEv
 libQt5Widgets.so.5:_ZNK14QGraphicsScene16inputMethodQueryEN2Qt16InputMethodQueryE
 libQt5Widgets.so.5:_ZNK14QGraphicsScene4fontEv
 libQt5Widgets.so.5:_ZNK14QGraphicsScene5itemsERK7QPointFN2Qt17ItemSelectionModeENS3_9SortOrderERK10QTransform
@@ -983,7 +985,6 @@ libQt5Widgets.so.5:_ZNK9QComboBox5countEv
 libQt5Widgets.so.5:_ZNK9QComboBox8findDataERK8QVarianti6QFlagsIN2Qt9MatchFlagEE
 libQt5Widgets.so.5:_ZNK9QComboBox8itemDataEii
 libQt5Widgets.so.5:_ZNK9QComboBox8itemTextEi
-libQt5Widgets.so.5:_ZNK9QLineEdit18hasAcceptableInputEv
 libQt5Widgets.so.5:_ZNK9QLineEdit4textEv
 libQt5Widgets.so.5:_ZNK9QTextEdit6toHtmlEv
 libQt5Widgets.so.5:_ZNK9QTextEdit8documentEv
@@ -1458,6 +1459,7 @@ libstdc++.so.6:_Znwm
 libstdc++.so.6:__cxa_allocate_exception
 libstdc++.so.6:__cxa_begin_catch
 libstdc++.so.6:__cxa_call_terminate
+libstdc++.so.6:__cxa_demangle
 libstdc++.so.6:__cxa_end_catch
 libstdc++.so.6:__cxa_free_exception
 libstdc++.so.6:__cxa_guard_abort

--- a/packages/d/drumstick/package.yml
+++ b/packages/d/drumstick/package.yml
@@ -1,8 +1,8 @@
 name       : drumstick
-version    : 2.9.1
-release    : 15
+version    : 2.10.0
+release    : 16
 source     :
-    - https://sourceforge.net/projects/drumstick/files/2.9.1/drumstick-2.9.1.tar.gz : a7049333d5411faf4d91a81ae666746106b578897fc0713a84325f65fdd06ffb
+    - https://sourceforge.net/projects/drumstick/files/2.10.0/drumstick-2.10.0.tar.gz : 92f5fc2a94b8c9067200897fd14027f707bf0103871ea942e388f9afe95e0f34
 homepage   : https://drumstick.sourceforge.io
 license    : GPL-2.0-or-later
 component  : programming.library

--- a/packages/d/drumstick/pspec_x86_64.xml
+++ b/packages/d/drumstick/pspec_x86_64.xml
@@ -39,13 +39,13 @@
             <Path fileType="library">/usr/lib64/drumstick2/libdrumstick-rt-oss-in.so</Path>
             <Path fileType="library">/usr/lib64/drumstick2/libdrumstick-rt-oss-out.so</Path>
             <Path fileType="library">/usr/lib64/libdrumstick-alsa.so.2</Path>
-            <Path fileType="library">/usr/lib64/libdrumstick-alsa.so.2.9.1</Path>
+            <Path fileType="library">/usr/lib64/libdrumstick-alsa.so.2.10.0</Path>
             <Path fileType="library">/usr/lib64/libdrumstick-file.so.2</Path>
-            <Path fileType="library">/usr/lib64/libdrumstick-file.so.2.9.1</Path>
+            <Path fileType="library">/usr/lib64/libdrumstick-file.so.2.10.0</Path>
             <Path fileType="library">/usr/lib64/libdrumstick-rt.so.2</Path>
-            <Path fileType="library">/usr/lib64/libdrumstick-rt.so.2.9.1</Path>
+            <Path fileType="library">/usr/lib64/libdrumstick-rt.so.2.10.0</Path>
             <Path fileType="library">/usr/lib64/libdrumstick-widgets.so.2</Path>
-            <Path fileType="library">/usr/lib64/libdrumstick-widgets.so.2.9.1</Path>
+            <Path fileType="library">/usr/lib64/libdrumstick-widgets.so.2.10.0</Path>
             <Path fileType="data">/usr/share/applications/net.sourceforge.drumstick-drumgrid.desktop</Path>
             <Path fileType="data">/usr/share/applications/net.sourceforge.drumstick-guiplayer.desktop</Path>
             <Path fileType="data">/usr/share/applications/net.sourceforge.drumstick-vpiano.desktop</Path>
@@ -100,7 +100,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="15">drumstick</Dependency>
+            <Dependency release="16">drumstick</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/drumstick.h</Path>
@@ -153,9 +153,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2024-12-14</Date>
-            <Version>2.9.1</Version>
+        <Update release="16">
+            <Date>2025-01-02</Date>
+            <Version>2.10.0</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>

--- a/packages/v/vmpk/abi_used_symbols
+++ b/packages/v/vmpk/abi_used_symbols
@@ -856,7 +856,6 @@ libgcc_s.so.1:_Unwind_Resume
 libstdc++.so.6:_ZSt11__once_call
 libstdc++.so.6:_ZSt15__once_callable
 libstdc++.so.6:_ZSt20__throw_system_errori
-libstdc++.so.6:_ZSt9terminatev
 libstdc++.so.6:_ZTVN10__cxxabiv117__class_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv120__si_class_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv121__vmi_class_type_infoE
@@ -864,6 +863,7 @@ libstdc++.so.6:_ZdlPv
 libstdc++.so.6:_ZdlPvm
 libstdc++.so.6:_Znwm
 libstdc++.so.6:__cxa_begin_catch
+libstdc++.so.6:__cxa_call_terminate
 libstdc++.so.6:__cxa_end_catch
 libstdc++.so.6:__cxa_guard_abort
 libstdc++.so.6:__cxa_guard_acquire

--- a/packages/v/vmpk/monitoring.yml
+++ b/packages/v/vmpk/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 5100
+  rss: https://sourceforge.net/projects/vmpk/rss?limit=200
+# No known CPE, checked 2025-01-02
+security:
+  cpe: ~

--- a/packages/v/vmpk/package.yml
+++ b/packages/v/vmpk/package.yml
@@ -1,8 +1,8 @@
 name       : vmpk
-version    : 0.9.0
-release    : 7
+version    : 0.9.1
+release    : 8
 source     :
-    - https://sourceforge.net/projects/vmpk/files/vmpk/0.9.0/vmpk-0.9.0.tar.bz2 : c47ee14cbf1903075440acad729d8e0e02e4c98606183756676eeac1a1aebcd9
+    - https://sourceforge.net/projects/vmpk/files/vmpk/0.9.1/vmpk-0.9.1.tar.gz : 3ac9cca97fcdbffd25605c5de88984e15a8b2dbeee885f626b1c5c499af80b51
 homepage   : https://vmpk.sourceforge.io
 license    : GPL-3.0-only
 component  : multimedia.audio

--- a/packages/v/vmpk/pspec_x86_64.xml
+++ b/packages/v/vmpk/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>vmpk</Name>
         <Homepage>https://vmpk.sourceforge.io</Homepage>
         <Packager>
-            <Name>Jarno Turkki</Name>
-            <Email>stalebrim@posteo.net</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <PartOf>multimedia.audio</PartOf>
@@ -32,6 +32,7 @@
             <Path fileType="data">/usr/share/metainfo/net.sourceforge.VMPK.metainfo.xml</Path>
             <Path fileType="data">/usr/share/vmpk/Serbian-cyr.xml</Path>
             <Path fileType="data">/usr/share/vmpk/Serbian-lat.xml</Path>
+            <Path fileType="data">/usr/share/vmpk/azerty-FR.xml</Path>
             <Path fileType="data">/usr/share/vmpk/azerty.xml</Path>
             <Path fileType="data">/usr/share/vmpk/german.xml</Path>
             <Path fileType="data">/usr/share/vmpk/gmgsxg.ins</Path>
@@ -60,12 +61,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2024-01-09</Date>
-            <Version>0.9.0</Version>
+        <Update release="8">
+            <Date>2025-01-02</Date>
+            <Version>0.9.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jarno Turkki</Name>
-            <Email>stalebrim@posteo.net</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

* Update drumstick to 2.10.0
* Update vmpk to 0.9.1 (to use new drumstick)

**Test Plan**

* Play "Hot crossed buns" on virtual keyboards in drumstick and vmpk

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
