### PR TITLE
Update libgtk-layer-shell to 0.9.0

### DIFF
--- a/packages/l/libgtk-layer-shell/abi_symbols
+++ b/packages/l/libgtk-layer-shell/abi_symbols
@@ -1,3 +1,5 @@
+libgtk-layer-shell.so.0:custom_shell_surface_add_popup
+libgtk-layer-shell.so.0:custom_shell_surface_force_commit
 libgtk-layer-shell.so.0:custom_shell_surface_get_gtk_window
 libgtk-layer-shell.so.0:custom_shell_surface_get_layer_surface
 libgtk-layer-shell.so.0:custom_shell_surface_get_xdg_popup
@@ -5,6 +7,7 @@ libgtk-layer-shell.so.0:custom_shell_surface_get_xdg_toplevel
 libgtk-layer-shell.so.0:custom_shell_surface_init
 libgtk-layer-shell.so.0:custom_shell_surface_needs_commit
 libgtk-layer-shell.so.0:custom_shell_surface_remap
+libgtk-layer-shell.so.0:custom_shell_surface_unmap
 libgtk-layer-shell.so.0:gdk_anchor_hints_get_xdg_positioner_constraint_adjustment
 libgtk-layer-shell.so.0:gdk_gravity_get_xdg_positioner_anchor
 libgtk-layer-shell.so.0:gdk_gravity_get_xdg_positioner_gravity
@@ -193,6 +196,7 @@ libgtk-layer-shell.so.0:gdk_wayland_touch_data_priv_set_touch_down_serial
 libgtk-layer-shell.so.0:gdk_wayland_touch_data_priv_set_window
 libgtk-layer-shell.so.0:gdk_window_get_priv_grab_seat
 libgtk-layer-shell.so.0:gdk_window_get_priv_latest_serial
+libgtk-layer-shell.so.0:gdk_window_get_priv_pending_commit
 libgtk-layer-shell.so.0:gdk_window_impl_class_priv_get_apply_fullscreen_mode
 libgtk-layer-shell.so.0:gdk_window_impl_class_priv_get_beep
 libgtk-layer-shell.so.0:gdk_window_impl_class_priv_get_begin_move_drag
@@ -402,7 +406,12 @@ libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_display_server_server_d
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_display_server_server_decoration_supported
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_display_server_wl_subsurface
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_display_server_wl_surface
-libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_display_server_xdg_exported
+libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_display_server_xdg_exported_or_abort
+libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_display_server_xdg_exported_supported
+libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_display_server_xdg_exported_v1_or_abort
+libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_display_server_xdg_exported_v1_supported
+libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_display_server_xdg_exported_v2_or_abort
+libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_display_server_xdg_exported_v2_supported
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_display_server_xdg_popup_or_abort
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_display_server_xdg_popup_supported
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_display_server_xdg_surface_or_abort
@@ -441,7 +450,12 @@ libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_geometry_hints_ptr
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_geometry_mask_ptr
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_grab_input_seat
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_hint_ptr
-libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_imported_transient_for
+libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_imported_transient_for_or_abort
+libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_imported_transient_for_supported
+libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_imported_v1_transient_for_or_abort
+libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_imported_v1_transient_for_supported
+libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_imported_v2_transient_for_or_abort
+libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_imported_v2_transient_for_supported
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_initial_configure_received
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_initial_fullscreen_monitor
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_get_input_region
@@ -520,7 +534,9 @@ libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_display_server_outputs
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_display_server_server_decoration_or_abort
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_display_server_wl_subsurface
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_display_server_wl_surface
-libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_display_server_xdg_exported
+libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_display_server_xdg_exported_or_abort
+libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_display_server_xdg_exported_v1_or_abort
+libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_display_server_xdg_exported_v2_or_abort
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_display_server_xdg_popup_or_abort
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_display_server_xdg_surface_or_abort
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_display_server_xdg_toplevel_or_abort
@@ -536,7 +552,9 @@ libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_fixed_size_height_or_ab
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_fixed_size_width_or_abort
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_frame_callback_surfaces_or_abort
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_grab_input_seat
-libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_imported_transient_for
+libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_imported_transient_for_or_abort
+libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_imported_v1_transient_for_or_abort
+libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_imported_v2_transient_for_or_abort
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_initial_configure_received
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_initial_fullscreen_monitor
 libgtk-layer-shell.so.0:gdk_window_impl_wayland_priv_set_input_region
@@ -752,6 +770,7 @@ libgtk-layer-shell.so.0:gtk_layer_set_monitor
 libgtk-layer-shell.so.0:gtk_layer_set_namespace
 libgtk-layer-shell.so.0:gtk_layer_shell_edge_array_get_zwlr_layer_shell_v1_anchor
 libgtk-layer-shell.so.0:gtk_layer_shell_layer_get_zwlr_layer_shell_v1_layer
