### PR TITLE
socat: Update to v1.8.0.3

### DIFF
--- a/packages/s/socat/abi_used_symbols
+++ b/packages/s/socat/abi_used_symbols
@@ -7,6 +7,7 @@ libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
 libc.so.6:__isoc23_fscanf
+libc.so.6:__isoc23_sscanf
 libc.so.6:__isoc23_strtol
 libc.so.6:__isoc23_strtoul
 libc.so.6:__libc_start_main
@@ -89,6 +90,8 @@ libc.so.6:getppid
 libc.so.6:getprotobynumber_r
 libc.so.6:getpwnam
 libc.so.6:getpwuid
+libc.so.6:getresgid
+libc.so.6:getresuid
 libc.so.6:getrlimit
 libc.so.6:getservbyname
 libc.so.6:getsid
@@ -122,6 +125,7 @@ libc.so.6:mkfifo
 libc.so.6:mknod
 libc.so.6:mkstemp
 libc.so.6:mq_close
+libc.so.6:mq_getattr
 libc.so.6:mq_open
 libc.so.6:mq_receive
 libc.so.6:mq_send
@@ -223,7 +227,6 @@ libcrypto.so.3:DH_set0_pqg
 libcrypto.so.3:EC_KEY_new_by_curve_name
 libcrypto.so.3:ERR_error_string
 libcrypto.so.3:ERR_error_string_n
-libcrypto.so.3:ERR_func_error_string
 libcrypto.so.3:ERR_get_error
 libcrypto.so.3:ERR_lib_error_string
 libcrypto.so.3:ERR_peek_error

--- a/packages/s/socat/monitoring.yaml
+++ b/packages/s/socat/monitoring.yaml
@@ -1,0 +1,7 @@
+releases:
+  id: 4848
+  rss: ~
+security:
+  cpe:
+    - vendor: dest-unreach
+      product: socat

--- a/packages/s/socat/package.yml
+++ b/packages/s/socat/package.yml
@@ -1,8 +1,8 @@
 name       : socat
-version    : 1.8.0.0
-release    : 7
+version    : 1.8.0.3
+release    : 8
 source     :
-    - http://www.dest-unreach.org/socat/download/socat-1.8.0.0.tar.gz : 6010f4f311e5ebe0e63c77f78613d264253680006ac8979f52b0711a9a231e82
+    - http://www.dest-unreach.org/socat/download/socat-1.8.0.3.tar.gz : a9f9eb6cfb9aa6b1b4b8fe260edbac3f2c743f294db1e362b932eb3feca37ba4
 homepage   : http://www.dest-unreach.org/socat/
 license    : GPL-2.0-or-later
 component  : network.util

--- a/packages/s/socat/pspec_x86_64.xml
+++ b/packages/s/socat/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>socat</Name>
         <Homepage>http://www.dest-unreach.org/socat/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>network.util</PartOf>
@@ -32,12 +32,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2024-06-09</Date>
-            <Version>1.8.0.0</Version>
+        <Update release="8">
+            <Date>2025-02-24</Date>
+            <Version>1.8.0.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Refer to changelog [here](http://www.dest-unreach.org/socat/CHANGES)

Resolves https://github.com/getsolus/packages/issues/5114

**Security**

- CVE-2024-54661

**Test Plan**

- kwallet-pam is a revdep. kwallet runs

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
