### PR TITLE
heroic-games-launcher: Use our own AppStream metainfo file

### DIFF
--- a/packages/h/heroic-games-launcher/files/com.heroicgameslauncher.hgl.metainfo.xml
+++ b/packages/h/heroic-games-launcher/files/com.heroicgameslauncher.hgl.metainfo.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.heroicgameslauncher.hgl</id>
+  <name>Heroic Games Launcher</name>
+  <developer_name>Heroic Games Launcher</developer_name>
+  <summary>An Open Source Epic Games, GOG and Amazon Prime Games Launcher.</summary>
+  <summary xml:lang="de">Ein Open Source Epic Games, GOG und Amazon Prime Games Launcher.</summary>
+  <url type="homepage">https://heroicgameslauncher.com</url>
+  <url type="bugtracker">https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues</url>
+  <url type="donation">https://ko-fi.com/heroicgames</url>
+  <url type="translate">https://hosted.weblate.org/projects/heroic-games-launcher</url>
+  <url type="help">https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/wiki</url>
+  <url type="vcs-browser">https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+  <description>
+    <p>Heroic is an Open Source Games Launcher. Right now it supports launching games from the
+			Epic Games Store using Legendary, GOG Games using our custom implementation with gogdl
+			and Amazon Games using Nile.</p>
+    <p xml:lang="de">Heroic ist ein Open Source Spielelauncher. Aktuell unterstützt er das Starten von
+			Spielen aus dem Epic Games Store mit Legendary, GOG Spielen mit unserer eigenen
+			Implementierung mit gogdl und Amazon Games mit Nile.</p>
+    <p>Main Features:</p>
+    <p xml:lang="de">Hauptfeatures:</p>
+    <ul>
+      <li>Have access to your Epic, GOG and Amazon Games in a intuitive User Interface.</li>
+      <li xml:lang="de">Zugriff auf deine Spielebibliothek von Epic Games, GOG und Amazon Games durch eine
+				intuitive Benutzeroberfläche.</li>
+      <li>Add Games outside GOG, Amazon or Epic Games Store native or not. Even Browser apps
+				are supported</li>
+      <li xml:lang="de">Spiele können hinzugefügt werden, die nicht von Epic Games, GOG oder Amazon Games
+				sind. Sogar Browser Apps werden unterstützt.</li>
+      <li>A Download queue to download multiple games at once.</li>
+      <li xml:lang="de">Eine Download-Warteschlange, um mehrere Spiele gleichzeitig herunterzuladen.</li>
+      <li xml:lang="de">Zugriff auf deine Spielebibliothek von Epic Games und GOG durch eine intuitive
+				Benutzeroberfläche.</li>
+      <li>Install and launch your Windows Games using Wine or Proton. Or Launch your Native
+				GOG Games.</li>
+      <li xml:lang="de">Windows Spiele könne mithilfe von Wine oder Proton gestartet werden. Native Spiele
+				von GOG können direkt gestartet werden.</li>
+      <li>Cloud Saves support for GOG and Epic Games.</li>
+      <li xml:lang="de">Cloud Saves werden für GOG und Epic Games unterstützt.</li>
+      <li>Import Games installed through the Epic Store or GOG Galaxy.</li>
+      <li xml:lang="de">Installierte Spiele können aus dem Epic Games Sore oder aus GOG Galaxy importiert
+				werden.</li>
+      <li>Verify and Repair corrupted installations or even move your installation to
+				different folders.</li>
+      <li xml:lang="de">Installationen können auf Beschädigungen überprüft und repariert werden, sowie in
+				andere Ordner verschoben werden.</li>
+      <li>Access the Epic and GOG store and also Heroic Wiki directly from the App.</li>
+      <li xml:lang="de">Der Epic Games Store sowie der GOG Store können direkt aus der App aufgerufen
+				werden.</li>
+      <li>Check HowLongtoBeat database to see how long it will take to finish a game. And also
+				check the Metacritic, IGCB or OpenCritc score for the game.</li>
+      <li xml:lang="de">Die HowLongtoBeat Datenbank kann genutzt werden, um zu sehen, wie lange es dauert,
+				ein Spiel durchzuspielen. Außerdem kann der Metacritic, IGCB oder OpenCritc Score
+				für ein Spiel abgerufen werden.</li>
+      <li>And many more features</li>
+      <li xml:lang="de">Und viele weitere Features</li>
+    </ul>
+    <p>Current Limitations on the Flatpak:</p>
+    <p xml:lang="de">Aktuelle Einschränkungen des Flatpaks:</p>
+    <ul>
+      <li>Heroic will not find or use Wine and Proton Flatpak versions. At least for now.</li>
+      <li xml:lang="de">Heroic findet aktuell keine Wine oder Proton Versionen, die per Flatpak installiert
+				sind</li>
+      <li>For now would be better to use the Built-in Wine Manager to download and install
+				Wine and Proton Versions.</li>
+      <li xml:lang="de">Momentan ist es am besten, den eingebauten Wine Manager zu benutzen, um Wine und
+				Proton Versionen zu downloaden und zu installieren.</li>
+      <li>It should find Proton from the Steam folder for both Steam Flatpak and non-Flatpak
+				if they are on installed on the library inside your $HOME folder</li>
+      <li xml:lang="de">Heroic sollte Proton Versionen von Steam (Nativ und Flatpak) finden, sofern sie
+				innerhalb der Bibliothek des Benutzerordners installiert sind.</li>
+      <li>Heroic cannot access /usr/bin so it won&apos;t be able to find any wine or proton
+				isntalled there for now.</li>
+      <li xml:lang="de">Heroic hat keinen Zugriff auf /usr/bin, weshalb es dort installierte Wine oder
+				Proton Versionen nicht finden kann.</li>
+    </ul>
+  </description>
+  <categories>
+    <category>Game</category>
+    <category>PackageManager</category>
+  </categories>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">moderate</content_attribute>
+    <content_attribute id="violence-fantasy">moderate</content_attribute>
+    <content_attribute id="violence-realistic">moderate</content_attribute>
+    <content_attribute id="violence-bloodshed">moderate</content_attribute>
+    <content_attribute id="money-purchasing">intense</content_attribute>
+  </content_rating>
+  <launchable type="desktop-id">com.heroicgameslauncher.hgl.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Library Grid</caption>
+      <image>https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/26871415/70c9e0f2-3fa8-4e56-9bb0-0e5f8713c968</image>
+    </screenshot>
+    <screenshot>
+      <caption>Game Screen</caption>
+      <image>https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/26871415/95e199d5-24de-4a23-a8b8-657afd657390</image>
+    </screenshot>
+    <screenshot>
+      <caption>Wine/Proton Download Manager</caption>
+      <image>https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/26871415/07e76bdb-e794-41fd-9028-062fa22f15b6</image>
+    </screenshot>
+    <screenshot>
+      <caption>Downloads Screen</caption>
+      <image>https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/26871415/e190ddce-b16c-40c6-a509-b1337669b65a</image>
+    </screenshot>
+    <screenshot>
+      <caption>Stores</caption>
+      <image>https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/26871415/9868d9eb-c141-4b46-874d-e13f668480cb</image>
+    </screenshot>
+    <screenshot>
+      <caption>Library With Filters</caption>
+      <image>https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/26871415/8daf7035-4f30-4dcd-a7ef-412ef690a286</image>
+    </screenshot>
+    <screenshot>
+      <caption>Install Screen</caption>
+      <image>https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/26871415/61467411-f518-4d10-b859-9c2adef3302e</image>
+    </screenshot>
+  </screenshots>
+</component>

