### PR TITLE
deno: Update to v2.1.10

### DIFF
--- a/packages/d/deno/abi_symbols
+++ b/packages/d/deno/abi_symbols
@@ -151,3 +151,10 @@ deno:node_api_get_module_file_name
 deno:node_api_post_finalizer
 deno:node_api_symbol_for
 deno:node_api_throw_syntax_error
+deno:uv_async_init
+deno:uv_async_send
+deno:uv_close
+deno:uv_mutex_destroy
+deno:uv_mutex_init
+deno:uv_mutex_lock
+deno:uv_mutex_unlock

--- a/packages/d/deno/abi_used_symbols
+++ b/packages/d/deno/abi_used_symbols
@@ -15,6 +15,7 @@ libc.so.6:__libc_current_sigrtmax
 libc.so.6:__libc_start_main
 libc.so.6:__mbrlen
 libc.so.6:__memcpy_chk
+libc.so.6:__memmove_chk
 libc.so.6:__memset_chk
 libc.so.6:__register_atfork
 libc.so.6:__res_init
@@ -29,6 +30,7 @@ libc.so.6:_exit
 libc.so.6:abort
 libc.so.6:accept4
 libc.so.6:access
+libc.so.6:aligned_alloc
 libc.so.6:backtrace
 libc.so.6:backtrace_symbols
 libc.so.6:bcmp
@@ -51,6 +53,7 @@ libc.so.6:dlclose
 libc.so.6:dlerror
 libc.so.6:dlopen
 libc.so.6:dlsym
+libc.so.6:dup
 libc.so.6:dup2
 libc.so.6:endmntent
 libc.so.6:environ
@@ -80,6 +83,7 @@ libc.so.6:fopen64
 libc.so.6:fork
 libc.so.6:fprintf
 libc.so.6:fputc
+libc.so.6:fputwc
 libc.so.6:fread
 libc.so.6:free
 libc.so.6:freeaddrinfo
@@ -119,6 +123,7 @@ libc.so.6:getsockname
 libc.so.6:getsockopt
 libc.so.6:gettimeofday
 libc.so.6:getuid
+libc.so.6:getwc
 libc.so.6:gnu_get_libc_version
 libc.so.6:hasmntopt
 libc.so.6:inotify_add_watch
@@ -160,6 +165,7 @@ libc.so.6:open
 libc.so.6:open64
 libc.so.6:openat64
 libc.so.6:opendir
+libc.so.6:pause
 libc.so.6:pipe2
 libc.so.6:poll
 libc.so.6:posix_memalign
@@ -173,6 +179,7 @@ libc.so.6:posix_spawnattr_setpgroup
 libc.so.6:posix_spawnattr_setsigdefault
 libc.so.6:posix_spawnp
 libc.so.6:prctl
+libc.so.6:pread64
 libc.so.6:printf
 libc.so.6:pthread_attr_destroy
 libc.so.6:pthread_attr_getguardsize
@@ -191,7 +198,6 @@ libc.so.6:pthread_condattr_setclock
 libc.so.6:pthread_create
 libc.so.6:pthread_detach
 libc.so.6:pthread_getattr_np
-libc.so.6:pthread_getspecific
 libc.so.6:pthread_join
 libc.so.6:pthread_key_create
 libc.so.6:pthread_key_delete
@@ -204,7 +210,6 @@ libc.so.6:pthread_mutex_unlock
 libc.so.6:pthread_mutexattr_destroy
 libc.so.6:pthread_mutexattr_init
 libc.so.6:pthread_mutexattr_settype
-libc.so.6:pthread_once
 libc.so.6:pthread_rwlock_destroy
 libc.so.6:pthread_rwlock_init
 libc.so.6:pthread_rwlock_rdlock
@@ -216,6 +221,7 @@ libc.so.6:pthread_self
 libc.so.6:pthread_setname_np
 libc.so.6:pthread_setspecific
 libc.so.6:puts
+libc.so.6:pwrite64
 libc.so.6:qsort
 libc.so.6:raise
 libc.so.6:read
