### PR TITLE
appstream-data: Update to v71

### DIFF
--- a/packages/a/appstream-data/package.yml
+++ b/packages/a/appstream-data/package.yml
@@ -1,8 +1,8 @@
 name       : appstream-data
-version    : '70'
-release    : 67
+version    : '71'
+release    : 68
 source     :
-    - https://github.com/getsolus/solus-appstream-data/archive/refs/tags/v70.tar.gz : 57d276f1c675fc50416dbd76aaf5316f530da2a327d71051d5ed5badf29abe4a
+    - https://github.com/getsolus/solus-appstream-data/archive/refs/tags/v71.tar.gz : 83260f58f437be20550f6f08a7ed6ba74d620df94d997e815343989bc0f3303e
 homepage   : https://www.freedesktop.org/wiki/Distributions/AppStream/
 license    :
     - CC-BY-SA-3.0

--- a/packages/a/appstream-data/pspec_x86_64.xml
+++ b/packages/a/appstream-data/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>appstream-data</Name>
         <Homepage>https://www.freedesktop.org/wiki/Distributions/AppStream/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>CC-BY-SA-3.0</License>
         <License>CC-BY-SA-4.0</License>
@@ -116,6 +116,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.ulduzsoft.Birdtray.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.ultimaker.cura.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.valvesoftware.Steam.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.viewizard.AstroMenace.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.wire.WireDesktop.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.wiz.Note.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/128x128/com.yacreader.YACReader.png</Path>
@@ -780,6 +781,7 @@
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.ulduzsoft.Birdtray.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.ultimaker.cura.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.valvesoftware.Steam.png</Path>
+            <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.viewizard.AstroMenace.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.wire.WireDesktop.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.wiz.Note.png</Path>
             <Path fileType="data">/usr/share/app-info/icons/solus-1/64x64/com.wordpress.firejail.firetools.png</Path>
@@ -1438,12 +1440,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="67">
-            <Date>2025-04-11</Date>
-            <Version>70</Version>
+        <Update release="68">
+            <Date>2025-04-12</Date>
+            <Version>71</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Update Appstream Data

**Test Plan**

- Build and install `appstream-data` from this PR.
- Open Discover and search for "Astromenace". 
- See that it is now listed correctly from the Solus repository.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
