### PR TITLE
adw-gtk3-theme: Update to v5.10

### DIFF
--- a/packages/a/adw-gtk3-theme/package.yml
+++ b/packages/a/adw-gtk3-theme/package.yml
@@ -1,8 +1,8 @@
 name       : adw-gtk3-theme
-version    : '5.8'
-release    : 17
+version    : '5.10'
+release    : 18
 source     :
-    - https://github.com/lassekongo83/adw-gtk3/archive/refs/tags/v5.8.tar.gz : 4dec5265f250473082dcba38995f44024b9d87a1e91c5adf79b9fdabf0c59fd4
+    - https://github.com/lassekongo83/adw-gtk3/archive/refs/tags/v5.10.tar.gz : 1439d432248a661ccc513a90ae1e5e9e65cac69842cbc090f09ec4f994c8b749
 license    : LGPL-2.1-only
 homepage   : https://github.com/lassekongo83/adw-gtk3
 component  : desktop.theme

--- a/packages/a/adw-gtk3-theme/pspec_x86_64.xml
+++ b/packages/a/adw-gtk3-theme/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>adw-gtk3-theme</Name>
         <Homepage>https://github.com/lassekongo83/adw-gtk3</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-only</License>
         <PartOf>desktop.theme</PartOf>
@@ -139,12 +139,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2025-04-10</Date>
-            <Version>5.8</Version>
+        <Update release="18">
+            <Date>2025-04-17</Date>
+            <Version>5.10</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Fixes a crash in chromium browser with the light theme.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Switch to this theme in Budgie.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
