### PR TITLE
wine: Update to v10.0

### DIFF
--- a/packages/w/wine/package.yml
+++ b/packages/w/wine/package.yml
@@ -1,8 +1,8 @@
 name       : wine
-version    : 10.0_rc6
-release    : 196
+version    : '10.0'
+release    : 197
 source     :
-    - https://dl.winehq.org/wine/source/10.0/wine-10.0-rc6.tar.xz : b751769cad3e9a4582d01e35d48a5a1ba59918825fae2a59c068b35f86fbd614
+    - https://dl.winehq.org/wine/source/10.0/wine-10.0.tar.xz : c5e0b3f5f7efafb30e9cd4d9c624b85c583171d33549d933cd3402f341ac3601
 license    : LGPL-2.1-or-later
 component  : virt
 homepage   : https://www.winehq.org/

--- a/packages/w/wine/pspec_x86_64.xml
+++ b/packages/w/wine/pspec_x86_64.xml
@@ -1007,7 +1007,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="196">wine</Dependency>
+            <Dependency release="197">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/wine</Path>
@@ -1862,7 +1862,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="196">wine</Dependency>
+            <Dependency release="197">wine</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wine/debug.h</Path>
@@ -3209,9 +3209,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="196">
-            <Date>2025-01-18</Date>
-            <Version>10.0_rc6</Version>
+        <Update release="197">
+            <Date>2025-01-21</Date>
+            <Version>10.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Bugfix release

Full commit log available [here](https://gitlab.winehq.org/wine/wine/-/compare/wine-10.0-rc6...wine-10.0)

Full release notes since 9.0 available [here](https://gitlab.winehq.org/wine/wine/-/releases/wine-10.0)

**Test Plan**
- Ran `winemine`, `winecfg`, `wineconsole`, `winefile`
- Played Age of Empires I Trial

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
