### PR TITLE
eopkg: Update to v4.2.0

### DIFF
--- a/packages/e/eopkg/package.yml
+++ b/packages/e/eopkg/package.yml
@@ -1,9 +1,8 @@
 name       : eopkg
-version    : 4.1.6
-release    : 18
+version    : 4.2.0
+release    : 19
 source     :
-    - git|https://github.com/getsolus/eopkg.git : aeeeb0b6b1013ce11814b31c6673b0425e17693b
-    # HEAD commit of https://github.com/getsolus/PackageKit/tree/eopkg4 unless stated otherwise
+    - https://github.com/getsolus/eopkg/archive/refs/tags/v4.2.0.tar.gz : ecea3ddf9d16d12041013597d86079c48113fb159c7783c6b6c68738d8c4409c
     - git|https://github.com/getsolus/PackageKit.git : 9b0f17c1ba6addc1c85bff34b64efad6a905ca50
 homepage   : https://github.com/getsolus/eopkg
 license    : GPL-2.0-or-later
@@ -34,6 +33,7 @@ builddeps  :
     - python-magic
     - python-ordered-set
     - python-packaging
+    - python-setuptools
     - python-wheel
     - python-xattr
     - python-zstandard
@@ -70,7 +70,8 @@ build      : |
     #       ca-certs to be able to check https connections.
 
     # We're not actually using self-execution. In this case, eopkg is using the -c flag as shorthand for --component, rather than for passing the program as a string (as is default python behavior).
-    nuitka3 --onefile --include-module=dbm.gnu --show-scons --no-deployment-flag=self-execution ./eopkg.py3
+    pushd eopkg-%version%
+    nuitka3 --onefile --include-module=dbm.gnu --show-scons --no-deployment-flag=self-execution eopkg.py3
     nuitka3 --onefile --include-module=dbm.gnu $sources/PackageKit.git/backends/eopkg/eopkgBackend.py
 install    : |
     # install the normal pure py3 stuff

--- a/packages/e/eopkg/pspec_x86_64.xml
+++ b/packages/e/eopkg/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>eopkg</Name>
         <Homepage>https://github.com/getsolus/eopkg</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -35,12 +35,12 @@
             <Path fileType="executable">/usr/bin/eopkg.py3</Path>
             <Path fileType="executable">/usr/bin/lseopkg.py3</Path>
             <Path fileType="executable">/usr/bin/uneopkg.py3</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.6.dist-info/AUTHORS</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.6.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.6.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.6.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.6.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.1.6.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.2.0.dist-info/AUTHORS</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.2.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.2.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.2.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.2.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.2.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/__pycache__/__init__.cpython-311.pyc</Path>
@@ -243,6 +243,8 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/cli/__pycache__/removeorphans.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/cli/__pycache__/removerepo.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/cli/__pycache__/removerepo.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/cli/__pycache__/repopriority.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/cli/__pycache__/repopriority.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/cli/__pycache__/search.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/cli/__pycache__/search.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/cli/__pycache__/searchfile.cpython-311.opt-1.pyc</Path>
@@ -281,6 +283,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/cli/remove.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/cli/removeorphans.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/cli/removerepo.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/cli/repopriority.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/cli/search.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/cli/searchfile.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/cli/updaterepo.py</Path>
@@ -296,7 +299,8 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/data/locale/ca/LC_MESSAGES/pisi.mo</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/data/locale/de/LC_MESSAGES/pisi.mo</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/data/locale/es/LC_MESSAGES/pisi.mo</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/data/locale/fr/LC_MESSAGES/pisi.mo</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/data/locale/es_ES/LC_MESSAGES/pisi.mo</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/data/locale/fr_FR/LC_MESSAGES/pisi.mo</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/data/locale/hr/LC_MESSAGES/pisi.mo</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/data/locale/hu/LC_MESSAGES/pisi.mo</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/data/locale/it/LC_MESSAGES/pisi.mo</Path>
@@ -445,12 +449,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2025-01-11</Date>
-            <Version>4.1.6</Version>
+        <Update release="19">
+            <Date>2025-04-30</Date>
+            <Version>4.2.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Release notes can be found [here](https://github.com/getsolus/eopkg/releases/v4.2.0).

Sync Notes: "This week, `eopkg.bin` was updated to version 4.2.0. This release adds a few exciting features and fixes, including the ability to reorder repositories and a fix for some very slow package updates. We've also removed some dead weight in the form of HTTP Basic-Auth support for repositories, which we couldn't think of a good use for. [Read the full changelog](https://github.com/getsolus/eopkg/releases/v4.2.0) if you're interested, and make sure to check out the `eopkg.bin` command if you do package management from the command line. This compiled python3 eopkg will replace the old python2 version as default on all Solus systems soon (we don't give ETAs)."

**Test Plan**

- Build and install the `eopkg` package from this PR.
- Try some command-line operations using `eopkg.bin`.
- Try some PackageKit operations via Discover, GNOME Software, or `pkcon`.
- Try reordering repositories using `eopkg.bin repo-priority`.
- Ensure that `eopkg.bin --password="password" ur` (for example) fails with an error warning the user that Basic-Auth is no longer supported.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
