### PR TITLE
freefilesync: Add appstream metainfo

### DIFF
--- a/packages/f/freefilesync/files/org.freefilesync.FreeFileSync.appdata.xml
+++ b/packages/f/freefilesync/files/org.freefilesync.FreeFileSync.appdata.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.freefilesync.FreeFileSync.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+  <name>FreeFileSync</name>
+  <summary>Visual folder comparison and synchronization</summary>
+  <developer id="freefilesync.org">
+    <name>Zenju</name>
+  </developer>
+  <description>
+    <p>FreeFileSync is a folder comparison and synchronization software that creates and manages backup copies of your important files. Instead of copying every file every time, FreeFileSync determines the differences between a source and a target folder and transfers only the minimum amount of data needed.</p>
+    <p><em>NOTE:</em>
+FreeFileSync allows you to open files in external applications or run custom scripts. However, when sandboxed as Flatpak, external applications or scripts from your host system are not accessible. If you want to give FreeFileSync access to your host applications/commands, run this command in terminal to give it access to your session DBus:
+<code>flatpak override --user --socket=session-bus org.freefilesync.FreeFileSync</code>
+(Or you can use Flatseal to configure this permission).
+Now you can run any app/command, if you prefix it with "<code>flatpak-spawn --host</code>", i.e.:
+<code>flatpak-spawn --host mycommand arguments</code></p>
+  </description>
+  <url type="homepage">https://freefilesync.org</url>
+  <url type="bugtracker">https://freefilesync.org/forum/</url>
+  <url type="faq">https://freefilesync.org/faq.php</url>
+  <url type="help">https://freefilesync.org/manual.php</url>
+  <url type="donation">https://freefilesync.org/download.php</url>
+  <screenshots>
+    <screenshot type="default" priority="4">
+      <caption>Manual synchronization of two folders</caption>
+      <image>https://www.freefilesync.org/images/screenshots/openSUSE.png</image>
+    </screenshot>
+    <screenshot priority="3">
+      <caption>Online storage support</caption>
+      <image>https://www.freefilesync.org/images/screenshots/sftp.png</image>
+    </screenshot>
+    <screenshot priority="2">
+      <caption>Synchronization settings</caption>
+      <image>https://www.freefilesync.org/images/screenshots/sync-settings.png</image>
+    </screenshot>
+    <screenshot priority="1">
+      <caption>Binary comparison</caption>
+      <image>https://freefilesync.org/images/screenshots/binary.png</image>
+    </screenshot>
+  </screenshots>
+  <launchable type="desktop-id">FreeFileSync.desktop</launchable>
+  <launchable type="desktop-id">RealTimeSync.desktop</launchable>
+  <provides>
+    <binary>FreeFileSync</binary>
+    <binary>RealTimeSync</binary>
+  </provides>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <display_length side="longest" compare="ge">1200</display_length>
+  </recommends>
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">mild</content_attribute>
+    <content_attribute id="money-purchasing">mild</content_attribute>
+  </content_rating>
+</component>

--- a/packages/f/freefilesync/package.yml
+++ b/packages/f/freefilesync/package.yml
@@ -1,6 +1,6 @@
 name       : freefilesync
 version    : '13.6'
-release    : 6
+release    : 7
 source     :
     - https://sources.getsol.us/FreeFileSync_13.6_Source.zip : 949e0b8a2b14cbcc3a38f778e3026e7c7fa89756308ce7c541fab38f71d66f6c
 homepage   : https://freefilesync.org/
@@ -47,3 +47,4 @@ install    : |
     install -Dm00644 $workdir/Build/Resources/* $installdir/usr/share/freefilesync
     install -Dm00644 $pkgfiles/FreeFileSync.png $installdir/usr/share/pixmaps/FreeFileSync.png
     install -Dm00644 $pkgfiles/RealTimeSync.png $installdir/usr/share/pixmaps/RealTimeSync.png
+    install -Dm00644 $pkgfiles/org.freefilesync.FreeFileSync.appdata.xml $installdir/usr/share/metainfo/org.freefilesync.FreeFileSync.appdata.xml

--- a/packages/f/freefilesync/pspec_x86_64.xml
+++ b/packages/f/freefilesync/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>freefilesync</Name>
         <Homepage>https://freefilesync.org/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.util</PartOf>
@@ -40,17 +40,18 @@
             <Path fileType="data">/usr/share/freefilesync/notify.wav</Path>
             <Path fileType="data">/usr/share/freefilesync/notify2.wav</Path>
             <Path fileType="data">/usr/share/freefilesync/remind.wav</Path>
+            <Path fileType="data">/usr/share/metainfo/org.freefilesync.FreeFileSync.appdata.xml</Path>
             <Path fileType="data">/usr/share/pixmaps/FreeFileSync.png</Path>
             <Path fileType="data">/usr/share/pixmaps/RealTimeSync.png</Path>
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2024-12-19</Date>
+        <Update release="7">
+            <Date>2025-02-25</Date>
             <Version>13.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add appstream metainfo (Part of getsolus/packages#1389)

**Test Plan**

<!-- Short description of how the package was tested -->
`appstream-builder --packages-dir=. --include-failed -v`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
