### PR TITLE
svtplay-dl: Update to v4.109

### DIFF
--- a/packages/s/svtplay-dl/package.yml
+++ b/packages/s/svtplay-dl/package.yml
@@ -1,8 +1,8 @@
 name       : svtplay-dl
-version    : '4.103'
-release    : 26
+version    : '4.109'
+release    : 27
 source     :
-    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.103.tar.gz : 55a117174f197b503e8782c0dec127187fca39ef1b93bad74a35e35c7b301e25
+    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.109.tar.gz : 82710b29c06810224fc3d5c184aefa0121ba4ca668f2551c3bea2a1a820ad515
 homepage   : https://svtplay-dl.se/
 license    : MIT
 component  : network.download

--- a/packages/s/svtplay-dl/pspec_x86_64.xml
+++ b/packages/s/svtplay-dl/pspec_x86_64.xml
@@ -21,12 +21,12 @@
         <PartOf>network.download</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/svtplay-dl</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.103-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.103-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.103-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.103-py3.11.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.103-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.103-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.109-py3.11.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.109-py3.11.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.109-py3.11.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.109-py3.11.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.109-py3.11.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl-4.109-py3.11.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/__pycache__/__init__.cpython-311.pyc</Path>
@@ -87,6 +87,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/sportlib.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/sr.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/svt.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/svtbarn.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/svtplay.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/tv4play.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/__pycache__/twitch.cpython-311.pyc</Path>
@@ -133,6 +134,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/sportlib.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/sr.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/svt.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/svtbarn.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/svtplay.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/tv4play.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/svtplay_dl/service/twitch.py</Path>
@@ -170,9 +172,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2025-03-18</Date>
-            <Version>4.103</Version>
+        <Update release="27">
+            <Date>2025-04-18</Date>
+            <Version>4.109</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
-   svtplay: when we have both subtitles `svenska` and `svenska (allt tal)` it will only download `allt tal`
-   svtplay: fixed -A on `kategorier`
-   svtplay: improve detection on season info based on year
-   subtitles wont be downloaded again on already existing file when using `-M` and `-A`
-   added support for svtbarn
-   tv4play: fixed a crash on downloading clips
-   fixed a crash on bad filenames on windows with `:` in the name
-   changed how configs works.
-   it will check current working directory first for the file `svtplay-dl.yaml`
    -   on *nix then `$XDG_CONFIG_HOME/svtplay-dl/svtplay.yaml` / `~/.config/svtplay-dl/svtplay-dl.yaml` then the old `~/.svtplay-dl.yaml`

**Test Plan**
- Downloaded a video from svtbarn.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