+libgtk-layer-shell.so.0:gtk_layer_try_force_commit
 libgtk-layer-shell.so.0:gtk_priv_access_init
 libgtk-layer-shell.so.0:gtk_priv_assert_gtk_version_valid
 libgtk-layer-shell.so.0:gtk_priv_warn_gtk_version_may_be_unsupported

--- a/packages/l/libgtk-layer-shell/abi_used_symbols
+++ b/packages/l/libgtk-layer-shell/abi_used_symbols
@@ -20,6 +20,10 @@ libglib-2.0.so.0:g_assertion_message_expr
 libglib-2.0.so.0:g_free
 libglib-2.0.so.0:g_hash_table_iter_init
 libglib-2.0.so.0:g_hash_table_iter_next
+libglib-2.0.so.0:g_list_append
+libglib-2.0.so.0:g_list_find
+libglib-2.0.so.0:g_list_remove
+libglib-2.0.so.0:g_list_remove_link
 libglib-2.0.so.0:g_log
 libglib-2.0.so.0:g_malloc
 libglib-2.0.so.0:g_malloc0

--- a/packages/l/libgtk-layer-shell/package.yml
+++ b/packages/l/libgtk-layer-shell/package.yml
@@ -1,8 +1,8 @@
 name       : libgtk-layer-shell
-version    : 0.8.2
-release    : 2
+version    : 0.9.0
+release    : 3
 source     :
-    - https://github.com/wmww/gtk-layer-shell/archive/refs/tags/v0.8.2.tar.gz : 254dd246303127c5d5236ea640f01a82e35d2d652a48d139dd669c832a0f0dce
+    - https://github.com/wmww/gtk-layer-shell/archive/refs/tags/v0.9.0.tar.gz : 3809e5565d9ed02e44bb73787ff218523e8760fef65830afe60ea7322e22da1c
 homepage   : https://wmww.github.io/gtk-layer-shell/
 license    : LGPL-3.0-or-later
 component  : desktop.gtk

--- a/packages/l/libgtk-layer-shell/pspec_x86_64.xml
+++ b/packages/l/libgtk-layer-shell/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libgtk-layer-shell</Name>
         <Homepage>https://wmww.github.io/gtk-layer-shell/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Packager>
         <License>LGPL-3.0-or-later</License>
         <PartOf>desktop.gtk</PartOf>
@@ -22,8 +22,7 @@
         <Files>
             <Path fileType="library">/usr/lib64/girepository-1.0/GtkLayerShell-0.1.typelib</Path>
             <Path fileType="library">/usr/lib64/libgtk-layer-shell.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgtk-layer-shell.so.0.8.2</Path>
-            <Path fileType="data">/usr/share/gir-1.0/GtkLayerShell-0.1.gir</Path>
+            <Path fileType="library">/usr/lib64/libgtk-layer-shell.so.0.9.0</Path>
         </Files>
     </Package>
     <Package>
@@ -33,23 +32,24 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">libgtk-layer-shell</Dependency>
+            <Dependency release="3">libgtk-layer-shell</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gtk-layer-shell/gtk-layer-shell.h</Path>
             <Path fileType="library">/usr/lib64/libgtk-layer-shell.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/gtk-layer-shell-0.pc</Path>
+            <Path fileType="data">/usr/share/gir-1.0/GtkLayerShell-0.1.gir</Path>
             <Path fileType="data">/usr/share/vala/vapi/gtk-layer-shell-0.deps</Path>
             <Path fileType="data">/usr/share/vala/vapi/gtk-layer-shell-0.vapi</Path>
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-03-24</Date>
-            <Version>0.8.2</Version>
+        <Update release="3">
+            <Date>2025-02-18</Date>
+            <Version>0.9.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/w/waybar/package.yml
+++ b/packages/w/waybar/package.yml
@@ -1,6 +1,6 @@
 name       : waybar
 version    : 0.11.0
-release    : 17
+release    : 18
 source     :
     - https://github.com/Alexays/Waybar/archive/refs/tags/0.11.0.tar.gz : 6a0e9f0f7f2eff503951958cbb16dc39041c0b67e86c35154e8507677c61be9d
 license    : MIT

--- a/packages/w/waybar/pspec_x86_64.xml
+++ b/packages/w/waybar/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>waybar</Name>
         <Homepage>https://github.com/Alexays/Waybar</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -79,12 +79,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2025-02-06</Date>
+        <Update release="18">
+            <Date>2025-02-18</Date>
             <Version>0.11.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/w/wlogout/package.yml
