### PR TITLE
tlp: Update to v1.8.0

### DIFF
--- a/packages/t/tlp/package.yml
+++ b/packages/t/tlp/package.yml
@@ -1,8 +1,8 @@
 name       : tlp
-version    : 1.7.0
-release    : 21
+version    : 1.8.0
+release    : 22
 source     :
-    - https://github.com/linrunner/TLP/archive/refs/tags/1.7.0.tar.gz : 547ff90bef0ea035f0ff6d7546d0d867690ebf60beec426885a884ee8d023e2e
+    - https://github.com/linrunner/TLP/archive/refs/tags/1.8.0.tar.gz : 65515f7652064a1be2940c031e045b762924bb1dbd94f5e58e3b765113cf5210
 homepage   : https://linrunner.de/tlp/
 license    : GPL-2.0-only
 component  : system.utils

--- a/packages/t/tlp/pspec_x86_64.xml
+++ b/packages/t/tlp/pspec_x86_64.xml
@@ -85,7 +85,10 @@
             <Path fileType="data">/usr/share/tlp/bat.d/40-sony</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/45-system76</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/50-toshiba</Path>
+            <Path fileType="data">/usr/share/tlp/bat.d/55-cros-ec</Path>
+            <Path fileType="data">/usr/share/tlp/bat.d/56-framework</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/60-macbook</Path>
+            <Path fileType="data">/usr/share/tlp/bat.d/65-dell</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/89-asus</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/90-generic</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/TEMPLATE</Path>
@@ -114,9 +117,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2024-12-09</Date>
-            <Version>1.7.0</Version>
+        <Update release="22">
+            <Date>2025-02-22</Date>
+            <Version>1.8.0</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Battery care is at the forefront of this new release, with charge thresholds and recalibrate/discharge for Chromebooks and Framework laptops, and charge thresholds for Dell laptops.
- Full changelog [here](https://github.com/linrunner/TLP/blob/main/changelog)

**Test Plan**

- disable power-profile-daemon
- enable tlp
- show status with `tlp-stat`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
