### PR TITLE
qpwgraph: Update to v0.8.3

### DIFF
--- a/packages/q/qpwgraph/abi_used_symbols
+++ b/packages/q/qpwgraph/abi_used_symbols
@@ -7,7 +7,7 @@ libQt6Core.so.6:_Z9qBadAllocv
 libQt6Core.so.6:_ZN10QArrayData19reallocateUnalignedEPS_PvxxNS_16AllocationOptionE
 libQt6Core.so.6:_ZN10QArrayData8allocateEPPS_xxxNS_16AllocationOptionE
 libQt6Core.so.6:_ZN10QByteArray11reallocDataExN10QArrayData16AllocationOptionE
-libQt6Core.so.6:_ZN10QByteArray6_emptyE
+libQt6Core.so.6:_ZN10QByteArray6appendEc
 libQt6Core.so.6:_ZN10QByteArray6insertEx14QByteArrayView
 libQt6Core.so.6:_ZN10QByteArrayC1EPKcx
 libQt6Core.so.6:_ZN11QBasicMutex12lockInternalEv
@@ -19,6 +19,7 @@ libQt6Core.so.6:_ZN11QFileDevice5closeEv
 libQt6Core.so.6:_ZN11QMetaObject10ConnectionD1Ev
 libQt6Core.so.6:_ZN11QMetaObject18connectSlotsByNameEP7QObject
 libQt6Core.so.6:_ZN11QMetaObject8activateEP7QObjectPKS_iPPv
+libQt6Core.so.6:_ZN11QTextStreamC1EP8_IO_FILE6QFlagsIN13QIODeviceBase12OpenModeFlagEE
 libQt6Core.so.6:_ZN11QTextStreamC1EP9QIODevice
 libQt6Core.so.6:_ZN11QTextStreamD1Ev
 libQt6Core.so.6:_ZN11QTextStreamlsERK7QString
@@ -35,6 +36,7 @@ libQt6Core.so.6:_ZN13QSharedMemoryC1ERK13QNativeIpcKeyP7QObject
 libQt6Core.so.6:_ZN15QSocketNotifierC1ExNS_4TypeEP7QObject
 libQt6Core.so.6:_ZN16QCoreApplication14applicationPidEv
 libQt6Core.so.6:_ZN16QCoreApplication15applicationNameEv
+libQt6Core.so.6:_ZN16QCoreApplication18applicationVersionEv
 libQt6Core.so.6:_ZN16QCoreApplication18setApplicationNameERK7QString
 libQt6Core.so.6:_ZN16QCoreApplication21setApplicationVersionERK7QString
 libQt6Core.so.6:_ZN16QCoreApplication4exitEi
@@ -47,7 +49,7 @@ libQt6Core.so.6:_ZN18QCommandLineParser13addHelpOptionEv
 libQt6Core.so.6:_ZN18QCommandLineParser16addVersionOptionEv
 libQt6Core.so.6:_ZN18QCommandLineParser21addPositionalArgumentERK7QStringS2_S2_
 libQt6Core.so.6:_ZN18QCommandLineParser25setApplicationDescriptionERK7QString
-libQt6Core.so.6:_ZN18QCommandLineParser7processERK5QListI7QStringE
+libQt6Core.so.6:_ZN18QCommandLineParser5parseERK5QListI7QStringE
 libQt6Core.so.6:_ZN18QCommandLineParser9addOptionERK18QCommandLineOption
 libQt6Core.so.6:_ZN18QCommandLineParserC1Ev
 libQt6Core.so.6:_ZN18QCommandLineParserD1Ev
@@ -63,7 +65,7 @@ libQt6Core.so.6:_ZN5QFile4openE6QFlagsIN13QIODeviceBase12OpenModeFlagEE
 libQt6Core.so.6:_ZN5QFileC1ERK7QString
 libQt6Core.so.6:_ZN5QFileD1Ev
 libQt6Core.so.6:_ZN6QDebugD1Ev
-libQt6Core.so.6:_ZN6QTimer10singleShotEiPK7QObjectPKc
+libQt6Core.so.6:_ZN6QTimer10singleShotENSt6chrono8durationIlSt5ratioILl1ELl1000000000EEEEN2Qt9TimerTypeEPK7QObjectPKc
 libQt6Core.so.6:_ZN7QLocaleC1Ev
 libQt6Core.so.6:_ZN7QLocaleD1Ev
 libQt6Core.so.6:_ZN7QLocaleaSERKS_
@@ -138,13 +140,17 @@ libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperI6QPointE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperI7QStringE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperIbE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperIiE8metaTypeE
+libQt6Core.so.6:_ZN9QtPrivate8qustrchrE11QStringViewDs
 libQt6Core.so.6:_ZNK11QMetaObject2trEPKcS1_i
 libQt6Core.so.6:_ZNK11QMetaObject4castEPK7QObject
 libQt6Core.so.6:_ZNK11QMetaObject9classNameEv
 libQt6Core.so.6:_ZNK11QObjectData17dynamicMetaObjectEv
 libQt6Core.so.6:_ZNK14QMessageLogger5debugEPKcz
 libQt6Core.so.6:_ZNK18QCommandLineParser19positionalArgumentsEv
+libQt6Core.so.6:_ZNK18QCommandLineParser5isSetERK18QCommandLineOption
 libQt6Core.so.6:_ZNK18QCommandLineParser5isSetERK7QString
+libQt6Core.so.6:_ZNK18QCommandLineParser8helpTextEv
+libQt6Core.so.6:_ZNK18QCommandLineParser9errorTextEv
 libQt6Core.so.6:_ZNK18QRegularExpression5matchERK7QStringxNS_9MatchTypeE6QFlagsINS_11MatchOptionEE
 libQt6Core.so.6:_ZNK18QRegularExpression7isValidEv
 libQt6Core.so.6:_ZNK23QRegularExpressionMatch8hasMatchEv
