### PR TITLE
weechat: Update to v4.6.2

### DIFF
--- a/packages/w/weechat/package.yml
+++ b/packages/w/weechat/package.yml
@@ -1,8 +1,8 @@
 name       : weechat
-version    : 4.6.1
-release    : 92
+version    : 4.6.2
+release    : 93
 source     :
-    - https://github.com/weechat/weechat/archive/refs/tags/v4.6.1.tar.gz : 1d3c77cc9d499e4291435549b25310e7fc59c123a39afdedef4da6b2909d8329
+    - https://github.com/weechat/weechat/archive/refs/tags/v4.6.2.tar.gz : 35af4273df099c80a5d1d642d8270df68c8a472e8d1960459d3619970bcdb811
 homepage   : https://weechat.org
 license    : GPL-3.0-or-later
 summary    : WeeChat is a fast, light and extensible chat client.

--- a/packages/w/weechat/pspec_x86_64.xml
+++ b/packages/w/weechat/pspec_x86_64.xml
@@ -72,7 +72,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="92">weechat</Dependency>
+            <Dependency release="93">weechat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/weechat/weechat-plugin.h</Path>
@@ -80,9 +80,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="92">
-            <Date>2025-04-09</Date>
-            <Version>4.6.1</Version>
+        <Update release="93">
+            <Date>2025-04-19</Date>
+            <Version>4.6.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- core: fix write of weechat.log to stdout with `weechat-headless --stdout`
- core: add refresh of window title on buffer switch, when option weechat.look.window_title is set

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Connect to Libera, send and receive messages.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
