### PR TITLE
inkscape: Add missing rundep python-tinycss2

### DIFF
--- a/packages/i/inkscape/package.yml
+++ b/packages/i/inkscape/package.yml
@@ -1,6 +1,6 @@
 name       : inkscape
 version    : '1.4'
-release    : 72
+release    : 73
 source     :
     - https://media.inkscape.org/dl/resources/file/inkscape-1.4.tar.xz : c59a85453b699addebcd51c1dc07684dd96a10c8aec716b19551db50562e13f5
 homepage   : https://inkscape.org/
@@ -37,6 +37,7 @@ rundeps    :
     - python-cssselect
     - python-lxml
     - python-pillow
+    - python-tinycss2
     - scour
 setup      : |
     %patch -p1 -i $pkgfiles/poppler-24.10.patch

--- a/packages/i/inkscape/pspec_x86_64.xml
+++ b/packages/i/inkscape/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>inkscape</Name>
         <Homepage>https://inkscape.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-3.0-or-later</License>
@@ -4763,12 +4763,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="72">
-            <Date>2025-03-06</Date>
+        <Update release="73">
+            <Date>2025-04-02</Date>
             <Version>1.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Add a rundep on python-tinycss2, as required by many of the extensions which ship by default with Inkscape.

**Test Plan**
1. Install Inkscape from the repository.
2. Navigate to Extensions > JessyInk > Transitions (or any number of other extensions).
3. Click "Apply". 
4. Note the ugly error.
5. Build Inkscape from this PR, install it, and try the extension again.
6. Note the lack of ugly error.

If you can't reproduce the problem, that's because you already fixed it by having `python-tinycss2` installed :)

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
