### PR TITLE
wildmidi: Update to v0.4.6

### DIFF
--- a/packages/w/wildmidi/abi_libs
+++ b/packages/w/wildmidi/abi_libs
@@ -1,2 +1,1 @@
 libWildMidi.so.2
-wildmidi

--- a/packages/w/wildmidi/abi_symbols
+++ b/packages/w/wildmidi/abi_symbols
@@ -19,13 +19,3 @@ libWildMidi.so.2:WildMidi_SetCvtOption
 libWildMidi.so.2:WildMidi_SetOption
 libWildMidi.so.2:WildMidi_Shutdown
 libWildMidi.so.2:WildMidi_SongSeek
-wildmidi:_IO_stdin_used
-wildmidi:__bss_start
-wildmidi:__data_start
-wildmidi:_edata
-wildmidi:_end
-wildmidi:_start
-wildmidi:_tty
-wildmidi:main
-wildmidi:wm_inittty
-wildmidi:wm_resetty

--- a/packages/w/wildmidi/abi_used_symbols
+++ b/packages/w/wildmidi/abi_used_symbols
@@ -30,9 +30,12 @@ libc.so.6:__vfprintf_chk
 libc.so.6:__vsprintf_chk
 libc.so.6:calloc
 libc.so.6:close
+libc.so.6:fclose
 libc.so.6:fcntl64
+libc.so.6:fopen64
 libc.so.6:fputc
 libc.so.6:free
+libc.so.6:fseek
 libc.so.6:fwrite
 libc.so.6:getcwd
 libc.so.6:getenv
@@ -40,13 +43,11 @@ libc.so.6:getopt_long
 libc.so.6:getpwuid
 libc.so.6:getuid
 libc.so.6:isatty
-libc.so.6:lseek64
 libc.so.6:malloc
 libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset
-libc.so.6:nanosleep
 libc.so.6:open64
 libc.so.6:optarg
 libc.so.6:optind
@@ -57,6 +58,7 @@ libc.so.6:realloc
 libc.so.6:stat64
 libc.so.6:stderr
 libc.so.6:strcat
+libc.so.6:strcmp
 libc.so.6:strcpy
 libc.so.6:strerror
 libc.so.6:strlen
@@ -67,7 +69,6 @@ libc.so.6:strtol
 libc.so.6:tcgetattr
 libc.so.6:tcsetattr
 libc.so.6:usleep
-libc.so.6:write
 libm.so.6:pow
 libm.so.6:sin
 libm.so.6:sincos

--- a/packages/w/wildmidi/package.yml
+++ b/packages/w/wildmidi/package.yml
@@ -1,8 +1,8 @@
 name       : wildmidi
-version    : 0.4.5
-release    : 4
+version    : 0.4.6
+release    : 5
 source     :
-    - https://github.com/Mindwerks/wildmidi/releases/download/wildmidi-0.4.5/wildmidi-0.4.5.tar.gz : d5e7bef00a7aa47534a53d43b1265f8d3d27f6a28e7f563c1cdf02ff4fa35b99
+    - https://github.com/Mindwerks/wildmidi/releases/download/wildmidi-0.4.6/wildmidi-0.4.6.tar.gz : 24ca992639ce76efa3737029fceb3672385d56e2ac0a15d50b40cc12d26e60de
 homepage   : https://github.com/Mindwerks/wildmidi/
 license    :
     - GPL-3.0-or-later

--- a/packages/w/wildmidi/pspec_x86_64.xml
+++ b/packages/w/wildmidi/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>wildmidi</Name>
         <Homepage>https://github.com/Mindwerks/wildmidi/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <License>LGPL-3.0-or-later</License>
@@ -36,7 +36,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="4">wildmidi</Dependency>
+            <Dependency release="5">wildmidi</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wildmidi_lib.h</Path>
@@ -70,12 +70,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2023-11-01</Date>
-            <Version>0.4.5</Version>
+        <Update release="5">
+            <Date>2025-01-07</Date>
+            <Version>0.4.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- A lot of player cleanup and refactoring, thanks to initial work by Azamat H. Hackimov, with addition of several safeguards and minor fixes. Ability to choose which audio output backends to include in the build system: see the cmake script for the relevant WANT_??? options. Player's --help command line switch lists the available backends. Thanks to initial work by Azamat H. Hackimov.
- Improved pkg-config file generation in cmake script
- Workaround a link failure on AmigaOS4 with newer SDKs
- Full changelog [here](https://github.com/Mindwerks/wildmidi/releases/tag/wildmidi-0.4.6)

Resolves https://github.com/getsolus/packages/issues/4744

**Test Plan**

- Play a test MIDI file from the command line

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