+++ b/packages/w/wlogout/package.yml
@@ -1,6 +1,6 @@
 name       : wlogout
 version    : 1.2.2
-release    : 1
+release    : 2
 source     :
     - https://github.com/ArtsyMacaw/wlogout/archive/refs/tags/1.2.2.tar.gz : 4c9204bfa19c73f51176c94c67711f54f3e393301c0809c61ae379054060fa46
 homepage   : https://github.com/ArtsyMacaw/wlogout

--- a/packages/w/wlogout/pspec_x86_64.xml
+++ b/packages/w/wlogout/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>wlogout</Name>
         <Homepage>https://github.com/ArtsyMacaw/wlogout</Homepage>
         <Packager>
-            <Name>Facundo Ciruzzi</Name>
-            <Email>ciruzzifacundo@gmail.com</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>desktop</PartOf>
@@ -42,12 +42,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-07-26</Date>
+        <Update release="2">
+            <Date>2025-02-18</Date>
             <Version>1.2.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Facundo Ciruzzi</Name>
-            <Email>ciruzzifacundo@gmail.com</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/x/xfce4-docklike-plugin/package.yml
+++ b/packages/x/xfce4-docklike-plugin/package.yml
@@ -1,6 +1,6 @@
 name       : xfce4-docklike-plugin
 version    : 0.4.3
-release    : 3
+release    : 4
 source     :
     - https://archive.xfce.org/src/panel-plugins/xfce4-docklike-plugin/0.4/xfce4-docklike-plugin-0.4.3.tar.bz2 : e81e16b4ab1c655a3202473d78cc81617bb4829e5dd102eecabf9addd7668a9d
 homepage   : https://docs.xfce.org/panel-plugins/xfce4-docklike-plugin/start

--- a/packages/x/xfce4-docklike-plugin/pspec_x86_64.xml
+++ b/packages/x/xfce4-docklike-plugin/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xfce4-docklike-plugin</Name>
         <Homepage>https://docs.xfce.org/panel-plugins/xfce4-docklike-plugin/start</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop.xfce</PartOf>
@@ -62,12 +62,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-12-24</Date>
+        <Update release="4">
+            <Date>2025-02-18</Date>
             <Version>0.4.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/x/xfce4-notifyd/package.yml
+++ b/packages/x/xfce4-notifyd/package.yml
@@ -1,6 +1,6 @@
 name       : xfce4-notifyd
 version    : 0.9.6
-release    : 8
+release    : 9
 source     :
     - https://archive.xfce.org/src/apps/xfce4-notifyd/0.9/xfce4-notifyd-0.9.6.tar.bz2 : 9e53265cca7d835c31b3c2c0d3ae961704870839ef583dcca3e4cc98ae3d2671
 homepage   : https://docs.xfce.org/apps/notifyd/start

--- a/packages/x/xfce4-notifyd/pspec_x86_64.xml
+++ b/packages/x/xfce4-notifyd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xfce4-notifyd</Name>
         <Homepage>https://docs.xfce.org/apps/notifyd/start</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.xfce</PartOf>
@@ -100,12 +100,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2024-12-15</Date>
+        <Update release="9">
+            <Date>2025-02-18</Date>
             <Version>0.9.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/x/xfce4-panel/package.yml
+++ b/packages/x/xfce4-panel/package.yml
@@ -1,6 +1,6 @@
 name       : xfce4-panel
 version    : 4.20.3
-release    : 16
+release    : 17
 source     :
     - https://archive.xfce.org/src/xfce/xfce4-panel/4.20/xfce4-panel-4.20.3.tar.bz2 : 4006dddf465a4ae02e14355941458c718f6da0896eae68435c9fd24fcd89b6b8
 homepage   : https://docs.xfce.org/xfce/xfce4-panel/start

--- a/packages/x/xfce4-panel/pspec_x86_64.xml
+++ b/packages/x/xfce4-panel/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xfce4-panel</Name>
         <Homepage>https://docs.xfce.org/xfce/xfce4-panel/start</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.xfce</PartOf>
@@ -222,7 +222,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="16">xfce4-panel</Dependency>
+            <Dependency release="17">xfce4-panel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/xfce4/libxfce4panel-2.0/libxfce4panel/libxfce4panel-config.h</Path>
@@ -283,12 +283,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2025-02-04</Date>
+        <Update release="17">
+            <Date>2025-02-18</Date>
             <Version>4.20.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/x/xfce4-session/package.yml
+++ b/packages/x/xfce4-session/package.yml
@@ -1,6 +1,6 @@
 name       : xfce4-session
 version    : 4.20.0
-release    : 14
+release    : 15
 source     :
     - https://archive.xfce.org/src/xfce/xfce4-session/4.20/xfce4-session-4.20.0.tar.bz2 : 5229233fe6ee692361cc28724886c5b08e0216d89f09c42d273191d38fd64f85
 homepage   : https://docs.xfce.org/xfce/xfce4-session/start

