### PR TITLE
msmtp: Update to 1.8.28

### DIFF
--- a/packages/m/msmtp/MAINTAINERS.md
+++ b/packages/m/msmtp/MAINTAINERS.md
@@ -1,0 +1,4 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Matthias Homann
+  - Email: palto@mailbox.org

--- a/packages/m/msmtp/abi_used_symbols
+++ b/packages/m/msmtp/abi_used_symbols
@@ -1,4 +1,5 @@
 libc.so.6:__ctype_b_loc
+libc.so.6:__ctype_tolower_loc
 libc.so.6:__ctype_toupper_loc
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
@@ -60,7 +61,6 @@ libc.so.6:getpwuid
 libc.so.6:getsockname
 libc.so.6:getsockopt
 libc.so.6:getuid
-libc.so.6:gmtime
 libc.so.6:inet_ntop
 libc.so.6:inet_pton
 libc.so.6:listen
@@ -70,6 +70,7 @@ libc.so.6:memchr
 libc.so.6:memcpy
 libc.so.6:memset
 libc.so.6:nanosleep
+libc.so.6:nl_langinfo
 libc.so.6:openlog
 libc.so.6:optarg
 libc.so.6:optind
@@ -131,9 +132,11 @@ libgnutls.so.30:gnutls_handshake
 libgnutls.so.30:gnutls_init
 libgnutls.so.30:gnutls_pkcs11_set_pin_function
 libgnutls.so.30:gnutls_priority_set_direct
+libgnutls.so.30:gnutls_protocol_get_version
 libgnutls.so.30:gnutls_record_recv
 libgnutls.so.30:gnutls_record_send
 libgnutls.so.30:gnutls_server_name_set
+libgnutls.so.30:gnutls_session_channel_binding
 libgnutls.so.30:gnutls_session_get_desc
 libgnutls.so.30:gnutls_set_default_priority
 libgnutls.so.30:gnutls_strerror

--- a/packages/m/msmtp/monitoring.yaml
+++ b/packages/m/msmtp/monitoring.yaml
@@ -1,0 +1,7 @@
+releases:
+  id: 2024
+  rss: https://marlam.de/msmtp/news/rss.xml
+security:
+  cpe:
+    - vendor: marlam
+      product: msmtp

--- a/packages/m/msmtp/package.yml
+++ b/packages/m/msmtp/package.yml
@@ -1,8 +1,8 @@
 name       : msmtp
-version    : 1.8.25
-release    : 9
+version    : 1.8.28
+release    : 10
 source     :
-    - https://marlam.de/msmtp/releases/msmtp-1.8.25.tar.xz : 2dfe1dbbb397d26fe0b0b6b2e9cd2efdf9d72dd42d18e70d7f363ada2652d738
+    - https://marlam.de/msmtp/releases/msmtp-1.8.28.tar.xz : 3a57f155f54e4860f7dd42138d9bea1af615b99dfab5ab4cd728fc8c09a647a4
 homepage   : https://marlam.de/msmtp
 license    : GPL-3.0-or-later
 component  : network.clients

--- a/packages/m/msmtp/pspec_x86_64.xml
+++ b/packages/m/msmtp/pspec_x86_64.xml
@@ -25,6 +25,7 @@
             <Path fileType="info">/usr/share/info/msmtp.info</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/msmtp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/eo/LC_MESSAGES/msmtp.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/msmtp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/msmtp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/msmtp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ro/LC_MESSAGES/msmtp.mo</Path>
@@ -38,9 +39,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2023-11-05</Date>
-            <Version>1.8.25</Version>
+        <Update release="10">
+            <Date>2025-03-02</Date>
+            <Version>1.8.28</Version>
             <Comment>Packaging update</Comment>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>


### PR DESCRIPTION
**Summary**

Bugfixes:

- The option -F was fixed

Enhancements:

- Support for SCRAM-SHA-*-PLUS authentication
- A Resent-From header, if present, is now taken into consideration when --read-envelope-from is used.
- Improved msmtpq script
- Improved internationalization support
- Translations were updated

Full release notes:

- [News](https://marlam.de/msmtp/news/)

Packaging:

- Added MAINTAINERS.md
- Added monitoring.yaml

**Test Plan**

Installed locally and sent a view emails using it.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
