### PR TITLE
firefox: Update to v134.0.2

### DIFF
--- a/packages/f/firefox/package.yml
+++ b/packages/f/firefox/package.yml
@@ -1,9 +1,9 @@
 name       : firefox
-version    : 134.0.1
-release    : 346
+version    : 134.0.2
+release    : 347
 source     :
-    - https://ftp.mozilla.org/pub/firefox/releases/134.0.1/source/firefox-134.0.1.source.tar.xz : e3a1853ce70f0fc0007a40a5000d8c9ca7ddd42a4de7d1eb52b0b22fcc2265e5
-    - https://sources.getsol.us/mozilla/firefox/firefox-134.0.1-langpacks.tar.zst : 9c3a9d7488204462aaf951f1d61a2a8fef89fa9ea80ab5b3b15b31764300076c
+    - https://ftp.mozilla.org/pub/firefox/releases/134.0.2/source/firefox-134.0.2.source.tar.xz : 6c6eb7ff13fa689c5cace23a28533361d1ca29158329b6f1c2f2d1c91c53dd27
+    - https://sources.getsol.us/mozilla/firefox/firefox-134.0.2-langpacks.tar.zst : c2dff7a32225caf9c54a6393c77530b4885d2474bd90ebc71549cc94f02caeb8
 homepage   : https://www.mozilla.org/firefox/
 license    :
     - GPL-2.0-or-later

--- a/packages/f/firefox/pspec_x86_64.xml
+++ b/packages/f/firefox/pspec_x86_64.xml
@@ -178,9 +178,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="346">
-            <Date>2025-01-18</Date>
-            <Version>134.0.1</Version>
+        <Update release="347">
+            <Date>2025-01-21</Date>
+            <Version>134.0.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Troy Harvey</Name>
             <Email>harveydevel@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Update firefox to v134.0.2

Changelog available [here](https://www.mozilla.org/en-US/firefox/134.0.2/releasenotes/)

**Test Plan**

- Watch Youtube.
- Test Widevine.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
