### PR TITLE
lcov: Update to v2.3.1

### DIFF
--- a/packages/l/lcov/package.yml
+++ b/packages/l/lcov/package.yml
@@ -1,8 +1,8 @@
 name       : lcov
-version    : '2.1'
-release    : 4
+version    : 2.3.1
+release    : 5
 source     :
-    - https://github.com/linux-test-project/lcov/archive/refs/tags/v2.1.tar.gz : c09fc48d1576da29a607a5f91cb51909f7be25d494733dc0fed957abf6317fa0
+    - https://github.com/linux-test-project/lcov/archive/refs/tags/v2.3.1.tar.gz : 035ce6271b775891ef63c325fd18738c43d559c9c160869e3f6731cfe734e6fa
 homepage   : https://github.com/linux-test-project/lcov
 license    : GPL-2.0-or-later
 component  : programming.tools

--- a/packages/l/lcov/pspec_x86_64.xml
+++ b/packages/l/lcov/pspec_x86_64.xml
@@ -26,6 +26,7 @@
             <Path fileType="executable">/usr/bin/geninfo</Path>
             <Path fileType="executable">/usr/bin/genpng</Path>
             <Path fileType="executable">/usr/bin/lcov</Path>
+            <Path fileType="executable">/usr/bin/llvm2lcov</Path>
             <Path fileType="executable">/usr/bin/perl2lcov</Path>
             <Path fileType="executable">/usr/bin/py2lcov</Path>
             <Path fileType="executable">/usr/bin/xml2lcov</Path>
@@ -41,8 +42,11 @@
             <Path fileType="data">/usr/share/lcov/example/methods/gauss.c</Path>
             <Path fileType="data">/usr/share/lcov/example/methods/iterate.c</Path>
             <Path fileType="data">/usr/share/lcov/example/methods/iterate_mod.c</Path>
+            <Path fileType="data">/usr/share/lcov/support-scripts/P4version.pm</Path>
             <Path fileType="data">/usr/share/lcov/support-scripts/analyzeInfoFiles</Path>
             <Path fileType="data">/usr/share/lcov/support-scripts/annotateutil.pm</Path>
+            <Path fileType="data">/usr/share/lcov/support-scripts/batchGitVersion.pm</Path>
+            <Path fileType="data">/usr/share/lcov/support-scripts/context.pm</Path>
             <Path fileType="data">/usr/share/lcov/support-scripts/criteria</Path>
             <Path fileType="data">/usr/share/lcov/support-scripts/criteria.pm</Path>
             <Path fileType="data">/usr/share/lcov/support-scripts/get_signature</Path>
@@ -57,6 +61,7 @@
             <Path fileType="data">/usr/share/lcov/support-scripts/p4udiff</Path>
             <Path fileType="data">/usr/share/lcov/support-scripts/select.pm</Path>
             <Path fileType="data">/usr/share/lcov/support-scripts/spreadsheet.py</Path>
+            <Path fileType="data">/usr/share/lcov/support-scripts/threshold.pm</Path>
             <Path fileType="data">/usr/share/lcov/tests/Makefile</Path>
             <Path fileType="data">/usr/share/lcov/tests/README.md</Path>
             <Path fileType="data">/usr/share/lcov/tests/bin/check_counts</Path>
@@ -71,9 +76,12 @@
             <Path fileType="data">/usr/share/lcov/tests/bin/testsuite_exit</Path>
             <Path fileType="data">/usr/share/lcov/tests/bin/testsuite_init</Path>
             <Path fileType="data">/usr/share/lcov/tests/common.mak</Path>
+            <Path fileType="data">/usr/share/lcov/tests/common.tst</Path>
             <Path fileType="data">/usr/share/lcov/tests/gendiffcov/Makefile</Path>
             <Path fileType="data">/usr/share/lcov/tests/gendiffcov/errs/Makefile</Path>
+            <Path fileType="data">/usr/share/lcov/tests/gendiffcov/errs/MsgContext.pm</Path>
             <Path fileType="data">/usr/share/lcov/tests/gendiffcov/errs/genError.pm</Path>
+            <Path fileType="data">/usr/share/lcov/tests/gendiffcov/errs/mcdc_errs.dat</Path>
             <Path fileType="data">/usr/share/lcov/tests/gendiffcov/errs/msgtest.sh</Path>
             <Path fileType="data">/usr/share/lcov/tests/gendiffcov/errs/select.sh</Path>
             <Path fileType="data">/usr/share/lcov/tests/gendiffcov/filter/Makefile</Path>
