### PR TITLE
qutebrowser: Update to v3.5.1

### DIFF
--- a/packages/q/qutebrowser/package.yml
+++ b/packages/q/qutebrowser/package.yml
@@ -1,8 +1,8 @@
 name       : qutebrowser
-version    : 3.5.0
-release    : 50
+version    : 3.5.1
+release    : 51
 source     :
-    - https://github.com/qutebrowser/qutebrowser/releases/download/v3.5.0/qutebrowser-3.5.0.tar.gz : fa142c8d1c2825b068b71b3604a8b2d682e2ed84a14c3e68b6de7844331d80bb
+    - https://github.com/qutebrowser/qutebrowser/releases/download/v3.5.1/qutebrowser-3.5.1.tar.gz : 826bba328a08357248d5e5a86faab0a73655497439ad54d269e212055926b38e
 homepage   : https://qutebrowser.org
 license    : GPL-3.0-or-later
 component  : network.web.browser

--- a/packages/q/qutebrowser/pspec_x86_64.xml
+++ b/packages/q/qutebrowser/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>qutebrowser</Name>
         <Homepage>https://qutebrowser.org</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.web.browser</PartOf>
@@ -21,13 +21,13 @@
         <PartOf>network.web.browser</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/qutebrowser</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.0-py3.12.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.0-py3.12.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.0-py3.12.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.0-py3.12.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.0-py3.12.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.0-py3.12.egg-info/top_level.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.0-py3.12.egg-info/zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.1-py3.12.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.1-py3.12.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.1-py3.12.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.1-py3.12.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.1-py3.12.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.1-py3.12.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.1-py3.12.egg-info/zip-safe</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -772,12 +772,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="50">
-            <Date>2025-05-08</Date>
-            <Version>3.5.0</Version>
+        <Update release="51">
+            <Date>2025-06-05</Date>
+            <Version>3.5.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/qutebrowser/qutebrowser/blob/main/doc/changelog.asciidoc#v351-2025-06-05).

**Test Plan**
- Surfed the web.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
