### PR TITLE
obs-cmd: Update to v0.18.3

### DIFF
--- a/packages/o/obs-cmd/files/fix-version.patch
+++ b/packages/o/obs-cmd/files/fix-version.patch
@@ -1,5 +1,5 @@
 diff --git a/Cargo.lock b/Cargo.lock
-index c491f7e..40bfe99 100644
+index c491f7e..82e0822 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
 @@ -586,7 +586,7 @@ dependencies = [
@@ -7,19 +7,19 @@ index c491f7e..40bfe99 100644
  [[package]]
  name = "obs-cmd"
 -version = "0.18.1"
-+version = "0.18.2"
++version = "0.18.3"
  dependencies = [
   "clap",
   "obws",
 diff --git a/Cargo.toml b/Cargo.toml
-index a801105..acfc349 100644
+index a801105..8614f37 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
 @@ -1,6 +1,6 @@
  [package]
  name = "obs-cmd"
 -version = "0.18.1"
-+version = "0.18.2"
++version = "0.18.3"
  edition = "2021"
  description = "A minimal command to control obs via obs-websocket"
  authors = ["Luigi Maselli <luigi@grigio.org>"]

--- a/packages/o/obs-cmd/package.yml
+++ b/packages/o/obs-cmd/package.yml
@@ -1,8 +1,8 @@
 name       : obs-cmd
-version    : 0.18.2
-release    : 6
+version    : 0.18.3
+release    : 7
 source     :
-    - https://github.com/grigio/obs-cmd/archive/refs/tags/v0.18.2.tar.gz : bc982ad3fbb69efca739a8dfaca5d9fc05b935b5f6b41497bac119acf5e5c2c2
+    - https://github.com/grigio/obs-cmd/archive/refs/tags/v0.18.3.tar.gz : dd416f318b218dc2bc834c2935137ffdc363c34e98d4601bccd8cb2833b86941
 homepage   : https://github.com/grigio/obs-cmd
 license    : MIT
 component  : system.utils

--- a/packages/o/obs-cmd/pspec_x86_64.xml
+++ b/packages/o/obs-cmd/pspec_x86_64.xml
@@ -24,9 +24,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2025-01-16</Date>
-            <Version>0.18.2</Version>
+        <Update release="7">
+            <Date>2025-04-19</Date>
+            <Version>0.18.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Ian M. Jones</Name>
             <Email>ian@ianmjones.com</Email>


### PR DESCRIPTION
**Summary**

Changelog: https://github.com/grigio/obs-cmd/releases/tag/v0.18.3

**Test Plan**

* Built and installed package locally.
* Ran a few manual commands.
* Ran a few scripted commands (via deckmaster).
* Checked version reported correctly.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