@@ -226,6 +232,7 @@ libc.so.6:realloc
 libc.so.6:realpath
 libc.so.6:recv
 libc.so.6:recvfrom
+libc.so.6:recvmmsg
 libc.so.6:recvmsg
 libc.so.6:rename
 libc.so.6:rewind
@@ -240,6 +247,7 @@ libc.so.6:sem_wait
 libc.so.6:send
 libc.so.6:sendmsg
 libc.so.6:sendto
+libc.so.6:setbuf
 libc.so.6:setenv
 libc.so.6:setgid
 libc.so.6:setgroups
@@ -281,6 +289,7 @@ libc.so.6:strncat
 libc.so.6:strncmp
 libc.so.6:strncpy
 libc.so.6:strrchr
+libc.so.6:strspn
 libc.so.6:strstr
 libc.so.6:strtod
 libc.so.6:strtod_l
@@ -307,6 +316,7 @@ libc.so.6:tzset
 libc.so.6:umask
 libc.so.6:uname
 libc.so.6:ungetc
+libc.so.6:ungetwc
 libc.so.6:unlink
 libc.so.6:unlinkat
 libc.so.6:unsetenv
@@ -322,6 +332,7 @@ libc.so.6:waitpid
 libc.so.6:wcrtomb
 libc.so.6:wcslen
 libc.so.6:wcsnrtombs
+libc.so.6:wmemchr
 libc.so.6:write
 libc.so.6:writev
 libgcc_s.so.1:_Unwind_Backtrace
@@ -345,6 +356,7 @@ libm.so.6:asinf
 libm.so.6:atan
 libm.so.6:atan2
 libm.so.6:atanf
+libm.so.6:cbrt
 libm.so.6:ceil
 libm.so.6:ceilf
 libm.so.6:cos
@@ -375,7 +387,6 @@ libm.so.6:log1pf
 libm.so.6:log2
 libm.so.6:log2f
 libm.so.6:logf
-libm.so.6:lrint
 libm.so.6:modf
 libm.so.6:modff
 libm.so.6:nearbyint
@@ -388,11 +399,10 @@ libm.so.6:round
 libm.so.6:roundf
 libm.so.6:scalbn
 libm.so.6:sin
+libm.so.6:sincos
 libm.so.6:sinf
 libm.so.6:sinh
 libm.so.6:sinhf
-libm.so.6:sqrt
-libm.so.6:sqrtf
 libm.so.6:tan
 libm.so.6:tanf
 libm.so.6:tanh

--- a/packages/d/deno/package.yml
+++ b/packages/d/deno/package.yml
@@ -1,8 +1,8 @@
 name       : deno
-version    : 1.45.2
-release    : 18
+version    : 2.1.10
+release    : 19
 source     :
-    - https://github.com/denoland/deno/archive/refs/tags/v1.45.2.tar.gz : 6f5c811b2a86b4aed73cb9bd48fb8b385ebf50292716fb84e8dc4983a43c86a6
+    - https://github.com/denoland/deno/archive/refs/tags/v2.1.10.tar.gz : 8945d3c4a18e04ab183185bf6728e9cf03d75548c122df2a154caf8b5d663399
 homepage   : https://deno.com/
 license    : MIT
 component  : programming.tools

--- a/packages/d/deno/pspec_x86_64.xml
+++ b/packages/d/deno/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>deno</Name>
         <Homepage>https://deno.com/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Gavin Zhao</Name>
+            <Email>me@gzgz.dev</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.tools</PartOf>
@@ -27,12 +27,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2024-07-13</Date>
-            <Version>1.45.2</Version>
+        <Update release="19">
+            <Date>2025-02-15</Date>
+            <Version>2.1.10</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Gavin Zhao</Name>
+            <Email>me@gzgz.dev</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Updated `deno` to v2.1.10. This update brings Deno 2.0, the latest major version release, of this alternative JavaScript/TypeScript runtime. For more details on the most notable changes, see the official Deno 2.0 [announcement](https://deno.com/blog/v2.0).

**Test Plan**

- Successfully built and ran the default `fresh` template project.
- Successfully ran some of my TypeScript scripts.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
