### PR TITLE
Update graphviz and pygraphviz

### DIFF
--- a/packages/g/graphviz/abi_used_symbols
+++ b/packages/g/graphviz/abi_used_symbols
@@ -79,11 +79,13 @@ libQt6Core.so.6:_ZN9QMetaType25registerNormalizedTypedefERK10QByteArrayS_
 libQt6Core.so.6:_ZN9QSettings8setValueE14QAnyStringViewRK8QVariant
 libQt6Core.so.6:_ZN9QSettingsC1ERK7QStringS2_P7QObject
 libQt6Core.so.6:_ZN9QSettingsD1Ev
+libQt6Core.so.6:_ZN9QtPrivate11lastIndexOfE11QStringViewxDsN2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZN9QtPrivate12equalStringsE11QStringView13QLatin1String
 libQt6Core.so.6:_ZN9QtPrivate12equalStringsE11QStringViewS0_
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperI7QStringE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperIbE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperIiE8metaTypeE
+libQt6Core.so.6:_ZN9QtPrivate8qustrchrE11QStringViewDs
 libQt6Core.so.6:_ZNK11QMetaObject2trEPKcS1_i
 libQt6Core.so.6:_ZNK11QMetaObject4castEPK7QObject
 libQt6Core.so.6:_ZNK11QMetaObject9classNameEv
@@ -93,11 +95,9 @@ libQt6Core.so.6:_ZNK14QTemporaryFile8fileNameEv
 libQt6Core.so.6:_ZNK18QCommandLineParser19positionalArgumentsEv
 libQt6Core.so.6:_ZNK18QCommandLineParser5isSetERK18QCommandLineOption
 libQt6Core.so.6:_ZNK7QObject10objectNameEv
-libQt6Core.so.6:_ZNK7QString11lastIndexOfE5QCharxN2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString3argERKS_i5QChar
 libQt6Core.so.6:_ZNK7QString3argExii5QChar
 libQt6Core.so.6:_ZNK7QString5splitE5QChar6QFlagsIN2Qt18SplitBehaviorFlagsEENS2_15CaseSensitivityE
-libQt6Core.so.6:_ZNK7QString7indexOfE5QCharxN2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString7indexOfERKS_xN2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK8QVariant6toSizeEv
 libQt6Core.so.6:_ZNK8QVariant7toPointEv
@@ -762,7 +762,7 @@ libstdc++.so.6:_ZTIPKc
 libstdc++.so.6:_ZTVN10__cxxabiv117__class_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv120__si_class_type_infoE
 libstdc++.so.6:_ZdaPv
-libstdc++.so.6:_ZdlPv
+libstdc++.so.6:_ZdlPvm
 libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
 libstdc++.so.6:__cxa_allocate_exception
@@ -783,10 +783,11 @@ libwebp.so.7:WebPPictureFree
 libwebp.so.7:WebPPictureImportBGRA
 libwebp.so.7:WebPPictureInitInternal
 libwebp.so.7:WebPValidateConfig
+libz.so.1:compress
+libz.so.1:compressBound
 libz.so.1:crc32
 libz.so.1:crc32_z
 libz.so.1:deflate
 libz.so.1:deflateBound
 libz.so.1:deflateEnd
 libz.so.1:deflateInit2_
-libz.so.1:deflateInit_

--- a/packages/g/graphviz/package.yml
+++ b/packages/g/graphviz/package.yml
@@ -1,8 +1,8 @@
 name       : graphviz
-version    : 12.2.0
-release    : 35
+version    : 12.2.1
+release    : 36
 source     :
-    - https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/12.2.0/graphviz-12.2.0.tar.gz : bd56a15908567ae56f77fcad167f30416b12f4147f91467cbf27265ce11140ad
+    - https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/12.2.1/graphviz-12.2.1.tar.gz : 242bc18942eebda6db4039f108f387ec97856fc91ba47f21e89341c34b554df8
 homepage   : https://www.graphviz.org
 license    : EPL-1.0
 component  : multimedia.graphics

--- a/packages/g/graphviz/pspec_x86_64.xml
+++ b/packages/g/graphviz/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>graphviz</Name>
         <Homepage>https://www.graphviz.org</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>EPL-1.0</License>
         <PartOf>multimedia.graphics</PartOf>
