### PR TITLE
discover: Allow notifier to autostart on all editions

### DIFF
--- a/packages/d/discover/files/0001-Allow-notifier-to-autostart-on-all-editions.patch
+++ b/packages/d/discover/files/0001-Allow-notifier-to-autostart-on-all-editions.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Muhammad Alfi Syahrin <malfisya.dev@hotmail.com>
+Date: Mon, 28 Apr 2025 11:38:46 +0700
+Subject: [PATCH] Allow notifier to autostart on all editions
+
+---
+ notifier/org.kde.discover.notifier.desktop.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/notifier/org.kde.discover.notifier.desktop.cmake b/notifier/org.kde.discover.notifier.desktop.cmake
+index e0cfcaf..3fc2f3f 100644
+--- a/notifier/org.kde.discover.notifier.desktop.cmake
++++ b/notifier/org.kde.discover.notifier.desktop.cmake
+@@ -63,4 +63,4 @@ Icon=system-software-update
+ Type=Application
+ NoDisplay=true
+ X-KDE-autostart-phase=1
+-OnlyShowIn=KDE
++OnlyShowIn=KDE;Budgie;GNOME;XFCE

--- a/packages/d/discover/package.yml
+++ b/packages/d/discover/package.yml
@@ -1,6 +1,6 @@
 name       : discover
 version    : 6.3.4
-release    : 33
+release    : 34
 source     :
     - https://download.kde.org/stable/plasma/6.3.4/discover-6.3.4.tar.xz : 2a18caed673493cbeb840aa166626d4283272c97578af0bf67e8887b672cf3d8
 homepage   : https://apps.kde.org/discover/
@@ -45,6 +45,7 @@ optimize   : thin-lto
 setup      : |
     # https://github.com/getsolus/discover/commit/61ddf4e7b0ef774bf79b69dd4ea964cb1ddc2554
     %patch -p1 -i $pkgfiles/0001-PackageKitBackend-Add-the-Drivers-menu-filtered-by-t.patch
+    %patch -p1 -i $pkgfiles/0001-Allow-notifier-to-autostart-on-all-editions.patch
 
     %cmake_kf6 -DPACKAGEKIT_AUTOREMOVE=ON
 build      : |

--- a/packages/d/discover/pspec_x86_64.xml
+++ b/packages/d/discover/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>discover</Name>
         <Homepage>https://apps.kde.org/discover/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.kde</PartOf>
@@ -291,12 +291,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2025-04-03</Date>
+        <Update release="34">
+            <Date>2025-04-28</Date>
             <Version>6.3.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

<!-- Info on what this pull request updates/changes/etc -->
Allow notifier to autostart on all editions

**Test Plan**

<!-- Short description of how the package was tested -->
Install on Budgie and see if update notification shows

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
