### PR TITLE
mutt: Update to v2.2.14

### DIFF
--- a/packages/m/mutt/abi_used_symbols
+++ b/packages/m/mutt/abi_used_symbols
@@ -8,10 +8,15 @@ libc.so.6:__fdelt_chk
 libc.so.6:__fgets_unlocked_chk
 libc.so.6:__fprintf_chk
 libc.so.6:__fread_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoll
+libc.so.6:__isoc23_strtoul
+libc.so.6:__isoc23_strtoull
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__memmove_chk
+libc.so.6:__memset_chk
 libc.so.6:__printf_chk
 libc.so.6:__realpath_chk
 libc.so.6:__snprintf_chk
@@ -174,7 +179,6 @@ libc.so.6:strerror
 libc.so.6:strftime
 libc.so.6:strlen
 libc.so.6:strncasecmp
-libc.so.6:strncat
 libc.so.6:strncmp
 libc.so.6:strncpy
 libc.so.6:strpbrk
@@ -185,10 +189,6 @@ libc.so.6:strstr
 libc.so.6:strtod
 libc.so.6:strtok
 libc.so.6:strtok_r
-libc.so.6:strtol
-libc.so.6:strtoll
-libc.so.6:strtoul
-libc.so.6:strtoull
 libc.so.6:symlink
 libc.so.6:sysconf
 libc.so.6:tcgetattr
@@ -324,6 +324,8 @@ libncursesw.so.6:curs_set
 libncursesw.so.6:curses_version
 libncursesw.so.6:endwin
 libncursesw.so.6:flushinp
+libncursesw.so.6:getcurx
+libncursesw.so.6:getcury
 libncursesw.so.6:has_colors
 libncursesw.so.6:init_pair
 libncursesw.so.6:initscr

--- a/packages/m/mutt/monitoring.yaml
+++ b/packages/m/mutt/monitoring.yaml
@@ -1,0 +1,7 @@
+releases:
+  id: 2035
+  rss: https://gitlab.com/muttmua/mutt/-/tags?format=atom
+security:
+  cpe:
+    - vendor: mutt
+      product: mutt

--- a/packages/m/mutt/package.yml
+++ b/packages/m/mutt/package.yml
@@ -1,9 +1,9 @@
 name       : mutt
-version    : 2.2.12
-release    : 32
+version    : 2.2.14
+release    : 33
 source     :
-    - https://gitlab.com/muttmua/mutt/-/archive/mutt-2-2-12-rel/mutt-mutt-2-2-12-rel.tar.bz2 : 70e4f8c11ce6f5e78d1cecd17499651b07f4d554435c792bec6993150af01915
-homepage   : http://www.mutt.org
+    - https://gitlab.com/muttmua/mutt/-/archive/mutt-2-2-14-rel/mutt-mutt-2-2-14-rel.tar.gz : 77148a941f8bec316a36224a7208d7bb6e0468c9f2a78a879e294c2bac8d43f0
+homepage   : https://gitlab.com/muttmua/mutt
 license    : GPL-2.0-or-later
 component  : network.mail
 summary    : Mutt (Small, powerful text based email client)

--- a/packages/m/mutt/pspec_x86_64.xml
+++ b/packages/m/mutt/pspec_x86_64.xml
@@ -1,17 +1,17 @@
 <PISI>
     <Source>
         <Name>mutt</Name>
-        <Homepage>http://www.mutt.org</Homepage>
+        <Homepage>https://gitlab.com/muttmua/mutt</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>network.mail</PartOf>
         <Summary xml:lang="en">Mutt (Small, powerful text based email client)</Summary>
         <Description xml:lang="en">Mutt is a small but powerful text-based mail client for Unix operating systems. It was originally based on ELM, and was written by Michael Elkins.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>mutt</Name>
@@ -127,12 +127,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2023-09-29</Date>
-            <Version>2.2.12</Version>
+        <Update release="33">
+            <Date>2025-05-23</Date>
+            <Version>2.2.14</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- 2.2.14:  This is a bug-fix release, fixing a couple possible crashes, in GPGME and with IMAP when logging out, and correcting a small issue with unnecessary encoding of "." in attachment names (2231 encoding).
- 2.2.13: This is a bug-fix release, fixing a possible dangling pointer reference in the SMTP client.
- Change homepage to GitLab, mutt.org does not support https

**Test Plan**

- Launch mutt, create an inbox

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
