### PR TITLE
sox_ng: Update to v14.5.1.1

### DIFF
--- a/packages/s/sox_ng/package.yml
+++ b/packages/s/sox_ng/package.yml
@@ -1,8 +1,8 @@
 name       : sox_ng
-version    : 14.5.1
-release    : 17
+version    : 14.5.1.1
+release    : 18
 source     :
-    - https://codeberg.org/sox_ng/sox_ng/releases/download/sox_ng-14.5.1/sox_ng-14.5.1.tar.gz : 6a00826169f9f2404fa9ba1679bd989be4050ab2a24c3f6bb607a4cf7b4ebf38
+    - https://codeberg.org/sox_ng/sox_ng/releases/download/sox_ng-14.5.1.1/sox_ng-14.5.1.1.tar.gz : 1ebb6e6eedd1bb9a7b25bf54492f372d80c987f8f586d7e7cde69678889ff958
 homepage   : https://codeberg.org/sox_ng/sox_ng
 license    :
     - GPL-2.0-only

--- a/packages/s/sox_ng/pspec_x86_64.xml
+++ b/packages/s/sox_ng/pspec_x86_64.xml
@@ -45,7 +45,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="17">sox_ng</Dependency>
+            <Dependency release="18">sox_ng</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/sox_ng.h</Path>
@@ -55,9 +55,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2025-03-18</Date>
-            <Version>14.5.1</Version>
+        <Update release="18">
+            <Date>2025-04-10</Date>
+            <Version>14.5.1.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
- o chorus: Fix segmentation fault caused by 'Raise limit on number of stages'
- o chorus: FIx double free when processing multiple channels

**Test Plan**
- Checked version.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
