### PR TITLE
helix: Add application info and completions

### DIFF
--- a/packages/h/helix/files/hx
+++ b/packages/h/helix/files/hx
@@ -1,3 +1,0 @@
-#!/usr/bin/env sh
-
-HELIX_RUNTIME=/var/lib/helix/runtime exec /usr/lib/helix/hx "$@"

--- a/packages/h/helix/package.yml
+++ b/packages/h/helix/package.yml
@@ -1,6 +1,6 @@
 name       : helix
 version    : 25.01.1
-release    : 6
+release    : 7
 source     :
     - https://github.com/helix-editor/helix/archive/refs/tags/25.01.1.tar.gz : 3f2364463e2e58b0e78ea16fd37a23a93ec2b086323b9ca1e6e310d86a9b3663
 license    : MPL-2.0
@@ -24,5 +24,12 @@ install    : |
     rm -r $workdir/runtime/grammars/sources
     cp -r $workdir/runtime $installdir/usr/lib/helix
     install -Dm00755 $workdir/target/release/hx $installdir/usr/lib/helix/hx
-    install -Dm00777 $pkgfiles/hx $installdir/usr/bin/hx
+    install -Dm00777 $workdir/contrib/hx_launcher.sh $installdir/usr/bin/hx
+    install -Dm00644 $workdir/contrib/Helix.desktop $installdir/usr/share/applications/Helix.desktop
+    install -Dm00644 $workdir/contrib/Helix.appdata.xml $installdir/usr/share/metainfo/Helix.metainfo.xml
+    install -Dm00644 $workdir/contrib/helix.png $installdir/usr/share/icons/hicolor/256x256/apps/helix.png
 
+    # Completions
+    install -Dm00644 $workdir/contrib/completion/hx.bash $installdir/usr/share/bash-completions/completions/hx
+    install -Dm00644 $workdir/contrib/completion/hx.fish $installdir/usr/share/fish/completions/hx.fish
+    install -Dm00644 $workdir/contrib/completion/hx.zsh $installdir/usr/share/zsh/site-functions/_hx

--- a/packages/h/helix/pspec_x86_64.xml
+++ b/packages/h/helix/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>helix</Name>
         <Homepage>https://helix-editor.com/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MPL-2.0</License>
         <PartOf>editor</PartOf>
@@ -1125,15 +1125,21 @@ It&apos;s a joke. If Neovim is the modern Vim, then Helix is post-modern.
             <Path fileType="library">/usr/lib/helix/runtime/themes/zed_onelight.toml</Path>
             <Path fileType="library">/usr/lib/helix/runtime/themes/zenburn.toml</Path>
             <Path fileType="library">/usr/lib/helix/runtime/tutor</Path>
+            <Path fileType="data">/usr/share/applications/Helix.desktop</Path>
+            <Path fileType="data">/usr/share/bash-completions/completions/hx</Path>
+            <Path fileType="data">/usr/share/fish/completions/hx.fish</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/helix.png</Path>
+            <Path fileType="data">/usr/share/metainfo/Helix.metainfo.xml</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_hx</Path>
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2025-01-19</Date>
+        <Update release="7">
+            <Date>2025-06-03</Date>
             <Version>25.01.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Add desktop appinfo file
- Add AppStream metainfo file
- Add application icon
- Add completions for Bash, Fish, and ZSH
- Use upstream Helix launcher, as ours used the wrong runtime path

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

- Open Budgie Menu and found Helix listed in applications.
- Ran `appstreamcli validate --explain` on the installed metainfo file
- Tested completions in Fish shell
- Edited and saved a file

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
