### PR TITLE
msmtp: Update to 1.8.30

### DIFF
--- a/packages/m/msmtp/package.yml
+++ b/packages/m/msmtp/package.yml
@@ -1,8 +1,8 @@
 name       : msmtp
-version    : 1.8.29
-release    : 11
+version    : 1.8.30
+release    : 12
 source     :
-    - https://marlam.de/msmtp/releases/msmtp-1.8.29.tar.xz : 13a78f3c6034b33008a7f2474fdddd0deaf7db6da89d0791d3d75eae721220d7
+    - https://marlam.de/msmtp/releases/msmtp-1.8.30.tar.xz : f826a3c500c4dfeed814685097cead9b2b3dca5a2ec3897967cb9032570fa9ab
 homepage   : https://marlam.de/msmtp
 license    : GPL-3.0-or-later
 component  : network.clients

--- a/packages/m/msmtp/pspec_x86_64.xml
+++ b/packages/m/msmtp/pspec_x86_64.xml
@@ -40,9 +40,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2025-05-31</Date>
-            <Version>1.8.29</Version>
+        <Update release="12">
+            <Date>2025-06-02</Date>
+            <Version>1.8.30</Version>
             <Comment>Packaging update</Comment>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>


### PR DESCRIPTION
**Summary**

Bugfixes:

- Fixes a double-free bug that was introduced in 1.8.29

Full release notes:

- [News](https://marlam.de/msmtp/news/)

**Test Plan**

Installed locally and sent test emails.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
