### PR TITLE
signal-desktop: Update to 7.38.0

### DIFF
--- a/packages/s/signal-desktop/package.yml
+++ b/packages/s/signal-desktop/package.yml
@@ -1,8 +1,8 @@
 name       : signal-desktop
-version    : 7.37.0
-release    : 178
+version    : 7.38.0
+release    : 179
 source     :
-    - https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.37.0_amd64.deb : 4ecd53483c48352b48b592fa04e27326d50e2eb20cb245d298b3033fef55bb44
+    - https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.38.0_amd64.deb : 3781f4870bef89e8e0a66414d645c3e64137e6176ed9ef2659fa7d8635515318
 homepage   : https://signal.org
 license    : AGPL-3.0-or-later
 component  : network.im

--- a/packages/s/signal-desktop/pspec_x86_64.xml
+++ b/packages/s/signal-desktop/pspec_x86_64.xml
@@ -143,6 +143,8 @@
             <Path fileType="data">/usr/share/signal-desktop/resources/app.asar.unpacked/node_modules/@signalapp/libsignal-client/prebuilds/linux-x64/@signalapp+libsignal-client.node</Path>
             <Path fileType="data">/usr/share/signal-desktop/resources/app.asar.unpacked/node_modules/@signalapp/ringrtc/build/linux/libringrtc-x64.node</Path>
             <Path fileType="data">/usr/share/signal-desktop/resources/app.asar.unpacked/node_modules/fs-xattr/build/Release/xattr.node</Path>
+            <Path fileType="data">/usr/share/signal-desktop/resources/app.asar.unpacked/node_modules/mac-screen-capture-permissions/build/Release/screencapturepermissions.node</Path>
+            <Path fileType="data">/usr/share/signal-desktop/resources/apparmor-profile</Path>
             <Path fileType="data">/usr/share/signal-desktop/resources/package-type</Path>
             <Path fileType="data">/usr/share/signal-desktop/signal-desktop</Path>
             <Path fileType="data">/usr/share/signal-desktop/snapshot_blob.bin</Path>
@@ -151,9 +153,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="178">
-            <Date>2025-01-09</Date>
-            <Version>7.37.0</Version>
+        <Update release="179">
+            <Date>2025-01-16</Date>
+            <Version>7.38.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Algent Albrahimi</Name>
             <Email>algent@protonmail.com</Email>


### PR DESCRIPTION
**Summary**
- We fixed a bug with @ mentions that sometimes incorrectly included your own account in the autocomplete suggestion list. As a narcissistic workaround, you can still use third-person narration to talk about yourself in your group chats if you ever miss this bug.

**Test Plan**
- Sent messages and checked them in my phone

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
