### PR TITLE
egl-x11: Update to v1.0.1

### DIFF
--- a/packages/e/egl-x11/abi_used_symbols
+++ b/packages/e/egl-x11/abi_used_symbols
@@ -36,7 +36,7 @@ libdrm.so.2:drmFreeVersion
 libdrm.so.2:drmGetDevice
 libdrm.so.2:drmGetVersion
 libdrm.so.2:drmIoctl
-libgbm.so.1:gbm_bo_create_with_modifiers2
+libgbm.so.1:gbm_bo_create_with_modifiers
 libgbm.so.1:gbm_bo_destroy
 libgbm.so.1:gbm_bo_get_fd
 libgbm.so.1:gbm_bo_get_format

--- a/packages/e/egl-x11/abi_used_symbols32
+++ b/packages/e/egl-x11/abi_used_symbols32
@@ -36,7 +36,7 @@ libdrm.so.2:drmFreeVersion
 libdrm.so.2:drmGetDevice
 libdrm.so.2:drmGetVersion
 libdrm.so.2:drmIoctl
-libgbm.so.1:gbm_bo_create_with_modifiers2
+libgbm.so.1:gbm_bo_create_with_modifiers
 libgbm.so.1:gbm_bo_destroy
 libgbm.so.1:gbm_bo_get_fd
 libgbm.so.1:gbm_bo_get_format

--- a/packages/e/egl-x11/package.yml
+++ b/packages/e/egl-x11/package.yml
@@ -1,8 +1,8 @@
 name       : egl-x11
-version    : 1.0.0
-release    : 1
+version    : 1.0.1
+release    : 2
 source     :
-    - https://github.com/NVIDIA/egl-x11/archive/refs/tags/v1.0.0.tar.gz : a25ea934c767511d5106c19b57a5bca448af40653770014f841c3627024fe1e2
+    - https://github.com/NVIDIA/egl-x11/archive/refs/tags/v1.0.1.tar.gz : 0dbc6c3fb76666af4e0e19d388b3f09247412aff549d31d35149a19ebb95422b
 homepage   : https://github.com/NVIDIA/egl-x11
 license    : Apache-2.0
 component  : programming.library

--- a/packages/e/egl-x11/pspec_x86_64.xml
+++ b/packages/e/egl-x11/pspec_x86_64.xml
@@ -21,9 +21,9 @@
         <PartOf>programming.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libnvidia-egl-xcb.so.1</Path>
-            <Path fileType="library">/usr/lib64/libnvidia-egl-xcb.so.1.0.0</Path>
+            <Path fileType="library">/usr/lib64/libnvidia-egl-xcb.so.1.0.1</Path>
             <Path fileType="library">/usr/lib64/libnvidia-egl-xlib.so.1</Path>
-            <Path fileType="library">/usr/lib64/libnvidia-egl-xlib.so.1.0.0</Path>
+            <Path fileType="library">/usr/lib64/libnvidia-egl-xlib.so.1.0.1</Path>
             <Path fileType="data">/usr/share/egl/egl_external_platform.d/20_nvidia_xcb.json</Path>
             <Path fileType="data">/usr/share/egl/egl_external_platform.d/20_nvidia_xlib.json</Path>
         </Files>
@@ -35,13 +35,13 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="1">egl-x11</Dependency>
+            <Dependency release="2">egl-x11</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnvidia-egl-xcb.so.1</Path>
-            <Path fileType="library">/usr/lib32/libnvidia-egl-xcb.so.1.0.0</Path>
+            <Path fileType="library">/usr/lib32/libnvidia-egl-xcb.so.1.0.1</Path>
             <Path fileType="library">/usr/lib32/libnvidia-egl-xlib.so.1</Path>
-            <Path fileType="library">/usr/lib32/libnvidia-egl-xlib.so.1.0.0</Path>
+            <Path fileType="library">/usr/lib32/libnvidia-egl-xlib.so.1.0.1</Path>
         </Files>
     </Package>
     <Package>
@@ -51,8 +51,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="1">egl-x11-32bit</Dependency>
-            <Dependency release="1">egl-x11-devel</Dependency>
+            <Dependency release="2">egl-x11-devel</Dependency>
+            <Dependency release="2">egl-x11-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnvidia-egl-xcb.so</Path>
@@ -66,7 +66,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="1">egl-x11</Dependency>
+            <Dependency release="2">egl-x11</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libnvidia-egl-xcb.so</Path>
@@ -74,9 +74,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-12-14</Date>
-            <Version>1.0.0</Version>
+        <Update release="2">
+            <Date>2025-04-20</Date>
+            <Version>1.0.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fix a crash if an application tries to call eglSwapInterval with a non-window surface
- Fix `eglQueryDisplayAttrib` so that it returns the correct value for `EGL_TRACK_REFERENCES_KHR`
- Relax the GBM dependency so that it can work with libgbm 21.2 or later

**Test Plan**

Used several XWayland apps in a GNOME Wayland session

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
