### PR TITLE
eza: Update to v0.21.1

### DIFF
--- a/packages/e/eza/abi_used_symbols
+++ b/packages/e/eza/abi_used_symbols
@@ -129,6 +129,7 @@ libc.so.6:time
 libc.so.6:unlink
 libc.so.6:utimes
 libc.so.6:write
+libc.so.6:writev
 libgcc_s.so.1:_Unwind_Backtrace
 libgcc_s.so.1:_Unwind_GetDataRelBase
 libgcc_s.so.1:_Unwind_GetIP

--- a/packages/e/eza/package.yml
+++ b/packages/e/eza/package.yml
@@ -1,8 +1,8 @@
 name       : eza
-version    : 0.21.0
-release    : 46
+version    : 0.21.1
+release    : 47
 source     :
-    - https://github.com/eza-community/eza/archive/refs/tags/v0.21.0.tar.gz : 885ae7a12c7ed68dd3a7cca76d4e8beaa100c9e9d6b7ad136b5bb6785e16b28b
+    - https://github.com/eza-community/eza/archive/refs/tags/v0.21.1.tar.gz : 04b0be58900b31680d5c507885a51eb6a6f323abaafcbb8b9db0f372704c188d
 homepage   : https://github.com/eza-community/eza
 license    : EUPL-1.2
 component  : system.utils

--- a/packages/e/eza/pspec_x86_64.xml
+++ b/packages/e/eza/pspec_x86_64.xml
@@ -33,9 +33,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="46">
-            <Date>2025-04-02</Date>
-            <Version>0.21.0</Version>
+        <Update release="47">
+            <Date>2025-04-19</Date>
+            <Version>0.21.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Don’t truncate branch name
- Fix Hi extension icon
- Add MS DOS icon for *.com
- Add ruby icon for config.ru, Gemfile, Gemfile.lock, procfile, rake, rakefile and change ruby icon
- Add python icon for *.pxd and *.pyx
- Add markdown icon for *.mdx
- Add fsharp icon for *.f# and *.fsscript
- Add clojure icon for *.cljc and *.edn

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

List files and folders in a directory.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
