### PR TITLE
github-cli: Update to v2.74.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.73.0
-release    : 73
+version    : 2.74.0
+release    : 74
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.73.0.tar.gz : e432fd7e8944f94624fbd287b3bdd46f6bbed23609178c940bdb7b5d55a6d1c4
+    - https://github.com/cli/cli/archive/refs/tags/v2.74.0.tar.gz : b13e60f114388cbc20ba410d57b43f262814dec7d3e37363accfd525c6885d3b
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -130,6 +130,8 @@
             <Path fileType="man">/usr/share/man/man1/gh-pr-update-branch.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-pr-view.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-pr.1</Path>
+            <Path fileType="man">/usr/share/man/man1/gh-preview-prompter.1</Path>
+            <Path fileType="man">/usr/share/man/man1/gh-preview.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-project-close.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-project-copy.1</Path>
             <Path fileType="man">/usr/share/man/man1/gh-project-create.1</Path>
@@ -230,9 +232,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="73">
-            <Date>2025-05-19</Date>
-            <Version>2.73.0</Version>
+        <Update release="74">
+            <Date>2025-05-31</Date>
+            <Version>2.74.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Add `preview prompter` command
- Revert "[gh config] Escape pipe symbol in Long desc for website manual"
- Fix formatting in allowed values for `gh config --help`
- Add retry logic when fetching TUF content in `gh attestation` commands

**Security**
- CVE-2025-48938

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
