### PR TITLE
gnome-software: Allow notification to autostart on all editions

### DIFF
--- a/packages/g/gnome-software/files/0001-Allow-notification-to-autostart-on-all-editions.patch
+++ b/packages/g/gnome-software/files/0001-Allow-notification-to-autostart-on-all-editions.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Muhammad Alfi Syahrin <malfisya.dev@hotmail.com>
+Date: Mon, 28 Apr 2025 12:50:15 +0700
+Subject: [PATCH] Allow notification to autostart on all editions
+
+---
+ data/autostart/org.gnome.Software.desktop.in | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/data/autostart/org.gnome.Software.desktop.in b/data/autostart/org.gnome.Software.desktop.in
+index 6c7a77b..98c5529 100644
+--- a/data/autostart/org.gnome.Software.desktop.in
++++ b/data/autostart/org.gnome.Software.desktop.in
+@@ -2,6 +2,5 @@
+ Type=Application
+ Name=GNOME Software
+ Exec=@bindir@/gnome-software --gapplication-service
+-OnlyShowIn=GNOME;Unity;
+-NotShowIn=Budgie
++OnlyShowIn=GNOME;Budgie;KDE;XFCE
+ NoDisplay=true

--- a/packages/g/gnome-software/package.yml
+++ b/packages/g/gnome-software/package.yml
@@ -1,6 +1,6 @@
 name       : gnome-software
 version    : '48.1'
-release    : 24
+release    : 25
 source     :
     - https://download.gnome.org/sources/gnome-software/48/gnome-software-48.1.tar.xz : 084a985040294c36454b464a2144f981c0274906b4c49d71613e61ced6a96e8f
 homepage   : https://apps.gnome.org/Software/
@@ -33,6 +33,7 @@ setup      : |
     %patch -p1 -i $pkgfiles/0001-packagekit-Set-PK_INFO_ENUM_SECURITY-as-AS_URGENCY_K.patch
     # https://gitlab.gnome.org/GNOME/gnome-software/-/issues/2610
     %patch -p1 -i $pkgfiles/0001-packagekit-HACK-Disable-req.-for-repo-plugin-to-show.patch
+    %patch -p1 -i $pkgfiles/0001-Allow-notification-to-autostart-on-all-editions.patch
 
     %meson_configure \
         -Dpackagekit_autoremove=true \

--- a/packages/g/gnome-software/pspec_x86_64.xml
+++ b/packages/g/gnome-software/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-software</Name>
         <Homepage>https://apps.gnome.org/Software/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.gnome</PartOf>
@@ -362,7 +362,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="24">gnome-software</Dependency>
+            <Dependency release="25">gnome-software</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gnome-software/gnome-software.h</Path>
@@ -480,12 +480,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2025-04-14</Date>
+        <Update release="25">
+            <Date>2025-04-28</Date>
             <Version>48.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

<!-- Info on what this pull request updates/changes/etc -->
Allow notification to autostart on all editions

**Test Plan**

<!-- Short description of how the package was tested -->
Install on non-Gnome VM and see if notification shows up
**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
