### PR TITLE
ghostty: Update to 1.1.2

### DIFF
--- a/packages/g/ghostty/abi_used_symbols
+++ b/packages/g/ghostty/abi_used_symbols
@@ -2,6 +2,8 @@ ld-linux-x86-64.so.2:__tls_get_addr
 libX11.so.6:XChangeProperty
 libX11.so.6:XDeleteProperty
 libX11.so.6:XEventsQueued
+libX11.so.6:XFree
+libX11.so.6:XGetWindowProperty
 libX11.so.6:XPeekEvent
 libX11.so.6:XkbQueryExtension
 libX11.so.6:XkbSelectEventDetails
@@ -506,6 +508,7 @@ libgtk-4.so.1:gtk_widget_get_display
 libgtk-4.so.1:gtk_widget_get_first_child
 libgtk-4.so.1:gtk_widget_get_height
 libgtk-4.so.1:gtk_widget_get_last_child
+libgtk-4.so.1:gtk_widget_get_parent
 libgtk-4.so.1:gtk_widget_get_primary_clipboard
 libgtk-4.so.1:gtk_widget_get_scale_factor
 libgtk-4.so.1:gtk_widget_get_visible

--- a/packages/g/ghostty/files/5762-add-back-fetch-script.patch
+++ b/packages/g/ghostty/files/5762-add-back-fetch-script.patch
@@ -1,0 +1,44 @@
+From cdd287c88b6af7a2a362286376209c95ec0ffcea Mon Sep 17 00:00:00 2001
+From: Mitchell Hashimoto <m@mitchellh.com>
+Date: Fri, 14 Feb 2025 07:23:10 -0800
+Subject: [PATCH] Add back `fetch-zig-cache.sh` for packaging
+
+See the comment on more details, which also covers when and how we can
+remove this.
+---
+ nix/build-support/fetch-zig-cache.sh | 26 ++++++++++++++++++++++++++
+ 1 file changed, 26 insertions(+)
+ create mode 100755 nix/build-support/fetch-zig-cache.sh
+
+diff --git a/nix/build-support/fetch-zig-cache.sh b/nix/build-support/fetch-zig-cache.sh
+new file mode 100755
+index 0000000000..cb6b52a1c8
+--- /dev/null
++++ b/nix/build-support/fetch-zig-cache.sh
+@@ -0,0 +1,26 @@
++#!/bin/sh
++
++# NOTE THIS IS A TEMPORARY SCRIPT TO SUPPORT PACKAGE MAINTAINERS.
++# Since #5439[1], we've been moving away from this and using an alternate
++# nix-based approach to cache our dependencies. #5733 aims to make this more
++# readily consumable by people who don't have Nix installed so that Nix
++# is not a hard dependency.
++#
++# Further, a future Zig version will hopefully fix the issue where
++# `zig build --fetch` doesn't fetch transitive dependencies[3]. When that
++# is resolved, we won't need any special machinery for the general use case
++# at all and packagers can just use `zig build --fetch`.
++#
++# [1]: https://github.com/ghostty-org/ghostty/pull/5439
++# [2]: https://github.com/ghostty-org/ghostty/pull/5733
++# [3]: https://github.com/ziglang/zig/issues/20976
++
++if [ -z ${ZIG_GLOBAL_CACHE_DIR+x} ]
++then
++  echo "must set ZIG_GLOBAL_CACHE_DIR!"
++  exit 1
++fi
++
++zig build --fetch
++zig fetch git+https://github.com/zigimg/zigimg#3a667bdb3d7f0955a5a51c8468eac83210c1439e
++zig fetch git+https://github.com/mitchellh/libxev#f6a672a78436d8efee1aa847a43a900ad773618b

--- a/packages/g/ghostty/package.yml
+++ b/packages/g/ghostty/package.yml
@@ -1,8 +1,8 @@
 name       : ghostty
-version    : 1.1.0
-release    : 7
+version    : 1.1.2
+release    : 8
 source     :
-    - https://github.com/ghostty-org/ghostty/archive/refs/tags/v1.1.0.tar.gz : b499f3811416b9bdea0b26599f8147955ffa1da468129eb44bc45609c2775fb7
+    - https://github.com/ghostty-org/ghostty/archive/refs/tags/v1.1.2.tar.gz : 54d74a49df9f2e4b9a8b7c88372bdb78f4e3c4f072f6cee197c873e90ba27d19
 homepage   : https://ghostty.org/
 license    : MIT
 component  : system.utils
