### PR TITLE
fritzing-parts: Update to 1.0.4

### DIFF
--- a/packages/f/fritzing-parts/MAINTAINERS.md
+++ b/packages/f/fritzing-parts/MAINTAINERS.md
@@ -1,0 +1,4 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Matthias Homann
+  - Email: palto@mailbox.org

--- a/packages/f/fritzing-parts/monitoring.yaml
+++ b/packages/f/fritzing-parts/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 8274
+  rss: ~
+security:
+  # No known CPE, last checked 2025-03-02
+  cpe: ~

--- a/packages/f/fritzing-parts/package.yml
+++ b/packages/f/fritzing-parts/package.yml
@@ -1,10 +1,10 @@
 name       : fritzing-parts
-version    : 1.0.2
-release    : 6
+version    : 1.0.4
+release    : 7
 source     :
     # This must be a git clone according to: https://github.com/fritzing/fritzing-app/wiki/2.1-Part-file-format
-    # Use latest commit from branch "1.0.2"
-    - git|https://github.com/fritzing/fritzing-parts.git : 015626e6cafb1fc7831c2e536d97ca2275a83d32
+    # Use latest commit from branch "1.0.4"
+    - git|https://github.com/fritzing/fritzing-parts.git : 76235099ed556e52003de63522fdd74e61d53a36
 homepage   : https://fritzing.org/
 license    : CC-BY-SA-3.0
 component  : programming

