### PR TITLE
github-cli: Update to v2.65.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.64.0
-release    : 64
+version    : 2.65.0
+release    : 65
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.64.0.tar.gz : 229fd8fc51325ebb5a357af6af116094d6be6a5f1e0f0923b7892ed01b208abb
+    - https://github.com/cli/cli/archive/refs/tags/v2.65.0.tar.gz : af026f1b0368b1444a67a941f179ddce7e97333881ec0bbcb49fed29f4151241
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -160,6 +160,8 @@
             <Path fileType="man">/usr/share/man/man1/gh-release-view.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-release.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-repo-archive.1</Path>
+            <Path fileType="man">/usr/share/man/man1/gh-repo-autolink-list.1</Path>
+            <Path fileType="man">/usr/share/man/man1/gh-repo-autolink.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-repo-clone.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-repo-create.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-repo-delete.1</Path>
@@ -225,9 +227,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="64">
-            <Date>2024-12-22</Date>
-            <Version>2.64.0</Version>
+        <Update release="65">
+            <Date>2025-01-06</Date>
+            <Version>2.65.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Document the base repo resolution functions
- Document how to set gh-merge-base
- Add pending status for workflow runs
- Add support for listing autolink references
- Add mention of classic token in gh auth login docs
- Allow setting security_and_analysis settings in gh repo edit
- Upgrade generated workflows
- Myriad fixes to provide clarity on determining tracking ref in PR create
- Handle missing upstream configs for `gh pr create`
- Add non-TTY output when fork is newly created

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
