### PR TITLE
doflicky: Remove NVIDIA 470 driver series

### DIFF
--- a/packages/d/doflicky/package.yml
+++ b/packages/d/doflicky/package.yml
@@ -1,8 +1,8 @@
 name       : doflicky
 version    : '6'
-release    : 22
+release    : 23
 source     :
-    - git|https://github.com/getsolus/doflicky.git : 5c4a0dbb83cdef50e5e7f1e4bfbe3ef16485821b
+    - git|https://github.com/getsolus/doflicky.git : e533f9c62b05209641f6a5a4fe7f7eb4e32840df
 homepage   : https://github.com/getsolus/doflicky
 license    : GPL-2.0-or-later
 component  : system.utils
@@ -14,7 +14,6 @@ builddeps  :
     - python-distutils-extra
     - python-setuptools
 rundeps    :
-    - nvidia-470-glx-driver-modaliases
     - nvidia-glx-driver-modaliases
     - python2-gobject
 build      : |

--- a/packages/d/doflicky/pspec_x86_64.xml
+++ b/packages/d/doflicky/pspec_x86_64.xml
@@ -47,8 +47,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2024-08-12</Date>
+        <Update release="23">
+            <Date>2025-01-24</Date>
             <Version>6</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>


### PR DESCRIPTION
**Summary**

Update to the latest commit removing support for the NVIDIA 470 driver series. This avoids situations where an unsupported (by upstream) driver gets recommended for new installations (with old GPUs).

**Test Plan**

Installed and launched `doflicky` without the 470 modaliases

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
