### PR TITLE
weechat: Update to v4.6.0

### DIFF
--- a/packages/w/weechat/abi_symbols
+++ b/packages/w/weechat/abi_symbols
@@ -502,6 +502,7 @@ guile.so:plugin_script_alloc
 guile.so:plugin_script_api_bar_item_new
 guile.so:plugin_script_api_buffer_new
 guile.so:plugin_script_api_buffer_new_props
+guile.so:plugin_script_api_build_option_full_name
 guile.so:plugin_script_api_charset_set
 guile.so:plugin_script_api_command
 guile.so:plugin_script_api_command_options
@@ -610,6 +611,7 @@ guile.so:weechat_guile_api_completion_get_string
 guile.so:weechat_guile_api_completion_list_add
 guile.so:weechat_guile_api_completion_new
 guile.so:weechat_guile_api_completion_search
+guile.so:weechat_guile_api_completion_set
 guile.so:weechat_guile_api_config_boolean
 guile.so:weechat_guile_api_config_boolean_default
 guile.so:weechat_guile_api_config_boolean_inherited
@@ -1992,6 +1994,7 @@ lua.so:plugin_script_alloc
 lua.so:plugin_script_api_bar_item_new
 lua.so:plugin_script_api_buffer_new
 lua.so:plugin_script_api_buffer_new_props
+lua.so:plugin_script_api_build_option_full_name
 lua.so:plugin_script_api_charset_set
 lua.so:plugin_script_api_command
 lua.so:plugin_script_api_command_options
@@ -2163,6 +2166,7 @@ perl.so:XS_weechat_api_completion_get_string
 perl.so:XS_weechat_api_completion_list_add
 perl.so:XS_weechat_api_completion_new
 perl.so:XS_weechat_api_completion_search
+perl.so:XS_weechat_api_completion_set
 perl.so:XS_weechat_api_config_boolean
 perl.so:XS_weechat_api_config_boolean_default
 perl.so:XS_weechat_api_config_boolean_inherited
@@ -2385,6 +2389,7 @@ perl.so:plugin_script_alloc
 perl.so:plugin_script_api_bar_item_new
 perl.so:plugin_script_api_buffer_new
 perl.so:plugin_script_api_buffer_new_props
+perl.so:plugin_script_api_build_option_full_name
 perl.so:plugin_script_api_charset_set
 perl.so:plugin_script_api_command
 perl.so:plugin_script_api_command_options
@@ -2534,6 +2539,7 @@ python.so:plugin_script_alloc
 python.so:plugin_script_api_bar_item_new
 python.so:plugin_script_api_buffer_new
 python.so:plugin_script_api_buffer_new_props
+python.so:plugin_script_api_build_option_full_name
 python.so:plugin_script_api_charset_set
 python.so:plugin_script_api_command
 python.so:plugin_script_api_command_options
@@ -2710,6 +2716,7 @@ relay.so:relay_api_get_initial_status
 relay.so:relay_api_hook_signals
 relay.so:relay_api_msg_buffer_add_local_vars_cb
 relay.so:relay_api_msg_buffer_to_json
+relay.so:relay_api_msg_completion_to_json
 relay.so:relay_api_msg_hotlist_to_json
 relay.so:relay_api_msg_key_to_json
 relay.so:relay_api_msg_keys_to_json
@@ -2723,6 +2730,7 @@ relay.so:relay_api_msg_send_json
 relay.so:relay_api_msg_send_json_internal
 relay.so:relay_api_print_log
 relay.so:relay_api_protocol_cb_buffers
+relay.so:relay_api_protocol_cb_completion
 relay.so:relay_api_protocol_cb_handshake
 relay.so:relay_api_protocol_cb_hotlist
 relay.so:relay_api_protocol_cb_input
@@ -2810,6 +2818,8 @@ relay.so:relay_completion_remotes_cb
 relay.so:relay_config_api_remote_autoreconnect_delay_growing
 relay.so:relay_config_api_remote_autoreconnect_delay_max
 relay.so:relay_config_api_remote_get_lines
+relay.so:relay_config_api_remote_input_cmd_local
+relay.so:relay_config_api_remote_input_cmd_remote
 relay.so:relay_config_auto_open_buffer
 relay.so:relay_config_change_auto_open_buffer_cb
 relay.so:relay_config_change_display_clients_cb
@@ -2979,6 +2989,7 @@ relay.so:relay_irc_signal_irc_disc_cb
 relay.so:relay_irc_signal_irc_in2_cb
 relay.so:relay_irc_signal_irc_outtags_cb
 relay.so:relay_irc_tag_relay_client_id
