### PR TITLE
marble: Fix appstream metainfo

### DIFF
--- a/packages/m/marble/files/0001-Fix-appstream-metainfo.patch
+++ b/packages/m/marble/files/0001-Fix-appstream-metainfo.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Muhammad Alfi Syahrin <malfisya.dev@hotmail.com>
+Date: Mon, 26 May 2025 11:20:21 +0700
+Subject: [PATCH] Fix appstream metainfo
+
+---
+ src/apps/marble-maps/org.kde.marble.maps.appdata.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/apps/marble-maps/org.kde.marble.maps.appdata.xml b/src/apps/marble-maps/org.kde.marble.maps.appdata.xml
+index 83c6c2c..cb4f67b 100644
+--- a/src/apps/marble-maps/org.kde.marble.maps.appdata.xml
++++ b/src/apps/marble-maps/org.kde.marble.maps.appdata.xml
+@@ -7,7 +7,7 @@
+   <id>org.kde.marble.maps.desktop</id>
+   <metadata_license>CC0-1.0</metadata_license>
+   <project_license>LGPL-2.1-or-later</project_license>
+-  <launchable type="desktop-id">org.kde.marble.desktop</launchable>
++  <launchable type="desktop-id">org.kde.marble.maps.desktop</launchable>
+   <name>Marble Maps</name>
+   <name xml:lang="ar">خرائط ماربل</name>
+   <name xml:lang="bg">Карти Marble</name>

--- a/packages/m/marble/package.yml
+++ b/packages/m/marble/package.yml
@@ -1,6 +1,6 @@
 name       : marble
 version    : 25.04.1
-release    : 97
+release    : 98
 source     :
     - https://download.kde.org/stable/release-service/25.04.1/src/marble-25.04.1.tar.xz : 6d2469827644f728f9fc9a023388a66813f819687d15fd2c9392d8323e37f0e2
 homepage   : https://kde.org/applications/education/org.kde.marble
@@ -24,17 +24,18 @@ builddeps  :
     - pkgconfig(shapelib)
     - kf6-kconfig-devel
     - kf6-kcoreaddons-devel
-    - kf6-kdoctools-devel
     - kf6-kcrash-devel
-    - kf6-krunner-devel
+    - kf6-kdoctools-devel
     - kf6-ki18n-devel
     - kf6-kparts-devel
+    - kf6-krunner-devel
     - libplasma-devel
 clang      : yes
 optimize   :
     - speed
     - thin-lto
 setup      : |
+    %patch -p1 -i $pkgfiles/0001-Fix-appstream-metainfo.patch
     %cmake_kf6 -DBUILD_MARBLE_TOOLS=YES \
                -DBUILD_TOUCH=ON \
                -DMOBILE=OFF \

--- a/packages/m/marble/pspec_x86_64.xml
+++ b/packages/m/marble/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>marble</Name>
         <Homepage>https://kde.org/applications/education/org.kde.marble</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>network.web</PartOf>
@@ -20,7 +20,7 @@
 </Description>
         <PartOf>network.web</PartOf>
         <RuntimeDependencies>
-            <Dependency release="97">marble-libs</Dependency>
+            <Dependency release="98">marble-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/marble</Path>
@@ -1701,8 +1701,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="97">marble</Dependency>
-            <Dependency release="97">marble-libs</Dependency>
+            <Dependency release="98">marble-libs</Dependency>
+            <Dependency release="98">marble</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/astro/astr2lib.h</Path>
@@ -1959,12 +1959,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="97">
-            <Date>2025-05-12</Date>
+        <Update release="98">
+            <Date>2025-05-26</Date>
             <Version>25.04.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

<!-- Info on what this pull request updates/changes/etc -->
Fix appstream metainfo

**Test Plan**

<!-- Short description of how the package was tested -->
Run `appstreamcli compose install/ --media-dir=media --media-baseurl=localhost:8000 --verbose`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
