### PR TITLE
eopkg: Fix description and component of python-eopkg

### DIFF
--- a/packages/e/eopkg/monitoring.yml
+++ b/packages/e/eopkg/monitoring.yml
@@ -1,0 +1,9 @@
+---
+# Last checked on 2025-01-11
+releases:
+  rss: https://github.com/getsolus/eopkg/releases.atom
+  id: ~
+
+# Last checked 2025-01-11
+security:
+  cpe: ~

--- a/packages/e/eopkg/package.yml
+++ b/packages/e/eopkg/package.yml
@@ -1,19 +1,21 @@
 name       : eopkg
 version    : 4.1.6
-release    : 17
+release    : 18
 source     :
     - git|https://github.com/getsolus/eopkg.git : aeeeb0b6b1013ce11814b31c6673b0425e17693b
     # HEAD commit of https://github.com/getsolus/PackageKit/tree/eopkg4 unless stated otherwise
     - git|https://github.com/getsolus/PackageKit.git : 9b0f17c1ba6addc1c85bff34b64efad6a905ca50
 homepage   : https://github.com/getsolus/eopkg
 license    : GPL-2.0-or-later
-component  : system.base
+component  :
+    - system.base
+    - ^python-eopkg : programming.python
 summary    :
     - The Solus package manager (python3 eopkg.bin nuitka-compiled version)
-    - python-eopkg : The Solus package manager (pure python3 eopkg.py3 version)
+    - ^python-eopkg : The Solus package manager (pure python3 eopkg.py3 version)
 description:
     - The Solus package manager (python3 eopkg.bin nuitka-compiled version)
-    - python-eopkg : The Solus package manager (pure python3 eopkg.py3 version)
+    - ^python-eopkg : The Solus package manager (pure python3 eopkg.py3 version)
 strip      : no
 debug      : no
 # Sadly necessary for now to deal with rel8 having the bad "reorder eopkg code"

--- a/packages/e/eopkg/pspec_x86_64.xml
+++ b/packages/e/eopkg/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>eopkg</Name>
         <Homepage>https://github.com/getsolus/eopkg</Homepage>
         <Packager>
-            <Name>Rune Morling</Name>
-            <Email>ermo@serpentos.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -28,8 +28,9 @@
     </Package>
     <Package>
         <Name>python-eopkg</Name>
-        <Summary xml:lang="en">The Solus package manager (python3 eopkg.bin nuitka-compiled version)</Summary>
-        <Description xml:lang="en">The Solus package manager (python3 eopkg.bin nuitka-compiled version)</Description>
+        <Summary xml:lang="en">The Solus package manager (pure python3 eopkg.py3 version)</Summary>
+        <Description xml:lang="en">The Solus package manager (pure python3 eopkg.py3 version)</Description>
+        <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/eopkg.py3</Path>
             <Path fileType="executable">/usr/bin/lseopkg.py3</Path>
@@ -444,12 +445,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2024-10-23</Date>
+        <Update release="18">
+            <Date>2025-01-11</Date>
             <Version>4.1.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Rune Morling</Name>
-            <Email>ermo@serpentos.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Packaging**

Fix the description and component of `python-eopkg`, these were not overridden for the pure Python package.

**Test Plan**

```console
$ env LC_ALL=C eopkg info python-eopkg
Installed package:
Name                : python-eopkg, version: 4.1.6, release: 18
Summary             : The Solus package manager (pure python3 eopkg.py3 version)
Description         : The Solus package manager (pure python3 eopkg.py3 version)
Licenses            : GPL-2.0-or-later
Component           : programming.python
Dependencies        : iksemel python-ordered-set python-xattr 
Distribution        : Solus, Dist. Release: 1
Architecture        : x86_64, Installed Size: 3.91 MB
Reverse Dependencies: ypkg 
```

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
