### PR TITLE
brave: Fix metainfo location

### DIFF
--- a/packages/b/brave/package.yml
+++ b/packages/b/brave/package.yml
@@ -1,6 +1,6 @@
 name       : brave
 version    : 1.78.102
-release    : 229
+release    : 230
 source     :
     - https://github.com/brave/brave-browser/releases/download/v1.78.102/brave-browser_1.78.102_amd64.deb : 4b978ddf72e5a50245a0f92eacb2a8a0690fbea2c257bd138ea1d58f67b9e2b9
 homepage   : https://brave.com
@@ -48,4 +48,6 @@ install    : |
 
     # Fix appdata
     rm -f $installdir/usr/share/appdata/brave-browser.appdata.xml
-    install -Dm00644 $pkgfiles/com.brave.Browser.metainfo.xml $installdir/usr/share/appdata/brave-browser.appdata.xml
+    rmdir $installdir/usr/share/appdata
+    install -dm00755 $installdir/usr/share/metainfo
+    install -Dm00644 $pkgfiles/com.brave.Browser.metainfo.xml $installdir/usr/share/metainfo/brave-browser.metainfo.xml

--- a/packages/b/brave/pspec_x86_64.xml
+++ b/packages/b/brave/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>brave</Name>
         <Homepage>https://brave.com</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>GPL-3.0-or-later</License>
@@ -23,7 +23,6 @@
         <PartOf>network.web.browser</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/brave-browser</Path>
-            <Path fileType="data">/usr/share/appdata/brave-browser.appdata.xml</Path>
             <Path fileType="data">/usr/share/applications/brave-browser.desktop</Path>
             <Path fileType="data">/usr/share/applications/com.brave.Browser.desktop</Path>
             <Path fileType="data">/usr/share/brave/MEIPreload/manifest.json</Path>
@@ -196,16 +195,17 @@
             <Path fileType="data">/usr/share/gnome-control-center/default-apps/brave-browser.xml</Path>
             <Path fileType="man">/usr/share/man/man1/brave-browser.1.gz</Path>
             <Path fileType="data">/usr/share/menu/brave-browser.menu</Path>
+            <Path fileType="data">/usr/share/metainfo/brave-browser.metainfo.xml</Path>
             <Path fileType="data">/usr/share/pixmaps/brave-browser.png</Path>
         </Files>
     </Package>
     <History>
-        <Update release="229">
-            <Date>2025-05-16</Date>
+        <Update release="230">
+            <Date>2025-05-22</Date>
             <Version>1.78.102</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fix install location for metainfo

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Extract the built `.eopkg` file, and run `appstreamcli validate install/usr/share/metainfo/com.brave.Browser.metainfo.xml --explain`, and see that validation was successful.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
