### PR TITLE
typst: Update to 0.13.1

### DIFF
--- a/packages/t/typst/abi_used_symbols
+++ b/packages/t/typst/abi_used_symbols
@@ -109,6 +109,7 @@ libc.so.6:recvmsg
 libc.so.6:sched_getaffinity
 libc.so.6:sched_yield
 libc.so.6:send
+libc.so.6:sendfile64
 libc.so.6:sendmsg
 libc.so.6:setgid
 libc.so.6:setgroups
@@ -124,6 +125,7 @@ libc.so.6:sigemptyset
 libc.so.6:signal
 libc.so.6:socket
 libc.so.6:socketpair
+libc.so.6:splice
 libc.so.6:stat64
 libc.so.6:strlen
 libc.so.6:symlink

--- a/packages/t/typst/package.yml
+++ b/packages/t/typst/package.yml
@@ -1,8 +1,8 @@
 name       : typst
-version    : 0.13.0
-release    : 6
+version    : 0.13.1
+release    : 7
 source     :
-    - https://github.com/typst/typst/archive/refs/tags/v0.13.0.tar.gz : 5a7224e32a555ac647ff202667a183b80d35539b685b3ce64bedf5d4e5a1a286
+    - https://github.com/typst/typst/archive/refs/tags/v0.13.1.tar.gz : 2ffd8443668bc0adb59e9893f7904fd9f64dce8799a1930569f56a91305e8b71
 homepage   : https://typst.app
 license    : Apache-2.0
 component  : office

--- a/packages/t/typst/pspec_x86_64.xml
+++ b/packages/t/typst/pspec_x86_64.xml
@@ -4,7 +4,7 @@
         <Homepage>https://typst.app</Homepage>
         <Packager>
             <Name>Marcus Mellor</Name>
-            <Email>infinitymdm@gmail.com</Email>
+            <Email>marcus@infinitymdm.dev</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>office</PartOf>
@@ -24,12 +24,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2025-02-19</Date>
-            <Version>0.13.0</Version>
+        <Update release="7">
+            <Date>2025-03-24</Date>
+            <Version>0.13.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Marcus Mellor</Name>
-            <Email>infinitymdm@gmail.com</Email>
+            <Email>marcus@infinitymdm.dev</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Update to the latest Typst release. 
- Fix CPU usage when running `typst watch`
- Fix a few bugs with HTML export (experimental!)
- Fix a regression re. querieing labeled symbols
- Fix false positive deprecation warnings for type/str comparisons

See the [changelog](https://typst.app/docs/changelog/0.13.1/) for full details.

**Test Plan**

Compile a complex document (an IEEE conference paper in my case) and verify the result.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
