### PR TITLE
qtractor: Update to v1.5.2

### DIFF
--- a/packages/q/qtractor/abi_used_symbols
+++ b/packages/q/qtractor/abi_used_symbols
@@ -1126,7 +1126,6 @@ libQt6Widgets.so.6:_ZN15QTreeWidgetItem8addChildEPS_
 libQt6Widgets.so.6:_ZN15QTreeWidgetItem8setFlagsE6QFlagsIN2Qt8ItemFlagEE
 libQt6Widgets.so.6:_ZN15QTreeWidgetItem9takeChildEi
 libQt6Widgets.so.6:_ZN15QTreeWidgetItemC1EP11QTreeWidgetPS_i
-libQt6Widgets.so.6:_ZN15QTreeWidgetItemC1EP11QTreeWidgeti
 libQt6Widgets.so.6:_ZN15QTreeWidgetItemC1EPS_S0_i
 libQt6Widgets.so.6:_ZN15QTreeWidgetItemC1ERK5QListI7QStringEi
 libQt6Widgets.so.6:_ZN15QTreeWidgetItemC1Ei
@@ -1505,6 +1504,7 @@ libQt6Widgets.so.6:_ZN9QLineEdit16inputMethodEventEP17QInputMethodEvent
 libQt6Widgets.so.6:_ZN9QLineEdit16staticMetaObjectE
 libQt6Widgets.so.6:_ZN9QLineEdit17mouseReleaseEventEP11QMouseEvent
 libQt6Widgets.so.6:_ZN9QLineEdit17setCursorPositionEi
+libQt6Widgets.so.6:_ZN9QLineEdit18setPlaceholderTextERK7QString
 libQt6Widgets.so.6:_ZN9QLineEdit21mouseDoubleClickEventEP11QMouseEvent
 libQt6Widgets.so.6:_ZN9QLineEdit21setClearButtonEnabledEb
 libQt6Widgets.so.6:_ZN9QLineEdit5clearEv

--- a/packages/q/qtractor/package.yml
+++ b/packages/q/qtractor/package.yml
@@ -1,8 +1,8 @@
 name       : qtractor
-version    : 1.5.1
-release    : 36
+version    : 1.5.2
+release    : 37
 source     :
-    - https://sourceforge.net/projects/qtractor/files/qtractor/1.5.1/qtractor-1.5.1.tar.gz : 8c127caabb9605eba4b96ef3ce2f6b45ac892fe142d5eddff8eddc6fa41f7621
+    - https://sourceforge.net/projects/qtractor/files/qtractor/1.5.2/qtractor-1.5.2.tar.gz : 677d9f392f149bbc76885cbed92966b14f26ac32f06e8352238766d11962801a
 homepage   : https://qtractor.org/
 license    : GPL-2.0-or-later
 component  : multimedia.audio

--- a/packages/q/qtractor/pspec_x86_64.xml
+++ b/packages/q/qtractor/pspec_x86_64.xml
@@ -52,9 +52,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2024-12-31</Date>
-            <Version>1.5.1</Version>
+        <Update release="37">
+            <Date>2025-01-28</Date>
+            <Version>1.5.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
             <Email>malfisya.dev@hotmail.com</Email>


### PR DESCRIPTION
**Summary**

- Duplex MIDI Clock mode is not allowed anymore
- Immediate and consecutive plugin parameter changes are now merged into a single undo-able command, reflecting only the first value change in the series, dropping the previous old algorithm, which was dead wrong if not utterly defective
- Unique track names resolve to the first line only
- Help/Shortcuts: Search tool gets implemented; all changed MIDI controller shortcuts are reverted to their previous settings, when discarding or dismissing the dialog
- Fixed missing MIDI SPP in some cases

**Test Plan**

<!-- Short description of how the package was tested -->
Launch the app, play midi

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
