### PR TITLE
xfdesktop: Enable usage of application menu

### DIFF
--- a/packages/x/xfdesktop/MAINTAINERS.md
+++ b/packages/x/xfdesktop/MAINTAINERS.md
@@ -1,5 +1,9 @@
 This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
 
-- Name Surname
-  - Matrix: thatzachbacon:matrix.org
+- Zach Bacon
+  - Matrix: @thatzachbacon:matrix.org
   - Email: zachbacon@vba-m.com
+
+- Evan Maddock
+  - Matrix: @ebonjaeger:matrix.org
+  - Email: maddock.evan@vivaldi.net

--- a/packages/x/xfdesktop/abi_used_libs
+++ b/packages/x/xfdesktop/abi_used_libs
@@ -3,6 +3,8 @@ libc.so.6
 libcairo-gobject.so.2
 libcairo.so.2
 libexo-2.so.0
+libgarcon-1.so.0
+libgarcon-gtk3-1.so.0
 libgdk-3.so.0
 libgdk_pixbuf-2.0.so.0
 libgio-2.0.so.0

--- a/packages/x/xfdesktop/abi_used_symbols
+++ b/packages/x/xfdesktop/abi_used_symbols
@@ -97,6 +97,9 @@ libcairo.so.2:cairo_xlib_surface_get_drawable
 libexo-2.so.0:exo_execute_preferred_application_on_screen
 libexo-2.so.0:exo_gdk_pixbuf_lucent
 libexo-2.so.0:exo_gdk_pixbuf_scale_down
+libgarcon-1.so.0:garcon_menu_new_applications
+libgarcon-1.so.0:garcon_set_environment_xdg
+libgarcon-gtk3-1.so.0:garcon_gtk_menu_get_type
 libgdk-3.so.0:gdk_app_launch_context_set_screen
 libgdk-3.so.0:gdk_atom_intern
 libgdk-3.so.0:gdk_atom_intern_static_string
@@ -780,6 +783,7 @@ libgtk-3.so.0:gtk_icon_view_get_selected_items
 libgtk-3.so.0:gtk_icon_view_select_path
 libgtk-3.so.0:gtk_icon_view_set_model
 libgtk-3.so.0:gtk_image_menu_item_new_with_label
+libgtk-3.so.0:gtk_image_menu_item_new_with_mnemonic
 libgtk-3.so.0:gtk_image_menu_item_set_image
 libgtk-3.so.0:gtk_image_new_from_gicon
 libgtk-3.so.0:gtk_image_new_from_icon_name

--- a/packages/x/xfdesktop/package.yml
+++ b/packages/x/xfdesktop/package.yml
@@ -1,6 +1,6 @@
 name       : xfdesktop
 version    : 4.20.0
-release    : 6
+release    : 7
 source     :
     - https://archive.xfce.org/src/xfce/xfdesktop/4.20/xfdesktop-4.20.0.tar.bz2 : 227041ba80c7f3eb9c99dec817f1132b35d8aec7a4335703f61ba1735cd65632
 homepage   : https://docs.xfce.org/xfce/xfdesktop/start
@@ -11,6 +11,7 @@ description: |
     Xfce's desktop manager.
 builddeps  :
     - pkgconfig(exo-2)
+    - pkgconfig(garcon-1)
     - pkgconfig(gtk-layer-shell-0)
     - pkgconfig(libnotify)
     - pkgconfig(libwnck-3.0)
@@ -24,7 +25,6 @@ setup      : |
         --enable-thunarx \
         --enable-notifications \
         --disable-debug \
-        --disable-desktop-menu \
         --with-default-backdrop-filename="/usr/share/backgrounds/solus/cloud-covered-mountains.jpg"
 build      : |
     %make

--- a/packages/x/xfdesktop/pspec_x86_64.xml
+++ b/packages/x/xfdesktop/pspec_x86_64.xml
@@ -119,8 +119,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2025-01-14</Date>
+        <Update release="7">
+            <Date>2025-02-10</Date>
             <Version>4.20.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
- Enable the usage of application menu

Fixes https://github.com/getsolus/packages/issues/5011

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new Xfce session, enable the application menu on right click in Desktop settings, right click on the desktop.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
