### PR TITLE
darkly: Update to v0.5.20

### DIFF
--- a/packages/d/darkly/abi_used_symbols
+++ b/packages/d/darkly/abi_used_symbols
@@ -633,6 +633,7 @@ libQt5Widgets.so.5:_ZN9QTextEdit16staticMetaObjectE
 libQt5Widgets.so.5:_ZN9QTreeView16staticMetaObjectE
 libQt5Widgets.so.5:_ZNK10QBoxLayout7spacingEv
 libQt5Widgets.so.5:_ZNK10QTabWidget12documentModeEv
+libQt5Widgets.so.5:_ZNK10QTabWidget6tabBarEv
 libQt5Widgets.so.5:_ZNK11QDockWidget14titleBarWidgetEv
 libQt5Widgets.so.5:_ZNK11QDockWidget8featuresEv
 libQt5Widgets.so.5:_ZNK11QHeaderView11orientationEv
@@ -1218,6 +1219,7 @@ libQt6Widgets.so.6:_ZN11QGridLayout7addItemEP11QLayoutItemiiii6QFlagsIN2Qt13Alig
 libQt6Widgets.so.6:_ZN11QGridLayout9addLayoutEP7QLayoutiiii6QFlagsIN2Qt13AlignmentFlagEE
 libQt6Widgets.so.6:_ZN11QGridLayout9addWidgetEP7QWidgetiiii6QFlagsIN2Qt13AlignmentFlagEE
 libQt6Widgets.so.6:_ZN11QGridLayoutC1EP7QWidget
+libQt6Widgets.so.6:_ZN11QHBoxLayoutC1EP7QWidget
 libQt6Widgets.so.6:_ZN11QHBoxLayoutC1Ev
 libQt6Widgets.so.6:_ZN11QHeaderView16staticMetaObjectE
 libQt6Widgets.so.6:_ZN11QListWidget16staticMetaObjectE
@@ -1305,10 +1307,7 @@ libQt6Widgets.so.6:_ZN21QAbstractItemDelegate9helpEventEP10QHelpEventP17QAbstrac
 libQt6Widgets.so.6:_ZN22QStyleOptionToolButtonC1Ev
 libQt6Widgets.so.6:_ZN5QDial16staticMetaObjectE
 libQt6Widgets.so.6:_ZN5QMenu16staticMetaObjectE
-libQt6Widgets.so.6:_ZN6QFrame13setFrameShapeENS_5ShapeE
-libQt6Widgets.so.6:_ZN6QFrame14setFrameShadowENS_6ShadowE
 libQt6Widgets.so.6:_ZN6QFrame16staticMetaObjectE
-libQt6Widgets.so.6:_ZN6QFrameC1EP7QWidget6QFlagsIN2Qt10WindowTypeEE
 libQt6Widgets.so.6:_ZN6QLabel12setAlignmentE6QFlagsIN2Qt13AlignmentFlagEE
 libQt6Widgets.so.6:_ZN6QLabel16staticMetaObjectE
 libQt6Widgets.so.6:_ZN6QLabel7setTextERK7QString
@@ -1445,7 +1444,10 @@ libQt6Widgets.so.6:_ZN9QComboBox15setCurrentIndexEi
 libQt6Widgets.so.6:_ZN9QComboBox16staticMetaObjectE
 libQt6Widgets.so.6:_ZN9QComboBox19setSizeAdjustPolicyENS_16SizeAdjustPolicyE
 libQt6Widgets.so.6:_ZN9QComboBoxC1EP7QWidget
+libQt6Widgets.so.6:_ZN9QGroupBox12setAlignmentEi
+libQt6Widgets.so.6:_ZN9QGroupBox12setCheckableEb
 libQt6Widgets.so.6:_ZN9QGroupBox16staticMetaObjectE
+libQt6Widgets.so.6:_ZN9QGroupBox7setFlatEb
 libQt6Widgets.so.6:_ZN9QGroupBox8setTitleERK7QString
 libQt6Widgets.so.6:_ZN9QGroupBoxC1EP7QWidget
 libQt6Widgets.so.6:_ZN9QLineEdit11textChangedERK7QString
@@ -1463,6 +1465,7 @@ libQt6Widgets.so.6:_ZN9QTreeView22resizeColumnToContentsEi
 libQt6Widgets.so.6:_ZN9QTreeView22setAllColumnsShowFocusEb
 libQt6Widgets.so.6:_ZN9QTreeViewC1EP7QWidget
 libQt6Widgets.so.6:_ZNK10QTabWidget12documentModeEv
+libQt6Widgets.so.6:_ZNK10QTabWidget6tabBarEv
 libQt6Widgets.so.6:_ZNK10QTabWidget7indexOfEPK7QWidget
 libQt6Widgets.so.6:_ZNK11QDockWidget14titleBarWidgetEv
 libQt6Widgets.so.6:_ZNK11QDockWidget8featuresEv
@@ -1744,7 +1747,6 @@ libm.so.6:round
 libm.so.6:sin
 libstdc++.so.6:_ZNSt8__detail15_List_node_base7_M_hookEPS0_
 libstdc++.so.6:_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
-libstdc++.so.6:_ZSt18_Rb_tree_incrementPKSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt28_Rb_tree_rebalance_for_erasePSt18_Rb_tree_node_baseRS_

--- a/packages/d/darkly/package.yml
+++ b/packages/d/darkly/package.yml
@@ -1,8 +1,8 @@
 name       : darkly
-version    : 0.5.19
-release    : 3
+version    : 0.5.20
+release    : 4
 source     :
-    - https://github.com/Bali10050/Darkly/archive/refs/tags/v0.5.19.tar.gz : e4ab5d8e90a4792ab077bf4e7fc745cfe09592ec5cc77ea6cea291057390f380
+    - https://github.com/Bali10050/Darkly/archive/refs/tags/v0.5.20.tar.gz : a7503527d47fae0594355158b9640f01e08d490af7c47fb44b40194e1a5dcc50
 homepage   : https://github.com/Bali10050/Darkly
 license    : GPL-2.0-or-later
 component  : desktop.theme

--- a/packages/d/darkly/pspec_x86_64.xml
+++ b/packages/d/darkly/pspec_x86_64.xml
@@ -41,7 +41,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="3">darkly</Dependency>
+            <Dependency release="4">darkly</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/cmake/Darkly/DarklyConfig.cmake</Path>
@@ -49,9 +49,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2025-04-19</Date>
-            <Version>0.5.19</Version>
+        <Update release="4">
+            <Date>2025-05-22</Date>
+            <Version>0.5.20</Version>
             <Comment>Packaging update</Comment>
             <Name>Hurican Solas</Name>
             <Email>hurican@keemail.me</Email>


### PR DESCRIPTION
**Summary**

Updated to v0.5.20

Release notes can be found [here](https://github.com/Bali10050/Darkly/releases/tag/v0.5.20).

**Test Plan**

Checked to see if everything still works and is themed.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
