### PR TITLE
gpxsee: Update to 13.41

### DIFF
--- a/packages/g/gpxsee/package.yml
+++ b/packages/g/gpxsee/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.38'
-release    : 53
+version    : '13.41'
+release    : 54
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.38.tar.gz : fb10d4c5d2058b1bbac41daf0341a3e294c73b63dffe721680b3b0a61f70f956
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.41.tar.gz : 3f197c66450970bbb68e8f2dc392b2192bb1334ef2749e7a6b8bbde9e9c5b615
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/packages/g/gpxsee/pspec_x86_64.xml
+++ b/packages/g/gpxsee/pspec_x86_64.xml
@@ -172,9 +172,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="53">
-            <Date>2025-04-02</Date>
-            <Version>13.38</Version>
+        <Update release="54">
+            <Date>2025-04-27</Date>
+            <Version>13.41</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
**Summary**
- Fixed switched ENC maps units multipliers
- Fixed Vakaros VKX MIME magic detection
- Improved ENC maps style/rendering
- Added support for Vakaros VKX files
- Improved ENC maps rendering performance
- [changelog](https://build.opensuse.org/projects/home:tumic:GPXSee/packages/gpxsee/files/gpxsee.changes)

**Test Plan**
- open map file; zoom and pan

**Checklist**
- [X] Package was built and tested against unstable
