### PR TITLE
common/Hooks: Auto-generate commit msg from "autocommitmsg" with -m flag

### DIFF
--- a/common/Hooks/prepare-commit-msg.py
+++ b/common/Hooks/prepare-commit-msg.py
@@ -62,6 +62,19 @@ def render_template(file: str, commit_dir: str) -> None:
         f.write(contents)
 
 
+def write_auto_commit_msg(file: str, commit_dir: str) -> None:
+    with open(file, 'w') as f:
+        f.write(commit_scope(commit_dir))
+
+
+def is_auto_commit_msg(file: str) -> bool:
+    contents = current_message(file).strip()
+
+    if contents == "autocommitmsg":
+        return True
+    return False
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('file', type=str,
@@ -74,7 +87,12 @@ if __name__ == "__main__":
     pwd = os.getenv('PWD') or '/'
 
     match args.source:
-        case 'message' | 'template' | 'merge' | 'squash' | 'commit':
+        case 'template' | 'merge' | 'squash' | 'commit':
             pass
+        case 'message':
+            if is_auto_commit_msg(args.file):
+                write_auto_commit_msg(args.file, pwd)
+            else:
+                pass
         case _:
             render_template(args.file, pwd)


### PR DESCRIPTION
Helps with scriptability for large stack updates and will attempt to autowrite the commit message without needing to open up the editor.

e.g. git commit -m "autocommitmsg" -> "nano: Update to v1.2.3"

Use with caution as not all cases are handled, notably "Rebuild against libfoo" is not currently.

**Test Plan**

`git commit -m "autocommitmsg"` gets transformed to "libquotient: Update to v0.9.3" for a libquotient update.
`git commit -m "do my normal message"` does not get transformed. 

**Checklist**

- [ ] Package was built and tested against unstable n/a
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label --> n/a
