### PR TITLE
inkscape: Rename inkscape-docs to inkscape-tutorials

### DIFF
--- a/packages/i/inkscape/package.yml
+++ b/packages/i/inkscape/package.yml
@@ -1,6 +1,6 @@
 name       : inkscape
 version    : '1.4'
-release    : 73
+release    : 74
 source     :
     - https://media.inkscape.org/dl/resources/file/inkscape-1.4.tar.xz : c59a85453b699addebcd51c1dc07684dd96a10c8aec716b19551db50562e13f5
 homepage   : https://inkscape.org/
@@ -9,13 +9,15 @@ license    :
     - LGPL-3.0-or-later
     - MPL-1.1
 component  : multimedia.graphics
-summary    : Inkscape is an open-source vector graphics editor similar to Adobe Illustrator, Corel Draw, Freehand, or Xara X
+summary    :
+    - Inkscape is an open-source vector graphics editor similar to Adobe Illustrator, Corel Draw, Freehand, or Xara X
+    - tutorials : Tutorial for Inkscape
 description: |
     Inkscape is an open-source vector graphics editor similar to Adobe Illustrator, Corel Draw, Freehand, or Xara X. What sets Inkscape apart is its use of Scalable Vector Graphics (SVG), an open XML-based W3C standard, as the native format.
 clang      : yes
 builddeps  :
-    - pkgconfig(GraphicsMagick)
     - pkgconfig(2geom)
+    - pkgconfig(GraphicsMagick)
     - pkgconfig(bdw-gc)
     - pkgconfig(gsl)
     - pkgconfig(gspell-1)
@@ -56,7 +58,9 @@ install    : |
     rm -rfv $installdir/usr/share/inkscape/themes/LICENSE.txt
     rm -rfv $installdir/usr/share/inkscape/themes/README.md
 patterns   :
-    - docs :
+    - tutorials :
         - /usr/share/inkscape/examples
         - /usr/share/inkscape/extensions/docs/
         - /usr/share/inkscape/tutorials
+replaces   :
+    - tutorials : inkscape-docs

--- a/packages/i/inkscape/pspec_x86_64.xml
+++ b/packages/i/inkscape/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>inkscape</Name>
         <Homepage>https://inkscape.org/</Homepage>
         <Packager>
-            <Name>Hans K</Name>
-            <Email>hans@communitycomputing.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-3.0-or-later</License>
@@ -4441,11 +4441,10 @@
         </Files>
     </Package>
     <Package>
-        <Name>inkscape-docs</Name>
-        <Summary xml:lang="en">Documentation for inkscape</Summary>
+        <Name>inkscape-tutorials</Name>
+        <Summary xml:lang="en">Tutorial for Inkscape</Summary>
         <Description xml:lang="en">Inkscape is an open-source vector graphics editor similar to Adobe Illustrator, Corel Draw, Freehand, or Xara X. What sets Inkscape apart is its use of Scalable Vector Graphics (SVG), an open XML-based W3C standard, as the native format.
 </Description>
-        <PartOf>programming.docs</PartOf>
         <Files>
             <Path fileType="data">/usr/share/inkscape/examples/animated-clock.svg</Path>
             <Path fileType="data">/usr/share/inkscape/examples/art-nouveau-P3.svg</Path>
@@ -4761,14 +4760,17 @@
             <Path fileType="data">/usr/share/inkscape/tutorials/tutorial-tracing.zh_TW.svg</Path>
             <Path fileType="data">/usr/share/inkscape/tutorials/tux.png</Path>
         </Files>
+        <Replaces>
+            <Package>inkscape-docs</Package>
+        </Replaces>
     </Package>
     <History>
-        <Update release="73">
-            <Date>2025-04-02</Date>
+        <Update release="74">
+            <Date>2025-05-10</Date>
             <Version>1.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Hans K</Name>
-            <Email>hans@communitycomputing.net</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2832,5 +2832,6 @@
 		<Package>libsignal-protocol-c-dbginfo</Package>
 		<Package>libsignal-protocol-c-devel</Package>
 		<Package>megacmd-devel</Package>
+		<Package>inkscape-docs</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3820,6 +3820,8 @@
 
 		<!-- Removed in latest version, not used by any other packages -->
 		<Package>megacmd-devel</Package>
+
+		<!-- Renamed to inkscape-tutorials -->
+		<Package>inkscape-docs</Package>
 	</Obsoletes>
 </PISI>
-


### PR DESCRIPTION
**Summary**

Rename inkscape-docs to inkscape-tutorials to match what upstream calls it                                                                                           
                                                                                                                                                                         
Resolves getsolus/packages#3050

**Test Plan**

<!-- Short description of how the package was tested -->
Install the package and open tutorial

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->