### PR TITLE
stress-ng: Update to v0.18.12

### DIFF
--- a/packages/s/stress-ng/abi_used_symbols
+++ b/packages/s/stress-ng/abi_used_symbols
@@ -67,6 +67,7 @@ libc.so.6:clock_nanosleep
 libc.so.6:clock_settime
 libc.so.6:clone
 libc.so.6:close
+libc.so.6:close_range
 libc.so.6:closedir
 libc.so.6:closelog
 libc.so.6:connect

--- a/packages/s/stress-ng/package.yml
+++ b/packages/s/stress-ng/package.yml
@@ -1,8 +1,8 @@
 name       : stress-ng
-version    : 0.18.09
-release    : 14
+version    : 0.18.12
+release    : 15
 source     :
-    - https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V0.18.09.tar.gz : 0694f2c24eb5d839fe11f41adc2c0ea31bb7e9c1a53316fc251847d1d55f6344
+    - https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V0.18.12.tar.gz : 20401a5a52a3b3b5d84fbdd561e4daf1076b0368a1ccbbbc8d41af2be6ea6f34
 license    : GPL-2.0-or-later
 component  : system.utils
 homepage   : https://kernel.ubuntu.com/~cking/stress-ng/

--- a/packages/s/stress-ng/pspec_x86_64.xml
+++ b/packages/s/stress-ng/pspec_x86_64.xml
@@ -41,9 +41,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2025-01-30</Date>
-            <Version>0.18.09</Version>
+        <Update release="15">
+            <Date>2025-04-28</Date>
+            <Version>0.18.12</Version>
             <Comment>Packaging update</Comment>
             <Name>Robert Gonzalez</Name>
             <Email>uni.dos12@outlook.com</Email>


### PR DESCRIPTION
**Summary**
- adds new stressors
- changelog is located [here](https://github.com/ColinIanKing/stress-ng/releases/tag/V0.18.12)


**Test Plan**

Run s-tui see cpu utilization increase

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
