### PR TITLE
common: Lift the freeze for 4.7

### DIFF
--- a/common/CI/config.yaml
+++ b/common/CI/config.yaml
@@ -3,7 +3,7 @@
 # Dates can be generated using `date --iso-8601=s`.
 freeze:
   start: "2025-01-10T23:59:59+00:00"
-  end: "2025-01-26T23:59:59+00:00"
+  end: "2025-01-25T23:30:30+00:00"
 
 # Configuration for including static libraries.
 static_libs:


### PR DESCRIPTION
**Summary**

Solus 4.7 has been released, so we have no more need of a freeze.

**Test Plan**

n/a

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
