### PR TITLE
q4wine: Update to v1.4.2

### DIFF
--- a/packages/q/q4wine/abi_used_symbols
+++ b/packages/q/q4wine/abi_used_symbols
@@ -5,6 +5,7 @@ libQt6Core.so.6:_Z20qt_qFindChild_helperPK7QObject14QAnyStringViewRK11QMetaObjec
 libQt6Core.so.6:_Z21qRegisterResourceDataiPKhS0_S0_
 libQt6Core.so.6:_Z23qUnregisterResourceDataiPKhS0_S0_
 libQt6Core.so.6:_Z26qt_QMetaEnum_debugOperatorR6QDebugxPK11QMetaObjectPKc
+libQt6Core.so.6:_Z30qt_QMetaEnum_flagDebugOperatorR6QDebugyPK11QMetaObjectPKc
 libQt6Core.so.6:_Z5qHash11QStringViewm
 libQt6Core.so.6:_Z7qgetenvPKc
 libQt6Core.so.6:_Z8qstrncpyPcPKcm
@@ -96,6 +97,7 @@ libQt6Core.so.6:_ZN18QRegularExpressionC1ERK7QString6QFlagsINS_13PatternOptionEE
 libQt6Core.so.6:_ZN18QRegularExpressionD1Ev
 libQt6Core.so.6:_ZN20QStringConverterBase5State5clearEv
 libQt6Core.so.6:_ZN23QRegularExpressionMatchD1Ev
+libQt6Core.so.6:_ZN2Qt16staticMetaObjectE
 libQt6Core.so.6:_ZN2Qt4endlER11QTextStream
 libQt6Core.so.6:_ZN2Qt4leftER11QTextStream
 libQt6Core.so.6:_ZN4QDir10setSortingE6QFlagsINS_8SortFlagEE
@@ -208,6 +210,7 @@ libQt6Core.so.6:_ZN8QProcess4killEv
 libQt6Core.so.6:_ZN8QProcess5startERK7QStringRK5QListIS0_E6QFlagsIN13QIODeviceBase12OpenModeFlagEE
 libQt6Core.so.6:_ZN8QProcessC1EP7QObject
 libQt6Core.so.6:_ZN8QProcessD1Ev
+libQt6Core.so.6:_ZN8QVariant13moveConstructE9QMetaTypePv
 libQt6Core.so.6:_ZN8QVariantC1E5QSize
 libQt6Core.so.6:_ZN8QVariantC1E6QPoint
 libQt6Core.so.6:_ZN8QVariantC1E9QMetaTypePKv
@@ -246,7 +249,6 @@ libQt6Core.so.6:_ZN9QMetaType27registerMutableViewFunctionERKSt8functionIFbPvS1_
 libQt6Core.so.6:_ZN9QMetaType27unregisterConverterFunctionES_S_
 libQt6Core.so.6:_ZN9QMetaType29unregisterMutableViewFunctionES_S_
 libQt6Core.so.6:_ZN9QMetaType7convertES_PKvS_Pv
-libQt6Core.so.6:_ZN9QMetaTypeC1Ei
 libQt6Core.so.6:_ZN9QMimeData7setUrlsERK5QListI4QUrlE
 libQt6Core.so.6:_ZN9QMimeDataC1Ev
 libQt6Core.so.6:_ZN9QSettings10beginGroupE14QAnyStringView
@@ -854,7 +856,6 @@ libQt6Widgets.so.6:_ZN9QListView20rowsAboutToBeRemovedERK11QModelIndexii
 libQt6Widgets.so.6:_ZN9QListView23setSelectionRectVisibleEb
 libQt6Widgets.so.6:_ZN9QListView5resetEv
 libQt6Widgets.so.6:_ZN9QListView8scrollToERK11QModelIndexN17QAbstractItemView10ScrollHintE
-libQt6Widgets.so.6:_ZN9QListView9startDragE6QFlagsIN2Qt10DropActionEE
 libQt6Widgets.so.6:_ZN9QSplitter8setSizesERK5QListIiE
 libQt6Widgets.so.6:_ZN9QSplitter9addWidgetEP7QWidget
 libQt6Widgets.so.6:_ZN9QSplitterC1EP7QWidget

--- a/packages/q/q4wine/package.yml
+++ b/packages/q/q4wine/package.yml
@@ -1,8 +1,8 @@
 name       : q4wine
-version    : 1.4.0
-release    : 14
+version    : 1.4.2
+release    : 15
 source     :
-    - https://github.com/brezerk/q4wine/archive/v1.4.0.tar.gz : 32552d2554a5800460ae0c37cdde1a52aad82213c55eab3167311404ecce46b6
+    - https://github.com/brezerk/q4wine/archive/v1.4.2.tar.gz : e27d32c09e53c36cdd6ab9e9a2587f1d5a8800b3efab8784ead3e1713c8cbfd9
 homepage   : https://q4wine.brezblock.org.ua/
 license    : GPL-3.0-or-later
 summary    : Qt GUI for Wine

--- a/packages/q/q4wine/pspec_x86_64.xml
+++ b/packages/q/q4wine/pspec_x86_64.xml
@@ -83,9 +83,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2025-04-18</Date>
-            <Version>1.4.0</Version>
+        <Update release="15">
+            <Date>2025-04-30</Date>
+            <Version>1.4.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Updated Dutch translation
- Fixed: qm files are created in CMAKE_BINARY_DIR
- Fixed: Qt6 deprecation warnings
- Fixed: No such signal QComboBox::currentIndexChanged(const QString)
- Fixed: Ignoring return value of function declared with 'nodiscard' attribute
- Fixed: No such signal SingleApplication::messageReceived(const QString)
- Fixed: Wine variables are not parsed properly for wine prefix kill action
- Fixed: Invalid qm file location for cmake 4.x and qt6.9.x

**Test Plan**

Configured my wine prefixes and launched some apps

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
