### PR TITLE
neovim-qt: Update to v0.2.19

### DIFF
--- a/packages/n/neovim-qt/abi_used_symbols
+++ b/packages/n/neovim-qt/abi_used_symbols
@@ -343,6 +343,7 @@ libQt5Gui.so.5:_ZN12QPainterPathC1ERK7QPointF
 libQt5Gui.so.5:_ZN12QPainterPathD1Ev
 libQt5Gui.so.5:_ZN15QGuiApplication11inputMethodEv
 libQt5Gui.so.5:_ZN15QGuiApplication25setQuitOnLastWindowClosedEb
+libQt5Gui.so.5:_ZN15QGuiApplication8screenAtERK6QPoint
 libQt5Gui.so.5:_ZN15QGuiApplication9clipboardEv
 libQt5Gui.so.5:_ZN4QPen8setColorERK6QColor
 libQt5Gui.so.5:_ZN4QPen8setWidthEi
@@ -440,6 +441,8 @@ libQt5Gui.so.5:_ZNK7QRegion10subtractedERKS_
 libQt5Gui.so.5:_ZNK7QRegion11intersectedERKS_
 libQt5Gui.so.5:_ZNK7QRegion3endEv
 libQt5Gui.so.5:_ZNK7QRegion5beginEv
+libQt5Gui.so.5:_ZNK7QScreen11orientationEv
+libQt5Gui.so.5:_ZNK7QScreen17availableGeometryEv
 libQt5Gui.so.5:_ZNK8QPainter10clipRegionEv
 libQt5Gui.so.5:_ZNK8QPainter11hasClippingEv
 libQt5Gui.so.5:_ZNK8QPainter11renderHintsEv
@@ -802,6 +805,7 @@ libQt5Widgets.so.5:_ZNK7QTabBar5countEv
 libQt5Widgets.so.5:_ZNK7QTabBar7tabDataEi
 libQt5Widgets.so.5:_ZNK7QWidget10redirectedEP6QPoint
 libQt5Widgets.so.5:_ZNK7QWidget11initPainterEP8QPainter
+libQt5Widgets.so.5:_ZNK7QWidget11mapToGlobalERK6QPoint
 libQt5Widgets.so.5:_ZNK7QWidget11paintEngineEv
 libQt5Widgets.so.5:_ZNK7QWidget11windowStateEv
 libQt5Widgets.so.5:_ZNK7QWidget12isFullScreenEv
@@ -882,7 +886,6 @@ libmsgpack-c.so.2:msgpack_zone_free
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt20__throw_system_errori
 libstdc++.so.6:_ZSt28__throw_bad_array_new_lengthv
-libstdc++.so.6:_ZSt9terminatev
 libstdc++.so.6:_ZTISt9bad_alloc
 libstdc++.so.6:_ZTVN10__cxxabiv117__class_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv120__si_class_type_infoE
@@ -892,6 +895,7 @@ libstdc++.so.6:_ZdlPv
 libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
 libstdc++.so.6:__cxa_begin_catch
+libstdc++.so.6:__cxa_call_terminate
 libstdc++.so.6:__cxa_end_catch
 libstdc++.so.6:__cxa_guard_abort
 libstdc++.so.6:__cxa_guard_acquire

--- a/packages/n/neovim-qt/package.yml
+++ b/packages/n/neovim-qt/package.yml
@@ -1,8 +1,8 @@
 name       : neovim-qt
-version    : 0.2.18
-release    : 14
+version    : 0.2.19
+release    : 15
 source     :
-    - https://github.com/equalsraf/neovim-qt/archive/refs/tags/v0.2.18.tar.gz : b1e1e019946ecb106b3aea8e35fc6e367d2efce44ca1c1599a2ccdfb35a28635
+    - https://github.com/equalsraf/neovim-qt/archive/refs/tags/v0.2.19.tar.gz : 2c5a5de6813566aeec9449be61e1a8cd8ef85979a9e234d420f2882efcfde382
 homepage   : https://github.com/equalsraf/neovim-qt
 license    : ISC
 component  : editor

--- a/packages/n/neovim-qt/pspec_x86_64.xml
+++ b/packages/n/neovim-qt/pspec_x86_64.xml
@@ -31,9 +31,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2024-05-21</Date>
-            <Version>0.2.18</Version>
+        <Update release="15">
+            <Date>2025-01-22</Date>
+            <Version>0.2.19</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- settings: store window geometry in ~/.config/nvim-qt/window_geometry.conf
- Discard resize if already resizing for same size
- Add option restore_window_geometry
- Avoid a flashing window blink during startup
- Set a default size on first launch

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Open and edit a file with `nvim-qt`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
