### PR TITLE
neovide: Update to v0.14.1

### DIFF
--- a/packages/n/neovide/abi_used_symbols
+++ b/packages/n/neovide/abi_used_symbols
@@ -5,9 +5,7 @@ libc.so.6:__fxstat
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_current_sigrtmax
 libc.so.6:__libc_start_main
-libc.so.6:__register_atfork
 libc.so.6:__res_init
-libc.so.6:__stack_chk_fail
 libc.so.6:__xpg_strerror_r
 libc.so.6:__xstat
 libc.so.6:_exit
@@ -29,7 +27,6 @@ libc.so.6:dlopen
 libc.so.6:dlsym
 libc.so.6:dup2
 libc.so.6:environ
-libc.so.6:epoll_create
 libc.so.6:epoll_create1
 libc.so.6:epoll_ctl
 libc.so.6:epoll_wait
@@ -66,7 +63,7 @@ libc.so.6:getsockopt
 libc.so.6:getuid
 libc.so.6:gnu_get_libc_version
 libc.so.6:inotify_add_watch
-libc.so.6:inotify_init
+libc.so.6:inotify_init1
 libc.so.6:inotify_rm_watch
 libc.so.6:ioctl
 libc.so.6:isatty
@@ -91,7 +88,7 @@ libc.so.6:newlocale
 libc.so.6:open
 libc.so.6:open64
 libc.so.6:opendir
-libc.so.6:pipe
+libc.so.6:pause
 libc.so.6:pipe2
 libc.so.6:poll
 libc.so.6:posix_memalign
@@ -113,7 +110,6 @@ libc.so.6:pthread_attr_setstacksize
 libc.so.6:pthread_create
 libc.so.6:pthread_detach
 libc.so.6:pthread_getattr_np
-libc.so.6:pthread_getspecific
 libc.so.6:pthread_join
 libc.so.6:pthread_key_create
 libc.so.6:pthread_key_delete
@@ -154,7 +150,6 @@ libc.so.6:signal
 libc.so.6:snprintf
 libc.so.6:socket
 libc.so.6:socketpair
-libc.so.6:sscanf
 libc.so.6:stat64
 libc.so.6:stderr
 libc.so.6:strcat
@@ -237,6 +232,7 @@ libfreetype.so.6:FT_Done_Face
 libfreetype.so.6:FT_Done_Library
 libfreetype.so.6:FT_Done_Size
 libfreetype.so.6:FT_Get_Char_Index
+libfreetype.so.6:FT_Get_Color_Glyph_Layer
 libfreetype.so.6:FT_Get_FSType_Flags
 libfreetype.so.6:FT_Get_First_Char
 libfreetype.so.6:FT_Get_Glyph_Name
@@ -262,6 +258,8 @@ libfreetype.so.6:FT_Outline_Embolden
 libfreetype.so.6:FT_Outline_Get_Bitmap
 libfreetype.so.6:FT_Outline_Get_CBox
 libfreetype.so.6:FT_Outline_Translate
+libfreetype.so.6:FT_Palette_Data_Get
+libfreetype.so.6:FT_Palette_Select
 libfreetype.so.6:FT_Render_Glyph
 libfreetype.so.6:FT_Select_Charmap
 libfreetype.so.6:FT_Select_Size
@@ -336,7 +334,6 @@ libm.so.6:tanhf
 libm.so.6:trunc
 libm.so.6:truncf
 libstdc++.so.6:_ZNKSt6locale4nameB5cxx11Ev
-libstdc++.so.6:_ZNKSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE3strEv
 libstdc++.so.6:_ZNKSt8__detail20_Prime_rehash_policy14_M_need_rehashEmmm
 libstdc++.so.6:_ZNSi10_M_extractIdEERSiRT_
 libstdc++.so.6:_ZNSi10_M_extractIfEERSiRT_
@@ -345,11 +342,24 @@ libstdc++.so.6:_ZNSt18condition_variable10notify_allEv
 libstdc++.so.6:_ZNSt18condition_variable4waitERSt11unique_lockISt5mutexE
 libstdc++.so.6:_ZNSt18condition_variableC1Ev
 libstdc++.so.6:_ZNSt18condition_variableD1Ev
+libstdc++.so.6:_ZNSt19_Sp_make_shared_tag5_S_eqERKSt9type_info
 libstdc++.so.6:_ZNSt6chrono3_V212steady_clock3nowEv
 libstdc++.so.6:_ZNSt6locale7classicEv
 libstdc++.so.6:_ZNSt6localeC1Ev
 libstdc++.so.6:_ZNSt6localeD1Ev
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE14_M_replace_auxEmmmc
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6resizeEmc
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7reserveEm
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE8_M_eraseEmm
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_appendEPKcm
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_assignERKS4_
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createERmm
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_mutateEmmPKcm
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEaSEPKc
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEpLEPKc
 libstdc++.so.6:_ZNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE7_M_syncEPcmm
+libstdc++.so.6:_ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEEC1ERKNS_12basic_stringIcS2_S3_EESt13_Ios_Openmode
 libstdc++.so.6:_ZNSt8__detail15_List_node_base7_M_hookEPS0_
 libstdc++.so.6:_ZNSt8__detail15_List_node_base9_M_unhookEv
 libstdc++.so.6:_ZNSt8ios_baseC2Ev
