### PR TITLE
syncthing: Update to v1.29.7

### DIFF
--- a/packages/s/syncthing/package.yml
+++ b/packages/s/syncthing/package.yml
@@ -1,9 +1,9 @@
 name       : syncthing
-version    : 1.29.6
-release    : 101
+version    : 1.29.7
+release    : 102
 homepage   : https://syncthing.net
 source     :
-    - https://github.com/syncthing/syncthing/archive/refs/tags/v1.29.6.tar.gz : 9731b302f3abcf08a29b0f404a46b26d1f3b89bec0e2bc40313471173da8358d
+    - https://github.com/syncthing/syncthing/archive/refs/tags/v1.29.7.tar.gz : 0e2f2574334fc65220977156caffc521314298c43b361a669ea3ea0507267652
 license    : MPL-2.0
 component  : network.util
 networking : yes

--- a/packages/s/syncthing/pspec_x86_64.xml
+++ b/packages/s/syncthing/pspec_x86_64.xml
@@ -50,9 +50,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="101">
-            <Date>2025-05-08</Date>
-            <Version>1.29.6</Version>
+        <Update release="102">
+            <Date>2025-06-06</Date>
+            <Version>1.29.7</Version>
             <Comment>Packaging update</Comment>
             <Name>Tracey Clark</Name>
             <Email>traceyc.dev@tlcnet.info</Email>


### PR DESCRIPTION
**Summary**

**Syncthing 2 is coming**

Syncthing version 1.x will soon be replaced by Syncthing version 2.x. Version 2 brings a new database format and various cleanups, but remains protocol compatible with Syncthing 1.

More detailed information about Syncthing 2 can be found in the release notes at [https://github.com/syncthing/syncthing/releases](https://github.com/syncthing/syncthing/releases).

**Fixes**
- fix(config): deep copy configuration defaults
- fix(config): mark audit log options as needing restart
- fix(versioner): fix perms of created folders
- fix(syncthing): ensure both config and data dirs exist at startup
- fix(gui): update `uncamel()` to handle strings like 'IDs'

**Features**
- feat(gui): close a modal when pressing ESC after switching modal tabs

Full changelog available [here](https://github.com/syncthing/syncthing/releases/)

**Test Plan**
- Restart Syncthing-GTK, use it to restart syncthing, verify all folders sync
- View syncthing gui in web browser, ensure everything looks good

**Checklist**

- [x] pkg was built and tested against unstable
