### PR TITLE
gnome-software: Enable show console applications

### DIFF
--- a/packages/g/gnome-software/files/0001-Show-console-apps.patch
+++ b/packages/g/gnome-software/files/0001-Show-console-apps.patch
@@ -1,0 +1,32 @@
+From 861d3b2d6642789c0be32d7a03501940c8916fb8 Mon Sep 17 00:00:00 2001
+From: Troy Harvey <harveydevel@gmail.com>
+Date: Sun, 8 Jun 2025 12:21:15 +1000
+Subject: [PATCH] Show console apps
+
+Signed-off-by: Troy Harvey <harveydevel@gmail.com>
+---
+ lib/gs-plugin-loader.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/lib/gs-plugin-loader.c b/lib/gs-plugin-loader.c
+index e2d08eaec..a2645087b 100644
+--- a/lib/gs-plugin-loader.c
++++ b/lib/gs-plugin-loader.c
+@@ -759,12 +759,13 @@ gs_plugin_loader_app_is_valid (GsApp               *app,
+ 		return FALSE;
+ 	}
+ 
+-	/* never show CLI apps */
++	/* never show CLI apps
+ 	if (gs_app_get_kind (app) == AS_COMPONENT_KIND_CONSOLE_APP) {
+ 		g_debug ("app invalid as console %s",
+ 			 gs_plugin_loader_get_app_str (app));
+ 		return FALSE;
+ 	}
++	*/
+ 
+ 	/* don't show unknown state */
+ 	if (gs_app_get_state (app) == GS_APP_STATE_UNKNOWN) {
+-- 
+2.49.0
+

--- a/packages/g/gnome-software/package.yml
+++ b/packages/g/gnome-software/package.yml
@@ -1,6 +1,6 @@
 name       : gnome-software
 version    : '48.2'
-release    : 26
+release    : 27
 source     :
     - https://download.gnome.org/sources/gnome-software/48/gnome-software-48.2.tar.xz : abfd30643a86c65f4886b6765eb3bb6215c9ea09817d6bd165c50056890822c9
 homepage   : https://apps.gnome.org/Software/
@@ -34,6 +34,7 @@ setup      : |
     # https://gitlab.gnome.org/GNOME/gnome-software/-/issues/2610
     %patch -p1 -i $pkgfiles/0001-packagekit-HACK-Disable-req.-for-repo-plugin-to-show.patch
     %patch -p1 -i $pkgfiles/0001-Allow-notification-to-autostart-on-all-editions.patch
+    %patch -p1 -i $pkgfiles/0001-Show-console-apps.patch
 
     %meson_configure \
         -Dpackagekit_autoremove=true \

--- a/packages/g/gnome-software/pspec_x86_64.xml
+++ b/packages/g/gnome-software/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-software</Name>
         <Homepage>https://apps.gnome.org/Software/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.gnome</PartOf>
@@ -383,7 +383,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="26">gnome-software</Dependency>
+            <Dependency release="27">gnome-software</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gnome-software/gnome-software.h</Path>
@@ -501,12 +501,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2025-06-03</Date>
+        <Update release="27">
+            <Date>2025-06-08</Date>
             <Version>48.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Discover shows console applications by default, make gnome-software do the same.

**Test Plan**

- See if wine is available as a native package.
- Install wine.

**Checklist**

- [X] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
