### PR TITLE
egl-gbm: Update to 1.1.2.1 and rebuild nvidia drivers

### DIFF
--- a/packages/e/egl-gbm/package.yml
+++ b/packages/e/egl-gbm/package.yml
@@ -1,8 +1,8 @@
 name       : egl-gbm
-version    : 1.1.2
-release    : 2
+version    : 1.1.2.1
+release    : 3
 source     :
-    - https://github.com/NVIDIA/egl-gbm/archive/refs/tags/1.1.2.tar.gz : 40c8a1a3df0639ea83031a92e9adcbef92ed696445307aa23cfc5895e63d11f0
+    - https://github.com/NVIDIA/egl-gbm/archive/refs/tags/1.1.2.1.tar.gz : 7485553525b4212842230098b12671469bddb3c37063a89383f31865aea63aef
 homepage   : https://github.com/NVIDIA/egl-gbm
 license    : MIT
 component  : programming.library

--- a/packages/e/egl-gbm/pspec_x86_64.xml
+++ b/packages/e/egl-gbm/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>egl-gbm</Name>
         <Homepage>https://github.com/NVIDIA/egl-gbm</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.library</PartOf>
@@ -22,6 +22,7 @@
         <Files>
             <Path fileType="library">/usr/lib64/libnvidia-egl-gbm.so.1</Path>
             <Path fileType="library">/usr/lib64/libnvidia-egl-gbm.so.1.1.2</Path>
+            <Path fileType="data">/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json</Path>
         </Files>
     </Package>
     <Package>
@@ -31,7 +32,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">egl-gbm</Dependency>
+            <Dependency release="3">egl-gbm</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnvidia-egl-gbm.so.1</Path>
@@ -45,8 +46,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">egl-gbm-32bit</Dependency>
-            <Dependency release="2">egl-gbm-devel</Dependency>
+            <Dependency release="3">egl-gbm-32bit</Dependency>
+            <Dependency release="3">egl-gbm-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnvidia-egl-gbm.so</Path>
@@ -59,19 +60,19 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">egl-gbm</Dependency>
+            <Dependency release="3">egl-gbm</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libnvidia-egl-gbm.so</Path>
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-10-22</Date>
-            <Version>1.1.2</Version>
+        <Update release="3">
+            <Date>2025-03-25</Date>
+            <Version>1.1.2.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/n/nvidia-beta-driver/package.yml
+++ b/packages/n/nvidia-beta-driver/package.yml
@@ -1,6 +1,6 @@
 name       : nvidia-beta-driver
 version    : 570.124.04
-release    : 305
+release    : 306
 source     :
     - https://us.download.nvidia.com/XFree86/Linux-x86_64/570.124.04/NVIDIA-Linux-x86_64-570.124.04.run : 1b786a4b7122d7c4216c58ae4007688a4f778c196c148d919163815ee10d53c4
 extract    : no
@@ -171,9 +171,6 @@ install    : |
     install -Dm00644 nvidia_icd.json $installdir/usr/share/vulkan/icd.d/10_nvidia.json
     install -Dm00644 nvidia_icd_vksc.json $installdir/usr/share/vulkansc/icd.d/nvidia_icd_vksc.json
     install -Dm00644 nvidia_layers.json $installdir/usr/share/vulkan/implicit_layer.d/nvidia_layers.json
-
-    # GBM ICD
-    install -Dm00644 15_nvidia_gbm.json $installdir/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json
 
     # GBM
     install -D -d -m 00755 $installdir/%libdir%/gbm

--- a/packages/n/nvidia-beta-driver/pspec_x86_64.xml
+++ b/packages/n/nvidia-beta-driver/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nvidia-beta-driver</Name>
         <Homepage>https://nvidia.com</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>EULA</License>
         <PartOf>kernel.drivers</PartOf>
@@ -24,7 +24,7 @@ NVIDIA Short-lived Binary Driver
 </Description>
         <PartOf>kernel.drivers</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="305">nvidia-beta-driver-common</Dependency>
+            <Dependency releaseFrom="306">nvidia-beta-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.6.83-266.lts/kernel/drivers/video/nvidia-drm.ko.zst</Path>
@@ -54,7 +54,7 @@ NVIDIA Short-lived Binary Driver
 </Description>
         <PartOf>xorg.driver</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="305">nvidia-beta-driver-common</Dependency>
