### PR TITLE
perl-capture-tiny: Update to v0.50

### DIFF
--- a/packages/p/perl-capture-tiny/package.yml
+++ b/packages/p/perl-capture-tiny/package.yml
@@ -1,8 +1,8 @@
 name       : perl-capture-tiny
-version    : '0.48'
-release    : 11
+version    : '0.50'
+release    : 12
 source     :
-    - https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/Capture-Tiny-0.48.tar.gz : 6c23113e87bad393308c90a207013e505f659274736638d8c79bac9c67cc3e19
+    - https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/Capture-Tiny-0.50.tar.gz : ca6e8d7ce7471c2be54e1009f64c367d7ee233a2894cacf52ebe6f53b04e81e5
 homepage   : https://metacpan.org/pod/Capture::Tiny
 license    : Apache-2.0
 component  : programming.perl
@@ -19,4 +19,4 @@ install    : |
     %perl_install
 check      : |
     %perl_build test
-patterns    : /*
+patterns   : /*

--- a/packages/p/perl-capture-tiny/pspec_x86_64.xml
+++ b/packages/p/perl-capture-tiny/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>perl-capture-tiny</Name>
         <Homepage>https://metacpan.org/pod/Capture::Tiny</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.perl</PartOf>
@@ -26,12 +26,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2024-08-02</Date>
-            <Version>0.48</Version>
+        <Update release="12">
+            <Date>2025-01-12</Date>
+            <Version>0.50</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
  
 - Stringify '$]' for far future compatibility. 
 - Fixed docs about custom files for capture

**Test Plan**
- Ran below code and checked it worked as expected:
```perl
use strict;
use warnings;
use Capture::Tiny 'capture';

# Capture standard output
my ($stdout, $stderr) = capture {
    print "Hello, Capture::Tiny!\n";
    warn "This is an error message.\n";
};

print "Captured STDOUT: $stdout\n";
print "Captured STDERR: $stderr\n";
```

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
