### PR TITLE
wine: Update to v10.0-rc6

### DIFF
--- a/packages/w/wine/package.yml
+++ b/packages/w/wine/package.yml
@@ -1,8 +1,8 @@
 name       : wine
-version    : 10.0_rc5
-release    : 195
+version    : 10.0_rc6
+release    : 196
 source     :
-    - https://dl.winehq.org/wine/source/10.0/wine-10.0-rc5.tar.xz : ec894f7b5c07d2d4c21d534d7f4394667b8ef27807e30e21289869a74d976ed2
+    - https://dl.winehq.org/wine/source/10.0/wine-10.0-rc6.tar.xz : b751769cad3e9a4582d01e35d48a5a1ba59918825fae2a59c068b35f86fbd614
 license    : LGPL-2.1-or-later
 component  : virt
 homepage   : https://www.winehq.org/

--- a/packages/w/wine/pspec_x86_64.xml
+++ b/packages/w/wine/pspec_x86_64.xml
@@ -1007,7 +1007,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="195">wine</Dependency>
+            <Dependency release="196">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/wine</Path>
@@ -1862,7 +1862,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="195">wine</Dependency>
+            <Dependency release="196">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wine/debug.h</Path>
@@ -3209,9 +3209,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="195">
-            <Date>2025-01-12</Date>
-            <Version>10.0_rc5</Version>
+        <Update release="196">
+            <Date>2025-01-18</Date>
+            <Version>10.0_rc6</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Bugfix release

Full changelog available [here](https://gitlab.winehq.org/wine/wine/-/releases/wine-10.0-rc6)

**Test Plan**
- Ran `winemine`, `winecfg`, `wineconsole`, `winefile`
- Played Age of Empires I Trial

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
