### PR TITLE
firefox: Use beacondb geolocation

### DIFF
--- a/packages/f/firefox/files/prefs.js
+++ b/packages/f/firefox/files/prefs.js
@@ -26,8 +26,8 @@ pref("extensions.webextensions.base-content-security-policy", "script-src 'self'
 // Enable smooth scrolling
 pref("general.smoothScroll",                true);
 // Geolocation preferences
-pref("geo.provider.network.url", "https://location.services.mozilla.com/v1/geolocate?key=%MOZILLA_API_KEY%");
-pref("geo.wifi.uri", "https://location.services.mozilla.com/v1/geolocate?key=%MOZILLA_API_KEY%");
+pref("geo.provider.network.url", "https://api.beacondb.net/v1/geolocate");
+pref("geo.wifi.uri", "https://api.beacondb.net/v1/geolocate");
 pref("layers.use-image-offscreen-surfaces", false);
 // Enable MSE (Media Source Extensions) API
 pref("media.mediasource.enabled",           true);

--- a/packages/f/firefox/package.yml
+++ b/packages/f/firefox/package.yml
@@ -1,6 +1,6 @@
 name       : firefox
 version    : 136.0.2
-release    : 353
+release    : 354
 source     :
     - https://ftp.mozilla.org/pub/firefox/releases/136.0.2/source/firefox-136.0.2.source.tar.xz : 53187c9e84543f77836e557c2a29f95238b111e779154217df2ed9b50ddbf200
     - https://sources.getsol.us/mozilla/firefox/firefox-136.0.2-langpacks.tar.zst : c0c6d851de9a22fe468de39939b7a45e18fbea832cb6d991acb6ea76976c938a

--- a/packages/f/firefox/pspec_x86_64.xml
+++ b/packages/f/firefox/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>firefox</Name>
         <Homepage>https://www.mozilla.org/firefox/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>MPL-2.0</License>
@@ -178,12 +178,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="353">
-            <Date>2025-03-19</Date>
+        <Update release="354">
+            <Date>2025-03-20</Date>
             <Version>136.0.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

This makes firefox use beacondb as a geolocation service.

Necessary for systems without geoclue, or with geoclue but no WiFi.

**Test Plan**
- Tested using https://browserleaks.com/geo
- Geolocation now works on my desktop PC
- Geolocation now works on laptop (with WiFi) when geoclue is disabled

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
