### PR TITLE
github-cli: Update to v2.71.2

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.70.0
-release    : 70
+version    : 2.71.2
+release    : 71
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.70.0.tar.gz : 9e2247e5b31131fd4ac63916b9483a065fcfb861ebb93588cf2ff42952ae08c5
+    - https://github.com/cli/cli/archive/refs/tags/v2.71.2.tar.gz : f63adebce6e555005674b46ea6d96843b5e870bdb698759834276a69a121875c
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -230,9 +230,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="70">
-            <Date>2025-04-17</Date>
-            <Version>2.70.0</Version>
+        <Update release="71">
+            <Date>2025-04-25</Date>
+            <Version>2.71.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- `gh pr create`: Support Git's `@{push}` revision syntax for determining head ref
- Introduce option to opt-out of spinners
- Update configuration support for accessible colors
- `gh config`: add config settings for accessible prompter and disabling spinner
- Fix multi pages search for gh search
- Fix: `project` commands use shared progress indicator
- Issue commands should parse args early
- Feature detect v1 projects on `issue view`
- Feature detect v1 projects on `issue create`
- Feature detect v1 projects on web mode issue create
- Feature detect v1 projects on issue edit

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
