### PR TITLE
xfce4-settings: Update to v4.20.1

### DIFF
--- a/packages/x/xfce4-settings/MAINTAINERS.md
+++ b/packages/x/xfce4-settings/MAINTAINERS.md
@@ -1,5 +1,9 @@
 This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
 
-- Name Surname
-  - Matrix: thatzachbacon:matrix.org
+- Zach Bacon
+  - Matrix: @thatzachbacon:matrix.org
   - Email: zachbacon@vba-m.com
+
+- Evan Maddock
+  - Matrix: @ebonjaeger:matrix.org
+  - Email: maddock.evan@vivaldi.net

--- a/packages/x/xfce4-settings/abi_used_libs
+++ b/packages/x/xfce4-settings/abi_used_libs
@@ -1,5 +1,6 @@
 libX11.so.6
 libXcursor.so.1
+libXext.so.6
 libXi.so.6
 libXrandr.so.2
 libatk-1.0.so.0

--- a/packages/x/xfce4-settings/abi_used_symbols
+++ b/packages/x/xfce4-settings/abi_used_symbols
@@ -27,6 +27,7 @@ libX11.so.6:XkbSetControls
 libXcursor.so.1:XcursorFilenameLoadImage
 libXcursor.so.1:XcursorImageDestroy
 libXcursor.so.1:XcursorLibraryPath
+libXext.so.6:DPMSInfo
 libXi.so.6:XChangeDeviceProperty
 libXi.so.6:XChangeFeedbackControl
 libXi.so.6:XCloseDevice
@@ -424,6 +425,7 @@ libglib-2.0.so.0:g_list_remove
 libglib-2.0.so.0:g_list_reverse
 libglib-2.0.so.0:g_list_sort
 libglib-2.0.so.0:g_log_structured_standard
+libglib-2.0.so.0:g_main_context_find_source_by_id
 libglib-2.0.so.0:g_main_context_ref_thread_default
 libglib-2.0.so.0:g_main_context_unref
 libglib-2.0.so.0:g_malloc
@@ -487,6 +489,7 @@ libglib-2.0.so.0:g_slist_remove
 libglib-2.0.so.0:g_snprintf
 libglib-2.0.so.0:g_source_attach
 libglib-2.0.so.0:g_source_destroy
+libglib-2.0.so.0:g_source_get_name
 libglib-2.0.so.0:g_source_remove
 libglib-2.0.so.0:g_source_set_callback
 libglib-2.0.so.0:g_source_set_name

--- a/packages/x/xfce4-settings/package.yml
+++ b/packages/x/xfce4-settings/package.yml
@@ -1,8 +1,8 @@
 name       : xfce4-settings
-version    : 4.20.0
-release    : 11
+version    : 4.20.1
+release    : 12
 source     :
-    - https://archive.xfce.org/src/xfce/xfce4-settings/4.20/xfce4-settings-4.20.0.tar.bz2 : 23548da3429a296501fbfdbc98a861ee241b9fdd47e8d5de1781f57c6bbce5a9
+    - https://archive.xfce.org/src/xfce/xfce4-settings/4.20/xfce4-settings-4.20.1.tar.bz2 : fd0d602853ea75d94024e5baae2d2bf5ca8f8aa4dad7bfd5d08f9ff8afee77b2
 homepage   : https://docs.xfce.org/xfce/xfce4-settings/start
 license    : GPL-2.0-or-later
 component  : desktop.xfce

--- a/packages/x/xfce4-settings/pspec_x86_64.xml
+++ b/packages/x/xfce4-settings/pspec_x86_64.xml
@@ -245,6 +245,7 @@
             <Path fileType="data">/usr/share/xfce4/helpers/netscape-navigator.desktop</Path>
             <Path fileType="data">/usr/share/xfce4/helpers/nxterm.desktop</Path>
             <Path fileType="data">/usr/share/xfce4/helpers/opera-browser.desktop</Path>
+            <Path fileType="data">/usr/share/xfce4/helpers/opera-mailer.desktop</Path>
             <Path fileType="data">/usr/share/xfce4/helpers/pcmanfm-qt.desktop</Path>
             <Path fileType="data">/usr/share/xfce4/helpers/pcmanfm.desktop</Path>
             <Path fileType="data">/usr/share/xfce4/helpers/qterminal.desktop</Path>
@@ -268,9 +269,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2024-12-15</Date>
-            <Version>4.20.0</Version>
+        <Update release="12">
+            <Date>2025-02-10</Date>
+            <Version>4.20.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Install missing helper opera-mailer.desktop
- Delay RRScreenChangeNotify handling when DPMSModeOff
- Fix error handling in main()
- Don't disable DPI setting by default
- wayland: Add missing struct member initialization
- displays: Always enable first output
- Translation Updates

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new Xfce session, observe that nothing is out of the ordinary.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
