### PR TITLE
papers: Update to v47.4

### DIFF
--- a/packages/p/papers/abi_used_symbols
+++ b/packages/p/papers/abi_used_symbols
@@ -227,7 +227,6 @@ libc.so.6:textdomain
 libc.so.6:time
 libc.so.6:unlink
 libc.so.6:write
-libc.so.6:writev
 libcairo.so.2:cairo_create
 libcairo.so.2:cairo_destroy
 libcairo.so.2:cairo_format_stride_for_width
@@ -600,7 +599,6 @@ libglib-2.0.so.0:g_hash_table_new_full
 libglib-2.0.so.0:g_hash_table_remove
 libglib-2.0.so.0:g_hash_table_size
 libglib-2.0.so.0:g_hash_table_unref
-libglib-2.0.so.0:g_idle_add
 libglib-2.0.so.0:g_idle_add_full
 libglib-2.0.so.0:g_idle_add_once
 libglib-2.0.so.0:g_intern_static_string
@@ -1013,6 +1011,7 @@ libgtk-4.so.1:gdk_rgba_to_string
 libgtk-4.so.1:gdk_scroll_event_get_direction
 libgtk-4.so.1:gdk_seat_get_pointer
 libgtk-4.so.1:gdk_surface_get_device_position
+libgtk-4.so.1:gdk_surface_get_scale
 libgtk-4.so.1:gdk_texture_get_height
 libgtk-4.so.1:gdk_texture_get_width
 libgtk-4.so.1:gdk_texture_new_for_pixbuf
@@ -1452,7 +1451,6 @@ libgtk-4.so.1:gtk_widget_activate_action_variant
 libgtk-4.so.1:gtk_widget_add_controller
 libgtk-4.so.1:gtk_widget_add_css_class
 libgtk-4.so.1:gtk_widget_add_tick_callback
-libgtk-4.so.1:gtk_widget_child_focus
 libgtk-4.so.1:gtk_widget_class_add_binding
 libgtk-4.so.1:gtk_widget_class_add_binding_signal
 libgtk-4.so.1:gtk_widget_class_bind_template_callback_full

--- a/packages/p/papers/package.yml
+++ b/packages/p/papers/package.yml
@@ -1,8 +1,8 @@
 name       : papers
-version    : '47.3'
-release    : 4
+version    : '47.4'
+release    : 5
 source     :
-    - https://download.gnome.org/sources/papers/47/papers-47.3.tar.xz : 3e585393e81e7fa0f9af9e54dfc86f6126b5c3d852ea90dfdc3ba6b07952c4aa
+    - https://download.gnome.org/sources/papers/47/papers-47.4.tar.xz : 6727e876cc234eecd99c60d71606733433038a5f609b51c19fad5d2d10a2d065
 homepage   : https://apps.gnome.org/Papers/
 license    : GPL-2.0-or-later
 component  : office.viewers

--- a/packages/p/papers/pspec_x86_64.xml
+++ b/packages/p/papers/pspec_x86_64.xml
@@ -2651,7 +2651,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="4">papers</Dependency>
+            <Dependency release="5">papers</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/papers/4.0/libdocument/pps-annotation.h</Path>
@@ -2722,9 +2722,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2025-03-05</Date>
-            <Version>47.3</Version>
+        <Update release="5">
+            <Date>2025-03-10</Date>
+            <Version>47.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
             <Email>malfisya.dev@hotmail.com</Email>


### PR DESCRIPTION
**Summary**

Release notes can be read [here]( https://download.gnome.org/sources/papers/47/papers-47.4.news)

**Test Plan**

<!-- Short description of how the package was tested -->
Launch the app, open a document and test print preview

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
