### PR TITLE
watchexec: Update to v2.3.2

### DIFF
--- a/packages/w/watchexec/abi_used_symbols
+++ b/packages/w/watchexec/abi_used_symbols
@@ -1,7 +1,6 @@
 libc.so.6:__errno_location
 libc.so.6:__libc_current_sigrtmax
 libc.so.6:__libc_start_main
-libc.so.6:__register_atfork
 libc.so.6:__res_init
 libc.so.6:__xpg_strerror_r
 libc.so.6:_exit
@@ -37,6 +36,7 @@ libc.so.6:getauxval
 libc.so.6:getcwd
 libc.so.6:getenv
 libc.so.6:geteuid
+libc.so.6:getgrouplist
 libc.so.6:getpeername
 libc.so.6:getpid
 libc.so.6:getpwnam
@@ -93,8 +93,6 @@ libc.so.6:pthread_getattr_np
 libc.so.6:pthread_join
 libc.so.6:pthread_key_create
 libc.so.6:pthread_key_delete
-libc.so.6:pthread_mutex_lock
-libc.so.6:pthread_mutex_unlock
 libc.so.6:pthread_self
 libc.so.6:pthread_setname_np
 libc.so.6:pthread_setspecific

--- a/packages/w/watchexec/package.yml
+++ b/packages/w/watchexec/package.yml
@@ -1,8 +1,8 @@
 name       : watchexec
-version    : 2.3.0
-release    : 4
+version    : 2.3.2
+release    : 5
 source     :
-    - https://github.com/watchexec/watchexec/archive/refs/tags/v2.3.0.tar.gz : bf508d3662fe85294a61ab39a3fbfb0a76f79202448fb3c038a3003ae3e18245
+    - https://github.com/watchexec/watchexec/archive/refs/tags/v2.3.2.tar.gz : 52201822ab00bfaf6757f953f667870b3aada52f887813e94b4f322f239ff8fb
 homepage   : https://watchexec.github.io
 license    : Apache-2.0
 component  : system.utils

--- a/packages/w/watchexec/pspec_x86_64.xml
+++ b/packages/w/watchexec/pspec_x86_64.xml
@@ -28,9 +28,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2025-02-10</Date>
-            <Version>2.3.0</Version>
+        <Update release="5">
+            <Date>2025-06-03</Date>
+            <Version>2.3.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Ian M. Jones</Name>
             <Email>ian@ianmjones.com</Email>


### PR DESCRIPTION
**Summary**

Changelog v2.3.2: https://github.com/watchexec/watchexec/releases/tag/v2.3.2
Changelog v2.3.1: https://github.com/watchexec/watchexec/releases/tag/v2.3.1

**Test Plan**

* Built and installed package locally.
* Ran within a few projects to run tests.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
