### PR TITLE
woeusb: add p7zip as rundep

### DIFF
--- a/packages/w/woeusb/package.yml
+++ b/packages/w/woeusb/package.yml
@@ -1,6 +1,6 @@
 name       : woeusb
 version    : 0.2.12
-release    : 19
+release    : 20
 source     :
     - https://github.com/WoeUSB/WoeUSB-ng/archive/refs/tags/v0.2.12.tar.gz : 64b9346490e88c627f0034973771620474acb9482bb6a5045c27e52d23987779
 homepage   : https://github.com/WoeUSB/WoeUSB-ng
@@ -16,6 +16,7 @@ builddeps  :
     - python-wheel
 rundeps    :
     - grub2
+    - p7zip
     - parted
     - python-termcolor
     - wxPython

--- a/packages/w/woeusb/pspec_x86_64.xml
+++ b/packages/w/woeusb/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>woeusb</Name>
         <Homepage>https://github.com/WoeUSB/WoeUSB-ng</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -73,12 +73,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2024-02-17</Date>
+        <Update release="20">
+            <Date>2025-01-25</Date>
             <Version>0.2.12</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Needs p7zip to work.

**Test Plan**
- Checked it installed p7zip and did not complain.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
