### PR TITLE
sdl2: Update to v2.32.2

### DIFF
--- a/packages/s/sdl2/package.yml
+++ b/packages/s/sdl2/package.yml
@@ -1,8 +1,8 @@
 name       : sdl2
-version    : 2.32.0
-release    : 56
+version    : 2.32.2
+release    : 57
 source     :
-    - https://www.libsdl.org/release/SDL2-2.32.0.tar.gz : f5c2b52498785858f3de1e2996eba3c1b805d08fe168a47ea527c7fc339072d0
+    - https://www.libsdl.org/release/SDL2-2.32.2.tar.gz : c5f30c427fd8107ee4a400c84d4447dd211352512eaf0b6e89cc6a50a2821922
 homepage   : https://libsdl.org/
 license    : Zlib
 component  : multimedia.library

--- a/packages/s/sdl2/pspec_x86_64.xml
+++ b/packages/s/sdl2/pspec_x86_64.xml
@@ -21,7 +21,7 @@
         <PartOf>multimedia.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libSDL2-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libSDL2-2.0.so.0.3200.0</Path>
+            <Path fileType="library">/usr/lib64/libSDL2-2.0.so.0.3200.2</Path>
             <Path fileType="data">/usr/share/licenses/SDL2/LICENSE.txt</Path>
         </Files>
     </Package>
@@ -32,11 +32,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="56">sdl2</Dependency>
+            <Dependency release="57">sdl2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libSDL2-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libSDL2-2.0.so.0.3200.0</Path>
+            <Path fileType="library">/usr/lib32/libSDL2-2.0.so.0.3200.2</Path>
         </Files>
     </Package>
     <Package>
@@ -46,8 +46,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="56">sdl2-devel</Dependency>
-            <Dependency release="56">sdl2-32bit</Dependency>
+            <Dependency release="57">sdl2-devel</Dependency>
+            <Dependency release="57">sdl2-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/cmake/SDL2/SDL2Config.cmake</Path>
@@ -70,7 +70,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="56">sdl2</Dependency>
+            <Dependency release="57">sdl2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/sdl2-config</Path>
@@ -168,9 +168,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="56">
-            <Date>2025-02-14</Date>
-            <Version>2.32.0</Version>
+        <Update release="57">
+            <Date>2025-03-12</Date>
+            <Version>2.32.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Robert Gonzalez</Name>
             <Email>uni.dos12@outlook.com</Email>


### PR DESCRIPTION
**Summary**

[changelog](https://github.com/libsdl-org/SDL/releases/tag/release-2.32.2)

Main focus for Linux is a fix with pulseaudio


**Test Plan**

Rebuild lite-xl, and launch

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
