### PR TITLE
seatd: Update to v0.9.1

### DIFF
--- a/packages/s/seatd/abi_used_symbols
+++ b/packages/s/seatd/abi_used_symbols
@@ -64,6 +64,7 @@ libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strncpy
+libc.so.6:strnlen
 libc.so.6:strtol
 libc.so.6:unlink
 libc.so.6:waitpid

--- a/packages/s/seatd/monitoring.yml
+++ b/packages/s/seatd/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 234932
+  rss: https://github.com/kennylevinsen/seatd/tags.atom
+# No known CPE, checked 2024-12-18
+security:
+  cpe: ~

--- a/packages/s/seatd/package.yml
+++ b/packages/s/seatd/package.yml
@@ -1,8 +1,8 @@
 name       : seatd
-version    : 0.8.0
-release    : 3
+version    : 0.9.1
+release    : 4
 source     :
-    - https://git.sr.ht/~kennylevinsen/seatd/archive/0.8.0.tar.gz : a562a44ee33ccb20954a1c1ec9a90ecb2db7a07ad6b18d0ac904328efbcf65a0
+    - https://git.sr.ht/~kennylevinsen/seatd/archive/0.9.1.tar.gz : 819979c922a0be258aed133d93920bce6a3d3565a60588d6d372ce9db2712cd3
 homepage   : https://sr.ht/~kennylevinsen/seatd/
 license    : MIT
 component  : desktop.library

--- a/packages/s/seatd/pspec_x86_64.xml
+++ b/packages/s/seatd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>seatd</Name>
         <Homepage>https://sr.ht/~kennylevinsen/seatd/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>desktop.library</PartOf>
@@ -32,7 +32,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="3">seatd</Dependency>
+            <Dependency release="4">seatd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libseat.h</Path>
@@ -41,12 +41,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-06-26</Date>
-            <Version>0.8.0</Version>
+        <Update release="4">
+            <Date>2025-01-09</Date>
+            <Version>0.9.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- [0.9.1](https://git.sr.ht/~kennylevinsen/seatd/refs/0.9.1)
- [0.9.0](https://git.sr.ht/~kennylevinsen/seatd/refs/0.9.0)

**Test Plan**
- Test revdeps:
- Test `gamescope`: launch supertuxkart
- Test `aquamarine`: launch hyprland session
- Test `wlroots`: launch sway session
- No quick way to test `cosmic-comp`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
