### PR TITLE
python-sdl2: Update to v0.9.17 and add monitoring.yml

### DIFF
--- a/packages/py/python-sdl2/monitoring.yaml
+++ b/packages/py/python-sdl2/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 12950
+  rss: https://github.com/py-sdl/py-sdl2/releases.atom
+# No known CPE, checked 2025-02-14
+security:
+  cpe: ~

--- a/packages/py/python-sdl2/package.yml
+++ b/packages/py/python-sdl2/package.yml
@@ -1,10 +1,12 @@
 name       : python-sdl2
-version    : 0.9.16
-release    : 13
+version    : 0.9.17
+release    : 14
 source     :
-    - https://github.com/py-sdl/py-sdl2/archive/refs/tags/0.9.16.tar.gz : 0da6b0c041a6197059936f461cc004227e04de148a22f7d0295b2877be000254
+    - https://github.com/py-sdl/py-sdl2/archive/refs/tags/0.9.17.tar.gz : f3ae2232075271d997502f6c90a0c41778296248d86b6780623dc3d88efdde0f
 homepage   : https://github.com/py-sdl/py-sdl2
-license    : Public-Domain
+license    :
+     - Zlib
+     - Public-Domain # examples/resources/tuffy.ttf, sdl2/test/resources/tuffy.ttf
 component  : programming.python
 summary    : PySDL2 is a wrapper around the SDL2 library
 description: |

--- a/packages/py/python-sdl2/pspec_x86_64.xml
+++ b/packages/py/python-sdl2/pspec_x86_64.xml
@@ -3,9 +3,10 @@
         <Name>python-sdl2</Name>
         <Homepage>https://github.com/py-sdl/py-sdl2</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
+        <License>Zlib</License>
         <License>Public-Domain</License>
         <PartOf>programming.python</PartOf>
         <Summary xml:lang="en">PySDL2 is a wrapper around the SDL2 library</Summary>
@@ -20,10 +21,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/PySDL2-0.9.16-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/PySDL2-0.9.16-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/PySDL2-0.9.16-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/PySDL2-0.9.16-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/PySDL2-0.9.17-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/PySDL2-0.9.17-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/PySDL2-0.9.17-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/PySDL2-0.9.17-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/sdl2/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/sdl2/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/sdl2/__pycache__/_internal.cpython-311.pyc</Path>
@@ -294,6 +295,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/sdl2/test/rect_test.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/sdl2/test/render_test.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/sdl2/test/resources/animationtest.gif</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/sdl2/test/resources/animationtest.webp</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/sdl2/test/resources/font.bmp</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/sdl2/test/resources/resources.tar.gz</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/sdl2/test/resources/resources.zip</Path>
@@ -364,12 +366,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2024-02-15</Date>
-            <Version>0.9.16</Version>
+        <Update release="14">
+            <Date>2025-02-14</Date>
+            <Version>0.9.17</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Updated to wrap new functions and constants in SDL 2.30.10
- Updated to wrap new functions and constants in SDL_mixer 2.8.0
- Updated to wrap new function in SDL_image 2.8.0
- Added a new function `sdl2.ext.get_key_state` for checking if a given key is currently down or up independently of the SDL event queue

Packaging changes: Changed license terms to be mostly SPDX, guided by [this](https://github.com/py-sdl/py-sdl2/blob/master/doc/copying.rst)

**Test Plan**

Launched and configured `m64py`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
