### PR TITLE
common/Scripts: Add a script to validate AppStream

### DIFF
--- a/common/Scripts/validate-appstream.py
+++ b/common/Scripts/validate-appstream.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import subprocess
+import sys
+from typing import TypedDict
+
+
+class SubprocessResult(TypedDict):
+    stdout: str
+    stderr: str
+    returncode: int
+
+
+def validate(path: str, *args: str) -> SubprocessResult:
+    if not os.path.isfile(path):
+        raise FileNotFoundError("AppStream file not found")
+
+    overrides = {
+        "all-categories-ignored": "error",
+        "category-invalid": "error",
+        "cid-desktopapp-is-not-rdns": "error",
+        # "cid-domain-not-lowercase": "info",
+        "cid-has-number-prefix": "error",
+        "cid-missing-affiliation-gnome": "error",
+        "cid-rdns-contains-hyphen": "error",
+        # "component-name-too-long": "info",
+        "content-rating-missing": "error",
+        # "description-has-plaintext-url": "info",
+        "desktop-app-launchable-omitted": "error",
+        "desktop-file-not-found": "error",
+        # "developer-id-invalid": "info",
+        "developer-id-missing": "error",
+        "invalid-child-tag-name": "error",
+        "metainfo-filename-cid-mismatch": "error",
+        "metainfo-legacy-path": "error",
+        "metainfo-multiple-components": "error",
+        "name-has-dot-suffix": "info",
+        "releases-info-missing": "error",
+        # "summary-too-long": "info",
+        "unknown-tag": "error",
+        # "app-categories-missing": "info",
+    }
+
+    overrides_value = ",".join([f"{k}={v}" for k, v in overrides.items()])
+
+    cmd = subprocess.run(
+        ["appstreamcli", "validate", f"--override={overrides_value}", *args, path],
+        capture_output=True,
+        check=False,
+    )
+
+    ret: SubprocessResult = {
+        "stdout": cmd.stdout.decode("utf-8"),
+        "stderr": cmd.stderr.decode("utf-8"),
+        "returncode": cmd.returncode,
+    }
+
+    return ret
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="A script to lint AppStream metainfo files",
+        formatter_class=argparse.RawTextHelpFormatter,
+        add_help=False,
+    )
+
+    parser.add_argument(
+        "-h",
+        "--help",
+        help="Show this help message and exit.",
+        action="help",
+        default=argparse.SUPPRESS,
+    )
+
+    parser.add_argument(
+        "path",
+        help="Path to an AppStream metainfo file.",
+        type=str,
+        nargs=1,
+    )
+
+    args = parser.parse_args()
+    exit_code = 0
+
+    try:
+        ret = validate(args.path, "--explain")
+        print(ret["stdout"])  # noqa: T201
+        print(ret["stderr"])  # noqa: T201
+        exit_code = ret["returncode"]
+    except Exception as e:
+        print(f"Error validating {args.path}: {e}")
+        sys.exit(1)
+
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Summary**

Adds a script to validate an AppStream metainfo XML file. It uses a bunch of overrides sourced from Flathub. I decided to use these to try to maintain the best compatibility; the idea is if a metainfo file works for Flathub, it should work for us.

Some exceptions are commented out as they rely on patches to appstream (I think?), and I haven't looked into locating those yet. We can decide to pursue that at a later time and uncomment them, or just drop them.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run the script against some metainfo XML files in my system, and in the package repository files.

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
