### PR TITLE
github-cli: Update to v2.70.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.69.0
-release    : 69
+version    : 2.70.0
+release    : 70
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.69.0.tar.gz : e2deb3759bbe4da8ad4f071ca604fda5c2fc803fef8b3b89896013e4b1c1fe65
+    - https://github.com/cli/cli/archive/refs/tags/v2.70.0.tar.gz : 9e2247e5b31131fd4ac63916b9483a065fcfb861ebb93588cf2ff42952ae08c5
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -230,9 +230,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="69">
-            <Date>2025-03-22</Date>
-            <Version>2.69.0</Version>
+        <Update release="70">
+            <Date>2025-04-17</Date>
+            <Version>2.70.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
This release contains dark shipped [sic?] changes that are part of a larger GitHub CLI accessibility preview still under development. More information about these will be announced later this month including various channels to work with GitHub and GitHub CLI maintainers on shaping these experiences.

- Ensure table headers are thematically contrasting

Full changelog available [here](https://github.com/cli/cli/releases/tag/v2.70.0).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
