### PR TITLE
caddy: Update to v2.9.1

### DIFF
--- a/packages/c/caddy/files/0001-Remove-update-command-functionality.patch
+++ b/packages/c/caddy/files/0001-Remove-update-command-functionality.patch
@@ -1,18 +1,18 @@
-From 9630358a66ef7dd1e6e656b8260c022b52925f80 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Evan Maddock <maddock.evan@vivaldi.net>
-Date: Thu, 12 Oct 2023 09:43:54 -0400
+Date: Wed, 29 Jan 2025 11:12:43 -0500
 Subject: [PATCH] Remove update command functionality
 
 Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
 ---
- cmd/commands.go | 44 --------------------------------------------
- 1 file changed, 44 deletions(-)
+ cmd/commands.go | 45 ---------------------------------------------
+ 1 file changed, 45 deletions(-)
 
 diff --git a/cmd/commands.go b/cmd/commands.go
-index e5e1265e..972d24dc 100644
+index 259dd358..31b85a18 100644
 --- a/cmd/commands.go
 +++ b/cmd/commands.go
-@@ -394,50 +394,6 @@ is always printed to stdout.
+@@ -395,51 +395,6 @@ is always printed to stdout.
  		},
  	})
  
@@ -31,12 +31,13 @@ index e5e1265e..972d24dc 100644
 -
 -	RegisterCommand(Command{
 -		Name:  "add-package",
--		Usage: "<packages...>",
+-		Usage: "<package[@version]...>",
 -		Short: "Adds Caddy packages (EXPERIMENTAL)",
 -		Long: `
 -Downloads an updated Caddy binary with the specified packages (module/plugin)
--added. Retains existing packages. Returns an error if the any of packages are
--already included. EXPERIMENTAL: May be changed or removed.
+-added, with an optional version specified (e.g., "package@version"). Retains
+-existing packages. Returns an error if any of the specified packages are already
+-included. EXPERIMENTAL: May be changed or removed.
 -`,
 -		CobraFunc: func(cmd *cobra.Command) {
 -			cmd.Flags().BoolP("keep-backup", "k", false, "Keep the backed up binary, instead of deleting it")
@@ -60,9 +61,6 @@ index e5e1265e..972d24dc 100644
 -		},
 -	})
 -
- 	RegisterCommand(Command{
- 		Name:  "manpage",
- 		Usage: "--directory <path>",
--- 
-2.42.0
-
+ 	defaultFactory.Use(func(rootCmd *cobra.Command) {
+ 		rootCmd.AddCommand(caddyCmdToCobra(Command{
+ 			Name:  "manpage",

--- a/packages/c/caddy/package.yml
+++ b/packages/c/caddy/package.yml
@@ -1,8 +1,8 @@
 name       : caddy
-version    : 2.8.4
-release    : 19
+version    : 2.9.1
+release    : 20
 source     :
-    - https://github.com/caddyserver/caddy/archive/refs/tags/v2.8.4.tar.gz : 5c2e95ad9e688a18dd9d9099c8c132331e01e0bebd401183e8d9123372cf4fcc
+    - https://github.com/caddyserver/caddy/archive/refs/tags/v2.9.1.tar.gz : beb52478dfb34ad29407003520d94ee0baccbf210d1af72cebf430d6d7dd7b63
     - git|https://github.com/caddyserver/dist.git : v2.8.4
 homepage   : https://caddyserver.com
 license    : Apache-2.0

--- a/packages/c/caddy/pspec_x86_64.xml
+++ b/packages/c/caddy/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>caddy</Name>
         <Homepage>https://caddyserver.com</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming</PartOf>
@@ -34,12 +34,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2024-06-05</Date>
-            <Version>2.8.4</Version>
+        <Update release="20">
+            <Date>2025-01-29</Date>
+            <Version>2.9.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- [2.9.0](https://github.com/caddyserver/caddy/releases/tag/v2.9.0)
- [2.9.1](https://github.com/caddyserver/caddy/releases/tag/v2.9.1)

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start and stop a local Caddy server.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
