### PR TITLE
double-conversion: Update to v3.3.1

### DIFF
--- a/packages/d/double-conversion/abi_used_symbols
+++ b/packages/d/double-conversion/abi_used_symbols
@@ -1,6 +1,5 @@
 libc.so.6:__stack_chk_fail
 libc.so.6:abort
-libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset
 libc.so.6:strlen

--- a/packages/d/double-conversion/package.yml
+++ b/packages/d/double-conversion/package.yml
@@ -1,8 +1,8 @@
 name       : double-conversion
-version    : 3.3.0
-release    : 2
+version    : 3.3.1
+release    : 3
 source     :
-    - https://github.com/google/double-conversion/archive/refs/tags/v3.3.0.tar.gz : 04ec44461850abbf33824da84978043b22554896b552c5fd11a9c5ae4b4d296e
+    - https://github.com/google/double-conversion/archive/refs/tags/v3.3.1.tar.gz : fe54901055c71302dcdc5c3ccbe265a6c191978f3761ce1414d0895d6b0ea90e
 homepage   : https://github.com/google/double-conversion
 license    : BSD-3-Clause
 component  : programming.library

--- a/packages/d/double-conversion/pspec_x86_64.xml
+++ b/packages/d/double-conversion/pspec_x86_64.xml
@@ -31,9 +31,10 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">double-conversion</Dependency>
+            <Dependency release="3">double-conversion</Dependency>
         </RuntimeDependencies>
         <Files>
+            <Path fileType="header">/usr/include/double-conversion/bignum-dtoa.h</Path>
             <Path fileType="header">/usr/include/double-conversion/bignum.h</Path>
             <Path fileType="header">/usr/include/double-conversion/cached-powers.h</Path>
             <Path fileType="header">/usr/include/double-conversion/diy-fp.h</Path>
@@ -53,9 +54,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-04-02</Date>
-            <Version>3.3.0</Version>
+        <Update release="3">
+            <Date>2025-04-10</Date>
+            <Version>3.3.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
             <Email>malfisya.dev@hotmail.com</Email>


### PR DESCRIPTION
**Summary**

Release note can be read [here](https://github.com/google/double-conversion/releases/tag/v3.3.1)

**Test Plan**

<!-- Short description of how the package was tested -->
Rebuild `python-ujson` locally

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
