### PR TITLE
xreader: Update to v4.2.6

### DIFF
--- a/packages/x/xreader/abi_used_symbols
+++ b/packages/x/xreader/abi_used_symbols
@@ -720,6 +720,7 @@ libglib-2.0.so.0:g_variant_builder_add
 libglib-2.0.so.0:g_variant_builder_close
 libglib-2.0.so.0:g_variant_builder_end
 libglib-2.0.so.0:g_variant_builder_init
+libglib-2.0.so.0:g_variant_builder_init_static
 libglib-2.0.so.0:g_variant_builder_open
 libglib-2.0.so.0:g_variant_classify
 libglib-2.0.so.0:g_variant_get
@@ -1115,7 +1116,6 @@ libgtk-3.so.0:gtk_notebook_new
 libgtk-3.so.0:gtk_notebook_set_current_page
 libgtk-3.so.0:gtk_notebook_set_show_border
 libgtk-3.so.0:gtk_notebook_set_show_tabs
-libgtk-3.so.0:gtk_offscreen_window_new
 libgtk-3.so.0:gtk_orientable_set_orientation
 libgtk-3.so.0:gtk_page_setup_get_bottom_margin
 libgtk-3.so.0:gtk_page_setup_get_left_margin
@@ -1773,11 +1773,8 @@ libwebkit2gtk-4.1.so.0:webkit_web_view_can_execute_editing_command
 libwebkit2gtk-4.1.so.0:webkit_web_view_can_execute_editing_command_finish
 libwebkit2gtk-4.1.so.0:webkit_web_view_execute_editing_command
 libwebkit2gtk-4.1.so.0:webkit_web_view_get_find_controller
-libwebkit2gtk-4.1.so.0:webkit_web_view_get_snapshot
-libwebkit2gtk-4.1.so.0:webkit_web_view_get_snapshot_finish
 libwebkit2gtk-4.1.so.0:webkit_web_view_get_type
 libwebkit2gtk-4.1.so.0:webkit_web_view_load_uri
-libwebkit2gtk-4.1.so.0:webkit_web_view_new
 libwebkit2gtk-4.1.so.0:webkit_web_view_reload
 libwebkit2gtk-4.1.so.0:webkit_web_view_set_zoom_level
 libxapp.so.1:xapp_dark_mode_manager_new

--- a/packages/x/xreader/package.yml
+++ b/packages/x/xreader/package.yml
@@ -1,8 +1,8 @@
 name       : xreader
-version    : 4.2.3
-release    : 3
+version    : 4.2.6
+release    : 4
 source     :
-    - https://github.com/linuxmint/xreader/archive/refs/tags/4.2.3.tar.gz : 57d8c20eddcb90ba768f386c444519b5f330c1aacfcaa3deb33db1ad1d7bbd6d
+    - https://github.com/linuxmint/xreader/archive/refs/tags/4.2.6.tar.gz : 0a02051fed4919f0accb891b4374adf6431e1d2acd788ef553a6629c878d6a39
 homepage   : https://github.com/linuxmint/xreader
 license    : GPL-2.0-or-later
 component  : office.viewers

--- a/packages/x/xreader/pspec_x86_64.xml
+++ b/packages/x/xreader/pspec_x86_64.xml
@@ -284,7 +284,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="3">xreader</Dependency>
+            <Dependency release="4">xreader</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/xreader/1.5/libdocument/ev-annotation.h</Path>
@@ -345,9 +345,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-12-31</Date>
-            <Version>4.2.3</Version>
+        <Update release="4">
+            <Date>2025-04-29</Date>
+            <Version>4.2.6</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- epub: Disable support for sidebar thumbnails
- ev-sidebar-thumbnails.c: Don't attempt to generate thumbnails for epub docs.
- ev-window.c: Check that we have a document set before accessing it.
- epub-document.c: Fix null pointer crash when building a TOC.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Open a PDF document with `xreader`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
