### PR TITLE
lutris: Update to v0.5.19

### DIFF
--- a/packages/l/lutris/package.yml
+++ b/packages/l/lutris/package.yml
@@ -1,8 +1,8 @@
 name       : lutris
-version    : 0.5.18
-release    : 79
+version    : 0.5.19
+release    : 80
 source     :
-    - https://github.com/lutris/lutris/archive/refs/tags/v0.5.18.tar.gz : b9d4ad052d1c750910940d5cc7c583967c0c65c1584b7f4a1abaf46e40c3d8d1
+    - https://github.com/lutris/lutris/archive/refs/tags/v0.5.19.tar.gz : 54edba892517473920b04423037dd480afb5e3b5e197040db33d15b1535d5096
 license    : GPL-3.0-or-later
 component  : games
 homepage   : https://lutris.net/

--- a/packages/l/lutris/pspec_x86_64.xml
+++ b/packages/l/lutris/pspec_x86_64.xml
@@ -92,6 +92,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/__pycache__/storage_box.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/__pycache__/sysinfo_box.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/__pycache__/updates_box.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/__pycache__/widget_generator.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/accounts_box.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/add_game_dialog.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/base_config_box.py</Path>
@@ -110,6 +111,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/storage_box.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/sysinfo_box.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/updates_box.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/config/widget_generator.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/dialogs/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/dialogs/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/dialogs/__pycache__/cache.cpython-311.pyc</Path>
@@ -175,7 +177,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/widgets/__pycache__/notifications.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/widgets/__pycache__/progress_box.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/widgets/__pycache__/scaled_image.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/widgets/__pycache__/searchable_combobox.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/widgets/__pycache__/searchable_entrybox.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/widgets/__pycache__/sidebar.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/widgets/__pycache__/status_icon.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/widgets/__pycache__/utils.cpython-311.pyc</Path>
@@ -192,7 +194,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/widgets/notifications.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/widgets/progress_box.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/widgets/scaled_image.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/widgets/searchable_combobox.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/widgets/searchable_entrybox.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/widgets/sidebar.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/widgets/status_icon.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/gui/widgets/utils.py</Path>
@@ -216,14 +218,14 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/migrations/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/migrations/__pycache__/__init__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/migrations/__pycache__/mess_to_mame.cpython-311.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/migrations/__pycache__/migrate_banners.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/migrations/__pycache__/migrate_ge_proton.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/migrations/__pycache__/migrate_hidden_category.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/migrations/__pycache__/migrate_hidden_ids.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/migrations/__pycache__/migrate_sortname.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/migrations/__pycache__/migrate_steam_appids.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/migrations/__pycache__/retrieve_discord_appids.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/migrations/mess_to_mame.py</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/migrations/migrate_banners.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/migrations/migrate_ge_proton.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/migrations/migrate_hidden_category.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/migrations/migrate_hidden_ids.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/migrations/migrate_sortname.py</Path>
@@ -379,6 +381,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/__pycache__/downloader.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/__pycache__/extract.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/__pycache__/fileio.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/__pycache__/files.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/__pycache__/flatpak.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/__pycache__/game_finder.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/__pycache__/gamecontrollerdb.cpython-311.pyc</Path>
@@ -446,6 +449,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/egs/egs_launcher.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/extract.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/fileio.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/files.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/flatpak.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/game_finder.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/gamecontrollerdb.py</Path>
@@ -489,7 +493,9 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/process_watcher.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/resources.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/retroarch/__pycache__/core_config.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/retroarch/__pycache__/firmware.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/retroarch/core_config.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/retroarch/firmware.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/savesync.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/settings.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/shell.py</Path>
@@ -558,18 +564,19 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/xdgshortcuts.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/lutris/util/yaml.py</Path>
             <Path fileType="data">/usr/share/applications/net.lutris.Lutris.desktop</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/lutris.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/16x16/apps/lutris.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/22x22/apps/lutris.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/24x24/apps/lutris.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/lutris.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/lutris.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/lutris.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/lutris.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/net.lutris.Lutris.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16/apps/net.lutris.Lutris.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/22x22/apps/net.lutris.Lutris.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24/apps/net.lutris.Lutris.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/net.lutris.Lutris.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/net.lutris.Lutris.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/net.lutris.Lutris.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/net.lutris.Lutris.svg</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/lutris.mo</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/lutris.mo</Path>
             <Path fileType="localedata">/usr/share/locale/el/LC_MESSAGES/lutris.mo</Path>
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/lutris.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/fa/LC_MESSAGES/lutris.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fi/LC_MESSAGES/lutris.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/lutris.mo</Path>
             <Path fileType="localedata">/usr/share/locale/hr/LC_MESSAGES/lutris.mo</Path>
@@ -627,9 +634,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="79">
-            <Date>2024-12-02</Date>
-            <Version>0.5.18</Version>
+        <Update release="80">
+            <Date>2025-02-27</Date>
+            <Version>0.5.19</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fix Proton integration bugs so Proton-fixes are applied
- Do not offer DXVK, VKD3D, D3D Extras or DDXVK-NVAPI on Proton versions
- The "Enable Esync" and "Enable Fsync" settings are now passed on to Proton
- DXVK's integrated D8VK will be enabled in Proton
- Emulator BIOS file location (used by libretro) may be set in Preferences
- Obtain the release year from GOG and Itch.io
- MAME Machine setting uses a searchable entry for its enourmous list
- Support for importing Commodore 64 ROMs

**Test Plan**

Installed, played, configured and uninstalled a (Windows) game

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
