### PR TITLE
caddy: Update to v2.10.0

### DIFF
--- a/packages/c/caddy/abi_used_symbols
+++ b/packages/c/caddy/abi_used_symbols
@@ -20,10 +20,10 @@ libc.so.6:pthread_attr_destroy
 libc.so.6:pthread_attr_getstack
 libc.so.6:pthread_attr_getstacksize
 libc.so.6:pthread_attr_init
+libc.so.6:pthread_attr_setdetachstate
 libc.so.6:pthread_cond_broadcast
 libc.so.6:pthread_cond_wait
 libc.so.6:pthread_create
-libc.so.6:pthread_detach
 libc.so.6:pthread_getattr_np
 libc.so.6:pthread_key_create
 libc.so.6:pthread_mutex_lock

--- a/packages/c/caddy/files/0001-Remove-update-command-functionality.patch
+++ b/packages/c/caddy/files/0001-Remove-update-command-functionality.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Evan Maddock <maddock.evan@vivaldi.net>
-Date: Wed, 29 Jan 2025 11:12:43 -0500
+Date: Sat, 19 Apr 2025 11:02:23 -0400
 Subject: [PATCH] Remove update command functionality
 
 Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

--- a/packages/c/caddy/files/0001-Tweak-welcome-site-for-Solus.patch
+++ b/packages/c/caddy/files/0001-Tweak-welcome-site-for-Solus.patch
@@ -1,27 +1,27 @@
-From 31347ec84c0314c9455aa07bcfc5fbb864f2838a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Evan Maddock <maddock.evan@vivaldi.net>
-Date: Wed, 30 Aug 2023 15:41:37 -0400
+Date: Sat, 19 Apr 2025 10:57:10 -0400
 Subject: [PATCH] Tweak welcome site for Solus
 
 Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
 ---
- welcome/index.html | 5 ++++-
+ dist/welcome/index.html | 5 ++++-
  1 file changed, 4 insertions(+), 1 deletion(-)
 
-diff --git a/welcome/index.html b/welcome/index.html
-index 4ae61ee..391b168 100644
+diff --git a/dist/welcome/index.html b/dist/welcome/index.html
+index 4db41ef..359d31a 100644
 --- a/dist/welcome/index.html
 +++ b/dist/welcome/index.html
 @@ -298,7 +298,7 @@
  			<h1>
  				<!-- English --> <span class="lang">Congratulations!</span>
  				<!-- Japanese --> <span class="lang">おめでとう!</span>
--				<!-- Spanish --> <span class="lang">Felicidades!</span>
-+				<!-- Spanish --> <span class="lang">Felicitaciones!</span>
+-				<!-- Spanish --> <span class="lang">¡Felicidades!</span>
++				<!-- Spanish --> <span class="lang">¡Felicitaciones!</span>
  				<!-- Chinese --> <span class="lang">恭喜!</span>
  				<!-- Hindi --> <span class="lang">बधाई हो!</span>
  				<!-- Russian --> <span class="lang">Поздравляю!</span>
-@@ -308,6 +308,9 @@
+@@ -311,6 +311,9 @@
  			<p>
  				Your web server is working. Now make it work for you. 💪
  			</p>
@@ -31,6 +31,3 @@ index 4ae61ee..391b168 100644
  			<p>
  				Caddy is ready to serve your site over HTTPS:
  			</p>
--- 
-2.42.0
-

--- a/packages/c/caddy/package.yml
+++ b/packages/c/caddy/package.yml
@@ -1,9 +1,9 @@
 name       : caddy
-version    : 2.9.1
-release    : 20
+version    : 2.10.0
+release    : 21
 source     :
-    - https://github.com/caddyserver/caddy/archive/refs/tags/v2.9.1.tar.gz : beb52478dfb34ad29407003520d94ee0baccbf210d1af72cebf430d6d7dd7b63
-    - git|https://github.com/caddyserver/dist.git : v2.8.4
+    - https://github.com/caddyserver/caddy/archive/refs/tags/v2.10.0.tar.gz : e07e2747c394a6549751950ec8f7457ed346496f131ee38538ae39cf89ebcc68
+    - git|https://github.com/caddyserver/dist.git : v2.10.0
 homepage   : https://caddyserver.com
 license    : Apache-2.0
 component  : programming

--- a/packages/c/caddy/pspec_x86_64.xml
+++ b/packages/c/caddy/pspec_x86_64.xml
@@ -34,9 +34,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2025-01-29</Date>
-            <Version>2.9.1</Version>
+        <Update release="21">
+            <Date>2025-04-19</Date>
+            <Version>2.10.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/caddyserver/caddy/releases/tag/v2.10.0).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start and stop a Caddy webserver.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
