### PR TITLE
gleam: Update to v1.8.1

### DIFF
--- a/packages/g/gleam/package.yml
+++ b/packages/g/gleam/package.yml
@@ -1,8 +1,8 @@
 name       : gleam
-version    : 1.8.0
-release    : 7
+version    : 1.8.1
+release    : 8
 source     :
-    - https://github.com/gleam-lang/gleam/archive/refs/tags/v1.8.0.tar.gz : 296a04e27c8df16750c36d4d167646967a2ed71e3e2e1ae6e724c631a22c99df
+    - https://github.com/gleam-lang/gleam/archive/refs/tags/v1.8.1.tar.gz : 5ad243c092fb229d0ae77214beaa462cd9a53018e553decb9b12a2ea1fab6494
 homepage   : https://gleam.run
 license    : Apache-2.0
 component  : programming

--- a/packages/g/gleam/pspec_x86_64.xml
+++ b/packages/g/gleam/pspec_x86_64.xml
@@ -32,9 +32,9 @@ Gleam can additionally compile to JavaScript, enabling you to use your code in t
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2025-02-10</Date>
-            <Version>1.8.0</Version>
+        <Update release="8">
+            <Date>2025-02-13</Date>
+            <Version>1.8.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Ian M. Jones</Name>
             <Email>ian@ianmjones.com</Email>


### PR DESCRIPTION
**Summary**

* Fixed a metadata caching bug where accessors for opaque types could sometimes be used in other modules.

Changelog:
https://github.com/gleam-lang/gleam/blob/main/CHANGELOG.md#v181---2025-02-11

**Test Plan**

* Built and installed package locally.
* Edited Gleam code with built in LSP doing its thing.
* Used `gleam run` on existing projects.
* Used `gleam test` on existing projects.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
