### PR TITLE
repo_data: Deprecate `shiboken-devel`

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -950,6 +950,7 @@
 		<Package>qt4-devel</Package>
 		<Package>shiboken</Package>
 		<Package>shiboken-dbginfo</Package>
+		<Package>shiboken-devel</Package>
 		<Package>cgmanager</Package>
 		<Package>cgmanager-dbginfo</Package>
 		<Package>cgmanager-devel</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -1314,6 +1314,7 @@
 		<Package>qt4-devel</Package>
 		<Package>shiboken</Package>
 		<Package>shiboken-dbginfo</Package>
+		<Package>shiboken-devel</Package>
 
 		<!-- Deprecated upstream -->
 		<Package>cgmanager</Package>


### PR DESCRIPTION
**Summary**
Looks like it was missed when Qt4 was deprecated.

Fixes https://github.com/getsolus/packages/issues/5649

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

n/a

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
