### PR TITLE
heroic-games-launcher: Update to 2.16.1

### DIFF
--- a/packages/h/heroic-games-launcher/abi_used_symbols
+++ b/packages/h/heroic-games-launcher/abi_used_symbols
@@ -521,6 +521,7 @@ libc.so.6:openlog
 libc.so.6:optarg
 libc.so.6:optind
 libc.so.6:pathconf
+libc.so.6:pause
 libc.so.6:perror
 libc.so.6:pipe
 libc.so.6:pipe2
@@ -554,7 +555,6 @@ libc.so.6:pthread_attr_setstacksize
 libc.so.6:pthread_create
 libc.so.6:pthread_detach
 libc.so.6:pthread_getattr_np
-libc.so.6:pthread_getspecific
 libc.so.6:pthread_join
 libc.so.6:pthread_key_create
 libc.so.6:pthread_key_delete

--- a/packages/h/heroic-games-launcher/package.yml
+++ b/packages/h/heroic-games-launcher/package.yml
@@ -1,8 +1,8 @@
 name       : heroic-games-launcher
-version    : 2.15.2
-release    : 31
+version    : 2.16.1
+release    : 32
 source     :
-    - git|https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher.git : v2.15.2
+    - git|https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher.git : v2.16.1
 homepage   : https://heroicgameslauncher.com/
 license    : GPL-3.0-or-later
 component  : games
@@ -36,6 +36,9 @@ install    : |
         ln -s $heroicdir/resources/app.asar.unpacked/build/bin/x64/linux/$binfile $installdir/usr/bin/$binfile
     done
     popd
+
+    # Remove arm64 binaries
+    rm -r $installdir/$heroicdir/resources/app.asar.unpacked/build/bin/arm64
 
     # Copy icon
     install -Dm00644 ./dist/linux-unpacked/resources/app.asar.unpacked/build/icon.png $installdir/usr/share/icons/hicolor/512x512/apps/com.heroicgameslauncher.hgl.png

--- a/packages/h/heroic-games-launcher/pspec_x86_64.xml
+++ b/packages/h/heroic-games-launcher/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>heroic-games-launcher</Name>
         <Homepage>https://heroicgameslauncher.com/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>games</PartOf>
@@ -108,7 +108,6 @@
             <Path fileType="data">/usr/share/heroic/resources/app.asar.unpacked/build/icon-light.png</Path>
             <Path fileType="data">/usr/share/heroic/resources/app.asar.unpacked/build/icon.icns</Path>
             <Path fileType="data">/usr/share/heroic/resources/app.asar.unpacked/build/icon.png</Path>
-            <Path fileType="data">/usr/share/heroic/resources/app.asar.unpacked/build/webviewPreload.js</Path>
             <Path fileType="data">/usr/share/heroic/resources/app.asar.unpacked/build/win_icon.ico</Path>
             <Path fileType="data">/usr/share/heroic/resources/app.asar.unpacked/node_modules/font-list/LICENSE</Path>
             <Path fileType="data">/usr/share/heroic/resources/app.asar.unpacked/node_modules/font-list/demo.js</Path>
@@ -130,12 +129,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2025-03-19</Date>
-            <Version>2.15.2</Version>
+        <Update release="32">
+            <Date>2025-03-30</Date>
+            <Version>2.16.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Update Heroic to the latest upstream release. Fixes #5321.

Improvements:
- Switch to Proton-GE as default (from Wine-GE) for better compatibility
- Use Unified Launcher (umu) by default for Proton games
- Better anti-cheat logging to help you troubleshoot
- Built-in wiki links for relevant information on specific games
- New "Guided Tour" for library, filters, and sidebar
- Lots of UI & customization improvements
- ... and much more! See release notes for complete details

Release Notes:
[2.16.0](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/tag/v2.16.0)
[2.16.1](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/tag/v2.16.1)

**Test Plan**

Open Heroic and navigate around store pages & library. Launch a game and make sure things work.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
