### PR TITLE
meson: Install autocompletions

### DIFF
--- a/packages/m/meson/package.yml
+++ b/packages/m/meson/package.yml
@@ -1,6 +1,6 @@
 name       : meson
 version    : 1.8.1
-release    : 67
+release    : 68
 source     :
     - https://github.com/mesonbuild/meson/releases/download/1.8.1/meson-1.8.1.tar.gz : b4e3b80e8fa633555abf447a95a700aba1585419467b2710d5e5bf88df0a7011
 homepage   : https://mesonbuild.com/
@@ -22,3 +22,7 @@ build      : |
     %python3_setup
 install    : |
     %python3_install
+    
+    # install autocompletions
+    install -Dm 00644 $workdir/data/shell-completions/bash/meson $installdir/usr/share/bash-completion/completions/meson
+    install -Dm 00644 $workdir/data/shell-completions/zsh/_meson $installdir/usr/share/zsh/site-functions/_meson

--- a/packages/m/meson/pspec_x86_64.xml
+++ b/packages/m/meson/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>meson</Name>
         <Homepage>https://mesonbuild.com/</Homepage>
         <Packager>
-            <Name>Automated Package Build</Name>
-            <Email>no.email.set.in.config</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>system.devel</PartOf>
@@ -737,17 +737,19 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/mesonbuild/wrap/__pycache__/wraptool.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/mesonbuild/wrap/wrap.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/mesonbuild/wrap/wraptool.py</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/meson</Path>
             <Path fileType="man">/usr/share/man/man1/meson.1</Path>
             <Path fileType="data">/usr/share/polkit-1/actions/com.mesonbuild.install.policy</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_meson</Path>
         </Files>
     </Package>
     <History>
-        <Update release="67">
-            <Date>2025-06-03</Date>
+        <Update release="68">
+            <Date>2025-06-04</Date>
             <Version>1.8.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Automated Package Build</Name>
-            <Email>no.email.set.in.config</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- meson includes bash and zsh autocompletions but are not install when building. This installs them.

**Test Plan**

run meson in command line and tab to see options

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
