### PR TITLE
r2modman: Add icon installation

### DIFF
--- a/packages/r/r2modman/package.yml
+++ b/packages/r/r2modman/package.yml
@@ -1,6 +1,6 @@
 name       : r2modman
 version    : 3.1.55
-release    : 1
+release    : 2
 source     :
     - https://github.com/ebkr/r2modmanPlus/archive/refs/tags/v3.1.55.tar.gz : 2954aae37c12c6d27df932a73f08ea1a503171a85138c5625b3a0047b44c78e9
 homepage   : https://github.com/ebkr/r2modmanPlus
@@ -28,5 +28,10 @@ install    : |
 
     # Install desktop file
     install -Dm00644 $pkgfiles/r2modman.desktop -t $installdir/usr/share/applications
+
+    # Install icons
+    for s in 16x16 24x24 32x32 48x48 64x64 96x96 128x128 192x192 256x256; do
+        install -Dm0644 src/assets/icon/${s}.png $installdir/usr/share/icons/hicolor/${s}/apps/r2modman.png
+    done
 
     # TODO: Install appstream metadata

--- a/packages/r/r2modman/pspec_x86_64.xml
+++ b/packages/r/r2modman/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>r2modman</Name>
         <Homepage>https://github.com/ebkr/r2modmanPlus</Homepage>
         <Packager>
-            <Name>Marcus Mellor</Name>
-            <Email>infinitymdm@gmail.com</Email>
+            <Name>Hurican Solas</Name>
+            <Email>hurican@keemail.me</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>games</PartOf>
@@ -22,6 +22,15 @@
         <Files>
             <Path fileType="executable">/usr/bin/r2modman</Path>
             <Path fileType="data">/usr/share/applications/r2modman.desktop</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/r2modman.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16/apps/r2modman.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/192x192/apps/r2modman.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24/apps/r2modman.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/r2modman.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/r2modman.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/r2modman.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/r2modman.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/96x96/apps/r2modman.png</Path>
             <Path fileType="data">/usr/share/r2modman/LICENSE.electron.txt</Path>
             <Path fileType="data">/usr/share/r2modman/LICENSES.chromium.html</Path>
             <Path fileType="data">/usr/share/r2modman/chrome-sandbox</Path>
@@ -98,12 +107,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2025-02-20</Date>
+        <Update release="2">
+            <Date>2025-03-28</Date>
             <Version>3.1.55</Version>
             <Comment>Packaging update</Comment>
-            <Name>Marcus Mellor</Name>
-            <Email>infinitymdm@gmail.com</Email>
+            <Name>Hurican Solas</Name>
+            <Email>hurican@keemail.me</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Icons for r2modman should now be installed.

**Test Plan**

Installed the package and everything seems to be working fine. The icon now shows on the taskbar + application menu and i've checked the font directories to make sure everything was installed in the right place. This is my first ever commit so please check it carefully and I apologise in advance if there are any mistakes. I originally did it manually with a line per font size but saw how the firefox package did its font installation and copied that over and tried to change it to work with r2modman as i assume this is the way it should be done.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
