### PR TITLE
puzzles: Update to v20250303

### DIFF
--- a/packages/p/puzzles/package.yml
+++ b/packages/p/puzzles/package.yml
@@ -1,8 +1,8 @@
 name       : puzzles
-version    : '20241021'
-release    : 23
+version    : '20250303'
+release    : 24
 source     :
-    - https://www.chiark.greenend.org.uk/~sgtatham/puzzles/puzzles-20241021.05f4f63.tar.gz : ade66c07899a27fccddf5cff22a31bc7872bc0aaac169670cc123d6f755169c1
+    - https://www.chiark.greenend.org.uk/~sgtatham/puzzles/puzzles-20250303.7da4641.tar.gz : 7f0a61478ef3515f87f80be3728d0395bf784de1feb3abfcd4c53f1fe99b1009
 homepage   : https://www.chiark.greenend.org.uk/~sgtatham/puzzles/
 license    : MIT
 component  : games.puzzle

--- a/packages/p/puzzles/pspec_x86_64.xml
+++ b/packages/p/puzzles/pspec_x86_64.xml
@@ -464,9 +464,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2024-11-05</Date>
-            <Version>20241021</Version>
+        <Update release="24">
+            <Date>2025-04-30</Date>
+            <Version>20250303</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

No changelog available.
Full commit log available [here](https://git.tartarus.org/?p=simon/puzzles.git;a=shortlog)

**Test Plan**

Played a bunch of puzzles

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
