### PR TITLE
flask-cors: Update to v5.0.1

### DIFF
--- a/packages/f/flask-cors/package.yml
+++ b/packages/f/flask-cors/package.yml
@@ -1,8 +1,8 @@
 name       : flask-cors
-version    : 4.0.2
-release    : 11
+version    : 5.0.1
+release    : 12
 source     :
-    - https://github.com/corydolphin/flask-cors/archive/refs/tags/4.0.2.tar.gz : f252679632d1a6c6f5c628d271bdbf3def30fea07c86aea6b7227dda07b83795
+    - https://github.com/corydolphin/flask-cors/archive/refs/tags/5.0.1.tar.gz : fb1d01eb16187b945856fc207980b3c1c637ed7e47e29a12d63d7aecf937d5fe
 license    : MIT
 homepage   : https://flask-cors.corydolphin.com/
 component  : programming.python
@@ -11,9 +11,12 @@ description: |
     A Flask extension for handling Cross Origin Resource Sharing (CORS), making cross-origin AJAX possible.
 builddeps  :
     - flask
-    - python-nose
-    - python-pytest
+    - python-build
+    - python-installer
+    - python-packaging
     - python-wheel
+checkdeps  :
+    - python-pytest
 rundeps    :
     - flask
 build      : |
@@ -21,4 +24,4 @@ build      : |
 install    : |
     %python3_install
 check      : |
-    %python3_test
+    %python3_test pytest -v

--- a/packages/f/flask-cors/pspec_x86_64.xml
+++ b/packages/f/flask-cors/pspec_x86_64.xml
@@ -20,17 +20,20 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/Flask_Cors-4.0.2-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/Flask_Cors-4.0.2-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/Flask_Cors-4.0.2-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/Flask_Cors-4.0.2-py3.11.egg-info/not-zip-safe</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/Flask_Cors-4.0.2-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/Flask_Cors-4.0.2-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/flask_cors-0.0.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/flask_cors-0.0.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/flask_cors-0.0.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/flask_cors-0.0.1.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/flask_cors/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/flask_cors/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/flask_cors/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/flask_cors/__pycache__/core.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/flask_cors/__pycache__/core.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/flask_cors/__pycache__/decorator.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/flask_cors/__pycache__/decorator.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/flask_cors/__pycache__/extension.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/flask_cors/__pycache__/extension.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/flask_cors/__pycache__/version.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/flask_cors/__pycache__/version.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/flask_cors/core.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/flask_cors/decorator.py</Path>
@@ -39,9 +42,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2024-08-30</Date>
-            <Version>4.0.2</Version>
+        <Update release="12">
+            <Date>2025-02-27</Date>
+            <Version>5.0.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Highlighted change:
- Breaking: Change default to disable private network access

Release notes:
- [5.0.0](https://github.com/corydolphin/flask-cors/releases/tag/5.0.0)
- [5.0.1](https://github.com/corydolphin/flask-cors/releases/tag/5.0.1)

**Test Plan**

Ran some examples from the project's README and docs

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
