### PR TITLE
Python ipython sortout

### DIFF
--- a/packages/py/python-ipython/package.yml
+++ b/packages/py/python-ipython/package.yml
@@ -1,6 +1,6 @@
 name       : python-ipython
 version    : 8.32.0
-release    : 1
+release    : 2
 source     :
     - https://files.pythonhosted.org/packages/source/i/ipython/ipython-8.32.0.tar.gz : be2c91895b0b9ea7ba49d33b23e2040c352b33eb6a519cca7ce6e0c743444251
 homepage   : https://ipython.org/

--- a/packages/py/python-ipython/pspec_x86_64.xml
+++ b/packages/py/python-ipython/pspec_x86_64.xml
@@ -670,7 +670,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/IPython/utils/ulinecache.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/IPython/utils/version.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/IPython/utils/wildcard.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/__pycache__/tmpezl9yzkd.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/__pycache__/tmp7uetcpcp.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/ipython-8.32.0-py3.11.egg-info/PKG-INFO</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/ipython-8.32.0-py3.11.egg-info/SOURCES.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/ipython-8.32.0-py3.11.egg-info/dependency_links.txt</Path>
@@ -686,8 +686,8 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2025-02-16</Date>
+        <Update release="2">
+            <Date>2025-02-18</Date>
             <Version>8.32.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Joey Riches</Name>

--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -714,7 +714,6 @@
 		<Package>python-photohash</Package>
 		<Package>python2-pylint</Package>
 		<Package>python-seccure</Package>
-		<Package>python-ipython</Package>
 		<Package>python-pmw</Package>
 		<Package>python-pymol</Package>
 		<Package>python-pymol-dbginfo</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -994,7 +994,6 @@
 		<Package>python-photohash</Package>
 		<Package>python2-pylint</Package>
 		<Package>python-seccure</Package>
-		<Package>python-ipython</Package>
 		<Package>python-pmw</Package>
 		<Package>python-pymol</Package>
 		<Package>python-pymol-dbginfo</Package>


### PR DESCRIPTION
**Summary**

Undeprecate python-ipython to replace python3-ipython

NOTE: The undeprecation must be done first before performing the rest of the rebuilds

**Test Plan**

N/A

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
