### PR TITLE
python-neovim: Add missing runtime dependency

### DIFF
--- a/packages/py/python-neovim/package.yml
+++ b/packages/py/python-neovim/package.yml
@@ -1,6 +1,6 @@
 name       : python-neovim
 version    : 0.5.2
-release    : 23
+release    : 24
 source     :
     - https://github.com/neovim/pynvim/archive/refs/tags/0.5.2.tar.gz : c86e304d55fc8996296554b959cad483aeaafb47e425ebe3a7d0f96e3222f035
 homepage   : https://github.com/neovim/pynvim
@@ -13,6 +13,7 @@ rundeps    :
     - neovim
     - python-greenlet
     - python-msgpack
+    - python-typing-extensions
 build      : |
     %python3_setup
 install    : |

--- a/packages/py/python-neovim/pspec_x86_64.xml
+++ b/packages/py/python-neovim/pspec_x86_64.xml
@@ -74,8 +74,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2024-12-22</Date>
+        <Update release="24">
+            <Date>2025-01-05</Date>
             <Version>0.5.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
- Add missing runtime dependency on `python-typing-extensions`

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Inspect the built package and see `python-typing-extensions` in the list of dependencies.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
