### PR TITLE
calamares: Explicitly set /etc/vconsole.conf font

### DIFF
--- a/packages/c/calamares/files/install/modules/shellprocess_postinstall.conf
+++ b/packages/c/calamares/files/install/modules/shellprocess_postinstall.conf
@@ -10,8 +10,13 @@ script:
       timeout: 300
 
     # Add a comment to the vconsole conf about how to change the font in the future
-    - "echo \"## The default console font on Solus is ter-v32b, if you would like to change that uncomment this and set it to your selection\" >> /etc/vconsole.conf"
-    - "echo \"# FONT=ter-v32b\" >> /etc/vconsole.conf"
+    - |
+      cat << 'EOF' >> /etc/vconsole.conf
+      ## The default console font on Solus is ter-v32b,
+      ## it can be changed to a different font of your preference here.
+      ## Run 'sudo clr-boot-manager update' after updating it.
+      FONT=ter-v32b
+      EOF
 
     # If the ISO was generated from unstable then remove the local repo and switch back to shannon
     # TODO: We could make a UI to configure this. Perhaps an advanced option to make the installed system run from unstable?

--- a/packages/c/calamares/package.yml
+++ b/packages/c/calamares/package.yml
@@ -1,6 +1,6 @@
 name       : calamares
 version    : 3.3.13
-release    : 28
+release    : 29
 source     :
     - https://github.com/calamares/calamares/releases/download/v3.3.13/calamares-3.3.13.tar.gz : e49cf7d894e02ba04898cd0770cb578b4e24dfd0808ab7660bf95bb2456648d4
 homepage   : https://calamares.io

--- a/packages/c/calamares/pspec_x86_64.xml
+++ b/packages/c/calamares/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>calamares</Name>
         <Homepage>https://calamares.io</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <License>CC-BY-4.0</License>
@@ -292,7 +292,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="28">calamares</Dependency>
+            <Dependency release="29">calamares</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libcalamares/Branding.h</Path>
@@ -415,12 +415,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2025-01-13</Date>
+        <Update release="29">
+            <Date>2025-01-16</Date>
             <Version>3.3.13</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/c/clr-boot-manager/abi_used_symbols
+++ b/packages/c/clr-boot-manager/abi_used_symbols
@@ -30,7 +30,6 @@ libc.so.6:__ctype_toupper_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
 libc.so.6:__getdelim
-libc.so.6:__isoc23_fscanf
 libc.so.6:__isoc23_sscanf
 libc.so.6:__isoc23_strtol
 libc.so.6:__isoc99_sscanf
@@ -99,6 +98,7 @@ libc.so.6:stdout
 libc.so.6:strcasecmp
 libc.so.6:strchr
 libc.so.6:strcmp
+libc.so.6:strcspn
 libc.so.6:strdup
 libc.so.6:strerror
 libc.so.6:strlen

--- a/packages/c/clr-boot-manager/package.yml
+++ b/packages/c/clr-boot-manager/package.yml
@@ -1,8 +1,8 @@
 name       : clr-boot-manager
-version    : 3.5.0
-release    : 37
+version    : 3.6.0
+release    : 38
 source     :
-    - https://github.com/getsolus/clr-boot-manager/releases/download/solus-3.5.0/clr-boot-manager-3.5.0.tar.xz : 5749a728b56a313991729457c1a123974341397408038ae7163c176531177bac
+    - https://github.com/getsolus/clr-boot-manager/releases/download/solus-3.6.0/clr-boot-manager-3.6.0.tar.xz : f05cafc9fe808adbe9532a734551497d4810a163877cb316cb2fb12613fdc49e
 homepage   : https://www.clearlinux.org
 license    : LGPL-2.1-or-later
 component  : system.base

--- a/packages/c/clr-boot-manager/pspec_x86_64.xml
+++ b/packages/c/clr-boot-manager/pspec_x86_64.xml
@@ -38,9 +38,9 @@ Most importantly, clr-boot-manager provides a simple mechanism to provide kernel
         </Files>
     </Package>
     <History>
-        <Update release="37">
-            <Date>2024-07-15</Date>
-            <Version>3.5.0</Version>
+        <Update release="38">
+            <Date>2025-01-16</Date>
+            <Version>3.6.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Silke Hofstra</Name>
             <Email>silke@slxh.eu</Email>


### PR DESCRIPTION
**Summary**
As part of the CBM changes in [CBM PR 7], CBM will now parse the system `/etc/vconsole.conf` file and explicitly set the corresponding

`rd.vconsole.font=(...) rd.vconsole.keymap=(...)`

options on the kernel commandline, such that they are used in rescue initrd shells.

[CBM PR 7]: https://github.com/getsolus/clr-boot-manager/pull/7

To make it clearer and more discoverable to the user what these variables are currently set to in the root fs, the present change ensures that, on new installs, the Solus default font selection of the terminus 32px bold console font with unicode support (ter-v32b), will now also be explicitly listed on the kernel command line for troubleshooting/rescue purposes via CBM.

This is primarily an ergonomics change meant to help Solus users understand how to influence these settings in the face of error modes that prevent them from logging in via their normal graphical session.

The consensus seemed to be that this PR ought to be followed up by a Documentation PR on the help center, expanding on the options between which the user can choose in terms of font sizes, font styles, and keyboard mappings, should they need to change the settings for whatever reason.

**Test Plan**

N/A (covered by CBM PR)

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
