### PR TITLE
sway & labwc: decouple rundeps

### DIFF
--- a/packages/l/labwc/package.yml
+++ b/packages/l/labwc/package.yml
@@ -1,14 +1,17 @@
 name       : labwc
 version    : 0.8.1
-release    : 6
+release    : 7
 source     :
     - https://github.com/labwc/labwc/archive/refs/tags/0.8.1.tar.gz : 8e510655cf0c84875c541f4afeb636e707d365210993ad22d64d8bc3108a3433
 homepage   : https://labwc.github.io/
 license    : GPL-2.0-or-later
 component  : desktop
-summary    : Labwc is a window-stacking compositor for wayland
-description: |
-    Labwc is a wlroots-based window-stacking compositor for wayland, inspired by openbox.
+summary    :
+    - Labwc is a window-stacking compositor for wayland
+    - session: Labwc session
+description:
+    - Labwc is a wlroots-based window-stacking compositor for wayland, inspired by openbox.
+    - session: Labwc session
 builddeps  :
     - pkgconfig(cairo)
     - pkgconfig(glib-2.0)
@@ -25,13 +28,13 @@ builddeps  :
     - pkgconfig(xkbcommon)
     - pkgconfig(xwayland)
 rundeps    :
-    - alacritty
-    - swaybg
-    - swayidle
-    - swaylock
-    - waybar
-    - wlopm
-    - xdg-desktop-portal-gtk
+    - session :
+        - alacritty
+        - labwc
+        - swaybg
+        - swayidle
+        - swaylock
+        - waybar
     - xdg-desktop-portal-wlr
     - xorg-xwayland
 clang      : yes
@@ -42,3 +45,7 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+patterns:
+    - session:
+        - /usr/share/icons
+        - /usr/share/wayland-sessions/labwc.desktop

--- a/packages/l/labwc/pspec_x86_64.xml
+++ b/packages/l/labwc/pspec_x86_64.xml
@@ -3,21 +3,19 @@
         <Name>labwc</Name>
         <Homepage>https://labwc.github.io/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop</PartOf>
         <Summary xml:lang="en">Labwc is a window-stacking compositor for wayland</Summary>
-        <Description xml:lang="en">Labwc is a wlroots-based window-stacking compositor for wayland, inspired by openbox.
-</Description>
+        <Description xml:lang="en">Labwc is a wlroots-based window-stacking compositor for wayland, inspired by openbox.</Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>labwc</Name>
         <Summary xml:lang="en">Labwc is a window-stacking compositor for wayland</Summary>
-        <Description xml:lang="en">Labwc is a wlroots-based window-stacking compositor for wayland, inspired by openbox.
-</Description>
+        <Description xml:lang="en">Labwc is a wlroots-based window-stacking compositor for wayland, inspired by openbox.</Description>
         <PartOf>desktop</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/labwc</Path>
@@ -29,8 +27,6 @@
             <Path fileType="doc">/usr/share/doc/labwc/rc.xml.all</Path>
             <Path fileType="doc">/usr/share/doc/labwc/shutdown</Path>
             <Path fileType="doc">/usr/share/doc/labwc/themerc</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/labwc-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/labwc.svg</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/labwc.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/labwc.mo</Path>
             <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/labwc.mo</Path>
@@ -65,17 +61,29 @@
             <Path fileType="man">/usr/share/man/man5/labwc-config.5</Path>
             <Path fileType="man">/usr/share/man/man5/labwc-menu.5</Path>
             <Path fileType="man">/usr/share/man/man5/labwc-theme.5</Path>
-            <Path fileType="data">/usr/share/wayland-sessions/labwc.desktop</Path>
             <Path fileType="data">/usr/share/xdg-desktop-portal/labwc-portals.conf</Path>
         </Files>
     </Package>
+    <Package>
+        <Name>labwc-session</Name>
+        <Summary xml:lang="en">Labwc session</Summary>
+        <Description xml:lang="en">Labwc session</Description>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="7">labwc</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/labwc-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/labwc.svg</Path>
+            <Path fileType="data">/usr/share/wayland-sessions/labwc.desktop</Path>
+        </Files>
+    </Package>
     <History>
-        <Update release="6">
-            <Date>2024-10-28</Date>
+        <Update release="7">
+            <Date>2025-02-15</Date>
             <Version>0.8.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/s/sway/package.yml
+++ b/packages/s/sway/package.yml
@@ -1,14 +1,17 @@
 name       : sway
 version    : 1.10.1
-release    : 33
+release    : 34
 source     :
     - https://github.com/swaywm/sway/archive/refs/tags/1.10.1.tar.gz : 8565ab3b359780f02b1dcb24dc48e5b6b82c64dd97ca795782c2fb4cab62457b
 license    : MIT
 homepage   : https://swaywm.org/
 component  : desktop
-summary    : sway is an i3-compatible Wayland compositor
-description: |
-    sway is an i3-compatible Wayland compositor.
+summary    :
+    - sway is an i3-compatible Wayland compositor
+    - session: sway session
+description:
+    - sway is an i3-compatible Wayland compositor.
+    - session: sway session
 builddeps  :
     - pkgconfig(cairo)
     - pkgconfig(gdk-pixbuf-2.0)
@@ -20,15 +23,15 @@ builddeps  :
     - pkgconfig(wayland-protocols)
     - pkgconfig(wlroots-0.18)
 rundeps    :
+    - session:
+        - alacritty
+        - dmenu
+        - sway
+        - xdg-desktop-portal-gtk
     # TODO package brightnessctl
