### PR TITLE
packagekit: Remove "unsupported" warning

### DIFF
--- a/packages/p/packagekit/package.yml
+++ b/packages/p/packagekit/package.yml
@@ -1,14 +1,13 @@
 name       : packagekit
 version    : 1.3.0
-release    : 33
+release    : 34
 source     :
     - git|https://github.com/getsolus/PackageKit.git : e33f35b2209cc8de99e48c1db48891f5d94a08d8
 license    : GPL-2.0-or-later
 component  : programming.library
 homepage   : https://www.freedesktop.org/software/PackageKit/
-summary    : A D-BUS abstraction layer that allows the user to manage packages in a secure way using a cross-distro, cross-architecture API. (NOT SUPPORTED)
+summary    : A D-BUS abstraction layer that allows the user to manage packages in a secure way using a cross-distro, cross-architecture API.
 description: |
-    This package is experimental and not supported! Help will not currently be provided.
     PackageKit is a DBUS abstraction layer that allows the session user to manage packages in a secure way using a cross-distro, cross-architecture API.
 builddeps  :
     - pkgconfig(appstream)

--- a/packages/p/packagekit/pspec_x86_64.xml
+++ b/packages/p/packagekit/pspec_x86_64.xml
@@ -3,22 +3,20 @@
         <Name>packagekit</Name>
         <Homepage>https://www.freedesktop.org/software/PackageKit/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>programming.library</PartOf>
-        <Summary xml:lang="en">A D-BUS abstraction layer that allows the user to manage packages in a secure way using a cross-distro, cross-architecture API. (NOT SUPPORTED)</Summary>
-        <Description xml:lang="en">This package is experimental and not supported! Help will not currently be provided.
-PackageKit is a DBUS abstraction layer that allows the session user to manage packages in a secure way using a cross-distro, cross-architecture API.
+        <Summary xml:lang="en">A D-BUS abstraction layer that allows the user to manage packages in a secure way using a cross-distro, cross-architecture API.</Summary>
+        <Description xml:lang="en">PackageKit is a DBUS abstraction layer that allows the session user to manage packages in a secure way using a cross-distro, cross-architecture API.
 </Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>packagekit</Name>
-        <Summary xml:lang="en">A D-BUS abstraction layer that allows the user to manage packages in a secure way using a cross-distro, cross-architecture API. (NOT SUPPORTED)</Summary>
-        <Description xml:lang="en">This package is experimental and not supported! Help will not currently be provided.
-PackageKit is a DBUS abstraction layer that allows the session user to manage packages in a secure way using a cross-distro, cross-architecture API.
+        <Summary xml:lang="en">A D-BUS abstraction layer that allows the user to manage packages in a secure way using a cross-distro, cross-architecture API.</Summary>
+        <Description xml:lang="en">PackageKit is a DBUS abstraction layer that allows the session user to manage packages in a secure way using a cross-distro, cross-architecture API.
 </Description>
         <PartOf>programming.library</PartOf>
         <Files>
@@ -144,12 +142,11 @@ PackageKit is a DBUS abstraction layer that allows the session user to manage pa
     <Package>
         <Name>packagekit-devel</Name>
         <Summary xml:lang="en">Development files for packagekit</Summary>
-        <Description xml:lang="en">This package is experimental and not supported! Help will not currently be provided.
-PackageKit is a DBUS abstraction layer that allows the session user to manage packages in a secure way using a cross-distro, cross-architecture API.
+        <Description xml:lang="en">PackageKit is a DBUS abstraction layer that allows the session user to manage packages in a secure way using a cross-distro, cross-architecture API.
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="33">packagekit</Dependency>
+            <Dependency release="34">packagekit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/PackageKit/packagekit-glib2/packagekit.h</Path>
@@ -197,12 +194,12 @@ PackageKit is a DBUS abstraction layer that allows the session user to manage pa
         </Files>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2024-10-03</Date>
+        <Update release="34">
+            <Date>2025-02-24</Date>
             <Version>1.3.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
PackageKit software centers are now supported on Solus, so we don't need to have a scary warning on the PackageKit package anymore.

**Test Plan**
- Build the package from this PR.
- Install the resulting .eopkg.
- Sanity check that PackageKit isn't completely broken.

This change only touches the description and summary fields, so extensive testing is unnecessary.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
