### PR TITLE
repo_data: Deprecate rocm-hip-devel

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2837,5 +2837,6 @@
 		<Package>onboard</Package>
 		<Package>onboard-dbginfo</Package>
 		<Package>steam-udev-rules</Package>
+		<Package>rocm-hip-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3832,7 +3832,8 @@
 		<!-- Renamed to steam-devices -->
 		<Package>steam-udev-rules</Package>
 
-
+		<!-- Merged into main package -->
+		<Package>rocm-hip-devel</Package>
 
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
**Summary**

Files have been merged into the main `rocm-hip` package (in https://github.com/getsolus/packages/pull/2019)

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