@@ -29,6 +29,7 @@
             <Path fileType="executable">/usr/bin/dot</Path>
             <Path fileType="executable">/usr/bin/dot2gxl</Path>
             <Path fileType="executable">/usr/bin/dot_builtins</Path>
+            <Path fileType="executable">/usr/bin/dot_sandbox</Path>
             <Path fileType="executable">/usr/bin/edgepaint</Path>
             <Path fileType="executable">/usr/bin/fdp</Path>
             <Path fileType="executable">/usr/bin/gc</Path>
@@ -275,6 +276,7 @@
             <Path fileType="man">/usr/share/man/man1/dijkstra.1</Path>
             <Path fileType="man">/usr/share/man/man1/dot.1</Path>
             <Path fileType="man">/usr/share/man/man1/dot2gxl.1</Path>
+            <Path fileType="man">/usr/share/man/man1/dot_sandbox.1</Path>
             <Path fileType="man">/usr/share/man/man1/edgepaint.1</Path>
             <Path fileType="man">/usr/share/man/man1/fdp.1</Path>
             <Path fileType="man">/usr/share/man/man1/gc.1</Path>
@@ -313,7 +315,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="35">graphviz</Dependency>
+            <Dependency release="36">graphviz</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/graphviz/arith.h</Path>
@@ -376,12 +378,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="35">
-            <Date>2024-11-25</Date>
-            <Version>12.2.0</Version>
+        <Update release="36">
+            <Date>2025-04-30</Date>
+            <Version>12.2.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/py/pygraphviz/abi_used_symbols
+++ b/packages/py/pygraphviz/abi_used_symbols
@@ -3,6 +3,7 @@ UNKNOWN:PyBool_FromLong
 UNKNOWN:PyBytes_AsString
 UNKNOWN:PyBytes_AsStringAndSize
 UNKNOWN:PyBytes_FromStringAndSize
+UNKNOWN:PyCFunction_Type
 UNKNOWN:PyCapsule_GetPointer
 UNKNOWN:PyCapsule_Import
 UNKNOWN:PyCapsule_New
@@ -50,6 +51,7 @@ UNKNOWN:PyObject_GetAttrString
 UNKNOWN:PyObject_IsTrue
 UNKNOWN:PyObject_SetAttr
 UNKNOWN:PyTuple_New
+UNKNOWN:PyType_IsSubtype
 UNKNOWN:PyType_Modified
 UNKNOWN:PyType_Ready
 UNKNOWN:PyUnicode_AsUTF8String
@@ -62,6 +64,7 @@ UNKNOWN:_PyObject_New
 UNKNOWN:_Py_Dealloc
 UNKNOWN:_Py_NoneStruct
 UNKNOWN:_Py_NotImplementedStruct
+libc.so.6:__assert_fail
 libc.so.6:__printf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:dup
@@ -70,6 +73,7 @@ libc.so.6:fdopen
 libc.so.6:free
 libc.so.6:malloc
 libc.so.6:memcpy
+libc.so.6:memset
 libc.so.6:strcmp
 libc.so.6:strdup
 libc.so.6:strlen

--- a/packages/py/pygraphviz/monitoring.yaml
+++ b/packages/py/pygraphviz/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 15839
+  rss: https://github.com/pygraphviz/pygraphviz/releases.atom
+# No known CPE, checked 2025-04-30
+security:
+  cpe: ~

--- a/packages/py/pygraphviz/package.yml
+++ b/packages/py/pygraphviz/package.yml
@@ -1,8 +1,8 @@
 name       : pygraphviz
-version    : '1.11'
-release    : 17
+version    : '1.14'
+release    : 18
 source     :
-    - https://github.com/pygraphviz/pygraphviz/archive/pygraphviz-1.11.tar.gz : 5d34274833b21d9ed69cecd1abb9c1f2e12abe1856c5197809a38e8df8229ae7
+    - https://github.com/pygraphviz/pygraphviz/archive/pygraphviz-1.14.tar.gz : d9a43f34b920367fa89a2598083b47db42a28078aff7d4e2cb41475137532560
 homepage   : https://pygraphviz.github.io/
 license    : BSD-3-Clause
 component  : programming.python
@@ -12,6 +12,10 @@ description: |
 builddeps  :
     - pkgconfig(libpathplan)
     - pkgconfig(python3)
