### PR TITLE
discover: Add missing dependencies for Budgie and Xfce

### DIFF
--- a/packages/d/discover/package.yml
+++ b/packages/d/discover/package.yml
@@ -1,6 +1,6 @@
 name       : discover
 version    : 6.3.3
-release    : 31
+release    : 32
 source     :
     - https://download.kde.org/stable/plasma/6.3.3/discover-6.3.3.tar.xz : de29ad7e914e9bbd30a3466222f9542449583871afe856aca0071409cf5c586d
 homepage   : https://apps.kde.org/discover/
@@ -37,6 +37,8 @@ builddeps  :
 rundeps    :
     - kf6-kirigami
     - kf6-kitemmodels
+    - kf6-purpose
+    - kf6-qqc2-desktop-style
     - kirigami-addons
 clang      : yes
 optimize   : thin-lto

--- a/packages/d/discover/pspec_x86_64.xml
+++ b/packages/d/discover/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>discover</Name>
         <Homepage>https://apps.kde.org/discover/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.kde</PartOf>
@@ -291,12 +291,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2025-03-12</Date>
+        <Update release="32">
+            <Date>2025-03-24</Date>
             <Version>6.3.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Add missing dependencies for Budgie and Xfce

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install this package in an Xfce VM that did not previously have Discover installed.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
