### PR TITLE
picard: Update to 2.13.3

### DIFF
--- a/packages/p/picard/monitoring.yaml
+++ b/packages/p/picard/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 3633
+  rss: https://github.com/metabrainz/picard/releases.atom
+# No known CPE, checked 2025-02-20
+security:
+  cpe: ~

--- a/packages/p/picard/package.yml
+++ b/packages/p/picard/package.yml
@@ -1,8 +1,8 @@
 name       : picard
-version    : 2.12.3
-release    : 33
+version    : 2.13.3
+release    : 34
 source     :
-    - https://github.com/metabrainz/picard/archive/refs/tags/release-2.12.3.tar.gz : 1c39ab22cff39a7eede94510f6d035ea2d4600811b62f8f4a58399ede3d8e6a4
+    - https://github.com/metabrainz/picard/archive/refs/tags/release-2.13.3.tar.gz : 35c9eb3bf2eaaed2687faf50bebf9c13423de6f4ed404dbbf8f97cfb04526294
 homepage   : https://picard.musicbrainz.org/
 license    : GPL-2.0-or-later
 component  : multimedia.audio

--- a/packages/p/picard/pspec_x86_64.xml
+++ b/packages/p/picard/pspec_x86_64.xml
@@ -25,11 +25,11 @@ Additionally, there are several plugins available that extend Picard&apos;s feat
         <PartOf>multimedia.audio</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/picard</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/picard-2.12.3-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/picard-2.12.3-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/picard-2.12.3-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/picard-2.12.3-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/picard-2.12.3-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/picard-2.13.3-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/picard-2.13.3-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/picard-2.13.3-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/picard-2.13.3-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/picard-2.13.3-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/picard/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/picard/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/picard/__pycache__/album.cpython-311.pyc</Path>
@@ -585,6 +585,7 @@ Additionally, there are several plugins available that extend Picard&apos;s feat
             <Path fileType="localedata">/usr/share/locale/ko/LC_MESSAGES/picard-constants.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ko/LC_MESSAGES/picard-countries.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ko/LC_MESSAGES/picard.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/lt/LC_MESSAGES/picard-attributes.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lt/LC_MESSAGES/picard-constants.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lt/LC_MESSAGES/picard-countries.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lt/LC_MESSAGES/picard.mo</Path>
@@ -672,7 +673,9 @@ Additionally, there are several plugins available that extend Picard&apos;s feat
             <Path fileType="localedata">/usr/share/locale/zh_Hans/LC_MESSAGES/picard-attributes.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_Hans/LC_MESSAGES/picard-constants.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_Hans/LC_MESSAGES/picard-countries.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/zh_Hant/LC_MESSAGES/picard-attributes.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_Hant/LC_MESSAGES/picard-constants.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/zh_Hant/LC_MESSAGES/picard-countries.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/picard-attributes.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/picard-countries.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/picard.mo</Path>
@@ -680,9 +683,9 @@ Additionally, there are several plugins available that extend Picard&apos;s feat
         </Files>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2024-09-10</Date>
-            <Version>2.12.3</Version>
+        <Update release="34">
+            <Date>2025-02-20</Date>
+            <Version>2.13.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Marcus Mellor</Name>
             <Email>infinitymdm@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Update MusicBrainz Picard to the latest upstream release.

Enhancements:
- Avoid manual copying of authentication tokens
- Support PKCE for OAuth2 authorization
- Implement OAuth2 token revocation on the server
- Add context menu action to merge original and new metadata values

Bugfixes:
- Fix endless recursion on opening script editor dialog
- Fix inaccessible filename options when target path has permissions errors
- Correct capitalization for some headings
- Fix crashes caused by poorly formatted date tags
- Fix incorrect disc numbers when submitting release
- Fix crash when right-clicking on a multi-selection of new tag values
- Correctly handle cover image size for OPUS audio file metadata

Full changelog [here](https://github.com/metabrainz/picard/compare/release-2.12.3...release-2.13.3)

**Test Plan**

Open a few album folders in Picard, test clustering and tagging

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