+    - python-build
+    - python-installer
+    - python-setuptools
+    - python-wheel
 checkdeps  :
     - python-pytest
 setup      : |
@@ -19,4 +23,5 @@ setup      : |
 install    : |
     %python3_install
 check      : |
-    %python3_test
+    %python3_test pytest --doctest-modules --durations=10 --pyargs pygraphviz \
+                         -k 'not test_layout_prog_arg and not TestExperimentalGraphvizLibInterface'

--- a/packages/py/pygraphviz/pspec_x86_64.xml
+++ b/packages/py/pygraphviz/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pygraphviz</Name>
         <Homepage>https://pygraphviz.github.io/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -20,15 +20,21 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz-1.11-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz-1.11-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz-1.11-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz-1.11-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz-1.14.dist-info/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz-1.14.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz-1.14.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz-1.14.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz-1.14.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/__pycache__/agraph.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/__pycache__/agraph.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/__pycache__/graphviz.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/__pycache__/graphviz.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/__pycache__/scraper.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/__pycache__/scraper.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/__pycache__/testing.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/__pycache__/testing.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/_graphviz.cpython-311-x86_64-linux-gnu.so</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/agraph.py</Path>
@@ -38,21 +44,52 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/scraper.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/testing.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_attribute_defaults.cpython-311-pytest-8.3.5.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_attribute_defaults.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_attribute_defaults.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_clear.cpython-311-pytest-8.3.5.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_clear.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_clear.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_close.cpython-311-pytest-8.3.5.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_close.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_close.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_drawing.cpython-311-pytest-8.3.5.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_drawing.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_drawing.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_edge_attributes.cpython-311-pytest-8.3.5.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_edge_attributes.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_edge_attributes.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_graph.cpython-311-pytest-8.3.5.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_graph.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_graph.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_html.cpython-311-pytest-8.3.5.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_html.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_html.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_layout.cpython-311-pytest-8.3.5.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_layout.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_layout.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_node_attributes.cpython-311-pytest-8.3.5.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_node_attributes.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_node_attributes.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_readwrite.cpython-311-pytest-8.3.5.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_readwrite.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_readwrite.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_repr_mimebundle.cpython-311-pytest-8.3.5.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_repr_mimebundle.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_repr_mimebundle.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_scraper.cpython-311-pytest-8.3.5.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_scraper.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_scraper.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_string.cpython-311-pytest-8.3.5.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_string.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_string.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_subgraph.cpython-311-pytest-8.3.5.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_subgraph.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_subgraph.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_unicode.cpython-311-pytest-8.3.5.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_unicode.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/__pycache__/test_unicode.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/test_attribute_defaults.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/test_clear.py</Path>
@@ -69,23 +106,15 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/test_string.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/test_subgraph.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pygraphviz/tests/test_unicode.py</Path>
-            <Path fileType="doc">/usr/share/doc/pygraphviz-1.11/INSTALL.txt</Path>
-            <Path fileType="doc">/usr/share/doc/pygraphviz-1.11/examples/plot_attributes.py</Path>
-            <Path fileType="doc">/usr/share/doc/pygraphviz-1.11/examples/plot_miles.py</Path>
-            <Path fileType="doc">/usr/share/doc/pygraphviz-1.11/examples/plot_simple.py</Path>
-            <Path fileType="doc">/usr/share/doc/pygraphviz-1.11/examples/plot_star.py</Path>
-            <Path fileType="doc">/usr/share/doc/pygraphviz-1.11/examples/plot_subgraph.py</Path>
-            <Path fileType="doc">/usr/share/doc/pygraphviz-1.11/examples/skip_django_simple.py</Path>
-            <Path fileType="doc">/usr/share/doc/pygraphviz-1.11/examples/skip_utf8_encoding.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2024-02-15</Date>
-            <Version>1.11</Version>
+        <Update release="18">
+            <Date>2025-04-30</Date>
+            <Version>1.14</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Update `graphviz` to v12.2.1 and `pygraphviz` to 1.14 (for changelogs see the commit messages)

Also change the `check` commands for `pygraphviz` to something that still works (and more closely matches upstream CI workflow).

Two tests had to be disabled (they also fail for the old version). The `graphviz` updates fixes additional test failures.

**Test Plan**
- Create some simple graphs with `graphviz`
- Test some examples from the `pygraphviz` tutorial
- Test some examples from the `networkx` tutorial

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
