### PR TITLE
ypkg: Patch for python312

### DIFF
--- a/packages/y/ypkg/files/python312-compat.patch
+++ b/packages/y/ypkg/files/python312-compat.patch
@@ -1,0 +1,27 @@
+From 9d980c6da6d37244de2ef3ccdf7bcea0db5a2070 Mon Sep 17 00:00:00 2001
+From: Troy Harvey <harveydevel@gmail.com>
+Date: Thu, 5 Jun 2025 10:49:27 +1000
+Subject: [PATCH] Switch from readfp to read_file
+
+"configparser.ConfigParser no longer has a readfp method. Use read_file() instead."
+
+https://docs.python.org/3/whatsnew/3.12.html
+
+Signed-off-by: Troy Harvey <harveydevel@gmail.com>
+---
+ ypkg2/main.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ypkg2/main.py b/ypkg2/main.py
+index 0d31606..2a8d825 100644
+--- a/ypkg2/main.py
++++ b/ypkg2/main.py
+@@ -210,7 +210,7 @@ def build_package(filename, outputDir, buildDir=None):
+             continue
+         try:
+             c = configparser.ConfigParser()
+-            c.readfp(open(fpath))
++            c.read_file(open(fpath))
+             pname = c.get("Packager", "Name")
+             pemail = c.get("Packager", "Email")
+ 

--- a/packages/y/ypkg/package.yml
+++ b/packages/y/ypkg/package.yml
@@ -1,6 +1,6 @@
 name       : ypkg
 version    : '34'
-release    : 207
+release    : 208
 source     :
     - git|https://github.com/getsolus/ypkg.git : cf4745a723e6909c77aad85003769a6a7dec1dda
 homepage   : https://github.com/getsolus/ypkg
@@ -33,6 +33,8 @@ environment: |
     # ensure our nuitka build doesn't pull in -v3 hwcaps libs
     export GLIBC_TUNABLES=glibc.cpu.hwcaps=-AVX
 setup      : |
+    %patch -p1 -i $pkgfiles/python312-compat.patch
+
     %python3_setup
 build      : |
     # build static bins from ypkg

--- a/packages/y/ypkg/pspec_x86_64.xml
+++ b/packages/y/ypkg/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ypkg</Name>
         <Homepage>https://github.com/getsolus/ypkg</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.devel</PartOf>
@@ -75,12 +75,12 @@ Simply put, it is a tool to convert a build process into a packaging operation.
         </Files>
     </Package>
     <History>
-        <Update release="207">
-            <Date>2025-05-29</Date>
+        <Update release="208">
+            <Date>2025-06-05</Date>
             <Version>34</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Cherry-pick ConfigParser fix

**Test Plan**

- Build ypkg with patched ypkg and see that packager information is populated in pspec.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
