### PR TITLE
unbound: update to v1.22.0

### DIFF
--- a/packages/u/unbound/package.yml
+++ b/packages/u/unbound/package.yml
@@ -1,8 +1,8 @@
 name       : unbound
-version    : 1.20.0
-release    : 15
+version    : 1.22.0
+release    : 16
 source     :
-    - https://github.com/NLnetLabs/unbound/archive/release-1.20.0.tar.gz : e84d56ea1990abc7e8f1ee1954f3aa504bff0d382efbc9ec172db50770789911
+    - https://nlnetlabs.nl/downloads/unbound/unbound-1.22.0.tar.gz : c5dd1bdef5d5685b2cedb749158dd152c52d44f65529a34ac15cd88d4b1b3d43
 homepage   : https://nlnetlabs.nl/projects/unbound/about/
 license    : BSD-3-Clause
 component  : network.util

--- a/packages/u/unbound/pspec_x86_64.xml
+++ b/packages/u/unbound/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>unbound</Name>
         <Homepage>https://nlnetlabs.nl/projects/unbound/about/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>network.util</PartOf>
@@ -21,7 +21,7 @@
         <PartOf>network.util</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libunbound.so.8</Path>
-            <Path fileType="library">/usr/lib64/libunbound.so.8.1.27</Path>
+            <Path fileType="library">/usr/lib64/libunbound.so.8.1.30</Path>
             <Path fileType="library">/usr/lib64/systemd/system/unbound.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/unbound.socket</Path>
             <Path fileType="library">/usr/lib64/sysusers.d/unbound.conf</Path>
@@ -49,7 +49,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="15">unbound</Dependency>
+            <Dependency release="16">unbound</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/unbound-event.h</Path>
@@ -90,12 +90,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2024-06-27</Date>
-            <Version>1.20.0</Version>
+        <Update release="16">
+            <Date>2025-03-14</Date>
+            <Version>1.22.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- [1.22.0](https://nlnetlabs.nl/projects/unbound/download/#unbound-1-22-0)
- [1.21.1](https://nlnetlabs.nl/projects/unbound/download/#unbound-1-21-1)
- [1.20.0](https://nlnetlabs.nl/projects/unbound/download/#unbound-1-21-0)

**Security**

- CVE-2024-8508

**Test Plan**

- Revdeps built without notable changes

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
