### PR TITLE
mousepad: Update to v0.6.5

### DIFF
--- a/packages/m/mousepad/MAINTAINERS.md
+++ b/packages/m/mousepad/MAINTAINERS.md
@@ -1,5 +1,5 @@
-This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
 
-- Name Surname
-  - Matrix: thatzachbacon:matrix.org
-  - Email: zachbacon@vba-m.com
+- Evan Maddock
+  - Matrix: @ebonjaeger:matrix.org
+  - Email: maddock.evan@vivaldi.net

--- a/packages/m/mousepad/abi_libs
+++ b/packages/m/mousepad/abi_libs
@@ -1,4 +1,3 @@
 libmousepad-plugin-gspell.so
 libmousepad-plugin-shortcuts.so
 libmousepad.so.0
-mousepad

--- a/packages/m/mousepad/abi_symbols
+++ b/packages/m/mousepad/abi_symbols
@@ -1,15 +1,7 @@
-libmousepad-plugin-gspell.so:gspell_plugin_get_type
-libmousepad-plugin-gspell.so:gspell_plugin_register
 libmousepad-plugin-gspell.so:mousepad_plugin_get_data
 libmousepad-plugin-gspell.so:mousepad_plugin_initialize
 libmousepad-plugin-shortcuts.so:mousepad_plugin_get_data
 libmousepad-plugin-shortcuts.so:mousepad_plugin_initialize
-libmousepad-plugin-shortcuts.so:shortcuts_plugin_get_type
-libmousepad-plugin-shortcuts.so:shortcuts_plugin_register
-libmousepad.so.0:_mousepad_marshal_VOID__FLAGS_STRING_STRING
-libmousepad.so.0:_mousepad_marshal_VOID__INT_INT_INT
-libmousepad.so.0:_mousepad_marshal_VOID__INT_INT_STRING_FLAGS
-libmousepad.so.0:_mousepad_marshal_VOID__OBJECT_INT_INT
 libmousepad.so.0:mousepad_application_get_prefs_dialog
 libmousepad.so.0:mousepad_application_get_providers
 libmousepad.so.0:mousepad_application_get_type
@@ -75,7 +67,6 @@ libmousepad.so.0:mousepad_file_set_language
 libmousepad.so.0:mousepad_file_set_line_ending
 libmousepad.so.0:mousepad_file_set_location
 libmousepad.so.0:mousepad_file_set_write_bom
-libmousepad.so.0:mousepad_get_resource
 libmousepad.so.0:mousepad_history_autosave_get_location
 libmousepad.so.0:mousepad_history_finalize
 libmousepad.so.0:mousepad_history_init
@@ -207,10 +198,3 @@ libmousepad.so.0:mousepad_window_new
 libmousepad.so.0:mousepad_window_open_files
 libmousepad.so.0:mousepad_window_update_document_menu_items
 libmousepad.so.0:mousepad_window_update_window_menu_items
-mousepad:_IO_stdin_used
-mousepad:__bss_start
-mousepad:__data_start
-mousepad:_edata
-mousepad:_end
-mousepad:_start
-mousepad:main

--- a/packages/m/mousepad/abi_used_symbols
+++ b/packages/m/mousepad/abi_used_symbols
@@ -1,5 +1,4 @@
 libc.so.6:__errno_location
-libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__stack_chk_fail
 libc.so.6:bind_textdomain_codeset
@@ -13,6 +12,7 @@ libc.so.6:realpath
 libc.so.6:setlocale
 libc.so.6:strcmp
 libc.so.6:strlen
+libc.so.6:strtol
 libc.so.6:textdomain
 libgdk-3.so.0:gdk_display_get_default
 libgdk-3.so.0:gdk_drag_context_get_suggested_action
@@ -34,6 +34,7 @@ libgio-2.0.so.0:g_action_get_state_type
 libgio-2.0.so.0:g_action_group_activate_action
 libgio-2.0.so.0:g_action_group_change_action_state
 libgio-2.0.so.0:g_action_group_get_action_enabled
+libgio-2.0.so.0:g_action_group_get_action_parameter_type
 libgio-2.0.so.0:g_action_group_list_actions
 libgio-2.0.so.0:g_action_map_add_action
 libgio-2.0.so.0:g_action_map_add_action_entries
