### PR TITLE
typst: Update to 0.13.0

### DIFF
--- a/packages/t/typst/abi_used_symbols
+++ b/packages/t/typst/abi_used_symbols
@@ -4,7 +4,9 @@ libc.so.6:__res_init
 libc.so.6:__xpg_strerror_r
 libc.so.6:_exit
 libc.so.6:abort
+libc.so.6:accept4
 libc.so.6:bcmp
+libc.so.6:bind
 libc.so.6:calloc
 libc.so.6:chdir
 libc.so.6:chmod
@@ -17,7 +19,6 @@ libc.so.6:dl_iterate_phdr
 libc.so.6:dlsym
 libc.so.6:dup2
 libc.so.6:environ
-libc.so.6:epoll_create
 libc.so.6:epoll_create1
 libc.so.6:epoll_ctl
 libc.so.6:epoll_wait
@@ -48,12 +49,13 @@ libc.so.6:getsockopt
 libc.so.6:getuid
 libc.so.6:gnu_get_libc_version
 libc.so.6:inotify_add_watch
-libc.so.6:inotify_init
+libc.so.6:inotify_init1
 libc.so.6:inotify_rm_watch
 libc.so.6:ioctl
 libc.so.6:isatty
 libc.so.6:lchown
 libc.so.6:linkat
+libc.so.6:listen
 libc.so.6:lseek64
 libc.so.6:lstat64
 libc.so.6:lutimes
@@ -108,13 +110,13 @@ libc.so.6:sched_getaffinity
 libc.so.6:sched_yield
 libc.so.6:send
 libc.so.6:sendmsg
-libc.so.6:setenv
 libc.so.6:setgid
 libc.so.6:setgroups
 libc.so.6:setpgid
 libc.so.6:setsid
 libc.so.6:setsockopt
 libc.so.6:setuid
+libc.so.6:shutdown
 libc.so.6:sigaction
 libc.so.6:sigaddset
 libc.so.6:sigaltstack
@@ -225,6 +227,7 @@ libssl.so.3:OPENSSL_init_ssl
 libssl.so.3:SSL_CTX_ctrl
 libssl.so.3:SSL_CTX_free
 libssl.so.3:SSL_CTX_get_cert_store
+libssl.so.3:SSL_CTX_load_verify_locations
 libssl.so.3:SSL_CTX_new
 libssl.so.3:SSL_CTX_set_cert_store
 libssl.so.3:SSL_CTX_set_cipher_list

--- a/packages/t/typst/monitoring.yaml
+++ b/packages/t/typst/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 332526
+  rss: https://github.com/typst/typst/releases.atom
+# No known CPE, checked 2025-02-20
+security:
+  cpe: ~

--- a/packages/t/typst/package.yml
+++ b/packages/t/typst/package.yml
@@ -1,8 +1,8 @@
 name       : typst
-version    : 0.12.0
-release    : 5
+version    : 0.13.0
+release    : 6
 source     :
-    - https://github.com/typst/typst/archive/refs/tags/v0.12.0.tar.gz : 5e92463965c0cf6aa003a3bacd1c68591ef2dc0db59dcdccb8f7b084836a1266
+    - https://github.com/typst/typst/archive/refs/tags/v0.13.0.tar.gz : 5a7224e32a555ac647ff202667a183b80d35539b685b3ce64bedf5d4e5a1a286
 homepage   : https://typst.app
 license    : Apache-2.0
 component  : office

--- a/packages/t/typst/pspec_x86_64.xml
+++ b/packages/t/typst/pspec_x86_64.xml
@@ -24,9 +24,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2024-10-26</Date>
-            <Version>0.12.0</Version>
+        <Update release="6">
+            <Date>2025-02-19</Date>
+            <Version>0.13.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Marcus Mellor</Name>
             <Email>infinitymdm@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Update to the latest upstream release.

Enhancements:
- There is now a distinction between proper paragraphs and inline-level content
- `outline` has a better out-of-the-box look and is more customizable
- `curve` supersedes `path` for simpler and more flexible Bézier curves
- `image` now supports raw pixel raster formats (for generating images within Typst documents)
- Functions that accept file paths now also accept raw bytes
- Wasm plubins are more flexible and automatically run multi-threaded
- Single-letter strings in math are no longer displayed in italics
- You can now specify which charset should be covered by which font family
- `pdf.embed` lets you embed arbitrary files in the exported PDF
- Experimental HTML export is now available (behind the `--features html` CLI flag)

For more details and a migration guide, see the [announcment blog post](https://typst.app/blog/2025/typst-0.13/).

You can find a more detailed changelog with links into the documentation on [typst.app/docs](https://typst.app/docs/changelog/0.13.0/).

**Test Plan**

Use typst to compile several documents, including some conference papers and project reports.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
