### PR TITLE
update xfce budgie backgrounds

### DIFF
--- a/packages/b/budgie-desktop-branding/package.yml
+++ b/packages/b/budgie-desktop-branding/package.yml
@@ -1,8 +1,8 @@
 name       : budgie-desktop-branding
-version    : '22.1'
-release    : 76
+version    : '23.0'
+release    : 77
 source     :
-    - git|https://github.com/getsolus/budgie-desktop-branding.git : 0b9f6ac6dd18140b5e2c5236ccfbef4f64a413c3
+    - https://github.com/getsolus/budgie-desktop-branding/archive/refs/tags/v23.0.tar.gz : 317dcea94eaa8b42ad2f8bcaad33131c55a14403a01b1595984c3b8817f26795
 homepage   : https://github.com/getsolus/budgie-desktop-branding
 license    : GPL-2.0-only
 summary    :

--- a/packages/b/budgie-desktop-branding/pspec_x86_64.xml
+++ b/packages/b/budgie-desktop-branding/pspec_x86_64.xml
@@ -36,7 +36,7 @@
         <Description xml:lang="en">Budgie LiveCD-specific Configuration</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="76">budgie-desktop-branding</Dependency>
+            <Dependency releaseFrom="77">budgie-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/glib-2.0/schemas/50_budgie_settings.gschema.override</Path>
@@ -44,9 +44,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="76">
-            <Date>2024-09-21</Date>
-            <Version>22.1</Version>
+        <Update release="77">
+            <Date>2025-01-14</Date>
+            <Version>23.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>

--- a/packages/x/xfce4-desktop-branding/package.yml
+++ b/packages/x/xfce4-desktop-branding/package.yml
@@ -1,8 +1,8 @@
 name       : xfce4-desktop-branding
-version    : 1.0.0
-release    : 14
+version    : 1.1.0
+release    : 15
 source     :
-    - git|https://github.com/getsolus/xfce4-desktop-branding.git : 646efec2592be97a3162a34aa0da8a14a6288b25
+    - https://github.com/getsolus/xfce4-desktop-branding/archive/refs/tags/v1.1.0.tar.gz : 30c460387c2519d97d4724cc2f231ba7ab11fe1fa5395f093275bb643a46f091
 homepage   : https://github.com/getsolus/xfce4-desktop-branding
 license    : GPL-2.0-only
 component  :

--- a/packages/x/xfce4-desktop-branding/pspec_x86_64.xml
+++ b/packages/x/xfce4-desktop-branding/pspec_x86_64.xml
@@ -33,16 +33,16 @@
         <Description xml:lang="en">Defaults for the XFCE4 Desktop.</Description>
         <PartOf>desktop.xfce</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="14">xfce4-desktop-branding</Dependency>
+            <Dependency releaseFrom="15">xfce4-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/lightdm/lightdm.conf.d/xfce_config.conf</Path>
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2024-12-15</Date>
-            <Version>1.0.0</Version>
+        <Update release="15">
+            <Date>2025-01-14</Date>
+            <Version>1.1.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>

--- a/packages/x/xfdesktop/package.yml
+++ b/packages/x/xfdesktop/package.yml
@@ -1,6 +1,6 @@
 name       : xfdesktop
 version    : 4.20.0
-release    : 5
+release    : 6
 source     :
     - https://archive.xfce.org/src/xfce/xfdesktop/4.20/xfdesktop-4.20.0.tar.bz2 : 227041ba80c7f3eb9c99dec817f1132b35d8aec7a4335703f61ba1735cd65632
 homepage   : https://docs.xfce.org/xfce/xfdesktop/start
@@ -25,7 +25,7 @@ setup      : |
         --enable-notifications \
         --disable-debug \
         --disable-desktop-menu \
-        --with-default-backdrop-filename="/usr/share/backgrounds/solus/LakeSideView.jpg"
+        --with-default-backdrop-filename="/usr/share/backgrounds/solus/cloud-covered-mountains.jpg"
 build      : |
     %make
 install    : |

--- a/packages/x/xfdesktop/pspec_x86_64.xml
+++ b/packages/x/xfdesktop/pspec_x86_64.xml
@@ -119,8 +119,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2024-12-15</Date>
+        <Update release="6">
+            <Date>2025-01-14</Date>
             <Version>4.20.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**

- **xfdesktop: Update default background**
- **xfce4-desktop-branding: Update to v1.1.0**
- **budgie-desktop-branding: Update to v23.0**

**Test Plan**

Start sessions in a VM, see new backgrounds

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
