### PR TITLE
mir: Update to v2.20.1

### DIFF
--- a/packages/m/mir/abi_used_symbols
+++ b/packages/m/mir/abi_used_symbols
@@ -1066,6 +1066,7 @@ libwayland-server.so.0:wl_display_add_socket
 libwayland-server.so.0:wl_display_add_socket_auto
 libwayland-server.so.0:wl_display_create
 libwayland-server.so.0:wl_display_destroy
+libwayland-server.so.0:wl_display_destroy_clients
 libwayland-server.so.0:wl_display_flush_clients
 libwayland-server.so.0:wl_display_get_event_loop
 libwayland-server.so.0:wl_display_next_serial

--- a/packages/m/mir/package.yml
+++ b/packages/m/mir/package.yml
@@ -1,8 +1,8 @@
 name       : mir
-version    : 2.20.0
-release    : 1
+version    : 2.20.1
+release    : 2
 source     :
-    - https://github.com/canonical/mir/releases/download/v2.20.0/mir-2.20.0.tar.xz : 3656b2f3751346d1afd70963b5de062179602cb7e6fd8d0ca3aba03ccae83a44
+    - https://github.com/canonical/mir/releases/download/v2.20.1/mir-2.20.1.tar.xz : ba57313abc6e4ef6819907d6968a79e033cd25aa8844de0074411808e72caba7
 homepage   : https://mir-server.io/
 license    :
     - GPL-2.0-only

--- a/packages/m/mir/pspec_x86_64.xml
+++ b/packages/m/mir/pspec_x86_64.xml
@@ -45,7 +45,7 @@
         <Description xml:lang="en">Demo applications for the Mir compositor</Description>
         <PartOf>desktop</PartOf>
         <RuntimeDependencies>
-            <Dependency release="1">mir</Dependency>
+            <Dependency release="2">mir</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/mir-x11-kiosk</Path>
@@ -69,7 +69,7 @@
         <Description xml:lang="en">Mir is set of libraries for building Wayland based shells. Mir simplifies the complexity that shell authors need to deal with. It provides a stable, well tested and performant platform with touch, mouse and tablet input, multi-display capability and secure client-server communications.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="1">mir</Dependency>
+            <Dependency release="2">mir</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/miral/miral/add_init_callback.h</Path>
@@ -455,9 +455,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2025-03-11</Date>
-            <Version>2.20.0</Version>
+        <Update release="2">
+            <Date>2025-03-22</Date>
+            <Version>2.20.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Do not mutate a container whilst iterating over it
- Fix crash when disconnecting monitors
- Fix policy destructors not getting called when a surface has been launched on the desktop

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new Budgie Wayland session using Miriway.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
