### PR TITLE
zellij: Update to v0.42.0

### DIFF
--- a/packages/z/zellij/abi_used_symbols
+++ b/packages/z/zellij/abi_used_symbols
@@ -89,7 +89,6 @@ libc.so.6:ioctl
 libc.so.6:isatty
 libc.so.6:kill
 libc.so.6:listen
-libc.so.6:localtime_r
 libc.so.6:login_tty
 libc.so.6:lseek
 libc.so.6:lseek64
@@ -388,6 +387,8 @@ libm.so.6:fmod
 libm.so.6:fmodf
 libm.so.6:pow
 libm.so.6:powf
+libm.so.6:rint
+libm.so.6:rintf
 libm.so.6:round
 libm.so.6:sincosf
 libm.so.6:trunc

--- a/packages/z/zellij/package.yml
+++ b/packages/z/zellij/package.yml
@@ -1,8 +1,8 @@
 name       : zellij
-version    : 0.41.2
-release    : 9
+version    : 0.42.0
+release    : 10
 source     :
-    - https://github.com/zellij-org/zellij/archive/refs/tags/v0.41.2.tar.gz : 12e7f0f80c1e39deed5638c4662fc070855cee0250a7eb1d76cefbeef8c2f376
+    - https://github.com/zellij-org/zellij/archive/refs/tags/v0.42.0.tar.gz : 35f620f8aca7128047e8be520c88514156c8249763cfbc103107499dd2052f2a
 homepage   : https://zellij.dev
 license    : MIT
 component  : system.utils

--- a/packages/z/zellij/pspec_x86_64.xml
+++ b/packages/z/zellij/pspec_x86_64.xml
@@ -31,9 +31,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2024-11-19</Date>
-            <Version>0.41.2</Version>
+        <Update release="10">
+            <Date>2025-03-17</Date>
+            <Version>0.42.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Added stacked resizing: When resizing panes, Zellij will attempt to stack them with their neighbors
- Added pinned floating panes
- New theme definition spec
- New Rust plugin APIs
- Added double/triple mouse click text selection in terminals
- Added showing release notes and tips on startup

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Re-open Konsole, autostarting Zellij, see the new release notes pane appear. Change directories, make this PR.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
