### PR TITLE
opera-stable: Add appstream metainfo

### DIFF
--- a/packages/o/opera-stable/files/com.opera.Opera.metainfo.xml
+++ b/packages/o/opera-stable/files/com.opera.Opera.metainfo.xml
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.opera.Opera</id>
+  <launchable type="desktop-id">opera.desktop</launchable>
+  <name>Opera</name>
+  <developer_name>Opera</developer_name>
+  <summary>Your personal browser</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LicenseRef-proprietary</project_license>
+  <url type="homepage">https://www.opera.com/</url>
+  <url type="faq">https://help.opera.com/en/faq/</url>
+  <url type="help">https://www.opera.com/help</url>
+  <description>
+    <p>
+      Faster, safer and smarter than default browsers. Opera Browser is fully-featured for privacy, security, and everything you do online.
+    </p>
+    <p>
+      Opera's free VPN, Ad blocker, and Flow file sharing. Just a few of the must-have features built into Opera for faster, smoother and distraction-free browsing designed to improve your online experience.
+    </p>
+    <p>
+      Experience faster, distraction-free browsing with Ad blocking, and browse privately. Smoothly sync your data and send files between Opera on Mac, Windows, Linux, iOS, Android, and Chromebook.
+    </p>
+  </description>
+  <keywords>
+    <keyword>web browser</keyword>
+  </keywords>
+  <categories>
+    <category>Network</category>
+    <category>WebBrowser</category>
+    <category>InstantMessaging</category>
+    <category>Chat</category>
+    <category>Feed</category>
+  </categories>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/flathub/com.opera.Opera/master/screenshots/opera-newpage.png</image>
+      <caption>Speed dial page</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/flathub/com.opera.Opera/master/screenshots/opera-dark-newpage.png</image>
+      <caption>Speed dial page - dark theme</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/flathub/com.opera.Opera/master/screenshots/opera-dark-updated.png</image>
+      <caption>Client upgraded page - dark theme</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/flathub/com.opera.Opera/master/screenshots/opera-updated.png</image>
+      <caption>Client upgraded page</caption>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="117.0.5408.35" date="2025-02-19">
+      <description></description>
+    </release>
+    <release version="117.0.5408.32" date="2025-02-13">
+      <description/>
+    </release>
+    <release version="116.0.5366.71" date="2025-01-28">
+      <description/>
+    </release>
+    <release version="116.0.5366.51" date="2025-01-21">
+      <description/>
+    </release>
+    <release version="116.0.5366.35" date="2025-01-14">
+      <description/>
+    </release>
+    <release version="116.0.5366.21" date="2025-01-08">
+      <description/>
+    </release>
+    <release version="115.0.5322.119" date="2024-12-23">
+      <description/>
+    </release>
+    <release version="115.0.5322.109" date="2024-12-18">
+      <description/>
+    </release>
+    <release version="115.0.5322.77" date="2024-12-05">
+      <description/>
+    </release>
+    <release version="115.0.5322.68" date="2024-11-27">
+      <description/>
+    </release>
+    <release version="114.0.5282.185" date="2024-11-12">
+      <description/>
+    </release>
+    <release version="114.0.5282.154" date="2024-11-05">
+      <description/>
+    </release>
+    <release version="114.0.5282.144" date="2024-10-31">
+      <description/>
+    </release>
+    <release version="114.0.5282.115" date="2024-10-23">
+      <description/>
+    </release>
+    <release version="114.0.5282.102" date="2024-10-15">
+      <description/>
+    </release>
+    <release version="114.0.5282.86" date="2024-10-07">
+      <description/>
+    </release>
+    <release version="114.0.5282.21" date="2024-09-25">
+      <description/>
+    </release>
+    <release version="113.0.5230.86" date="2024-09-11">
+      <description/>
+    </release>
+    <release version="113.0.5230.62" date="2024-09-04">
+      <description/>
+    </release>
+    <release version="113.0.5230.32" date="2024-08-23">
+      <description/>
+    </release>
+    <release version="112.0.5197.53" date="2024-08-06">
+      <description/>
+    </release>
+    <release version="112.0.5197.30" date="2024-07-19">
+      <description/>
+    </release>
+    <release version="112.0.5197.25" date="2024-07-16">
+      <description/>
+    </release>
+    <release version="112.0.5197.24" date="2024-07-11">
+      <url type="details">https://blogs.opera.com/desktop/changelog-for-112/</url>
+      <description>
+        <ul>
+          <li>Chromium Update: Opera 112 is built on the latest Chromium version 126.0.6478.62, ensuring that users benefit from the most recent security patches.</li>
+          <li>Visual Enhancements: The “Add to Opera” text on Start Page is now clearly visible in light mode, and we’ve resolved numerous issues related to Tab Art and the display of emojis on tabs.</li>
+          <li>Performance and Stability: We have resolved numerous crashes and fixed issues with corrupted extensions after their removal. Additionally, we have ensured that the Adblocker is blocking or displaying ads according to user settings.</li>
+          <li>User Interface and Usability: We’ve fixed the rounded corners in fullscreen mode, enhanced workspace switch animations on Mac, and improved the handling of tab islands.</li>
+        </ul>
+      </description>
+    </release>
+    <release version="111.0.5168.61" date="2024-07-04">
+      <url type="details">https://blogs.opera.com/desktop/changelog-for-111/</url>
+      <description>
+        <ul>
+          <li>Emoji Disappearance on Tabs After Restart/Update: Corrected an issue where emojis on tabs would disappear after a restart or update, ensuring consistent emoji visibility.</li>
+          <li>Emoji Visibility Behind Tab Island Handle: Resolved an issue where emojis were displayed behind the tab island handle, ensuring clear visibility.</li>
+          <li>Hover Emoji Display During Intro on Windows: Fixed a bug causing emojis to appear at the top of the window when hovering during the intro on Windows systems.</li>
+        </ul>
+      </description>
+    </release>
+    <release version="111.0.5168.55" date="2024-07-01"/>
+    <release version="111.0.5168.25" date="2024-06-12"/>
+    <release version="110.0.5130.66" date="2024-06-04"/>
+    <release version="110.0.5130.64" date="2024-06-04"/>
+    <release version="110.0.5130.49" date="2024-05-28"/>
+    <release version="110.0.5130.39" date="2024-05-24"/>
+    <release version="110.0.5130.35" date="2024-05-22"/>
+    <release version="110.0.5130.23" date="2024-05-14">
+      <url type="details">https://blogs.opera.com/desktop/changelog-for-110/</url>
+      <description>
+        <ul>
+          <li>Chromium Update: The browser has been updated to Chromium version 124.0.6367.62, enhancing both performance and security.</li>
+          <li>Scrollbar Button Fix: The issue of invisible scrollbar buttons on Windows has been resolved, providing a smoother user experience.</li>
+          <li>Show Duplicate Indicator on Link: This feature helps users identify and avoid navigating to duplicate links.</li>
+          <li>Drag Multiple Tabs: Users can now drag multiple tabs simultaneously, improving tab management and workflow efficiency.</li>
+        </ul>
+      </description>
+    </release>
+    <release version="109.0.5097.80" date="2024-05-08"/>
+    <release version="109.0.5097.38" date="2024-04-02"/>
+    <release version="109.0.5097.35" date="2024-03-28"/>
+    <release version="109.0.5097.33" date="2024-03-27"/>
+    <release version="108.0.5067.40" date="2024-03-21"/>
+    <release version="108.0.5067.29" date="2024-03-14"/>
+    <release version="108.0.5067.24" date="2024-03-11"/>
+    <release version="108.0.5067.20" date="2024-03-05"/>
+    <release version="107.0.5045.36" date="2024-02-22"/>
+    <release version="107.0.5045.21" date="2024-02-13"/>
+    <release version="107.0.5045.15" date="2024-02-07"/>
+    <release version="106.0.4998.70" date="2024-01-31"/>
+    <release version="106.0.4998.66" date="2024-01-25"/>
+    <release version="106.0.4998.52" date="2024-01-18"/>
+    <release version="106.0.4998.28" date="2024-01-05"/>
+    <release version="106.0.4998.19" date="2023-12-22"/>
+    <release version="106.0.4998.16" date="2023-12-19"/>
+    <release version="105.0.4970.48" date="2023-12-13"/>
+    <release version="105.0.4970.34" date="2023-12-05"/>
+    <release version="105.0.4970.29" date="2023-11-30"/>
+    <release version="105.0.4970.21" date="2023-11-22"/>
+    <release version="105.0.4970.16" date="2023-11-17"/>
+    <release version="105.0.4970.13" date="2023-11-14"/>
+    <release version="104.0.4944.54" date="2023-11-09"/>
+    <release version="104.0.4944.36" date="2023-10-30"/>
+    <release version="104.0.4944.33" date="2023-10-25"/>
+    <release version="104.0.4944.28" date="2023-10-24"/>
+    <release version="104.0.4944.23" date="2023-10-23"/>
+    <release version="103.0.4928.34" date="2023-10-16"/>
+    <release version="103.0.4928.26" date="2023-10-09"/>
+    <release version="103.0.4928.16" date="2023-10-03"/>
+    <release version="102.0.4880.78" date="2023-09-29"/>
+    <release version="102.0.4880.70" date="2023-09-27"/>
+    <release version="102.0.4880.56" date="2023-09-15"/>
+    <release version="102.0.4880.51" date="2023-09-13"/>
+    <release version="102.0.4880.46" date="2023-09-11"/>
+    <release version="102.0.4880.40" date="2023-09-06"/>
+    <release version="102.0.4880.33" date="2023-08-31"/>
+    <release version="102.0.4880.29" date="2023-08-29"/>
+    <release version="102.0.4880.16" date="2023-08-23"/>
+    <release version="101.0.4843.58" date="2023-08-17"/>
+    <release version="101.0.4843.43" date="2023-08-09"/>
+    <release version="101.0.4843.33" date="2023-08-02"/>
+    <release version="101.0.4843.25" date="2023-07-26"/>
+    <release version="100.0.4815.76" date="2023-07-17"/>
+    <release version="100.0.4815.54" date="2023-07-11"/>
+    <release version="100.0.4815.47" date="2023-07-06"/>
+    <release version="100.0.4815.30" date="2023-06-29"/>
+    <release version="100.0.4815.21" date="2023-06-20"/>
+    <release version="100.0.4815.20" date="2023-06-20"/>
+    <release version="99.0.4788.77" date="2023-06-15"/>
+    <release version="99.0.4788.65" date="2023-06-07"/>
+    <release version="99.0.4788.47" date="2023-06-02"/>
+    <release version="99.0.4788.31" date="2023-05-25"/>
+    <release version="99.0.4788.13" date="2023-05-18"/>
+    <release version="98.0.4759.39" date="2023-05-08"/>
+    <release version="98.0.4759.15" date="2023-04-26"/>
+    <release version="98.0.4759.6" date="2023-04-20"/>
+    <release version="97.0.4719.83" date="2023-04-18"/>
+    <release version="97.0.4719.63" date="2023-04-05"/>
+    <release version="97.0.4719.43" date="2023-03-29"/>
+    <release version="97.0.4719.28" date="2023-03-23"/>
+    <release version="97.0.4719.26" date="2023-03-22"/>
+    <release version="96.0.4693.80" date="2023-03-15"/>
+    <release version="96.0.4693.50" date="2023-03-08"/>
+    <release version="96.0.4693.31" date="2023-03-02"/>
+    <release version="96.0.4693.20" date="2023-02-22"/>
+    <release version="95.0.4635.46" date="2023-02-15"/>
+    <release version="95.0.4635.37" date="2023-02-08"/>
+    <release version="95.0.4635.25" date="2023-02-01"/>
+    <release version="94.0.4606.76" date="2023-01-19"/>
+    <release version="94.0.4606.65" date="2023-01-12"/>
+    <release version="94.0.4606.54" date="2023-01-04"/>
+    <release version="94.0.4606.38" date="2022-12-20"/>
+  </releases>
+  <content_rating type="oars-1.1"/>
+  <update_contact>prace@vseta.cz</update_contact>
+</component>

