### PR TITLE
vivaldi fix metainfo

### DIFF
--- a/packages/v/vivaldi-snapshot/package.yml
+++ b/packages/v/vivaldi-snapshot/package.yml
@@ -1,6 +1,6 @@
 name       : vivaldi-snapshot
 version    : 7.4.3684.34
-release    : 494
+release    : 495
 source     :
     - https://downloads.vivaldi.com/snapshot/vivaldi-snapshot_7.4.3684.34-1_amd64.deb : 929d58f9ec33724afe739b206b8616f73a9e900df96172a956d62af019f5fd40
 license    : Distributable
@@ -39,8 +39,11 @@ install    : |
     install -D -d -m 00755 $installdir/usr/bin
     install -D -d -m 00644 $installdir/usr/share
     cp -R root/usr/share/applications $installdir/usr/share/
-    cp -R root/usr/share/appdata $installdir/usr/share/
-    sed -i 's|vivaldi-snapshot-snapshot.desktop|vivaldi-snapshot.desktop|g' $installdir/usr/share/appdata/vivaldi-snapshot.appdata.xml
+
+    # Fix metainfo
+    install -Dm00644 root/usr/share/appdata/vivaldi-snapshot.appdata.xml $installdir/usr/share/metainfo/vivaldi-snapshot.metainfo.xml
+    sed -i 's|vivaldi-snapshot-snapshot.desktop|vivaldi-snapshot.desktop|g' $installdir/usr/share/metainfo/vivaldi-snapshot.metainfo.xml
+    sed -i 's|<translation/>||g' $installdir/usr/share/metainfo/vivaldi-snapshot.metainfo.xml
 
     # We do not use /opt for binary packages in Solus, so just use /usr/share.
     cp -R root/opt/* $installdir/usr/share/.

--- a/packages/v/vivaldi-snapshot/pspec_x86_64.xml
+++ b/packages/v/vivaldi-snapshot/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>vivaldi-snapshot</Name>
         <Homepage>https://vivaldi.com</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Distributable</License>
         <PartOf>network.web.browser</PartOf>
@@ -21,7 +21,6 @@
         <PartOf>network.web.browser</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/vivaldi-snapshot</Path>
-            <Path fileType="data">/usr/share/appdata/vivaldi-snapshot.appdata.xml</Path>
             <Path fileType="data">/usr/share/applications/vivaldi-snapshot.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/vivaldi-snapshot.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/16x16/apps/vivaldi-snapshot.png</Path>
@@ -31,6 +30,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/vivaldi-snapshot.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/vivaldi-snapshot.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/vivaldi-snapshot.png</Path>
+            <Path fileType="data">/usr/share/metainfo/vivaldi-snapshot.metainfo.xml</Path>
             <Path fileType="data">/usr/share/vivaldi-snapshot/LICENSE.html</Path>
             <Path fileType="data">/usr/share/vivaldi-snapshot/MEIPreload/manifest.json</Path>
             <Path fileType="data">/usr/share/vivaldi-snapshot/MEIPreload/preloaded_data.pb</Path>
@@ -1078,12 +1078,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="494">
-            <Date>2025-05-16</Date>
+        <Update release="495">
+            <Date>2025-05-22</Date>
             <Version>7.4.3684.34</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/v/vivaldi-stable/package.yml
+++ b/packages/v/vivaldi-stable/package.yml
@@ -1,6 +1,6 @@
 name       : vivaldi-stable
 version    : 7.4.3684.38
-release    : 295
+release    : 296
 source     :
     - https://downloads.vivaldi.com/stable/vivaldi-stable_7.4.3684.38-1_amd64.deb : 87f65c26ae7582c6f4dd5e4a1653ce13d1f43689d8c4935e59583650240404fb
 license    : Distributable
@@ -39,8 +39,11 @@ install    : |
     install -D -d -m 00755 $installdir/usr/bin
     install -D -d -m 00644 $installdir/usr/share
     cp -R root/usr/share/applications $installdir/usr/share/
-    cp -R root/usr/share/appdata $installdir/usr/share/
-    sed -i 's|vivaldi.desktop|vivaldi-stable.desktop|g' $installdir/usr/share/appdata/vivaldi.appdata.xml
+
+    # Fix metainfo
+    install -Dm00644 root/usr/share/appdata/vivaldi.appdata.xml $installdir/usr/share/metainfo/vivaldi.metainfo.xml
+    sed -i 's|vivaldi.desktop|vivaldi-stable.desktop|g' $installdir/usr/share/metainfo/vivaldi.metainfo.xml
+    sed -i 's|<translation/>||g' $installdir/usr/share/metainfo/vivaldi.metainfo.xml
 
     # We do not use /opt for binary packages in Solus, so just use /usr/share.
     cp -R root/opt/* $installdir/usr/share/.

--- a/packages/v/vivaldi-stable/pspec_x86_64.xml
+++ b/packages/v/vivaldi-stable/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>vivaldi-stable</Name>
         <Homepage>https://vivaldi.com</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Distributable</License>
         <PartOf>network.web.browser</PartOf>
@@ -21,7 +21,6 @@
         <PartOf>network.web.browser</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/vivaldi-stable</Path>
-            <Path fileType="data">/usr/share/appdata/vivaldi.appdata.xml</Path>
             <Path fileType="data">/usr/share/applications/vivaldi-stable.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/vivaldi.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/16x16/apps/vivaldi.png</Path>
@@ -31,6 +30,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/vivaldi.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/vivaldi.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/vivaldi.png</Path>
+            <Path fileType="data">/usr/share/metainfo/vivaldi.metainfo.xml</Path>
             <Path fileType="data">/usr/share/vivaldi-stable/LICENSE.html</Path>
             <Path fileType="data">/usr/share/vivaldi-stable/MEIPreload/manifest.json</Path>
             <Path fileType="data">/usr/share/vivaldi-stable/MEIPreload/preloaded_data.pb</Path>
@@ -1077,12 +1077,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="295">
-            <Date>2025-05-19</Date>
+        <Update release="296">
+            <Date>2025-05-22</Date>
             <Version>7.4.3684.38</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Switches both packages to use the newer metainfo directory, and ensures that the metainfo files pass validation.

- **vivaldi-stable: Fix metainfo file**
- **vivaldi-snapshot: Fix appstream metainfo**

**Test Plan**

Extract each built `.eopkg`, and run `appstreamcli validate --explain` on each appstream metainfo file.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
