### PR TITLE
fb2converter: Update to 1.77.0

### DIFF
--- a/packages/f/fb2converter/package.yml
+++ b/packages/f/fb2converter/package.yml
@@ -1,8 +1,8 @@
 name       : fb2converter
-version    : 1.76.4
-release    : 32
+version    : 1.77.0
+release    : 33
 source     :
-    - git|https://github.com/rupor-github/fb2converter.git : v1.76.4
+    - git|https://github.com/rupor-github/fb2converter.git : v1.77.0
 homepage   : https://github.com/rupor-github/fb2converter
 license    : GPL-3.0-only
 component  : office.viewers

--- a/packages/f/fb2converter/pspec_x86_64.xml
+++ b/packages/f/fb2converter/pspec_x86_64.xml
@@ -26,9 +26,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2025-01-20</Date>
-            <Version>1.76.4</Version>
+        <Update release="33">
+            <Date>2025-01-26</Date>
+            <Version>1.77.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- [changelog](https://github.com/rupor-github/fb2converter/compare/v1.76.4...v1.77.0)

**Test Plan**
- fb2c convert in.fb2

**Checklist**
- [X] Package was built and tested against unstable
