### PR TITLE
opensnitch: Automatically add users to opensnitch group

### DIFF
--- a/packages/o/opensnitch/files/opensnitch_group_update.toml
+++ b/packages/o/opensnitch/files/opensnitch_group_update.toml
@@ -1,0 +1,5 @@
+description = "Add active users to the opensnitch group for opensnitch functionality"
+
+[[users-update]]
+only = ["active"]
+group = "opensnitch"

--- a/packages/o/opensnitch/package.yml
+++ b/packages/o/opensnitch/package.yml
@@ -1,6 +1,6 @@
 name       : opensnitch
 version    : 1.6.8
-release    : 1
+release    : 2
 source     :
     - https://github.com/evilsocket/opensnitch/archive/refs/tags/v1.6.8.tar.gz : 3c44f585a6a78f63c86f331da099bd001cd199b3c907c262cc6645bf9b3a1825
 homepage   : https://github.com/evilsocket/opensnitch
@@ -61,6 +61,9 @@ install    : |
     # need this or else the gui will not launch
     sed -i 's.#!python.#!/usr/bin/env python3.' $installdir/usr/bin/opensnitch-ui
 
+    # install these so the socket directory is created & create the opensnitch group
     install -Dm00644 $pkgfiles/opensnitch.sysusers $installdir/usr/lib/sysusers.d/opensnitch.conf
     install -Dm00644 $pkgfiles/opensnitch.tmpfile $installdir/usr/lib/tmpfiles.d/opensnitch.conf
+
+    install -Dm00644 $pkgfiles/opensnitch_group_update.toml $installdir/usr/share/defaults/qol-assist.d/opensnitch_group_update.toml
 

--- a/packages/o/opensnitch/pspec_x86_64.xml
+++ b/packages/o/opensnitch/pspec_x86_64.xml
@@ -183,6 +183,7 @@
             <Path fileType="data">/usr/share/applications/opensnitch_ui.desktop</Path>
             <Path fileType="data">/usr/share/defaults/etc/opensnitchd/default-config.json</Path>
             <Path fileType="data">/usr/share/defaults/etc/opensnitchd/system-fw.json</Path>
+            <Path fileType="data">/usr/share/defaults/qol-assist.d/opensnitch_group_update.toml</Path>
             <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/opensnitch-ui.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/opensnitch-ui.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/opensnitch-ui.svg</Path>
@@ -191,8 +192,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2025-02-27</Date>
+        <Update release="2">
+            <Date>2025-04-06</Date>
             <Version>1.6.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Robert Gonzalez</Name>


### PR DESCRIPTION
**Summary**
- Utilize qol-assist to add users on next boot

**Test Plan**

Remove myself from opensnitch group and install package. Reboot and verify I am part of the opensnitch group.
Finally launch opensnitch

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
