### PR TITLE
wavpack: Update to v5.8.1

### DIFF
--- a/packages/w/wavpack/abi_used_symbols
+++ b/packages/w/wavpack/abi_used_symbols
@@ -31,6 +31,7 @@ libc.so.6:ftell
 libc.so.6:ftello
 libc.so.6:ftruncate
 libc.so.6:fwrite
+libc.so.6:get_nprocs
 libc.so.6:gettimeofday
 libc.so.6:glob
 libc.so.6:globfree
@@ -38,10 +39,22 @@ libc.so.6:iconv
 libc.so.6:iconv_close
 libc.so.6:iconv_open
 libc.so.6:malloc
+libc.so.6:memchr
 libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset
+libc.so.6:pthread_cond_destroy
+libc.so.6:pthread_cond_init
+libc.so.6:pthread_cond_signal
+libc.so.6:pthread_cond_wait
+libc.so.6:pthread_create
+libc.so.6:pthread_exit
+libc.so.6:pthread_join
+libc.so.6:pthread_mutex_destroy
+libc.so.6:pthread_mutex_init
+libc.so.6:pthread_mutex_lock
+libc.so.6:pthread_mutex_unlock
 libc.so.6:puts
 libc.so.6:realloc
 libc.so.6:remove
@@ -73,3 +86,4 @@ libm.so.6:exp2
 libm.so.6:floor
 libm.so.6:log10
 libm.so.6:pow
+libm.so.6:sqrt

--- a/packages/w/wavpack/package.yml
+++ b/packages/w/wavpack/package.yml
@@ -1,8 +1,8 @@
 name       : wavpack
-version    : 5.6.0
-release    : 13
+version    : '5.8.1'
+release    : 14
 source     :
-    - https://github.com/dbry/WavPack/releases/download/5.6.0/wavpack-5.6.0.tar.xz : af8035f457509c3d338b895875228a9b81de276c88c79bb2d3e31d9b605da9a9
+    - https://github.com/dbry/WavPack/releases/download/5.8.1/wavpack-5.8.1.tar.xz : 7322775498602c8850afcfc1ae38f99df4cbcd51386e873d6b0f8047e55c0c26
 homepage   : https://www.wavpack.com
 license    : BSD-3-Clause
 component  :

--- a/packages/w/wavpack/pspec_x86_64.xml
+++ b/packages/w/wavpack/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>wavpack</Name>
         <Homepage>https://www.wavpack.com</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>multimedia.codecs</PartOf>
         <Summary xml:lang="en">WavPack audio compression tools</Summary>
         <Description xml:lang="en">WavPack is a completely open audio compression format providing lossless, high-quality lossy, and a unique hybrid compression mode.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>wavpack</Name>
@@ -21,7 +21,7 @@
         <PartOf>multimedia.codecs</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libwavpack.so.1</Path>
-            <Path fileType="library">/usr/lib64/libwavpack.so.1.2.5</Path>
+            <Path fileType="library">/usr/lib64/libwavpack.so.1.2.7</Path>
         </Files>
     </Package>
     <Package>
@@ -31,7 +31,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="13">wavpack</Dependency>
+            <Dependency release="14">wavpack</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wavpack/wavpack.h</Path>
@@ -46,7 +46,7 @@
 </Description>
         <PartOf>multimedia.codecs</PartOf>
         <RuntimeDependencies>
-            <Dependency release="13">wavpack</Dependency>
+            <Dependency release="14">wavpack</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/wavpack</Path>
@@ -60,12 +60,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2023-01-11</Date>
-            <Version>5.6.0</Version>
+        <Update release="14">
+            <Date>2025-03-24</Date>
+            <Version>5.8.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- [5.8.1](https://github.com/dbry/WavPack/releases/tag/5.8.1)
- [5.7.0](https://github.com/dbry/WavPack/releases/tag/5.7.0)

**Test Plan**

Run some the the revdeps: easytag, mixx, audacity

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
