### PR TITLE
youtube-viewer: Update to v3.11.4

### DIFF
--- a/packages/y/youtube-viewer/package.yml
+++ b/packages/y/youtube-viewer/package.yml
@@ -1,8 +1,8 @@
 name       : youtube-viewer
-version    : 3.11.3
-release    : 43
+version    : 3.11.4
+release    : 44
 source     :
-    - https://github.com/trizen/youtube-viewer/archive/refs/tags/3.11.3.tar.gz : f750637f8ce71648e8f0fe44ba34c3b944f46b2cc499ba5a19e773fe6b9ce7f2
+    - https://github.com/trizen/youtube-viewer/archive/refs/tags/3.11.4.tar.gz : e2a3c3b1a8a0cd248022c1b775153794c0e9e22988a5c78194e3850765ad0ac3
 homepage   : https://github.com/trizen/youtube-viewer
 license    : Artistic-2.0
 component  : network.web

--- a/packages/y/youtube-viewer/pspec_x86_64.xml
+++ b/packages/y/youtube-viewer/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>youtube-viewer</Name>
         <Homepage>https://github.com/trizen/youtube-viewer</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>Artistic-2.0</License>
         <PartOf>network.web</PartOf>
@@ -74,12 +74,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="43">
-            <Date>2024-11-16</Date>
-            <Version>3.11.3</Version>
+        <Update release="44">
+            <Date>2025-01-22</Date>
+            <Version>3.11.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- GUI: Added the keybind `CTRL+B` for playing only the audio of a selected video
- CLI: added the `--set-mtime` option and the `set_mtime` config-option
- CLI: normalize the filename after applying the formatting
- CLI: fixed the posting of comments that contain Unicode characters
- When the selected audio quality is not available, fallback to the best available
- No longer try to extract streaming URLs from invidious instances

**Test Plan**

Watched a bunch of YouTube videos using CLI and GUI interfaces

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
