### PR TITLE
ack: Update to v3.8.2

### DIFF
--- a/packages/a/ack/package.yml
+++ b/packages/a/ack/package.yml
@@ -1,8 +1,8 @@
 name       : ack
-version    : 3.8.1
-release    : 20
+version    : 3.8.2
+release    : 21
 source     :
-    - https://github.com/beyondgrep/ack3/archive/refs/tags/v3.8.1.tar.gz : d2e61f08dbee1d0dd3caa841febed2eef0e0f50c500f320c9c5dd49d1e7cef67
+    - https://github.com/beyondgrep/ack3/archive/refs/tags/v3.8.2.tar.gz : f7dfd4f3e473d1a9243e025d44a115bc9f7a7b616e50705a0c0f4c2bd7b1b8b4
 homepage   : https://beyondgrep.com/
 license    : Artistic-2.0
 component  : system.utils

--- a/packages/a/ack/pspec_x86_64.xml
+++ b/packages/a/ack/pspec_x86_64.xml
@@ -45,9 +45,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2025-02-14</Date>
-            <Version>3.8.1</Version>
+        <Update release="21">
+            <Date>2025-05-03</Date>
+            <Version>3.8.2</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- ack would always set a return code of 1 if -c was used.  Now it properly returns 1 if no files match, and 0 if any files match.

**Test Plan**

- Run some basic filters on file outputs

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
