### PR TITLE
github-cli: Update to v2.69.0

### DIFF
--- a/packages/g/github-cli/monitoring.yaml
+++ b/packages/g/github-cli/monitoring.yaml
@@ -1,6 +1,7 @@
 releases:
   id: 135615
   rss: https://github.com/cli/cli/releases.atom
-# No known CPE. Checked 2024-02-18
 security:
-  cpe: ~
+  cpe:
+    - vendor: github
+      product: cli

--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.68.1
-release    : 68
+version    : 2.69.0
+release    : 69
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.68.1.tar.gz : 520ab7ca5eda31af4aab717e1f9bc65497cdc23a46f71dab56d47513e00c7b82
+    - https://github.com/cli/cli/archive/refs/tags/v2.69.0.tar.gz : e2deb3759bbe4da8ad4f071ca604fda5c2fc803fef8b3b89896013e4b1c1fe65
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -230,9 +230,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="68">
-            <Date>2025-03-06</Date>
-            <Version>2.68.1</Version>
+        <Update release="69">
+            <Date>2025-03-22</Date>
+            <Version>2.69.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Commands that accept filepath arguments will do glob expansion for `*` characters
- `gh issue/pr comment --edit-last` no longer creates a comment in non-interactive mode if there weren't one. A new flag `--create-if-none` provides this behaviour
- `gh repo sync` provides a more informative error for missing workflow permissions when the token is provided by a GitHub app
- `gh api` no longer tries to encode URLs incorrectly

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
