### PR TITLE
codespell: Update to v2.4.1

### DIFF
--- a/packages/c/codespell/package.yml
+++ b/packages/c/codespell/package.yml
@@ -1,8 +1,8 @@
 name       : codespell
-version    : 2.3.0
-release    : 3
+version    : 2.4.1
+release    : 4
 source     :
-    - https://pypi.debian.net/codespell/codespell-2.3.0.tar.gz : 360c7d10f75e65f67bad720af7007e1060a5d395670ec11a7ed1fed9dd17471f
+    - https://files.pythonhosted.org/packages/source/c/codespell/codespell-2.4.1.tar.gz : 299fcdcb09d23e81e35a671bbe746d5ad7e8385972e65dbb833a2eaac33c01e5
 homepage   : https://github.com/codespell-project/codespell
 license    : GPL-2.0-only
 component  : programming.python

--- a/packages/c/codespell/pspec_x86_64.xml
+++ b/packages/c/codespell/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>codespell</Name>
         <Homepage>https://github.com/codespell-project/codespell</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>programming.python</PartOf>
@@ -21,12 +21,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/codespell</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/codespell-2.3.0.dist-info/COPYING</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/codespell-2.3.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/codespell-2.3.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/codespell-2.3.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/codespell-2.3.0.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/codespell-2.3.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/codespell-2.4.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/codespell-2.4.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/codespell-2.4.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/codespell-2.4.1.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/codespell-2.4.1.dist-info/licenses/COPYING</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/codespell-2.4.1.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/codespell_lib/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/codespell_lib/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/codespell_lib/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
@@ -35,9 +35,15 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/codespell_lib/__pycache__/__main__.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/codespell_lib/__pycache__/_codespell.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/codespell_lib/__pycache__/_codespell.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/codespell_lib/__pycache__/_spellchecker.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/codespell_lib/__pycache__/_spellchecker.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/codespell_lib/__pycache__/_text_util.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/codespell_lib/__pycache__/_text_util.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/codespell_lib/__pycache__/_version.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/codespell_lib/__pycache__/_version.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/codespell_lib/_codespell.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/codespell_lib/_spellchecker.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/codespell_lib/_text_util.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/codespell_lib/_version.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/codespell_lib/data/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/codespell_lib/data/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
@@ -65,12 +71,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-07-28</Date>
-            <Version>2.3.0</Version>
+        <Update release="4">
+            <Date>2025-04-10</Date>
+            <Version>2.4.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Release notes:
- [2.4.1](https://github.com/codespell-project/codespell/releases/tag/v2.4.1)
- [2.4.0](https://github.com/codespell-project/codespell/releases/tag/v2.4.0)

**Test Plan**

<!-- Short description of how the package was tested -->
Check my personal website spelling

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