@@ -23,12 +23,12 @@ environment: |
     export ZIG_GLOBAL_CACHE_DIR=$workdir/zig-cache
     export DESTDIR=%installroot%
 setup      : |
+    %patch -p1 -i $pkgfiles/5125-add-appstream-metainfo.patch
+    %patch -p1 -i $pkgfiles/5762-add-back-fetch-script.patch
+
     # See PACKAGING.md at the root of the ghostty repo
     # So we can use `--system` flag
     ./nix/build-support/fetch-zig-cache.sh
-
-    # Add appstream metainfo
-    %patch -p1 -i $pkgfiles/5125-add-appstream-metainfo.patch
 build      : |
     zig build %JOBS% \
         --release=fast \

--- a/packages/g/ghostty/pspec_x86_64.xml
+++ b/packages/g/ghostty/pspec_x86_64.xml
@@ -118,6 +118,7 @@
             <Path fileType="data">/usr/share/ghostty/themes/Duotone Dark</Path>
             <Path fileType="data">/usr/share/ghostty/themes/ENCOM</Path>
             <Path fileType="data">/usr/share/ghostty/themes/Earthsong</Path>
+            <Path fileType="data">/usr/share/ghostty/themes/Elegant</Path>
             <Path fileType="data">/usr/share/ghostty/themes/Elemental</Path>
             <Path fileType="data">/usr/share/ghostty/themes/Elementary</Path>
             <Path fileType="data">/usr/share/ghostty/themes/Espresso</Path>
@@ -140,6 +141,7 @@
             <Path fileType="data">/usr/share/ghostty/themes/FunForrest</Path>
             <Path fileType="data">/usr/share/ghostty/themes/Galaxy</Path>
             <Path fileType="data">/usr/share/ghostty/themes/Galizur</Path>
+            <Path fileType="data">/usr/share/ghostty/themes/Ghostty Default StyleDark</Path>
             <Path fileType="data">/usr/share/ghostty/themes/GitHub Dark</Path>
             <Path fileType="data">/usr/share/ghostty/themes/GitHub-Dark-Colorblind</Path>
             <Path fileType="data">/usr/share/ghostty/themes/GitHub-Dark-Default</Path>
@@ -402,6 +404,7 @@
             <Path fileType="data">/usr/share/ghostty/themes/seoulbones_dark</Path>
             <Path fileType="data">/usr/share/ghostty/themes/seoulbones_light</Path>
             <Path fileType="data">/usr/share/ghostty/themes/shades-of-purple</Path>
+            <Path fileType="data">/usr/share/ghostty/themes/solarized-osaka-night</Path>
             <Path fileType="data">/usr/share/ghostty/themes/srcery</Path>
             <Path fileType="data">/usr/share/ghostty/themes/starlight</Path>
             <Path fileType="data">/usr/share/ghostty/themes/synthwave</Path>
@@ -441,7 +444,7 @@
             <Path fileType="man">/usr/share/man/man5/ghostty.5</Path>
             <Path fileType="data">/usr/share/metainfo/com.mitchellh.ghostty.appdata.xml</Path>
             <Path fileType="data">/usr/share/metainfo/com.mitchellh.ghostty.metainfo.xml</Path>
-            <Path fileType="data">/usr/share/nautilus-python/extensions/com.mitchellh.ghostty.py</Path>
+            <Path fileType="data">/usr/share/nautilus-python/extensions/ghostty.py</Path>
             <Path fileType="data">/usr/share/nvim/site/compiler/ghostty.vim</Path>
             <Path fileType="data">/usr/share/nvim/site/ftdetect/ghostty.vim</Path>
             <Path fileType="data">/usr/share/nvim/site/ftplugin/ghostty.vim</Path>
@@ -456,9 +459,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2025-02-11</Date>
-            <Version>1.1.0</Version>
+        <Update release="8">
+            <Date>2025-02-14</Date>
+            <Version>1.1.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Marcus Mellor</Name>
             <Email>marcus@infinitymdm.dev</Email>


### PR DESCRIPTION
**Summary**

Update ghostty to 1.1.2. Resolves #5043

Enhancements:
- Server-side decorations work for X11 too now
- More input method editor improvements

See the [1.1.1 Release Notes](https://ghostty.org/docs/install/release-notes/1-1-1) for detailed changes since 1.1.0 (as the 1.1.2 release contains no changes for Linux users).

**Test Plan**

- Use ghostty to submit this PR

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
