### PR TITLE
xfce4-session: Fix service access on Wayland

### DIFF
--- a/packages/x/xfce4-session/files/0001-scripts-Only-use-dbus-run-session-if-address-is-unse.patch
+++ b/packages/x/xfce4-session/files/0001-scripts-Only-use-dbus-run-session-if-address-is-unse.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Evan Maddock <maddock.evan@vivaldi.net>
+Date: Thu, 27 Mar 2025 10:53:54 -0400
+Subject: [PATCH] scripts: Only use dbus-run-session if address is unset or
+ empty
+
+Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
+---
+ scripts/startxfce4.in | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/scripts/startxfce4.in b/scripts/startxfce4.in
+index 45360b20..6711f347 100644
+--- a/scripts/startxfce4.in
++++ b/scripts/startxfce4.in
+@@ -161,7 +161,10 @@ then
+     # Also: Xfce will use its own config directory and config file
+     # to avoid conflict with current labwc setup and avoid launching 
+     # anything from ~/.config/labwc/autostart
+-    XFCE4_SESSION_COMPOSITOR="dbus-run-session -- ${OPTS:-labwc --config-dir ${XDG_CONFIG_HOME:-${HOME}/.config}/xfce4/labwc --config ${XDG_CONFIG_HOME:-${HOME}/.config}/xfce4/labwc/rc.xml $startup_option xfce4-session}"
++    XFCE4_SESSION_COMPOSITOR="${OPTS:-labwc --config-dir ${XDG_CONFIG_HOME:-${HOME}/.config}/xfce4/labwc --config ${XDG_CONFIG_HOME:-${HOME}/.config}/xfce4/labwc/rc.xml $startup_option xfce4-session}"
++    if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
++       XFCE4_SESSION_COMPOSITOR="dbus-run-session -- ${XFCE4_SESSION_COMPOSITOR}"
++    fi
+   fi
+ fi
+ 

--- a/packages/x/xfce4-session/package.yml
+++ b/packages/x/xfce4-session/package.yml
@@ -1,6 +1,6 @@
 name       : xfce4-session
 version    : 4.20.2
-release    : 16
+release    : 17
 source     :
     - https://archive.xfce.org/src/xfce/xfce4-session/4.20/xfce4-session-4.20.2.tar.bz2 : a0b80b7136515bc3c0c54fa859ad420365e29b715b6da0b58a2d2781bfbe73c3
 homepage   : https://docs.xfce.org/xfce/xfce4-session/start
@@ -41,6 +41,7 @@ setup      : |
     %patch -p1 -i $pkgfiles/xfce-session-4.10-startxfce4.patch
     %patch -p1 -i $pkgfiles/0001-labwc-Set-snapping-range-to-10.patch
     %patch -p1 -i $pkgfiles/0001-labwc-Use-Breeze-cursors.patch
+    %patch -p1 -i $pkgfiles/0001-scripts-Only-use-dbus-run-session-if-address-is-unse.patch
 
     %configure \
                  --disable-debug \

--- a/packages/x/xfce4-session/pspec_x86_64.xml
+++ b/packages/x/xfce4-session/pspec_x86_64.xml
@@ -143,15 +143,15 @@
         <Description xml:lang="en">Experimental Wayland session for XFCE4. May result in a subpar experience. For advanced users only.</Description>
         <PartOf>desktop.xfce</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="16">xfce4-session</Dependency>
+            <Dependency releaseFrom="17">xfce4-session</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/wayland-sessions/xfce-wayland.desktop</Path>
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2025-03-26</Date>
+        <Update release="17">
+            <Date>2025-03-27</Date>
             <Version>4.20.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
- Fix service access on Wayland

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new Xfce4 Wayland session and see that Neochat auto logs in normally.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
