### PR TITLE
showtime: Add missing rundeps

### DIFF
--- a/packages/s/showtime/package.yml
+++ b/packages/s/showtime/package.yml
@@ -1,6 +1,6 @@
 name       : showtime
 version    : '48.0'
-release    : 1
+release    : 2
 source     :
     - https://download.gnome.org/sources/showtime/48/showtime-48.0.tar.xz : 03e5e62b37d3a7d34344b9b0c8805dd041987a7305bd70e4c596bc4ccaec30e4
 homepage   : https://apps.gnome.org/Showtime/
@@ -13,6 +13,8 @@ builddeps  :
     - pkgconfig(libadwaita-1)
     - blueprint-compiler
     - desktop-file-utils
+rundeps    :
+    - gstreamer-1.0-plugins-rs
 setup      : |
     %meson_configure
 build      : |

--- a/packages/s/showtime/pspec_x86_64.xml
+++ b/packages/s/showtime/pspec_x86_64.xml
@@ -75,8 +75,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2025-04-03</Date>
+        <Update release="2">
+            <Date>2025-04-12</Date>
             <Version>48.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>


### PR DESCRIPTION
**Summary**

Add `gstreamer-1.0-plugins-rs` to rundeps

**Test Plan**

<!-- Short description of how the package was tested -->
Launch it in Xfce VM and play video

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
