### PR TITLE
bash: Fix source error

### DIFF
--- a/packages/b/bash/files/profile/profile
+++ b/packages/b/bash/files/profile/profile
@@ -4,17 +4,19 @@
 # Begin /usr/share/defaults/etc/profile
 
 if [ -d /usr/share/defaults/etc/profile.d ] ; then
-    for script in /usr/share/defaults/etc/profile.d/*.sh
-    do
-      source $script
+    for script in /usr/share/defaults/etc/profile.d/*.sh; do
+        if [ -r $script ] ; then
+            source $script
+        fi
     done
     unset script
 fi
 
 if [ -d /etc/profile.d ] ; then
-    for script in /etc/profile.d/*.sh
-    do
-      source $script
+    for script in /etc/profile.d/*.sh; do
+        if [ -r $script ] ; then
+            source $script
+        fi
     done
     unset script
 fi

--- a/packages/b/bash/package.yml
+++ b/packages/b/bash/package.yml
@@ -1,6 +1,6 @@
 name       : bash
 version    : 5.2.37
-release    : 85
+release    : 86
 source     :
     - https://ftp.gnu.org/gnu/bash/bash-5.2.37.tar.gz : 9599b22ecd1d5787ad7d3b7bf0c59f312b3396d1e281175dd1f8a4014da621ff
 license    :

--- a/packages/b/bash/pspec_x86_64.xml
+++ b/packages/b/bash/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>bash</Name>
         <Homepage>https://www.gnu.org/software/bash</Homepage>
         <Packager>
-            <Name>Tracey Clark</Name>
-            <Email>traceyc.dev@tlcnet.info</Email>
+            <Name>nelson</Name>
+            <Email>nelson@truran.dev</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -135,7 +135,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="85">bash</Dependency>
+            <Dependency release="86">bash</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/bash/alias.h</Path>
@@ -201,12 +201,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="85">
-            <Date>2025-02-02</Date>
+        <Update release="86">
+            <Date>2025-02-07</Date>
             <Version>5.2.37</Version>
             <Comment>Packaging update</Comment>
-            <Name>Tracey Clark</Name>
-            <Email>traceyc.dev@tlcnet.info</Email>
+            <Name>nelson</Name>
+            <Email>nelson@truran.dev</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

If a user creates `/etc/profile.d` but does not add a script to the folder, opening a terminal shows an error.

**Test Plan**

- mkdir -p /etc/profile.d
- open terminal
- see `bash: /etc/profile.d/*.sh: No such file or directory` error
- install package
- open terminal
- see no error

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged
