### PR TITLE
oniguruma: Update to 6.9.10

### DIFF
--- a/packages/o/oniguruma/abi_symbols
+++ b/packages/o/oniguruma/abi_symbols
@@ -45,6 +45,7 @@ libonig.so.5:OnigSyntaxPerl
 libonig.so.5:OnigSyntaxPerl_NG
 libonig.so.5:OnigSyntaxPosixBasic
 libonig.so.5:OnigSyntaxPosixExtended
+libonig.so.5:OnigSyntaxPython
 libonig.so.5:OnigSyntaxRuby
 libonig.so.5:OnigUnicodeFolds1
 libonig.so.5:OnigUnicodeFolds2
@@ -56,6 +57,7 @@ libonig.so.5:onig_builtin_error
 libonig.so.5:onig_builtin_fail
 libonig.so.5:onig_builtin_max
 libonig.so.5:onig_builtin_mismatch
+libonig.so.5:onig_builtin_skip
 libonig.so.5:onig_builtin_total_count
 libonig.so.5:onig_callout_tag_is_exist_at_callout_num
 libonig.so.5:onig_callout_tag_table_free
@@ -80,11 +82,13 @@ libonig.so.5:onig_free_match_param_content
 libonig.so.5:onig_free_reg_callout_list
 libonig.so.5:onig_get_arg_by_callout_args
 libonig.so.5:onig_get_args_num_by_callout_args
+libonig.so.5:onig_get_callback_each_match
 libonig.so.5:onig_get_callout_data
 libonig.so.5:onig_get_callout_data_by_callout_args
 libonig.so.5:onig_get_callout_data_by_callout_args_self
 libonig.so.5:onig_get_callout_data_by_callout_args_self_dont_clear_old
 libonig.so.5:onig_get_callout_data_by_tag
+libonig.so.5:onig_get_callout_data_by_tag_dont_clear_old
 libonig.so.5:onig_get_callout_data_dont_clear_old
 libonig.so.5:onig_get_callout_end_func_by_name_id
 libonig.so.5:onig_get_callout_in_by_callout_args
@@ -191,6 +195,7 @@ libonig.so.5:onig_scan
 libonig.so.5:onig_scan_env_set_error_string
 libonig.so.5:onig_search
 libonig.so.5:onig_search_with_param
+libonig.so.5:onig_set_callback_each_match
 libonig.so.5:onig_set_callout_data
 libonig.so.5:onig_set_callout_data_by_callout_args
 libonig.so.5:onig_set_callout_data_by_callout_args_self

--- a/packages/o/oniguruma/monitoring.yaml
+++ b/packages/o/oniguruma/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 11184
+  rss: https://github.com/kkos/oniguruma/releases.atom
+# No known CPE, checked 2025-02-11
+security:
+  cpe: ~

--- a/packages/o/oniguruma/package.yml
+++ b/packages/o/oniguruma/package.yml
@@ -1,8 +1,8 @@
 name       : oniguruma
-version    : 6.9.6
-release    : 4
+version    : 6.9.10
+release    : 5
 source     :
-    - https://github.com/kkos/oniguruma/releases/download/v6.9.6/onig-6.9.6.tar.gz : bd0faeb887f748193282848d01ec2dad8943b5dfcb8dc03ed52dcc963549e819
+    - https://github.com/kkos/oniguruma/releases/download/v6.9.10/onig-6.9.10.tar.gz : 2a5cfc5ae259e4e97f86b68dfffc152cdaffe94e2060b770cb827238d769fc05
 homepage   : https://github.com/kkos/oniguruma
 license    : BSD-2-Clause
 summary    : Oniguruma is a modern and flexible regular expressions library

--- a/packages/o/oniguruma/pspec_x86_64.xml
+++ b/packages/o/oniguruma/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>oniguruma</Name>
         <Homepage>https://github.com/kkos/oniguruma</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>marcus@infinitymdm.dev</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>programming.library</PartOf>
@@ -22,7 +22,7 @@
         <Files>
             <Path fileType="executable">/usr/bin/onig-config</Path>
             <Path fileType="library">/usr/lib64/libonig.so.5</Path>
-            <Path fileType="library">/usr/lib64/libonig.so.5.1.0</Path>
+            <Path fileType="library">/usr/lib64/libonig.so.5.5.0</Path>
         </Files>
     </Package>
     <Package>
@@ -32,7 +32,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="4">oniguruma</Dependency>
+            <Dependency release="5">oniguruma</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/oniggnu.h</Path>
@@ -42,12 +42,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-05-26</Date>
-            <Version>6.9.6</Version>
+        <Update release="5">
+            <Date>2025-02-11</Date>
+            <Version>6.9.10</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>marcus@infinitymdm.dev</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Update oniguruma to the latest upstream release. Also added monitoring.yaml. Required for #5023 

**Test Plan**

Built, installed, and tested latest ghostty (1.1.0)

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
