### PR TITLE
watchexec: Update to v2.2.1

### DIFF
--- a/packages/w/watchexec/package.yml
+++ b/packages/w/watchexec/package.yml
@@ -1,8 +1,8 @@
 name       : watchexec
-version    : 2.2.0
-release    : 2
+version    : 2.2.1
+release    : 3
 source     :
-    - https://github.com/watchexec/watchexec/archive/refs/tags/v2.2.0.tar.gz : 372def49d02a53864ede5fd821feb6f8de96bbbde8a94dbcd1b77aeed01d4a7b
+    - https://github.com/watchexec/watchexec/archive/refs/tags/v2.2.1.tar.gz : 67845d1c07bc47f74016cf93e7f7390e193c679003f97be7ab1ca95acf730380
 homepage   : https://watchexec.github.io
 license    : Apache-2.0
 component  : system.utils

--- a/packages/w/watchexec/pspec_x86_64.xml
+++ b/packages/w/watchexec/pspec_x86_64.xml
@@ -28,9 +28,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-11-19</Date>
-            <Version>2.2.0</Version>
+        <Update release="3">
+            <Date>2025-01-06</Date>
+            <Version>2.2.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Ian M. Jones</Name>
             <Email>ian@ianmjones.com</Email>


### PR DESCRIPTION
**Summary**

Changelog: https://github.com/watchexec/watchexec/releases/tag/v2.2.1

**Test Plan**

* Built and installed package locally.
* Ran within a few projects to run tests.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
