### PR TITLE
gpxsee: Update to 13.38

### DIFF
--- a/packages/g/gpxsee/abi_used_symbols
+++ b/packages/g/gpxsee/abi_used_symbols
@@ -27,6 +27,7 @@ libQt6Core.so.6:_Z5qHash6QPointm
 libQt6Core.so.6:_Z5qHashRK4QUrlm
 libQt6Core.so.6:_Z5qHashdm
 libQt6Core.so.6:_Z9qBadAllocv
+libQt6Core.so.6:_Z9qstrnicmpPKcxS0_x
 libQt6Core.so.6:_ZN10QArrayData19reallocateUnalignedEPS_PvxxNS_16AllocationOptionE
 libQt6Core.so.6:_ZN10QArrayData8allocateEPPS_xxxNS_16AllocationOptionE
 libQt6Core.so.6:_ZN10QArrayData9allocate1EPPS_xNS_16AllocationOptionE
@@ -47,6 +48,7 @@ libQt6Core.so.6:_ZN10QByteArray6setNumExi
 libQt6Core.so.6:_ZN10QByteArray6setNumEyi
 libQt6Core.so.6:_ZN10QByteArray7replaceEcc
 libQt6Core.so.6:_ZN10QByteArrayC1EPKcx
+libQt6Core.so.6:_ZN10QByteArrayC1ExN2Qt14InitializationE
 libQt6Core.so.6:_ZN10QByteArrayaSERKS_
 libQt6Core.so.6:_ZN10QEventLoop4execE6QFlagsINS_17ProcessEventsFlagEE
 libQt6Core.so.6:_ZN10QEventLoop4quitEv
@@ -187,6 +189,7 @@ libQt6Core.so.6:_ZN5QFileC1ERK7QString
 libQt6Core.so.6:_ZN5QFileD1Ev
 libQt6Core.so.6:_ZN5QTimeC1Eiiii
 libQt6Core.so.6:_ZN6QDebugD1Ev
+libQt6Core.so.6:_ZN6QLineF8setAngleEd
 libQt6Core.so.6:_ZN7QBufferC1EP10QByteArrayP7QObject
 libQt6Core.so.6:_ZN7QBufferD1Ev
 libQt6Core.so.6:_ZN7QLocale6systemEv
@@ -270,6 +273,7 @@ libQt6Core.so.6:_ZN8QVariantaSERKS_
 libQt6Core.so.6:_ZN9QDateTime10fromStringE11QStringViewN2Qt10DateFormatE
 libQt6Core.so.6:_ZN9QDateTime18fromSecsSinceEpochExRK9QTimeZone
 libQt6Core.so.6:_ZN9QDateTime19fromMSecsSinceEpochEx
+libQt6Core.so.6:_ZN9QDateTime19fromMSecsSinceEpochExRK9QTimeZone
 libQt6Core.so.6:_ZN9QDateTimeC1E5QDate5QTimeNS_20TransitionResolutionE
 libQt6Core.so.6:_ZN9QDateTimeC1E5QDate5QTimeRK9QTimeZoneNS_20TransitionResolutionE
 libQt6Core.so.6:_ZN9QDateTimeC1EOS_
@@ -348,11 +352,13 @@ libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperIdE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperIiE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate8endsWithE14QByteArrayViewS0_
 libQt6Core.so.6:_ZN9QtPrivate8qustrchrE11QStringViewDs
+libQt6Core.so.6:_ZNK10QByteArray11toULongLongEPbi
 libQt6Core.so.6:_ZNK10QByteArray5splitEc
 libQt6Core.so.6:_ZNK10QByteArray5toHexEc
 libQt6Core.so.6:_ZNK10QByteArray5toIntEPbi
 libQt6Core.so.6:_ZNK10QByteArray6toUIntEPbi
 libQt6Core.so.6:_ZNK10QByteArray7toFloatEPb
