### PR TITLE
fsearch: Update to v0.2.3

### DIFF
--- a/packages/f/fsearch/abi_used_symbols
+++ b/packages/f/fsearch/abi_used_symbols
@@ -39,7 +39,6 @@ libc.so.6:strcasestr
 libc.so.6:strchr
 libc.so.6:strcmp
 libc.so.6:strdup
-libc.so.6:strftime
 libc.so.6:strlen
 libc.so.6:strptime
 libc.so.6:strrchr
@@ -177,6 +176,9 @@ libglib-2.0.so.0:g_date_new
 libglib-2.0.so.0:g_date_set_time_t
 libglib-2.0.so.0:g_date_subtract_days
 libglib-2.0.so.0:g_date_subtract_months
+libglib-2.0.so.0:g_date_time_format
+libglib-2.0.so.0:g_date_time_new_from_unix_local
+libglib-2.0.so.0:g_date_time_unref
 libglib-2.0.so.0:g_date_to_struct_tm
 libglib-2.0.so.0:g_direct_equal
 libglib-2.0.so.0:g_direct_hash

--- a/packages/f/fsearch/monitoring.yaml
+++ b/packages/f/fsearch/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 231581
+  rss: https://github.com/cboxdoerfer/fsearch/tags.atom
+# No known CPE, checked 2025-04-01
+security:
+  cpe: ~

--- a/packages/f/fsearch/package.yml
+++ b/packages/f/fsearch/package.yml
@@ -1,8 +1,8 @@
 name       : fsearch
-version    : 0.2.2
-release    : 12
+version    : 0.2.3
+release    : 13
 source     :
-    - https://github.com/cboxdoerfer/fsearch/archive/refs/tags/0.2.2.tar.gz : c98d73000436c7182a86c33298f7390c82bce7854b824c80978acc080d979445
+    - https://github.com/cboxdoerfer/fsearch/archive/refs/tags/0.2.3.tar.gz : b3c576bf1230da7c374d00bb32d72686b940b4dee80d941495acfdd5437bf117
 homepage   : https://github.com/cboxdoerfer/fsearch
 license    : GPL-2.0-or-later
 component  : system.utils

--- a/packages/f/fsearch/pspec_x86_64.xml
+++ b/packages/f/fsearch/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>fsearch</Name>
         <Homepage>https://github.com/cboxdoerfer/fsearch</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -62,12 +62,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2025-03-11</Date>
-            <Version>0.2.2</Version>
+        <Update release="13">
+            <Date>2025-04-01</Date>
+            <Version>0.2.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- This release fixes a buffer overflow on some systems where the data type time_t is less than 8 bytes in size. Typically this affects 32bit systems.

**Test Plan**

- Use fsearch to find all recent pdfs

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
