### PR TITLE
adw-gtk3-theme: Update to v6.2

### DIFF
--- a/packages/a/adw-gtk3-theme/package.yml
+++ b/packages/a/adw-gtk3-theme/package.yml
@@ -1,8 +1,9 @@
 name       : adw-gtk3-theme
-version    : '5.10'
-release    : 18
+version    : '6.2'
+release    : 19
 source     :
-    - https://github.com/lassekongo83/adw-gtk3/archive/refs/tags/v5.10.tar.gz : 1439d432248a661ccc513a90ae1e5e9e65cac69842cbc090f09ec4f994c8b749
+    - https://github.com/lassekongo83/adw-gtk3/archive/refs/tags/v6.2.tar.gz : ef554d3d0e7ee65833150b9af4fb2efeadd666c739d3de7b2e26ecaeb9bb026a
+    - https://github.com/sass/dart-sass/releases/download/1.87.0/dart-sass-1.87.0-linux-x64.tar.gz#sass.tar.gz : 1e7cf8d190c24c28b09389121d7eee328b5ed23524a3f1feca416a8124927bde
 license    : LGPL-2.1-only
 homepage   : https://github.com/lassekongo83/adw-gtk3
 component  : desktop.theme
@@ -11,10 +12,12 @@ description: |
     An unofficial GTK3 port of libadwaita
 builddeps  :
     - gnome-themes-extra
-    - sassc
 rundeps    :
     - gnome-themes-extra
+environment: |
+    export PATH="$PATH:$sources/dart-sass"
 setup      : |
+    tar -xvf $sources/sass.tar.gz -C $sources/
     %meson_configure
 build      : |
     %ninja_build

--- a/packages/a/adw-gtk3-theme/pspec_x86_64.xml
+++ b/packages/a/adw-gtk3-theme/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>adw-gtk3-theme</Name>
         <Homepage>https://github.com/lassekongo83/adw-gtk3</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>LGPL-2.1-only</License>
         <PartOf>desktop.theme</PartOf>
@@ -30,36 +30,37 @@
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/dash-symbolic.svg</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/dash-symbolic.symbolic.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/dash@2-symbolic.symbolic.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/devel-symbolic.svg</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-above-dark.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-above-dark@2.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-above-insensitive-dark.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-above-insensitive-dark@2.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-above-insensitive.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-above-insensitive@2.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-above-disabled-dark.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-above-disabled-dark@2.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-above-disabled.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-above-disabled@2.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-above.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-above@2.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-below-dark.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-below-dark@2.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-below-insensitive-dark.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-below-insensitive-dark@2.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-below-insensitive.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-below-insensitive@2.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-below-disabled-dark.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-below-disabled-dark@2.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-below-disabled.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-below-disabled@2.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-below.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-horz-scale-has-marks-below@2.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-above-dark.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-above-dark@2.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-above-insensitive-dark.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-above-insensitive-dark@2.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-above-insensitive.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-above-insensitive@2.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-above-disabled-dark.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-above-disabled-dark@2.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-above-disabled.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-above-disabled@2.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-above.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-above@2.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-below-dark.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-below-dark@2.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-below-insensitive-dark.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-below-insensitive-dark@2.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-below-insensitive.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-below-insensitive@2.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-below-disabled-dark.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-below-disabled-dark@2.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-below-disabled.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-below-disabled@2.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-below.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/slider-vert-scale-has-marks-below@2.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/text-select-end-dark.png</Path>
@@ -72,11 +73,21 @@
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/text-select-start@2.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/gtk-dark.css</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/gtk.css</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/libadwaita-tweaks.css</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/libadwaita.css</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/thumbnail.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/assets/bullet-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/assets/bullet-symbolic.symbolic.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/assets/bullet@2-symbolic.symbolic.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/assets/check-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/assets/check-symbolic.symbolic.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/assets/check@2-symbolic.symbolic.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/assets/dash-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/assets/dash-symbolic.symbolic.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/assets/dash@2-symbolic.symbolic.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/assets/devel-symbolic.svg</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/gtk-dark.css</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/gtk.css</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/libadwaita-tweaks.css</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/libadwaita.css</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/index.theme</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-2.0</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/bullet-symbolic.svg</Path>
@@ -88,36 +99,37 @@
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/dash-symbolic.svg</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/dash-symbolic.symbolic.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/dash@2-symbolic.symbolic.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/devel-symbolic.svg</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-above-dark.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-above-dark@2.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-above-insensitive-dark.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-above-insensitive-dark@2.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-above-insensitive.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-above-insensitive@2.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-above-disabled-dark.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-above-disabled-dark@2.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-above-disabled.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-above-disabled@2.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-above.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-above@2.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-below-dark.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-below-dark@2.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-below-insensitive-dark.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-below-insensitive-dark@2.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-below-insensitive.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-below-insensitive@2.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-below-disabled-dark.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-below-disabled-dark@2.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-below-disabled.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-below-disabled@2.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-below.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-horz-scale-has-marks-below@2.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-above-dark.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-above-dark@2.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-above-insensitive-dark.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-above-insensitive-dark@2.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-above-insensitive.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-above-insensitive@2.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-above-disabled-dark.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-above-disabled-dark@2.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-above-disabled.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-above-disabled@2.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-above.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-above@2.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-below-dark.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-below-dark@2.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-below-insensitive-dark.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-below-insensitive-dark@2.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-below-insensitive.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-below-insensitive@2.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-below-disabled-dark.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-below-disabled-dark@2.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-below-disabled.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-below-disabled@2.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-below.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/slider-vert-scale-has-marks-below@2.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/text-select-end-dark.png</Path>
@@ -130,21 +142,31 @@
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/assets/text-select-start@2.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/gtk-dark.css</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/gtk.css</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/libadwaita-tweaks.css</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/libadwaita.css</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/thumbnail.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/assets/bullet-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/assets/bullet-symbolic.symbolic.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/assets/bullet@2-symbolic.symbolic.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/assets/check-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/assets/check-symbolic.symbolic.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/assets/check@2-symbolic.symbolic.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/assets/dash-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/assets/dash-symbolic.symbolic.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/assets/dash@2-symbolic.symbolic.png</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/assets/devel-symbolic.svg</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/gtk-dark.css</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/gtk.css</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/libadwaita-tweaks.css</Path>
+            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/libadwaita.css</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/index.theme</Path>
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2025-04-17</Date>
-            <Version>5.10</Version>
+        <Update release="19">
+            <Date>2025-05-10</Date>
+            <Version>6.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Message dialogs now closer to libadwaita.
- Some minor color changes.
- Libhandy viewswitcher buttons now look like normal buttons.
- Many other various tweaks.

Full changelog can be read [here](https://github.com/lassekongo83/adw-gtk3/compare/v5.10...v6.2)

**Test Plan**

<!-- Short description of how the package was tested -->
Use the theme and make sure nothing looks wrong

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
