### PR TITLE
ack: Update to v3.8.1

### DIFF
--- a/packages/a/ack/monitoring.yaml
+++ b/packages/a/ack/monitoring.yaml
@@ -1,0 +1,7 @@
+releases:
+  id: 15
+  rss: https://github.com/beyondgrep/ack3/tags.atom
+security:
+  cpe:
+    - vendor: beyondgrep
+      product: ack

--- a/packages/a/ack/package.yml
+++ b/packages/a/ack/package.yml
@@ -1,8 +1,8 @@
 name       : ack
-version    : 3.7.0
-release    : 19
+version    : 3.8.1
+release    : 20
 source     :
-    - https://github.com/beyondgrep/ack3/archive/refs/tags/v3.7.0.tar.gz : 91b28ef612de4f3c02b93283f21fabe0841a0b936b3d782bc28b9acdc05e18e5
+    - https://github.com/beyondgrep/ack3/archive/refs/tags/v3.8.1.tar.gz : d2e61f08dbee1d0dd3caa841febed2eef0e0f50c500f320c9c5dd49d1e7cef67
 homepage   : https://beyondgrep.com/
 license    : Artistic-2.0
 component  : system.utils

--- a/packages/a/ack/pspec_x86_64.xml
+++ b/packages/a/ack/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>ack</Name>
         <Homepage>https://beyondgrep.com/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>Artistic-2.0</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">ack is a grep-like search tool optimized for source code</Summary>
         <Description xml:lang="en">ack is a code-searching tool, similar to grep but optimized for programmers searching large trees of source code. It is highly portable and runs on any platform that runs Perl.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>ack</Name>
@@ -45,12 +45,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2023-08-16</Date>
-            <Version>3.7.0</Version>
+        <Update release="20">
+            <Date>2025-02-14</Date>
+            <Version>3.8.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- The rules for Pytest were modified so that zsh's ad hoc scraping of filetypes for tab completion wouldn't blow up.
- Add --and and --or options to allow combinations of search terms. This is in addition to the --not that was added in v3.7.0.
- Add support for Pytest filetype.
- Add support for Terraform. Thanks, Thiago Perrotta.
- Full changelog [here](https://beyondgrep.com/changes.txt)

**Test Plan**

- Run some basic filters on file outputs

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
