### PR TITLE
Install `maliit-keyboard` on Budgie and Xfce

### DIFF
--- a/packages/b/budgie-desktop-branding/package.yml
+++ b/packages/b/budgie-desktop-branding/package.yml
@@ -1,6 +1,6 @@
 name       : budgie-desktop-branding
 version    : '23.1'
-release    : 78
+release    : 79
 source     :
     - https://github.com/getsolus/budgie-desktop-branding/archive/refs/tags/v23.1.tar.gz : e5605da107e5f3a6659c323571d085381ee1021e5c4ce69f53635f651e1a9281
 homepage   : https://github.com/getsolus/budgie-desktop-branding
@@ -27,6 +27,7 @@ rundeps    :
     - budgie-backgrounds
     - budgie-desktop
     - font-hack-ttf
+    - maliit-keyboard
     - materia-gtk-theme
     - materia-gtk-theme-dark
     - noto-sans-ttf

--- a/packages/b/budgie-desktop-branding/pspec_x86_64.xml
+++ b/packages/b/budgie-desktop-branding/pspec_x86_64.xml
@@ -36,7 +36,7 @@
         <Description xml:lang="en">Budgie LiveCD-specific Configuration</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="78">budgie-desktop-branding</Dependency>
+            <Dependency releaseFrom="79">budgie-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/glib-2.0/schemas/50_budgie_settings.gschema.override</Path>
@@ -44,8 +44,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="78">
-            <Date>2025-02-19</Date>
+        <Update release="79">
+            <Date>2025-05-11</Date>
             <Version>23.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>

--- a/packages/x/xfce4-desktop-branding/package.yml
+++ b/packages/x/xfce4-desktop-branding/package.yml
@@ -1,6 +1,6 @@
 name       : xfce4-desktop-branding
 version    : 1.1.1
-release    : 16
+release    : 17
 source     :
     - https://github.com/getsolus/xfce4-desktop-branding/archive/refs/tags/v1.1.1.tar.gz : a2e5487d0364f77d3ca7211ca3f5d20cc427553f1c233d2e6df7054b5606dde6
 homepage   : https://github.com/getsolus/xfce4-desktop-branding
@@ -17,6 +17,7 @@ description:
 rundeps    :
     - breeze-cursor-theme
     - font-hack-ttf
+    - maliit-keyboard
     - noto-sans-ttf
     - noto-serif-ttf
     - papirus-icon-theme

--- a/packages/x/xfce4-desktop-branding/pspec_x86_64.xml
+++ b/packages/x/xfce4-desktop-branding/pspec_x86_64.xml
@@ -33,15 +33,15 @@
         <Description xml:lang="en">Defaults for the XFCE4 Desktop.</Description>
         <PartOf>desktop.xfce</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="16">xfce4-desktop-branding</Dependency>
+            <Dependency releaseFrom="17">xfce4-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/lightdm/lightdm.conf.d/xfce_config.conf</Path>
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2025-02-19</Date>
+        <Update release="17">
+            <Date>2025-05-13</Date>
             <Version>1.1.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
Add dependency on `maliit-keyboard` to Budgie and Xfce desktop brandings.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

I don't actually know how to get an onscreen keyboard to pop up.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
