### PR TITLE
eza: Update to v0.20.22

### DIFF
--- a/packages/e/eza/package.yml
+++ b/packages/e/eza/package.yml
@@ -1,8 +1,8 @@
 name       : eza
-version    : 0.20.20
-release    : 43
+version    : 0.20.22
+release    : 44
 source     :
-    - https://github.com/eza-community/eza/archive/refs/tags/v0.20.20.tar.gz : 8731184ff1b1d3dbd6bb8fda8f750780a58ccac682fd6344d92160dc518937de
+    - https://github.com/eza-community/eza/archive/refs/tags/v0.20.22.tar.gz : 81a8b5c86054042da50a9a7aad38117a051b7e9fd6de3bcece1391e39d2edfd4
 homepage   : https://github.com/eza-community/eza
 license    : EUPL-1.2
 component  : system.utils

--- a/packages/e/eza/pspec_x86_64.xml
+++ b/packages/e/eza/pspec_x86_64.xml
@@ -33,9 +33,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="43">
-            <Date>2025-02-07</Date>
-            <Version>0.20.20</Version>
+        <Update release="44">
+            <Date>2025-02-20</Date>
+            <Version>0.20.22</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Add prettier icon for *.prettierignore
- Add icon for *.hrl
- Add photoshop icon for *.psb
- Add eslint icon for .eslintignore
- Add renovate icon for renovate.json
- Add elixir icon for *.eex, *.leex and mix.lock

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

List files and folders.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