@@ -348,6 +349,11 @@ libgobject-2.0.so.0:g_type_module_use
 libgobject-2.0.so.0:g_type_name
 libgobject-2.0.so.0:g_type_register_static_simple
 libgobject-2.0.so.0:g_value_dup_string
+libgobject-2.0.so.0:g_value_get_boolean
+libgobject-2.0.so.0:g_value_get_boxed
+libgobject-2.0.so.0:g_value_get_flags
+libgobject-2.0.so.0:g_value_get_object
+libgobject-2.0.so.0:g_value_get_string
 libgobject-2.0.so.0:g_value_peek_pointer
 libgobject-2.0.so.0:g_value_set_boolean
 libgobject-2.0.so.0:g_value_set_flags
@@ -485,6 +491,7 @@ libgtk-3.so.0:gtk_file_chooser_get_action
 libgtk-3.so.0:gtk_file_chooser_get_file
 libgtk-3.so.0:gtk_file_chooser_get_files
 libgtk-3.so.0:gtk_file_chooser_set_current_folder_file
+libgtk-3.so.0:gtk_file_chooser_set_current_name
 libgtk-3.so.0:gtk_file_chooser_set_do_overwrite_confirmation
 libgtk-3.so.0:gtk_file_chooser_set_extra_widget
 libgtk-3.so.0:gtk_file_chooser_set_file
@@ -510,7 +517,6 @@ libgtk-3.so.0:gtk_grid_set_row_spacing
 libgtk-3.so.0:gtk_header_bar_get_show_close_button
 libgtk-3.so.0:gtk_header_bar_get_type
 libgtk-3.so.0:gtk_header_bar_new
-libgtk-3.so.0:gtk_header_bar_set_decoration_layout
 libgtk-3.so.0:gtk_header_bar_set_has_subtitle
 libgtk-3.so.0:gtk_header_bar_set_show_close_button
 libgtk-3.so.0:gtk_header_bar_set_title

--- a/packages/m/mousepad/package.yml
+++ b/packages/m/mousepad/package.yml
@@ -1,8 +1,8 @@
 name       : mousepad
-version    : 0.6.3
-release    : 3
+version    : 0.6.5
+release    : 4
 source     :
-    - https://archive.xfce.org/src/apps/mousepad/0.6/mousepad-0.6.3.tar.bz2 : 2ff162c185f18014ab9c82c2ac2dfce4fba20eb0005e7690ee27f00b9cb929b9
+    - https://archive.xfce.org/src/apps/mousepad/0.6/mousepad-0.6.5.tar.xz : 21762bc8c3c4f120a4a509ce39f4a5a58dbc10e3f0da66cdc6d9a8c735fff2ac
 homepage   : https://docs.xfce.org/apps/mousepad/start
 license    : GPL-2.0-or-later
 component  : desktop.xfce
@@ -14,8 +14,8 @@ builddeps  :
     - pkgconfig(gtksourceview-4)
     - pkgconfig(libxfce4ui-2)
 setup      : |
-    %configure
+    %meson_configure
 build      : |
-    %make
+    %ninja_build
 install    : |
-    %make_install
+    %ninja_install

--- a/packages/m/mousepad/pspec_x86_64.xml
+++ b/packages/m/mousepad/pspec_x86_64.xml
@@ -101,16 +101,16 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="3">mousepad</Dependency>
+            <Dependency release="4">mousepad</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libmousepad.so</Path>
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-11-04</Date>
-            <Version>0.6.3</Version>
+        <Update release="4">
+            <Date>2025-04-02</Date>
+            <Version>0.6.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Fix GError leak in mousepad_file_autosave_delete_finish
- Save session when an inactive tab is closed
- Fix possible dereference of null pointer
- Extend saved state comparison to auto-saved modified files
- Avoid unnecessary switching to the tab to be closed
- Set current name in save-as dialog for deleted files too
- Fix broken shortcut for reload action
- Hide the launcher for mousepad-settings
- Make widgets focusable again in preferences dialog
- Fix broken conditional to exit on allowed error
- Disconnect from buffer signals when data object is released
- Translation updates

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Open and edit a yaml file in Mousepad.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
