### PR TITLE
xfce-clipman-plugin: Update to v1.7.0

### DIFF
--- a/packages/x/xfce4-clipman-plugin/abi_symbols
+++ b/packages/x/xfce4-clipman-plugin/abi_symbols
@@ -1,1 +1,5 @@
+libclipman.so:xcp_clipboard_manager_get
+libclipman.so:xcp_clipboard_manager_get_type
+libclipman.so:xcp_clipboard_manager_wayland_get_type
+libclipman.so:xcp_clipboard_manager_x11_get_type
 libclipman.so:xfce_panel_module_construct

--- a/packages/x/xfce4-clipman-plugin/abi_used_symbols
+++ b/packages/x/xfce4-clipman-plugin/abi_used_symbols
@@ -57,6 +57,9 @@ libgio-2.0.so.0:g_file_replace_contents
 libgio-2.0.so.0:g_input_stream_read_async
 libgio-2.0.so.0:g_input_stream_read_finish
 libgio-2.0.so.0:g_io_error_quark
+libgio-2.0.so.0:g_static_resource_fini
+libgio-2.0.so.0:g_static_resource_get_resource
+libgio-2.0.so.0:g_static_resource_init
 libgio-2.0.so.0:g_unix_input_stream_new
 libglib-2.0.so.0:g_ascii_strcasecmp
 libglib-2.0.so.0:g_assertion_message_expr
@@ -129,7 +132,6 @@ libglib-2.0.so.0:g_slist_find_custom
 libglib-2.0.so.0:g_slist_free
 libglib-2.0.so.0:g_slist_free_full
 libglib-2.0.so.0:g_slist_insert_sorted
-libglib-2.0.so.0:g_slist_last
 libglib-2.0.so.0:g_slist_length
 libglib-2.0.so.0:g_slist_nth
 libglib-2.0.so.0:g_slist_prepend
@@ -215,7 +217,7 @@ libgobject-2.0.so.0:g_value_set_uint
 libgtk-3.so.0:gtk_application_new
 libgtk-3.so.0:gtk_box_new
 libgtk-3.so.0:gtk_box_pack_start
-libgtk-3.so.0:gtk_builder_add_from_string
+libgtk-3.so.0:gtk_builder_add_from_resource
 libgtk-3.so.0:gtk_builder_get_object
 libgtk-3.so.0:gtk_builder_new
 libgtk-3.so.0:gtk_button_set_image

--- a/packages/x/xfce4-clipman-plugin/package.yml
+++ b/packages/x/xfce4-clipman-plugin/package.yml
@@ -1,21 +1,21 @@
-name       : xfce4-clipman-plugin
-version    : 1.6.7
-release    : 2
-source     :
-    - https://archive.xfce.org/src/panel-plugins/xfce4-clipman-plugin/1.6/xfce4-clipman-plugin-1.6.7.tar.bz2 : 9bae27808a50e959e0912b7202ea5d651ed7401a6fc227f811d9bdaf2e44178c
-homepage   : https://docs.xfce.org/panel-plugins/xfce4-clipman-plugin/start
-license    : GPL-2.0-or-later
-component  : desktop.xfce
-summary    : Clipman is a clipboard manager for Xfce.
+name: xfce4-clipman-plugin
+version: 1.7.0
+release: 3
+source:
+  - https://archive.xfce.org/src/panel-plugins/xfce4-clipman-plugin/1.7/xfce4-clipman-plugin-1.7.0.tar.xz: 903302c3070a951d44ee17a84fa3cf21d36c6787678af8fbfc79e469fd00cb46
+homepage: https://docs.xfce.org/panel-plugins/xfce4-clipman-plugin/start
+license: GPL-2.0-or-later
+component: desktop.xfce
+summary: Clipman is a clipboard manager for Xfce.
 description: |
-    Clipman is a clipboard manager for Xfce. It keeps the clipboard contents around while it is usually lost when you close an application. It is able to handle text and images, and has a feature to execute actions on specific text by matching them against regular expressions.
-builddeps  :
-    - pkgconfig(libxfce4panel-2.0)
-    - pkgconfig(libxfce4ui-2)
-    - pkgconfig(libxfce4util-1.0)
-setup      : |
-    %configure --sysconfdir=/usr/share
-build      : |
-    %make
-install    : |
-    %make_install
+  Clipman is a clipboard manager for Xfce. It keeps the clipboard contents around while it is usually lost when you close an application. It is able to handle text and images, and has a feature to execute actions on specific text by matching them against regular expressions.
+builddeps:
+  - pkgconfig(libxfce4panel-2.0)
+  - pkgconfig(libxfce4ui-2)
+  - pkgconfig(libxfce4util-1.0)
+setup: |
+  %meson_configure --sysconfdir=/usr/share
+build: |
+  %ninja_build
+install: |
+  %ninja_install

--- a/packages/x/xfce4-clipman-plugin/pspec_x86_64.xml
+++ b/packages/x/xfce4-clipman-plugin/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xfce4-clipman-plugin</Name>
         <Homepage>https://docs.xfce.org/panel-plugins/xfce4-clipman-plugin/start</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Minh Nguyen</Name>
+            <Email>minhhut@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.xfce</PartOf>
@@ -96,12 +96,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-12-24</Date>
-            <Version>1.6.7</Version>
+        <Update release="3">
+            <Date>2025-05-24</Date>
+            <Version>1.7.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Minh Nguyen</Name>
+            <Email>minhhut@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Update README after switchover to meson
- build: Automate copyright year management
- build: Replace xdt-csource with glib-compile-resources
- meson-build: Use shared_module()
- Replace deprecated exo with libxfce4ui 4.21.0
- Use HTTPS for action URLs
- history: Add missing sanity checks
- history: Update size when max values change at runtime
- history: Fix truncation when max_images changes
- collector: Avoid default clipboard restoration while waiting for image
- tests: Print more test results
- gcc-analyzer: Adapt regexes to meson
- Add meson build
- build: Add missing dep flags
- Translation Updates: Albanian, Catalan, Greek, Slovak, Vietnamese

<!-- Info on what this pull request updates/changes/etc -->

**Test Plan**

- Run Clipboard Manage, see the icon
- Copy a random text, use Ctrl + C
- Left click to open menu, see the copied text in menu
- Open Clipman Settings
- Click around the tabs, checkboxes
- Click Close

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
