### PR TITLE
ibus: Update to v1.5.31

### DIFF
--- a/packages/i/ibus/abi_symbols
+++ b/packages/i/ibus/abi_symbols
@@ -16,6 +16,7 @@ libibus-1.0.so.5:ibus_attr_list_append
 libibus-1.0.so.5:ibus_attr_list_get
 libibus-1.0.so.5:ibus_attr_list_get_type
 libibus-1.0.so.5:ibus_attr_list_new
+libibus-1.0.so.5:ibus_attr_preedit_get_type
 libibus-1.0.so.5:ibus_attr_type_get_type
 libibus-1.0.so.5:ibus_attr_underline_get_type
 libibus-1.0.so.5:ibus_attr_underline_new

--- a/packages/i/ibus/abi_used_symbols
+++ b/packages/i/ibus/abi_used_symbols
@@ -67,7 +67,6 @@ libc.so.6:getppid
 libc.so.6:getpwuid
 libc.so.6:gettimeofday
 libc.so.6:getuid
-libc.so.6:index
 libc.so.6:kill
 libc.so.6:localtime_r
 libc.so.6:lstat
@@ -415,10 +414,13 @@ libglib-2.0.so.0:g_direct_hash
 libglib-2.0.so.0:g_error_free
 libglib-2.0.so.0:g_error_matches
 libglib-2.0.so.0:g_error_new
+libglib-2.0.so.0:g_error_new_literal
+libglib-2.0.so.0:g_file_error_quark
 libglib-2.0.so.0:g_file_get_contents
 libglib-2.0.so.0:g_file_read_link
 libglib-2.0.so.0:g_file_set_contents
 libglib-2.0.so.0:g_file_test
+libglib-2.0.so.0:g_find_program_in_path
 libglib-2.0.so.0:g_free
 libglib-2.0.so.0:g_get_application_name
 libglib-2.0.so.0:g_get_environ
@@ -450,6 +452,7 @@ libglib-2.0.so.0:g_idle_add
 libglib-2.0.so.0:g_idle_add_full
 libglib-2.0.so.0:g_idle_source_new
 libglib-2.0.so.0:g_intern_static_string
+libglib-2.0.so.0:g_key_file_error_quark
 libglib-2.0.so.0:g_list_append
 libglib-2.0.so.0:g_list_concat
 libglib-2.0.so.0:g_list_copy
@@ -459,6 +462,8 @@ libglib-2.0.so.0:g_list_find_custom
 libglib-2.0.so.0:g_list_foreach
 libglib-2.0.so.0:g_list_free
 libglib-2.0.so.0:g_list_free_full
+libglib-2.0.so.0:g_list_insert_before
+libglib-2.0.so.0:g_list_last
 libglib-2.0.so.0:g_list_length
 libglib-2.0.so.0:g_list_prepend
 libglib-2.0.so.0:g_list_remove
@@ -518,6 +523,7 @@ libglib-2.0.so.0:g_path_get_dirname
 libglib-2.0.so.0:g_print
 libglib-2.0.so.0:g_printerr
 libglib-2.0.so.0:g_printf
+libglib-2.0.so.0:g_propagate_error
 libglib-2.0.so.0:g_ptr_array_add
 libglib-2.0.so.0:g_ptr_array_free
 libglib-2.0.so.0:g_ptr_array_new
@@ -615,6 +621,7 @@ libglib-2.0.so.0:g_tree_lookup_extended
 libglib-2.0.so.0:g_tree_new_full
 libglib-2.0.so.0:g_tree_remove
 libglib-2.0.so.0:g_ucs4_to_utf8
+libglib-2.0.so.0:g_unichar_isalnum
 libglib-2.0.so.0:g_unichar_iscntrl
 libglib-2.0.so.0:g_unichar_isgraph
 libglib-2.0.so.0:g_unichar_isprint
@@ -631,9 +638,11 @@ libglib-2.0.so.0:g_unlink
 libglib-2.0.so.0:g_unsetenv
 libglib-2.0.so.0:g_usleep
 libglib-2.0.so.0:g_utf8_get_char
+libglib-2.0.so.0:g_utf8_get_char_validated
 libglib-2.0.so.0:g_utf8_normalize
 libglib-2.0.so.0:g_utf8_offset_to_pointer
 libglib-2.0.so.0:g_utf8_pointer_to_offset
+libglib-2.0.so.0:g_utf8_prev_char
 libglib-2.0.so.0:g_utf8_skip
 libglib-2.0.so.0:g_utf8_strchr
 libglib-2.0.so.0:g_utf8_strdown
@@ -696,12 +705,15 @@ libgobject-2.0.so.0:g_boxed_copy
 libgobject-2.0.so.0:g_boxed_free
 libgobject-2.0.so.0:g_boxed_type_register_static
 libgobject-2.0.so.0:g_cclosure_marshal_VOID__OBJECT
+libgobject-2.0.so.0:g_cclosure_marshal_VOID__OBJECTv
 libgobject-2.0.so.0:g_cclosure_marshal_VOID__POINTER
 libgobject-2.0.so.0:g_cclosure_marshal_VOID__STRING
+libgobject-2.0.so.0:g_cclosure_marshal_VOID__STRINGv
 libgobject-2.0.so.0:g_cclosure_marshal_VOID__UINT
 libgobject-2.0.so.0:g_cclosure_marshal_VOID__UINT_POINTER
 libgobject-2.0.so.0:g_cclosure_marshal_VOID__VARIANT
 libgobject-2.0.so.0:g_cclosure_marshal_VOID__VOID
