### PR TITLE
appstream-data: Update to v69

### DIFF
--- a/packages/a/appstream-data/package.yml
+++ b/packages/a/appstream-data/package.yml
@@ -1,8 +1,8 @@
 name       : appstream-data
-version    : '68'
-release    : 65
+version    : '69'
+release    : 66
 source     :
-    - https://github.com/getsolus/solus-appstream-data/archive/refs/tags/v68.tar.gz : 657ed7572a652f95bc17080c33fb6189ae5ef0d79594ee33e10372303d48124a
+    - https://github.com/getsolus/solus-appstream-data/archive/refs/tags/v69.tar.gz : ba5f98e8c6020a1c9a0ffcf13c91be9f269ce627d4b81a41749bb4cf1ff0050d
 homepage   : https://www.freedesktop.org/wiki/Distributions/AppStream/
 license    :
     - CC-BY-SA-3.0

--- a/packages/a/appstream-data/pspec_x86_64.xml
+++ b/packages/a/appstream-data/pspec_x86_64.xml
@@ -88,6 +88,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.github.xarchiver.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.github.xournalpp.xournalpp.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.gitlab.dogtail.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.gitlab.gaming_backup_multitool_for_linux.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.heroicgameslauncher.hgl.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.kvibes.MediaElch.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.leinardi.gx52.png</Path>
@@ -221,6 +222,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.winetricks.Winetricks.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.wxmaxima_developers.wxMaxima.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.github.zyedidia.micro.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.gitlab.gcstar.gcstar.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.keybase.keybase.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.lmms.LMMS.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/io.mgba.mGBA.png</Path>
@@ -713,6 +715,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.bitwarden.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.borgbase.Vorta.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.brave.Browser.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.crea_si.eviacam.enable_viacam.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.cubicsdr.cubicsdr.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.dec05eba.gpu_screen_recorder.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.dev47apps.droidcam.DroidCam.png</Path>
@@ -748,6 +751,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.github.xarchiver.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.github.xournalpp.xournalpp.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.gitlab.dogtail.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.gitlab.gaming_backup_multitool_for_linux.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.heroicgameslauncher.hgl.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.httrack.httrack_website_copier.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.kvibes.MediaElch.png</Path>
@@ -926,6 +930,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.winff.winff.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.wxmaxima_developers.wxMaxima.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.github.zyedidia.micro.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.gitlab.gcstar.gcstar.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.keybase.keybase.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.lmms.LMMS.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/io.mgba.mGBA.png</Path>
@@ -985,6 +990,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/net.sourceforge.drumstick-guiplayer.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/net.sourceforge.drumstick-vpiano.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/net.sourceforge.foobillardplus.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/net.sourceforge.gprename.gprename.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/net.sourceforge.gretl.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/net.sourceforge.gscan2pdf.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/net.sourceforge.guvcview.png</Path>
@@ -1432,9 +1438,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="65">
-            <Date>2025-04-02</Date>
-            <Version>68</Version>
+        <Update release="66">
+            <Date>2025-04-06</Date>
+            <Version>69</Version>
             <Comment>Packaging update</Comment>
             <Name>Hans K</Name>
             <Email>hans@communitycomputing.net</Email>


### PR DESCRIPTION
**Summary**

Update Appstream Data to v69

**Test Plan**

- Build `appstream-data` from this PR.
- Install it.
- Launch Discover and make sure applications show up.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