@@ -357,6 +367,7 @@ libstdc++.so.6:_ZNSt8ios_baseD2Ev
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE4initEPSt15basic_streambufIcS1_E
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE5clearESt12_Ios_Iostate
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE5imbueERKSt6locale
+libstdc++.so.6:_ZNSt9exceptionD2Ev
 libstdc++.so.6:_ZSt11_Hash_bytesPKvmm
 libstdc++.so.6:_ZSt11__once_call
 libstdc++.so.6:_ZSt15__once_callable
@@ -370,6 +381,7 @@ libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
 libstdc++.so.6:_ZSt25__throw_bad_function_callv
 libstdc++.so.6:_ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_
 libstdc++.so.6:_ZSt7getlineIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EES4_
+libstdc++.so.6:_ZSt9terminatev
 libstdc++.so.6:_ZSt9use_facetISt5ctypeIcEERKT_RKSt6locale
 libstdc++.so.6:_ZTTNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEEE
 libstdc++.so.6:_ZTVN10__cxxabiv117__class_type_infoE
@@ -381,15 +393,16 @@ libstdc++.so.6:_ZTVSt15basic_streambufIcSt11char_traitsIcEE
 libstdc++.so.6:_ZTVSt9basic_iosIcSt11char_traitsIcEE
 libstdc++.so.6:_ZdaPv
 libstdc++.so.6:_ZdlPv
-libstdc++.so.6:_ZdlPvm
 libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
+libstdc++.so.6:__cxa_allocate_exception
 libstdc++.so.6:__cxa_begin_catch
 libstdc++.so.6:__cxa_end_catch
 libstdc++.so.6:__cxa_guard_acquire
 libstdc++.so.6:__cxa_guard_release
 libstdc++.so.6:__cxa_pure_virtual
 libstdc++.so.6:__cxa_rethrow
+libstdc++.so.6:__cxa_throw
 libstdc++.so.6:__dynamic_cast
 libstdc++.so.6:__gxx_personality_v0
 libstdc++.so.6:__once_proxy

--- a/packages/n/neovide/files/0001-Use-fully-qualified-app_id.patch
+++ b/packages/n/neovide/files/0001-Use-fully-qualified-app_id.patch
@@ -40,15 +40,15 @@ index 4fc16dc..dd0c4fe 100644
      pub x11_wm_class_instance: String,
  }
 diff --git a/src/window/mod.rs b/src/window/mod.rs
-index 6b4e0b3..fdcd55c 100644
+index 353ca6f..be2b910 100644
 --- a/src/window/mod.rs
 +++ b/src/window/mod.rs
-@@ -119,7 +119,7 @@ pub fn create_window() {
-     let winit_window_builder = {
+@@ -201,7 +201,7 @@ pub fn create_window(
+     let window_attributes = {
          if env::var("WAYLAND_DISPLAY").is_ok() {
              let app_id = &cmd_line_settings.wayland_app_id;
--            WindowBuilderExtWayland::with_name(winit_window_builder, "neovide", app_id.clone())
-+            WindowBuilderExtWayland::with_name(winit_window_builder, "dev.neovide.Neovide", app_id.clone())
+-            WindowAttributesExtWayland::with_name(window_attributes, app_id.clone(), "neovide")
++            WindowAttributesExtWayland::with_name(window_attributes, app_id.clone(), "dev.neovide.Neovide")
          } else {
              let class = &cmd_line_settings.x11_wm_class;
              let instance = &cmd_line_settings.x11_wm_class_instance;

--- a/packages/n/neovide/package.yml
+++ b/packages/n/neovide/package.yml
@@ -1,8 +1,8 @@
 name       : neovide
-version    : 0.13.3
-release    : 4
+version    : 0.14.1
+release    : 5
 source     :
-    - https://github.com/neovide/neovide/archive/refs/tags/0.13.3.tar.gz : 21c8eaa53cf3290d2b1405c8cb2cde5f39bc14ef597b328e76f1789b0ef3539a
+    - https://github.com/neovide/neovide/archive/refs/tags/0.14.1.tar.gz : ca89ddd63b2a321ff0b7fb2afbaa33d125c207ed6b8663e5fb6d6f665329b899
 homepage   : https://neovide.dev/
 license    :
     - MIT

--- a/packages/n/neovide/pspec_x86_64.xml
+++ b/packages/n/neovide/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>neovide</Name>
         <Homepage>https://neovide.dev/</Homepage>
         <Packager>
-            <Name>Wouter Horlings</Name>
-            <Email>wouter@horlin.gs</Email>
+            <Name>Gavin Zhao</Name>
+            <Email>me@gzgz.dev</Email>
         </Packager>
         <License>MIT</License>
         <License>CC-BY-4.0</License>
@@ -36,12 +36,12 @@ To checkout all the cool features, installation instructions, configuration sett
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-07-17</Date>
-            <Version>0.13.3</Version>
+        <Update release="5">
+            <Date>2025-03-31</Date>
+            <Version>0.14.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Wouter Horlings</Name>
-            <Email>wouter@horlin.gs</Email>
+            <Name>Gavin Zhao</Name>
+            <Email>me@gzgz.dev</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Updated neovide to v0.14.1. On my computer this update fixes my malfunctioning `<` key that can type normally in `nvim` but is not picked by `neovide` at all.

Changelog:
- [0.14.1](https://github.com/neovide/neovide/releases/tag/0.14.1)
- [0.14.0](https://github.com/neovide/neovide/releases/tag/0.14.0)

**Test Plan**

An afternoon of coding in Neovide with all of my plugins working.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
