### PR TITLE
egl-x11: Update to v1.0.2

### DIFF
--- a/packages/e/egl-x11/package.yml
+++ b/packages/e/egl-x11/package.yml
@@ -1,8 +1,8 @@
 name       : egl-x11
-version    : 1.0.1
-release    : 2
+version    : 1.0.2
+release    : 3
 source     :
-    - https://github.com/NVIDIA/egl-x11/archive/refs/tags/v1.0.1.tar.gz : 0dbc6c3fb76666af4e0e19d388b3f09247412aff549d31d35149a19ebb95422b
+    - https://github.com/NVIDIA/egl-x11/archive/refs/tags/v1.0.2.tar.gz : 021d0b01b50b6500a4c97ddc43827ebfd10e8ca041a46a9cb00b63c9a07a67cb
 homepage   : https://github.com/NVIDIA/egl-x11
 license    : Apache-2.0
 component  : programming.library

--- a/packages/e/egl-x11/pspec_x86_64.xml
+++ b/packages/e/egl-x11/pspec_x86_64.xml
@@ -21,9 +21,9 @@
         <PartOf>programming.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libnvidia-egl-xcb.so.1</Path>
-            <Path fileType="library">/usr/lib64/libnvidia-egl-xcb.so.1.0.1</Path>
+            <Path fileType="library">/usr/lib64/libnvidia-egl-xcb.so.1.0.2</Path>
             <Path fileType="library">/usr/lib64/libnvidia-egl-xlib.so.1</Path>
-            <Path fileType="library">/usr/lib64/libnvidia-egl-xlib.so.1.0.1</Path>
+            <Path fileType="library">/usr/lib64/libnvidia-egl-xlib.so.1.0.2</Path>
             <Path fileType="data">/usr/share/egl/egl_external_platform.d/20_nvidia_xcb.json</Path>
             <Path fileType="data">/usr/share/egl/egl_external_platform.d/20_nvidia_xlib.json</Path>
         </Files>
@@ -35,13 +35,13 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">egl-x11</Dependency>
+            <Dependency release="3">egl-x11</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnvidia-egl-xcb.so.1</Path>
-            <Path fileType="library">/usr/lib32/libnvidia-egl-xcb.so.1.0.1</Path>
+            <Path fileType="library">/usr/lib32/libnvidia-egl-xcb.so.1.0.2</Path>
             <Path fileType="library">/usr/lib32/libnvidia-egl-xlib.so.1</Path>
-            <Path fileType="library">/usr/lib32/libnvidia-egl-xlib.so.1.0.1</Path>
+            <Path fileType="library">/usr/lib32/libnvidia-egl-xlib.so.1.0.2</Path>
         </Files>
     </Package>
     <Package>
@@ -51,8 +51,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">egl-x11-devel</Dependency>
-            <Dependency release="2">egl-x11-32bit</Dependency>
+            <Dependency release="3">egl-x11-devel</Dependency>
+            <Dependency release="3">egl-x11-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnvidia-egl-xcb.so</Path>
@@ -66,7 +66,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">egl-x11</Dependency>
+            <Dependency release="3">egl-x11</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libnvidia-egl-xcb.so</Path>
@@ -74,9 +74,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2025-04-20</Date>
-            <Version>1.0.1</Version>
+        <Update release="3">
+            <Date>2025-05-30</Date>
+            <Version>1.0.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fix a double-close bug in the implicit sync path
- Fix a KHR_EGL_debug error message getting reported on a successful call

**Test Plan**

Launched a GNOME Wayland session and used a bunch of XWayland apps/games

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
