### PR TITLE
libheif: Update to v1.19.7

### DIFF
--- a/packages/l/libheif/abi_used_libs
+++ b/packages/l/libheif/abi_used_libs
@@ -10,8 +10,10 @@ libglib-2.0.so.0
 libgobject-2.0.so.0
 libjpeg.so.8
 libm.so.6
+libopenh264.so.7
 libpng16.so.16
 librav1e.so.0.7
+libsharpyuv.so.0
 libstdc++.so.6
 libtiff.so.6
 libx265.so.209

--- a/packages/l/libheif/abi_used_symbols
+++ b/packages/l/libheif/abi_used_symbols
@@ -18,6 +18,7 @@ libaom.so.3:aom_codec_enc_config_default
 libaom.so.3:aom_codec_enc_init_ver
 libaom.so.3:aom_codec_encode
 libaom.so.3:aom_codec_err_to_string
+libaom.so.3:aom_codec_error
 libaom.so.3:aom_codec_error_detail
 libaom.so.3:aom_codec_get_cx_data
 libaom.so.3:aom_codec_get_frame
@@ -37,6 +38,7 @@ libc.so.6:__libc_start_main
 libc.so.6:__longjmp_chk
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
+libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__strcat_chk
 libc.so.6:__strcpy_chk
@@ -146,6 +148,9 @@ libm.so.6:log10
 libm.so.6:lroundf
 libm.so.6:pow
 libm.so.6:sincos
+libopenh264.so.7:WelsCreateDecoder
+libopenh264.so.7:WelsDestroyDecoder
+libopenh264.so.7:WelsGetCodecVersion
 libpng16.so.16:png_create_info_struct
 libpng16.so.16:png_create_read_struct
 libpng16.so.16:png_create_write_struct
@@ -191,6 +196,9 @@ librav1e.so.0.7:rav1e_frame_unref
 librav1e.so.0.7:rav1e_packet_unref
 librav1e.so.0.7:rav1e_receive_packet
 librav1e.so.0.7:rav1e_send_frame
+librav1e.so.0.7:rav1e_version_short
+libsharpyuv.so.0:SharpYuvComputeConversionMatrix
+libsharpyuv.so.0:SharpYuvConvert
 libstdc++.so.6:_ZNKRSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE3strEv
 libstdc++.so.6:_ZNKSt10filesystem7__cxx1118directory_iteratordeEv
 libstdc++.so.6:_ZNKSt10filesystem7__cxx114path11parent_pathEv

--- a/packages/l/libheif/package.yml
+++ b/packages/l/libheif/package.yml
@@ -1,9 +1,11 @@
 name       : libheif
-version    : 1.19.5
-release    : 45
+version    : 1.19.7
+release    : 46
 source     :
-    - https://github.com/strukturag/libheif/releases/download/v1.19.5/libheif-1.19.5.tar.gz : d3cf0a76076115a070f9bc87cf5259b333a1f05806500045338798486d0afbaf
-license    : LGPL-3.0-or-later
+    - https://github.com/strukturag/libheif/releases/download/v1.19.7/libheif-1.19.7.tar.gz : 161c042d2102665fcee3ded851c78a0eb5f2d4bfe39fba48ba6e588fd6e964f3
+license    :
+    - LGPL-3.0-or-later
+    - MIT # /usr/include/libheif/heif_cxx.h
 homepage   : https://github.com/strukturag/libheif
 component  : multimedia.codecs
 summary    : libheif is an ISO/IEC 23008-12:2017 HEIF and AVIF (AV1 Image File Format) file format decoder and encoder
@@ -17,7 +19,9 @@ builddeps  :
     - pkgconfig(gdk-pixbuf-2.0)
     - pkgconfig(libde265)
     - pkgconfig(libpng)
+    - pkgconfig(libsharpyuv)
     - pkgconfig(libturbojpeg)
+    - pkgconfig(openh264)
     - pkgconfig(rav1e)
     - pkgconfig(x265)
 setup      : |

--- a/packages/l/libheif/pspec_x86_64.xml
+++ b/packages/l/libheif/pspec_x86_64.xml
@@ -7,6 +7,7 @@
             <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>LGPL-3.0-or-later</License>
+        <License>MIT</License>
         <PartOf>multimedia.codecs</PartOf>
         <Summary xml:lang="en">libheif is an ISO/IEC 23008-12:2017 HEIF and AVIF (AV1 Image File Format) file format decoder and encoder</Summary>
         <Description xml:lang="en">HEIF is a new image file format employing HEVC (h.265) or AV1 image coding, respectively, for the best compression ratios currently possible.
@@ -30,7 +31,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
             <Path fileType="library">/usr/lib64/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-heif.so</Path>
             <Path fileType="library">/usr/lib64/libheif</Path>
             <Path fileType="library">/usr/lib64/libheif.so.1</Path>
-            <Path fileType="library">/usr/lib64/libheif.so.1.19.5</Path>
+            <Path fileType="library">/usr/lib64/libheif.so.1.19.7</Path>
             <Path fileType="man">/usr/share/man/man1/heif-dec.1</Path>
             <Path fileType="man">/usr/share/man/man1/heif-enc.1</Path>
             <Path fileType="man">/usr/share/man/man1/heif-info.1</Path>
@@ -46,7 +47,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="45">libheif</Dependency>
+            <Dependency release="46">libheif</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libheif/heif.h</Path>
@@ -64,9 +65,9 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
         </Files>
     </Package>
     <History>
-        <Update release="45">
-            <Date>2024-11-19</Date>
-            <Version>1.19.5</Version>
+        <Update release="46">
+            <Date>2025-03-13</Date>
+            <Version>1.19.7</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- C++ and Go wrapper licenses have been changed to MIT
- Support SVT-AV1 v3.0.0 encoder
- Support emscripten builds for ES6 modules

Packaging change: Enable libsharpyuv (high quality color space conversion) and openh264 functionality

**Test Plan**

Encoded and decoded a bunch of images

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
