### PR TITLE
sox: Deprecate

### DIFF
--- a/packages/k/k3b/package.yml
+++ b/packages/k/k3b/package.yml
@@ -1,6 +1,6 @@
 name       : k3b
 version    : 24.12.1
-release    : 91
+release    : 92
 source     :
     - https://download.kde.org/stable/release-service/24.12.1/src/k3b-24.12.1.tar.xz : 26ca9a5b17293434d54bf14fa333f90d5b72d8473c540da01006080eb423e3ea
 homepage   : https://kde.org/applications/multimedia/org.kde.k3b
@@ -38,7 +38,7 @@ rundeps    :
     - cdrdao
     - cdrtools
     - dvd_rw-tools
-    - sox
+    - sox_ng
 clang      : yes
 optimize   :
     - speed

--- a/packages/k/k3b/pspec_x86_64.xml
+++ b/packages/k/k3b/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>k3b</Name>
         <Homepage>https://kde.org/applications/multimedia/org.kde.k3b</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Packager>
         <License>GFDL-1.2-or-later</License>
         <License>GPL-2.0-or-later</License>
@@ -486,7 +486,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="91">k3b</Dependency>
+            <Dependency release="92">k3b</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/k3b_export.h</Path>
@@ -612,12 +612,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="91">
-            <Date>2025-01-12</Date>
+        <Update release="92">
+            <Date>2025-01-30</Date>
             <Version>24.12.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2793,5 +2793,8 @@
 		<Package>libmongoc</Package>
 		<Package>libmongoc-dbginfo</Package>
 		<Package>libmongoc-devel</Package>
+		<Package>sox</Package>
+		<Package>sox-devel</Package>
+		<Package>sox-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3758,6 +3758,10 @@
 		<Package>libmongoc-dbginfo</Package>
 		<Package>libmongoc-devel</Package>
 
+		<!-- Sox was renamed to sox_ng -->
+		<Package>sox</Package>
+		<Package>sox-devel</Package>
+		<Package>sox-dbginfo</Package>
 	</Obsoletes>
 </PISI>
 


### PR DESCRIPTION
**Summary**

Sox was not deprecated properly and k3b needs to switch to using sox_ng

Signed-off-by: Troy Harvey <harveydevel@gmail.com>

**Test Plan**

Make sure the k3b installs using sox_ng rundep.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
