### PR TITLE
darktable: Update to v5.0.1

### DIFF
--- a/packages/d/darktable/abi_symbols
+++ b/packages/d/darktable/abi_symbols
@@ -1600,7 +1600,6 @@ libdarktable.so:_compute_rel_pos
 libdarktable.so:_conf_get_float_fast
 libdarktable.so:_cursor_clear_busy
 libdarktable.so:_datetime_gdatetime_to_numbers
-libdarktable.so:_get_multi_priority
 libdarktable.so:_get_multi_show
 libdarktable.so:_get_packing_info
 libdarktable.so:_get_pragma_int_val
@@ -1623,6 +1622,7 @@ libdarktable.so:_hist_worker
 libdarktable.so:_images_list_cmp
 libdarktable.so:_insert_text_event
 libdarktable.so:_iop_order_tables
+libdarktable.so:_iop_set_darktable_iop_table
 libdarktable.so:_iop_tooltip_callback
 libdarktable.so:_iop_validate_params
 libdarktable.so:_ioppr_get_default_iop_order_version
@@ -2897,7 +2897,6 @@ libdarktable.so:dt_iop_refresh_preview
 libdarktable.so:dt_iop_refresh_preview2
 libdarktable.so:dt_iop_reload_defaults
 libdarktable.so:dt_iop_request_focus
-libdarktable.so:dt_iop_set_darktable_iop_table
 libdarktable.so:dt_iop_set_description
 libdarktable.so:dt_iop_set_module_trouble_message
 libdarktable.so:dt_iop_setup_binfo
@@ -2969,7 +2968,6 @@ libdarktable.so:dt_ioppr_transform_image_colorspace
 libdarktable.so:dt_ioppr_transform_image_colorspace_cl
 libdarktable.so:dt_ioppr_transform_image_colorspace_rgb
 libdarktable.so:dt_ioppr_transform_image_colorspace_rgb_cl
-libdarktable.so:dt_ioppr_update_for_entries
 libdarktable.so:dt_ioppr_update_for_modules
 libdarktable.so:dt_ioppr_update_for_style_items
 libdarktable.so:dt_ioppr_write_iop_order

--- a/packages/d/darktable/abi_used_symbols
+++ b/packages/d/darktable/abi_used_symbols
@@ -1528,6 +1528,7 @@ libgtk-3.so.0:gtk_revealer_set_transition_duration
 libgtk-3.so.0:gtk_scale_new_with_range
 libgtk-3.so.0:gtk_scale_set_draw_value
 libgtk-3.so.0:gtk_scale_set_value_pos
+libgtk-3.so.0:gtk_scrollable_get_vadjustment
 libgtk-3.so.0:gtk_scrollbar_new
 libgtk-3.so.0:gtk_scrolled_window_get_min_content_height
 libgtk-3.so.0:gtk_scrolled_window_get_type
@@ -1840,6 +1841,7 @@ libgtk-3.so.0:gtk_widget_style_get_property
 libgtk-3.so.0:gtk_widget_translate_coordinates
 libgtk-3.so.0:gtk_widget_trigger_tooltip_query
 libgtk-3.so.0:gtk_widget_unset_state_flags
+libgtk-3.so.0:gtk_window_close
 libgtk-3.so.0:gtk_window_deiconify
 libgtk-3.so.0:gtk_window_fullscreen
 libgtk-3.so.0:gtk_window_get_focus
@@ -1987,6 +1989,7 @@ libjxl.so.0.10:JxlDecoderReleaseBoxBuffer
 libjxl.so.0.10:JxlDecoderSetBoxBuffer
 libjxl.so.0.10:JxlDecoderSetImageOutBuffer
 libjxl.so.0.10:JxlDecoderSetInput
+libjxl.so.0.10:JxlDecoderSetKeepOrientation
 libjxl.so.0.10:JxlDecoderSetParallelRunner
 libjxl.so.0.10:JxlDecoderSubscribeEvents
 libjxl.so.0.10:JxlEncoderAddBox

--- a/packages/d/darktable/package.yml
+++ b/packages/d/darktable/package.yml
@@ -1,8 +1,8 @@
 name       : darktable
-version    : 5.0.0
-release    : 85
+version    : 5.0.1
+release    : 86
 source     :
-    - https://github.com/darktable-org/darktable/releases/download/release-5.0.0/darktable-5.0.0.tar.xz : eaa136e6e624bb53127282e26aafa0441abcc189b55371465e1f5a8a493fa3a1
+    - https://github.com/darktable-org/darktable/releases/download/release-5.0.1/darktable-5.0.1.tar.xz : 4a918d094ebba983ef67a10cc715c3d7e8ca738009920a9ff65d33417b6dd984
 homepage   : https://darktable.org/
 license    : GPL-3.0-or-later
 component  : multimedia.graphics

--- a/packages/d/darktable/pspec_x86_64.xml
+++ b/packages/d/darktable/pspec_x86_64.xml
@@ -948,11 +948,14 @@
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/darktable.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fi/LC_MESSAGES/darktable.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/darktable.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/hu/LC_MESSAGES/darktable.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/darktable.mo</Path>
             <Path fileType="localedata">/usr/share/locale/nl/LC_MESSAGES/darktable.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/pl/LC_MESSAGES/darktable.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/darktable.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sl/LC_MESSAGES/darktable.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sq/LC_MESSAGES/darktable.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/darktable.mo</Path>
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/darktable.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/darktable.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/darktable.mo</Path>
@@ -965,9 +968,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="85">
-            <Date>2024-12-22</Date>
-            <Version>5.0.0</Version>
+        <Update release="86">
+            <Date>2025-02-13</Date>
+            <Version>5.0.1</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://www.darktable.org/2025/02/darktable-5.0.1-released/)

**Test Plan**

- Look at a RAW image

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
