### PR TITLE
geoclue: Add recommended patches for beacondb

### DIFF
--- a/packages/g/geoclue/abi_used_symbols
+++ b/packages/g/geoclue/abi_used_symbols
@@ -177,6 +177,7 @@ libglib-2.0.so.0:g_file_get_contents
 libglib-2.0.so.0:g_file_test
 libglib-2.0.so.0:g_free
 libglib-2.0.so.0:g_get_monotonic_time
+libglib-2.0.so.0:g_get_os_info
 libglib-2.0.so.0:g_get_real_time
 libglib-2.0.so.0:g_getenv
 libglib-2.0.so.0:g_hash_table_get_values
@@ -485,3 +486,4 @@ libsoup-3.0.so.0:soup_session_new
 libsoup-3.0.so.0:soup_session_send_and_read_async
 libsoup-3.0.so.0:soup_session_send_and_read_finish
 libsoup-3.0.so.0:soup_session_set_proxy_resolver
+libsoup-3.0.so.0:soup_session_set_user_agent

--- a/packages/g/geoclue/files/beacondb-fixes.patch
+++ b/packages/g/geoclue/files/beacondb-fixes.patch
@@ -1,0 +1,91 @@
+From 7500e385a1a0f0f9985f74870f8504bd9ac77ea1 Mon Sep 17 00:00:00 2001
+From: Chris Talbot <chris@talbothome.com>
+Date: Sun, 1 Dec 2024 21:33:38 -0700
+Subject: [PATCH 1/2] Mozilla: Include SSID for geolocate and submission
+ requests
+
+---
+ src/gclue-mozilla.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/src/gclue-mozilla.c b/src/gclue-mozilla.c
+index 9e8feb1d..abb2280c 100644
+--- a/src/gclue-mozilla.c
++++ b/src/gclue-mozilla.c
+@@ -257,6 +257,7 @@ gclue_mozilla_create_query (GClueMozilla  *mozilla,
+                 for (iter = bss_list; iter != NULL; iter = iter->next) {
+                         WPABSS *bss = WPA_BSS (iter->data);
+                         char mac[BSSID_STR_LEN + 1] = { 0 };
++                        char ssid[MAX_SSID_LEN + 1] = { 0 };
+                         gint16 strength_dbm;
+                         guint age_ms;
+ 
+@@ -269,6 +270,10 @@ gclue_mozilla_create_query (GClueMozilla  *mozilla,
+                         get_bssid_from_bss (bss, mac);
+                         json_builder_add_string_value (builder, mac);
+ 
++                        json_builder_set_member_name (builder, "ssid");
++                        get_ssid_from_bss (bss, ssid);
++                        json_builder_add_string_value (builder, ssid);
++
+                         json_builder_set_member_name (builder, "signalStrength");
+                         strength_dbm = wpa_bss_get_signal (bss);
+                         json_builder_add_int_value (builder, strength_dbm);
+@@ -486,6 +491,7 @@ gclue_mozilla_create_submit_query (GClueMozilla  *mozilla,
+                 for (iter = bss_list; iter != NULL; iter = iter->next) {
+                         WPABSS *bss = WPA_BSS (iter->data);
+                         char mac[BSSID_STR_LEN + 1] = { 0 };
++                        char ssid[MAX_SSID_LEN + 1] = { 0 };
+                         gint16 strength_dbm;
+                         guint16 frequency;
+                         guint age_ms;
+@@ -499,6 +505,10 @@ gclue_mozilla_create_submit_query (GClueMozilla  *mozilla,
+                         get_bssid_from_bss (bss, mac);
+                         json_builder_add_string_value (builder, mac);
+ 
++                        json_builder_set_member_name (builder, "ssid");
++                        get_ssid_from_bss (bss, ssid);
++                        json_builder_add_string_value (builder, ssid);
++
+                         json_builder_set_member_name (builder, "signalStrength");
+                         strength_dbm = wpa_bss_get_signal (bss);
+                         json_builder_add_int_value (builder, strength_dbm);
+-- 
+GitLab
+
+
+From 87efd9a932cf9b723d6fc84f7b61ebb4cc09d635 Mon Sep 17 00:00:00 2001
+From: Chris Talbot <chris@talbothome.com>
+Date: Sun, 1 Dec 2024 21:34:44 -0700
+Subject: [PATCH 2/2] Mozilla: replace rather than append User-Agent
+
+It won't actually attach if you don't do this
+---
+ src/gclue-mozilla.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/gclue-mozilla.c b/src/gclue-mozilla.c
+index abb2280c..2b3467d4 100644
+--- a/src/gclue-mozilla.c
++++ b/src/gclue-mozilla.c
+@@ -301,7 +301,7 @@ gclue_mozilla_create_query (GClueMozilla  *mozilla,
+         uri = gclue_mozilla_get_locate_url (mozilla);
+         ret = soup_message_new ("POST", uri);
+         request_headers = soup_message_get_request_headers (ret);
+-        soup_message_headers_append (request_headers, "User-Agent", USER_AGENT);
++        soup_message_headers_replace (request_headers, "User-Agent", USER_AGENT);
+         body = g_bytes_new_take (data, data_len);
+         soup_message_set_request_body_from_bytes (ret, "application/json", body);
+         g_debug ("Sending following request to '%s':\n%s", uri, data);
+@@ -566,7 +566,7 @@ gclue_mozilla_create_submit_query (GClueMozilla  *mozilla,
+ 
+         ret = soup_message_new ("POST", url);
+         request_headers = soup_message_get_request_headers (ret);
+-        soup_message_headers_append (request_headers, "User-Agent", USER_AGENT);
++        soup_message_headers_replace (request_headers, "User-Agent", USER_AGENT);
+         if (nick != NULL && nick[0] != '\0')
+                 soup_message_headers_append (request_headers,
+                                              "X-Nickname",
+-- 
+GitLab
+

--- a/packages/g/geoclue/files/beacondb-user-agent.patch
+++ b/packages/g/geoclue/files/beacondb-user-agent.patch
@@ -1,0 +1,110 @@
+From 32101976945e51536aff3b6945c12ec4d15dd203 Mon Sep 17 00:00:00 2001
+From: Chris Talbot <chris@talbothome.com>
+Date: Thu, 5 Dec 2024 06:58:48 -0700
+Subject: [PATCH] Web-Source: Set User-Agent on Soup Session Construction
+
+Also add OS Info to user-agent
+---
+ src/gclue-mozilla.c    |  6 ------
+ src/gclue-web-source.c | 30 ++++++++++++++++++++++++++++++
+ 2 files changed, 30 insertions(+), 6 deletions(-)
+
+diff --git a/src/gclue-mozilla.c b/src/gclue-mozilla.c
+index 2b3467d4..5680e451 100644
+--- a/src/gclue-mozilla.c
++++ b/src/gclue-mozilla.c
+@@ -174,8 +174,6 @@ towertec_to_radiotype (GClueTowerTec tec,
+         return TRUE;
+ }
+ 
+-#define USER_AGENT (PACKAGE_NAME "/" PACKAGE_VERSION)
+-
+ SoupMessage *
+ gclue_mozilla_create_query (GClueMozilla  *mozilla,
+                             gboolean skip_tower,
+@@ -185,7 +183,6 @@ gclue_mozilla_create_query (GClueMozilla  *mozilla,
+ {
+         gboolean has_tower = FALSE, has_bss = FALSE;
+         SoupMessage *ret = NULL;
+-        SoupMessageHeaders *request_headers;
+         JsonBuilder *builder;
+         g_autoptr(GList) bss_list = NULL;
+         JsonGenerator *generator;
+@@ -300,8 +297,6 @@ gclue_mozilla_create_query (GClueMozilla  *mozilla,
+ 
+         uri = gclue_mozilla_get_locate_url (mozilla);
+         ret = soup_message_new ("POST", uri);
+-        request_headers = soup_message_get_request_headers (ret);
+-        soup_message_headers_replace (request_headers, "User-Agent", USER_AGENT);
+         body = g_bytes_new_take (data, data_len);
+         soup_message_set_request_body_from_bytes (ret, "application/json", body);
+         g_debug ("Sending following request to '%s':\n%s", uri, data);
+@@ -566,7 +561,6 @@ gclue_mozilla_create_submit_query (GClueMozilla  *mozilla,
+ 
+         ret = soup_message_new ("POST", url);
+         request_headers = soup_message_get_request_headers (ret);
+-        soup_message_headers_replace (request_headers, "User-Agent", USER_AGENT);
+         if (nick != NULL && nick[0] != '\0')
+                 soup_message_headers_append (request_headers,
+                                              "X-Nickname",
+diff --git a/src/gclue-web-source.c b/src/gclue-web-source.c
+index 92d94b88..56d511bd 100644
+--- a/src/gclue-web-source.c
++++ b/src/gclue-web-source.c
+@@ -28,6 +28,7 @@
+ #include "gclue-error.h"
+ #include "gclue-location.h"
+ #include "gclue-mozilla.h"
++#include "config.h"
+ 
+ /**
+  * SECTION:gclue-web-source
+@@ -402,16 +403,45 @@ gclue_web_source_finalize (GObject *gsource)
+         G_OBJECT_CLASS (gclue_web_source_parent_class)->finalize (gsource);
+ }
+ 
++static char *
++get_os_info (void)
++{
++        g_autofree char *pretty_name = NULL;
++        g_autofree char *os_name = g_get_os_info (G_OS_INFO_KEY_NAME);
++        g_autofree char *os_version = g_get_os_info (G_OS_INFO_KEY_VERSION);
++
++        if (os_name && os_version)
++                return g_strdup_printf ("%s; %s", os_name, os_version);
++
++        pretty_name = g_get_os_info (G_OS_INFO_KEY_PRETTY_NAME);
++        if (pretty_name)
++                return g_steal_pointer (&pretty_name);
++
++        /* Translators: Not marked as translatable as debug output should stay English */
++        return g_strdup ("Unknown");
++}
++
++#define USER_AGENT (PACKAGE_NAME "/" PACKAGE_VERSION)
++
++static char *
++get_user_agent (void)
++{
++        g_autofree char *os_info = get_os_info ();
++        return g_strdup_printf ("%s (%s)", USER_AGENT, os_info);
++}
++
+ static void
+ gclue_web_source_constructed (GObject *object)
+ {
+         GNetworkMonitor *monitor;
+         GClueWebSourcePrivate *priv = GCLUE_WEB_SOURCE (object)->priv;
++        g_autofree char *user_agent = get_user_agent ();
+ 
+         G_OBJECT_CLASS (gclue_web_source_parent_class)->constructed (object);
+ 
+         priv->soup_session = soup_session_new ();
+         soup_session_set_proxy_resolver (priv->soup_session, NULL);
++        soup_session_set_user_agent (priv->soup_session, user_agent);
+ 
+         monitor = g_network_monitor_get_default ();
+         priv->network_changed_id =
+-- 
+GitLab
+

--- a/packages/g/geoclue/package.yml
+++ b/packages/g/geoclue/package.yml
@@ -1,6 +1,6 @@
 name       : geoclue
 version    : 2.7.2
-release    : 24
+release    : 25
 source     :
     - https://gitlab.freedesktop.org/geoclue/geoclue/-/archive/2.7.2/geoclue-2.7.2.tar.gz : 9c2f3626e3131abc037955cb38a8c0f28a29b4d6cc9992a067fe04be46e37fbe
 homepage   : https://gitlab.freedesktop.org/geoclue/geoclue/-/wikis/home
@@ -22,6 +22,8 @@ replaces   :
 setup      : |
     %patch -p1 -i $pkgfiles/0001-Support-a-stateless-configuration.patch
     %patch -p1 -i $pkgfiles/0001-Add-redshift-to-default-config.patch
+    %patch -p1 -i $pkgfiles/beacondb-fixes.patch
+    %patch -p1 -i $pkgfiles/beacondb-user-agent.patch
     %meson_configure \
         -Ddbus-sys-dir=/usr/share/dbus-1/system.d/ \
         -Ddefault-wifi-url="https://api.beacondb.net/v1/geolocate" \

--- a/packages/g/geoclue/pspec_x86_64.xml
+++ b/packages/g/geoclue/pspec_x86_64.xml
@@ -54,7 +54,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="24">geoclue</Dependency>
+            <Dependency release="25">geoclue</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libgeoclue-2.0/gclue-client.h</Path>
@@ -77,8 +77,8 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2025-02-10</Date>
+        <Update release="25">
+            <Date>2025-02-13</Date>
             <Version>2.7.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>


### PR DESCRIPTION
**Summary**

Add two patches recommended by the beacondb maintainer

One patch enables users to successfully submit WiFi geolocation data.

The other patch includes OS name and version in the User Agent string.
This has been requested by beacondb because they don't use API keys.

Details:
https://gitlab.freedesktop.org/geoclue/geoclue/-/merge_requests/192
https://gitlab.freedesktop.org/geoclue/geoclue/-/issues/207

**Test Plan**

Confirmed geolocation was working using `where-am-i` demo

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
