### PR TITLE
python-maturin: Update to v1.8.2

### DIFF
--- a/packages/py/python-maturin/package.yml
+++ b/packages/py/python-maturin/package.yml
@@ -1,8 +1,8 @@
 name       : python-maturin
-version    : 1.8.1
-release    : 53
+version    : 1.8.2
+release    : 54
 source     :
-    - https://github.com/PyO3/maturin/archive/refs/tags/v1.8.1.tar.gz : 8ddaf1655509ae079406635654cbc0c73d622e7c2a537f2465a83e8021dd0cc4
+    - https://github.com/PyO3/maturin/archive/refs/tags/v1.8.2.tar.gz : 204f22de5c56a3d599f427344e7389270d71ea183bcc0c719c3725931459180b
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-maturin/pspec_x86_64.xml
+++ b/packages/py/python-maturin/pspec_x86_64.xml
@@ -22,12 +22,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/maturin</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.8.1-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.8.1-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.8.1-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.8.1-py3.11.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.8.1-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.8.1-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.8.2-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.8.2-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.8.2-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.8.2-py3.11.egg-info/not-zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.8.2-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/maturin-1.8.2-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/maturin/__pycache__/__init__.cpython-311.pyc</Path>
@@ -35,9 +35,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="53">
-            <Date>2025-01-05</Date>
-            <Version>1.8.1</Version>
+        <Update release="54">
+            <Date>2025-02-09</Date>
+            <Version>1.8.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Update manylinux/musllinux policies to the latest main
- Exclude packages not in the dependency tree when finding bindings
- Use `uv` automatically when running `maturin develop` inside a uv-created venv
- Consider abi3 minor version when resolving Python interpreters
- Fix clippy warning
- Handle archived dylibs on AIX
- Fix constant rebuilds
- Fix the name of the .data directory in the generated wheel
- Update minimal manylinux version for loongarch64
- Simplify emcc_version using -dumpversion flag
- Strip a possible -git suffix from emcc version

Full release notes available [here](https://github.com/PyO3/maturin/releases/tag/v1.8.2)

**Test Plan**

Successfully built `python-orjson`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
