### PR TITLE
xfce4-pulseaudio-plugin: Update to v0.5.0

### DIFF
--- a/packages/x/xfce4-pulseaudio-plugin/abi_used_symbols
+++ b/packages/x/xfce4-pulseaudio-plugin/abi_used_symbols
@@ -26,6 +26,9 @@ libgio-2.0.so.0:g_dbus_message_new_method_call
 libgio-2.0.so.0:g_dbus_proxy_new_sync
 libgio-2.0.so.0:g_desktop_app_info_new_from_filename
 libgio-2.0.so.0:g_desktop_app_info_search
+libgio-2.0.so.0:g_static_resource_fini
+libgio-2.0.so.0:g_static_resource_get_resource
+libgio-2.0.so.0:g_static_resource_init
 libgio-2.0.so.0:g_themed_icon_new
 libgio-2.0.so.0:g_themed_icon_new_with_default_fallbacks
 libglib-2.0.so.0:g_ascii_strcasecmp
@@ -55,9 +58,7 @@ libglib-2.0.so.0:g_key_file_get_locale_string
 libglib-2.0.so.0:g_key_file_get_string
 libglib-2.0.so.0:g_key_file_load_from_data_dirs
 libglib-2.0.so.0:g_key_file_new
-libglib-2.0.so.0:g_list_find_custom
 libglib-2.0.so.0:g_list_free
-libglib-2.0.so.0:g_list_free_full
 libglib-2.0.so.0:g_list_length
 libglib-2.0.so.0:g_list_sort_with_data
 libglib-2.0.so.0:g_log
@@ -107,7 +108,6 @@ libglib-2.0.so.0:g_variant_iter_next_value
 libglib-2.0.so.0:g_variant_new
 libglib-2.0.so.0:g_variant_new_boolean
 libglib-2.0.so.0:g_variant_new_int32
-libglib-2.0.so.0:g_variant_new_string
 libglib-2.0.so.0:g_variant_type_checked_
 libglib-2.0.so.0:g_variant_unref
 libgobject-2.0.so.0:g_cclosure_marshal_VOID__BOOLEAN
@@ -154,7 +154,8 @@ libgtk-3.so.0:gtk_bin_get_child
 libgtk-3.so.0:gtk_box_new
 libgtk-3.so.0:gtk_box_pack_start
 libgtk-3.so.0:gtk_box_set_center_widget
-libgtk-3.so.0:gtk_builder_add_from_string
+libgtk-3.so.0:gtk_box_set_homogeneous
+libgtk-3.so.0:gtk_builder_add_from_resource
 libgtk-3.so.0:gtk_builder_get_object
 libgtk-3.so.0:gtk_builder_get_type
 libgtk-3.so.0:gtk_button_get_image
@@ -207,6 +208,8 @@ libgtk-3.so.0:gtk_menu_set_screen
 libgtk-3.so.0:gtk_menu_shell_append
 libgtk-3.so.0:gtk_menu_shell_get_type
 libgtk-3.so.0:gtk_message_dialog_new_with_markup
+libgtk-3.so.0:gtk_orientable_get_orientation
+libgtk-3.so.0:gtk_orientable_set_orientation
 libgtk-3.so.0:gtk_radio_menu_item_get_group
 libgtk-3.so.0:gtk_radio_menu_item_new_with_label
 libgtk-3.so.0:gtk_range_get_value
@@ -238,14 +241,15 @@ libgtk-3.so.0:gtk_tree_view_get_model
 libgtk-3.so.0:gtk_widget_add_events
 libgtk-3.so.0:gtk_widget_destroy
 libgtk-3.so.0:gtk_widget_event
+libgtk-3.so.0:gtk_widget_get_allocated_height
 libgtk-3.so.0:gtk_widget_get_allocated_width
 libgtk-3.so.0:gtk_widget_get_allocation
 libgtk-3.so.0:gtk_widget_get_parent
 libgtk-3.so.0:gtk_widget_get_scale_factor
 libgtk-3.so.0:gtk_widget_get_screen
+libgtk-3.so.0:gtk_widget_get_size_request
 libgtk-3.so.0:gtk_widget_get_style_context
 libgtk-3.so.0:gtk_widget_get_type
-libgtk-3.so.0:gtk_widget_get_visible
 libgtk-3.so.0:gtk_widget_has_screen
 libgtk-3.so.0:gtk_widget_is_visible
 libgtk-3.so.0:gtk_widget_set_can_default
@@ -256,6 +260,7 @@ libgtk-3.so.0:gtk_widget_set_has_tooltip
 libgtk-3.so.0:gtk_widget_set_name
 libgtk-3.so.0:gtk_widget_set_sensitive
 libgtk-3.so.0:gtk_widget_set_size_request
+libgtk-3.so.0:gtk_widget_set_valign
 libgtk-3.so.0:gtk_widget_set_visible
 libgtk-3.so.0:gtk_widget_show
 libgtk-3.so.0:gtk_widget_show_all
@@ -267,7 +272,6 @@ libkeybinder-3.0.so.0:keybinder_bind
 libkeybinder-3.0.so.0:keybinder_init
 libkeybinder-3.0.so.0:keybinder_unbind
 libm.so.6:round
