### PR TITLE
man-pages: Update to v6.13

### DIFF
--- a/packages/m/man-pages/package.yml
+++ b/packages/m/man-pages/package.yml
@@ -1,8 +1,8 @@
 name       : man-pages
-version    : '6.10'
-release    : 23
+version    : '6.13'
+release    : 24
 source     :
-    - https://mirrors.edge.kernel.org/pub/linux/docs/man-pages/man-pages-6.10.tar.xz : db49503ad4da07633fa28012a278915f0f0178ad6c33346e59b7ada731925709
+    - https://mirrors.edge.kernel.org/pub/linux/docs/man-pages/man-pages-6.13.tar.xz : a2c8a0c2efe8a978ce51ce800461eb9e8931f12cc7ba4b7faa3082b69ba7f12c
 license    :
     - BSD-3-Clause
     - GPL-1.0-or-later
@@ -20,7 +20,7 @@ mancompress: yes
 rundeps    :
     - man-db
 install    : |
-    %make_install prefix=/usr
+    %make_install -R prefix=/usr
 
     # Remove conflicting files
     while read -r conflict; do

--- a/packages/m/man-pages/pspec_x86_64.xml
+++ b/packages/m/man-pages/pspec_x86_64.xml
@@ -2910,6 +2910,7 @@
             <Path fileType="man">/usr/share/man/man7/operator.7.gz</Path>
             <Path fileType="man">/usr/share/man/man7/packet.7.gz</Path>
             <Path fileType="man">/usr/share/man/man7/path_resolution.7.gz</Path>
+            <Path fileType="man">/usr/share/man/man7/pathname.7.gz</Path>
             <Path fileType="man">/usr/share/man/man7/persistent-keyring.7.gz</Path>
             <Path fileType="man">/usr/share/man/man7/pid_namespaces.7.gz</Path>
             <Path fileType="man">/usr/share/man/man7/pipe.7.gz</Path>
@@ -2980,9 +2981,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2025-02-11</Date>
-            <Version>6.10</Version>
+        <Update release="24">
+            <Date>2025-04-18</Date>
+            <Version>6.13</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Release notes:
- [6.11](https://lkml.iu.edu/hypermail/linux/kernel/2502.1/10564.html)
- [6.12](https://kernel.googlesource.com/pub/scm/docs/man-pages/man-pages/+/refs/tags/man-pages-6.12)
- [6.13](https://lkml.org/lkml/2025/3/7/1714)

**Test Plan**
- Checked out some new and updated man pages

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
