### PR TITLE
libvte: Hide desktop entry by default

### DIFF
--- a/packages/l/libvte/files/0001-Hide-desktop-entry-by-default.patch
+++ b/packages/l/libvte/files/0001-Hide-desktop-entry-by-default.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Muhammad Alfi Syahrin <malfisya.dev@hotmail.com>
+Date: Tue, 15 Apr 2025 08:01:14 +0700
+Subject: [PATCH] Hide desktop entry by default
+
+---
+ src/app/vte.desktop.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/app/vte.desktop.in b/src/app/vte.desktop.in
+index 0c425fa..faeb09b 100644
+--- a/src/app/vte.desktop.in
++++ b/src/app/vte.desktop.in
+@@ -16,3 +16,4 @@ X-TerminalArgTitle=--title
+ X-TerminalArgDir=--working-directory
+ # X-TerminalArgHold=
+ X-KDE-AuthorizeAction=shell_access
++NoDisplay=true

--- a/packages/l/libvte/package.yml
+++ b/packages/l/libvte/package.yml
@@ -1,6 +1,6 @@
 name       : libvte
 version    : 0.80.1
-release    : 75
+release    : 76
 source     :
     - https://download.gnome.org/sources/vte/0.80/vte-0.80.1.tar.xz : 0cdbd0e983afd9d22e065e323a743160072bf64b453e00b15edbe6f2dcdda46c
 homepage   : https://gitlab.gnome.org/GNOME/vte
@@ -29,6 +29,7 @@ patterns   :
     - docs :
         - /usr/share/doc/*
 setup      : |
+    %patch -p1 -i $pkgfiles/0001-Hide-desktop-entry-by-default.patch
     %meson_configure -Ddocs=true -Dgtk4=true
 build      : |
     %ninja_build

--- a/packages/l/libvte/pspec_x86_64.xml
+++ b/packages/l/libvte/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libvte</Name>
         <Homepage>https://gitlab.gnome.org/GNOME/vte</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>LGPL-3.0-or-later</License>
         <PartOf>desktop.library</PartOf>
@@ -146,7 +146,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="75">libvte</Dependency>
+            <Dependency release="76">libvte</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/vte-2.91-gtk4/vte/vte.h</Path>
@@ -1028,12 +1028,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="75">
-            <Date>2025-04-14</Date>
+        <Update release="76">
+            <Date>2025-04-15</Date>
             <Version>0.80.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

<!-- Info on what this pull request updates/changes/etc -->
`libvte` ships desktop file since version 0.80. Since people usually uses Gnome Terminal, Ptyxis or  Gnome Console to actually uses it, I think it is better to hide its desktop entry by default.

**Test Plan**

<!-- Short description of how the package was tested -->
Install this package and all VTE desktop entry disappear

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
