### PR TITLE
scd2html: Add at v1.0.0

### DIFF
--- a/packages/s/scd2html/MAINTAINERS.md
+++ b/packages/s/scd2html/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Ian M. Jones
+  - Matrix: @ianmjones:matrix.org
+  - Email: ian@ianmjones.com

--- a/packages/s/scd2html/monitoring.yml
+++ b/packages/s/scd2html/monitoring.yml
@@ -1,0 +1,6 @@
+releases:
+  id: 316146
+  rss: https://git.sr.ht/~bitfehler/scd2html/refs/rss.xml
+# No known CPE, checked 2025-04-30
+security:
+  cpe: ~

--- a/packages/s/scd2html/package.yml
+++ b/packages/s/scd2html/package.yml
@@ -1,0 +1,19 @@
+name       : scd2html
+version    : 1.0.0
+release    : 1
+source     :
+    - https://git.sr.ht/~bitfehler/scd2html/archive/v1.0.0.tar.gz : 43143e11688f1681e1453609b7073032d613e4758fc205f7876672d14c5b47e9
+homepage   : https://git.sr.ht/~bitfehler/scd2html
+license    : MIT
+component  : programming.tools
+summary    : scd2html generates HTML from scdoc source files.
+description: |
+    scd2html generates HTML from scdoc source files.
+builddeps  :
+    - scdoc
+patterns   :
+    - /usr/share/pkgconfig/scd2html.pc
+build      : |
+    %make PREFIX=/usr
+install    : |
+    %make_install PREFIX=/usr

--- a/packages/s/scd2html/pspec_x86_64.xml
+++ b/packages/s/scd2html/pspec_x86_64.xml
@@ -1,0 +1,37 @@
+<PISI>
+    <Source>
+        <Name>scd2html</Name>
+        <Homepage>https://git.sr.ht/~bitfehler/scd2html</Homepage>
+        <Packager>
+            <Name>Ian M. Jones</Name>
+            <Email>ian@ianmjones.com</Email>
+        </Packager>
+        <License>MIT</License>
+        <PartOf>programming.tools</PartOf>
+        <Summary xml:lang="en">scd2html generates HTML from scdoc source files.</Summary>
+        <Description xml:lang="en">scd2html generates HTML from scdoc source files.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>scd2html</Name>
+        <Summary xml:lang="en">scd2html generates HTML from scdoc source files.</Summary>
+        <Description xml:lang="en">scd2html generates HTML from scdoc source files.
+</Description>
+        <PartOf>programming.tools</PartOf>
+        <Files>
+            <Path fileType="executable">/usr/bin/scd2html</Path>
+            <Path fileType="man">/usr/share/man/man1/scd2html.1</Path>
+            <Path fileType="data">/usr/share/pkgconfig/scd2html.pc</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2025-04-30</Date>
+            <Version>1.0.0</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Ian M. Jones</Name>
+            <Email>ian@ianmjones.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**

Add package scd2html, which generates HTML from scdoc source files.

Resolves getsolus/packages#3574

**Test Plan**

* Built and installed package locally.
* Used with various *.scd files to generate HTML

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
