### PR TITLE
kitty: Update to 0.41.1

### DIFF
--- a/packages/k/kitty/abi_symbols
+++ b/packages/k/kitty/abi_symbols
@@ -153,6 +153,7 @@ glfw-wayland.so:glfwUpdateTimer
 glfw-wayland.so:glfwVulkanSupported
 glfw-wayland.so:glfwWaylandActivateWindow
 glfw-wayland.so:glfwWaylandCompositorPID
+glfw-wayland.so:glfwWaylandIsWindowFullyCreated
 glfw-wayland.so:glfwWaylandMissingCapabilities
 glfw-wayland.so:glfwWaylandRedrawCSDWindowTitle
 glfw-wayland.so:glfwWaylandRunWithActivationToken

--- a/packages/k/kitty/package.yml
+++ b/packages/k/kitty/package.yml
@@ -1,8 +1,8 @@
 name       : kitty
-version    : 0.41.0
-release    : 82
+version    : 0.41.1
+release    : 83
 source     :
-    - https://github.com/kovidgoyal/kitty/releases/download/v0.41.0/kitty-0.41.0.tar.xz : 30c59848585d89d2d25bd0050b172c1cd9dfdc0071cfce6917e6b035fec766b7
+    - https://github.com/kovidgoyal/kitty/releases/download/v0.41.1/kitty-0.41.1.tar.xz : e30150fad1bcc885a7adbd87380696ef7b67a62a38f74634efbc05c3745f26aa
     - git|https://github.com/simd-everywhere/simde.git : v0.8.2
     - https://github.com/ryanoasis/nerd-fonts/releases/download/v3.3.0/NerdFontsSymbolsOnly.tar.xz : 8b5ecbe2612cb37d75e2645f7644876bc38960574909b1c01c002d0e8d33deb3
 license    :

--- a/packages/k/kitty/pspec_x86_64.xml
+++ b/packages/k/kitty/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>kitty</Name>
         <Homepage>https://sw.kovidgoyal.net/kitty/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Nazar Stasiv</Name>
+            <Email>nazar@autistici.org</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <License>MIT</License>
@@ -825,12 +825,12 @@ Kitty is designed from the ground up to support all modern terminal features, su
         </Files>
     </Package>
     <History>
-        <Update release="82">
-            <Date>2025-03-29</Date>
-            <Version>0.41.0</Version>
+        <Update release="83">
+            <Date>2025-04-27</Date>
+            <Version>0.41.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Nazar Stasiv</Name>
+            <Email>nazar@autistici.org</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fixed rendering of emoji using the VS16 variation selector to fail
- Fixed tab bar margins to not be properly blanked
- Fixed incorrect initial font size on some compositors
- Fixed regression hyperlink underline on hover to remain on screen
- [changelog](https://sw.kovidgoyal.net/kitty/changelog/#id1)

**Test Plan**
- run cli; view cli output with pager kitten

**Checklist**
- [X] Package was built and tested against unstable
