### PR TITLE
steam: rename udev-rules to device

### DIFF
--- a/packages/s/steam/package.yml
+++ b/packages/s/steam/package.yml
@@ -1,21 +1,21 @@
 name       : steam
 version    : 1.0.0.83
-release    : 98
+release    : 99
 source     :
     - https://repo.steampowered.com/steam/pool/steam/s/steam/steam_1.0.0.83.tar.gz : 791682b0cc7efd946c7002f917c9dd474d2619b7f9ed00891216a8a6b4ac8f82
 homepage   : https://store.steampowered.com
 license    : Distributable
 component  :
     - games
-    - udev-rules : games
+    - devices : games
 summary    :
     - Launcher for the Steam software distribution service
-    - udev-rules : udev rules for Steam and SteamVR
+    - devices : udev rules for Steam and SteamVR
 description:
     - Launcher for the Steam software distribution service
-    - udev-rules : udev rules for Steam and SteamVR
+    - devices : udev rules for Steam and SteamVR
 patterns   :
-    - udev-rules :
+    - devices :
         - /usr/lib64/udev/rules.d/
 rundeps    :
     - acl-32bit
@@ -92,7 +92,7 @@ rundeps    :
     - sdl2-mixer-32bit
     - sdl2-net-32bit
     - sdl2-ttf-32bit
-    - steam-udev-rules
+    - steam-devices
     - tcp_wrappers-32bit
     - vulkan-32bit
     - zenity
@@ -107,3 +107,5 @@ install    : |
 
     # Integrate with LSI.
     mv $installdir/usr/bin/steam $installdir/usr/lib/steam/.
+replaces    :
+    - devices : steam-udev-rules

--- a/packages/s/steam/pspec_x86_64.xml
+++ b/packages/s/steam/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>steam</Name>
         <Homepage>https://store.steampowered.com</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Packager>
         <License>Distributable</License>
         <PartOf>games</PartOf>
@@ -18,7 +18,7 @@
         <Description xml:lang="en">Launcher for the Steam software distribution service</Description>
         <PartOf>games</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="98">steam-udev-rules</Dependency>
+            <Dependency releaseFrom="99">steam-devices</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/steamdeps</Path>
@@ -44,7 +44,7 @@
         </Files>
     </Package>
     <Package>
-        <Name>steam-udev-rules</Name>
+        <Name>steam-devices</Name>
         <Summary xml:lang="en">udev rules for Steam and SteamVR</Summary>
         <Description xml:lang="en">udev rules for Steam and SteamVR</Description>
         <PartOf>games</PartOf>
@@ -52,14 +52,17 @@
             <Path fileType="library">/usr/lib64/udev/rules.d/60-steam-input.rules</Path>
             <Path fileType="library">/usr/lib64/udev/rules.d/60-steam-vr.rules</Path>
         </Files>
+        <Replaces>
+            <Package>steam-udev-rules</Package>
+        </Replaces>
     </Package>
     <History>
-        <Update release="98">
-            <Date>2025-04-25</Date>
+        <Update release="99">
+            <Date>2025-05-17</Date>
             <Version>1.0.0.83</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Renames steam-udev-rules to steam-devices
	- matches upstream name and in external documentation

**Test Plan**

Play balatro using steam flatpak with controller

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->

Resolves https://github.com/getsolus/packages/issues/5643