### PR TITLE
ardour: Update to v8.11

### DIFF
--- a/packages/a/ardour/abi_libs
+++ b/packages/a/ardour/abi_libs
@@ -4,12 +4,12 @@ a-eq.so
 a-exp.so
 a-fluidsynth.so
 a-reverb.so
-ardour-8.10.0
+ardour-8.11.0
 ardour8-copy-mixer
 ardour8-export
 ardour8-new_empty_session
 ardour8-new_session
-hardour-8.10.0
+hardour-8.11.0
 libaaf.so.0
 libalsa_audiobackend.so
 libardour.so.3

--- a/packages/a/ardour/abi_symbols
+++ b/packages/a/ardour/abi_symbols
@@ -4,10 +4,10 @@ a-eq.so:lv2_descriptor
 a-exp.so:lv2_descriptor
 a-fluidsynth.so:lv2_descriptor
 a-reverb.so:lv2_descriptor
-ardour-8.10.0:_Z10vstfx_exitv
-ardour-8.10.0:_Z10vstfx_initPv
-ardour-8.10.0:_Z20vstfx_destroy_editorP9_VSTState
-ardour-8.10.0:main
+ardour-8.11.0:_Z10vstfx_exitv
+ardour-8.11.0:_Z10vstfx_initPv
+ardour-8.11.0:_Z20vstfx_destroy_editorP9_VSTState
+ardour-8.11.0:main
 ardour8-copy-mixer:_Z10vstfx_exitv
 ardour8-copy-mixer:_Z10vstfx_initPv
 ardour8-copy-mixer:_Z20vstfx_destroy_editorP9_VSTState
@@ -24,10 +24,10 @@ ardour8-new_session:_Z10vstfx_exitv
 ardour8-new_session:_Z10vstfx_initPv
 ardour8-new_session:_Z20vstfx_destroy_editorP9_VSTState
 ardour8-new_session:main
-hardour-8.10.0:_Z10vstfx_exitv
-hardour-8.10.0:_Z10vstfx_initPv
-hardour-8.10.0:_Z20vstfx_destroy_editorP9_VSTState
-hardour-8.10.0:main
+hardour-8.11.0:_Z10vstfx_exitv
+hardour-8.11.0:_Z10vstfx_initPv
+hardour-8.11.0:_Z20vstfx_destroy_editorP9_VSTState
+hardour-8.11.0:main
 libaaf.so.0:_aaf_foreach_ObjectInSet
 libaaf.so.0:aaf_ObjectInheritsClass
 libaaf.so.0:aaf_alloc
@@ -16624,6 +16624,7 @@ libtemporal.so.0:_ZNK8Temporal5Beats20round_to_subdivisionEiNS_9RoundModeE
 libtemporal.so.0:_ZNK8Temporal5Meter11to_quartersERKNS_10BBT_OffsetE
 libtemporal.so.0:_ZNK8Temporal5Meter12bbt_subtractERKNS_8BBT_TimeERKNS_10BBT_OffsetE
 libtemporal.so.0:_ZNK8Temporal5Meter12round_to_barERKNS_8BBT_TimeE
+libtemporal.so.0:_ZNK8Temporal5Meter13round_to_beatERKNS_5BeatsE
 libtemporal.so.0:_ZNK8Temporal5Meter13round_to_beatERKNS_8BBT_TimeE
 libtemporal.so.0:_ZNK8Temporal5Meter20round_up_to_beat_divERKNS_8BBT_TimeEi
 libtemporal.so.0:_ZNK8Temporal5Meter7bbt_addERKNS_8BBT_TimeERKNS_10BBT_OffsetE

--- a/packages/a/ardour/package.yml
+++ b/packages/a/ardour/package.yml
@@ -1,8 +1,8 @@
 name       : ardour
-version    : '8.10'
-release    : 48
+version    : '8.11'
+release    : 49
 source     :
-    - git|https://github.com/Ardour/ardour.git : 8.10
+    - git|https://github.com/Ardour/ardour.git : 8.11
 homepage   : https://ardour.org/
 license    : GPL-3.0-or-later
 component  : multimedia.audio

--- a/packages/a/ardour/pspec_x86_64.xml
+++ b/packages/a/ardour/pspec_x86_64.xml
@@ -57,7 +57,7 @@
             <Path fileType="library">/usr/lib64/ardour8/LV2/reasonablesynth.lv2/manifest.ttl</Path>
             <Path fileType="library">/usr/lib64/ardour8/LV2/reasonablesynth.lv2/reasonablesynth.so</Path>
             <Path fileType="library">/usr/lib64/ardour8/LV2/reasonablesynth.lv2/reasonablesynth.ttl</Path>
-            <Path fileType="library">/usr/lib64/ardour8/ardour-8.10.0</Path>
+            <Path fileType="library">/usr/lib64/ardour8/ardour-8.11.0</Path>
             <Path fileType="library">/usr/lib64/ardour8/ardour-avahi</Path>
             <Path fileType="library">/usr/lib64/ardour8/ardour-exec-wrapper</Path>
             <Path fileType="library">/usr/lib64/ardour8/ardour-request-device</Path>
@@ -68,7 +68,7 @@
             <Path fileType="library">/usr/lib64/ardour8/backends/libjack_audiobackend.so</Path>
             <Path fileType="library">/usr/lib64/ardour8/backends/libpulseaudio_backend.so</Path>
             <Path fileType="library">/usr/lib64/ardour8/engines/libclearlooks.so</Path>
-            <Path fileType="library">/usr/lib64/ardour8/hardour-8.10.0</Path>
+            <Path fileType="library">/usr/lib64/ardour8/hardour-8.11.0</Path>
             <Path fileType="library">/usr/lib64/ardour8/libaaf.so</Path>
             <Path fileType="library">/usr/lib64/ardour8/libaaf.so.0</Path>
             <Path fileType="library">/usr/lib64/ardour8/libaaf.so.0.0.0</Path>
@@ -1193,9 +1193,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="48">
-            <Date>2024-10-18</Date>
-            <Version>8.10</Version>
+        <Update release="49">
+            <Date>2025-02-04</Date>
+            <Version>8.11</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Ardour 8.11 is a hotfix release that contains a fix for a critical workflow-blocking bug. All users of 8.10 and all Linux distributions should upgrade to 8.11 as soon as possible.
- Full release notes [here](http://ardour.org/whatsnew.html)

**Test Plan**

- Listen to a click track

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
