### PR TITLE
update budgie xfce branding

### DIFF
--- a/packages/b/budgie-desktop-branding/package.yml
+++ b/packages/b/budgie-desktop-branding/package.yml
@@ -1,8 +1,8 @@
 name       : budgie-desktop-branding
-version    : '23.0'
-release    : 77
+version    : '23.1'
+release    : 78
 source     :
-    - https://github.com/getsolus/budgie-desktop-branding/archive/refs/tags/v23.0.tar.gz : 317dcea94eaa8b42ad2f8bcaad33131c55a14403a01b1595984c3b8817f26795
+    - https://github.com/getsolus/budgie-desktop-branding/archive/refs/tags/v23.1.tar.gz : e5605da107e5f3a6659c323571d085381ee1021e5c4ce69f53635f651e1a9281
 homepage   : https://github.com/getsolus/budgie-desktop-branding
 license    : GPL-2.0-only
 summary    :

--- a/packages/b/budgie-desktop-branding/pspec_x86_64.xml
+++ b/packages/b/budgie-desktop-branding/pspec_x86_64.xml
@@ -36,7 +36,7 @@
         <Description xml:lang="en">Budgie LiveCD-specific Configuration</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="77">budgie-desktop-branding</Dependency>
+            <Dependency releaseFrom="78">budgie-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/glib-2.0/schemas/50_budgie_settings.gschema.override</Path>
@@ -44,9 +44,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="77">
-            <Date>2025-01-14</Date>
-            <Version>23.0</Version>
+        <Update release="78">
+            <Date>2025-02-19</Date>
+            <Version>23.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>

--- a/packages/x/xfce4-desktop-branding/package.yml
+++ b/packages/x/xfce4-desktop-branding/package.yml
@@ -1,8 +1,8 @@
 name       : xfce4-desktop-branding
-version    : 1.1.0
-release    : 15
+version    : 1.1.1
+release    : 16
 source     :
-    - https://github.com/getsolus/xfce4-desktop-branding/archive/refs/tags/v1.1.0.tar.gz : 30c460387c2519d97d4724cc2f231ba7ab11fe1fa5395f093275bb643a46f091
+    - https://github.com/getsolus/xfce4-desktop-branding/archive/refs/tags/v1.1.1.tar.gz : a2e5487d0364f77d3ca7211ca3f5d20cc427553f1c233d2e6df7054b5606dde6
 homepage   : https://github.com/getsolus/xfce4-desktop-branding
 license    : GPL-2.0-only
 component  :

--- a/packages/x/xfce4-desktop-branding/pspec_x86_64.xml
+++ b/packages/x/xfce4-desktop-branding/pspec_x86_64.xml
@@ -33,16 +33,16 @@
         <Description xml:lang="en">Defaults for the XFCE4 Desktop.</Description>
         <PartOf>desktop.xfce</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="15">xfce4-desktop-branding</Dependency>
+            <Dependency releaseFrom="16">xfce4-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/lightdm/lightdm.conf.d/xfce_config.conf</Path>
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2025-01-14</Date>
-            <Version>1.1.0</Version>
+        <Update release="16">
+            <Date>2025-02-19</Date>
+            <Version>1.1.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**

- **budgie-desktop-branding: Update to v23.1**
- **xfce4-desktop-branding: Update to v1.1.1**

**Test Plan**

Read `/usr/share/applications/budgie-mimeapps.list` and `/usr/share/applications/xfce-mimeapps.list` and see that Engrampa has been replaced by xarchiver.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
