### PR TITLE
labwc: Update to v0.8.4

### DIFF
--- a/packages/l/labwc/abi_used_symbols
+++ b/packages/l/labwc/abi_used_symbols
@@ -173,7 +173,6 @@ libm.so.6:round
 libpango-1.0.so.0:pango_context_set_round_glyph_positions
 libpango-1.0.so.0:pango_extents_to_pixels
 libpango-1.0.so.0:pango_font_description_free
-libpango-1.0.so.0:pango_font_description_get_weight
 libpango-1.0.so.0:pango_font_description_new
 libpango-1.0.so.0:pango_font_description_set_family
 libpango-1.0.so.0:pango_font_description_set_size
@@ -285,9 +284,9 @@ libwlroots-0.18.so:wlr_backend_start
 libwlroots-0.18.so:wlr_box_contains_point
 libwlroots-0.18.so:wlr_box_empty
 libwlroots-0.18.so:wlr_box_equal
+libwlroots-0.18.so:wlr_box_intersection
+libwlroots-0.18.so:wlr_box_transform
 libwlroots-0.18.so:wlr_buffer_drop
-libwlroots-0.18.so:wlr_buffer_get_dmabuf
-libwlroots-0.18.so:wlr_buffer_get_shm
 libwlroots-0.18.so:wlr_buffer_init
 libwlroots-0.18.so:wlr_buffer_lock
 libwlroots-0.18.so:wlr_buffer_unlock
@@ -418,6 +417,7 @@ libwlroots-0.18.so:wlr_output_state_set_mode
 libwlroots-0.18.so:wlr_output_state_set_scale
 libwlroots-0.18.so:wlr_output_state_set_transform
 libwlroots-0.18.so:wlr_output_test_state
+libwlroots-0.18.so:wlr_output_transform_coords
 libwlroots-0.18.so:wlr_output_transform_invert
 libwlroots-0.18.so:wlr_pointer_constraint_v1_send_activated
 libwlroots-0.18.so:wlr_pointer_constraint_v1_send_deactivated

--- a/packages/l/labwc/package.yml
+++ b/packages/l/labwc/package.yml
@@ -1,8 +1,8 @@
 name       : labwc
-version    : 0.8.3
-release    : 8
+version    : 0.8.4
+release    : 9
 source     :
-    - https://github.com/labwc/labwc/archive/refs/tags/0.8.3.tar.gz : 746be2ff2d0c0c0b795c97fa24c7058f75586685c88a1194c243b6a846f938a5
+    - https://github.com/labwc/labwc/archive/refs/tags/0.8.4.tar.gz : 2d3ded90f78efb5060f7057ea802c78a79dc9b2e82ae7a2ad902af957b8b9797
 homepage   : https://labwc.github.io/
 license    : GPL-2.0-or-later
 component  : desktop

--- a/packages/l/labwc/pspec_x86_64.xml
+++ b/packages/l/labwc/pspec_x86_64.xml
@@ -28,6 +28,7 @@
             <Path fileType="doc">/usr/share/doc/labwc/shutdown</Path>
             <Path fileType="doc">/usr/share/doc/labwc/themerc</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/labwc.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/labwc.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/labwc.mo</Path>
             <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/labwc.mo</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/labwc.mo</Path>
@@ -46,6 +47,7 @@
             <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/labwc.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ko/LC_MESSAGES/labwc.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lt/LC_MESSAGES/labwc.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ms/LC_MESSAGES/labwc.mo</Path>
             <Path fileType="localedata">/usr/share/locale/nl/LC_MESSAGES/labwc.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pa/LC_MESSAGES/labwc.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pl/LC_MESSAGES/labwc.mo</Path>
@@ -69,7 +71,7 @@
         <Summary xml:lang="en">Labwc session</Summary>
         <Description xml:lang="en">Labwc session</Description>
         <RuntimeDependencies>
-            <Dependency releaseFrom="8">labwc</Dependency>
+            <Dependency releaseFrom="9">labwc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/labwc-symbolic.svg</Path>
@@ -78,9 +80,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2025-02-25</Date>
-            <Version>0.8.3</Version>
+        <Update release="9">
+            <Date>2025-05-02</Date>
+            <Version>0.8.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Support all pango font weight options
- Add theme option `osd.workspace-switcher.boxes.border.width`
- Add theme option `osd.window-switcher.item.icon.size`
- Localize desktop-entry application names used by the window switcher via `desktop_entry_name` or the `%n` specifier
- Add `HideCursor` action
- Support application icons in window-switcher using `<field content="icon"/>` and use this by default
- Support application icons in client-list-combined-menu
- Support the use of the keypad-enter key when using menu
- Show fallback icon in SSD titlebar when no `app_id` is set via `<theme><fallbackAppIcon>`

Full changelog available [here](https://github.com/labwc/labwc/releases/tag/0.8.4).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new session, open a bunch of windows, switch focus between windows, use the Alt+Tab window-switcher.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
