### PR TITLE
acpica-unix: Update to v20241212

### DIFF
--- a/packages/a/acpica-unix/package.yml
+++ b/packages/a/acpica-unix/package.yml
@@ -1,8 +1,8 @@
 name       : acpica-unix
-version    : '20240927'
-release    : 10
+version    : '20241212'
+release    : 11
 source     :
-    - https://github.com/acpica/acpica/archive/refs/tags/R09_27_24.tar.gz : cc167c0825c3807f9812f892e77ec918b7f62c3faeaf9a2e3664de7639b00b6b
+    - https://github.com/acpica/acpica/archive/refs/tags/R2024_12_12.tar.gz : adde693d2486d77940bef81acb45fec1ca285266ecbc4d10c5cd058bca19dc07
 license    : GPL-2.0-or-later
 homepage   : https://www.intel.com/content/www/us/en/developer/topic-technology/open/acpica/overview.html
 component  : programming.tools

--- a/packages/a/acpica-unix/pspec_x86_64.xml
+++ b/packages/a/acpica-unix/pspec_x86_64.xml
@@ -31,9 +31,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2024-11-11</Date>
-            <Version>20240927</Version>
+        <Update release="11">
+            <Date>2025-01-04</Date>
+            <Version>20241212</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Fix 2 critical CVE addressing memory leaks
- EINJ V2 updates
- CDAT updates
- Fix mutex handling, don't release ones that were never acquired

**Security**

- Note these CVEs only affect very old kernels no longer used by Solus
- CVE-2017-13693
- CVE-2017-13694

**Test Plan**

- Rebuild edk2-ovmf, run a qemu virtual machine with UEFI

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
