### PR TITLE
eopkg: Update to v4.2.1

### DIFF
--- a/packages/e/eopkg/package.yml
+++ b/packages/e/eopkg/package.yml
@@ -1,8 +1,8 @@
 name       : eopkg
-version    : 4.2.0
-release    : 19
+version    : 4.2.1
+release    : 20
 source     :
-    - https://github.com/getsolus/eopkg/archive/refs/tags/v4.2.0.tar.gz : ecea3ddf9d16d12041013597d86079c48113fb159c7783c6b6c68738d8c4409c
+    - https://github.com/getsolus/eopkg/archive/refs/tags/v4.2.1.tar.gz : 5db28176ef8d35c18b7578f4ec240815c58aaf744d0f0f85283e052cd47fd6d9
     - git|https://github.com/getsolus/PackageKit.git : 9b0f17c1ba6addc1c85bff34b64efad6a905ca50
 homepage   : https://github.com/getsolus/eopkg
 license    : GPL-2.0-or-later

--- a/packages/e/eopkg/pspec_x86_64.xml
+++ b/packages/e/eopkg/pspec_x86_64.xml
@@ -35,12 +35,12 @@
             <Path fileType="executable">/usr/bin/eopkg.py3</Path>
             <Path fileType="executable">/usr/bin/lseopkg.py3</Path>
             <Path fileType="executable">/usr/bin/uneopkg.py3</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.2.0.dist-info/AUTHORS</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.2.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.2.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.2.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.2.0.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.2.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.2.1.dist-info/AUTHORS</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.2.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.2.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.2.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.2.1.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/eopkg-4.2.1.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/pisi/__pycache__/__init__.cpython-311.pyc</Path>
@@ -449,9 +449,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2025-04-30</Date>
-            <Version>4.2.0</Version>
+        <Update release="20">
+            <Date>2025-05-16</Date>
+            <Version>4.2.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Hans K</Name>
             <Email>hans@communitycomputing.net</Email>


### PR DESCRIPTION
**Summary**
Updates eopkg to v4.2.1. See the full changelog [here](https://github.com/getsolus/eopkg/releases/tag/v4.2.1).

Fixes #2892.

**Test Plan**
1. Extract [componentdb.cache.zip](https://github.com/user-attachments/files/20199048/componentdb.cache.zip) somewhere on your system. This is a known-bad ComponentDB cache file which triggers the aforementioned bug.
2. Regenerate caches using `sudo eopkg.bin ur --force`.
3. Note that `eopkg.bin lc --debug` works.
4. Copy `componentdb.cache` which you just downloaded to `/var/cache/eopkg/`. Do not remove or alter `componentdb.cache.version` in that directory.
5. Note that `eopkg.bin lc --debug` now crashes with a terrible error.
6. Build and install `eopkg` from this PR.
7. Regenerate caches using `sudo eopkg.bin ur --force`.
8.  Note that `eopkg.bin lc --debug` works.
9. Copy `componentdb.cache` which you downloaded to `/var/cache/eopkg/` again. Do not remove or alter `componentdb.cache.version` in that directory.
10. Try `eopkg.bin lc --debug` and note that instead of crashing, eopkg now emits a debug message and ignores the cache for further operations.
11. Try `sudo eopkg.bin lc --debug` and note that it now emits the aforementioned debug message, plus another noting that it has removed the offending cache file.
12. Try `eopkg.bin lc --debug` again and note that the debug message about the malformed XML is gone.
13. Play around with various operations after re-copying the bad cache file to ensure that all probable failure points are worked around by this new eopkg release.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
