### PR TITLE
github-cli: Update to v2.67.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.66.1
-release    : 66
+version    : 2.67.0
+release    : 67
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.66.1.tar.gz : e0bb259c61f15f41c1ca04632045d0aaf8fe456e2bc64f15dbfae41cc28d4fea
+    - https://github.com/cli/cli/archive/refs/tags/v2.67.0.tar.gz : 8f685207c63cebfde375a20b235e34012d75d4d41fbaad8b2cc1b8cfc1eceae8
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -161,6 +161,7 @@
             <Path fileType="man">/usr/share/man/man1/gh-release.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-repo-archive.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-repo-autolink-create.1</Path>
+            <Path fileType="man">/usr/share/man/man1/gh-repo-autolink-delete.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-repo-autolink-list.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-repo-autolink-view.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-repo-autolink.1</Path>
@@ -229,9 +230,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="66">
-            <Date>2025-02-03</Date>
-            <Version>2.66.1</Version>
+        <Update release="67">
+            <Date>2025-02-19</Date>
+            <Version>2.67.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Changelog available [here](https://github.com/cli/cli/releases/tag/v2.67.0).

**Security**
- CVE-2025-25204

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
