### PR TITLE
github-cli: Update to v2.72.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.71.2
-release    : 71
+version    : 2.72.0
+release    : 72
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.71.2.tar.gz : f63adebce6e555005674b46ea6d96843b5e870bdb698759834276a69a121875c
+    - https://github.com/cli/cli/archive/refs/tags/v2.72.0.tar.gz : 5a2cd4f2601d254d11a55dab463849ccccb5fa4bdcaa72b792ea9c3bf8c67d23
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -230,9 +230,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="71">
-            <Date>2025-04-25</Date>
-            <Version>2.71.2</Version>
+        <Update release="72">
+            <Date>2025-04-30</Date>
+            <Version>2.72.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- This release marks the public preview of several accessibility improvements to the GitHub CLI that have been under development over the past year in partnership with our friends at Charm including:
  - customizable and contrasting colors
  - non-interactive user input prompting
  - text-based spinners
- Introduce `gh accessibility` help topic highlighting GitHub CLI accessibility experiences
- [gh pr view] Support `closingIssuesReferences` JSON field
- Fix expected error output of `TestRepo/repo-set-default`
- Ensure accessible password and auth token prompters disable echo mode
- Fix: Accessible multiselect prompt respects default selections

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
