### PR TITLE
noto-sans-ttf: Update to v2025.03.01

### DIFF
--- a/packages/n/noto-sans-ttf/package.yml
+++ b/packages/n/noto-sans-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : noto-sans-ttf
-version    : 2025.02.01
-release    : 38
+version    : 2025.03.01
+release    : 39
 source     :
-    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-2025.02.01.tar.gz : 00cb71dbc595491f30f55d251b81da55da4c7887f36852e494b46c129958d383
+    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-2025.03.01.tar.gz : 780a43c2c4f607a3e7192b88d1401640b0c041f6c2d7a6313c30157f5367c771
     - https://github.com/googlefonts/noto-emoji/archive/refs/tags/v2.047.tar.gz : 2cfaf5a427eb26334cdb30d98e4a0c005b660504a339249dc54373e566f09b50
 homepage   : https://fonts.google.com/noto
 extract    : no

--- a/packages/n/noto-sans-ttf/pspec_x86_64.xml
+++ b/packages/n/noto-sans-ttf/pspec_x86_64.xml
@@ -1537,9 +1537,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="38">
-            <Date>2025-02-03</Date>
-            <Version>2025.02.01</Version>
+        <Update release="39">
+            <Date>2025-03-05</Date>
+            <Version>2025.03.01</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Commit log available [here](https://github.com/notofonts/notofonts.github.io/compare/noto-monthly-release-2025.02.01...noto-monthly-release-2025.03.01)

**Test Plan**
- Wrote some text in Noto Sans and Noto Serif
- Confirmed system looked alright with Noto Sans system font

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