+libgobject-2.0.so.0:g_cclosure_marshal_VOID__VOIDv
 libgobject-2.0.so.0:g_cclosure_new
 libgobject-2.0.so.0:g_enum_register_static
 libgobject-2.0.so.0:g_flags_register_static
@@ -758,6 +770,7 @@ libgobject-2.0.so.0:g_signal_handlers_destroy
 libgobject-2.0.so.0:g_signal_handlers_disconnect_matched
 libgobject-2.0.so.0:g_signal_lookup
 libgobject-2.0.so.0:g_signal_new
+libgobject-2.0.so.0:g_signal_set_va_marshaller
 libgobject-2.0.so.0:g_signal_stop_emission_by_name
 libgobject-2.0.so.0:g_strv_get_type
 libgobject-2.0.so.0:g_type_add_instance_private
@@ -929,6 +942,7 @@ libgtk-3.so.0:gtk_menu_new
 libgtk-3.so.0:gtk_menu_popup_at_rect
 libgtk-3.so.0:gtk_menu_popup_at_widget
 libgtk-3.so.0:gtk_menu_shell_append
+libgtk-3.so.0:gtk_menu_shell_insert
 libgtk-3.so.0:gtk_menu_shell_set_take_focus
 libgtk-3.so.0:gtk_message_dialog_new
 libgtk-3.so.0:gtk_orientable_get_orientation

--- a/packages/i/ibus/monitoring.yaml
+++ b/packages/i/ibus/monitoring.yaml
@@ -1,0 +1,7 @@
+releases:
+  id: 1352
+  rss: https://github.com/ibus/ibus/tags.atom
+security:
+  cpe:
+    - vendor: ibus_project
+      product: ibus

--- a/packages/i/ibus/package.yml
+++ b/packages/i/ibus/package.yml
@@ -1,10 +1,8 @@
 name       : ibus
-version    : 1.5.29
-release    : 32
+version    : 1.5.31
+release    : 33
 source     :
-    # Source archive doesn't build but git tag does (?)
-    # - https://github.com/ibus/ibus/releases/download/1.5.29/ibus-1.5.29.tar.gz : 4a457f10e29da0623e96cbbaca89cc529145587141f8e64c305f17dc875d5e6e
-    - git|https://github.com/ibus/ibus.git : 1.5.29
+    - https://github.com/ibus/ibus/releases/download/1.5.31/ibus-1.5.31.tar.gz : 5093994c8342551134c81f2d271575efbc459bb756cef1173c22430c8601a1e1
 homepage   : https://github.com/ibus/ibus
 license    : LGPL-2.0-only
 component  : desktop.core

--- a/packages/i/ibus/pspec_x86_64.xml
+++ b/packages/i/ibus/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ibus</Name>
         <Homepage>https://github.com/ibus/ibus</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.0-only</License>
         <PartOf>desktop.core</PartOf>
@@ -40,7 +40,7 @@
             <Path fileType="library">/usr/lib64/ibus/ibus-wayland</Path>
             <Path fileType="library">/usr/lib64/ibus/ibus-x11</Path>
             <Path fileType="library">/usr/lib64/libibus-1.0.so.5</Path>
-            <Path fileType="library">/usr/lib64/libibus-1.0.so.5.0.529</Path>
+            <Path fileType="library">/usr/lib64/libibus-1.0.so.5.0.531</Path>
             <Path fileType="data">/usr/share/GConf/gsettings/ibus.convert</Path>
             <Path fileType="data">/usr/share/applications/org.freedesktop.IBus.Panel.Emojier.desktop</Path>
             <Path fileType="data">/usr/share/applications/org.freedesktop.IBus.Panel.Extension.Gtk3.desktop</Path>
@@ -233,6 +233,7 @@
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/ibus10.mo</Path>
             <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/ibus10.mo</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/ibus10.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/el/LC_MESSAGES/ibus10.mo</Path>
             <Path fileType="localedata">/usr/share/locale/en_GB/LC_MESSAGES/ibus10.mo</Path>
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/ibus10.mo</Path>
             <Path fileType="localedata">/usr/share/locale/et/LC_MESSAGES/ibus10.mo</Path>
@@ -294,7 +295,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="32">ibus</Dependency>
+            <Dependency release="33">ibus</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/ibus-1.0/ibus.h</Path>
@@ -406,12 +407,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2024-10-06</Date>
-            <Version>1.5.29</Version>
+        <Update release="33">
+            <Date>2025-01-22</Date>
+            <Version>1.5.31</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Implement preedit color in Plasma Wayland
- Implement `ibus start/restart` for Plasma Wayland
- Show preferences menu item in activate menu
- Fix control keys with game application
- Fix typing freeze with barcode reader
- Fix memory issues
- Fix preedit issue with X applications
- Improve the search for engines
- Identify SUPER_MASK in GTK4 with MOD4_MASK
- Fix SEGV with Super-space in Wayland
- Free names in `ibus_engine_filter_key_event()`
- Fix ibus-daemon timeout in Plasma Wayland
- Set Indicator status at launching time
- Enhance compose keys
- Update compose keys with latest Xorg and GTK
- Use localectl to get current XKB in Wayland instead of setxkbmap
- Update XKB engines
- Update Unicode category
- Change IBus unique name for security issue
- Ignore Super modifier for compose keys for GNOME Wayland
- Fix X11 application and game issues
- Fix Emoji issues
- Fix Flatpak issues
- Fix preedit issues with `m17n:sa:itrans`
- Update translations

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

I've been using this for about a month now without any noticible issue. (I may or may not have forgotten to submit the PR.)

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
