### PR TITLE
nemo: Update to v6.4.5

### DIFF
--- a/packages/n/nemo/package.yml
+++ b/packages/n/nemo/package.yml
@@ -1,8 +1,8 @@
 name       : nemo
-version    : 6.4.4
-release    : 13
+version    : 6.4.5
+release    : 14
 source     :
-    - https://github.com/linuxmint/nemo/archive/refs/tags/6.4.4.tar.gz : f70adb63e3a50b613bdc029ad3172bd88fb75ca96422d823f2657abdd8303230
+    - https://github.com/linuxmint/nemo/archive/refs/tags/6.4.5.tar.gz : 06dc3c7884dc0ec8ce4d55ed48f0cd77cbf7bd6be5dba9ed883d49a43118ebdf
 homepage   : https://github.com/linuxmint/nemo
 license    :
     - GPL-2.0-or-later

--- a/packages/n/nemo/pspec_x86_64.xml
+++ b/packages/n/nemo/pspec_x86_64.xml
@@ -142,7 +142,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="13">nemo</Dependency>
+            <Dependency release="14">nemo</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/nemo/libnemo-extension/nemo-column-provider.h</Path>
@@ -165,9 +165,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2025-02-19</Date>
-            <Version>6.4.4</Version>
+        <Update release="14">
+            <Date>2025-02-26</Date>
+            <Version>6.4.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- layout editor: Don't use gettext.install to set up the locale
- nemo-places-sidebar.c: Fix query-tooltip callback
- nemo-style-fallback-mandatory.css: Add fallback support for the floating status bar

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Open Nemo and navigate between different folders.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