--- a/packages/x/xfce4-session/pspec_x86_64.xml
+++ b/packages/x/xfce4-session/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xfce4-session</Name>
         <Homepage>https://docs.xfce.org/xfce/xfce4-session/start</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.xfce</PartOf>
@@ -145,12 +145,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2024-12-15</Date>
+        <Update release="15">
+            <Date>2025-02-18</Date>
             <Version>4.20.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/x/xfce4-terminal/package.yml
+++ b/packages/x/xfce4-terminal/package.yml
@@ -1,6 +1,6 @@
 name       : xfce4-terminal
 version    : 1.1.4
-release    : 5
+release    : 6
 source     :
     - https://archive.xfce.org/src/apps/xfce4-terminal/1.1/xfce4-terminal-1.1.4.tar.bz2 : 873c921da1f4b986ffb459d4960789c9c063af98648c9f0ca146dc6f6f5b71b7
 homepage   : https://docs.xfce.org/apps/xfce4-terminal/start

--- a/packages/x/xfce4-terminal/pspec_x86_64.xml
+++ b/packages/x/xfce4-terminal/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xfce4-terminal</Name>
         <Homepage>https://docs.xfce.org/apps/xfce4-terminal/start</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.xfce</PartOf>
@@ -111,12 +111,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2024-12-26</Date>
+        <Update release="6">
+            <Date>2025-02-18</Date>
             <Version>1.1.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/x/xfce4-whiskermenu-plugin/package.yml
+++ b/packages/x/xfce4-whiskermenu-plugin/package.yml
@@ -1,6 +1,6 @@
 name       : xfce4-whiskermenu-plugin
 version    : 2.9.1
-release    : 5
+release    : 6
 source     :
     - https://archive.xfce.org/src/panel-plugins/xfce4-whiskermenu-plugin/2.9/xfce4-whiskermenu-plugin-2.9.1.tar.bz2 : 4d6a3664a5cf4087d9bdbce8964e1f42386f5625fbea8337b5cea4d6c0b7bdc4
 homepage   : https://gottcode.org/xfce4-whiskermenu-plugin/

--- a/packages/x/xfce4-whiskermenu-plugin/pspec_x86_64.xml
+++ b/packages/x/xfce4-whiskermenu-plugin/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xfce4-whiskermenu-plugin</Name>
         <Homepage>https://gottcode.org/xfce4-whiskermenu-plugin/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.xfce</PartOf>
@@ -91,12 +91,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2025-02-14</Date>
+        <Update release="6">
+            <Date>2025-02-18</Date>
             <Version>2.9.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/x/xfdesktop/package.yml
+++ b/packages/x/xfdesktop/package.yml
@@ -1,6 +1,6 @@
 name       : xfdesktop
 version    : 4.20.0
-release    : 7
+release    : 8
 source     :
     - https://archive.xfce.org/src/xfce/xfdesktop/4.20/xfdesktop-4.20.0.tar.bz2 : 227041ba80c7f3eb9c99dec817f1132b35d8aec7a4335703f61ba1735cd65632
 homepage   : https://docs.xfce.org/xfce/xfdesktop/start

--- a/packages/x/xfdesktop/pspec_x86_64.xml
+++ b/packages/x/xfdesktop/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xfdesktop</Name>
         <Homepage>https://docs.xfce.org/xfce/xfdesktop/start</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.xfce</PartOf>
@@ -119,12 +119,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2025-02-10</Date>
+        <Update release="8">
+            <Date>2025-02-18</Date>
             <Version>4.20.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joshua Strobl</Name>
+            <Email>me@joshuastrobl.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- **libgtk-layer-shell: Update to v0.9.0**
- **xfce4-session: Rebuild against gtk-layer-shell 0.9.0**
- **xfce4-terminal: Rebuild against gtk-layer-shell 0.9.0**
- **xfce4-docklike-plugin: Rebuild against gtk-layer-shell 0.9.0**
- **xfce4-notifyd: Rebuild against gtk-layer-shell 0.9.0**
- **xfce4-whiskermenu-plugin: Rebuild against gtk-layer-shell 0.9.0**
- **xfce4-panel: Rebuild against gtk-layer-shell 0.9.0**
- **xfdesktop: Rebuild against gtk-layer-shell 0.9.0**
- **wlogout: Rebuild against gtk-layer-shell 0.9.0**
- **waybar: Rebuild against gtk-layer-shell 0.9.0**

**Test Plan**

Build budgie-desktop-view (main) against libgtk-layer-shell. gtk_layer_shell_try_commit was now available, I was able to cook, and my local b-d-v supports Wayland again.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