--- a/packages/f/fritzing-parts/pspec_x86_64.xml
+++ b/packages/f/fritzing-parts/pspec_x86_64.xml
@@ -275,7 +275,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/DFRobot-DFPlayer-Mini.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/DFRobot-PH-sensor.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/DIP_Relay_D31A_14fadb0_002.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/DRV8825_breakout.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/DRV8825_breakout_1be7926_002.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/DS1302.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/DS1307.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/DS18B20.fzp</Path>
@@ -319,7 +319,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/HLK-PM12.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/HMC5883L_Breakout-v11.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/HMC6352-v18.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Half_breadboard.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Half_breadboard_v2.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Heltec_WiFi_LoRa_32_V2.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/HiFive1.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Humidity_Sensor_SHT15.fzp</Path>
@@ -331,6 +331,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/ISD1932 Breakout-v11.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/ITG-3200-v11.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/IchigoJamT.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Infineon_CY8CKIT-062S2-AI.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Infineon_H-BRIDGE_KIT2GO.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/Infineon_MY_IOT_ADAPTER.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/InvenSense_MPU6050.fzp</Path>
@@ -646,7 +647,6 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/XBee-Regulated-v12.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/XL4016_DC_DC_Converter.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/YumoE6B2_1.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/acpower.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/ad5330 breakout-v11.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/aisler_cloud.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/amplified-mic-electret_15e7e05_002.fzp</Path>
@@ -696,6 +696,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/bmp180_breakout.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/breadboard.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/breadboard2.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/calliope-mini-3_2.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/canbus_shield-v12.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/capacitor_ceramic_100mil.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/capacitor_ceramic_200mil.fzp</Path>
@@ -725,7 +726,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/crystal-smd-3.2x2.5mm.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/crystal.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/dc_motor.fzp</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/dcpower2.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/dcpower_pulse.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/diac_diode_db3.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/din-5_midi_connector.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/diode_1N4001_300mil.fzp</Path>
@@ -850,6 +851,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/optical_jack_orj-8.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/optical_jack_otj-8.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/optocoupler.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/oscilloscope_4channel_v1.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/peltier element.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/piezo sensor.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/pinoccio-proto.fzp</Path>
@@ -863,6 +865,15 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/potentiometer_slider_5.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/potentiometer_trimmer_12mm_5.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/potentiometer_trimmer_6mm_5.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/power_supply_dc_5.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/power_supply_dc_lab_1.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/power_supply_generic_pulse_1.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/power_supply_pulse_1.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/power_supply_pwm_1.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/power_supply_sawtooth_1.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/power_supply_sine_1.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/power_supply_square_1.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/power_supply_triangular_1.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/powerbutton_adafruit.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/proto_shield_v6MEGA.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/core/pushbutton_2_horizontal.fzp</Path>
@@ -1888,6 +1899,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/Cherry-MX-Keyswitch_44a6316938b1b0a2c83ac0276dac5539_22.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/DB25M.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/DIP_Relay_D31A.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/DRV8825_breakout.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/DS18B20.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/DS18B20__5240d891e23cace35a4de6acc361c049.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/Dial Potentiometer with switch_4.fzp</Path>
@@ -1903,6 +1915,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/Generic male header.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/HC-05-male_50ef644d14e5d1dfea3ec45159c12c96_4.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/HC-SR04 Ultrasonic Distance Sensor.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/Half_breadboard.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/LBT2088AH.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/LDR_photocell_300mil_v4.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/LED-blue-5mm (2).fzp</Path>
@@ -1993,6 +2006,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/WeMos-D1-mini-female-headers-above.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/WeMos-D1-mini-male-headers-above.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/accelerometer-adxl.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/acpower.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/alps-starter-pot9mm_5.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/arduino-mega-r3-shield_two_layer.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/arduino-shield_two_layer.fzp</Path>
@@ -2037,6 +2051,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/crystal (2).fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/crystal.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/dc_motor.fzp</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/dcpower2.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/diode_1N4001_300mil.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/diode_zener_0_5w_3_6v_300mil.fzp</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/obsolete/diode_zener_1w_4_7v_300mil.fzp</Path>
@@ -2257,6 +2272,37 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checkascii.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checkcase.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checkcopies.py</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/checkascii.py</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/checkcase.py</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/checkcopies.py</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/connectors_misnumbered.py</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/explain_errors.md</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/fzp_checker_runner.py</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/fzp_checkers.py</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/fzp_utils.py</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/invisibleconnectors.py</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/nolayeridcheck.txt</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/requirements.txt</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/svgNoLayer.py</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/svg_checkers.py</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/svg_utils.py</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/test_checkers.py</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/test_data/core/css_connector.fzp.test</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/test_data/core/font_size.fzp.test</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/test_data/core/hybrid_connectors.fzp.test</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/test_data/core/invalid_xml.fzp.test</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/test_data/core/pcb_only.fzp.test</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/test_data/core/stroke_test.fzp.test</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/test_data/core/valid_xml.fzp.test</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/test_data/svg/core/breadboard/hybrid_connectors_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/test_data/svg/core/icon/hybrid_connectors_icon.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/test_data/svg/core/icon/plain_pcb.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/test_data/svg/core/pcb/css_connector.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/test_data/svg/core/pcb/font_size.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/test_data/svg/core/pcb/hybrid_connectors_pcb.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/test_data/svg/core/pcb/pcb-arduino-shield.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/test_data/svg/core/pcb/stroke_test.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/checks/test_data/svg/core/schematic/hybrid_connectors_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/cleanschem.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/connectors_misnumbered.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/copper01find.py</Path>
@@ -2274,7 +2320,6 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/fzpzclean.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/genmoduleidfzphash.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/grep.py</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/invisibleconnectors.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/listfamilies.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/listpropnames.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/nolayeridcheck.txt</Path>
@@ -2294,6 +2339,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/syncconnectors.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/tagsmd.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/thtsmd.py</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/tools/obsolete.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/unusedsvgs.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/unzeroradius.py</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/scripts/utf8stats.py</Path>
@@ -2453,7 +2499,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/DENSO 174917 ECU socket 48pin_1.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/DFRobot-DFPlayer-Mini_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/DIP_Relay_D31A_14fadb0_002.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/DRV8825_breakout_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/DRV8825_breakout_breadboard_1be7926_002.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/DS1302_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/DS1307_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/DS18B20_breadboard.svg</Path>
@@ -2514,6 +2560,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/ISD1932 Breakout-v11_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/ITG-3200-v11_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/IchigoJamT_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Infineon_CY8CKIT-062S2-AI_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Infineon_H-BRIDGE_KIT2GO_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/Infineon_MY_IOT_ADAPTER_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/JST-03JQ-BT_breadboard.svg</Path>
@@ -2809,6 +2856,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/bmp180_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/breadboard2.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/calliope-mini-3_2_1_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/canbus_shield-v12_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/capacitor_elko_goldcap_4.0F_8647a5c11c9b485c095f1ac7ddec049d_2_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/capacitor_pp_10mm_leg.svg</Path>
@@ -2949,6 +2997,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/optical_jack_orj-8_breadoard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/optical_jack_otj-8_breadoard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/optocoupler4n35_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/oscilloscope_v1_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/peltier_element.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/piccolo_0.9.1_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/piezo_sensor.svg</Path>
@@ -2963,6 +3012,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/potentiometer_trimmer_12mm_5_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/potentiometer_trimmer_6mm_5_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/power_plug.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/power_supply_dc_lab_1_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/powerpushbutton_adafruit_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/powertransistor_npn.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/powertransistor_pnp.svg</Path>
@@ -3661,6 +3711,14 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/usb_connector.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/varistor.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/voltage_regulator_vreg.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/waveform_generator_generic_pulse_v1_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/waveform_generator_pulse_v1_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/waveform_generator_pwm_v1_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/waveform_generator_sawtooth_v1_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/waveform_generator_sine_v1_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/waveform_generator_square_pulse_v1_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/waveform_generator_triangular_v1_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/waveform_generator_v1_breadboard_template.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/ws2812b_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/xbee.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/breadboard/xbee_pro_rf_module_4.svg</Path>
@@ -3878,7 +3936,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/DENSO 174917 ECU socket 48pin_1.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/DIN7.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/DIP_Relay_D31A_14fadb0_002.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/DRV8825_breakout_icon.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/DRV8825_breakout_icon_1be7926_002.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/DS1302_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/DS1307_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/DS18B20_icon.svg</Path>
@@ -3959,6 +4017,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/HMC1051Z3.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/HMC1051Z_2.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/HUZZAH_ESP8266_Breakout_icon.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Half_breadboard56a_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Heltec_WiFi_LoRa_32_V2_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/HiFive1_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Humidity_Sensor_SHT15_icon.svg</Path>
@@ -3972,6 +4031,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/IPOD_MALE_CONNECTOR.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/IRF520_mos_module_5.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/IchigoJamT_icon.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Infineon_CY8CKIT-062S2-AI_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Infineon_H-BRIDGE_KIT2GO_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/Infineon_MY_IOT_ADAPTER_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/JOYSTICK-PSP1000.svg</Path>
@@ -4292,6 +4352,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/batterypack_4xAAA.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/bmp180_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/breadboardicon.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/calliope-mini-3_2_1_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/camera_cmos_con.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/camera_cmos_plug.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/icon/capacitor_elko_goldcap_4.0F_8647a5c11c9b485c095f1ac7ddec049d_2_icon.svg</Path>
@@ -4612,7 +4673,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/DIP_Relay_D31A_14fadb0_002.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/DIP___40_pins491bd.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/DO-41_diode_2_300mil_pcb.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/DRV8825_breakout_pcb.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/DRV8825_breakout_pcb_1be7926_002.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/DS18B20_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/DS2Y-5-DC5V_2.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/DUO_LED_RG_pcb.svg</Path>
@@ -4672,6 +4733,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/ISD1932 Breakout-v11_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/ITG-3200-v11_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/IchigoJamT_pcb.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/Infineon_CY8CKIT-062S2-AI_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/Infineon_H-BRIDGE_KIT2GO_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/Infineon_MY_IOT_ADAPTER_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/JST-03JQ-BT_pcb.svg</Path>
@@ -4971,6 +5033,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/battery_pack_mounted_500mil_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/blueIOT_Rc1-final_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/bmp180_pcb.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/calliope-mini-3_2_1_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/canbus_shield-v12_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/capacitor_ceramic_100mil.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/pcb/capacitor_ceramic_200mil.svg</Path>
@@ -6090,7 +6153,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/DENSO 174917 ECU socket 48pin_1.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/DFRobot-DFPlayer-Mini_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/DIP_Relay_D31A_14fadb0_002.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/DRV8825_breakout_schematic.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/DRV8825_breakout_schematic_1be7926_002.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/DS1302_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/DS1307_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/DS18B20_schematic.svg</Path>
@@ -6172,6 +6235,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/ISD1932 Breakout-v11_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/ITG-3200-v11_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/IchigoJamT_schematic.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/Infineon_CY8CKIT-062S2-AI_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/Infineon_H-BRIDGE_KIT2GO_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/Infineon_MY_IOT_ADAPTER_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/JST-03JQ-BT_schematic.svg</Path>
@@ -6410,7 +6474,6 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/Wiring_Sa99.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/XBee-Regulated-v12_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/YumoE6B2_1_schematic.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/acpower.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/ad5330 breakout-v11_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/adi_OP27.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/amplified-mic-electret_15e7e05_002.svg</Path>
@@ -6452,6 +6515,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/blueIOT_Rc1-final_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/bmp180_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/bussed-resistor-x8.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/calliope-mini-3_2_1_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/canbus_shield-v12_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/capacitor.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/capacitor_elko_goldcap_4.0F_8647a5c11c9b485c095f1ac7ddec049d_2_schematic.svg</Path>
@@ -6474,7 +6538,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/crystal.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/dc_motor.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/dc_powersupply.svg</Path>
-            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/dcpower.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/dcpower_pulse.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/diac_db3_1.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/din-5_midi_connector.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/diode.svg</Path>
@@ -6588,6 +6652,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/optical_jack_orj-8_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/optical_jack_otj-8_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/optocoupler4n35_schematic.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/oscilloscope_v1_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/peltier_element.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/piccolo_0.9.1_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/piezo_sensor.svg</Path>
@@ -6599,6 +6664,13 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/potentiometer_with_switch_1_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/power.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/power_plug.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/power_supply_ac_1_schematic.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/power_supply_dc_5_schematic.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/power_supply_dc_lab_1_schematic.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/power_supply_generic_pulse_1_schematic.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/power_supply_pulse_1_schematic.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/power_supply_sawtooth_1_schematic.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/power_supply_triangular_1_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/powerpushbutton_adafruit_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/prefix0000_1.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/prefix0000_SFE-10467-v10_2.svg</Path>
@@ -6631,6 +6703,8 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/seeed_arch_pro_v1_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/seeed_arch_v1.1_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/seeed_grove_generic_schematic.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/seeed_grove_rx_schematic.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/seeed_grove_scl_sda_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/seeed_seeeduino_v3_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/servo_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/core/schematic/shaft-encoder_1_schematic.svg</Path>
@@ -7207,6 +7281,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/Cherry-MX-Keyswitch_44a6316938b1b0a2c83ac0276dac5539_22_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/DB25M.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/DIP_Relay_D31A_breadboard.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/DRV8825_breakout_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/DS18B20__5240d891e23cace35a4de6acc361c04__breadboard__7b535917175078873c2dd8e438e15652.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/DS18B20_old_breadboard.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/breadboard/Dual_VNH2SP30_Motor_Driver_breadboard.svg</Path>
@@ -7413,6 +7488,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/Cherry-MX-Keyswitch_44a6316938b1b0a2c83ac0276dac5539_22_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/DB25M.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/DIP_Relay_D31A_icon.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/DRV8825_breakout_icon.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/DS18B20__5240d891e23cace35a4de6acc361c04__icon__d53cbcd19f32fb9a9236373b10833a61.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/Dial_Potentiometer_with_switch.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/icon/Dual_VNH2SP30_Motor_Driver_icon.svg</Path>
@@ -7963,6 +8039,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/DO-41.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/DO214.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/DO214AB.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/DRV8825_breakout_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/DS18B20__5240d891e23cace35a4de6acc361c04__pcb__1d5382571b4af4033f2c8ff3b34d64f3.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/DS18B20_old_pcb.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/pcb/DW 24.svg</Path>
@@ -9744,6 +9821,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/Cherry-MX-Keyswitch_44a6316938b1b0a2c83ac0276dac5539_22_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/DB25M.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/DIP_Relay_D31A_schematic.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/DRV8825_breakout_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/DS18B20__5240d891e23cace35a4de6acc361c04__schematic__7051cf864e168372439496e5f0a88453.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/Dial_Potentiometer_with_switch_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/Dual_VNH2SP30_Motor_Driver_schematic.svg</Path>
@@ -9770,6 +9848,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/TI_Launchpad_MSP430G2__ebb2b2673b63f5dd6__schematic__757b16f66078595db54ede6cdf9a8d2a.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/WeMos-D1-mini_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/accelerometer-adxl.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/acpower.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/artreeno.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/atmega168_schematic.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/basic_fsr.svg</Path>
@@ -9778,6 +9857,7 @@
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/controller_arduino_mega.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/controller_arduino_mini.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/controller_arduino_pro_mini.svg</Path>
+            <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/dcpower.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/generic-female-header_schem_10.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/generic-female-header_schem_11.svg</Path>
             <Path fileType="data">/usr/share/fritzing/fritzing-parts/svg/obsolete/schematic/generic-female-header_schem_12.svg</Path>
@@ -9862,9 +9942,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2024-02-04</Date>
-            <Version>1.0.2</Version>
+        <Update release="7">
+            <Date>2025-03-02</Date>
+            <Version>1.0.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>


### PR DESCRIPTION
**Summary**

Depends on #5177

Enhancements:

- Added PSoC™ 6 Artificial Intelligence Evaluation Kit
- Added Calliope Mini 3

Full release notes:

- [1.0.4](https://blog.fritzing.org/2024/10/08/fritzing-1-0-4.html)

Packaging:

- Added MAINTAINERS.md
- Added minitoring.yaml

**Test Plan**

Installed, opened and edited some projects.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
