### PR TITLE
msmtp: Update to 1.8.29

### DIFF
--- a/packages/m/msmtp/package.yml
+++ b/packages/m/msmtp/package.yml
@@ -1,8 +1,8 @@
 name       : msmtp
-version    : 1.8.28
-release    : 10
+version    : 1.8.29
+release    : 11
 source     :
-    - https://marlam.de/msmtp/releases/msmtp-1.8.28.tar.xz : 3a57f155f54e4860f7dd42138d9bea1af615b99dfab5ab4cd728fc8c09a647a4
+    - https://marlam.de/msmtp/releases/msmtp-1.8.29.tar.xz : 13a78f3c6034b33008a7f2474fdddd0deaf7db6da89d0791d3d75eae721220d7
 homepage   : https://marlam.de/msmtp
 license    : GPL-3.0-or-later
 component  : network.clients

--- a/packages/m/msmtp/pspec_x86_64.xml
+++ b/packages/m/msmtp/pspec_x86_64.xml
@@ -34,14 +34,15 @@
             <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/msmtp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ta/LC_MESSAGES/msmtp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/msmtp.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/msmtp.mo</Path>
             <Path fileType="man">/usr/share/man/man1/msmtp.1</Path>
             <Path fileType="man">/usr/share/man/man1/msmtpd.1</Path>
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2025-03-02</Date>
-            <Version>1.8.28</Version>
+        <Update release="11">
+            <Date>2025-05-31</Date>
+            <Version>1.8.29</Version>
             <Comment>Packaging update</Comment>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>


### PR DESCRIPTION
**Summary**

Enhancements:

- Added a new configuration command set_to_header
- Added a new substitution pattern %F for the from command
- Many improvements in the msmtpq script
- Updated translations

Full release notes:

- [News](https://marlam.de/msmtp/news/)

**Test Plan**

Installed locally and sent a view emails using it.
**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
