### PR TITLE
liteide: Update to v38.4

### DIFF
--- a/packages/l/liteide/abi_used_symbols
+++ b/packages/l/liteide/abi_used_symbols
@@ -380,6 +380,7 @@ libQt5Core.so.5:_ZN7QStringaSERKS_
 libQt5Core.so.5:_ZN7QThread11qt_metacallEN11QMetaObject4CallEiPPv
 libQt5Core.so.5:_ZN7QThread11qt_metacastEPKc
 libQt5Core.so.5:_ZN7QThread16staticMetaObjectE
+libQt5Core.so.5:_ZN7QThread4quitEv
 libQt5Core.so.5:_ZN7QThread4waitEm
 libQt5Core.so.5:_ZN7QThread5eventEP6QEvent
 libQt5Core.so.5:_ZN7QThread5startENS_8PriorityE
@@ -2575,9 +2576,7 @@ libstdc++.so.6:_ZSt16__throw_bad_castv
 libstdc++.so.6:_ZSt17__throw_bad_allocv
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt21ios_base_library_initv
-libstdc++.so.6:_ZSt28__throw_bad_array_new_lengthv
 libstdc++.so.6:_ZSt4cerr
-libstdc++.so.6:_ZSt9terminatev
 libstdc++.so.6:_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_c
 libstdc++.so.6:_ZTIPKc
 libstdc++.so.6:_ZTISt9bad_alloc
@@ -2591,6 +2590,7 @@ libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
 libstdc++.so.6:__cxa_allocate_exception
 libstdc++.so.6:__cxa_begin_catch
+libstdc++.so.6:__cxa_call_terminate
 libstdc++.so.6:__cxa_end_catch
 libstdc++.so.6:__cxa_free_exception
 libstdc++.so.6:__cxa_guard_abort

--- a/packages/l/liteide/monitoring.yaml
+++ b/packages/l/liteide/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 227233
+  rss: https://github.com/visualfc/liteide/releases.atom
+# No known CPE, checked 2025-05-25
+security:
+  cpe: ~

--- a/packages/l/liteide/package.yml
+++ b/packages/l/liteide/package.yml
@@ -1,8 +1,8 @@
 name       : liteide
-version    : '38.3'
-release    : 26
+version    : '38.4'
+release    : 27
 source     :
-    - git|https://github.com/visualfc/liteide.git : x38.3
+    - https://github.com/visualfc/liteide/archive/refs/tags/x38.4.tar.gz : dd022cd74b6c34f042632abda9641ee5f4420d80b093324d1310cb317984bbaf
 homepage   : https://github.com/visualfc/liteide
 license    : LGPL-2.1-or-later
 component  : programming.ide

--- a/packages/l/liteide/pspec_x86_64.xml
+++ b/packages/l/liteide/pspec_x86_64.xml
@@ -662,9 +662,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2024-06-22</Date>
-            <Version>38.3</Version>
+        <Update release="27">
+            <Date>2025-05-25</Date>
+            <Version>38.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**

- LiteIDE support Go1.24
- LiteFind fix FindFilesThread stop
- LiteBuild Add FileBuild menu item
- Fix src/3rdparty/libvterm: crash when out of memory while opening a terminal window Potential Vulnerability in Cloned Function

**Test Plan**
- Installed, checked version and loaded plugins.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
