### PR TITLE
git: Update to v2.47.1

### DIFF
--- a/packages/g/git/package.yml
+++ b/packages/g/git/package.yml
@@ -1,8 +1,8 @@
 name       : git
-version    : 2.47.0
-release    : 133
+version    : 2.47.1
+release    : 134
 source     :
-    - https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.47.0.tar.xz : 1ce114da88704271b43e027c51e04d9399f8c88e9ef7542dae7aebae7d87bc4e
+    - https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.47.1.tar.xz : f3d8f9bb23ae392374e91cd9d395970dabc5b9c5ee72f39884613cd84a6ed310
 license    :
     - GPL-2.0-only
     - LGPL-2.1-or-later

--- a/packages/g/git/pspec_x86_64.xml
+++ b/packages/g/git/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>git</Name>
         <Homepage>https://git-scm.com/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <License>LGPL-2.1-or-later</License>
@@ -568,12 +568,12 @@ and full access to internals.
         </Files>
     </Package>
     <History>
-        <Update release="133">
-            <Date>2024-10-07</Date>
-            <Version>2.47.0</Version>
+        <Update release="134">
+            <Date>2025-01-09</Date>
+            <Version>2.47.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Use after free and double freeing at the end in "git log -L... -p" had been identified and fixed.
- "git maintenance start" crashed due to an uninitialized variable reference, which has been corrected.
- Fail gracefully instead of crashing when attempting to write the contents of a corrupt in-core index as a tree object.
- A "git fetch" from the superproject going down to a submodule used a wrong remote when the default remote names are set differently between them.
- The "gitk" project tree has been synchronized again with its new maintainer, Johannes Sixt.

**Test Plan**

- Make some commits

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
