### PR TITLE
valkey: Update to v8.0.2

### DIFF
--- a/packages/v/valkey/abi_symbols
+++ b/packages/v/valkey/abi_symbols
@@ -3636,7 +3636,10 @@ valkey-server:dbExpand
 valkey-server:dbExpandExpires
 valkey-server:dbFind
 valkey-server:dbFindExpires
+valkey-server:dbFindExpiresWithDictIndex
+valkey-server:dbFindWithDictIndex
 valkey-server:dbGenericDelete
+valkey-server:dbGenericDeleteWithDictIndex
 valkey-server:dbRandomKey
 valkey-server:dbReplaceValue
 valkey-server:dbScan
@@ -3661,6 +3664,7 @@ valkey-server:delGenericCommand
 valkey-server:delKeysInSlot
 valkey-server:deleteCachedResponseClient
 valkey-server:deleteExpiredKeyAndPropagate
+valkey-server:deleteExpiredKeyAndPropagateWithDictIndex
 valkey-server:deleteExpiredKeyFromOverwriteAndPropagate
 valkey-server:deriveAnnouncedPorts
 valkey-server:detectAndUpdateCachedNodeHealth
@@ -3832,6 +3836,7 @@ valkey-server:exitFromChild
 valkey-server:expireCommand
 valkey-server:expireGenericCommand
 valkey-server:expireIfNeeded
+valkey-server:expireIfNeededWithDictIndex
 valkey-server:expireReplicaKeys
 valkey-server:expireScanCallback
 valkey-server:expireatCommand
@@ -4038,6 +4043,7 @@ valkey-server:getDoubleFromObject
 valkey-server:getDoubleFromObjectOrReply
 valkey-server:getExpansiveClientsInfo
 valkey-server:getExpire
+valkey-server:getExpireWithDictIndex
 valkey-server:getFailoverStateString
 valkey-server:getFlushCommandFlags
 valkey-server:getGenericCommand
@@ -4338,6 +4344,7 @@ valkey-server:is_hex_digit
 valkey-server:jemalloc_purge
 valkey-server:keyHashSlot
 valkey-server:keyIsExpired
+valkey-server:keyIsExpiredWithDictIndex
 valkey-server:keylistDictType
 valkey-server:keysCommand
 valkey-server:keyspaceEventsFlagsToString
@@ -5199,6 +5206,7 @@ valkey-server:rdbLoadObjectType
 valkey-server:rdbLoadProgressCallback
 valkey-server:rdbLoadRio
 valkey-server:rdbLoadRioWithLoadingCtx
+valkey-server:rdbLoadRioWithLoadingCtxScopedRdb
 valkey-server:rdbLoadStringObject
 valkey-server:rdbLoadTime
 valkey-server:rdbLoadType

--- a/packages/v/valkey/package.yml
+++ b/packages/v/valkey/package.yml
@@ -1,8 +1,8 @@
 name       : valkey
-version    : 8.0.1
-release    : 1
+version    : 8.0.2
+release    : 2
 source     :
-    - https://github.com/valkey-io/valkey/archive/refs/tags/8.0.1.tar.gz : 1e1d6dfbed2f932a87afbc7402be050a73974a9b19a9116897e537a6638e5e1d
+    - https://github.com/valkey-io/valkey/archive/refs/tags/8.0.2.tar.gz : e052c45b3cbe512e24fdfdc3fd337f9f5e4b8f8b8713f349ba867b829c8ff11a
 homepage   : https://valkey.io/
 license    : BSD-3-Clause
 component  : database

--- a/packages/v/valkey/pspec_x86_64.xml
+++ b/packages/v/valkey/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>valkey</Name>
         <Homepage>https://valkey.io/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>database</PartOf>
@@ -39,12 +39,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-10-31</Date>
-            <Version>8.0.1</Version>
+        <Update release="2">
+            <Date>2025-01-10</Date>
+            <Version>8.0.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fix an uncommon crash when using TLS with dual channel replication.
- Make sure repl_down_since is correctly reset when dual channel replication fails.
- Fix a performance regression where a replica does not properly initialize
- the database size when loading a snapshot during replication.
- Make sure the last accessed time is correctly updated when using the TOUCH command with the CLIENT NO-TOUCH option.
- Fix a bug where total_net_repl_output_bytes may report the wrong.
- Fix a bug where used_memory_scripts may report the wrong value.
- Fix a bug where server might crash when using active defrag when scripts are evicted from the script cache.
- Fix a bug where extra memory would be used when storing strings in the inline protocol.
- Fix a bug where the SORT command may throw a cross slot error.
- Fix a bug where the RANDOMKEY command may omit returning keys in cluster mode.
- Send the correct error message when FUNCTION KIlL is used to kill an ongoing script.
- Fix a potential memory corruption when databases are emptied, such as through FLUSHDB, when during active defrag is running. 

**Security**
Includes fixes for:
- CVE-2024-46981
- CVE-2024-51741

**Test Plan**
- Started the standalone server.

**Checklist**

- [X] Package was built and tested against unstable
- [X] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