-libnotify.so.4:notify_get_server_caps
 libnotify.so.4:notify_init
 libnotify.so.4:notify_notification_new
 libnotify.so.4:notify_notification_set_hint
@@ -308,14 +312,16 @@ libpulse.so.0:pa_proplist_sets
 libpulse.so.0:pa_strerror
 libxfce4panel-2.0.so.4:xfce_panel_plugin_get_icon_size
 libxfce4panel-2.0.so.4:xfce_panel_plugin_get_nrows
+libxfce4panel-2.0.so.4:xfce_panel_plugin_get_orientation
 libxfce4panel-2.0.so.4:xfce_panel_plugin_get_property_base
+libxfce4panel-2.0.so.4:xfce_panel_plugin_get_size
 libxfce4panel-2.0.so.4:xfce_panel_plugin_get_type
 libxfce4panel-2.0.so.4:xfce_panel_plugin_menu_show_about
 libxfce4panel-2.0.so.4:xfce_panel_plugin_menu_show_configure
 libxfce4panel-2.0.so.4:xfce_panel_plugin_popup_menu
 libxfce4panel-2.0.so.4:xfce_panel_plugin_set_small
 libxfce4ui-2.so.0:xfce_dialog_show_help
-libxfce4ui-2.so.0:xfce_spawn_command_line_on_screen
+libxfce4ui-2.so.0:xfce_spawn_command_line
 libxfce4ui-2.so.0:xfce_titled_dialog_get_type
 libxfce4util.so.7:xfce_get_license_text
 libxfce4util.so.7:xfce_textdomain

--- a/packages/x/xfce4-pulseaudio-plugin/package.yml
+++ b/packages/x/xfce4-pulseaudio-plugin/package.yml
@@ -1,8 +1,8 @@
 name       : xfce4-pulseaudio-plugin
-version    : 0.4.9
-release    : 3
+version    : 0.5.0
+release    : 4
 source     :
-    - https://archive.xfce.org/src/panel-plugins/xfce4-pulseaudio-plugin/0.4/xfce4-pulseaudio-plugin-0.4.9.tar.bz2 : a0807615fb2848d0361b7e4568a44f26d189fda48011c7ba074986c8bfddc99a
+    - https://archive.xfce.org/src/panel-plugins/xfce4-pulseaudio-plugin/0.5/xfce4-pulseaudio-plugin-0.5.0.tar.xz : 3fe69bc6f9c0dd68bd317c0a7813975cf162ba1dd64e23c2ffef372d4b4f808a
 homepage   : https://docs.xfce.org/panel-plugins/xfce4-pulseaudio-plugin/start
 license    : GPL-2.0-or-later
 component  : desktop.xfce
@@ -21,8 +21,8 @@ builddeps  :
 rundeps    :
     - pavucontrol
 setup      : |
-    %configure
+    %meson_configure
 build      : |
-    %make
+    %ninja_build
 install    : |
-    %make_install
+    %ninja_install

--- a/packages/x/xfce4-pulseaudio-plugin/pspec_x86_64.xml
+++ b/packages/x/xfce4-pulseaudio-plugin/pspec_x86_64.xml
@@ -21,6 +21,7 @@
         <PartOf>desktop.xfce</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/xfce4/panel/plugins/libpulseaudio-plugin.so</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/xfce4-pulseaudio-plugin.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/xfce4-pulseaudio-plugin.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/xfce4-pulseaudio-plugin.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/status/audio-volume-high-symbolic.svg</Path>
@@ -69,6 +70,7 @@
             <Path fileType="localedata">/usr/share/locale/pl/LC_MESSAGES/xfce4-pulseaudio-plugin.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt/LC_MESSAGES/xfce4-pulseaudio-plugin.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/xfce4-pulseaudio-plugin.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ro/LC_MESSAGES/xfce4-pulseaudio-plugin.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ru/LC_MESSAGES/xfce4-pulseaudio-plugin.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sk/LC_MESSAGES/xfce4-pulseaudio-plugin.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sl/LC_MESSAGES/xfce4-pulseaudio-plugin.mo</Path>
@@ -78,15 +80,16 @@
             <Path fileType="localedata">/usr/share/locale/th/LC_MESSAGES/xfce4-pulseaudio-plugin.mo</Path>
             <Path fileType="localedata">/usr/share/locale/tr/LC_MESSAGES/xfce4-pulseaudio-plugin.mo</Path>
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/xfce4-pulseaudio-plugin.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/vi/LC_MESSAGES/xfce4-pulseaudio-plugin.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/xfce4-pulseaudio-plugin.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/xfce4-pulseaudio-plugin.mo</Path>
             <Path fileType="data">/usr/share/xfce4/panel/plugins/pulseaudio.desktop</Path>
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-12-15</Date>
-            <Version>0.4.9</Version>
+        <Update release="4">
+            <Date>2025-04-11</Date>
+            <Version>0.5.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Fix gauge notifications
- Change plugin behavior when recording indicator is visible/hidden
- Avoid ScaleMenuItem conflicts
- Prevent "g_hash_table_lookup" crash when "key" is NULL
- Rotate plugin in vertical/deskbar orientation
- Fix libxfce4panel include
- Translation updates

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Restart an Xfce VM and play a youtube video with sound. Hear sound.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
