### PR TITLE
zellij: Update to v0.42.2

### DIFF
--- a/packages/z/zellij/package.yml
+++ b/packages/z/zellij/package.yml
@@ -1,8 +1,8 @@
 name       : zellij
-version    : 0.42.1
-release    : 11
+version    : 0.42.2
+release    : 12
 source     :
-    - https://github.com/zellij-org/zellij/archive/refs/tags/v0.42.1.tar.gz : e9516879483c1bb617a13e6278878883943c05f87bdc41fc02cc550a7b06c0b4
+    - https://github.com/zellij-org/zellij/archive/refs/tags/v0.42.2.tar.gz : f1cd4b36775dd367b839e394b54e91042b0cd0f2b9e0901b1dec8517ff3929c0
 homepage   : https://zellij.dev
 license    : MIT
 component  : system.utils

--- a/packages/z/zellij/pspec_x86_64.xml
+++ b/packages/z/zellij/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>zellij</Name>
         <Homepage>https://zellij.dev</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -31,12 +31,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2025-03-24</Date>
-            <Version>0.42.1</Version>
+        <Update release="12">
+            <Date>2025-04-17</Date>
+            <Version>0.42.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
This patch release is mainly intended to address a breaking change in the Rust compiler that caused compilation to fail with `--locked` starting from Rust version 1.86.

This patch also includes some terminal rendering performance improvements - namely consolidating some renders and thus reducing the occasional text flicker.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new zellij session, run commands, make this PR.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
