### PR TITLE
bibletime: Update to v3.1.1

### DIFF
--- a/packages/b/bibletime/abi_used_symbols
+++ b/packages/b/bibletime/abi_used_symbols
@@ -306,6 +306,7 @@ libQt6Core.so.6:_ZN9QFileInfoC1ERK7QString
 libQt6Core.so.6:_ZN9QFileInfoC1ERKS_
 libQt6Core.so.6:_ZN9QFileInfoD1Ev
 libQt6Core.so.6:_ZN9QHashSeed10globalSeedEv
+libQt6Core.so.6:_ZN9QIODevice4peekEPcx
 libQt6Core.so.6:_ZN9QIODevice5writeEPKcx
 libQt6Core.so.6:_ZN9QIODevice5writeERK10QByteArray
 libQt6Core.so.6:_ZN9QIODevice7putCharEc

--- a/packages/b/bibletime/package.yml
+++ b/packages/b/bibletime/package.yml
@@ -1,8 +1,8 @@
 name       : bibletime
-version    : 3.1.0
-release    : 4
+version    : 3.1.1
+release    : 5
 source     :
-    - https://github.com/bibletime/bibletime/releases/download/v3.1.0/bibletime-3.1.0.tar.xz : cfd85a416cfbae467ad2687df98cd553af952aa02869954d33250bdcb4840280
+    - https://github.com/bibletime/bibletime/releases/download/v3.1.1/bibletime-3.1.1.tar.xz : 71dbafdc8d29518aede79269d027d80b4192633e7a614c89ed76aeb0e0bd1dd4
 homepage   : http://bibletime.info/
 license    : GPL-2.0-or-later
 component  : office

--- a/packages/b/bibletime/pspec_x86_64.xml
+++ b/packages/b/bibletime/pspec_x86_64.xml
@@ -1390,9 +1390,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2025-03-18</Date>
-            <Version>3.1.0</Version>
+        <Update release="5">
+            <Date>2025-03-23</Date>
+            <Version>3.1.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
- Fixed a compatibility issue causing BibleTime to loop on startup consuming all memory and crashing when reading configuration files written by previous versions of BibleTime based on Qt5.
- Fixed compilation against Sword 1.8.1.

**Test Plan**
- Changed language and read a bible verse.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
