### PR TITLE
which: Update to v2.23

### DIFF
--- a/packages/w/which/package.yml
+++ b/packages/w/which/package.yml
@@ -1,8 +1,8 @@
 name       : which
-version    : '2.21'
-release    : 6
+version    : '2.23'
+release    : 7
 source     :
-    - https://carlowood.github.io/which/which-2.21.tar.gz : f4a245b94124b377d8b49646bf421f9155d36aa7614b6ebf83705d3ffc76eaad
+    - https://ftp.gnu.org/gnu/which/which-2.23.tar.gz : a2c558226fc4d9e4ce331bd2fd3c3f17f955115d2c00e447618a4ef9978a2a73
 homepage   : https://carlowood.github.io/which/
 license    : GPL-3.0-only
 component  : system.base

--- a/packages/w/which/pspec_x86_64.xml
+++ b/packages/w/which/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>which</Name>
         <Homepage>https://carlowood.github.io/which/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <PartOf>system.base</PartOf>
@@ -26,12 +26,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2023-11-01</Date>
-            <Version>2.21</Version>
+        <Update release="7">
+            <Date>2025-03-23</Date>
+            <Version>2.23</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- The function that decides if a found path is executable (file_status) was updated to that of bash version 5.2.
- Full changelog [here](https://git.savannah.gnu.org/cgit/which.git/tree/NEWS)

**Test Plan**

- Locate some binaries

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
