### PR TITLE
armagetronad: Fix appstream generation

### DIFF
--- a/packages/a/armagetronad/package.yml
+++ b/packages/a/armagetronad/package.yml
@@ -1,6 +1,6 @@
 name       : armagetronad
 version    : 0.2.9.2.3
-release    : 14
+release    : 15
 source     :
     - https://launchpad.net/armagetronad/0.2.9/0.2.9.2.3/+download/armagetronad-0.2.9.2.3.tbz : 330cb65610d1f6f1374f4156352eb687d7b1bccc0b391fde3d771549c5a5d928
 homepage   : https://www.armagetronad.org/
@@ -36,6 +36,6 @@ install    : |
     #Places files in correct directory
     install -Dm00644 desktop/armagetronad.desktop $installdir/usr/share/applications/org.armagetronad.armagetronad.desktop
     install -Dm00644 desktop/armagetronad.appdata.xml $installdir/usr/share/appdata/armagetronad.appdata.xml
-    install -Dm00644 desktop/icons/16x16/armagetronad.png $installdir/usr/share/icons/hicolor/16x16/apps/armagetronad.png
-    install -Dm00644 desktop/icons/32x32/armagetronad.png $installdir/usr/share/icons/hicolor/32x32/apps/armagetronad.png
-    install -Dm00644 desktop/icons/48x48/armagetronad.png $installdir/usr/share/icons/hicolor/48x48/apps/armagetronad.png
+    install -Dm00644 desktop/icons/16x16/armagetronad.png $installdir/usr/share/icons/hicolor/16x16/apps/org.armagetronad.armagetronad.png
+    install -Dm00644 desktop/icons/32x32/armagetronad.png $installdir/usr/share/icons/hicolor/32x32/apps/org.armagetronad.armagetronad.png
+    install -Dm00644 desktop/icons/48x48/armagetronad.png $installdir/usr/share/icons/hicolor/48x48/apps/org.armagetronad.armagetronad.png

--- a/packages/a/armagetronad/pspec_x86_64.xml
+++ b/packages/a/armagetronad/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>armagetronad</Name>
         <Homepage>https://www.armagetronad.org/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>games.arcade</PartOf>
@@ -130,18 +130,18 @@
             <Path fileType="doc">/usr/share/doc/armagetronad/html/readme_macosx.html</Path>
             <Path fileType="doc">/usr/share/doc/armagetronad/html/todo.html</Path>
             <Path fileType="doc">/usr/share/doc/armagetronad/html/versions.html</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/16x16/apps/armagetronad.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/armagetronad.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/armagetronad.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16/apps/org.armagetronad.armagetronad.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/org.armagetronad.armagetronad.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/org.armagetronad.armagetronad.png</Path>
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2024-12-17</Date>
+        <Update release="15">
+            <Date>2025-01-11</Date>
             <Version>0.2.9.2.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Rename app  icon to follow appstream metainfo

**Test Plan**

<!-- Short description of how the package was tested -->
`appstream-builder --packages-dir=. --include-failed -v`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
