### PR TITLE
antidote: Update to v1.9.8

### DIFF
--- a/packages/a/antidote/package.yml
+++ b/packages/a/antidote/package.yml
@@ -1,8 +1,8 @@
 name       : antidote
-version    : 1.9.7
-release    : 3
+version    : 1.9.8
+release    : 4
 source     :
-    - https://github.com/mattmc3/antidote/archive/refs/tags/v1.9.7.tar.gz : 67245a39d9719251e295cbeae7b050c99eccff5b978badd1e4b61e90575a6fac
+    - https://github.com/mattmc3/antidote/archive/refs/tags/v1.9.8.tar.gz : c9c4f4f7ba2e696e80bc3e4c7df184389641f5aaf5ede660f9ce5093d37efa03
 homepage   : https://getantidote.github.io/
 license    : MIT
 component  : system.utils

--- a/packages/a/antidote/pspec_x86_64.xml
+++ b/packages/a/antidote/pspec_x86_64.xml
@@ -28,12 +28,13 @@
             <Path fileType="data">/usr/share/antidote/functions/__antidote_bundle_zcompile</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_collect_input</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_del</Path>
-            <Path fileType="data">/usr/share/antidote/functions/__antidote_filter_defers</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_get_cachedir</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_indent</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_initfiles</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_load_prep</Path>
+            <Path fileType="data">/usr/share/antidote/functions/__antidote_mktemp</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_parse_bundles</Path>
+            <Path fileType="data">/usr/share/antidote/functions/__antidote_parser</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_print_path</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_setup</Path>
             <Path fileType="data">/usr/share/antidote/functions/__antidote_tourl</Path>
@@ -59,9 +60,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-07-19</Date>
-            <Version>1.9.7</Version>
+        <Update release="4">
+            <Date>2025-04-14</Date>
+            <Version>1.9.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/mattmc3/antidote/releases/tag/v1.9.8).

**Test Plan**
- Loaded plugins.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
