### PR TITLE
sof-firmware: Update to v2.12.1

### DIFF
--- a/packages/s/sof-firmware/package.yml
+++ b/packages/s/sof-firmware/package.yml
@@ -1,9 +1,9 @@
 name       : sof-firmware
 homepage   : https://github.com/thesofproject/sof-bin
-version    : '2.12'
-release    : 25
+version    : 2.12.1
+release    : 26
 source     :
-    - https://github.com/thesofproject/sof-bin/releases/download/v2025.01/sof-bin-2025.01.tar.gz : 34d565db757a32450106317cc51f38bf67962e0fc8b7f7c72e6e39fd89e99263
+    - https://github.com/thesofproject/sof-bin/releases/download/v2025.01.1/sof-bin-2025.01.1.tar.gz : a36210d9c245e81b0d9674d6b27d1fd4122968cf925aefc55b486d3650f88323
 license    :
     - BSD-3-Clause
     - ISC

--- a/packages/s/sof-firmware/pspec_x86_64.xml
+++ b/packages/s/sof-firmware/pspec_x86_64.xml
@@ -58,10 +58,13 @@
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-2ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-4ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l23-2ch.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l23-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l23.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l3-2ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l3.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0.tplg</Path>
+            <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l2-cs35l56x6-l13.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt1318-l12-rt714-l0.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt711-4ch.tplg</Path>
             <Path fileType="data">/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt711-l0-rt1316-l23-rt714-l1.tplg</Path>
@@ -552,10 +555,13 @@
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-hda-generic.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-2ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-4ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l23-2ch.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l23-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l23.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l3-2ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l3.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0.tplg</Path>
+            <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l2-cs35l56x6-l13.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt1318-l12-rt714-l0.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt711-4ch.tplg</Path>
             <Path fileType="library">/usr/lib64/firmware/intel/sof-ipc4-tplg/sof-lnl-rt711-l0-rt1316-l23-rt714-l1.tplg</Path>
@@ -1013,9 +1019,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="25">
-            <Date>2025-02-16</Date>
-            <Version>2.12</Version>
+        <Update release="26">
+            <Date>2025-04-10</Date>
+            <Version>2.12.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Tracey Clark</Name>
             <Email>traceyc.dev@tlcnet.info</Email>


### PR DESCRIPTION
**Summary**

- The binary release includes latest versions of firmware, tool and DSP topologies for all Intel released platforms

**Highlights**

For v2.12 series (Meteor Lake and newer), the following new topology files have been added since v2.12:

v2.12.x/sof-ipc4-tplg-v2.12
├── sof-lnl-cs42l43-l0-cs35l56-l23-2ch.tplg
├── sof-lnl-cs42l43-l0-cs35l56-l23-4ch.tplg
├── sof-lnl-cs42l43-l0-cs35l56-l3-2ch.tplg
├── sof-lnl-cs42l43-l2-cs35l56x6-l13.tplg

Full release notes [here](https://github.com/thesofproject/sof-bin/releases)

**Test Plan**

Verified firmware files were installed to correct paths.
Restarted pipewire.
    systemctl --user restart pipewire.service
Listened to music and triggered system sounds to verify that sound still works.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
