### PR TITLE
blueman: Update to v2.4.4

### DIFF
--- a/packages/b/blueman/package.yml
+++ b/packages/b/blueman/package.yml
@@ -1,8 +1,8 @@
 name       : blueman
-version    : 2.4.3
-release    : 28
+version    : 2.4.4
+release    : 29
 source     :
-    - https://github.com/blueman-project/blueman/releases/download/2.4.3/blueman-2.4.3.tar.gz : a6a4077102c9cf3d4b1642bec6942026da0788a5c39c069d81d9b7bcfa2bfd50
+    - https://github.com/blueman-project/blueman/releases/download/2.4.4/blueman-2.4.4.tar.gz : 1c0689d51d784c6f0408119c6280d1c3f0c1027cecd58ff8d558e4fff73da858
 homepage   : https://github.com/blueman-project/blueman
 license    : GPL-3.0-or-later
 component  : desktop.mate

--- a/packages/b/blueman/pspec_x86_64.xml
+++ b/packages/b/blueman/pspec_x86_64.xml
@@ -575,12 +575,14 @@
             <Path fileType="localedata">/usr/share/locale/el/LC_MESSAGES/blueman.mo</Path>
             <Path fileType="localedata">/usr/share/locale/en_AU/LC_MESSAGES/blueman.mo</Path>
             <Path fileType="localedata">/usr/share/locale/en_GB/LC_MESSAGES/blueman.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/eo/LC_MESSAGES/blueman.mo</Path>
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/blueman.mo</Path>
             <Path fileType="localedata">/usr/share/locale/et/LC_MESSAGES/blueman.mo</Path>
             <Path fileType="localedata">/usr/share/locale/eu/LC_MESSAGES/blueman.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fa/LC_MESSAGES/blueman.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fi/LC_MESSAGES/blueman.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/blueman.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ga/LC_MESSAGES/blueman.mo</Path>
             <Path fileType="localedata">/usr/share/locale/gl/LC_MESSAGES/blueman.mo</Path>
             <Path fileType="localedata">/usr/share/locale/he/LC_MESSAGES/blueman.mo</Path>
             <Path fileType="localedata">/usr/share/locale/hi/LC_MESSAGES/blueman.mo</Path>
@@ -634,9 +636,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2024-07-26</Date>
-            <Version>2.4.3</Version>
+        <Update release="29">
+            <Date>2025-02-04</Date>
+            <Version>2.4.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fix Rfcom plugin dbus signature
- Set an initial selected device in blueman-sendto
- AutoConnect: Store bluetooth address instead of object path
- Applet: Handle UnknownObject DBus error
- Make search button available after device list becomes empty
- Fix Fatal LoadException
- Terminate applet on manager termination if it was started by manager
- Add Galic and Esperanto translations
- AutoConnect: Automatically convert path to address
- Add toggle to force symbolic statusicon

**Test Plan**
- Connected and disconnected my Bluetooth headphones
- Switched Bluetooth audio codec for my headphones

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
