### PR TITLE
man-pages: Update to v6.10

### DIFF
--- a/packages/m/man-pages/package.yml
+++ b/packages/m/man-pages/package.yml
@@ -1,12 +1,15 @@
 name       : man-pages
-version    : 6.9.1
-release    : 22
+version    : '6.10'
+release    : 23
 source     :
-    - https://mirrors.edge.kernel.org/pub/linux/docs/man-pages/man-pages-6.9.1.tar.xz : e23cbac29f110ba571f0da8523e79d373691466ed7f2a31301721817d34530bd
+    - https://mirrors.edge.kernel.org/pub/linux/docs/man-pages/man-pages-6.10.tar.xz : db49503ad4da07633fa28012a278915f0f0178ad6c33346e59b7ada731925709
 license    :
     - BSD-3-Clause
     - GPL-1.0-or-later
-    - GPL-2.0-or-later
+    - GPL-2.0-only # scripts/bash_aliases
+    - GPL-2.0-or-later # scripts/* (except bash_aliases), share/mk/pdf/book/prepare.pl
+    - GPL-3.0-or-later # src/bin/*
+    - LGPL-3.0-only WITH LGPL-3.0-linking-exception # share/mk/* (except pdf/book/prepare.pl), GNUmakefile
     - MIT
 homepage   : https://www.kernel.org/doc/man-pages/
 component  : system.utils

--- a/packages/m/man-pages/pspec_x86_64.xml
+++ b/packages/m/man-pages/pspec_x86_64.xml
@@ -8,7 +8,10 @@
         </Packager>
         <License>BSD-3-Clause</License>
         <License>GPL-1.0-or-later</License>
+        <License>GPL-2.0-only</License>
         <License>GPL-2.0-or-later</License>
+        <License>GPL-3.0-or-later</License>
+        <License>LGPL-3.0-only WITH LGPL-3.0-linking-exception</License>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">Linux manual pages</Summary>
@@ -23,15 +26,23 @@
 </Description>
         <PartOf>system.utils</PartOf>
         <Files>
+            <Path fileType="executable">/usr/bin/diffman-git</Path>
+            <Path fileType="executable">/usr/bin/mansect</Path>
+            <Path fileType="executable">/usr/bin/pdfman</Path>
+            <Path fileType="executable">/usr/bin/sortman</Path>
+            <Path fileType="man">/usr/share/man/man1/diffman-git.1.gz</Path>
             <Path fileType="man">/usr/share/man/man1/getent.1.gz</Path>
             <Path fileType="man">/usr/share/man/man1/intro.1.gz</Path>
             <Path fileType="man">/usr/share/man/man1/ldd.1.gz</Path>
             <Path fileType="man">/usr/share/man/man1/locale.1.gz</Path>
             <Path fileType="man">/usr/share/man/man1/localedef.1.gz</Path>
+            <Path fileType="man">/usr/share/man/man1/mansect.1.gz</Path>
             <Path fileType="man">/usr/share/man/man1/memusage.1.gz</Path>
             <Path fileType="man">/usr/share/man/man1/memusagestat.1.gz</Path>
             <Path fileType="man">/usr/share/man/man1/mtrace.1.gz</Path>
+            <Path fileType="man">/usr/share/man/man1/pdfman.1.gz</Path>
             <Path fileType="man">/usr/share/man/man1/pldd.1.gz</Path>
+            <Path fileType="man">/usr/share/man/man1/sortman.1.gz</Path>
             <Path fileType="man">/usr/share/man/man1/sprof.1.gz</Path>
             <Path fileType="man">/usr/share/man/man1/time.1.gz</Path>
             <Path fileType="man">/usr/share/man/man2/_Exit.2.gz</Path>
@@ -232,6 +243,7 @@
             <Path fileType="man">/usr/share/man/man2/link.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/linkat.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/listen.2.gz</Path>
+            <Path fileType="man">/usr/share/man/man2/listmount.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/listxattr.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/llistxattr.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/llseek.2.gz</Path>
@@ -364,6 +376,7 @@
             <Path fileType="man">/usr/share/man/man2/renameat2.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/request_key.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/restart_syscall.2.gz</Path>
+            <Path fileType="man">/usr/share/man/man2/riscv_flush_icache.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/rmdir.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/rt_sigaction.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/rt_sigpending.2.gz</Path>
@@ -472,6 +485,7 @@
             <Path fileType="man">/usr/share/man/man2/stat64.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/statfs.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/statfs64.2.gz</Path>
+            <Path fileType="man">/usr/share/man/man2/statmount.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/statx.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/stime.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/stty.2.gz</Path>
@@ -515,6 +529,7 @@
             <Path fileType="man">/usr/share/man/man2/unlink.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/unlinkat.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/unshare.2.gz</Path>
