### PR TITLE
[NFC] darkly: update abi_used_symbols

### DIFF
--- a/packages/d/darkly/abi_used_symbols
+++ b/packages/d/darkly/abi_used_symbols
@@ -59,7 +59,6 @@ libKF6ConfigGui.so.6:_ZN15KConfigSkeleton9ItemColorC1ERK7QStringS3_R6QColorRKS4_
 libKF6ConfigGui.so.6:_ZN15KConfigSkeletonC2ERK7QStringP7QObject
 libKF6ConfigGui.so.6:_ZNK15KConfigSkeleton10metaObjectEv
 libKF6ConfigGui.so.6:_ZTI15KConfigSkeleton
-libKF6ConfigGui.so.6:_ZTV15KConfigSkeleton
 libKF6CoreAddons.so.6:_ZN14KPluginFactory11qt_metacallEN11QMetaObject4CallEiPPv
 libKF6CoreAddons.so.6:_ZN14KPluginFactory11qt_metacastEPKc
 libKF6CoreAddons.so.6:_ZN14KPluginFactory14registerPluginEPK11QMetaObjectPFP7QObjectP7QWidgetS4_RK15KPluginMetaDataRK5QListI8QVariantEE
@@ -91,7 +90,7 @@ libKF6KCMUtils.so.6:_ZN8KCModule4loadEv
 libKF6KCMUtils.so.6:_ZN8KCModule4saveEv
 libKF6KCMUtils.so.6:_ZN8KCModule6widgetEv
 libKF6KCMUtils.so.6:_ZN8KCModule8defaultsEv
-libKF6KCMUtils.so.6:_ZN8KCModuleC1EP7QWidgetRK15KPluginMetaData
+libKF6KCMUtils.so.6:_ZN8KCModuleC2EP7QWidgetRK15KPluginMetaData
 libKF6KCMUtils.so.6:_ZN8KCModuleD2Ev
 libKF6KCMUtils.so.6:_ZTI8KCModule
 libKF6KCMUtilsCore.so.6:_ZN21KAbstractConfigModule12setNeedsSaveEb
@@ -278,6 +277,7 @@ libQt6Core.so.6:_ZN8QVariantC1ERK7QString
 libQt6Core.so.6:_ZN8QVariantC1Eb
 libQt6Core.so.6:_ZN8QVariantC1Ed
 libQt6Core.so.6:_ZN8QVariantC1Ei
+libQt6Core.so.6:_ZN8QVariantC2ERK7QString
 libQt6Core.so.6:_ZN8QVariantD1Ev
 libQt6Core.so.6:_ZN9QHashSeed10globalSeedEv
 libQt6Core.so.6:_ZN9QMetaType14registerHelperEPKN9QtPrivate18QMetaTypeInterfaceE
@@ -322,7 +322,6 @@ libQt6Core.so.6:_ZNK18QAbstractItemModel9multiDataERK11QModelIndex18QModelRoleDa
 libQt6Core.so.6:_ZNK18QAbstractItemModel9roleNamesEv
 libQt6Core.so.6:_ZNK18QRegularExpression5matchERK7QStringxNS_9MatchTypeE6QFlagsINS_11MatchOptionEE
 libQt6Core.so.6:_ZNK18QRegularExpression7isValidEv
-libQt6Core.so.6:_ZNK19QItemSelectionModel10isSelectedERK11QModelIndex
 libQt6Core.so.6:_ZNK19QItemSelectionModel12currentIndexEv
 libQt6Core.so.6:_ZNK19QItemSelectionModel12selectedRowsEi
 libQt6Core.so.6:_ZNK19QItemSelectionModel13isRowSelectedEiRK11QModelIndex
@@ -443,7 +442,6 @@ libQt6Gui.so.6:_ZN7QPixmapC1Eii
 libQt6Gui.so.6:_ZN7QPixmapC1Ev
 libQt6Gui.so.6:_ZN7QPixmapD1Ev
 libQt6Gui.so.6:_ZN7QPixmapaSERKS_
