### PR TITLE
wine: Update to v10.0-rc5

### DIFF
--- a/packages/w/wine/abi_used_symbols
+++ b/packages/w/wine/abi_used_symbols
@@ -893,7 +893,6 @@ libm.so.6:round
 libm.so.6:roundf
 libm.so.6:sin
 libm.so.6:sincos
-libm.so.6:sqrt
 libpcap.so.1:pcap_activate
 libpcap.so.1:pcap_breakloop
 libpcap.so.1:pcap_bufsize

--- a/packages/w/wine/abi_used_symbols32
+++ b/packages/w/wine/abi_used_symbols32
@@ -812,7 +812,6 @@ libm.so.6:round
 libm.so.6:roundf
 libm.so.6:sin
 libm.so.6:sincos
-libm.so.6:sqrt
 libpcap.so.1:pcap_activate
 libpcap.so.1:pcap_breakloop
 libpcap.so.1:pcap_bufsize

--- a/packages/w/wine/package.yml
+++ b/packages/w/wine/package.yml
@@ -1,8 +1,8 @@
 name       : wine
-version    : 10.0_rc4
-release    : 194
+version    : 10.0_rc5
+release    : 195
 source     :
-    - https://dl.winehq.org/wine/source/10.0/wine-10.0-rc4.tar.xz : fe8a2cdf09fdd4c341a5ec346ac72f0b224de0bdd0a7ae09f911b02e9caf1008
+    - https://dl.winehq.org/wine/source/10.0/wine-10.0-rc5.tar.xz : ec894f7b5c07d2d4c21d534d7f4394667b8ef27807e30e21289869a74d976ed2
 license    : LGPL-2.1-or-later
 component  : virt
 homepage   : https://www.winehq.org/

--- a/packages/w/wine/pspec_x86_64.xml
+++ b/packages/w/wine/pspec_x86_64.xml
@@ -1007,7 +1007,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="194">wine</Dependency>
+            <Dependency release="195">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/wine</Path>
@@ -1862,7 +1862,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="194">wine</Dependency>
+            <Dependency release="195">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wine/debug.h</Path>
@@ -3209,9 +3209,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="194">
-            <Date>2025-01-04</Date>
-            <Version>10.0_rc4</Version>
+        <Update release="195">
+            <Date>2025-01-12</Date>
+            <Version>10.0_rc5</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Bugfix release

Full release notes available [here](https://gitlab.winehq.org/wine/wine/-/releases/wine-10.0-rc5)

**Test Plan**
- Ran `winecfg`, `winemine`, `wineconsole`, `winefile`
- Played Age of Empires I Trial

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