+            <Path fileType="man">/usr/share/man/man2/uretprobe.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/uselib.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/userfaultfd.2.gz</Path>
             <Path fileType="man">/usr/share/man/man2/ustat.2.gz</Path>
@@ -578,6 +593,31 @@
             <Path fileType="man">/usr/share/man/man2const/KDSKBMETA.2const.gz</Path>
             <Path fileType="man">/usr/share/man/man2const/KDSKBMODE.2const.gz</Path>
             <Path fileType="man">/usr/share/man/man2const/KDSKBSENT.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_ASSUME_AUTHORITY.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_CHOWN.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_CLEAR.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_DESCRIBE.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_DH_COMPUTE.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_GET_KEYRING_ID.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_GET_PERSISTENT.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_GET_SECURITY.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_INSTANTIATE.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_INSTANTIATE_IOV.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_INVALIDATE.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_JOIN_SESSION_KEYRING.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_LINK.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_NEGATE.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_READ.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_REJECT.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_RESTRICT_KEYRING.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_REVOKE.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_SEARCH.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_SESSION_TO_PARENT.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_SETPERM.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_SET_REQKEY_KEYRING.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_SET_TIMEOUT.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_UNLINK.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/KEYCTL_UPDATE.2const.gz</Path>
             <Path fileType="man">/usr/share/man/man2const/KIOCSOUND.2const.gz</Path>
             <Path fileType="man">/usr/share/man/man2const/NS_GET_NSTYPE.2const.gz</Path>
             <Path fileType="man">/usr/share/man/man2const/NS_GET_OWNER_UID.2const.gz</Path>
@@ -629,6 +669,7 @@
             <Path fileType="man">/usr/share/man/man2const/PR_MPX_DISABLE_MANAGEMENT.2const.gz</Path>
             <Path fileType="man">/usr/share/man/man2const/PR_MPX_ENABLE_MANAGEMENT.2const.gz</Path>
             <Path fileType="man">/usr/share/man/man2const/PR_PAC_RESET_KEYS.2const.gz</Path>
+            <Path fileType="man">/usr/share/man/man2const/PR_RISCV_SET_ICACHE_FLUSH_CTX.2const.gz</Path>
             <Path fileType="man">/usr/share/man/man2const/PR_SET_CHILD_SUBREAPER.2const.gz</Path>
             <Path fileType="man">/usr/share/man/man2const/PR_SET_DUMPABLE.2const.gz</Path>
             <Path fileType="man">/usr/share/man/man2const/PR_SET_ENDIAN.2const.gz</Path>
@@ -911,6 +952,7 @@
             <Path fileType="man">/usr/share/man/man3/__ppc_set_ppr_very_low.3.gz</Path>
             <Path fileType="man">/usr/share/man/man3/__ppc_yield.3.gz</Path>
             <Path fileType="man">/usr/share/man/man3/__realloc_hook.3.gz</Path>
+            <Path fileType="man">/usr/share/man/man3/__riscv_flush_icache.3.gz</Path>
             <Path fileType="man">/usr/share/man/man3/__setfpucw.3.gz</Path>
             <Path fileType="man">/usr/share/man/man3/_flushlbf.3.gz</Path>
             <Path fileType="man">/usr/share/man/man3/a64l.3.gz</Path>
@@ -2283,6 +2325,8 @@
             <Path fileType="man">/usr/share/man/man3/timercmp.3.gz</Path>
             <Path fileType="man">/usr/share/man/man3/timerisset.3.gz</Path>
             <Path fileType="man">/usr/share/man/man3/timersub.3.gz</Path>
+            <Path fileType="man">/usr/share/man/man3/timespec_get.3.gz</Path>
+            <Path fileType="man">/usr/share/man/man3/timespec_getres.3.gz</Path>
             <Path fileType="man">/usr/share/man/man3/timezone.3.gz</Path>
             <Path fileType="man">/usr/share/man/man3/tmpfile.3.gz</Path>
             <Path fileType="man">/usr/share/man/man3/tmpnam.3.gz</Path>
@@ -2936,9 +2980,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2024-07-17</Date>
-            <Version>6.9.1</Version>
+        <Update release="23">
+            <Date>2025-02-11</Date>
+            <Version>6.10</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Highlighted changes:
- Add a few programs that are useful for maintaining manual pages
- Split keyctl.2
- man2/, man3/: SYNOPSIS: Rename function parameters for consistency and correctness
- man2/, man3/: SYNOPSIS: Use typeof() to improve readability of function pointers
- man1/: SYNOPSIS: Use .SY/.YS for formatting commands
- Refactor *FLAGS and LDLIBS variables, as requested by some distros.

Full release notes available [here](https://lore.kernel.org/lkml/5879567.Si16P0KhqQ@pip/T/)

Packaging change: clean up license terms a bit and add some missing licenses

**Test Plan**
- Looked at some of the new and changed man pages
- Used the `pdfman` utility to view the `pdfman` man page as pdf

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
