### PR TITLE
firefox: Update to v134.0.1

### DIFF
--- a/packages/f/firefox/package.yml
+++ b/packages/f/firefox/package.yml
@@ -1,9 +1,9 @@
 name       : firefox
-version    : 134.0
-release    : 345
+version    : 134.0.1
+release    : 346
 source     :
-    - https://ftp.mozilla.org/pub/firefox/releases/134.0/source/firefox-134.0.source.tar.xz : ca88068bd72784c10de16df62359b2dc354672a1a427b4fd6a5fcdb34c06457e
-    - https://sources.getsol.us/mozilla/firefox/firefox-134.0-langpacks.tar.zst : 7e7dcd2b52b00b0860a3543dfe1405e483b022478455454a1a36aff3703b9afe
+    - https://ftp.mozilla.org/pub/firefox/releases/134.0.1/source/firefox-134.0.1.source.tar.xz : e3a1853ce70f0fc0007a40a5000d8c9ca7ddd42a4de7d1eb52b0b22fcc2265e5
+    - https://sources.getsol.us/mozilla/firefox/firefox-134.0.1-langpacks.tar.zst : 9c3a9d7488204462aaf951f1d61a2a8fef89fa9ea80ab5b3b15b31764300076c
 homepage   : https://www.mozilla.org/firefox/
 license    :
     - GPL-2.0-or-later

--- a/packages/f/firefox/pspec_x86_64.xml
+++ b/packages/f/firefox/pspec_x86_64.xml
@@ -178,9 +178,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="345">
-            <Date>2025-01-09</Date>
-            <Version>134.0</Version>
+        <Update release="346">
+            <Date>2025-01-18</Date>
+            <Version>134.0.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Troy Harvey</Name>
             <Email>harveydevel@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Update firefox to v134.0.1

Changelog available [here](https://www.mozilla.org/en-US/firefox/134.0.1/releasenotes/)

**Test Plan**

- Watch Youtube.
- Test widevine

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
