### PR TITLE
papirus-icon-theme: Update to v20250501

### DIFF
--- a/packages/p/papirus-icon-theme/files/0001-Revert-redesign-System-Software-Install.patch
+++ b/packages/p/papirus-icon-theme/files/0001-Revert-redesign-System-Software-Install.patch
@@ -12,8 +12,7 @@ Subject: [PATCH] Revert "redesign System Software Install"
  Papirus/32x32/apps/system-software-install.svg   | 16 ++++++----------
  Papirus/48x48/apps/system-software-install.svg   | 16 ++++++----------
  Papirus/64x64/apps/system-software-install.svg   | 16 ++++++----------
- .../16x16/actions/system-software-install.svg    |  4 ++--
- 9 files changed, 39 insertions(+), 63 deletions(-)
+ 8 files changed, 37 insertions(+), 61 deletions(-)
 
 diff --git a/Papirus-Dark/16x16/actions/system-software-install.svg b/Papirus-Dark/16x16/actions/system-software-install.svg
 index 3682760aef..ce28760311 100644
@@ -170,21 +169,6 @@ index fea4147009..67de3b5158 100644
 + <path style="opacity:0.2" d="M 28,17 V 29 H 22 L 32,40 42,29 H 36 V 17 Z M 14,37 v 12 h 6 24 6 V 37 h -6 v 6 H 20 v -6 z"/>
 + <path style="fill:#ffffff" d="M 28,16 V 28 H 22 L 32,39 42,28 H 36 V 16 Z M 14,36 v 12 h 6 24 6 V 36 h -6 v 6 H 20 v -6 z"/>
 + <path style="opacity:0.1;fill:#ffffff" d="M 6.8007812 4 C 5.2495812 4 4 5.2495812 4 6.8007812 L 4 7.8007812 C 4 6.2495813 5.2495812 5 6.8007812 5 L 57.199219 5 C 58.750419 5 60 6.2495812 60 7.8007812 L 60 6.8007812 C 60 5.2495813 58.750419 4 57.199219 4 L 6.8007812 4 z"/>
- </svg>
-diff --git a/ePapirus/16x16/actions/system-software-install.svg b/ePapirus/16x16/actions/system-software-install.svg
-index ec3773cea6..d321432aa0 100644
---- a/ePapirus/16x16/actions/system-software-install.svg
-+++ b/ePapirus/16x16/actions/system-software-install.svg
-@@ -1,8 +1,8 @@
--<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" version="1.1">
-+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-  <defs>
-   <style id="current-color-scheme" type="text/css">
-    .ColorScheme-Text { color:#6e6e6e; } .ColorScheme-Highlight { color:#4285f4; } .ColorScheme-NeutralText { color:#ff9800; } .ColorScheme-PositiveText { color:#4caf50; } .ColorScheme-NegativeText { color:#f44336; }
-   </style>
-  </defs>
-- <path style="fill:currentColor" class="ColorScheme-Text" d="m 1.9995103,0.99991816 c -0.5540001,0 -1.00000003,0.44599994 -1.00000003,1.00000004 v 4 c 0,0.5540001 0.44599993,1.0000001 1.00000003,1.0000001 h 4.0000004 c 0.554,0 1,-0.446 1,-1.0000001 v -4 c 0,-0.5540001 -0.446,-1.00000004 -1,-1.00000004 z m 8.0000004,0 c -0.554,0 -1,0.44600004 -1,1.00000004 v 4 c 0,0.5540001 0.446,1.0000001 1,1.0000001 h 4.0000003 c 0.554,0 1,-0.446 1,-1.0000001 v -4 c 0,-0.554 -0.446,-1.00000004 -1,-1.00000004 z M 1.9995103,8.9999183 c -0.554,0 -1.00000003,0.446 -1.00000003,1 v 3.9999997 c 0,0.554 0.44600003,1 1.00000003,1 h 4.0000004 c 0.554,0 1,-0.446 1,-1 V 9.9999183 c 0,-0.554 -0.446,-1 -1,-1 z m 10.0000007,0 c -0.554,0 -1,0.454225 -1,1.0195307 v 1.980469 H 9.4272447 a 0.42863216,0.37504649 0 0 0 -0.302734,0.640625 l 2.5722663,2.25 a 0.42863216,0.37504649 0 0 0 0.605468,0 l 2.572266,-2.25 a 0.42863216,0.37504649 0 0 0 -0.302734,-0.640625 h -1.572266 v -1.980469 c 0,-0.5653057 -0.446,-1.0195307 -1,-1.0195307 z"/>
-+ <path style="fill:currentColor" class="ColorScheme-Text" d="M 3 3.0039062 L 3 7.0039062 L 7 7.0039062 L 7 3.0039062 L 3 3.0039062 z M 9 3.0039062 L 9 7.0039062 L 13 7.0039062 L 13 3.0039062 L 9 3.0039062 z M 3 9.0039062 L 3 13.003906 L 7 13.003906 L 7 9.0039062 L 3 9.0039062 z M 9 9.0039062 L 9 13.003906 L 13 13.003906 L 13 9.0039062 L 9 9.0039062 z"/>
  </svg>
 -- 
 2.35.4

--- a/packages/p/papirus-icon-theme/package.yml
+++ b/packages/p/papirus-icon-theme/package.yml
@@ -1,8 +1,8 @@
 name       : papirus-icon-theme
-version    : '20250201'
-release    : 90
+version    : '20250501'
+release    : 91
 source     :
-    - https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/archive/refs/tags/20250201.tar.gz : 01a7a07293db9e22437b96fae9d7fd8dad74c33c5460af8c86227973cb3a9846
+    - https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/archive/refs/tags/20250501.tar.gz : 3831a487f813479ad3224fdbfb0c7023f23056899bc78c93737f341aa655558e
 license    : GPL-3.0-or-later
 homepage   : https://git.io/papirus-icon-theme
 component  :
@@ -23,7 +23,7 @@ replaces   :
 setup      : |
     %patch -p1 -i $pkgfiles/0001-Revert-redesign-System-Software-Install.patch
 install    : |
-    EXCLUDE="ePapirus ePapirus-Dark" %make_install
+    %make_install
     scDir=$installdir/usr/share/icons/solus-sc
     thirdPartyIcons=(
         "android-studio"


### PR DESCRIPTION
**Summary**

Release notes available [here](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/releases/tag/20250501)

**Test Plan**
- Looked at icons in my app drawer
- Looked at folders full of different file types in my file manager
- Opened `solus-sc` and looked through the different categories

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
