### PR TITLE
watchexec: Update to v2.3.0

### DIFF
--- a/packages/w/watchexec/abi_used_symbols
+++ b/packages/w/watchexec/abi_used_symbols
@@ -7,6 +7,7 @@ libc.so.6:__xpg_strerror_r
 libc.so.6:_exit
 libc.so.6:abort
 libc.so.6:bcmp
+libc.so.6:bind
 libc.so.6:calloc
 libc.so.6:chdir
 libc.so.6:clock_gettime
@@ -18,7 +19,6 @@ libc.so.6:dl_iterate_phdr
 libc.so.6:dlsym
 libc.so.6:dup2
 libc.so.6:environ
-libc.so.6:epoll_create
 libc.so.6:epoll_create1
 libc.so.6:epoll_ctl
 libc.so.6:epoll_wait
@@ -46,12 +46,13 @@ libc.so.6:getsockopt
 libc.so.6:getuid
 libc.so.6:gnu_get_libc_version
 libc.so.6:inotify_add_watch
-libc.so.6:inotify_init
+libc.so.6:inotify_init1
 libc.so.6:inotify_rm_watch
 libc.so.6:ioctl
 libc.so.6:isatty
 libc.so.6:kill
 libc.so.6:killpg
+libc.so.6:listen
 libc.so.6:lseek64
 libc.so.6:lstat64
 libc.so.6:malloc
@@ -112,6 +113,7 @@ libc.so.6:setgid
 libc.so.6:setgroups
 libc.so.6:setpgid
 libc.so.6:setsid
+libc.so.6:setsockopt
 libc.so.6:setuid
 libc.so.6:shutdown
 libc.so.6:sigaction
@@ -149,6 +151,7 @@ libgcc_s.so.1:_Unwind_SetIP
 libm.so.6:ceil
 libm.so.6:floor
 libm.so.6:floorf
+libm.so.6:fmod
 libm.so.6:logf
 libm.so.6:pow
 libm.so.6:round

--- a/packages/w/watchexec/package.yml
+++ b/packages/w/watchexec/package.yml
@@ -1,8 +1,8 @@
 name       : watchexec
-version    : 2.2.1
-release    : 3
+version    : 2.3.0
+release    : 4
 source     :
-    - https://github.com/watchexec/watchexec/archive/refs/tags/v2.2.1.tar.gz : 67845d1c07bc47f74016cf93e7f7390e193c679003f97be7ab1ca95acf730380
+    - https://github.com/watchexec/watchexec/archive/refs/tags/v2.3.0.tar.gz : bf508d3662fe85294a61ab39a3fbfb0a76f79202448fb3c038a3003ae3e18245
 homepage   : https://watchexec.github.io
 license    : Apache-2.0
 component  : system.utils

--- a/packages/w/watchexec/pspec_x86_64.xml
+++ b/packages/w/watchexec/pspec_x86_64.xml
@@ -28,9 +28,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2025-01-06</Date>
-            <Version>2.2.1</Version>
+        <Update release="4">
+            <Date>2025-02-10</Date>
+            <Version>2.3.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Ian M. Jones</Name>
             <Email>ian@ianmjones.com</Email>


### PR DESCRIPTION
**Summary**

Changelog: https://github.com/watchexec/watchexec/releases/tag/v2.3.0

**Test Plan**

* Built and installed package locally.
* Ran within a few projects to run tests.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
