### PR TITLE
gpxsee: Update to 13.34

### DIFF
--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.33'
-release    : 51
+version    : '13.34'
+release    : 52
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.33.tar.gz : 93b7ec67acc0914549255dd11df607496b9eec5b002ae50b1e03fee4ad3026be
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.34.tar.gz : 5e3522315dc4b6a860902c02152bc2cd004500a4114e02094d916d623637a24f
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -172,9 +172,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="51">
-            <Date>2024-12-12</Date>
-            <Version>13.33</Version>
+        <Update release="52">
+            <Date>2025-01-11</Date>
+            <Version>13.34</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Improved ENC maps style/rendering.
- Minor IMG maps fixes.

**Test Plan**
- open map; zoom and pan

**Checklist**
- [X] Package was built and tested against unstable
