### PR TITLE
egl-wayland: Update to v1.1.19

### DIFF
--- a/packages/e/egl-wayland/package.yml
+++ b/packages/e/egl-wayland/package.yml
@@ -1,8 +1,8 @@
 name       : egl-wayland
-version    : 1.1.18
-release    : 28
+version    : 1.1.19
+release    : 29
 source     :
-    - https://github.com/NVIDIA/egl-wayland/archive/refs/tags/1.1.18.tar.gz : c561485ee65efb7ffb0dbedd6c7031f0be69c861efa63f831c8b6c3178a0f871
+    - https://github.com/NVIDIA/egl-wayland/archive/refs/tags/1.1.19.tar.gz : b9a63e59eb552ef925b9fda96e466457edfe4b7728dd861ee06152b064edccdf
 homepage   : https://github.com/NVIDIA/egl-wayland
 license    : MIT
 component  : programming.library

--- a/packages/e/egl-wayland/pspec_x86_64.xml
+++ b/packages/e/egl-wayland/pspec_x86_64.xml
@@ -21,7 +21,7 @@
         <PartOf>programming.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libnvidia-egl-wayland.so.1</Path>
-            <Path fileType="library">/usr/lib64/libnvidia-egl-wayland.so.1.1.18</Path>
+            <Path fileType="library">/usr/lib64/libnvidia-egl-wayland.so.1.1.19</Path>
             <Path fileType="data">/usr/share/egl/egl_external_platform.d/10_nvidia_wayland.json</Path>
         </Files>
     </Package>
@@ -32,11 +32,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="28">egl-wayland</Dependency>
+            <Dependency release="29">egl-wayland</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnvidia-egl-wayland.so.1</Path>
-            <Path fileType="library">/usr/lib32/libnvidia-egl-wayland.so.1.1.18</Path>
+            <Path fileType="library">/usr/lib32/libnvidia-egl-wayland.so.1.1.19</Path>
         </Files>
     </Package>
     <Package>
@@ -46,8 +46,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="28">egl-wayland-32bit</Dependency>
-            <Dependency release="28">egl-wayland-devel</Dependency>
+            <Dependency release="29">egl-wayland-devel</Dependency>
+            <Dependency release="29">egl-wayland-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnvidia-egl-wayland.so</Path>
@@ -61,7 +61,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="28">egl-wayland</Dependency>
+            <Dependency release="29">egl-wayland</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libnvidia-egl-wayland.so</Path>
@@ -73,9 +73,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2025-03-04</Date>
-            <Version>1.1.18</Version>
+        <Update release="29">
+            <Date>2025-04-22</Date>
+            <Version>1.1.19</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fix an issue causing EGL_EXT_present_opaque to be advertised on non-Wayland EGLDisplays

**Test Plan**

Used my GNOME Wayland session with various apps for half an hour

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