-    - alacritty
-    - dmenu
-    - grim
-    - pipewire
     - swaybg
     - swayidle
     - swaylock
-    - xdg-desktop-portal-gtk
     - xdg-desktop-portal-wlr
 clang      : yes
 optimize   : thin-lto
@@ -52,3 +55,6 @@ install    : |
 
     # Install xdg-desktop-portals configuration
     install -Dm00644 $pkgfiles/sway-portals.conf -t $installdir/usr/share/xdg-desktop-portal
+patterns:
+    - session:
+        - /usr/share/wayland-sessions/sway.desktop

--- a/packages/s/sway/pspec_x86_64.xml
+++ b/packages/s/sway/pspec_x86_64.xml
@@ -3,21 +3,19 @@
         <Name>sway</Name>
         <Homepage>https://swaywm.org/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>desktop</PartOf>
         <Summary xml:lang="en">sway is an i3-compatible Wayland compositor</Summary>
-        <Description xml:lang="en">sway is an i3-compatible Wayland compositor.
-</Description>
+        <Description xml:lang="en">sway is an i3-compatible Wayland compositor.</Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>sway</Name>
         <Summary xml:lang="en">sway is an i3-compatible Wayland compositor</Summary>
-        <Description xml:lang="en">sway is an i3-compatible Wayland compositor.
-</Description>
+        <Description xml:lang="en">sway is an i3-compatible Wayland compositor.</Description>
         <PartOf>desktop</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/sway</Path>
@@ -50,19 +48,29 @@
             <Path fileType="man">/usr/share/man/man5/swaynag.5</Path>
             <Path fileType="man">/usr/share/man/man7/sway-ipc.7</Path>
             <Path fileType="man">/usr/share/man/man7/swaybar-protocol.7</Path>
-            <Path fileType="data">/usr/share/wayland-sessions/sway.desktop</Path>
             <Path fileType="data">/usr/share/xdg-desktop-portal/sway-portals.conf</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_sway</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_swaymsg</Path>
         </Files>
     </Package>
+    <Package>
+        <Name>sway-session</Name>
+        <Summary xml:lang="en">sway session</Summary>
+        <Description xml:lang="en">sway session</Description>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="34">sway</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="data">/usr/share/wayland-sessions/sway.desktop</Path>
+        </Files>
+    </Package>
     <History>
-        <Update release="33">
-            <Date>2025-01-28</Date>
+        <Update release="34">
+            <Date>2025-02-15</Date>
             <Version>1.10.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/x/xdg-desktop-portal-wlr/abi_used_symbols
+++ b/packages/x/xdg-desktop-portal-wlr/abi_used_symbols
@@ -95,7 +95,9 @@ libsystemd.so.0:sd_bus_add_match
 libsystemd.so.0:sd_bus_add_object_vtable
 libsystemd.so.0:sd_bus_close
 libsystemd.so.0:sd_bus_flush
+libsystemd.so.0:sd_bus_get_events
 libsystemd.so.0:sd_bus_get_fd
+libsystemd.so.0:sd_bus_get_timeout
 libsystemd.so.0:sd_bus_get_unique_name
 libsystemd.so.0:sd_bus_message_append
 libsystemd.so.0:sd_bus_message_close_container

--- a/packages/x/xdg-desktop-portal-wlr/package.yml
+++ b/packages/x/xdg-desktop-portal-wlr/package.yml
@@ -1,8 +1,8 @@
 name       : xdg-desktop-portal-wlr
-version    : 0.7.0
-release    : 1
+version    : 0.7.1
+release    : 2
 source     :
-    - https://github.com/emersion/xdg-desktop-portal-wlr/releases/download/v0.7.0/xdg-desktop-portal-wlr-0.7.0.tar.gz : e397a72314165ef736d91655fe95867056efe371935f2d1e4a10d34fa0fffb4f
+    - https://github.com/emersion/xdg-desktop-portal-wlr/releases/download/v0.7.1/xdg-desktop-portal-wlr-0.7.1.tar.gz : eec6e4be808e1a445e677dba1e20e5acb2f091825f5ff4c6ac49d5843b2185f9
 license    : MIT
 component  : desktop.util
 homepage   : https://github.com/emersion/xdg-desktop-portal-wlr
@@ -19,6 +19,8 @@ builddeps  :
     - pkgconfig(wayland-protocols)
     - scdoc
 rundeps    :
+    - grim
+    - pipewire
     - xdg-desktop-portal
 setup      : |
     %meson_configure

--- a/packages/x/xdg-desktop-portal-wlr/pspec_x86_64.xml
+++ b/packages/x/xdg-desktop-portal-wlr/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>xdg-desktop-portal-wlr</Name>
         <Homepage>https://github.com/emersion/xdg-desktop-portal-wlr</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>desktop.util</PartOf>
         <Summary xml:lang="en">xdg-desktop-portal backend for wlroots</Summary>
         <Description xml:lang="en">xdg-desktop-portal backend for wlroots
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>xdg-desktop-portal-wlr</Name>
@@ -28,12 +28,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2023-09-30</Date>
-            <Version>0.7.0</Version>
+        <Update release="2">
+            <Date>2025-02-15</Date>
+            <Version>0.7.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- **labwc: split extraneous rundeps and session into session sub-package**
- **xdg-desktop-portal-wlr: Update to 0.7.1**
- **sway: split extraneous rundeps and session into session sub-package**

Resolves https://github.com/getsolus/packages/issues/4698

**Test Plan**

Installed labwc and then was able to uninstall alacritty.

xdg-desktop-portal-wlr: Validated with screensharing

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
