### PR TITLE
discord: Disabled forced updates

### DIFF
--- a/packages/d/discord/files/disable-breaking-updates.py
+++ b/packages/d/discord/files/disable-breaking-updates.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+Disable breaking updates which will prompt users to download a deb or tar file
+and lock them out of Discord making the program unusable.
+
+This will dramatically improve the experience :
+
+ 1) The maintainer doesn't need to be worried at all times of an update which will break Discord.
+ 2) People will not be locked out of the program while the maintainer runs to update it.
+
+"""
+
+import json
+import os
+from pathlib import Path
+
+XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME") or os.path.join(
+    os.path.expanduser("~"), ".config"
+)
+
+settings_path = Path(f"{XDG_CONFIG_HOME}/discord/settings.json")
+settings_path_temp = Path(f"{XDG_CONFIG_HOME}/discord/settings.json.tmp")
+try:
+    with settings_path.open() as settings_file:
+        settings = json.load(settings_file)
+except (IOError, json.decoder.JSONDecodeError):
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings = {}
+
+if settings.get("SKIP_HOST_UPDATE"):
+    print("Disabling updates already done")
+else:
+    skip_host_update = {"SKIP_HOST_UPDATE":True}
+    settings.update(skip_host_update)
+
+    with settings_path_temp.open('w') as settings_file_temp:
+        json.dump(settings, settings_file_temp, indent=2)
+
+    settings_path_temp.rename(settings_path)
+    print("Disabled updates")

--- a/packages/d/discord/files/discord.sh
+++ b/packages/d/discord/files/discord.sh
@@ -19,4 +19,5 @@ if [ -z "${DISCORD_NO_WAYLAND+set}" ]; then
   fi
 fi
 
+/usr/share/discord/disable-breaking-updates.py
 exec /usr/share/discord/Discord $DISCORD_FLAGS "$@"

--- a/packages/d/discord/package.yml
+++ b/packages/d/discord/package.yml
@@ -1,6 +1,6 @@
 name       : discord
 version    : 0.0.84
-release    : 102
+release    : 103
 source     :
     - https://dl.discordapp.net/apps/linux/0.0.84/discord-0.0.84.tar.gz : 19bc5af187a48f1f1adc190f05f50074b5b981d9eadd631cc16debcd58198e88
 license    : Distributable
@@ -26,6 +26,7 @@ install    : |
     install -Dm00644 $pkgfiles/discord.desktop $installdir/usr/share/applications/discord.desktop
     install -Dm00644 discord.png $installdir/usr/share/pixmaps/discord.png
     install -Dm00644 $pkgfiles/discord.appdata.xml $installdir/usr/share/metainfo/discord.appdata.xml
+    install -Dm00755 $pkgfiles/disable-breaking-updates.py $installdir/usr/share/discord/disable-breaking-updates.py
 
     # Binary
     install -Dm00755 Discord $installdir/usr/share/discord/Discord

--- a/packages/d/discord/pspec_x86_64.xml
+++ b/packages/d/discord/pspec_x86_64.xml
@@ -26,6 +26,7 @@
             <Path fileType="data">/usr/share/discord/chrome_100_percent.pak</Path>
             <Path fileType="data">/usr/share/discord/chrome_200_percent.pak</Path>
             <Path fileType="data">/usr/share/discord/chrome_crashpad_handler</Path>
+            <Path fileType="data">/usr/share/discord/disable-breaking-updates.py</Path>
             <Path fileType="data">/usr/share/discord/discord.png</Path>
             <Path fileType="data">/usr/share/discord/icudtl.dat</Path>
             <Path fileType="data">/usr/share/discord/libEGL.so</Path>
@@ -101,8 +102,8 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="102">
-            <Date>2025-02-04</Date>
+        <Update release="103">
+            <Date>2025-02-05</Date>
             <Version>0.0.84</Version>
             <Comment>Packaging update</Comment>
             <Name>Troy Harvey</Name>


### PR DESCRIPTION
**Summary**

Disable forced client updates that break discord until an update can be cherry-picked.
Taken from https://github.com/flathub/com.discordapp.Discord/blob/master/disable-breaking-updates.py

**Test Plan**

- Make sure discord launches correctly.
- Check that script works when Discord is not updated to the latest version.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
