### PR TITLE
putty: Update to v0.83

### DIFF
--- a/packages/p/putty/package.yml
+++ b/packages/p/putty/package.yml
@@ -1,8 +1,8 @@
 name       : putty
-version    : '0.82'
-release    : 15
+version    : '0.83'
+release    : 16
 source     :
-    - https://the.earth.li/~sgtatham/putty/latest/putty-0.82.tar.gz : 195621638bb6b33784b4e96cdc296f332991b5244968dc623521c3703097b5d9
+    - https://the.earth.li/~sgtatham/putty/latest/putty-0.83.tar.gz : 718777c13d63d0dff91fe03162bc2a05b4dfc8b0827634cd60b51cefdff631c6
 license    : MIT
 component  : network.remote
 homepage   : https://www.chiark.greenend.org.uk/~sgtatham/putty

--- a/packages/p/putty/pspec_x86_64.xml
+++ b/packages/p/putty/pspec_x86_64.xml
@@ -43,9 +43,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2024-12-20</Date>
-            <Version>0.82</Version>
+        <Update release="16">
+            <Date>2025-03-26</Date>
+            <Version>0.83</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
- Support for ML-KEM, the NIST-standardised post-quantum key exchange mechanism. (In addition to NTRU Prime, which has been supported since 0.78.)
- Bug fix: psftp -b works again.
- Bug fix: assertion failure if an SSH connection times out at the login prompt.
- Bug fix: crash in Pageant if an SSH connection is abandoned while waiting for a deferred decryption passphrase.
- Bug fix: tight loop if PuTTY tried to send an empty answerback string.
- Bug fix: accidental truncation of some configuration edit boxes' contents to 127 characters.
- Bug fix: restored interoperation with third-party tools that auto-fill login prompts by sending ^M for Return.
- Bug fix: confusion when terminal window resized by tools like FancyZones.
- Bug fix: the small keypad keys didn't reliably work in the terminal on Unix.

**Test Plan**
- Connected to a server over SSH.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
