### PR TITLE
password-store: Add wl-clipboard as a rundep

### DIFF
--- a/packages/p/password-store/monitoring.yaml
+++ b/packages/p/password-store/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 10071
+  rss: ~
+# No known CPE, checked 2025-02-10
+security:
+  cpe: ~

--- a/packages/p/password-store/package.yml
+++ b/packages/p/password-store/package.yml
@@ -1,6 +1,6 @@
 name       : password-store
 version    : 1.7.4
-release    : 12
+release    : 13
 source     :
     - https://github.com/zx2c4/password-store/archive/refs/tags/1.7.4.tar.gz : ff00bd2db86d8be722fc674f40abdc9b88701e47396378b15a4222c63c1d5243
 homepage   : https://www.passwordstore.org
@@ -10,9 +10,10 @@ summary    : Stores, retrieves, generates, and synchronizes passwords securely
 description: |
     This is a very simple password store that encrypts passwords using gpg and places the encrypted password in a directory. It can generate new passwords and keep track of old ones.
 rundeps    :
-    - qrencode
     - gnupg
+    - qrencode
     - tree
+    - wl-clipboard
     - xclip
 install    : |
     %make_install WITH_BASHCOMP=yes WITH_ZSHCOMP=yes WITH_FISHCOMP=yes

--- a/packages/p/password-store/pspec_x86_64.xml
+++ b/packages/p/password-store/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>password-store</Name>
         <Homepage>https://www.passwordstore.org</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>security</PartOf>
         <Summary xml:lang="en">Stores, retrieves, generates, and synchronizes passwords securely</Summary>
         <Description xml:lang="en">This is a very simple password store that encrypts passwords using gpg and places the encrypted password in a directory. It can generate new passwords and keep track of old ones.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>password-store</Name>
@@ -36,12 +36,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2023-09-29</Date>
+        <Update release="13">
+            <Date>2025-02-10</Date>
             <Version>1.7.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Add wl-clipboard as a rundep
- Resolves https://github.com/getsolus/packages/issues/4991

**Test Plan**

- Follow guide [here](https://medium.com/@chasinglogic/the-definitive-guide-to-password-store-c337a8f023a1) to create a test password, see that it copies in wayland session

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
