### PR TITLE
terminator: Update to v2.1.5

### DIFF
--- a/packages/t/terminator/package.yml
+++ b/packages/t/terminator/package.yml
@@ -1,8 +1,8 @@
 name       : terminator
-version    : 2.1.4
-release    : 16
+version    : 2.1.5
+release    : 17
 source     :
-    - https://github.com/gnome-terminator/terminator/archive/refs/tags/v2.1.4.tar.gz : b6a544426a19829f9e9bb41441a2f4789edc04f1867c84a436822d1af6a36d06
+    - https://github.com/gnome-terminator/terminator/archive/refs/tags/v2.1.5.tar.gz : df46cb8fbf4bc80289cabbf59e22a03948a65278c637573db3bc5e7acfd1966b
 homepage   : https://gnome-terminator.org/
 license    : GPL-2.0-only
 component  : system.utils
@@ -12,6 +12,9 @@ description: |
 builddeps  :
     - desktop-file-utils
     - pytest-runner
+    - python-build
+    - python-installer
+    - python-setuptools
 rundeps    :
     - desktop-file-utils
     - gconf

--- a/packages/t/terminator/pspec_x86_64.xml
+++ b/packages/t/terminator/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>terminator</Name>
         <Homepage>https://gnome-terminator.org/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>system.utils</PartOf>
@@ -22,39 +22,68 @@
         <Files>
             <Path fileType="executable">/usr/bin/remotinator</Path>
             <Path fileType="executable">/usr/bin/terminator</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/terminator-2.1.4-py3.11.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/terminator-2.1.4-py3.11.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/terminator-2.1.4-py3.11.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/terminator-2.1.4-py3.11.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.11/site-packages/terminator-2.1.4-py3.11.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminator-2.1.5.dist-info/AUTHORS</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminator-2.1.5.dist-info/COPYING</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminator-2.1.5.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminator-2.1.5.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminator-2.1.5.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminator-2.1.5.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/borg.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/borg.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/config.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/config.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/configjson.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/configjson.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/container.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/container.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/cwd.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/cwd.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/debugserver.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/debugserver.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/editablelabel.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/editablelabel.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/factory.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/factory.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/ipc.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/ipc.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/keybindings.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/keybindings.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/layoutlauncher.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/layoutlauncher.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/notebook.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/notebook.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/optionparse.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/optionparse.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/paned.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/paned.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/plugin.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/plugin.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/prefseditor.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/prefseditor.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/regex.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/regex.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/searchbar.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/searchbar.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/signalman.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/signalman.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/terminal.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/terminal.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/terminal_popup_menu.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/terminal_popup_menu.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/terminator.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/terminator.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/titlebar.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/titlebar.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/translation.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/translation.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/util.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/util.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/version.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/version.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/window.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/__pycache__/window.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/borg.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/config.py</Path>
@@ -73,20 +102,37 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/paned.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugin.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/__init__.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/__init__.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/activitywatch.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/activitywatch.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/command_notify.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/command_notify.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/custom_commands.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/custom_commands.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/dir_open.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/dir_open.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/insert_term_name.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/insert_term_name.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/logger.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/logger.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/maven.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/maven.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/mousefree_url_handler.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/mousefree_url_handler.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/remote.cpython-311.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/remote.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/run_cmd_on_match.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/run_cmd_on_match.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/save_last_session_layout.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/save_last_session_layout.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/save_user_session_layout.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/save_user_session_layout.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/terminalshot.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/terminalshot.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/testplugin.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/testplugin.cpython-311.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/url_handlers.cpython-311.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/__pycache__/url_handlers.cpython-311.pyc</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/activitywatch.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/command_notify.py</Path>
@@ -96,6 +142,7 @@
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/logger.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/maven.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/mousefree_url_handler.py</Path>
+            <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/remote.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/run_cmd_on_match.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/save_last_session_layout.py</Path>
             <Path fileType="library">/usr/lib/python3.11/site-packages/terminatorlib/plugins/save_user_session_layout.py</Path>
@@ -265,12 +312,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2024-05-30</Date>
-            <Version>2.1.4</Version>
+        <Update release="17">
+            <Date>2025-05-23</Date>
+            <Version>2.1.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Fix invalid escape sequences
- Add plugin to clone ssh and container sessions when terminal is split
- Add reverse search keyboard binding
- Fix translation in popup menu
- Searchbar improvements
- Fix the Save button behavior for Layouts
- Fix test failure
- Ensure that when the layout item is changed the layout sub item also gets reset to first item
- Clean up VTE notification-received signal check
- Fix TypeError in reconfigure() of terminal.py
- Updates for file po/terminator.pot in hu

**Test Plan**
- Check and submit these changes using `terminator`
- Play around with vertical/horizontal splits

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
