### PR TITLE
astromenace: Fix appstream metainfo generation

### DIFF
--- a/packages/a/astromenace/files/0001-Remove-remote-icon-from-appdata.patch
+++ b/packages/a/astromenace/files/0001-Remove-remote-icon-from-appdata.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Muhammad Alfi Syahrin <malfisya.dev@hotmail.com>
+Date: Sat, 12 Apr 2025 06:58:37 +0700
+Subject: [PATCH] Remove remote icon from appdata
+
+---
+ share/astromenace.appdata.xml | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/share/astromenace.appdata.xml b/share/astromenace.appdata.xml
+index 4194cb7..d044367 100644
+--- a/share/astromenace.appdata.xml
++++ b/share/astromenace.appdata.xml
+@@ -6,8 +6,6 @@
+   <project_license>GPL-3.0+ AND GPL-3.0 AND CC-BY-SA-4.0 AND OFL-1.1</project_license>
+   <name>AstroMenace</name>
+   <summary>Hardcore 3D space scroll-shooter with spaceship upgrade possibilities</summary>
+-  <icon type="remote" width="64" height="64">https://raw.githubusercontent.com/viewizard/astromenace/master/share/astromenace_64.png</icon>
+-  <icon type="remote" width="128" height="128">https://raw.githubusercontent.com/viewizard/astromenace/master/share/astromenace_128.png</icon>
+   <description>
+     <p>
+       AstroMenace is an astonishing hardcore scroll-shooter where brave space warriors may find a great opportunity to hone their combat skills. Gather money during the battle to spend them on turning your spaceship into an ultimate weapon of mass destruction and give hell to swarms of adversaries. Enjoy the wonderfully crafted 3d graphics and high-quality special effects along with a detailed difficulty adjustment and a handy interface of AstroMenace.

--- a/packages/a/astromenace/package.yml
+++ b/packages/a/astromenace/package.yml
@@ -1,6 +1,6 @@
 name       : astromenace
 version    : 1.4.3
-release    : 15
+release    : 16
 source     :
     - https://github.com/viewizard/astromenace/archive/v1.4.3.tar.gz : c16b56bfa91f0b1ac1520d09ead2a1fbb536cbd3d4f3a792a222d44bc708eab1
 homepage   : https://viewizard.com/
@@ -19,6 +19,7 @@ builddeps  :
     - pkgconfig(sdl2)
     - pkgconfig(vorbis)
 setup      : |
+    %patch -p1 -i $pkgfiles/0001-Remove-remote-icon-from-appdata.patch
     %cmake_ninja \
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DDATADIR=/usr/share/astromenace

--- a/packages/a/astromenace/pspec_x86_64.xml
+++ b/packages/a/astromenace/pspec_x86_64.xml
@@ -31,8 +31,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2025-04-10</Date>
+        <Update release="16">
+            <Date>2025-04-12</Date>
             <Version>1.4.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>


### PR DESCRIPTION
**Summary**

<!-- Info on what this pull request updates/changes/etc -->
 Fix appstream metainfo generation

**Test Plan**

<!-- Short description of how the package was tested -->
`appstream-builder --packages-dir=. --include-failed -v`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
