### PR TITLE
sof-firmware: Update to v2.12

### DIFF
--- a/packages/s/sof-firmware/package.yml
+++ b/packages/s/sof-firmware/package.yml
@@ -1,9 +1,9 @@
 name       : sof-firmware
 homepage   : https://github.com/thesofproject/sof-bin
-version    : 2.11.3
-release    : 24
+version    : '2.12'
+release    : 25
 source     :
-    - https://github.com/thesofproject/sof-bin/releases/download/v2024.09.2/sof-bin-2024.09.2.tar.gz : 86e6841a55f1d6d1c91503a8482c1b475dbcadecdb6151bfa0ac0095d1d8a52a
+    - https://github.com/thesofproject/sof-bin/releases/download/v2025.01/sof-bin-2025.01.tar.gz : 34d565db757a32450106317cc51f38bf67962e0fc8b7f7c72e6e39fd89e99263
 license    :
     - BSD-3-Clause
     - ISC

--- a/packages/s/sof-firmware/pspec_x86_64.xml
+++ b/packages/s/sof-firmware/pspec_x86_64.xml
@@ -44,6 +44,10 @@
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace1-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace1-idisp-2ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace1-idisp-4ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace3-2ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace3-4ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace3-idisp-2ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace3-idisp-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-cavs25-2ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-cavs25-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-cavs25-idisp-2ch.tplg</Path>
@@ -52,7 +56,8 @@
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-idisp-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-idisp.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic.tplg</Path>
-            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-imx8mp-wm8960.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-2ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l23.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l3-2ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l3.tplg</Path>
@@ -60,12 +65,16 @@
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt1318-l12-rt714-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt711-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt711-l0-rt1316-l23-rt714-l1.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt712-l2-rt1320-l1.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt712-l2-rt1712-l3.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt713-l0-rt1318-l1-2ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt713-l2-rt1320-l13.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt722-l0.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs35l56-l01-fb8.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0-cs35l56-l12.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0-cs35l56-l23.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l3-cs35l56-l01-spkagg.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-es83x6-ssp1-hdmi-ssp02.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-es83x6-ssp1.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-hdmi-ssp02.tplg</Path>
@@ -96,8 +105,16 @@
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt713-l0-rt1318-l12-rt1713-l3.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt722-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-sdw-cs42l42-l0-max98363-l2.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-ptl-rt712-l2-rt1320-l1.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-ptl-rt713-l2-rt1320-l13.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-ptl-rt721-4ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-ptl-rt721.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-ptl-rt722-192k.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-ptl-rt722-4ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-ptl-rt722-96k.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-ptl-rt722.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-rpl-cs42l43-l0.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-tgl-cs35l56-l01-fb8.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-tgl-cs42l43-l3-cs35l56-l01.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-tgl-rt711-rt1308-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-tgl-rt711-rt1308-rt715.tplg</Path>
@@ -179,6 +196,7 @@
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-adl-rt1015-nau8825.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-adl-rt1019-nau8825.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-adl-rt1019-rt5682.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-adl-rt1316-l02-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-adl-rt1316-l1-mono-rt714-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-adl-rt1316-l12-rt714-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-tplg/sof-adl-rt1316-l2-mono-rt714-l0.tplg</Path>
@@ -520,6 +538,10 @@
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace1-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace1-idisp-2ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace1-idisp-4ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace3-2ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace3-4ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace3-idisp-2ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-ace3-idisp-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-cavs25-2ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-cavs25-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-cavs25-idisp-2ch.tplg</Path>
@@ -528,7 +550,8 @@
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-idisp-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic-idisp.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic.tplg</Path>
-            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-imx8mp-wm8960.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-2ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l23.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l3-2ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l3.tplg</Path>
@@ -536,12 +559,16 @@
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt1318-l12-rt714-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt711-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt711-l0-rt1316-l23-rt714-l1.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt712-l2-rt1320-l1.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt712-l2-rt1712-l3.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt713-l0-rt1318-l1-2ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt713-l2-rt1320-l13.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt722-l0.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs35l56-l01-fb8.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0-cs35l56-l12.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0-cs35l56-l23.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l0.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-cs42l43-l3-cs35l56-l01-spkagg.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-es83x6-ssp1-hdmi-ssp02.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-es83x6-ssp1.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-hdmi-ssp02.tplg</Path>
@@ -572,8 +599,16 @@
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt713-l0-rt1318-l12-rt1713-l3.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-rt722-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-mtl-sdw-cs42l42-l0-max98363-l2.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-ptl-rt712-l2-rt1320-l1.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-ptl-rt713-l2-rt1320-l13.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-ptl-rt721-4ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-ptl-rt721.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-ptl-rt722-192k.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-ptl-rt722-4ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-ptl-rt722-96k.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-ptl-rt722.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-rpl-cs42l43-l0.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-tgl-cs35l56-l01-fb8.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-tgl-cs42l43-l3-cs35l56-l01.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-tgl-rt711-rt1308-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-tgl-rt711-rt1308-rt715.tplg</Path>
@@ -655,6 +690,7 @@
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-adl-rt1015-nau8825.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-adl-rt1019-nau8825.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-adl-rt1019-rt5682.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-adl-rt1316-l02-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-adl-rt1316-l1-mono-rt714-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-adl-rt1316-l12-rt714-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-tplg/sof-adl-rt1316-l2-mono-rt714-l0.tplg</Path>
@@ -977,9 +1013,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2024-12-30</Date>
-            <Version>2.11.3</Version>
+        <Update release="25">
+            <Date>2025-02-16</Date>
+            <Version>2.12</Version>
             <Comment>Packaging update</Comment>
             <Name>Tracey Clark</Name>
             <Email>traceyc.dev@tlcnet.info</Email>


### PR DESCRIPTION
**Summary**
- The binary release includes latest versions of firmware, tool and DSP topologies for all Intel released platforms

**Highlights**

- New platforms: NXP IMX95
- Zephyr RTOS support added: AMD ACP6.0, MediaTek 8195/86/88
- HIFI5 optimization added to multiple components: IIR core, ARIA and volume
- Zephyr loadable module (LLEXT) support extended in SOF with capability to handle libraries of loadable modules.
- Support added to mark module functions as "cold", allowing code to be run directly from DRAM and save on SRAM usage on platforms supporting the feature.
- Topology: support for new product configurations for Intel LNL/ARL/MTL and NXP IMX95.
- Topology: microphone (IIR and DRC) and speaker processing (IIR, FIR and DRC) added to Intel DSP topologies with Soundwire codecs. This builds on similar support added to HDA codec based topologies added in SOF v2.11 release.
- And as with any new release, SOF 2.12 includes multiple bug fixes and optimizations to enhance overall performance and stability.

Full release notes [here](https://github.com/thesofproject/sof-bin/releases)

**Test Plan**

Verified firmware files were installed to correct paths.
Restarted pipewire.
    systemctl --user restart pipewire.service
Listened to music and triggered system sounds to verify that sound still works.

**Checklist**

- [x] Package was built and tested against unstable
