### PR TITLE
xrdp-xfce4-integration: Use the correct binary in the startwm.sh

### DIFF
--- a/packages/x/xrdp-xfce4-integration/files/startwm.sh
+++ b/packages/x/xrdp-xfce4-integration/files/startwm.sh
@@ -2,4 +2,4 @@
 
 source /usr/share/defaults/etc/profile
 
-exec /usr/bin/xfce4-session
+exec /usr/bin/startxfce4

--- a/packages/x/xrdp-xfce4-integration/package.yml
+++ b/packages/x/xrdp-xfce4-integration/package.yml
@@ -1,6 +1,6 @@
 name       : xrdp-xfce4-integration
 version    : 0.1.0
-release    : 1
+release    : 2
 source     :
     - https://sources.getsol.us/README.Solus : 65dcffb5d782abf60609195cc3e00eb55a9f02cb200441f498e4e30c11d1009e
 homepage   : https://getsol.us/

--- a/packages/x/xrdp-xfce4-integration/pspec_x86_64.xml
+++ b/packages/x/xrdp-xfce4-integration/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xrdp-xfce4-integration</Name>
         <Homepage>https://getsol.us/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Alexander Zhirov</Name>
+            <Email>azhirov1991@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>network.util</PartOf>
@@ -30,12 +30,12 @@
         </Conflicts>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-07-18</Date>
+        <Update release="2">
+            <Date>2025-04-24</Date>
             <Version>0.1.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Alexander Zhirov</Name>
+            <Email>azhirov1991@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Fixed an [issue](https://discuss.getsol.us/d/11513-xfce-panel-plugins-not-available-through-xrdp/3) with correctly starting an XFCE session when connecting via XRDP.

**Summary**

<!-- Info on what this pull request updates/changes/etc -->

**Test Plan**

<!-- Short description of how the package was tested -->

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
