### PR TITLE
calamares: Update branding for 4.7

### DIFF
--- a/packages/c/calamares/files/install/branding/solus/branding.desc
+++ b/packages/c/calamares/files/install/branding/solus/branding.desc
@@ -113,10 +113,10 @@ navigation: widget
 strings:
     productName:         "Solus"
     shortProductName:    "Solus"
-    version:             "4.6 Convergence"
-    shortVersion:        "4.6"
-    versionedName:       "Solus 4.6 Convergence"
-    shortVersionedName:  "Solus 4.6"
+    version:             "4.7 Endurance"
+    shortVersion:        "4.7"
+    versionedName:       "Solus 4.7 Endurance"
+    shortVersionedName:  "Solus 4.7"
     bootloaderEntryName: "Solus"
     productUrl:          https://getsol.us
     supportUrl:          https://help.getsol.us

--- a/packages/c/calamares/package.yml
+++ b/packages/c/calamares/package.yml
@@ -1,6 +1,6 @@
 name       : calamares
 version    : 3.3.13
-release    : 27
+release    : 28
 source     :
     - https://github.com/calamares/calamares/releases/download/v3.3.13/calamares-3.3.13.tar.gz : e49cf7d894e02ba04898cd0770cb578b4e24dfd0808ab7660bf95bb2456648d4
 homepage   : https://calamares.io

--- a/packages/c/calamares/pspec_x86_64.xml
+++ b/packages/c/calamares/pspec_x86_64.xml
@@ -292,7 +292,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="27">calamares</Dependency>
+            <Dependency release="28">calamares</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libcalamares/Branding.h</Path>
@@ -415,8 +415,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2025-01-06</Date>
+        <Update release="28">
+            <Date>2025-01-13</Date>
             <Version>3.3.13</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
Update branding for 4.7.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Spin a smoketest ISO, open the installer, and see the new version and name on the Welcome page.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
