### PR TITLE
stress-ng: Update to v0.19.01

### DIFF
--- a/packages/s/stress-ng/package.yml
+++ b/packages/s/stress-ng/package.yml
@@ -1,11 +1,11 @@
 name       : stress-ng
-version    : 0.18.12
-release    : 15
+version    : 0.19.01
+release    : 16
 source     :
-    - https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V0.18.12.tar.gz : 20401a5a52a3b3b5d84fbdd561e4daf1076b0368a1ccbbbc8d41af2be6ea6f34
+    - https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V0.19.01.tar.gz : 825e5004e6455dfb5a0483d810aeaeb0c96b8d2140e30629aaacea7292751198
 license    : GPL-2.0-or-later
 component  : system.utils
-homepage   : https://kernel.ubuntu.com/~cking/stress-ng/
+homepage   : https://github.com/ColinIanKing/stress-ng
 summary    : Multi-option stress test utility
 description: |
     stress-ng will stress test a computer system in various selectable ways. It was designed to exercise various physical subsystems of a computer as well as the various operating system kernel interfaces.

--- a/packages/s/stress-ng/pspec_x86_64.xml
+++ b/packages/s/stress-ng/pspec_x86_64.xml
@@ -1,7 +1,7 @@
 <PISI>
     <Source>
         <Name>stress-ng</Name>
-        <Homepage>https://kernel.ubuntu.com/~cking/stress-ng/</Homepage>
+        <Homepage>https://github.com/ColinIanKing/stress-ng</Homepage>
         <Packager>
             <Name>Robert Gonzalez</Name>
             <Email>uni.dos12@outlook.com</Email>
@@ -41,9 +41,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2025-04-28</Date>
-            <Version>0.18.12</Version>
+        <Update release="16">
+            <Date>2025-06-04</Date>
+            <Version>0.19.01</Version>
             <Comment>Packaging update</Comment>
             <Name>Robert Gonzalez</Name>
             <Email>uni.dos12@outlook.com</Email>


### PR DESCRIPTION
**Summary**
- update to 0.19 series
- change homepage to github as current one does not load

**Test Plan**

run s-tui and watch temps rise.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
