### PR TITLE
wlroots: Update to v0.18.2

### DIFF
--- a/packages/w/wlroots/package.yml
+++ b/packages/w/wlroots/package.yml
@@ -1,8 +1,8 @@
 name       : wlroots
-version    : 0.18.1
-release    : 21
+version    : 0.18.2
+release    : 22
 source     :
-    - https://gitlab.freedesktop.org/wlroots/wlroots/-/archive/0.18.1/wlroots-0.18.1.tar.gz : 10084bba57bf4162cd81eb79c2a0bee0d02c7ccd747eac0a7021b45b10bb821c
+    - https://gitlab.freedesktop.org/wlroots/wlroots/-/archive/0.18.2/wlroots-0.18.2.tar.bz2 : a28061f7778f28f7be377fd4d6f0ebd58cb2a63b52460e9fde28e2ab43e80cab
 license    : MIT
 component  : desktop.library
 homepage   : https://gitlab.freedesktop.org/wlroots/wlroots

--- a/packages/w/wlroots/pspec_x86_64.xml
+++ b/packages/w/wlroots/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>wlroots</Name>
         <Homepage>https://gitlab.freedesktop.org/wlroots/wlroots</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>desktop.library</PartOf>
@@ -30,7 +30,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="21">wlroots</Dependency>
+            <Dependency release="22">wlroots</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wlroots-0.18/wlr/backend.h</Path>
@@ -151,12 +151,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2024-10-28</Date>
-            <Version>0.18.1</Version>
+        <Update release="22">
+            <Date>2025-02-25</Date>
+            <Version>0.18.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- dnd: ensure internal dnd handlers are unlinked on xwm_destroy()
- xwayland: fix xdg->xwayland drag-and-drop
- backend/wayland: Account for shm buffer offset
- backend/drm: check whether clipped damage is empty
- output-management-v1: only create custom mode object for enabled heads
- backend/drm: check buffer format for multi-GPU
- backend/drm: fix drmModePageFlip() when disabling CRTC on legacy uAPI
- render/vulkan: fix crash on OOM
- xwayland: listen to drag focus destroy signal
- xwayland: remove loop to find drag focus surface
- data-device: reset focused surface when destroyed
- wlr_keyboard: don't emit key event for duplicated keycodes

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new Budgie Desktop Wayland session with labwc.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
