### PR TITLE
xfce4-panel: Update to v4.20.3

### DIFF
--- a/packages/x/xfce4-panel/package.yml
+++ b/packages/x/xfce4-panel/package.yml
@@ -1,8 +1,8 @@
 name       : xfce4-panel
-version    : 4.20.2
-release    : 15
+version    : 4.20.3
+release    : 16
 source     :
-    - https://archive.xfce.org/src/xfce/xfce4-panel/4.20/xfce4-panel-4.20.2.tar.bz2 : 2f7ffaf216b4dfdb1ae4c8e3cf8b9c5cb44ec43a64b80bd1608fb5dc3bde2c5d
+    - https://archive.xfce.org/src/xfce/xfce4-panel/4.20/xfce4-panel-4.20.3.tar.bz2 : 4006dddf465a4ae02e14355941458c718f6da0896eae68435c9fd24fcd89b6b8
 homepage   : https://docs.xfce.org/xfce/xfce4-panel/start
 license    : GPL-2.0-or-later
 component  : desktop.xfce

--- a/packages/x/xfce4-panel/pspec_x86_64.xml
+++ b/packages/x/xfce4-panel/pspec_x86_64.xml
@@ -222,7 +222,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="15">xfce4-panel</Dependency>
+            <Dependency release="16">xfce4-panel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/xfce4/libxfce4panel-2.0/libxfce4panel/libxfce4panel-config.h</Path>
@@ -283,9 +283,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2025-02-03</Date>
-            <Version>4.20.2</Version>
+        <Update release="16">
+            <Date>2025-02-04</Date>
+            <Version>4.20.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- libxfce4panel: Fix ABI break

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new Xfce session.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
