### PR TITLE
xdg-desktop-portal-wlr: Add portal config for screensharing

### DIFF
--- a/packages/x/xdg-desktop-portal-wlr/files/wlroots-portals.conf
+++ b/packages/x/xdg-desktop-portal-wlr/files/wlroots-portals.conf
@@ -1,0 +1,6 @@
+[preferred]
+# Use xdg-desktop-portal-gtk for every portal interface...
+default=gtk
+# ... except for the ScreenCast and Screenshot
+org.freedesktop.impl.portal.ScreenCast=wlr
+org.freedesktop.impl.portal.Screenshot=wlr

--- a/packages/x/xdg-desktop-portal-wlr/package.yml
+++ b/packages/x/xdg-desktop-portal-wlr/package.yml
@@ -1,6 +1,6 @@
 name       : xdg-desktop-portal-wlr
 version    : 0.7.1
-release    : 2
+release    : 3
 source     :
     - https://github.com/emersion/xdg-desktop-portal-wlr/releases/download/v0.7.1/xdg-desktop-portal-wlr-0.7.1.tar.gz : eec6e4be808e1a445e677dba1e20e5acb2f091825f5ff4c6ac49d5843b2185f9
 license    : MIT
@@ -21,10 +21,14 @@ builddeps  :
 rundeps    :
     - grim
     - pipewire
+    - slurp
     - xdg-desktop-portal
 setup      : |
-    %meson_configure
+    %meson_configure -Dsd-bus-provider=libsystemd
 build      : |
     %ninja_build
 install    : |
     %ninja_install
+
+    # Install our portal configuration
+    install -Dm00644 $pkgfiles/wlroots-portals.conf $installdir/usr/share/xdg-desktop-portal/wlroots-portals.conf

--- a/packages/x/xdg-desktop-portal-wlr/pspec_x86_64.xml
+++ b/packages/x/xdg-desktop-portal-wlr/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xdg-desktop-portal-wlr</Name>
         <Homepage>https://github.com/emersion/xdg-desktop-portal-wlr</Homepage>
         <Packager>
-            <Name>Joshua Strobl</Name>
-            <Email>me@joshuastrobl.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>desktop.util</PartOf>
@@ -25,15 +25,16 @@
             <Path fileType="data">/usr/share/dbus-1/services/org.freedesktop.impl.portal.desktop.wlr.service</Path>
             <Path fileType="man">/usr/share/man/man5/xdg-desktop-portal-wlr.5</Path>
             <Path fileType="data">/usr/share/xdg-desktop-portal/portals/wlr.portal</Path>
+            <Path fileType="data">/usr/share/xdg-desktop-portal/wlroots-portals.conf</Path>
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2025-02-15</Date>
+        <Update release="3">
+            <Date>2025-04-05</Date>
             <Version>0.7.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joshua Strobl</Name>
-            <Email>me@joshuastrobl.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Add a portal config to use the wlroots portal backend for screensharing

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Share a window in a Discord call on Budgie using labwc.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
