### PR TITLE
python-orjson: Update to v3.10.14

### DIFF
--- a/packages/py/python-orjson/abi_used_symbols
+++ b/packages/py/python-orjson/abi_used_symbols
@@ -25,6 +25,9 @@ UNKNOWN:PyLong_AsUnsignedLongLong
 UNKNOWN:PyLong_FromLongLong
 UNKNOWN:PyLong_FromUnsignedLongLong
 UNKNOWN:PyMapping_GetItemString
+UNKNOWN:PyMem_Free
+UNKNOWN:PyMem_Malloc
+UNKNOWN:PyMem_Realloc
 UNKNOWN:PyMemoryView_FromObject
 UNKNOWN:PyModuleDef_Init
 UNKNOWN:PyModule_AddIntConstant
@@ -60,7 +63,6 @@ libc.so.6:__stack_chk_fail
 libc.so.6:__xpg_strerror_r
 libc.so.6:abort
 libc.so.6:bcmp
-libc.so.6:calloc
 libc.so.6:close
 libc.so.6:dl_iterate_phdr
 libc.so.6:free
@@ -76,7 +78,6 @@ libc.so.6:memset
 libc.so.6:mmap64
 libc.so.6:munmap
 libc.so.6:open64
-libc.so.6:posix_memalign
 libc.so.6:pthread_key_create
 libc.so.6:pthread_key_delete
 libc.so.6:pthread_setspecific

--- a/packages/py/python-orjson/package.yml
+++ b/packages/py/python-orjson/package.yml
@@ -1,8 +1,8 @@
 name       : python-orjson
-version    : 3.10.13
-release    : 46
+version    : 3.10.14
+release    : 47
 source     :
-    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.13.tar.gz : eb9bfb14ab8f68d9d9492d4817ae497788a15fd7da72e14dfabc289c3bb088ec
+    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.14.tar.gz : cf31f6f071a6b8e7aa1ead1fa27b935b48d00fbfa6a28ce856cfff2d5dd68eed
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-orjson/pspec_x86_64.xml
+++ b/packages/py/python-orjson/pspec_x86_64.xml
@@ -21,11 +21,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.13.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.13.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.13.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.13.dist-info/licenses/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.13.dist-info/licenses/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.14.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.14.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.14.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.14.dist-info/licenses/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.14.dist-info/licenses/LICENSE-MIT</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
@@ -35,9 +35,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="46">
-            <Date>2024-12-29</Date>
-            <Version>3.10.13</Version>
+        <Update release="47">
+            <Date>2025-01-15</Date>
+            <Version>3.10.14</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Specify build system dependency on `maturin>=1,<2` again
- Allocate memory using `PyMem_Malloc()` and similar APIs for integration with pymalloc, mimalloc, and tracemalloc
- Source distribution does not ship compressed test documents and relevant tests skip if fixtures are not present
- Build now depends on Rust 1.82 or later instead of 1.72

**Test Plan**

Ran some examples from the project's README

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