-libQt6Gui.so.6:_ZN7QRegion12shared_emptyE
 libQt6Gui.so.6:_ZN7QRegionC1ERK5QRectNS_10RegionTypeE
 libQt6Gui.so.6:_ZN7QRegionC1ERK8QPolygonN2Qt8FillRuleE
 libQt6Gui.so.6:_ZN7QRegionC1EiiiiNS_10RegionTypeE
@@ -564,7 +562,6 @@ libQt6Gui.so.6:_ZNK8QPainter6deviceEv
 libQt6Gui.so.6:_ZNK8QPalette5brushENS_10ColorGroupENS_9ColorRoleE
 libQt6Gui.so.6:_ZNK8QPaletteeqERKS_
 libQt6Gui.so.6:_ZNK9QPolygonF9toPolygonEv
-libQt6Gui.so.6:_ZTV6QImage
 libQt6Gui.so.6:_ZTV7QPixmap
 libQt6Gui.so.6:_Zls6QDebugRK5QIcon
 libQt6Gui.so.6:_Zls6QDebugRK6QColor
@@ -576,7 +573,6 @@ libQt6Quick.so.6:_ZN10QQuickItem23setAcceptedMouseButtonsE6QFlagsIN2Qt11MouseBut
 libQt6Quick.so.6:_ZNK10QQuickItem6windowEv
 libQt6Quick.so.6:_ZNK12QQuickWindow11contentItemEv
 libQt6Widgets.so.6:_Z24qt_qscrollbarStyleOptionP10QScrollBar
-libQt6Widgets.so.6:_ZN10QBoxLayout10setSpacingEi
 libQt6Widgets.so.6:_ZN10QBoxLayout9addLayoutEP7QLayouti
 libQt6Widgets.so.6:_ZN10QBoxLayout9addWidgetEP7QWidgeti6QFlagsIN2Qt13AlignmentFlagEE
 libQt6Widgets.so.6:_ZN10QScrollBar16staticMetaObjectE
@@ -591,7 +587,6 @@ libQt6Widgets.so.6:_ZN11QDockWidget16staticMetaObjectE
 libQt6Widgets.so.6:_ZN11QFormLayout9setLayoutEiNS_8ItemRoleEP7QLayout
 libQt6Widgets.so.6:_ZN11QFormLayout9setWidgetEiNS_8ItemRoleEP7QWidget
 libQt6Widgets.so.6:_ZN11QFormLayoutC1EP7QWidget
-libQt6Widgets.so.6:_ZN11QGridLayout10setSpacingEi
 libQt6Widgets.so.6:_ZN11QGridLayout7addItemEP11QLayoutItemiiii6QFlagsIN2Qt13AlignmentFlagEE
 libQt6Widgets.so.6:_ZN11QGridLayout9addLayoutEP7QLayoutiiii6QFlagsIN2Qt13AlignmentFlagEE
 libQt6Widgets.so.6:_ZN11QGridLayout9addWidgetEP7QWidgetiiii6QFlagsIN2Qt13AlignmentFlagEE
@@ -1114,8 +1109,11 @@ libkdecorations3.so.6:_ZNK12KDecoration321DecorationButtonGroup7buttonsEv
 libkdecorations3.so.6:_ZNK12KDecoration321DecorationButtonGroup8geometryEv
 libkdecorations3.so.6:_ZTIN12KDecoration310DecorationE
 libkdecorations3.so.6:_ZTIN12KDecoration316DecorationButtonE
+libm.so.6:ceil
+libm.so.6:cos
+libm.so.6:floor
 libm.so.6:round
-libm.so.6:sincos
+libm.so.6:sin
 libstdc++.so.6:_ZNSt8__detail15_List_node_base7_M_hookEPS0_
 libstdc++.so.6:_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_incrementPKSt18_Rb_tree_node_base
@@ -1136,3 +1134,4 @@ libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
 libstdc++.so.6:__cxa_guard_acquire
 libstdc++.so.6:__cxa_guard_release
+libstdc++.so.6:__cxa_pure_virtual


### PR DESCRIPTION
**Summary**

Adds the updated abi_used_symbols file which was missing in the original merge.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
