### PR TITLE
python-orjson: Update to v3.10.16

### DIFF
--- a/packages/py/python-orjson/abi_used_symbols
+++ b/packages/py/python-orjson/abi_used_symbols
@@ -63,6 +63,7 @@ libc.so.6:__stack_chk_fail
 libc.so.6:__xpg_strerror_r
 libc.so.6:abort
 libc.so.6:bcmp
+libc.so.6:clock_gettime
 libc.so.6:close
 libc.so.6:dl_iterate_phdr
 libc.so.6:free

--- a/packages/py/python-orjson/package.yml
+++ b/packages/py/python-orjson/package.yml
@@ -1,8 +1,8 @@
 name       : python-orjson
-version    : 3.10.15
-release    : 48
+version    : 3.10.16
+release    : 49
 source     :
-    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.15.tar.gz : 05ca7fe452a2e9d8d9d706a2984c95b9c2ebc5db417ce0b7a49b91d50642a23e
+    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.16.tar.gz : d2aaa5c495e11d17b9b93205f5fa196737ee3202f000aaebf028dc9a73750f10
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-orjson/pspec_x86_64.xml
+++ b/packages/py/python-orjson/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-orjson</Name>
         <Homepage>https://github.com/ijl/orjson</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>MIT</License>
@@ -21,11 +21,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.15.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.15.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.15.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.15.dist-info/licenses/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.15.dist-info/licenses/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.16.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.16.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.16.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.16.dist-info/licenses/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/orjson-3.10.16.dist-info/licenses/LICENSE-MIT</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/orjson/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
@@ -35,12 +35,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="48">
-            <Date>2025-02-18</Date>
-            <Version>3.10.15</Version>
+        <Update release="49">
+            <Date>2025-03-26</Date>
+            <Version>3.10.16</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Improve performance of serialization on amd64 machines with AVX-512
- ABI compatibility with CPython 3.14 alpha 6
- Drop support for Python 3.8

**Test Plan**

Ran some examples from the project's README

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
