### PR TITLE
eza: Update to v0.20.24

### DIFF
--- a/packages/e/eza/abi_used_symbols
+++ b/packages/e/eza/abi_used_symbols
@@ -129,7 +129,6 @@ libc.so.6:time
 libc.so.6:unlink
 libc.so.6:utimes
 libc.so.6:write
-libc.so.6:writev
 libgcc_s.so.1:_Unwind_Backtrace
 libgcc_s.so.1:_Unwind_GetDataRelBase
 libgcc_s.so.1:_Unwind_GetIP

--- a/packages/e/eza/package.yml
+++ b/packages/e/eza/package.yml
@@ -1,8 +1,8 @@
 name       : eza
-version    : 0.20.22
-release    : 44
+version    : 0.20.24
+release    : 45
 source     :
-    - https://github.com/eza-community/eza/archive/refs/tags/v0.20.22.tar.gz : 81a8b5c86054042da50a9a7aad38117a051b7e9fd6de3bcece1391e39d2edfd4
+    - https://github.com/eza-community/eza/archive/refs/tags/v0.20.24.tar.gz : e5a1761f05adc74b80d59036819e768060971c6f5107e208024c752a2af02ccc
 homepage   : https://github.com/eza-community/eza
 license    : EUPL-1.2
 component  : system.utils

--- a/packages/e/eza/pspec_x86_64.xml
+++ b/packages/e/eza/pspec_x86_64.xml
@@ -33,9 +33,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="44">
-            <Date>2025-02-20</Date>
-            <Version>0.20.22</Version>
+        <Update release="45">
+            <Date>2025-03-17</Date>
+            <Version>0.20.24</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Make temp files visible on white background
- Add `.exercism` folder icon
- Add `.ocamlinit` icon
- Add `.opam` icon
- Add gcloud icon for .gcloudignore
- Add vim icon for .gvimrc, _vimrc and _gvimrc
- Add fennel icon for ~/.fennelrc and ~/.config/fennel/fennelrc

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

List files and folders in a directory.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