+            <Dependency releaseFrom="306">nvidia-beta-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libEGL_nvidia.so</Path>
@@ -262,7 +262,6 @@ NVIDIA Short-lived Binary Driver
             <Path fileType="data">/usr/share/X11/xorg.conf.d/10-nvidia.conf</Path>
             <Path fileType="data">/usr/share/applications/nvidia-settings.desktop</Path>
             <Path fileType="data">/usr/share/dbus-1/system.d/nvidia-dbus.conf</Path>
-            <Path fileType="data">/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json</Path>
             <Path fileType="data">/usr/share/glvnd/egl_vendor.d/10_nvidia.json</Path>
             <Path fileType="data">/usr/share/nvidia/files.d/sandboxutils-filelist.json</Path>
             <Path fileType="data">/usr/share/nvidia/nvidia-application-profiles-570.124.04-key-documentation</Path>
@@ -288,7 +287,7 @@ NVIDIA Short-lived Binary Driver
 </Description>
         <PartOf>kernel.drivers</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="305">nvidia-beta-driver-common</Dependency>
+            <Dependency releaseFrom="306">nvidia-beta-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.12.19-315.current/kernel/drivers/video/nvidia-drm.ko.zst</Path>
@@ -310,12 +309,12 @@ NVIDIA Short-lived Binary Driver
         </Conflicts>
     </Package>
     <History>
-        <Update release="305">
-            <Date>2025-03-14</Date>
+        <Update release="306">
+            <Date>2025-03-25</Date>
             <Version>570.124.04</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/n/nvidia-developer-driver/package.yml
+++ b/packages/n/nvidia-developer-driver/package.yml
@@ -1,6 +1,6 @@
 name       : nvidia-developer-driver
 version    : 570.123.06
-release    : 329
+release    : 330
 source     :
     - https://developer.nvidia.com/downloads/vulkan-beta-57012306-linux : dc5c13e41e753fe92d34cd94670ea7403b92ec43296df574aa4b91b688613679
 extract    : no
@@ -185,9 +185,6 @@ install    : |
     install -Dm00644 nvidia_icd.json $installdir/usr/share/vulkan/icd.d/10_nvidia.json
     install -Dm00644 nvidia_icd_vksc.json $installdir/usr/share/vulkansc/icd.d/nvidia_icd_vksc.json
     install -Dm00644 nvidia_layers.json $installdir/usr/share/vulkan/implicit_layer.d/nvidia_layers.json
-
-    # GBM ICD
-    install -Dm00644 15_nvidia_gbm.json $installdir/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json
 
     # GBM
     install -D -d -m 00755 $installdir/%libdir%/gbm

--- a/packages/n/nvidia-developer-driver/pspec_x86_64.xml
+++ b/packages/n/nvidia-developer-driver/pspec_x86_64.xml
@@ -20,7 +20,7 @@
 </Description>
         <PartOf>kernel.drivers</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="329">nvidia-developer-driver-common</Dependency>
+            <Dependency releaseFrom="330">nvidia-developer-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.6.83-266.lts/kernel/drivers/video/nvidia-drm.ko.zst</Path>
@@ -48,7 +48,7 @@
 </Description>
         <PartOf>xorg.driver</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="329">nvidia-developer-driver-common</Dependency>
+            <Dependency releaseFrom="330">nvidia-developer-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libEGL_nvidia.so</Path>
@@ -254,7 +254,6 @@
             <Path fileType="data">/usr/share/X11/xorg.conf.d/10-nvidia.conf</Path>
             <Path fileType="data">/usr/share/applications/nvidia-settings.desktop</Path>
             <Path fileType="data">/usr/share/dbus-1/system.d/nvidia-dbus.conf</Path>
-            <Path fileType="data">/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json</Path>
             <Path fileType="data">/usr/share/glvnd/egl_vendor.d/10_nvidia.json</Path>
             <Path fileType="data">/usr/share/nvidia/files.d/sandboxutils-filelist.json</Path>
             <Path fileType="data">/usr/share/nvidia/nvidia-application-profiles-570.123.06-key-documentation</Path>
