### PR TITLE
openshot-qt: Rundep on python-qtwebwngine

### DIFF
--- a/packages/o/openshot-qt/package.yml
+++ b/packages/o/openshot-qt/package.yml
@@ -1,6 +1,6 @@
 name       : openshot-qt
 version    : 3.3.0
-release    : 22
+release    : 23
 source     :
     - https://github.com/OpenShot/openshot-qt/archive/refs/tags/v3.3.0.tar.gz : f5471eec94d59830ea58351b93e69d4c56b42874d927fbd6482f83b9bb545d4f
 homepage   : https://www.openshot.org/
@@ -15,8 +15,8 @@ builddeps  :
 rundeps    :
     - libopenshot
     - python-pyzmq
+    - python-qtwebengine
     - python-requests
-    - python3-qt5
     - pyxdg
 setup      : |
     %apply_patches

--- a/packages/o/openshot-qt/pspec_x86_64.xml
+++ b/packages/o/openshot-qt/pspec_x86_64.xml
@@ -6432,8 +6432,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2025-01-02</Date>
+        <Update release="23">
+            <Date>2025-04-22</Date>
             <Version>3.3.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>


### PR DESCRIPTION
**Summary**

`python3-qt5` doesn't include Qt5WebView anymore, use `python-qtwebengine` instead

Resolves getsolus/packages#5503

**Test Plan**

<!-- Short description of how the package was tested -->
Make sure `openshot-qt` launches

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
