### PR TITLE
brlaser: Update to v6.2.7

### DIFF
--- a/packages/b/brlaser/abi_used_symbols
+++ b/packages/b/brlaser/abi_used_symbols
@@ -34,7 +34,6 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9push_backEc
 libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
 libstdc++.so.6:_ZSt17__throw_bad_allocv
 libstdc++.so.6:_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
-libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_

--- a/packages/b/brlaser/files/1000-solus-duplex.patch
+++ b/packages/b/brlaser/files/1000-solus-duplex.patch
@@ -1,0 +1,35 @@
+Author: Benjamin Lowell <lowell.bv@gmail.com>
+Date:   Wed Jan 22 02:08:25 2025 -0400
+
+	This patch addresses the issue of duplex printing not working as intended on Solus by setting Duplex Long edge to use `&l1S`.
+	The reason this patch is needed is that only the PLC duplex settings are honored, and `Duplex rotated` in `brlaser.drv` is ignored.
+	
+	PCL Command Overview:
+	&l2S: Duplex Short edge
+	&l1S: Duplex Long  edge
+	&l0S: Simplex (one sided)
+
+	This change has not been applied upstream for the following reasons:
+	- When duplex support was added to `brlaser`, printing Duplex Long edge on the `DCP-7065DN` resulted in missing lines.
+	- The workaround at the time involved always printing Short edge when duplexing, and rotating the reverse side by 180 degrees for Long edge printing.
+	- It is unknown if the missing lines issue is still present when using `&l1S` for Duplex Long edge on select printers.
+
+	Technically, `Duplex rotated` should be replaced with `Duplex normal` (in `brlaser.drv.in`), even though this change will not have a functional impact.  
+	Setting `Duplex normal` should avoid any further disruption if CUPS starts respecting the duplex settings in `brlaser.drv` at some point in the future.
+
+diff --git a/src/job.cc b/src/job.cc
+index 9cc5e35..bb3b25b 100644
+--- a/src/job.cc
++++ b/src/job.cc
+@@ -78,8 +78,10 @@ void job::write_page_header() {
+   fputs("\033E", out_);
+   fprintf(out_, "\033&l%dX", std::max(1, page_params_.num_copies));
+ 
+-  if (page_params_.duplex || page_params_.tumble) {
++  if (page_params_.tumble) {
+     fputs("\033&l2S", out_);
++  } else if (page_params_.duplex) {
++    fputs("\033&l1S", out_);
+   } else {
+     fputs("\033&l0S", out_);
+   }

--- a/packages/b/brlaser/monitoring.yaml
+++ b/packages/b/brlaser/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: ~ 376497
+  rss: https://github.com/Owl-Maintain/brlaser/tags.atom
+# No known CPE, checked 2025-01-21
+security:
+  cpe: ~

--- a/packages/b/brlaser/package.yml
+++ b/packages/b/brlaser/package.yml
@@ -1,8 +1,8 @@
 name       : brlaser
-version    : 6.2.6
-release    : 4
+version    : 6.2.7
+release    : 5
 source     :
-    - https://github.com/Owl-Maintain/brlaser/archive/refs/tags/v6.2.6.tar.gz : 551f85a234c75c52c52bb76f379eb458ebc7bd7164d55763d97e197a0ad47f6d
+    - https://github.com/Owl-Maintain/brlaser/archive/refs/tags/v6.2.7.tar.gz : e67c5726fc1fe53574c2e8b5f72634f1359d0f53586a555eb2489fafd7c81640
 homepage   : https://github.com/Owl-Maintain/brlaser
 license    : GPL-2.0-or-later
 component  : drivers.printer
@@ -15,6 +15,10 @@ builddeps  :
 rundeps    :
     - ghostscript
 setup      : |
+    # https://github.com/Owl-Maintain/brlaser/issues/26
+    %patch -p1 -i $pkgfiles/1000-solus-duplex.patch
+    # Setting the printers to Duplex normal should avoid any further disruption if CUPS starts respecting the duplex settings in brlaser.drv at some point in the future.
+    sed -i brlaser.drv.in -e 's|Duplex rotated|Duplex normal|g'
     %cmake
 build      : |
     %make

--- a/packages/b/brlaser/pspec_x86_64.xml
+++ b/packages/b/brlaser/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>brlaser</Name>
         <Homepage>https://github.com/Owl-Maintain/brlaser</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>drivers.printer</PartOf>
@@ -25,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-05-04</Date>
-            <Version>6.2.6</Version>
+        <Update release="5">
+            <Date>2025-01-22</Date>
+            <Version>6.2.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

New printers added:
- Brother DCP-7010
- Brother DCP-B7500D series
- Brother DCP-L2560DW series
- Brother HL-2240 series
- Brother HL-2260D
- Brother HL-5140 series
- Brother HL-5370DW series
- Brother HL-5450DN series
- Brother HL-L2402D
- Brother MFC-8440
- Brother MFC-L2690DW
- Brother HL-L2400DW
- Brother HL-L2405W

Full changelog [here](https://github.com/Owl-Maintain/brlaser/releases/tag/v6.2.7)

**Packaging**

- Added patch and sed fixup to address duplex printing issues particular to Solus

**Test Plan**

- Check duplex printing with long and short edge

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
