### PR TITLE
wxmaxima: Update to v25.01.0

### DIFF
--- a/packages/w/wxmaxima/abi_used_symbols
+++ b/packages/w/wxmaxima/abi_used_symbols
@@ -241,6 +241,7 @@ libwx_baseu-3.2.so.0:_ZN14wxOutputStreamD2Ev
 libwx_baseu-3.2.so.0:_ZN14wxPlatformInfo3GetEv
 libwx_baseu-3.2.so.0:_ZN14wxTranslations10AddCatalogERK8wxString10wxLanguage
 libwx_baseu-3.2.so.0:_ZN14wxTranslations11SetLanguageE10wxLanguage
+libwx_baseu-3.2.so.0:_ZN14wxTranslations13AddStdCatalogEv
 libwx_baseu-3.2.so.0:_ZN14wxTranslations21GetUntranslatedStringERK8wxString
 libwx_baseu-3.2.so.0:_ZN14wxTranslations3GetEv
 libwx_baseu-3.2.so.0:_ZN14wxTranslations3SetEPS_

--- a/packages/w/wxmaxima/package.yml
+++ b/packages/w/wxmaxima/package.yml
@@ -1,8 +1,8 @@
 name       : wxmaxima
-version    : 24.11.0
-release    : 32
+version    : 25.01.0
+release    : 33
 source     :
-    - https://github.com/wxMaxima-developers/wxmaxima/archive/refs/tags/Version-24.11.0.tar.gz : e01fd8ca9bb8054e38f6d973f619e2549ab6ab9d0aaebae70c4ed73580258055
+    - https://github.com/wxMaxima-developers/wxmaxima/archive/refs/tags/Version-25.01.0.tar.gz : 18cce36cc6c41ca012ec128aafe3c96659b1d670f8a8f7d98395eac1a19ade6f
 homepage   : https://wxmaxima-developers.github.io/wxmaxima/
 license    : GPL-2.0-or-later
 component  : office.maths

--- a/packages/w/wxmaxima/pspec_x86_64.xml
+++ b/packages/w/wxmaxima/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>wxmaxima</Name>
         <Homepage>https://wxmaxima-developers.github.io/wxmaxima/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>office.maths</PartOf>
@@ -114,12 +114,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2024-12-19</Date>
-            <Version>24.11.0</Version>
+        <Update release="33">
+            <Date>2025-01-30</Date>
+            <Version>25.01.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Remove the change label width popup menu.
- If an empty worksheet is saved as wxmx, allow it to be read again. The generated content.xml was empty, which was no valid XML.
- Fix compiling with clang++.
- CopyAsMathML: encode "<" and ">" as HTML entities (valid XML).
- CopyAsMathML: improvements (operators and identifiers)
- HTML export: print the output labels on the left side.

Full changelog can read [here](https://github.com/wxMaxima-developers/wxmaxima/compare/Version-24.11.0...Version-25.01.0)

**Test Plan**

<!-- Short description of how the package was tested -->
Launch the app and load recent file

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
