### PR TITLE
discover: Make hardware drivers icon consistent

### DIFF
--- a/packages/d/discover/files/0001-PackageKitBackend-Add-the-Drivers-menu-filtered-by-t.patch
+++ b/packages/d/discover/files/0001-PackageKitBackend-Add-the-Drivers-menu-filtered-by-t.patch
@@ -239,7 +239,7 @@ index 68c8299e1..0159843b5 100644
 +
 +  <Menu>
 +    <Name>Hardware Drivers</Name>
-+    <Icon>cpu</Icon>
++    <Icon>computer-laptop-symbolic</Icon>
 +    <Drivers />
 +    <Include>
 +      <And>
@@ -248,7 +248,7 @@ index 68c8299e1..0159843b5 100644
 +    </Include>
 +    <Menu>
 +      <Name>Drivers For This Device</Name>
-+      <Icon>cpu</Icon>
++      <Icon>computer-laptop-symbolic</Icon>
 +      <Drivers />
 +      <Include>
 +        <And>

--- a/packages/d/discover/package.yml
+++ b/packages/d/discover/package.yml
@@ -1,6 +1,6 @@
 name       : discover
 version    : 6.2.5
-release    : 26
+release    : 27
 source     :
     - https://download.kde.org/stable/plasma/6.2.5/discover-6.2.5.tar.xz : 8ccbb881392a4bad540ab0bb465637a0e206ef6b53e7bf02e71bc8fb6453a4a4
 homepage   : https://apps.kde.org/discover/

--- a/packages/d/discover/pspec_x86_64.xml
+++ b/packages/d/discover/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>discover</Name>
         <Homepage>https://apps.kde.org/discover/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Hans Kelson</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.kde</PartOf>
@@ -294,12 +294,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2025-01-01</Date>
+        <Update release="27">
+            <Date>2025-01-03</Date>
             <Version>6.2.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Hans Kelson</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Updates our "hardware drivers" category patch to make the icon more consistent with upstream's other icons.
Fixes #4678.

**Test Plan**

- Build from this PR.
- Install the resulting package.
- Launch Discover, ensure that the "hardware drivers" section has an icon that looks consistent and that Discover doesn't blow up on launch.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
