### PR TITLE
fluid-soundfont: Fix version number & add symlink

### DIFF
--- a/packages/f/fluid-soundfont/package.yml
+++ b/packages/f/fluid-soundfont/package.yml
@@ -1,6 +1,6 @@
 name       : fluid-soundfont
-version    : '3'
-release    : 4
+version    : '3.1'
+release    : 5
 source     :
     - https://deb.debian.org/debian/pool/main/f/fluid-soundfont/fluid-soundfont_3.1.orig.tar.gz : 2621acaa1c78e4abdb24bdd163230cc577e61276936d6aa6e3180582142f0343
 homepage   : https://tracker.debian.org/pkg/fluid-soundfont
@@ -16,3 +16,7 @@ install    : |
 
     # Symlink original name because apparently some programs actually depend on the explicit name.
     ln -s /usr/share/sounds/sf2/FluidR3.sf2 $installdir/usr/share/sounds/sf2/FluidR3_GM.sf2
+
+    # Symlink to the expected fluidsynth directory
+    mkdir $installdir/usr/share/soundfonts
+    ln -s /usr/share/sounds/sf2/FluidR3.sf2 $installdir/usr/share/soundfonts/default.sf2

--- a/packages/f/fluid-soundfont/pspec_x86_64.xml
+++ b/packages/f/fluid-soundfont/pspec_x86_64.xml
@@ -22,14 +22,15 @@
         <Files>
             <Path fileType="doc">/usr/share/doc/fluid-soundfont/COPYING</Path>
             <Path fileType="doc">/usr/share/doc/fluid-soundfont/README</Path>
+            <Path fileType="data">/usr/share/soundfonts/default.sf2</Path>
             <Path fileType="data">/usr/share/sounds/sf2/FluidR3.sf2</Path>
             <Path fileType="data">/usr/share/sounds/sf2/FluidR3_GM.sf2</Path>
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-05-03</Date>
-            <Version>3</Version>
+        <Update release="5">
+            <Date>2025-05-15</Date>
+            <Version>3.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
             <Email>malfisya.dev@hotmail.com</Email>


### PR DESCRIPTION
**Summary**

- Fluidsynth expect soundfont in `/usr/share/soundfonts/default.sf2`. The symlink ensure that midi file can be played without specifying a directory.
- Fix version number

**Test Plan**

<!-- Short description of how the package was tested -->
Install package and run `fluidsynth example.mid`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
