### PR TITLE
appstream-data: Update to v68

### DIFF
--- a/packages/a/appstream-data/package.yml
+++ b/packages/a/appstream-data/package.yml
@@ -1,8 +1,8 @@
 name       : appstream-data
-version    : '66'
-release    : 64
+version    : '68'
+release    : 65
 source     :
-    - https://github.com/getsolus/solus-appstream-data/archive/refs/tags/v66.tar.gz : 645fbe6b6a5ad649a5c4d1ba06cdfbd68f5899e9a1f568f5e4eb93ef196d737d
+    - https://github.com/getsolus/solus-appstream-data/archive/refs/tags/v68.tar.gz : 657ed7572a652f95bc17080c33fb6189ae5ef0d79594ee33e10372303d48124a
 homepage   : https://www.freedesktop.org/wiki/Distributions/AppStream/
 license    :
     - CC-BY-SA-3.0

--- a/packages/a/appstream-data/pspec_x86_64.xml
+++ b/packages/a/appstream-data/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>appstream-data</Name>
         <Homepage>https://www.freedesktop.org/wiki/Distributions/AppStream/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>CC-BY-SA-3.0</License>
         <License>CC-BY-SA-4.0</License>
@@ -312,6 +312,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.corectrl.CoreCtrl.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.cryptomator.Cryptomator.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.darktable.darktable.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.deskflow.deskflow.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.develz.Crawl_console.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.develz.Crawl_tiles.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/org.dhewm3.Dhewm3.png</Path>
@@ -1037,6 +1038,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.corectrl.CoreCtrl.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.cryptomator.Cryptomator.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.darktable.darktable.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.deskflow.deskflow.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.develz.Crawl_console.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.develz.Crawl_tiles.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/org.dhewm3.Dhewm3.png</Path>
@@ -1430,12 +1432,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="64">
-            <Date>2025-03-29</Date>
-            <Version>66</Version>
+        <Update release="65">
+            <Date>2025-04-02</Date>
+            <Version>68</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Update Appstream Data

**Test Plan**

- Built and installed `appstream-data` from this PR.
- Searched for Deskflow (newly added package) in Discover. It was listed correctly. 
- Searched for KDevelop in Discover. It was also listed correctly, unlike how things were in appstream-data v67.

This run was also conducted as a test of a new modification to the appstream generation automation, which no longer parses `-devel` packages. PR here to see how this works: https://github.com/getsolus/solus-appstream-data/pull/10

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