--- a/packages/o/opera-stable/package.yml
+++ b/packages/o/opera-stable/package.yml
@@ -1,8 +1,8 @@
 name       : opera-stable
 version    : 117.0.5408.35
-release    : 328
+release    : 329
 source     :
-    - https://get.geo.opera.com/pub/opera/desktop/117.0.5408.35/linux/opera-stable_117.0.5408.35_amd64.deb : ff1c053d3522398b7c33d912e5a7ca7d1bc42449388bf947a15fa9a22f038a45
+    - https://ftp.opera.com/pub/opera/desktop/117.0.5408.35/linux/opera-stable_117.0.5408.35_amd64.deb : ff1c053d3522398b7c33d912e5a7ca7d1bc42449388bf947a15fa9a22f038a45
 license    : Distributable
 homepage   : https://www.opera.com
 extract    : no
@@ -45,3 +45,6 @@ install    : |
 
     # Use system chromium ffmpeg
     rm $installdir/usr/lib/opera/libffmpeg.so
+
+    # Install AppStream metainfo
+    install -Dm00644 $pkgfiles/com.opera.Opera.metainfo.xml $installdir/usr/share/metainfo/com.opera.Opera.metainfo.xml

--- a/packages/o/opera-stable/pspec_x86_64.xml
+++ b/packages/o/opera-stable/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>opera-stable</Name>
         <Homepage>https://www.opera.com</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>Distributable</License>
         <PartOf>network.web.browser</PartOf>
@@ -194,17 +194,18 @@
             <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/opera.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/opera.png</Path>
             <Path fileType="data">/usr/share/menu/opera-stable</Path>
+            <Path fileType="data">/usr/share/metainfo/com.opera.Opera.metainfo.xml</Path>
             <Path fileType="data">/usr/share/mime/packages/opera-stable.xml</Path>
             <Path fileType="data">/usr/share/pixmaps/opera.xpm</Path>
         </Files>
     </Package>
     <History>
-        <Update release="328">
-            <Date>2025-02-19</Date>
+        <Update release="329">
+            <Date>2025-02-24</Date>
             <Version>117.0.5408.35</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add appstream metainfo (Part of getsolus/packages#1389)

**Test Plan**

<!-- Short description of how the package was tested -->
`appstream-builder --packages-dir=. --include-failed -v`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
