### PR TITLE
steam: Update to v1.0.0.83

### DIFF
--- a/packages/s/steam/package.yml
+++ b/packages/s/steam/package.yml
@@ -1,8 +1,8 @@
 name       : steam
-version    : 1.0.0.82
-release    : 97
+version    : 1.0.0.83
+release    : 98
 source     :
-    - https://repo.steampowered.com/steam/pool/steam/s/steam/steam_1.0.0.82.tar.gz : afa2f1dd6271fd2b645ba30b8f3ab40afd3654e354241a31cbd51000f7e6fc77
+    - https://repo.steampowered.com/steam/pool/steam/s/steam/steam_1.0.0.83.tar.gz : 791682b0cc7efd946c7002f917c9dd474d2619b7f9ed00891216a8a6b4ac8f82
 homepage   : https://store.steampowered.com
 license    : Distributable
 component  :

--- a/packages/s/steam/pspec_x86_64.xml
+++ b/packages/s/steam/pspec_x86_64.xml
@@ -18,7 +18,7 @@
         <Description xml:lang="en">Launcher for the Steam software distribution service</Description>
         <PartOf>games</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="97">steam-udev-rules</Dependency>
+            <Dependency releaseFrom="98">steam-udev-rules</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/steamdeps</Path>
@@ -54,9 +54,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="97">
-            <Date>2024-10-08</Date>
-            <Version>1.0.0.82</Version>
+        <Update release="98">
+            <Date>2025-04-25</Date>
+            <Version>1.0.0.83</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Build using updated Steam client
- steam.desktop: Update URL used to implement the Community action
- steam.desktop: Update URL used to implement the News action
- steam.desktop: Consistently use an absolute path for the steam executable
- bin_steam.sh: Take over responsibility for running steamdeps during launch
- bin_steam.sh: Remove support for parsing steamdeps.txt
- Appstream metainfo: Normalize homepage URL
- Appstream metainfo: Replace <developer_name> with <developer> as per Appstream 1.0

**Note regarding steam.desktop absolute path change:**
> Some users are known to have a script named steam earlier in the $PATH; for example they might have a /usr/local/bin/steam that passes extra options, sets environment variables, or runs Steam wrapped by some sort of "adverb" command). After this change, they would still be able to arrange for that script to be invoked by desktop environments' menus by putting a corresponding .desktop file earlier in $XDG_DATA_DIRS, for example /usr/local/share/applications/steam.desktop or ~/.local/share/applications/steam.desktop, which will take precedence over ours.

This only affects the additional Desktop Actions (like opening the Library, Store, etc.). The main entry was already using an absolute path.

**Test Plan**
- Launched Steam
- Played a game and messaged friends
- Checked Settings
- Browsed my library and game posts

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
