### PR TITLE
upx: Update to v5.0.0

### DIFF
--- a/packages/u/upx/abi_used_symbols
+++ b/packages/u/upx/abi_used_symbols
@@ -179,6 +179,7 @@ libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
 libstdc++.so.6:__cxa_allocate_exception
 libstdc++.so.6:__cxa_begin_catch
+libstdc++.so.6:__cxa_call_terminate
 libstdc++.so.6:__cxa_end_catch
 libstdc++.so.6:__cxa_guard_acquire
 libstdc++.so.6:__cxa_guard_release

--- a/packages/u/upx/package.yml
+++ b/packages/u/upx/package.yml
@@ -1,8 +1,8 @@
 name       : upx
-version    : 4.2.4
-release    : 8
+version    : 5.0.0
+release    : 9
 source     :
-    - https://github.com/upx/upx/releases/download/v4.2.4/upx-4.2.4-src.tar.xz : 5ed6561607d27fb4ef346fc19f08a93696fa8fa127081e7a7114068306b8e1c4
+    - https://github.com/upx/upx/releases/download/v5.0.0/upx-5.0.0-src.tar.xz : e0eb96f9c50aefdb02eca445f8ed76aca5cd70b6b132bf61bea3ba4b8ebb64cc
 homepage   : https://upx.github.io/
 license    : GPL-2.0-or-later
 component  : system.utils

--- a/packages/u/upx/pspec_x86_64.xml
+++ b/packages/u/upx/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>upx</Name>
         <Homepage>https://upx.github.io/</Homepage>
         <Packager>
-            <Name>Mislav &#x10c;akari&#x107;</Name>
-            <Email>mcakaric@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -25,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2024-05-22</Date>
-            <Version>4.2.4</Version>
+        <Update release="9">
+            <Date>2025-04-11</Date>
+            <Version>5.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Mislav &#x10c;akari&#x107;</Name>
-            <Email>mcakaric@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- ELF: use of memfd_create supports Enforcing mode of SELinux
- ELF: two-step de-compression enables future per-PT_LOAD work
- ELF: --unmap-all-pages completely avoids /proc/self/exe
- ELF: PT_MIPS_ABIFLAGS is now forwarded into the compressed output; qemu-mips can choose the right floating-point emulation
- ELF: many minor internal changes fix nits revealed by fuzzing
- bug fixes - see https://github.com/upx/upx/milestone/18

**Test Plan**

<!-- Short description of how the package was tested -->
Run `upx` to pack `moss` binary

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