@@ -159,7 +165,6 @@ libQt6Core.so.6:_ZNK7QObject6senderEv
 libQt6Core.so.6:_ZNK7QString3argERKS_i5QChar
 libQt6Core.so.6:_ZNK7QString3argExii5QChar
 libQt6Core.so.6:_ZNK7QString5splitE5QChar6QFlagsIN2Qt18SplitBehaviorFlagsEENS2_15CaseSensitivityE
-libQt6Core.so.6:_ZNK7QString7indexOfE5QCharxN2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString7indexOfERKS_xN2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString7sectionERKS_xx6QFlagsINS_11SectionFlagEE
 libQt6Core.so.6:_ZNK8QVariant11toByteArrayEv
@@ -260,6 +265,7 @@ libQt6Gui.so.6:_ZN7QAction7setDataERK8QVariant
 libQt6Gui.so.6:_ZN7QAction7setIconERK5QIcon
 libQt6Gui.so.6:_ZN7QAction7setTextERK7QString
 libQt6Gui.so.6:_ZN7QActionC1EP7QObject
+libQt6Gui.so.6:_ZN7QActionC1ERK7QStringP7QObject
 libQt6Gui.so.6:_ZN7QCursorC1EN2Qt11CursorShapeE
 libQt6Gui.so.6:_ZN7QCursorD1Ev
 libQt6Gui.so.6:_ZN7QPixmapC1Eii
@@ -573,6 +579,7 @@ libQt6Widgets.so.6:_ZN5QMenu15insertSeparatorEP7QAction
 libQt6Widgets.so.6:_ZN5QMenu4execERK6QPointP7QAction
 libQt6Widgets.so.6:_ZN5QMenu5clearEv
 libQt6Widgets.so.6:_ZN5QMenu7addMenuEPS_
+libQt6Widgets.so.6:_ZN5QMenu7addMenuERK7QString
 libQt6Widgets.so.6:_ZN5QMenu7setIconERK5QIcon
 libQt6Widgets.so.6:_ZN5QMenu8setTitleERK7QString
 libQt6Widgets.so.6:_ZN5QMenuC1EP7QWidget
@@ -641,6 +648,7 @@ libQt6Widgets.so.6:_ZN7QWidget11setTabOrderEPS_S0_
 libQt6Widgets.so.6:_ZN7QWidget11tabletEventEP12QTabletEvent
 libQt6Widgets.so.6:_ZN7QWidget12focusInEventEP11QFocusEvent
 libQt6Widgets.so.6:_ZN7QWidget12insertActionEP7QActionS1_
+libQt6Widgets.so.6:_ZN7QWidget12removeActionEP7QAction
 libQt6Widgets.so.6:_ZN7QWidget12setFixedSizeEii
 libQt6Widgets.so.6:_ZN7QWidget13dragMoveEventEP14QDragMoveEvent
 libQt6Widgets.so.6:_ZN7QWidget13focusOutEventEP11QFocusEvent
@@ -982,6 +990,7 @@ libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset
 libc.so.6:rand
+libc.so.6:stderr
 libc.so.6:strcmp
 libc.so.6:strlen
 libgcc_s.so.1:_Unwind_Resume
@@ -1020,7 +1029,8 @@ libstdc++.so.6:_ZSt9terminatev
 libstdc++.so.6:_ZTVN10__cxxabiv117__class_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv120__si_class_type_infoE
 libstdc++.so.6:_ZdaPv
-libstdc++.so.6:_ZdlPv
+libstdc++.so.6:_ZdaPvm
+libstdc++.so.6:_ZdlPvm
 libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
 libstdc++.so.6:__cxa_begin_catch

--- a/packages/q/qpwgraph/package.yml
+++ b/packages/q/qpwgraph/package.yml
@@ -1,8 +1,8 @@
 name       : qpwgraph
-version    : 0.8.0
-release    : 14
+version    : 0.8.3
+release    : 15
 source     :
-    - https://gitlab.freedesktop.org/rncbc/qpwgraph/-/archive/v0.8.0/qpwgraph-v0.8.0.tar.gz : 1b6dab91515c0c2a04bf549ac647723b70ff1506465876a969a591d37e966d7e
+    - https://gitlab.freedesktop.org/rncbc/qpwgraph/-/archive/v0.8.3/qpwgraph-v0.8.3.tar.gz : 2be36fb3704aea51e4e42fe2df23e191443d92ace1b17b6d0e4a7cf802dc85c7
 homepage   : https://gitlab.freedesktop.org/rncbc/qpwgraph
 license    : GPL-2.0-or-later
 component  : multimedia.audio
@@ -18,8 +18,7 @@ rundeps    :
 clang      : yes
 optimize   : thin-lto
 setup      : |
-    %cmake_ninja \
-                 -DCONFIG_WAYLAND=ON
+    %cmake_ninja -DCONFIG_WAYLAND=ON
 build      : |
     %ninja_build
 install    : |

--- a/packages/q/qpwgraph/pspec_x86_64.xml
+++ b/packages/q/qpwgraph/pspec_x86_64.xml
@@ -32,9 +32,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2024-11-26</Date>
-            <Version>0.8.0</Version>
+        <Update release="15">
+            <Date>2025-04-11</Date>
+            <Version>0.8.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
             <Email>malfisya.dev@hotmail.com</Email>


### PR DESCRIPTION
**Summary**

- Loading a patchbay profile (*.qpwgraph) from the command line, is now properly shown on the main window title and toolbar.
- Added PipeWire command line version information.

**Test Plan**

<!-- Short description of how the package was tested -->
Launch the apps, see my setup graph

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
