### PR TITLE
obs-vkcapture: Update to v1.5.2

### DIFF
--- a/packages/o/obs-vkcapture/abi_symbols
+++ b/packages/o/obs-vkcapture/abi_symbols
@@ -5,6 +5,7 @@ libobs_glcapture.so:eglCreateWindowSurface
 libobs_glcapture.so:eglDestroyContext
 libobs_glcapture.so:eglGetProcAddress
 libobs_glcapture.so:eglSwapBuffers
+libobs_glcapture.so:glXCreateWindow
 libobs_glcapture.so:glXDestroyContext
 libobs_glcapture.so:glXGetProcAddress
 libobs_glcapture.so:glXGetProcAddressARB

--- a/packages/o/obs-vkcapture/abi_symbols32
+++ b/packages/o/obs-vkcapture/abi_symbols32
@@ -5,6 +5,7 @@ libobs_glcapture.so:eglCreateWindowSurface
 libobs_glcapture.so:eglDestroyContext
 libobs_glcapture.so:eglGetProcAddress
 libobs_glcapture.so:eglSwapBuffers
+libobs_glcapture.so:glXCreateWindow
 libobs_glcapture.so:glXDestroyContext
 libobs_glcapture.so:glXGetProcAddress
 libobs_glcapture.so:glXGetProcAddressARB

--- a/packages/o/obs-vkcapture/package.yml
+++ b/packages/o/obs-vkcapture/package.yml
@@ -1,8 +1,8 @@
 name       : obs-vkcapture
-version    : 1.5.1
-release    : 11
+version    : 1.5.2
+release    : 12
 source     :
-    - https://github.com/nowrep/obs-vkcapture/archive/refs/tags/v1.5.1.tar.gz : 141edd95489d59e9af2597406d3200509a43bb6b012717a24c7afb163baa7f7f
+    - https://github.com/nowrep/obs-vkcapture/archive/refs/tags/v1.5.2.tar.gz : 2bc00d2848fdb00fb00bfe34a3cde8dc7f0cec4e7c37c69f75957290bc5c2bc5
 license    : GPL-2.0-or-later
 homepage   : https://github.com/nowrep/obs-vkcapture
 component  : multimedia.video

--- a/packages/o/obs-vkcapture/pspec_x86_64.xml
+++ b/packages/o/obs-vkcapture/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>obs-vkcapture</Name>
         <Homepage>https://github.com/nowrep/obs-vkcapture</Homepage>
         <Packager>
-            <Name>nelson</Name>
-            <Email>nelson@truran.dev</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>multimedia.video</PartOf>
@@ -48,7 +48,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="11">obs-vkcapture</Dependency>
+            <Dependency release="12">obs-vkcapture</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libVkLayer_obs_vkcapture.so</Path>
@@ -56,12 +56,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2025-02-08</Date>
-            <Version>1.5.1</Version>
+        <Update release="12">
+            <Date>2025-05-20</Date>
+            <Version>1.5.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>nelson</Name>
-            <Email>nelson@truran.dev</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Fixed washed out colors when using 10bit video format
- GL: Fixed capture for osu! and Minecraft Bedrock

**Test Plan**

Captured some gameplay footage in "b"

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
