### PR TITLE
rtmpdump: Update to v2.6

### DIFF
--- a/packages/r/rtmpdump/package.yml
+++ b/packages/r/rtmpdump/package.yml
@@ -1,8 +1,8 @@
 name       : rtmpdump
-version    : 2.4
-release    : 7
+version    : 2.6
+release    : 8
 source     :
-    - git|https://git.ffmpeg.org/rtmpdump.git : c5f04a58fc2aeea6296ca7c44ee4734c18401aa3
+    - git|https://git.ffmpeg.org/rtmpdump.git : 6f6bb1353fc84f4cc37138baa99f586750028a01
 homepage   : https://rtmpdump.mplayerhq.hu/
 license    : GPL-2.0-or-later
 component  : system.utils

--- a/packages/r/rtmpdump/pspec_x86_64.xml
+++ b/packages/r/rtmpdump/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>rtmpdump</Name>
         <Homepage>https://rtmpdump.mplayerhq.hu/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -36,7 +36,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="7">rtmpdump</Dependency>
+            <Dependency release="8">rtmpdump</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/librtmp.so.1</Path>
@@ -49,8 +49,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="7">rtmpdump-32bit</Dependency>
-            <Dependency release="7">rtmpdump-devel</Dependency>
+            <Dependency release="8">rtmpdump-devel</Dependency>
+            <Dependency release="8">rtmpdump-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/librtmp.so</Path>
@@ -64,7 +64,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="7">rtmpdump</Dependency>
+            <Dependency release="8">rtmpdump</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/librtmp/amf.h</Path>
@@ -77,12 +77,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2024-06-11</Date>
-            <Version>2.4</Version>
+        <Update release="8">
+            <Date>2025-02-08</Date>
+            <Version>2.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- March 2024, v2.6
- miscellaneous cleanup of authentication and encryption support
- miscellaneous protocol fixes
- withdraw v2.5 RTMPE type 10 support, code was too broken/non-portable
- 31 March 2012, v2.5
- add RTMPE type 10 handshake support for x86 systems
- add NetStream.Authenticate.UsherToken for Justin.tv

Full changelog [here](https://git.ffmpeg.org/gitweb/rtmpdump.git/blob_plain/6f6bb1353fc84f4cc37138baa99f586750028a01:/ChangeLog)

**Security**

- CVE-2015-8270
- CVE-2015-8271
- CVE-2015-8272

**Test Plan**

- Only revdep is `gstreamer-1.0-plugins-bad`; run nheko, which uses the gstreamer revdep

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