--- a/packages/h/heroic-games-launcher/package.yml
+++ b/packages/h/heroic-games-launcher/package.yml
@@ -1,6 +1,6 @@
 name       : heroic-games-launcher
 version    : 2.15.2
-release    : 30
+release    : 31
 source     :
     - git|https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher.git : v2.15.2
 homepage   : https://heroicgameslauncher.com/
@@ -45,4 +45,4 @@ install    : |
     install -Dm00644 ./flatpak/com.heroicgameslauncher.hgl.desktop -t $installdir/usr/share/applications
 
     # Install appstream metadata
-    install -Dm00644 ./flatpak/templates/com.heroicgameslauncher.hgl.metainfo.xml.template $installdir/usr/share/metainfo/com.heroicgameslauncher.hgl.metainfo.xml
+    install -Dm00644 $pkgfiles/com.heroicgameslauncher.hgl.metainfo.xml -t $installdir/usr/share/metainfo

--- a/packages/h/heroic-games-launcher/pspec_x86_64.xml
+++ b/packages/h/heroic-games-launcher/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>heroic-games-launcher</Name>
         <Homepage>https://heroicgameslauncher.com/</Homepage>
         <Packager>
-            <Name>Marcus Mellor</Name>
-            <Email>infinitymdm@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>games</PartOf>
@@ -130,12 +130,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="30">
-            <Date>2024-10-26</Date>
+        <Update release="31">
+            <Date>2025-03-19</Date>
             <Version>2.15.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Marcus Mellor</Name>
-            <Email>infinitymdm@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Use our own AppStream metainfo file because the one shipped in their source is a template that requires updating using upstream internal workflow.

**Test Plan**

<!-- Short description of how the package was tested -->
`appstream-builder --packages-dir=. --include-failed -v `

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
