### PR TITLE
egl-wayland: Update to v1.1.18

### DIFF
--- a/packages/e/egl-wayland/package.yml
+++ b/packages/e/egl-wayland/package.yml
@@ -1,8 +1,8 @@
 name       : egl-wayland
-version    : 1.1.17
-release    : 27
+version    : 1.1.18
+release    : 28
 source     :
-    - https://github.com/NVIDIA/egl-wayland/archive/refs/tags/1.1.17.tar.gz : 974351af2057a385e98f4a0d4a40adab4480b77f4b65449d1bd6137c758c25b7
+    - https://github.com/NVIDIA/egl-wayland/archive/refs/tags/1.1.18.tar.gz : c561485ee65efb7ffb0dbedd6c7031f0be69c861efa63f831c8b6c3178a0f871
 homepage   : https://github.com/NVIDIA/egl-wayland
 license    : MIT
 component  : programming.library

--- a/packages/e/egl-wayland/pspec_x86_64.xml
+++ b/packages/e/egl-wayland/pspec_x86_64.xml
@@ -21,7 +21,7 @@
         <PartOf>programming.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libnvidia-egl-wayland.so.1</Path>
-            <Path fileType="library">/usr/lib64/libnvidia-egl-wayland.so.1.1.17</Path>
+            <Path fileType="library">/usr/lib64/libnvidia-egl-wayland.so.1.1.18</Path>
             <Path fileType="data">/usr/share/egl/egl_external_platform.d/10_nvidia_wayland.json</Path>
         </Files>
     </Package>
@@ -32,11 +32,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="27">egl-wayland</Dependency>
+            <Dependency release="28">egl-wayland</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnvidia-egl-wayland.so.1</Path>
-            <Path fileType="library">/usr/lib32/libnvidia-egl-wayland.so.1.1.17</Path>
+            <Path fileType="library">/usr/lib32/libnvidia-egl-wayland.so.1.1.18</Path>
         </Files>
     </Package>
     <Package>
@@ -46,8 +46,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="27">egl-wayland-32bit</Dependency>
-            <Dependency release="27">egl-wayland-devel</Dependency>
+            <Dependency release="28">egl-wayland-32bit</Dependency>
+            <Dependency release="28">egl-wayland-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnvidia-egl-wayland.so</Path>
@@ -61,7 +61,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="27">egl-wayland</Dependency>
+            <Dependency release="28">egl-wayland</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libnvidia-egl-wayland.so</Path>
@@ -73,9 +73,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2024-12-10</Date>
-            <Version>1.1.17</Version>
+        <Update release="28">
+            <Date>2025-03-04</Date>
+            <Version>1.1.18</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fix possible undefined behavior while reading from socket in buffer release thread

**Test Plan**
- Rebooted
- Logged into a GNOME Wayland session
- Launched Steam and played two games
- Ran `xeglgears`, `vkcube`, `glxgears`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
