### PR TITLE
zenergy: Add at v1.0

### DIFF
--- a/packages/z/zenergy/monitoring.yaml
+++ b/packages/z/zenergy/monitoring.yaml
@@ -1,0 +1,7 @@
+# Remove all comments before submitting, except CPE check date if none found
+releases:
+  id: 376820
+  rss: https://github.com/uni-dos/zenergy/tags.atom
+# No known CPE, checked 2025-02-19
+security:
+  cpe: ~

--- a/packages/z/zenergy/package.yml
+++ b/packages/z/zenergy/package.yml
@@ -1,0 +1,30 @@
+name       : zenergy
+version    : 1.0
+release    : 1
+source     :
+    - https://github.com/uni-dos/zenergy/archive/refs/tags/v1.0.tar.gz : 10c687bb1211c09a9e16d0a7f01c43f2c2fb21983d4714df4a346ba4dce50e55
+homepage   : https://github.com/uni-dos/zenergy
+license    : GPL-2.0-only
+component  : kernel.drivers
+summary    : AMD Zen energy driver
+description: |
+    Based on AMD_ENERGY driver, modified so non-root users can read it safely. Exposes the energy counters that are reported via the Running Average Power Limit (RAPL) Model-specific Registers (MSRs) through the hardware monitor (HWMON) sysfs interface.
+builddeps  :
+    - linux-current
+    - linux-current-headers
+    - linux-lts
+    - linux-lts-headers
+patterns   :
+    - current :
+        - /usr/lib64/modules/*.current
+build      : |
+     for KVER in %kernel_version_lts% %kernel_version_current%
+     do
+        %make KERNELDIR=/usr/lib64/modules/$KVER/build
+     done
+install    : |
+    for KVER in %kernel_version_lts% %kernel_version_current%
+    do
+        install -Dm00644 zenergy.ko -t $installdir%libdir%/modules/$KVER/kernel/drivers/platform/x86/
+        find "$installdir" -name '*.ko' -exec strip --strip-debug {} \; -exec zstd {} \; -exec rm -v {} \;
+    done

--- a/packages/z/zenergy/pspec_x86_64.xml
+++ b/packages/z/zenergy/pspec_x86_64.xml
@@ -1,0 +1,44 @@
+<PISI>
+    <Source>
+        <Name>zenergy</Name>
+        <Homepage>https://github.com/uni-dos/zenergy</Homepage>
+        <Packager>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
+        </Packager>
+        <License>GPL-2.0-only</License>
+        <PartOf>kernel.drivers</PartOf>
+        <Summary xml:lang="en">AMD Zen energy driver</Summary>
+        <Description xml:lang="en">Based on AMD_ENERGY driver, modified so non-root users can read it safely. Exposes the energy counters that are reported via the Running Average Power Limit (RAPL) Model-specific Registers (MSRs) through the hardware monitor (HWMON) sysfs interface.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>zenergy</Name>
+        <Summary xml:lang="en">AMD Zen energy driver</Summary>
+        <Description xml:lang="en">Based on AMD_ENERGY driver, modified so non-root users can read it safely. Exposes the energy counters that are reported via the Running Average Power Limit (RAPL) Model-specific Registers (MSRs) through the hardware monitor (HWMON) sysfs interface.
+</Description>
+        <PartOf>kernel.drivers</PartOf>
+        <Files>
+            <Path fileType="library">/usr/lib64/modules/6.6.75-264.lts/kernel/drivers/platform/x86/zenergy.ko.zst</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>zenergy-current</Name>
+        <Summary xml:lang="en">AMD Zen energy driver</Summary>
+        <Description xml:lang="en">Based on AMD_ENERGY driver, modified so non-root users can read it safely. Exposes the energy counters that are reported via the Running Average Power Limit (RAPL) Model-specific Registers (MSRs) through the hardware monitor (HWMON) sysfs interface.
+</Description>
+        <Files>
+            <Path fileType="library">/usr/lib64/modules/6.12.12-313.current/kernel/drivers/platform/x86/zenergy.ko.zst</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2025-02-19</Date>
+            <Version>1.0</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**
- introduce the zenergy driver
- Allows users to monitor energy usage of AMD Zen CPU's

**Test Plan**

Install module and run goverlay.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged 

Resolves https://github.com/getsolus/packages/issues/5006

The zenergy driver is a fork of amd_energy modified to allow nonroot users to monitor the energy usage of their AMD Zen Cpus. Combined with MangoHud, users are able to log power usage when gaming. 