### PR TITLE
sox_ng: Update to v14.5.0.3

### DIFF
--- a/packages/s/sox_ng/package.yml
+++ b/packages/s/sox_ng/package.yml
@@ -1,8 +1,8 @@
 name       : sox_ng
-version    : 14.5.0.2
-release    : 15
+version    : 14.5.0.3
+release    : 16
 source     :
-    - https://codeberg.org/sox_ng/sox_ng/releases/download/sox_ng-14.5.0.2/sox_ng-14.5.0.2.tar.gz : 635899f9f7bdfde5b9847e33143388a4f65475f0ac7529656838981e875ef0de
+    - https://codeberg.org/sox_ng/sox_ng/releases/download/sox_ng-14.5.0.3/sox_ng-14.5.0.3.tar.gz : a011be3bdf027073929492beb4e640bd0ba21be891f7ccb40c68371aa3745cf7
 homepage   : https://codeberg.org/sox_ng/sox_ng
 license    :
     - GPL-2.0-only

--- a/packages/s/sox_ng/pspec_x86_64.xml
+++ b/packages/s/sox_ng/pspec_x86_64.xml
@@ -44,7 +44,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="15">sox_ng</Dependency>
+            <Dependency release="16">sox_ng</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/sox_ng.h</Path>
@@ -54,9 +54,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2024-12-26</Date>
-            <Version>14.5.0.2</Version>
+        <Update release="16">
+            <Date>2025-01-19</Date>
+            <Version>14.5.0.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
- Make reading from ffmpeg work on Unix too. popen("rb") returns NULL with glibc (!)

**Test Plan**
- Checked all build.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