+relay.so:relay_modifier_input_text_display_cb
 relay.so:relay_msg_type_string
 relay.so:relay_network_end
 relay.so:relay_network_init
@@ -3208,6 +3219,7 @@ ruby.so:plugin_script_alloc
 ruby.so:plugin_script_api_bar_item_new
 ruby.so:plugin_script_api_buffer_new
 ruby.so:plugin_script_api_buffer_new_props
+ruby.so:plugin_script_api_build_option_full_name
 ruby.so:plugin_script_api_charset_set
 ruby.so:plugin_script_api_command
 ruby.so:plugin_script_api_command_options
@@ -3550,7 +3562,6 @@ script.so:weechat_plugin_name
 script.so:weechat_plugin_priority
 script.so:weechat_plugin_version
 script.so:weechat_script_plugin
-spell.so:broker
 spell.so:spell_bar_item_dict
 spell.so:spell_bar_item_init
 spell.so:spell_bar_item_suggest
@@ -3612,6 +3623,7 @@ spell.so:spell_count_commands_to_check
 spell.so:spell_countries
 spell.so:spell_debug_libs_cb
 spell.so:spell_enabled
+spell.so:spell_enchant_broker
 spell.so:spell_enchant_dict_describe_cb
 spell.so:spell_get_dict
 spell.so:spell_get_dict_with_buffer_name
@@ -3665,6 +3677,7 @@ tcl.so:plugin_script_alloc
 tcl.so:plugin_script_api_bar_item_new
 tcl.so:plugin_script_api_buffer_new
 tcl.so:plugin_script_api_buffer_new_props
+tcl.so:plugin_script_api_build_option_full_name
 tcl.so:plugin_script_api_charset_set
 tcl.so:plugin_script_api_command
 tcl.so:plugin_script_api_command_options

--- a/packages/w/weechat/abi_used_symbols
+++ b/packages/w/weechat/abi_used_symbols
@@ -6,6 +6,7 @@ libc.so.6:__fprintf_chk
 libc.so.6:__isoc23_sscanf
 libc.so.6:__isoc23_strtol
 libc.so.6:__isoc23_strtoll
+libc.so.6:__isoc23_strtoull
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
@@ -489,7 +490,6 @@ libpython3.11.so.1.0:PyDict_GetItemString
 libpython3.11.so.1.0:PyDict_New
 libpython3.11.so.1.0:PyDict_Next
 libpython3.11.so.1.0:PyDict_SetItem
-libpython3.11.so.1.0:PyDict_SetItemString
 libpython3.11.so.1.0:PyErr_Occurred
 libpython3.11.so.1.0:PyErr_Print
 libpython3.11.so.1.0:PyImport_AddModule
@@ -499,6 +499,8 @@ libpython3.11.so.1.0:PyLong_AsLong
 libpython3.11.so.1.0:PyLong_FromLong
 libpython3.11.so.1.0:PyLong_FromLongLong
 libpython3.11.so.1.0:PyLong_FromUnsignedLongLong
+libpython3.11.so.1.0:PyModule_AddIntConstant
+libpython3.11.so.1.0:PyModule_AddStringConstant
 libpython3.11.so.1.0:PyModule_Create2
 libpython3.11.so.1.0:PyModule_GetDict
 libpython3.11.so.1.0:PyObject_CallFunction

--- a/packages/w/weechat/package.yml
+++ b/packages/w/weechat/package.yml
@@ -1,8 +1,8 @@
 name       : weechat
-version    : 4.5.1
-release    : 90
+version    : 4.6.0
+release    : 91
 source     :
-    - https://github.com/weechat/weechat/archive/refs/tags/v4.5.1.tar.gz : aae869ab8fe872961587ed487c2cad4627453118afa1510f536d53844785e1da
+    - https://github.com/weechat/weechat/archive/refs/tags/v4.6.0.tar.gz : 11d4914c5b51482c8ade026c3889b68e0c3e1938a0ce6127e36faba48f76e633
 homepage   : https://weechat.org
 license    : GPL-3.0-or-later
 summary    : WeeChat is a fast, light and extensible chat client.

--- a/packages/w/weechat/pspec_x86_64.xml
+++ b/packages/w/weechat/pspec_x86_64.xml
@@ -72,7 +72,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="90">weechat</Dependency>
+            <Dependency release="91">weechat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/weechat/weechat-plugin.h</Path>
@@ -80,9 +80,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="90">
-            <Date>2024-12-23</Date>
-            <Version>4.5.1</Version>
+        <Update release="91">
+            <Date>2025-03-24</Date>
+            <Version>4.6.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/weechat/weechat/releases/tag/v4.6.0).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Connect to Libera, send and receive messages.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
