### PR TITLE
deluge: [NFC] Add python-setuptools to rundeps

### DIFF
--- a/packages/d/deluge/package.yml
+++ b/packages/d/deluge/package.yml
@@ -1,6 +1,6 @@
 name       : deluge
 version    : 2.2.0
-release    : 26
+release    : 27
 source     :
     # We need to use the ftp source or the package fails to build
     - https://ftp.osuosl.org/pub/deluge/source/2.2/deluge-2.2.0.tar.xz : b9ba272b5ba42aaf1c694e6c29628ab816cc1a700a37bac08aacb52571606acd
@@ -28,6 +28,7 @@ rundeps    :
     - python-pillow
     - python-rencode
     - python-setproctitle
+    - python-setuptools
     - python-six
     - python-twisted
     - python3-dbus

--- a/packages/d/deluge/pspec_x86_64.xml
+++ b/packages/d/deluge/pspec_x86_64.xml
@@ -896,8 +896,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2025-05-11</Date>
+        <Update release="27">
+            <Date>2025-05-16</Date>
             <Version>2.2.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Tracey Clark</Name>


### PR DESCRIPTION
**Summary**
Add python-setuptools to rundeps

Prevents deluge from crashing on launch

**Test Plan**

Launched deluge. Verified it opened correctly and was able to process a torrent.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
