### PR TITLE
ardour: Update to v8.12

### DIFF
--- a/packages/a/ardour/abi_libs
+++ b/packages/a/ardour/abi_libs
@@ -4,12 +4,12 @@ a-eq.so
 a-exp.so
 a-fluidsynth.so
 a-reverb.so
-ardour-8.11.0
+ardour-8.12.0
 ardour8-copy-mixer
 ardour8-export
 ardour8-new_empty_session
 ardour8-new_session
-hardour-8.11.0
+hardour-8.12.0
 libaaf.so.0
 libalsa_audiobackend.so
 libardour.so.3

--- a/packages/a/ardour/abi_symbols
+++ b/packages/a/ardour/abi_symbols
@@ -4,10 +4,10 @@ a-eq.so:lv2_descriptor
 a-exp.so:lv2_descriptor
 a-fluidsynth.so:lv2_descriptor
 a-reverb.so:lv2_descriptor
-ardour-8.11.0:_Z10vstfx_exitv
-ardour-8.11.0:_Z10vstfx_initPv
-ardour-8.11.0:_Z20vstfx_destroy_editorP9_VSTState
-ardour-8.11.0:main
+ardour-8.12.0:_Z10vstfx_exitv
+ardour-8.12.0:_Z10vstfx_initPv
+ardour-8.12.0:_Z20vstfx_destroy_editorP9_VSTState
+ardour-8.12.0:main
 ardour8-copy-mixer:_Z10vstfx_exitv
 ardour8-copy-mixer:_Z10vstfx_initPv
 ardour8-copy-mixer:_Z20vstfx_destroy_editorP9_VSTState
@@ -24,10 +24,10 @@ ardour8-new_session:_Z10vstfx_exitv
 ardour8-new_session:_Z10vstfx_initPv
 ardour8-new_session:_Z20vstfx_destroy_editorP9_VSTState
 ardour8-new_session:main
-hardour-8.11.0:_Z10vstfx_exitv
-hardour-8.11.0:_Z10vstfx_initPv
-hardour-8.11.0:_Z20vstfx_destroy_editorP9_VSTState
-hardour-8.11.0:main
+hardour-8.12.0:_Z10vstfx_exitv
+hardour-8.12.0:_Z10vstfx_initPv
+hardour-8.12.0:_Z20vstfx_destroy_editorP9_VSTState
+hardour-8.12.0:main
 libaaf.so.0:_aaf_foreach_ObjectInSet
 libaaf.so.0:aaf_ObjectInheritsClass
 libaaf.so.0:aaf_alloc
@@ -1454,6 +1454,7 @@ libardour.so.3:_ZN6ARDOUR11AudioRegion19set_fade_out_activeEb
 libardour.so.3:_ZN6ARDOUR11AudioRegion19set_fade_out_lengthEl
 libardour.so.3:_ZN6ARDOUR11AudioRegion19set_scale_amplitudeEf
 libardour.so.3:_ZN6ARDOUR11AudioRegion19verify_xfade_boundsElb
+libardour.so.3:_ZN6ARDOUR11AudioRegion20ensure_length_sanityEv
 libardour.so.3:_ZN6ARDOUR11AudioRegion20make_property_quarksEv
 libardour.so.3:_ZN6ARDOUR11AudioRegion20set_default_envelopeEv
 libardour.so.3:_ZN6ARDOUR11AudioRegion20set_default_fade_outEv

--- a/packages/a/ardour/package.yml
+++ b/packages/a/ardour/package.yml
@@ -1,8 +1,8 @@
 name       : ardour
-version    : '8.11'
-release    : 49
+version    : '8.12'
+release    : 50
 source     :
-    - git|https://github.com/Ardour/ardour.git : 8.11
+    - git|https://github.com/Ardour/ardour.git : 8.12
 homepage   : https://ardour.org/
 license    : GPL-3.0-or-later
 component  : multimedia.audio

--- a/packages/a/ardour/pspec_x86_64.xml
+++ b/packages/a/ardour/pspec_x86_64.xml
@@ -57,7 +57,7 @@
             <Path fileType="library">/usr/lib64/ardour8/LV2/reasonablesynth.lv2/manifest.ttl</Path>
             <Path fileType="library">/usr/lib64/ardour8/LV2/reasonablesynth.lv2/reasonablesynth.so</Path>
             <Path fileType="library">/usr/lib64/ardour8/LV2/reasonablesynth.lv2/reasonablesynth.ttl</Path>
-            <Path fileType="library">/usr/lib64/ardour8/ardour-8.11.0</Path>
+            <Path fileType="library">/usr/lib64/ardour8/ardour-8.12.0</Path>
             <Path fileType="library">/usr/lib64/ardour8/ardour-avahi</Path>
             <Path fileType="library">/usr/lib64/ardour8/ardour-exec-wrapper</Path>
             <Path fileType="library">/usr/lib64/ardour8/ardour-request-device</Path>
@@ -68,7 +68,7 @@
             <Path fileType="library">/usr/lib64/ardour8/backends/libjack_audiobackend.so</Path>
             <Path fileType="library">/usr/lib64/ardour8/backends/libpulseaudio_backend.so</Path>
             <Path fileType="library">/usr/lib64/ardour8/engines/libclearlooks.so</Path>
-            <Path fileType="library">/usr/lib64/ardour8/hardour-8.11.0</Path>
+            <Path fileType="library">/usr/lib64/ardour8/hardour-8.12.0</Path>
             <Path fileType="library">/usr/lib64/ardour8/libaaf.so</Path>
             <Path fileType="library">/usr/lib64/ardour8/libaaf.so.0</Path>
             <Path fileType="library">/usr/lib64/ardour8/libaaf.so.0.0.0</Path>
@@ -1193,9 +1193,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="49">
-            <Date>2025-02-04</Date>
-            <Version>8.11</Version>
+        <Update release="50">
+            <Date>2025-03-15</Date>
+            <Version>8.12</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- The bug fix introduced in 8.11 turned out to be incorrect, and broke several other things in subtle ways. 8.12 is a completely new approach to fixing the problem with region lengths after certain operations could cause sessions to be unloadable. 8.12 will also correctly load sessions suffering from this problem.
- For several previous versions, the packaging of translation files on macOS was broken. This has been corrected, and translations should work again on that platform.

**Test Plan**

- Start a new session, listen to click track

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