+libQt6Core.so.6:_ZNK10QByteArray7toULongEPbi
 libQt6Core.so.6:_ZNK10QByteArray8toBase64E6QFlagsINS_12Base64OptionEE
 libQt6Core.so.6:_ZNK10QByteArray8toDoubleEPb
 libQt6Core.so.6:_ZNK10QJsonArray13toVariantListEv
@@ -417,6 +423,7 @@ libQt6Core.so.6:_ZNK4QDir8filePathERK7QString
 libQt6Core.so.6:_ZNK4QDir9entryListE6QFlagsINS_6FilterEES0_INS_8SortFlagEE
 libQt6Core.so.6:_ZNK4QUrl11isLocalFileEv
 libQt6Core.so.6:_ZNK4QUrl11toLocalFileEv
+libQt6Core.so.6:_ZNK4QUrl4pathE6QFlagsINS_25ComponentFormattingOptionEE
 libQt6Core.so.6:_ZNK4QUrl6schemeEv
 libQt6Core.so.6:_ZNK4QUrl7isValidEv
 libQt6Core.so.6:_ZNK4QUrl8fileNameE6QFlagsINS_25ComponentFormattingOptionEE
@@ -726,6 +733,7 @@ libQt6Gui.so.6:_ZN8QPainter6rotateEd
 libQt6Gui.so.6:_ZN8QPainter6setPenEN2Qt8PenStyleE
 libQt6Gui.so.6:_ZN8QPainter6setPenERK4QPen
 libQt6Gui.so.6:_ZN8QPainter6setPenERK6QColor
+libQt6Gui.so.6:_ZN8QPainter7drawArcERK6QRectFii
 libQt6Gui.so.6:_ZN8QPainter7restoreEv
 libQt6Gui.so.6:_ZN8QPainter7setFontERK5QFont
 libQt6Gui.so.6:_ZN8QPainter8drawPathERK12QPainterPath
@@ -786,6 +794,7 @@ libQt6Gui.so.6:_ZNK12QPainterPath14angleAtPercentEd
 libQt6Gui.so.6:_ZNK12QPainterPath14pointAtPercentEd
 libQt6Gui.so.6:_ZNK12QPainterPath6lengthEv
 libQt6Gui.so.6:_ZNK12QPainterPath7isEmptyEv
+libQt6Gui.so.6:_ZNK12QPainterPath8containsERK6QRectF
 libQt6Gui.so.6:_ZNK12QPainterPath9elementAtEi
 libQt6Gui.so.6:_ZNK19QPainterPathStroker12createStrokeERK12QPainterPath
 libQt6Gui.so.6:_ZNK4QPen5colorEv
@@ -1586,7 +1595,6 @@ libstdc++.so.6:_ZSt18_Rb_tree_incrementPKSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt28_Rb_tree_rebalance_for_erasePSt18_Rb_tree_node_baseRS_
 libstdc++.so.6:_ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_
-libstdc++.so.6:_ZSt7nothrow
 libstdc++.so.6:_ZSt9terminatev
 libstdc++.so.6:_ZTVN10__cxxabiv117__class_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv120__si_class_type_infoE

--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.34'
-release    : 52
+version    : '13.38'
+release    : 53
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.34.tar.gz : 5e3522315dc4b6a860902c02152bc2cd004500a4114e02094d916d623637a24f
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.38.tar.gz : fb10d4c5d2058b1bbac41daf0341a3e294c73b63dffe721680b3b0a61f70f956
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -172,9 +172,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="52">
-            <Date>2025-01-11</Date>
-            <Version>13.34</Version>
+        <Update release="53">
+            <Date>2025-04-02</Date>
+            <Version>13.38</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Added support for Velocitek VTK files
- Added support for 70mai cameras GPS logs
- Added support for geo URIs
- Improved IMG nautical charts rendering
- [changelog](https://build.opensuse.org/projects/home:tumic:GPXSee/packages/gpxsee/files/gpxsee.changes)

**Test Plan**
- open map, zoom and pan

**Checklist**
- [X] Package was built and tested against unstable
