### PR TITLE
fb2converter: Update to 1.76.4

### DIFF
--- a/packages/f/fb2converter/package.yml
+++ b/packages/f/fb2converter/package.yml
@@ -1,8 +1,8 @@
 name       : fb2converter
-version    : 1.76.3
-release    : 31
+version    : 1.76.4
+release    : 32
 source     :
-    - git|https://github.com/rupor-github/fb2converter.git : v1.76.3
+    - git|https://github.com/rupor-github/fb2converter.git : v1.76.4
 homepage   : https://github.com/rupor-github/fb2converter
 license    : GPL-3.0-only
 component  : office.viewers

--- a/packages/f/fb2converter/pspec_x86_64.xml
+++ b/packages/f/fb2converter/pspec_x86_64.xml
@@ -26,9 +26,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2025-01-12</Date>
-            <Version>1.76.3</Version>
+        <Update release="32">
+            <Date>2025-01-20</Date>
+            <Version>1.76.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- [changelog](https://github.com/rupor-github/fb2converter/compare/v1.76.3...v1.76.4)

**Test Plan**
- fb2c convert in.fb2

**Checklist**
- [X] Package was built and tested against unstable