@@ -120,6 +128,7 @@
             <Path fileType="data">/usr/share/lcov/tests/gendiffcov/simple/simple2.cpp.annotated</Path>
             <Path fileType="data">/usr/share/lcov/tests/gendiffcov/synthesize/Makefile</Path>
             <Path fileType="data">/usr/share/lcov/tests/gendiffcov/synthesize/munge.pl</Path>
+            <Path fileType="data">/usr/share/lcov/tests/gendiffcov/synthesize/munge2.pl</Path>
             <Path fileType="data">/usr/share/lcov/tests/gendiffcov/synthesize/synthesize.sh</Path>
             <Path fileType="data">/usr/share/lcov/tests/genhtml/Makefile</Path>
             <Path fileType="data">/usr/share/lcov/tests/genhtml/demangle.sh</Path>
@@ -153,33 +162,38 @@
             <Path fileType="data">/usr/share/lcov/tests/lcov/demangle/Makefile</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/demangle/demangle.cpp</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/demangle/demangle.sh</Path>
-            <Path fileType="data">/usr/share/lcov/tests/lcov/diff/Makefile</Path>
-            <Path fileType="data">/usr/share/lcov/tests/lcov/diff/new/Makefile</Path>
-            <Path fileType="data">/usr/share/lcov/tests/lcov/diff/new/prog.c</Path>
-            <Path fileType="data">/usr/share/lcov/tests/lcov/diff/old/Makefile</Path>
-            <Path fileType="data">/usr/share/lcov/tests/lcov/diff/old/prog.c</Path>
-            <Path fileType="data">/usr/share/lcov/tests/lcov/diff/test.sh</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/errs/Makefile</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/errs/badBranchLine.info</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/errs/badFncEndLine.info</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/errs/badFncLine.info</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/errs/badLine.info</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/errs/branchNoLine.info</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/errs/emptyFileRecord.info</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/errs/errs.sh</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/errs/exceptionBranch1.info</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/errs/exceptionBranch2.info</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/errs/fncMismatch.info</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/errs/funcNoLine.info</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/errs/lineNoBranch.info</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/errs/lineNoFunc.info</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/errs/noFunc.info</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/exception/Makefile</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/exception/example.data</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/exception/exception.cpp</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/exception/exception.sh</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/extract/Makefile</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/extract/brokenCallback.pm</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/extract/envErr.rc</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/extract/envVar.rc</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/extract/extract.cpp</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/extract/extract.sh</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/extract/fakeResolve.sh</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/extract/list.gold</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/extract/list_mcdc.gold</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/extract/testContext.sh</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/extract/unused.c</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/follow/Makefile</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/follow/follow.sh</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/format/Makefile</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/format/format.info</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/format/format.sh</Path>
@@ -187,16 +201,34 @@
             <Path fileType="data">/usr/share/lcov/tests/lcov/gcov-tool/mygcov.sh</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/gcov-tool/path.sh</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/gcov-tool/test.c</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/initializer/Makefile</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/initializer/initializer.cpp</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/initializer/initializer.sh</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/lambda/Makefile</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/lambda/lambda.dat</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/lambda/lambda.sh</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/lambda/lambda2.dat</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/mcdc/Makefile</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/mcdc/main.cpp</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/mcdc/mcdc.sh</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/mcdc/test.cpp</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/merge/Makefile</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/merge/a.dat</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/merge/a.info</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/merge/a_subtract_b.gold</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/merge/b.dat</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/merge/b.info</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/merge/b_subtract_a.gold</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/merge/functionBug_1.dat</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/merge/functionBug_2.dat</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/merge/intersect.gold</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/merge/mcdc.dat</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/merge/merge.sh</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/misc/Makefile</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/misc/help.sh</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/misc/version.sh</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/multiple/Makefile</Path>
+            <Path fileType="data">/usr/share/lcov/tests/lcov/multiple/multiple.sh</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/summary/Makefile</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/summary/concatenated.sh</Path>
             <Path fileType="data">/usr/share/lcov/tests/lcov/summary/concatenated2.sh</Path>
@@ -228,9 +260,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-05-25</Date>
-            <Version>2.1</Version>
+        <Update release="5">
+            <Date>2025-04-10</Date>
+            <Version>2.3.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
             <Email>malfisya.dev@hotmail.com</Email>


### PR DESCRIPTION
**Summary**

Release notes:
- [2.3.1](https://github.com/linux-test-project/lcov/releases/tag/v2.3.1)
- [2.3](https://github.com/linux-test-project/lcov/releases/tag/v2.3)
- [2.2](https://github.com/linux-test-project/lcov/releases/tag/v2.2)

**Test Plan**

<!-- Short description of how the package was tested -->
Rebuild `nomacs` locally

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