@@ -278,7 +277,7 @@
 </Description>
         <PartOf>kernel.drivers</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="329">nvidia-developer-driver-common</Dependency>
+            <Dependency releaseFrom="330">nvidia-developer-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.12.19-315.current/kernel/drivers/video/nvidia-drm.ko.zst</Path>
@@ -311,8 +310,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="329">
-            <Date>2025-03-16</Date>
+        <Update release="330">
+            <Date>2025-03-25</Date>
             <Version>570.123.06</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>

--- a/packages/n/nvidia-glx-driver/package.yml
+++ b/packages/n/nvidia-glx-driver/package.yml
@@ -2,7 +2,7 @@
 # nvidia-beta-driver should always be ahead of nvidia-glx-driver version-wise or at the same version, never behind.
 name       : nvidia-glx-driver
 version    : 570.133.07
-release    : 560
+release    : 561
 source     :
     - https://us.download.nvidia.com/XFree86/Linux-x86_64/570.133.07/NVIDIA-Linux-x86_64-570.133.07.run : 2d43e64c581be5ef554de9888b1aa90037ef6d45f54284d3d9dcedc08dc4dc26
 extract    : no
@@ -207,9 +207,6 @@ install    : |
     install -Dm00644 nvidia_icd.json $installdir/usr/share/vulkan/icd.d/10_nvidia.json
     install -Dm00644 nvidia_icd_vksc.json $installdir/usr/share/vulkansc/icd.d/nvidia_icd_vksc.json
     install -Dm00644 nvidia_layers.json $installdir/usr/share/vulkan/implicit_layer.d/nvidia_layers.json
-
-    # GBM ICD
-    install -Dm00644 15_nvidia_gbm.json $installdir/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json
 
     # GBM
     install -D -d -m 00755 $installdir/%libdir%/gbm

--- a/packages/n/nvidia-glx-driver/pspec_x86_64.xml
+++ b/packages/n/nvidia-glx-driver/pspec_x86_64.xml
@@ -18,7 +18,7 @@
         <Description xml:lang="en">NVIDIA Binary Driver (LTS Kernel)</Description>
         <PartOf>kernel.drivers</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="560">nvidia-glx-driver-common</Dependency>
+            <Dependency releaseFrom="561">nvidia-glx-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.6.83-266.lts/kernel/drivers/video/nvidia-drm.ko.zst</Path>
@@ -46,7 +46,7 @@
         <Description xml:lang="en">32-bit libraries for NVIDIA Binary Driver</Description>
         <PartOf>xorg.driver</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="560">nvidia-glx-driver-common</Dependency>
+            <Dependency releaseFrom="561">nvidia-glx-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libEGL_nvidia.so</Path>
@@ -252,7 +252,6 @@
             <Path fileType="data">/usr/share/X11/xorg.conf.d/10-nvidia.conf</Path>
             <Path fileType="data">/usr/share/applications/nvidia-settings.desktop</Path>
             <Path fileType="data">/usr/share/dbus-1/system.d/nvidia-dbus.conf</Path>
-            <Path fileType="data">/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json</Path>
             <Path fileType="data">/usr/share/glvnd/egl_vendor.d/10_nvidia.json</Path>
             <Path fileType="data">/usr/share/nvidia/files.d/sandboxutils-filelist.json</Path>
             <Path fileType="data">/usr/share/nvidia/nvidia-application-profiles-570.133.07-key-documentation</Path>
@@ -275,7 +274,7 @@
         <Description xml:lang="en">NVIDIA Binary Driver (Current Kernel)</Description>
         <PartOf>kernel.drivers</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="560">nvidia-glx-driver-common</Dependency>
+            <Dependency releaseFrom="561">nvidia-glx-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.12.19-315.current/kernel/drivers/video/nvidia-drm.ko.zst</Path>
@@ -308,8 +307,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="560">
-            <Date>2025-03-19</Date>
+        <Update release="561">
+            <Date>2025-03-25</Date>
             <Version>570.133.07</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>


### PR DESCRIPTION
**Summary**

egl-gbm 1.1.21 now provides its own ICD file. This updates egl-gbm and removes the ICD files from the nvidia drivers where applicable.

**Test Plan**
- Successfully booted into a GNOME Wayland session and ran `xeglgears`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
