### PR TITLE
xdg-desktop-portal-gnome: Add nautilus as rundep

### DIFF
--- a/packages/x/xdg-desktop-portal-gnome/package.yml
+++ b/packages/x/xdg-desktop-portal-gnome/package.yml
@@ -1,6 +1,6 @@
 name       : xdg-desktop-portal-gnome
 version    : '47.2'
-release    : 10
+release    : 11
 source     :
     - https://download.gnome.org/sources/xdg-desktop-portal-gnome/47/xdg-desktop-portal-gnome-47.2.tar.xz : 4b5368aa19dc0aa62c8a84e481c8a26490b4d77c7900b8e5c9d432ce91f1274c
 homepage   : https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome
@@ -16,6 +16,7 @@ builddeps  :
     - pkgconfig(xdg-desktop-portal)
     - gnome-keyring
 rundeps    :
+    - nautilus
     - xdg-desktop-portal-gtk
 setup      : |
     %meson_configure

--- a/packages/x/xdg-desktop-portal-gnome/pspec_x86_64.xml
+++ b/packages/x/xdg-desktop-portal-gnome/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xdg-desktop-portal-gnome</Name>
         <Homepage>https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Gavin Zhao</Name>
+            <Email>me@gzgz.dev</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>desktop.util</PartOf>
@@ -80,12 +80,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2025-02-03</Date>
+        <Update release="11">
+            <Date>2025-03-26</Date>
             <Version>47.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Gavin Zhao</Name>
+            <Email>me@gzgz.dev</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
Fixes #5293.

**Summary**

Add `nautilus` to the rundep of `xdg-desktop-portal-gnome`.

**Test Plan**

A file chooser dialogue pops up correctly when I try to upload an image to GitHub.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
