### PR TITLE
Split out font-noto-emoji into it's own package

### DIFF
--- a/packages/b/budgie-desktop-branding/package.yml
+++ b/packages/b/budgie-desktop-branding/package.yml
@@ -1,6 +1,6 @@
 name       : budgie-desktop-branding
 version    : '23.1'
-release    : 79
+release    : 80
 source     :
     - https://github.com/getsolus/budgie-desktop-branding/archive/refs/tags/v23.1.tar.gz : e5605da107e5f3a6659c323571d085381ee1021e5c4ce69f53635f651e1a9281
 homepage   : https://github.com/getsolus/budgie-desktop-branding
@@ -27,6 +27,7 @@ rundeps    :
     - budgie-backgrounds
     - budgie-desktop
     - font-hack-ttf
+    - font-noto-emoji
     - maliit-keyboard
     - materia-gtk-theme
     - materia-gtk-theme-dark

--- a/packages/b/budgie-desktop-branding/pspec_x86_64.xml
+++ b/packages/b/budgie-desktop-branding/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>budgie-desktop-branding</Name>
         <Homepage>https://github.com/getsolus/budgie-desktop-branding</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>desktop.budgie</PartOf>
@@ -36,7 +36,7 @@
         <Description xml:lang="en">Budgie LiveCD-specific Configuration</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="79">budgie-desktop-branding</Dependency>
+            <Dependency releaseFrom="80">budgie-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/glib-2.0/schemas/50_budgie_settings.gschema.override</Path>
@@ -44,12 +44,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="79">
-            <Date>2025-05-11</Date>
+        <Update release="80">
+            <Date>2025-06-08</Date>
             <Version>23.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/f/font-noto-emoji/files/noto-emoji.metainfo.xml
+++ b/packages/f/font-noto-emoji/files/noto-emoji.metainfo.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2025 Solus Developers <copyright@getsol.us -->
+<component type="font">
+  <id>com.google.noto-emoji</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Noto Emoji</name>
+  <url type="homepage">https://fonts.google.com/noto/specimen/Noto+Emoji</url>
+  <summary>Noto Emoji is an open source font that has you covered for all your emoji needs</summary>
+  <description>
+    <p>
+      Noto Emoji is an open source font that has you covered for all your emoji needs, including support for the latest Unicode emoji specification. It has multiple weights and features thousands of emoji.
+    </p>
+  </description>
+  <provides>
+    <font>Noto Color Emoji</font>
+  </provides>
+  <developer id="com.google">
+    <name>Google LLC</name>
+  </developer>
+</component>

--- a/packages/f/font-noto-emoji/monitoring.yaml
+++ b/packages/f/font-noto-emoji/monitoring.yaml
@@ -1,0 +1,5 @@
+releases:
+  id: 10556
+  rss: https://github.com/googlefonts/noto-emoji/releases.atom
+security:
+  cpe: ~ # Last checked 2025-06-08

--- a/packages/f/font-noto-emoji/package.yml
+++ b/packages/f/font-noto-emoji/package.yml
@@ -1,0 +1,15 @@
+name       : font-noto-emoji
+version    : 2.047
+release    : 1
+source     :
+    - https://github.com/googlefonts/noto-emoji/archive/refs/tags/v2.047.tar.gz : 2cfaf5a427eb26334cdb30d98e4a0c005b660504a339249dc54373e566f09b50
+homepage   : https://fonts.google.com/noto/specimen/Noto+Emoji
+license    : OFL-1.1
+component  : desktop.font
+summary    : Noto Emoji is an open source font that has you covered for all your emoji needs
+description: |
+    Noto Emoji is an open source font that has you covered for all your emoji needs, including support for the latest Unicode emoji specification. It has multiple weights and features thousands of emoji.
+install    : |
+    install -Dm00644 $pkgfiles/noto-emoji.metainfo.xml $installdir/usr/share/metainfo/noto-emoji.metainfo.xml
+
+    install -Dm00644 fonts/NotoColorEmoji.ttf $installdir/usr/share/fonts/truetype/noto-emoji/NotoColorEmoji.ttf

--- a/packages/f/font-noto-emoji/pspec_x86_64.xml
+++ b/packages/f/font-noto-emoji/pspec_x86_64.xml
@@ -1,0 +1,36 @@
+<PISI>
+    <Source>
+        <Name>font-noto-emoji</Name>
+        <Homepage>https://fonts.google.com/noto/specimen/Noto+Emoji</Homepage>
+        <Packager>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
+        </Packager>
+        <License>OFL-1.1</License>
+        <PartOf>desktop.font</PartOf>
+        <Summary xml:lang="en">Noto Emoji is an open source font that has you covered for all your emoji needs</Summary>
+        <Description xml:lang="en">Noto Emoji is an open source font that has you covered for all your emoji needs, including support for the latest Unicode emoji specification. It has multiple weights and features thousands of emoji.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>font-noto-emoji</Name>
+        <Summary xml:lang="en">Noto Emoji is an open source font that has you covered for all your emoji needs</Summary>
+        <Description xml:lang="en">Noto Emoji is an open source font that has you covered for all your emoji needs, including support for the latest Unicode emoji specification. It has multiple weights and features thousands of emoji.
+</Description>
+        <PartOf>desktop.font</PartOf>
+        <Files>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-emoji/NotoColorEmoji.ttf</Path>
+            <Path fileType="data">/usr/share/metainfo/noto-emoji.metainfo.xml</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2025-06-08</Date>
+            <Version>2.047</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
+        </Update>
+    </History>
+</PISI>

--- a/packages/g/gnome-desktop-branding/package.yml
+++ b/packages/g/gnome-desktop-branding/package.yml
@@ -1,6 +1,6 @@
 name       : gnome-desktop-branding
 version    : '19'
-release    : 56
+release    : 57
 source     :
     - git|https://github.com/getsolus/gnome-desktop-branding.git : 1c99fc38c128017ed5e80396d73e1bfdd3c5e964
 homepage   : https://github.com/getsolus/gnome-desktop-branding
@@ -26,6 +26,7 @@ rundeps    :
     - adw-gtk3-theme
     - breeze-cursor-theme
     - font-hack-ttf
+    - font-noto-emoji
     - gnome-browser-connector
     - gnome-shell
     - gnome-shell-extension-appindicator

--- a/packages/g/gnome-desktop-branding/pspec_x86_64.xml
+++ b/packages/g/gnome-desktop-branding/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-desktop-branding</Name>
         <Homepage>https://github.com/getsolus/gnome-desktop-branding</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>desktop.gnome</PartOf>
@@ -36,19 +36,19 @@
         <Description xml:lang="en">Solus 4.0 LiveCD configuration.</Description>
         <PartOf>desktop.gnome</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="56">gnome-desktop-branding</Dependency>
+            <Dependency releaseFrom="57">gnome-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/glib-2.0/schemas/50_gnome_livecd.gschema.override</Path>
         </Files>
     </Package>
     <History>
-        <Update release="56">
-            <Date>2025-01-18</Date>
+        <Update release="57">
+            <Date>2025-06-08</Date>
             <Version>19</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/m/mate-desktop-branding/package.yml
+++ b/packages/m/mate-desktop-branding/package.yml
@@ -1,6 +1,6 @@
 name       : mate-desktop-branding
 version    : '20'
-release    : 53
+release    : 54
 source     :
     - git|https://github.com/getsolus/mate-desktop-branding.git : aff4233d077caeb1be86ddc3208e1032c7b66c0d
 homepage   : https://github.com/getsolus/mate-desktop-branding
@@ -27,6 +27,7 @@ rundeps    :
     - breeze-cursor-theme
     - brisk-menu
     - font-hack-ttf
+    - font-noto-emoji
     - font-roboto-ttf
     - mate-notification-theme-slate
     - noto-sans-ttf

--- a/packages/m/mate-desktop-branding/pspec_x86_64.xml
+++ b/packages/m/mate-desktop-branding/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mate-desktop-branding</Name>
         <Homepage>https://github.com/getsolus/mate-desktop-branding</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>desktop.mate</PartOf>
@@ -37,7 +37,7 @@
         <Description xml:lang="en">Solus 4.0 MATE LiveCD configuration.</Description>
         <PartOf>desktop.mate</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="53">mate-desktop-branding</Dependency>
+            <Dependency releaseFrom="54">mate-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/glib-2.0/schemas/40_mate_settings_livecd.gschema.override</Path>
@@ -45,12 +45,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="53">
-            <Date>2024-05-21</Date>
+        <Update release="54">
+            <Date>2025-06-08</Date>
             <Version>20</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/n/noto-sans-ttf/files/noto-sans-ttf.metainfo.xml
+++ b/packages/n/noto-sans-ttf/files/noto-sans-ttf.metainfo.xml
@@ -1,14 +1,1046 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2024 Solus Developers <copyright@getsol.us -->
 <component type="font">
-  <id>noto-sans-ttf</id>
+  <id>com.google.noto-sans</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Noto Sans</name>
-  <url type="homepage">https://fonts.google.com/noto/</url>
-  <summary>A sans-serif variant of the Noto family created by Google.</summary>
+  <url type="homepage">https://fonts.google.com/noto/specimen/Noto+Sans</url>
+  <summary>Noto Sans is a global font collection for writing in all modern and ancient languages</summary>
   <description>
     <p>
-      Noto's goal is to provide a beautiful reading experience for all languages. It is a free, professionally-designed, open-source collection of fonts with a harmonious look and feel in multiple weights and styles.
+      Noto Sans is an unmodulated (“sans serif”) design for texts in the Latin, Cyrillic and Greek scripts, which is also suitable as the complementary choice for other script-specific Noto Sans fonts.
+    </p>
+    <p>
+      Noto Sans has italic styles, multiple weights and widths, contains 3,741 glyphs, 28 OpenType features, and supports 2,840 characters from 30 Unicode blocks: Latin Extended Additional, Cyrillic, Greek Extended, Latin Extended-B, Latin Extended-D, Latin Extended-A, Phonetic Extensions, Greek and Coptic, Combining Diacritical Marks, IPA Extensions, Cyrillic Extended-B, Latin-1 Supplement, General Punctuation, Basic Latin, Supplemental Punctuation, Spacing Modifier Letters, Letterlike Symbols, Phonetic Extensions Supplement, Combining Diacritical Marks Supplement, Latin Extended-E, Cyrillic Supplement, Currency Symbols, Latin Extended-C, Cyrillic Extended-A, Modifier Tone Letters, Superscripts and Subscripts, Combining Diacritical Marks Extended, Combining Half Marks, Cyrillic Extended-C, Alphabetic Presentation Forms.
     </p>
   </description>
+  <developer id="com.google">
+    <name>Google LLC</name>
+  </developer>
+  <provides>
+    <font>Noto Sans Lisu Bold</font>
+    <font>Noto Sans Mayan Numerals Regular</font>
+    <font>Noto Sans Meetei Mayek Light</font>
+    <font>Noto Sans New Tai Lue Semibold Regular</font>
+    <font>Noto Sans Hebrew Regular</font>
+    <font>Noto Sans Sinhala UI Condensed Thin</font>
+    <font>Noto Sans Gurmukhi SemiCondensed Light</font>
+    <font>Noto Sans Malayalam Condensed ExtraBold</font>
+    <font>Noto Sans Thai Looped Light</font>
+    <font>Noto Sans Malayalam Bold</font>
+    <font>Noto Sans SemiCondensed ExtraLight Italic</font>
+    <font>Noto Sans Test Regular</font>
+    <font>Noto Sans Mono Condensed Light</font>
+    <font>Noto Sans Kannada Condensed Light</font>
+    <font>Noto Sans Gurmukhi UI SemiCondensed ExtraBold</font>
+    <font>Noto Sans Devanagari SemiCondensed Black</font>
+    <font>Noto Sans Telugu SemiCondensed SemiBold</font>
+    <font>Noto Sans Tamil UI Condensed Medium</font>
+    <font>Noto Sans Hebrew Condensed Light</font>
+    <font>Noto Znamenny Musical Notation Regular</font>
+    <font>Noto Sans Mono Light</font>
+    <font>Noto Sans Lao Looped Medium</font>
+    <font>Noto Sans Tamil UI Light</font>
+    <font>Noto Kufi Arabic Regular</font>
+    <font>Noto Sans SemiBold Italic</font>
+    <font>Noto Sans Armenian SemiCondensed ExtraBold</font>
+    <font>Noto Sans Gujarati UI SemiCondensed SemiBold</font>
+    <font>Noto Sans Adlam Bold</font>
+    <font>Noto Sans Light</font>
+    <font>Noto Sans Gujarati UI Thin</font>
+    <font>Noto Sans Tamil Condensed Thin</font>
+    <font>Noto Sans Thai SemiCondensed SemiBold</font>
+    <font>Noto Sans Malayalam UI Condensed Thin</font>
+    <font>Noto Sans Devanagari Light</font>
+    <font>Noto Sans Sora Sompeng Semi Bold</font>
+    <font>Noto Sans Nabataean Regular</font>
+    <font>Noto Sans Lisu Medium</font>
+    <font>Noto Sans Malayalam UI SemiCondensed Light</font>
+    <font>Noto Sans Telugu Condensed Bold</font>
+    <font>Noto Sans Arabic UI Condensed Light</font>
+    <font>Noto Sans Condensed Medium</font>
+    <font>Noto Sans Tamil Thin</font>
+    <font>Noto Sans Hebrew Condensed Black</font>
+    <font>Noto Sans Devanagari Condensed ExtraBold</font>
+    <font>Noto Sans Psalter Pahlavi Regular</font>
+    <font>Noto Sans Khmer SemiCondensed</font>
+    <font>Noto Sans Cherokee Bold</font>
+    <font>Noto Sans Sinhala UI SemiCondensed Regular</font>
+    <font>Noto Sans Gurmukhi Medium</font>
+    <font>Noto Sans Gurmukhi Condensed Black</font>
+    <font>Noto Sans Ethiopic Condensed Thin</font>
+    <font>Noto Sans Gurmukhi SemiCondensed Thin</font>
+    <font>Noto Sans Telugu SemiCondensed ExtraBold</font>
+    <font>Noto Sans Gurmukhi Regular</font>
+    <font>Noto Sans Arabic UI Condensed ExtraBold</font>
+    <font>Noto Sans Lao Looped Light</font>
+    <font>Noto Sans Armenian SemiCondensed Bold</font>
+    <font>Noto Sans Arabic UI Light</font>
+    <font>Noto Sans Malayalam SemiBold</font>
+    <font>Noto Sans Lao Bold</font>
+    <font>Noto Sans Tamil SemiCondensed SemiBold</font>
+    <font>Noto Sans Mono Condensed SemiBold</font>
+    <font>Noto Sans Malayalam SemiCondensed Medium</font>
+    <font>Noto Sans Mono SemiCondensed Light</font>
+    <font>Noto Sans Tangsa SemiBold</font>
+    <font>Noto Sans Arabic UI SemiCondensed SemiBold</font>
+    <font>Noto Sans Tamil UI Regular</font>
+    <font>Noto Sans Brahmi Regular</font>
+    <font>Noto Sans Kannada SemiCondensed Medium</font>
+    <font>Noto Sans Tifinagh Air Regular</font>
+    <font>Noto Sans Tamil Condensed Bold</font>
+    <font>Noto Sans New Tai Lue Bold</font>
+    <font>Noto Sans Georgian Regular</font>
+    <font>Noto Sans Gurmukhi Condensed Light</font>
+    <font>Noto Sans Bengali Regular</font>
+    <font>Noto Sans Gujarati Condensed Bold</font>
+    <font>Noto Sans Sinhala Condensed SemiBold</font>
+    <font>Noto Sans Bold</font>
+    <font>Noto Sans Hebrew Thin</font>
+    <font>Noto Sans Ol Chiki Regular</font>
+    <font>Noto Sans Cypro Minoan Regular</font>
+    <font>Noto Sans Arabic UI SemiBold</font>
+    <font>Noto Sans Khmer Condensed Thin</font>
+    <font>Noto Sans Sinhala UI Condensed Bold</font>
+    <font>Noto Sans Ethiopic Regular</font>
+    <font>Noto Sans SemiCondensed Thin</font>
+    <font>Noto Sans Lisu SemiBold</font>
+    <font>Noto Sans Telugu SemiBold</font>
+    <font>Noto Sans Lao Looped Condensed Bold</font>
+    <font>Noto Sans Carian Regular</font>
+    <font>Noto Sans Telugu UI Light</font>
+    <font>Noto Sans Malayalam SemiCondensed Black</font>
+    <font>Noto Sans Mono SemiCondensed Bold</font>
+    <font>Noto Sans Malayalam Condensed Black</font>
+    <font>Noto Sans Tamil UI Condensed ExtraBold</font>
+    <font>Noto Sans Oriya Condensed</font>
+    <font>Noto Sans Sinhala UI SemiCondensed Bold</font>
+    <font>Noto Sans Tamil UI Thin</font>
+    <font>Noto Sans Medium</font>
+    <font>Noto Sans Lao Looped SemiCondensed Light</font>
+    <font>Noto Sans Lao Looped Condensed SemiBold</font>
+    <font>Noto Sans Elbasan Regular</font>
+    <font>Noto Sans Myanmar SemiCondensed ExtraBold</font>
+    <font>Noto Sans Kannada Condensed ExtraLight</font>
+    <font>Noto Sans Bamum Regular</font>
+    <font>Noto Sans Oriya Condensed Bold</font>
+    <font>Noto Sans Sinhala SemiCondensed Medium</font>
+    <font>Noto Sans Thai Looped SemiCondensed Light</font>
+    <font>Noto Sans Devanagari Condensed Bold</font>
+    <font>Noto Sans Rejang Regular</font>
+    <font>Noto Sans Devanagari UI Condensed ExtraBold</font>
+    <font>Noto Sans Arabic Medium</font>
+    <font>Noto Sans Myanmar Condensed Light</font>
+    <font>Noto Sans Arabic Condensed Light</font>
+    <font>Noto Sans Indic Siyaq Numbers Regular</font>
+    <font>Noto Sans Myanmar Condensed Regular</font>
+    <font>Noto Sans Buhid Regular</font>
+    <font>Noto Sans Tamil UI Medium</font>
+    <font>Noto Sans Malayalam UI Regular</font>
+    <font>Noto Sans Old Sogdian Regular</font>
+    <font>Noto Sans Gujarati UI Condensed ExtraBold</font>
+    <font>Noto Sans Ethiopic Condensed SemiBold</font>
+    <font>Noto Sans Canadian Aboriginal Bold</font>
+    <font>Noto Sans Kayah Li Regular</font>
+    <font>Noto Sans Georgian Condensed</font>
+    <font>Noto Sans Tamil SemiCondensed Thin</font>
+    <font>Noto Sans Kannada Bold</font>
+    <font>Noto Sans Lao SemiCondensed Light</font>
+    <font>Noto Sans Gunjala Gondi Bold</font>
+    <font>Noto Sans Thaana Regular</font>
+    <font>Noto Sans Gurmukhi UI Bold</font>
+    <font>Noto Sans SemiCondensed ExtraBold</font>
+    <font>Noto Sans Sogdian Regular</font>
+    <font>Noto Sans Kannada UI SemiCondensed Black</font>
+    <font>Noto Sans Kannada UI Condensed SemiBold</font>
+    <font>Noto Sans Egyptian Hieroglyphs Regular</font>
+    <font>Noto Sans Armenian Condensed Light</font>
+    <font>Noto Sans Lao Looped SemiCondensed SemiBold</font>
+    <font>Noto Sans Marchen Regular</font>
+    <font>Noto Sans Georgian Light</font>
+    <font>Noto Sans Anatolian Hieroglyphs Regular</font>
+    <font>Noto Sans Italic</font>
+    <font>Noto Fangsong KSS Rotated Regular</font>
+    <font>Noto Sans Bold Italic</font>
+    <font>Noto Sans Tamil UI SemiCondensed Regular</font>
+    <font>Noto Sans Lao Condensed Regular</font>
+    <font>Noto Sans Balinese Medium</font>
+    <font>Noto Sans Gujarati UI SemiCondensed Light</font>
+    <font>Noto Sans Telugu UI SemiCondensed Bold</font>
+    <font>Noto Sans Arabic SemiCondensed Medium</font>
+    <font>Noto Sans Gujarati Condensed ExtraLight</font>
+    <font>Noto Sans Tifinagh APT Regular</font>
+    <font>Noto Sans Sinhala UI Light</font>
+    <font>Noto Sans Syloti Nagri Regular</font>
+    <font>Noto Sans Khmer Light</font>
+    <font>Noto Sans Hebrew SemiCondensed Medium</font>
+    <font>Noto Sans Tagbanwa Regular</font>
+    <font>Noto Sans SemiCondensed Medium</font>
+    <font>Noto Sans Gujarati Light</font>
+    <font>Noto Sans Tamil Regular</font>
+    <font>Noto Sans Khmer Bold</font>
+    <font>Noto Sans Ogham Regular</font>
+    <font>Noto Sans Telugu Bold</font>
+    <font>Noto Sans Tamil SemiCondensed Regular</font>
+    <font>Noto Sans Mro Regular</font>
+    <font>Noto Sans Mono Condensed</font>
+    <font>Noto Sans Gurmukhi UI Regular</font>
+    <font>Noto Sans Armenian SemiCondensed SemiBold</font>
+    <font>Noto Sans Tifinagh Agraw Imazighen Regular</font>
+    <font>Noto Sans Lao Looped Condensed ExtraLight</font>
+    <font>Noto Sans Ethiopic Condensed ExtraBold</font>
+    <font>Noto Sans Sora Sompeng Bold</font>
+    <font>Noto Sans Myanmar SemiCondensed SemiBold</font>
+    <font>Noto Sans Sinhala Condensed Light</font>
+    <font>Noto Sans Khmer Regular</font>
+    <font>Noto Sans Tamil Condensed ExtraBold</font>
+    <font>Noto Sans Thai Looped Condensed Light</font>
+    <font>Noto Sans Devanagari UI Condensed Bold</font>
+    <font>Noto Sans Telugu UI SemiCondensed Thin</font>
+    <font>Noto Sans Lao Regular</font>
+    <font>Noto Sans Devanagari UI Regular</font>
+    <font>Noto Sans Arabic UI Condensed SemiBold</font>
+    <font>Noto Sans Tamil SemiCondensed ExtraBold</font>
+    <font>Noto Sans Mono Condensed ExtraLight</font>
+    <font>Noto Sans Kharoshthi Regular</font>
+    <font>Noto Sans Bamum Bold</font>
+    <font>Noto Sans Khmer SemiCondensed SemiBold</font>
+    <font>Noto Sans Tamil UI SemiCondensed ExtraBold</font>
+    <font>Noto Sans Malayalam Thin</font>
+    <font>Noto Sans Armenian Regular</font>
+    <font>Noto Sans Gurmukhi UI Condensed Bold</font>
+    <font>Noto Sans Mono Medium</font>
+    <font>Noto Sans Lao Looped SemiCondensed ExtraLight</font>
+    <font>Noto Sans Gurmukhi Bold</font>
+    <font>Noto Sans Devanagari UI Condensed Black</font>
+    <font>Noto Sans Malayalam UI Condensed Regular</font>
+    <font>Noto Sans Javanese Regular</font>
+    <font>Noto Sans Modi Regular</font>
+    <font>Noto Traditional Nushu Regular</font>
+    <font>Noto Sans Arabic SemiCondensed Thin</font>
+    <font>Noto Sans Telugu UI SemiCondensed Medium</font>
+    <font>Noto Sans Devanagari Condensed Light</font>
+    <font>Noto Sans Arabic UI Condensed Bold</font>
+    <font>Noto Sans Khmer SemiCondensed Light</font>
+    <font>Noto Sans Medefaidrin Regular</font>
+    <font>Noto Sans Lydian Regular</font>
+    <font>Noto Sans Kannada Condensed Medium</font>
+    <font>Noto Sans Devanagari SemiCondensed Bold</font>
+    <font>Noto Sans Condensed Bold Italic</font>
+    <font>Noto Sans Lao SemiCondensed Thin</font>
+    <font>Noto Sans Tagalog Regular</font>
+    <font>Noto Sans Mono Regular</font>
+    <font>Noto Sans Armenian SemiBold</font>
+    <font>Noto Sans Pahawh Hmong Regular</font>
+    <font>Noto Sans Cham Light</font>
+    <font>Noto Sans Gujarati SemiCondensed SemiBold</font>
+    <font>Noto Sans Myanmar Condensed Medium</font>
+    <font>Noto Sans Bengali UI Light</font>
+    <font>Noto Sans Bengali SemiBold</font>
+    <font>Noto Sans Sinhala UI Thin</font>
+    <font>Noto Sans Devanagari UI SemiCondensed Black</font>
+    <font>Noto Sans Nushu Regular</font>
+    <font>Noto Sans Lao Condensed Medium</font>
+    <font>Noto Sans Adlam Unjoined Bold</font>
+    <font>Noto Sans Javanese Bold</font>
+    <font>Noto Sans Bassa Vah Medium</font>
+    <font>Noto Sans Thaana Thin</font>
+    <font>Noto Sans Thai SemiCondensed ExtraLight</font>
+    <font>Noto Sans Sinhala Condensed ExtraBold</font>
+    <font>Noto Naskh Arabic Medium</font>
+    <font>Noto Sans Georgian Condensed Light</font>
+    <font>Noto Sans Ethiopic Thin</font>
+    <font>Noto Sans Thai Thin</font>
+    <font>Noto Sans Lao Condensed Black</font>
+    <font>Noto Sans Condensed Thin Italic</font>
+    <font>Noto Sans Tamil UI Condensed Regular</font>
+    <font>Noto Sans Gurmukhi UI SemiCondensed Thin</font>
+    <font>Noto Sans Malayalam SemiCondensed Bold</font>
+    <font>Noto Sans Devanagari Condensed ExtraLight</font>
+    <font>Noto Sans Gujarati UI Condensed</font>
+    <font>Noto Sans Wancho Regular</font>
+    <font>Noto Sans Gurmukhi SemiCondensed SemiBold</font>
+    <font>Noto Sans Lao Looped Condensed Black</font>
+    <font>Noto Sans Malayalam UI Condensed ExtraBold</font>
+    <font>Noto Sans Tai Tham Regular</font>
+    <font>Noto Sans Gurmukhi UI Condensed ExtraBold</font>
+    <font>Noto Sans Devanagari SemiCondensed</font>
+    <font>Noto Sans Tifinagh Rhissa Ixa Regular</font>
+    <font>Noto Sans Myanmar SemiCondensed Light</font>
+    <font>Noto Sans Bengali Bold</font>
+    <font>Noto Sans Tamil SemiCondensed ExtraLight</font>
+    <font>Noto Sans Gurmukhi UI Thin</font>
+    <font>Noto Sans Telugu Thin</font>
+    <font>Noto Sans Thai Looped SemiCondensed ExtraLight</font>
+    <font>Noto Sans Gunjala Gondi Medium</font>
+    <font>Noto Sans Armenian SemiCondensed ExtraLight</font>
+    <font>Noto Sans Kannada UI SemiCondensed</font>
+    <font>Noto Sans Condensed Black</font>
+    <font>Noto Sans Sora Sompeng Regular</font>
+    <font>Noto Sans Old South Arabian Regular</font>
+    <font>Noto Sans Gunjala Gondi Semibold Regular</font>
+    <font>Noto Sans Bengali Thin</font>
+    <font>Noto Sans Malayalam UI Condensed ExtraLight</font>
+    <font>Noto Sans Adlam Unjoined Regular</font>
+    <font>Noto Sans Arabic Condensed Black</font>
+    <font>Noto Sans Condensed Medium Italic</font>
+    <font>Noto Sans Gujarati SemiCondensed Light</font>
+    <font>Noto Sans Thai SemiCondensed Medium</font>
+    <font>Noto Sans Gujarati Condensed Light</font>
+    <font>Noto Sans Nag Mundari Bold</font>
+    <font>Noto Sans Malayalam UI Medium</font>
+    <font>Noto Sans Lao Looped SemiCondensed Bold</font>
+    <font>Noto Sans Gurmukhi Condensed Medium</font>
+    <font>Noto Sans Cherokee Light</font>
+    <font>Noto Sans Arabic UI SemiCondensed Thin</font>
+    <font>Noto Sans Thai Condensed SemiBold</font>
+    <font>Noto Sans Thai SemiCondensed</font>
+    <font>Noto Sans Masaram Gondi Regular</font>
+    <font>Noto Sans Lao Looped Condensed Regular</font>
+    <font>Noto Sans Medium Italic</font>
+    <font>Noto Sans Telugu Condensed Thin</font>
+    <font>Noto Sans Ethiopic Condensed Bold</font>
+    <font>Noto Sans Ethiopic SemiCondensed ExtraLight</font>
+    <font>Noto Sans Myanmar SemiCondensed Bold</font>
+    <font>Noto Sans Arabic SemiCondensed ExtraLight</font>
+    <font>Noto Sans Mono SemiBold</font>
+    <font>Noto Sans Canadian Aboriginal Light</font>
+    <font>Noto Sans Tifinagh Ahaggar Regular</font>
+    <font>Noto Sans Cherokee SemiBold</font>
+    <font>Noto Sans Gothic Regular</font>
+    <font>Noto Sans Armenian Condensed ExtraLight</font>
+    <font>Noto Sans Thaana Medium</font>
+    <font>Noto Sans Gurmukhi Condensed ExtraLight</font>
+    <font>Noto Sans Cham SemiBold</font>
+    <font>Noto Sans Gurmukhi Condensed ExtraBold</font>
+    <font>Noto Sans Bengali UI Medium</font>
+    <font>Noto Sans Sinhala UI Condensed Black</font>
+    <font>Noto Sans Cherokee Thin</font>
+    <font>Noto Sans Thai Looped Bold</font>
+    <font>Noto Sans Ugaritic Regular</font>
+    <font>Noto Sans Vithkuqi SemiBold</font>
+    <font>Noto Sans Adlam Regular</font>
+    <font>Noto Sans Tamil Condensed Regular</font>
+    <font>Noto Sans Gujarati UI SemiCondensed Thin</font>
+    <font>Noto Sans Tamil Condensed SemiBold</font>
+    <font>Noto Sans Georgian SemiCondensed Light</font>
+    <font>Noto Sans Nandinagari Regular</font>
+    <font>Noto Sans Telugu UI SemiCondensed Light</font>
+    <font>Noto Sans Osage Regular</font>
+    <font>Noto Sans Tamil Condensed ExtraLight</font>
+    <font>Noto Sans Khmer SemiCondensed Thin</font>
+    <font>Noto Sans Devanagari UI Condensed ExtraLight</font>
+    <font>Noto Sans Telugu SemiCondensed Black</font>
+    <font>Noto Sans Malayalam UI SemiBold</font>
+    <font>Noto Sans Telugu UI Condensed ExtraBold</font>
+    <font>Noto Sans Sinhala UI Condensed SemiBold</font>
+    <font>Noto Sans Gujarati SemiBold</font>
+    <font>Noto Sans SemiCondensed Light Italic</font>
+    <font>Noto Sans Sinhala UI Condensed Light</font>
+    <font>Noto Sans Gujarati UI Condensed ExtraLight</font>
+    <font>Noto Sans Telugu Medium</font>
+    <font>Noto Sans Thai Medium</font>
+    <font>Noto Sans Kannada SemiCondensed SemiBold</font>
+    <font>Noto Sans Tamil Bold</font>
+    <font>Noto Music Regular</font>
+    <font>Noto Sans Sundanese SemiBold</font>
+    <font>Noto Sans Mono Condensed Thin</font>
+    <font>Noto Sans Zanabazar Square Regular</font>
+    <font>Noto Sans Tangsa Bold</font>
+    <font>Noto Kufi Arabic Thin</font>
+    <font>Noto Sans Arabic UI Condensed</font>
+    <font>Noto Sans Ethiopic SemiCondensed Bold</font>
+    <font>Noto Sans Ethiopic Light</font>
+    <font>Noto Sans Malayalam UI SemiCondensed Black</font>
+    <font>Noto Sans Syriac Thin</font>
+    <font>Noto Sans Sinhala SemiCondensed ExtraBold</font>
+    <font>Noto Sans Condensed</font>
+    <font>Noto Sans Lao Condensed Light</font>
+    <font>Noto Sans Condensed SemiBold</font>
+    <font>Noto Sans Kaithi Regular</font>
+    <font>Noto Sans Old Italic Regular</font>
+    <font>Noto Sans Malayalam Medium</font>
+    <font>Noto Sans Linear A Regular</font>
+    <font>Noto Sans Georgian Condensed SemiBold</font>
+    <font>Noto Sans Lao Medium</font>
+    <font>Noto Sans Thai Condensed</font>
+    <font>Noto Sans Gujarati Condensed Medium</font>
+    <font>Noto Sans Cham Regular</font>
+    <font>Noto Sans Devanagari SemiCondensed Thin</font>
+    <font>Noto Sans Arabic SemiCondensed Light</font>
+    <font>Noto Sans Arabic UI Condensed ExtraLight</font>
+    <font>Noto Sans Kannada UI SemiCondensed Medium</font>
+    <font>Noto Rashi Hebrew SemiBold</font>
+    <font>Noto Sans Kannada SemiCondensed Black</font>
+    <font>Noto Sans Gurmukhi SemiCondensed Regular</font>
+    <font>Noto Sans Symbols Bold</font>
+    <font>Noto Sans Kannada UI Bold</font>
+    <font>Noto Sans Hebrew SemiCondensed Black</font>
+    <font>Noto Nastaliq Urdu Regular</font>
+    <font>Noto Sans Devanagari UI Condensed Regular</font>
+    <font>Noto Sans Medefaidrin Bold</font>
+    <font>Noto Sans Myanmar Light</font>
+    <font>Noto Sans Malayalam Condensed ExtraLight</font>
+    <font>Noto Sans Arabic UI SemiCondensed</font>
+    <font>Noto Sans Georgian Condensed ExtraBold</font>
+    <font>Noto Sans Kannada UI Thin</font>
+    <font>Noto Sans Malayalam UI Condensed Bold</font>
+    <font>Noto Sans Tamil UI SemiCondensed Medium</font>
+    <font>Noto Sans Vithkuqi Medium</font>
+    <font>Noto Sans Thai Looped Condensed Medium</font>
+    <font>Noto Sans Hanifi Rohingya Medium</font>
+    <font>Noto Sans Condensed Italic</font>
+    <font>Noto Sans Telugu UI Condensed Medium</font>
+    <font>Noto Sans Tamil Supplement Regular</font>
+    <font>Noto Sans Tamil Condensed Medium</font>
+    <font>Noto Sans Malayalam Condensed Bold</font>
+    <font>Noto Sans Armenian SemiCondensed Light</font>
+    <font>Noto Sans Malayalam UI Thin</font>
+    <font>Noto Sans Thai Condensed Medium</font>
+    <font>Noto Sans Malayalam Condensed Regular</font>
+    <font>Noto Sans Kayah Li Medium</font>
+    <font>Noto Sans Myanmar Condensed Thin</font>
+    <font>Noto Sans Kannada UI SemiCondensed ExtraLight</font>
+    <font>Noto Sans Sinhala UI Regular</font>
+    <font>Noto Sans Gurmukhi UI SemiBold</font>
+    <font>Noto Sans Gujarati SemiCondensed ExtraLight</font>
+    <font>Noto Sans Tamil Light</font>
+    <font>Noto Sans Georgian SemiCondensed Thin</font>
+    <font>Noto Sans Hanifi Rohingya Regular</font>
+    <font>Noto Sans Thin</font>
+    <font>Noto Sans Armenian Condensed SemiBold</font>
+    <font>Noto Sans Sinhala UI SemiCondensed Medium</font>
+    <font>Noto Sans Malayalam UI SemiCondensed ExtraLight</font>
+    <font>Noto Naskh Arabic UI Semi Bold</font>
+    <font>Noto Sans Gujarati Condensed ExtraBold</font>
+    <font>Noto Sans SemiCondensed Black Italic</font>
+    <font>Noto Sans Thai Regular</font>
+    <font>Noto Sans Thai Condensed Bold</font>
+    <font>Noto Sans Buginese Regular</font>
+    <font>Noto Sans Pau Cin Hau Regular</font>
+    <font>Noto Sans Syriac Eastern Regular</font>
+    <font>Noto Sans Tamil UI Bold</font>
+    <font>Noto Sans Lepcha Regular</font>
+    <font>Noto Sans Gurmukhi UI Light</font>
+    <font>Noto Sans Thai Looped SemiCondensed SemiBold</font>
+    <font>Noto Sans SemiCondensed SemiBold Italic</font>
+    <font>Noto Sans Limbu Regular</font>
+    <font>Noto Sans Thaana SemiBold</font>
+    <font>Noto Sans Gurmukhi UI SemiCondensed Medium</font>
+    <font>Noto Sans Hebrew SemiCondensed Bold</font>
+    <font>Noto Sans Vai Regular</font>
+    <font>Noto Sans Khmer Condensed Medium</font>
+    <font>Noto Sans Georgian SemiCondensed ExtraBold</font>
+    <font>Noto Sans Syriac Eastern Thin</font>
+    <font>Noto Traditional Nushu Light</font>
+    <font>Noto Sans Armenian Condensed Medium</font>
+    <font>Noto Sans Tamil Medium</font>
+    <font>Noto Sans Khojki Regular</font>
+    <font>Noto Sans Sinhala UI Condensed Medium</font>
+    <font>Noto Sans Gujarati Condensed Black</font>
+    <font>Noto Sans Gujarati UI Condensed Medium</font>
+    <font>Noto Sans Imperial Aramaic Regular</font>
+    <font>Noto Sans Yi Regular</font>
+    <font>Noto Sans Tai Tham Bold</font>
+    <font>Noto Sans Armenian Condensed Thin</font>
+    <font>Noto Sans Duployan Regular</font>
+    <font>Noto Sans Gujarati UI Condensed SemiBold</font>
+    <font>Noto Sans Mono SemiCondensed Thin</font>
+    <font>Noto Sans Hebrew SemiBold</font>
+    <font>Noto Sans Syriac Western Thin</font>
+    <font>Noto Sans Khmer Condensed Light</font>
+    <font>Noto Sans Khmer Condensed</font>
+    <font>Noto Sans Old Hungarian Regular</font>
+    <font>Noto Sans Hebrew Medium</font>
+    <font>Noto Sans Kawi Bold</font>
+    <font>Noto Sans Soyombo Regular</font>
+    <font>Noto Sans Devanagari SemiCondensed ExtraBold</font>
+    <font>Noto Sans Miao Regular</font>
+    <font>Noto Sans Malayalam SemiCondensed Regular</font>
+    <font>Noto Sans Thai Bold</font>
+    <font>Noto Naskh Arabic UI Bold</font>
+    <font>Noto Sans Condensed Thin</font>
+    <font>Noto Sans Kannada UI Condensed Black</font>
+    <font>Noto Sans Devanagari UI SemiCondensed Medium</font>
+    <font>Noto Sans Myanmar Condensed ExtraLight</font>
+    <font>Noto Sans Tamil UI Condensed Thin</font>
+    <font>Noto Sans Devanagari UI Condensed Thin</font>
+    <font>Noto Sans Tifinagh Adrar Regular</font>
+    <font>Noto Sans Armenian Condensed ExtraBold</font>
+    <font>Noto Sans Thai Looped Condensed Thin</font>
+    <font>Noto Sans Batak Regular</font>
+    <font>Noto Sans Kannada UI Condensed Medium</font>
+    <font>Noto Sans Hebrew SemiCondensed</font>
+    <font>Noto Sans Georgian Condensed Medium</font>
+    <font>Noto Sans Hebrew Condensed Bold</font>
+    <font>Noto Sans Devanagari Condensed</font>
+    <font>Noto Sans Lao Looped SemiCondensed Regular</font>
+    <font>Noto Sans Telugu UI Condensed Light</font>
+    <font>Noto Sans Hebrew Condensed ExtraBold</font>
+    <font>Noto Sans Telugu SemiCondensed ExtraLight</font>
+    <font>Noto Sans Thai Looped Condensed SemiBold</font>
+    <font>Noto Sans Thaana Light</font>
+    <font>Noto Sans Runic Regular</font>
+    <font>Noto Sans Malayalam UI Condensed Medium</font>
+    <font>Noto Sans Gujarati UI Condensed Thin</font>
+    <font>Noto Sans Arabic UI Condensed Black</font>
+    <font>Noto Sans Balinese SemiBold</font>
+    <font>Noto Sans Sora Sompeng Medium</font>
+    <font>Noto Sans Thai Looped Condensed ExtraBold</font>
+    <font>Noto Sans Gurmukhi Condensed Regular</font>
+    <font>Noto Sans Khmer Condensed SemiBold</font>
+    <font>Noto Sans Sharada Regular</font>
+    <font>Noto Sans Thai Looped Regular</font>
+    <font>Noto Sans Myanmar Thin</font>
+    <font>Noto Sans Mono SemiCondensed Medium</font>
+    <font>Noto Sans Sinhala Condensed Thin</font>
+    <font>Noto Sans Myanmar SemiCondensed Thin</font>
+    <font>Noto Sans Gujarati Thin</font>
+    <font>Noto Sans Telugu SemiCondensed</font>
+    <font>Noto Sans Khmer SemiCondensed ExtraBold</font>
+    <font>Noto Sans Sinhala SemiCondensed Bold</font>
+    <font>Noto Sans Thai Looped Medium</font>
+    <font>Noto Sans Condensed Bold</font>
+    <font>Noto Sans Sinhala Condensed Regular</font>
+    <font>Noto Sans Ol Chiki Bold</font>
+    <font>Noto Sans Mono Condensed ExtraBold</font>
+    <font>Noto Sans Arabic SemiCondensed SemiBold</font>
+    <font>Noto Sans Devanagari UI SemiCondensed Thin</font>
+    <font>Noto Sans Kannada SemiCondensed Bold</font>
+    <font>Noto Sans Tamil UI SemiCondensed ExtraLight</font>
+    <font>Noto Sans Arabic Thin</font>
+    <font>Noto Sans Gujarati UI Light</font>
+    <font>Noto Sans Georgian SemiCondensed SemiBold</font>
+    <font>Noto Sans Tamil UI Condensed Bold</font>
+    <font>Noto Sans Gujarati UI Medium</font>
+    <font>Noto Sans Tifinagh Tawellemmet Regular</font>
+    <font>Noto Sans Thai SemiCondensed Light</font>
+    <font>Noto Sans Inscriptional Parthian Regular</font>
+    <font>Noto Sans Meetei Mayek Thin</font>
+    <font>Noto Sans Gurmukhi UI Condensed Black</font>
+    <font>Noto Sans Condensed Light Italic</font>
+    <font>Noto Sans Phoenician Regular</font>
+    <font>Noto Sans Telugu UI SemiCondensed</font>
+    <font>Noto Sans Telugu SemiCondensed Thin</font>
+    <font>Noto Sans SemiCondensed Light</font>
+    <font>Noto Sans Malayalam SemiCondensed SemiBold</font>
+    <font>Noto Sans Cham Medium</font>
+    <font>Noto Sans Medefaidrin Medium</font>
+    <font>Noto Sans Thai Looped SemiCondensed ExtraBold</font>
+    <font>Noto Sans Duployan Bold</font>
+    <font>Noto Sans Chakma Regular</font>
+    <font>Noto Sans Kannada UI Regular</font>
+    <font>Noto Sans Bengali UI SemiCondensed Regular</font>
+    <font>Noto Sans Arabic Bold</font>
+    <font>Noto Sans Regular</font>
+    <font>Noto Sans Kannada Condensed Thin</font>
+    <font>Noto Sans Tifinagh Hawad Regular</font>
+    <font>Noto Sans Telugu UI Condensed</font>
+    <font>Noto Sans Arabic Condensed</font>
+    <font>Noto Sans Kayah Li Bold</font>
+    <font>Noto Sans Kannada Thin</font>
+    <font>Noto Sans Tamil UI Condensed SemiBold</font>
+    <font>Noto Sans Multani Regular</font>
+    <font>Noto Sans Devanagari Bold</font>
+    <font>Noto Sans Arabic UI Condensed Thin</font>
+    <font>Noto Sans Old North Arabian Regular</font>
+    <font>Noto Sans Gujarati UI SemiCondensed Black</font>
+    <font>Noto Sans Ethiopic Condensed ExtraLight</font>
+    <font>Noto Sans Arabic SemiCondensed ExtraBold</font>
+    <font>Noto Sans Hanifi Rohingya SemiBold</font>
+    <font>Noto Sans Ethiopic Condensed Medium</font>
+    <font>Noto Sans Gurmukhi UI SemiCondensed Black</font>
+    <font>Noto Naskh Arabic SemiBold</font>
+    <font>Noto Sans Ethiopic SemiCondensed Black</font>
+    <font>Noto Sans Arabic Condensed SemiBold</font>
+    <font>Noto Sans Armenian Condensed</font>
+    <font>Noto Sans Sinhala UI SemiCondensed Thin</font>
+    <font>Noto Sans Cuneiform Regular</font>
+    <font>Noto Sans Khmer Condensed ExtraBold</font>
+    <font>Noto Sans Hanunoo Regular</font>
+    <font>Noto Sans NKo Regular</font>
+    <font>Noto Sans Tamil UI SemiCondensed Thin</font>
+    <font>Noto Sans Gujarati Condensed Thin</font>
+    <font>Noto Sans Devanagari Medium</font>
+    <font>Noto Sans Devanagari Condensed Medium</font>
+    <font>Noto Sans Cham Thin</font>
+    <font>Noto Naskh Arabic UI Regular</font>
+    <font>Noto Sans Lao Looped Bold</font>
+    <font>Noto Sans Sinhala UI SemiCondensed Light</font>
+    <font>Noto Sans Georgian SemiBold</font>
+    <font>Noto Sans Lao SemiCondensed Black</font>
+    <font>Noto Sans Hanifi Rohingya Bold</font>
+    <font>Noto Sans Thai Looped SemiCondensed Thin</font>
+    <font>Noto Sans Sinhala Condensed Medium</font>
+    <font>Noto Sans Cypriot Regular</font>
+    <font>Noto Sans Gurmukhi Condensed SemiBold</font>
+    <font>Noto Sans Telugu Condensed Black</font>
+    <font>Noto Naskh Arabic UI Medium</font>
+    <font>Noto Sans Gurmukhi UI Condensed ExtraLight</font>
+    <font>Noto Sans Georgian SemiCondensed ExtraLight</font>
+    <font>Noto Sans Sinhala UI SemiCondensed SemiBold</font>
+    <font>Noto Sans Devanagari SemiCondensed ExtraLight</font>
+    <font>Noto Sans Caucasian Albanian Regular</font>
+    <font>Noto Sans SemiCondensed</font>
+    <font>Noto Sans Tifinagh Regular</font>
+    <font>Noto Sans Kannada SemiCondensed</font>
+    <font>Noto Sans Bamum SemiBold</font>
+    <font>Noto Sans Arabic UI SemiCondensed Black</font>
+    <font>Noto Sans Mono Thin</font>
+    <font>Noto Sans Tifinagh Ghat Regular</font>
+    <font>Noto Sans Palmyrene Regular</font>
+    <font>Noto Sans Arabic Condensed ExtraBold</font>
+    <font>Noto Sans Sinhala Condensed ExtraLight</font>
+    <font>Noto Sans Thai SemiCondensed ExtraBold</font>
+    <font>Noto Sans Symbols Regular</font>
+    <font>Noto Sans Condensed SemiBold Italic</font>
+    <font>Noto Sans Mono Condensed Bold</font>
+    <font>Noto Sans Gurmukhi UI Condensed Medium</font>
+    <font>Noto Sans Saurashtra Regular</font>
+    <font>Noto Sans Lao Condensed ExtraLight</font>
+    <font>Noto Sans Ethiopic SemiCondensed ExtraBold</font>
+    <font>Noto Sans Malayalam UI Light</font>
+    <font>Noto Sans Devanagari UI SemiCondensed SemiBold</font>
+    <font>Noto Sans Lao Condensed Bold</font>
+    <font>Noto Sans Sinhala Light</font>
+    <font>Noto Sans Sinhala SemiCondensed ExtraLight</font>
+    <font>Noto Kufi Arabic Light</font>
+    <font>Noto Sans Malayalam Regular</font>
+    <font>Noto Sans Condensed ExtraBold Italic</font>
+    <font>Noto Sans Gujarati Bold</font>
+    <font>Noto Sans Ethiopic Bold</font>
+    <font>Noto Sans Telugu UI Condensed Thin</font>
+    <font>Noto Sans Myanmar Bold</font>
+    <font>Noto Sans Light Italic</font>
+    <font>Noto Sans Thai Looped SemiCondensed Regular</font>
+    <font>Noto Sans Linear B Regular</font>
+    <font>Noto Sans Tamil UI SemiCondensed Bold</font>
+    <font>Noto Sans Inscriptional Pahlavi Regular</font>
+    <font>Noto Sans Thai Condensed ExtraBold</font>
+    <font>Noto Sans Siddham Regular</font>
+    <font>Noto Sans Bengali UI SemiBold</font>
+    <font>Noto Sans Arabic UI Bold</font>
+    <font>Noto Sans Oriya Condensed Black</font>
+    <font>Noto Sans SemiCondensed Bold</font>
+    <font>Noto Sans Gujarati SemiCondensed Thin</font>
+    <font>Noto Sans Lao SemiCondensed Medium</font>
+    <font>Noto Sans Takri Regular</font>
+    <font>Noto Sans Malayalam SemiCondensed ExtraBold</font>
+    <font>Noto Sans Devanagari UI SemiCondensed ExtraBold</font>
+    <font>Noto Sans Devanagari UI Condensed SemiBold</font>
+    <font>Noto Sans Cherokee Regular</font>
+    <font>Noto Sans Condensed Black Italic</font>
+    <font>Noto Sans Gujarati UI Condensed Bold</font>
+    <font>Noto Sans SemiCondensed Medium Italic</font>
+    <font>Noto Sans Oriya Bold</font>
+    <font>Noto Sans Arabic Regular</font>
+    <font>Noto Sans Gujarati UI SemiCondensed</font>
+    <font>Noto Sans Mandaic Regular</font>
+    <font>Noto Sans Telugu Condensed ExtraBold</font>
+    <font>Noto Sans Deseret Regular</font>
+    <font>Noto Sans Arabic Condensed Medium</font>
+    <font>Noto Sans Condensed ExtraBold</font>
+    <font>Noto Sans Coptic Regular</font>
+    <font>Noto Sans Armenian Condensed Black</font>
+    <font>Noto Sans Telugu Condensed</font>
+    <font>Noto Sans Georgian SemiCondensed</font>
+    <font>Noto Sans Sinhala UI SemiCondensed ExtraLight</font>
+    <font>Noto Sans Khmer SemiCondensed Medium</font>
+    <font>Noto Sans Georgian SemiCondensed Medium</font>
+    <font>Noto Sans Telugu Light</font>
+    <font>Noto Sans Georgian Thin</font>
+    <font>Noto Sans Gujarati UI SemiBold</font>
+    <font>Noto Sans Malayalam UI Condensed Black</font>
+    <font>Noto Sans Thai Looped Condensed Regular</font>
+    <font>Noto Sans Ethiopic SemiCondensed Thin</font>
+    <font>Noto Sans Kannada UI SemiCondensed Bold</font>
+    <font>Noto Sans Ethiopic Condensed Light</font>
+    <font>Noto Kufi Arabic Bold</font>
+    <font>Noto Sans Vithkuqi Bold</font>
+    <font>Noto Sans Thai SemiCondensed Black</font>
+    <font>Noto Sans Arabic UI Regular</font>
+    <font>Noto Sans NKo Unjoined Bold</font>
+    <font>Noto Sans New Tai Lue Medium</font>
+    <font>Noto Sans Condensed ExtraLight</font>
+    <font>Noto Sans Thai Condensed Light</font>
+    <font>Noto Sans Kayah Li SemiBold</font>
+    <font>Noto Rashi Hebrew Medium</font>
+    <font>Noto Sans Malayalam SemiCondensed Light</font>
+    <font>Noto Sans Kannada UI Condensed ExtraLight</font>
+    <font>Noto Sans Elymaic Regular</font>
+    <font>Noto Sans Ol Chiki SemiBold</font>
+    <font>Noto Naskh Arabic Bold</font>
+    <font>Noto Sans Mono Condensed Medium</font>
+    <font>Noto Sans Georgian Condensed Bold</font>
+    <font>Noto Sans Bengali Light</font>
+    <font>Noto Sans Ol Chiki Medium</font>
+    <font>Noto Sans Mahajani Regular</font>
+    <font>Noto Sans Lao Condensed SemiBold</font>
+    <font>Noto Sans Tai Le Regular</font>
+    <font>Noto Sans SemiCondensed Bold Italic</font>
+    <font>Noto Sans Devanagari UI Condensed Light</font>
+    <font>Noto Sans Lao SemiCondensed Bold</font>
+    <font>Noto Sans Gurmukhi SemiCondensed Bold</font>
+    <font>Noto Sans Hebrew Condensed Thin</font>
+    <font>Noto Rashi Hebrew Regular</font>
+    <font>Noto Sans Tangsa Medium</font>
+    <font>Noto Sans Khmer SemiCondensed Bold</font>
+    <font>Noto Sans Telugu UI Bold</font>
+    <font>Noto Sans Oriya Thin</font>
+    <font>Noto Sans Thaana Bold</font>
+    <font>Noto Sans Georgian Medium</font>
+    <font>Noto Sans Arabic UI Medium</font>
+    <font>Noto Sans Sinhala SemiBold</font>
+    <font>Noto Sans Georgian Bold</font>
+    <font>Noto Sans Kannada SemiCondensed Thin</font>
+    <font>Noto Sans Lao Light</font>
+    <font>Noto Sans Mongolian Regular</font>
+    <font>Noto Sans Symbols Thin</font>
+    <font>Noto Sans Tamil UI Condensed Black</font>
+    <font>Noto Sans Symbols Light</font>
+    <font>Noto Sans Thai SemiBold</font>
+    <font>Noto Sans Sinhala UI Medium</font>
+    <font>Noto Sans Gujarati SemiCondensed Black</font>
+    <font>Noto Sans Kannada UI Medium</font>
+    <font>Noto Sans Balinese Regular</font>
+    <font>Noto Sans Thin Italic</font>
+    <font>Noto Sans Avestan Regular</font>
+    <font>Noto Sans Kannada UI Condensed Light</font>
+    <font>Noto Sans Meetei Mayek Regular</font>
+    <font>Noto Sans Thai Looped Condensed Black</font>
+    <font>Noto Sans Hebrew Light</font>
+    <font>Noto Sans Devanagari Condensed Thin</font>
+    <font>Noto Sans Arabic SemiCondensed</font>
+    <font>Noto Sans Arabic Condensed Thin</font>
+    <font>Noto Sans Sinhala SemiCondensed Black</font>
+    <font>Noto Sans Ethiopic SemiBold</font>
+    <font>Noto Sans Lao Looped Condensed ExtraBold</font>
+    <font>Noto Sans Arabic UI SemiCondensed Light</font>
+    <font>Noto Sans Kannada UI SemiBold</font>
+    <font>Noto Sans Condensed ExtraLight Italic</font>
+    <font>Noto Sans Kannada Condensed Black</font>
+    <font>Noto Sans SignWriting Regular</font>
+    <font>Noto Sans Lao Looped Condensed Light</font>
+    <font>Noto Sans Tifinagh SIL Regular</font>
+    <font>Noto Sans Tamil SemiBold</font>
+    <font>Noto Rashi Hebrew Thin</font>
+    <font>Noto Sans Devanagari Condensed Black</font>
+    <font>Noto Sans Oriya Condensed Thin</font>
+    <font>Noto Sans Samaritan Regular</font>
+    <font>Noto Sans Ethiopic Condensed Black</font>
+    <font>Noto Sans Gurmukhi UI Medium</font>
+    <font>Noto Sans Sundanese Regular</font>
+    <font>Noto Sans Devanagari SemiCondensed Medium</font>
+    <font>Noto Sans Hatran Regular</font>
+    <font>Noto Sans Malayalam UI Condensed Light</font>
+    <font>Noto Sans Sinhala Regular</font>
+    <font>Noto Sans Hebrew SemiCondensed ExtraBold</font>
+    <font>Noto Sans Ethiopic SemiCondensed SemiBold</font>
+    <font>Noto Sans Telugu UI Condensed SemiBold</font>
+    <font>Noto Sans Lao Looped SemiCondensed Black</font>
+    <font>Noto Sans Lao Looped Condensed Medium</font>
+    <font>Noto Sans Symbols Medium</font>
+    <font>Noto Sans Gujarati UI Condensed Light</font>
+    <font>Noto Sans Malayalam SemiCondensed Thin</font>
+    <font>Noto Sans Condensed Light</font>
+    <font>Noto Sans Tamil SemiCondensed Bold</font>
+    <font>Noto Sans Devanagari UI SemiCondensed Regular</font>
+    <font>Noto Sans Bengali UI Condensed Regular</font>
+    <font>Noto Sans Devanagari SemiCondensed SemiBold</font>
+    <font>Noto Sans Kannada Condensed ExtraBold</font>
+    <font>Noto Sans Mono SemiCondensed Black</font>
+    <font>Noto Sans Bassa Vah Regular</font>
+    <font>Noto Sans Lao SemiCondensed ExtraBold</font>
+    <font>Noto Sans Hebrew SemiCondensed ExtraLight</font>
+    <font>Noto Sans Bengali UI Bold</font>
+    <font>Noto Sans Thai Condensed Black</font>
+    <font>Noto Sans Gurmukhi UI SemiCondensed Regular</font>
+    <font>Noto Nastaliq Urdu Bold</font>
+    <font>Noto Sans Gujarati UI SemiCondensed ExtraBold</font>
+    <font>Noto Sans Khmer Thin</font>
+    <font>Noto Sans Arabic SemiCondensed Bold</font>
+    <font>Noto Sans Sinhala UI Bold</font>
+    <font>Noto Sans Malayalam Condensed SemiBold</font>
+    <font>Noto Fangsong KSS Vertical Regular</font>
+    <font>Noto Sans Gujarati UI Regular</font>
+    <font>Noto Sans Kannada Regular</font>
+    <font>Noto Sans Tai Tham SemiBold</font>
+    <font>Noto Sans Khmer Condensed ExtraLight</font>
+    <font>Noto Sans Kannada Light</font>
+    <font>Noto Sans SemiCondensed Thin Italic</font>
+    <font>Noto Sans Malayalam Condensed Light</font>
+    <font>Noto Sans Tamil UI SemiBold</font>
+    <font>Noto Sans Lao Condensed Thin</font>
+    <font>Noto Sans Gujarati Condensed SemiBold</font>
+    <font>Noto Sans SemiCondensed Black</font>
+    <font>Noto Sans Thai SemiCondensed Thin</font>
+    <font>Noto Sans Sinhala SemiCondensed Light</font>
+    <font>Noto Sans Malayalam UI SemiCondensed Thin</font>
+    <font>Noto Sans Kannada UI SemiCondensed SemiBold</font>
+    <font>Noto Sans Telugu UI Condensed Bold</font>
+    <font>Noto Sans Telugu UI Condensed Black</font>
+    <font>Noto Sans Georgian Condensed Black</font>
+    <font>Noto Sans Telugu SemiCondensed Medium</font>
+    <font>Noto Sans Old Turkic Regular</font>
+    <font>Noto Sans Telugu UI SemiCondensed SemiBold</font>
+    <font>Noto Sans New Tai Lue Regular</font>
+    <font>Noto Sans Gujarati SemiCondensed Bold</font>
+    <font>Noto Sans Gurmukhi SemiCondensed Medium</font>
+    <font>Noto Sans Kannada UI Condensed</font>
+    <font>Noto Sans Warang Citi Regular</font>
+    <font>Noto Sans Meroitic Regular</font>
+    <font>Noto Sans Gurmukhi Thin</font>
+    <font>Noto Sans Manichaean Regular</font>
+    <font>Noto Sans Mende Kikakui Regular</font>
+    <font>Noto Sans SemiCondensed ExtraBold Italic</font>
+    <font>Noto Sans Sinhala Thin</font>
+    <font>Noto Sans Meetei Mayek SemiBold</font>
+    <font>Noto Sans Chorasmian Regular</font>
+    <font>Noto Sans Devanagari SemiBold</font>
+    <font>Noto Sans Georgian Condensed Thin</font>
+    <font>Noto Sans Khmer Medium</font>
+    <font>Noto Sans Symbols 2 Regular</font>
+    <font>Noto Sans Kannada UI SemiCondensed Light</font>
+    <font>Noto Sans Kannada SemiCondensed ExtraBold</font>
+    <font>Noto Sans Sinhala SemiCondensed Regular</font>
+    <font>Noto Sans Telugu UI Regular</font>
+    <font>Noto Sans Tamil UI SemiCondensed SemiBold</font>
+    <font>Noto Sans Gurmukhi Condensed Thin</font>
+    <font>Noto Sans Telugu UI SemiCondensed ExtraBold</font>
+    <font>Noto Sans Gurmukhi SemiCondensed ExtraLight</font>
+    <font>Noto Sans Myanmar SemiCondensed ExtraLight</font>
+    <font>Noto Sans Lao Looped SemiCondensed Thin</font>
+    <font>Noto Sans Myanmar Regular</font>
+    <font>Noto Sans Myanmar Medium</font>
+    <font>Noto Sans Khmer SemiCondensed ExtraLight</font>
+    <font>Noto Sans Kawi Regular</font>
+    <font>Noto Sans Arabic UI SemiCondensed Medium</font>
+    <font>Noto Sans Armenian SemiCondensed</font>
+    <font>Noto Sans NKo Unjoined Regular</font>
+    <font>Noto Sans Myanmar Condensed ExtraBold</font>
+    <font>Noto Sans Ethiopic SemiCondensed Medium</font>
+    <font>Noto Sans Gujarati SemiCondensed Medium</font>
+    <font>Noto Sans Malayalam UI SemiCondensed Bold</font>
+    <font>Noto Sans Georgian SemiCondensed Black</font>
+    <font>Noto Sans Cherokee Medium</font>
+    <font>Noto Sans Mono SemiCondensed ExtraBold</font>
+    <font>Noto Sans Canadian Aboriginal Thin</font>
+    <font>Noto Sans Khmer SemiBold</font>
+    <font>Noto Sans Canadian Aboriginal SemiBold</font>
+    <font>Noto Sans Devanagari Condensed SemiBold</font>
+    <font>Noto Sans Khudawadi Regular</font>
+    <font>Noto Sans Gujarati UI SemiCondensed Medium</font>
+    <font>Noto Sans Hebrew Condensed ExtraLight</font>
+    <font>Noto Sans Malayalam UI Condensed SemiBold</font>
+    <font>Noto Sans Lao Condensed ExtraBold</font>
+    <font>Noto Sans Devanagari Regular</font>
+    <font>Noto Sans Bamum Medium</font>
+    <font>Noto Sans Grantha Regular</font>
+    <font>Noto Sans Lao SemiCondensed Regular</font>
+    <font>Noto Sans Canadian Aboriginal Medium</font>
+    <font>Noto Sans Armenian Light</font>
+    <font>Noto Sans Tai Viet Regular</font>
+    <font>Noto Sans Gurmukhi UI SemiCondensed Bold</font>
+    <font>Noto Sans Kannada SemiCondensed ExtraLight</font>
+    <font>Noto Sans Myanmar Condensed Bold</font>
+    <font>Noto Sans SemiBold</font>
+    <font>Noto Sans Sinhala UI Condensed Regular</font>
+    <font>Noto Sans Lao Thin</font>
+    <font>Noto Sans Telugu UI Condensed ExtraLight</font>
+    <font>Noto Traditional Nushu Bold</font>
+    <font>Noto Sans Tai Tham Medium</font>
+    <font>Noto Sans Kannada Condensed</font>
+    <font>Noto Sans Gunjala Gondi Regular</font>
+    <font>Noto Sans Kannada UI SemiCondensed ExtraBold</font>
+    <font>Noto Sans Gurmukhi UI SemiCondensed SemiBold</font>
+    <font>Noto Sans Gurmukhi SemiCondensed Black</font>
+    <font>Noto Sans Georgian Condensed ExtraLight</font>
+    <font>Noto Sans Hebrew Condensed SemiBold</font>
+    <font>Noto Sans PhagsPa Regular</font>
+    <font>Noto Sans Ethiopic Condensed Regular</font>
+    <font>Noto Sans Hebrew Condensed</font>
+    <font>Noto Sans Arabic Light</font>
+    <font>Noto Sans Tangsa Regular</font>
+    <font>Noto Sans Mono Bold</font>
+    <font>Noto Sans Tamil UI SemiCondensed Black</font>
+    <font>Noto Sans Gujarati UI Bold</font>
+    <font>Noto Sans Malayalam Light</font>
+    <font>Noto Sans Telugu SemiCondensed Light</font>
+    <font>Noto Sans Khmer Condensed Bold</font>
+    <font>Noto Sans Old Permic Regular</font>
+    <font>Noto Sans Hebrew Condensed Medium</font>
+    <font>Noto Sans Tamil SemiCondensed Black</font>
+    <font>Noto Sans Telugu UI Thin</font>
+    <font>Noto Sans Newa Regular</font>
+    <font>Noto Sans Hebrew SemiCondensed SemiBold</font>
+    <font>Noto Sans Kannada Medium</font>
+    <font>Noto Sans Lao Looped SemiBold</font>
+    <font>Noto Sans Devanagari UI SemiCondensed Light</font>
+    <font>Noto Sans Gujarati UI SemiCondensed ExtraLight</font>
+    <font>Noto Sans Gurmukhi UI Condensed Light</font>
+    <font>Noto Sans Meetei Mayek Bold</font>
+    <font>Noto Sans Telugu SemiCondensed Bold</font>
+    <font>Noto Sans Devanagari UI SemiCondensed Bold</font>
+    <font>Noto Sans Glagolitic Regular</font>
+    <font>Noto Sans Syriac Regular</font>
+    <font>Noto Sans Cham Bold</font>
+    <font>Noto Sans Kannada SemiBold</font>
+    <font>Noto Sans Sundanese Bold</font>
+    <font>Noto Sans Devanagari Thin</font>
+    <font>Noto Sans Lao Looped Thin</font>
+    <font>Noto Sans Lao Looped Regular</font>
+    <font>Noto Sans Arabic UI SemiCondensed Bold</font>
+    <font>Noto Sans Telugu UI SemiBold</font>
+    <font>Noto Sans Telugu UI SemiCondensed ExtraLight</font>
+    <font>Noto Rashi Hebrew Bold</font>
+    <font>Noto Sans Kannada UI Light</font>
+    <font>Noto Sans Tamil SemiCondensed Medium</font>
+    <font>Noto Sans Sinhala UI Condensed ExtraBold</font>
+    <font>Noto Sans Devanagari UI Thin</font>
+    <font>Noto Sans Sinhala UI SemiCondensed Black</font>
+    <font>Noto Kufi Arabic Medium</font>
+    <font>Noto Sans Oriya Regular</font>
+    <font>Noto Sans Arabic Condensed Bold</font>
+    <font>Noto Sans SemiCondensed Italic</font>
+    <font>Noto Sans Nag Mundari Regular</font>
+    <font>Noto Sans Lao Looped SemiCondensed ExtraBold</font>
+    <font>Noto Sans Thai Light</font>
+    <font>Noto Sans Hebrew SemiCondensed Thin</font>
+    <font>Noto Sans Myanmar SemiCondensed Medium</font>
+    <font>Noto Sans Thai Looped SemiBold</font>
+    <font>Noto Sans Gurmukhi UI SemiCondensed Light</font>
+    <font>Noto Sans Gujarati SemiCondensed</font>
+    <font>Noto Sans Lycian Regular</font>
+    <font>Noto Sans Bassa Vah SemiBold</font>
+    <font>Noto Sans Kannada Condensed Bold</font>
+    <font>Noto Sans Thai SemiCondensed Bold</font>
+    <font>Noto Sans Gujarati SemiCondensed ExtraBold</font>
+    <font>Noto Sans Georgian SemiCondensed Bold</font>
+    <font>Noto Sans Khmer SemiCondensed Black</font>
+    <font>Noto Sans Telugu Regular</font>
+    <font>Noto Sans Sinhala SemiCondensed Thin</font>
+    <font>Noto Sans Mono Condensed Black</font>
+    <font>Noto Sans Kannada UI SemiCondensed Thin</font>
+    <font>Noto Sans Devanagari UI Bold</font>
+    <font>Noto Sans Thai Looped SemiCondensed Medium</font>
+    <font>Noto Sans Lao SemiCondensed ExtraLight</font>
+    <font>Noto Sans Devanagari SemiCondensed Light</font>
+    <font>Noto Sans Gurmukhi Condensed Bold</font>
+    <font>Noto Sans Tifinagh Azawagh Regular</font>
+    <font>Noto Sans Malayalam UI SemiCondensed Medium</font>
+    <font>Noto Sans Balinese Bold</font>
+    <font>Noto Sans Arabic UI SemiCondensed ExtraLight</font>
+    <font>Noto Sans Telugu UI SemiCondensed Black</font>
+    <font>Noto Sans Bassa Vah Bold</font>
+    <font>Noto Sans Devanagari UI SemiBold</font>
+    <font>Noto Sans Gurmukhi UI SemiCondensed ExtraLight</font>
+    <font>Noto Sans Gujarati UI SemiCondensed Bold</font>
+    <font>Noto Sans Telugu Condensed SemiBold</font>
+    <font>Noto Sans Myanmar SemiCondensed Regular</font>
+    <font>Noto Sans Armenian SemiCondensed Thin</font>
+    <font>Noto Sans Gurmukhi SemiBold</font>
+    <font>Noto Sans Bhaiksuki Regular</font>
+    <font>Noto Sans Tirhuta Regular</font>
+    <font>Noto Sans Arabic SemiCondensed Black</font>
+    <font>Noto Sans Telugu Condensed Medium</font>
+    <font>Noto Sans Bengali Condensed Regular</font>
+    <font>Noto Sans Malayalam UI Bold</font>
+    <font>Noto Sans Tamil UI Condensed Light</font>
+    <font>Noto Sans Thai Looped SemiCondensed Bold</font>
+    <font>Noto Sans Gujarati Condensed</font>
+    <font>Noto Sans Mono SemiCondensed SemiBold</font>
+    <font>Noto Sans Kannada Condensed SemiBold</font>
+    <font>Noto Sans Arabic UI Thin</font>
+    <font>Noto Sans Armenian Bold</font>
+    <font>Noto Sans Hebrew Bold</font>
+    <font>Noto Sans Hebrew SemiCondensed Light</font>
+    <font>Noto Sans SemiCondensed ExtraLight</font>
+    <font>Noto Sans Thai Condensed ExtraLight</font>
+    <font>Noto Sans Kannada UI Condensed Bold</font>
+    <font>Noto Sans Sinhala Medium</font>
+    <font>Noto Sans Myanmar SemiCondensed Black</font>
+    <font>Noto Sans Lao SemiCondensed SemiBold</font>
+    <font>Noto Sans Thai Looped Condensed Bold</font>
+    <font>Noto Sans Sinhala UI SemiCondensed ExtraBold</font>
+    <font>Noto Sans Math Regular</font>
+    <font>Noto Sans Telugu UI Medium</font>
+    <font>Noto Sans Armenian Medium</font>
+    <font>Noto Sans Gurmukhi UI Condensed Thin</font>
+    <font>Noto Sans Tamil SemiCondensed Light</font>
+    <font>Noto Sans Malayalam UI SemiCondensed ExtraBold</font>
+    <font>Noto Sans Telugu Condensed ExtraLight</font>
+    <font>Noto Sans Arabic Condensed ExtraLight</font>
+    <font>Noto Sans Sinhala Condensed Black</font>
+    <font>Noto Sans Tamil UI SemiCondensed Light</font>
+    <font>Noto Sans Bengali Medium</font>
+    <font>Noto Sans Telugu Condensed Light</font>
+    <font>Noto Sans Armenian SemiCondensed Black</font>
+    <font>Noto Sans Gurmukhi UI Condensed SemiBold</font>
+    <font>Noto Sans Thai Looped Thin</font>
+    <font>Noto Sans Armenian Condensed Bold</font>
+    <font>Noto Sans Gujarati Medium</font>
+    <font>Noto Sans Khmer Condensed Black</font>
+    <font>Noto Sans Myanmar Condensed SemiBold</font>
+    <font>Noto Sans Arabic SemiBold</font>
+    <font>Noto Sans Medefaidrin SemiBold</font>
+    <font>Noto Sans Tamil Condensed Light</font>
+    <font>Noto Kufi Arabic SemiBold</font>
+    <font>Noto Sans Armenian Thin</font>
+    <font>Noto Sans Lao SemiBold</font>
+    <font>Noto Sans Armenian SemiCondensed Medium</font>
+    <font>Noto Sans Tamil UI Condensed ExtraLight</font>
+    <font>Noto Sans Myanmar SemiBold</font>
+    <font>Noto Sans Arabic UI Condensed Medium</font>
+    <font>Noto Sans Thai Looped Condensed ExtraLight</font>
+    <font>Noto Sans Gurmukhi UI Condensed Regular</font>
+    <font>Noto Sans Meetei Mayek Medium</font>
+    <font>Noto Sans Malayalam Condensed Thin</font>
+    <font>Noto Sans Sinhala UI SemiBold</font>
+    <font>Noto Sans Devanagari UI Medium</font>
+    <font>Noto Sans Mono SemiCondensed ExtraLight</font>
+    <font>Noto Sans Gurmukhi SemiCondensed ExtraBold</font>
+    <font>Noto Sans Bengali UI Regular</font>
+    <font>Noto Sans Canadian Aboriginal Regular</font>
+    <font>Noto Sans Sinhala Condensed Bold</font>
+    <font>Noto Naskh Arabic Regular</font>
+    <font>Noto Sans Osmanya Regular</font>
+    <font>Noto Sans SemiCondensed SemiBold</font>
+    <font>Noto Sans Tamil Condensed Black</font>
+    <font>Noto Sans Malayalam SemiCondensed ExtraLight</font>
+    <font>Noto Sans Ethiopic Medium</font>
+    <font>Noto Sans Malayalam Condensed Medium</font>
+    <font>Noto Sans Sinhala SemiCondensed SemiBold</font>
+    <font>Noto Sans Kannada UI Condensed ExtraBold</font>
+    <font>Noto Sans Ethiopic SemiCondensed Regular</font>
+    <font>Noto Sans Gujarati UI Condensed Black</font>
+    <font>Noto Sans Thai Looped SemiCondensed Black</font>
+    <font>Noto Sans Symbols SemiBold</font>
+    <font>Noto Sans Sinhala UI Condensed ExtraLight</font>
+    <font>Noto Sans Malayalam UI SemiCondensed Regular</font>
+    <font>Noto Sans Thai Condensed Thin</font>
+    <font>Noto Sans Ethiopic SemiCondensed Light</font>
+    <font>Noto Sans Sundanese Medium</font>
+    <font>Noto Sans Gujarati Regular</font>
+    <font>Noto Rashi Hebrew Light</font>
+    <font>Noto Sans Devanagari UI SemiCondensed ExtraLight</font>
+    <font>Noto Sans Lao Looped SemiCondensed Medium</font>
+    <font>Noto Sans Devanagari UI Condensed Medium</font>
+    <font>Noto Sans Malayalam UI SemiCondensed SemiBold</font>
+    <font>Noto Sans Syriac Western Regular</font>
+    <font>Noto Sans Vithkuqi Regular</font>
+    <font>Noto Sans Devanagari UI Light</font>
+    <font>Noto Sans Bengali UI Thin</font>
+    <font>Noto Sans Lao Looped Condensed Thin</font>
+    <font>Noto Sans Lisu Regular</font>
+    <font>Noto Sans Sinhala Bold</font>
+    <font>Noto Sans Bengali SemiCondensed Regular</font>
+    <font>Noto Sans Shavian Regular</font>
+    <font>Noto Sans Old Persian Regular</font>
+    <font>Noto Sans Kannada SemiCondensed Light</font>
+    <font>Noto Sans Gurmukhi Light</font>
+    <font>Noto Sans Mono SemiCondensed</font>
+    <font>Noto Sans Myanmar Condensed Black</font>
+    <font>Noto Sans Kannada UI Condensed Thin</font>
+    <font>Noto Sans Arabic UI SemiCondensed ExtraBold</font>
+  </provides>
 </component>

--- a/packages/n/noto-sans-ttf/files/noto-serif-ttf.metainfo.xml
+++ b/packages/n/noto-sans-ttf/files/noto-serif-ttf.metainfo.xml
@@ -1,14 +1,500 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2024 Solus Developers <copyright@getsol.us -->
 <component type="font">
-  <id>noto-serif-ttf</id>
+  <id>com.google.noto-serif</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Noto Serif</name>
-  <url type="homepage">https://fonts.google.com/noto/</url>
-  <summary>A serif variant of the Noto family created by Google.</summary>
+  <url type="homepage">https://fonts.google.com/noto/specimen/Noto+Serif</url>
+  <summary>Noto Serif is a global font collection for writing in all modern and ancient languages</summary>
   <description>
     <p>
-      Noto's goal is to provide a beautiful reading experience for all languages. It is a free, professionally-designed, open-source collection of fonts with a harmonious look and feel in multiple weights and styles.
+      Noto Serif is a modulated (“serif”) design for texts in the Latin, Cyrillic and Greek scripts, also suitable as the complementary font for other script-specific Noto Serif fonts.
+    </p>
+    <p>
+      Noto Serif has italic styles, multiple weights and widths, contains 3,256 glyphs, 24 OpenType features, and supports 2,840 characters from 30 Unicode blocks: Latin Extended Additional, Cyrillic, Greek Extended, Latin Extended-B, Latin Extended-D, Latin Extended-A, Phonetic Extensions, Greek and Coptic, Combining Diacritical Marks, IPA Extensions, Cyrillic Extended-B, Latin-1 Supplement, General Punctuation, Basic Latin, Supplemental Punctuation, Spacing Modifier Letters, Letterlike Symbols, Phonetic Extensions Supplement, Combining Diacritical Marks Supplement, Latin Extended-E, Cyrillic Supplement, Currency Symbols, Latin Extended-C, Cyrillic Extended-A, Modifier Tone Letters, Superscripts and Subscripts, Combining Diacritical Marks Extended, Combining Half Marks, Cyrillic Extended-C, Alphabetic Presentation Forms.
     </p>
   </description>
+  <developer id="com.google">
+    <name>Google LLC</name>
+  </developer>
+  <provides>
+    <font>Noto Serif Georgian SemiCondensed Bold</font>
+    <font>Noto Serif Gurmukhi SemiBold</font>
+    <font>Noto Serif Georgian Condensed ExtraLight</font>
+    <font>Noto Serif Display SemiCondensed Light Italic</font>
+    <font>Noto Serif SemiCondensed ExtraBold</font>
+    <font>Noto Serif Bengali Condensed SemiBold</font>
+    <font>Noto Serif Lao Condensed ExtraBold</font>
+    <font>Noto Serif Hebrew Condensed SemiBold</font>
+    <font>Noto Serif Yezidi Medium</font>
+    <font>Noto Serif Thai SemiBold</font>
+    <font>Noto Serif Yezidi Bold</font>
+    <font>Noto Serif Ethiopic SemiCondensed Regular</font>
+    <font>Noto Serif Sinhala Bold</font>
+    <font>Noto Serif Tangut Regular</font>
+    <font>Noto Serif Tamil Medium Italic</font>
+    <font>Noto Serif Display Condensed Black Italic</font>
+    <font>Noto Serif Tamil SemiCondensed Black Italic</font>
+    <font>Noto Serif Tamil SemiCondensed Light Italic</font>
+    <font>Noto Serif Display Thin</font>
+    <font>Noto Serif Display Condensed Black</font>
+    <font>Noto Serif SemiCondensed Black Italic</font>
+    <font>Noto Serif Georgian Condensed ExtraBold</font>
+    <font>Noto Serif Toto SemiBold</font>
+    <font>Noto Serif Display Bold</font>
+    <font>Noto Serif Hebrew Regular</font>
+    <font>Noto Serif Hebrew SemiCondensed</font>
+    <font>Noto Serif Condensed Bold Italic</font>
+    <font>Noto Serif Medium Italic</font>
+    <font>Noto Serif Tamil SemiCondensed ExtraLight Italic</font>
+    <font>Noto Serif Gurmukhi Medium</font>
+    <font>Noto Serif Tamil SemiCondensed Bold</font>
+    <font>Noto Serif Thai SemiCondensed Light</font>
+    <font>Noto Serif Myanmar Condensed ExtraLight</font>
+    <font>Noto Serif Lao SemiCondensed Black</font>
+    <font>Noto Serif Armenian Thin</font>
+    <font>Noto Serif Display Condensed Light</font>
+    <font>Noto Serif SemiCondensed Light</font>
+    <font>Noto Serif Bengali SemiCondensed Bold</font>
+    <font>Noto Serif SemiCondensed Medium</font>
+    <font>Noto Serif Thai Bold</font>
+    <font>Noto Serif Ethiopic SemiCondensed ExtraBold</font>
+    <font>Noto Serif Khmer SemiCondensed Light</font>
+    <font>Noto Serif Display Condensed SemiBold Italic</font>
+    <font>Noto Serif Vithkuqi Regular</font>
+    <font>Noto Serif Georgian SemiCondensed SemiBold</font>
+    <font>Noto Serif Display Light Italic</font>
+    <font>Noto Serif Armenian Bold</font>
+    <font>Noto Serif Tamil Condensed Thin Italic</font>
+    <font>Noto Serif Myanmar Condensed Regular</font>
+    <font>Noto Serif Condensed ExtraBold Italic</font>
+    <font>Noto Serif SemiCondensed ExtraLight</font>
+    <font>Noto Serif Myanmar Condensed SemiBold</font>
+    <font>Noto Serif Khmer Condensed Black</font>
+    <font>Noto Serif SemiCondensed Thin</font>
+    <font>Noto Serif Khmer Condensed Thin</font>
+    <font>Noto Serif Oriya Medium</font>
+    <font>Noto Serif Armenian Condensed Medium</font>
+    <font>Noto Serif Thai SemiCondensed ExtraLight</font>
+    <font>Noto Serif Tamil Condensed Regular</font>
+    <font>Noto Serif Devanagari Condensed</font>
+    <font>Noto Serif Khmer Condensed</font>
+    <font>Noto Serif Malayalam Thin</font>
+    <font>Noto Serif Hebrew Condensed Black</font>
+    <font>Noto Serif Myanmar SemiCondensed Bold</font>
+    <font>Noto Serif Display SemiCondensed Thin</font>
+    <font>Noto Serif Tamil SemiCondensed SemiBold</font>
+    <font>Noto Serif Lao SemiBold</font>
+    <font>Noto Serif Display SemiCondensed ExtraBold</font>
+    <font>Noto Serif Lao Condensed Bold</font>
+    <font>Noto Serif Tamil SemiCondensed Thin Italic</font>
+    <font>Noto Serif Myanmar Condensed Black</font>
+    <font>Noto Serif Display Condensed SemiBold</font>
+    <font>Noto Serif Hebrew SemiCondensed Light</font>
+    <font>Noto Serif Myanmar Light</font>
+    <font>Noto Serif Georgian SemiCondensed ExtraLight</font>
+    <font>Noto Serif Devanagari Condensed Thin</font>
+    <font>Noto Serif Thai SemiCondensed ExtraBold</font>
+    <font>Noto Serif Display Condensed Thin Italic</font>
+    <font>Noto Serif Thai Thin</font>
+    <font>Noto Serif Condensed Medium</font>
+    <font>Noto Serif SemiCondensed Bold</font>
+    <font>Noto Serif Sinhala Regular</font>
+    <font>Noto Serif Bengali Condensed Light</font>
+    <font>Noto Serif Telugu Light</font>
+    <font>Noto Serif Thin</font>
+    <font>Noto Serif Tamil Condensed Thin</font>
+    <font>Noto Serif Hebrew SemiCondensed SemiBold</font>
+    <font>Noto Serif Georgian SemiCondensed Thin</font>
+    <font>Noto Serif Hebrew Condensed Thin</font>
+    <font>Noto Serif Kannada SemiBold</font>
+    <font>Noto Serif Tamil SemiBold</font>
+    <font>Noto Serif Tamil Condensed SemiBold Italic</font>
+    <font>Noto Serif Display SemiCondensed Medium</font>
+    <font>Noto Serif Sinhala SemiCondensed Light</font>
+    <font>Noto Serif Ethiopic SemiCondensed Light</font>
+    <font>Noto Serif Khitan Small Script Regular</font>
+    <font>Noto Serif Bengali SemiCondensed ExtraLight</font>
+    <font>Noto Serif Sinhala Condensed Regular</font>
+    <font>Noto Serif Kannada Thin</font>
+    <font>Noto Serif Georgian SemiCondensed Medium</font>
+    <font>Noto Serif Thai SemiCondensed Black</font>
+    <font>Noto Serif Sinhala SemiCondensed Regular</font>
+    <font>Noto Serif Ethiopic SemiCondensed Bold</font>
+    <font>Noto Serif Hebrew Condensed</font>
+    <font>Noto Serif Hebrew Light</font>
+    <font>Noto Serif Myanmar Condensed ExtraBold</font>
+    <font>Noto Serif Tamil Thin Italic</font>
+    <font>Noto Serif Tamil Condensed ExtraBold Italic</font>
+    <font>Noto Serif Khmer SemiCondensed Black</font>
+    <font>Noto Serif Tibetan Thin</font>
+    <font>Noto Serif Myanmar Condensed Medium</font>
+    <font>Noto Serif Khmer Condensed Medium</font>
+    <font>Noto Serif Thai SemiCondensed Bold</font>
+    <font>Noto Serif Display SemiCondensed Bold Italic</font>
+    <font>Noto Serif Devanagari SemiCondensed</font>
+    <font>Noto Serif Lao SemiCondensed Medium</font>
+    <font>Noto Serif Telugu Thin</font>
+    <font>Noto Serif Vithkuqi Medium</font>
+    <font>Noto Serif Armenian Regular</font>
+    <font>Noto Serif Sinhala Condensed Medium</font>
+    <font>Noto Serif Condensed SemiBold</font>
+    <font>Noto Serif Khmer Condensed Bold</font>
+    <font>Noto Serif Display SemiCondensed Black</font>
+    <font>Noto Serif Georgian Light</font>
+    <font>Noto Serif Hebrew Condensed Bold</font>
+    <font>Noto Serif Devanagari Condensed Medium</font>
+    <font>Noto Serif Khmer SemiCondensed</font>
+    <font>Noto Serif Sinhala Condensed Light</font>
+    <font>Noto Serif Display SemiCondensed ExtraLight</font>
+    <font>Noto Serif Devanagari Condensed ExtraBold</font>
+    <font>Noto Serif Thai Condensed SemiBold</font>
+    <font>Noto Serif Bengali Condensed Thin</font>
+    <font>Noto Serif Lao SemiCondensed ExtraLight</font>
+    <font>Noto Serif Display Condensed Light Italic</font>
+    <font>Noto Serif Bengali Thin</font>
+    <font>Noto Serif Armenian Condensed Bold</font>
+    <font>Noto Serif Khmer Thin</font>
+    <font>Noto Serif Devanagari Thin</font>
+    <font>Noto Serif Ethiopic Condensed Bold</font>
+    <font>Noto Serif Ethiopic Condensed ExtraBold</font>
+    <font>Noto Serif Devanagari Condensed Light</font>
+    <font>Noto Serif Bengali Condensed Bold</font>
+    <font>Noto Serif Hebrew SemiCondensed ExtraBold</font>
+    <font>Noto Serif Armenian SemiCondensed Light</font>
+    <font>Noto Serif Myanmar SemiCondensed Light</font>
+    <font>Noto Serif Bengali Medium</font>
+    <font>Noto Serif SemiCondensed Black</font>
+    <font>Noto Serif Display Condensed Bold Italic</font>
+    <font>Noto Serif Ethiopic SemiCondensed Medium</font>
+    <font>Noto Serif Hebrew SemiCondensed Thin</font>
+    <font>Noto Serif Lao Condensed Regular</font>
+    <font>Noto Serif Armenian SemiCondensed Thin</font>
+    <font>Noto Serif Hebrew SemiCondensed Medium</font>
+    <font>Noto Serif Kannada Medium</font>
+    <font>Noto Serif Tibetan Regular</font>
+    <font>Noto Serif Thai Condensed Light</font>
+    <font>Noto Serif Devanagari Light</font>
+    <font>Noto Serif Armenian Condensed Light</font>
+    <font>Noto Serif Tamil Condensed Italic</font>
+    <font>Noto Serif Hebrew Thin</font>
+    <font>Noto Serif Lao Condensed Medium</font>
+    <font>Noto Serif Devanagari Condensed ExtraLight</font>
+    <font>Noto Serif Oriya SemiBold</font>
+    <font>Noto Serif Ethiopic Condensed Light</font>
+    <font>Noto Serif Ethiopic Condensed Regular</font>
+    <font>Noto Serif Display SemiCondensed Black Italic</font>
+    <font>Noto Serif Display Condensed Thin</font>
+    <font>Noto Serif Myanmar Medium</font>
+    <font>Noto Serif Lao Medium</font>
+    <font>Noto Serif Tamil Condensed Medium Italic</font>
+    <font>Noto Serif Khmer Medium</font>
+    <font>Noto Serif Thai Condensed</font>
+    <font>Noto Serif NP Hmong SemiBold</font>
+    <font>Noto Serif Gujarati Bold</font>
+    <font>Noto Serif Ethiopic SemiCondensed SemiBold</font>
+    <font>Noto Serif Ethiopic Medium</font>
+    <font>Noto Serif Italic</font>
+    <font>Noto Serif Gujarati Light</font>
+    <font>Noto Serif Display Medium Italic</font>
+    <font>Noto Serif Armenian SemiCondensed</font>
+    <font>Noto Serif Georgian Bold</font>
+    <font>Noto Serif Myanmar Regular</font>
+    <font>Noto Serif Khmer Condensed Light</font>
+    <font>Noto Serif Hebrew Bold</font>
+    <font>Noto Serif Ethiopic SemiBold</font>
+    <font>Noto Serif Tamil SemiCondensed Italic</font>
+    <font>Noto Serif Devanagari Medium</font>
+    <font>Noto Serif Khmer SemiCondensed ExtraLight</font>
+    <font>Noto Serif Devanagari SemiBold</font>
+    <font>Noto Serif Toto Bold</font>
+    <font>Noto Serif Thai Regular</font>
+    <font>Noto Serif Bengali Regular</font>
+    <font>Noto Serif Tamil Condensed Bold</font>
+    <font>Noto Serif Kannada Regular</font>
+    <font>Noto Serif Bengali Condensed Black</font>
+    <font>Noto Serif Hebrew Condensed ExtraLight</font>
+    <font>Noto Serif Lao SemiCondensed ExtraBold</font>
+    <font>Noto Serif Condensed Light</font>
+    <font>Noto Serif Lao Condensed ExtraLight</font>
+    <font>Noto Serif Bengali Light</font>
+    <font>Noto Serif Tamil SemiCondensed Medium</font>
+    <font>Noto Serif Myanmar SemiCondensed Black</font>
+    <font>Noto Serif Armenian Condensed ExtraLight</font>
+    <font>Noto Serif Condensed ExtraLight Italic</font>
+    <font>Noto Serif Tamil Medium</font>
+    <font>Noto Serif Georgian Thin</font>
+    <font>Noto Serif Ethiopic Condensed Medium</font>
+    <font>Noto Serif SemiCondensed</font>
+    <font>Noto Serif Thai Condensed ExtraLight</font>
+    <font>Noto Serif Hebrew SemiCondensed ExtraLight</font>
+    <font>Noto Serif SemiCondensed Medium Italic</font>
+    <font>Noto Serif Armenian Condensed SemiBold</font>
+    <font>Noto Serif SemiBold</font>
+    <font>Noto Serif Devanagari SemiCondensed Thin</font>
+    <font>Noto Serif Old Uyghur Regular</font>
+    <font>Noto Serif Condensed Black</font>
+    <font>Noto Serif Devanagari Condensed Black</font>
+    <font>Noto Serif Tamil Condensed ExtraBold</font>
+    <font>Noto Serif Display Condensed ExtraLight Italic</font>
+    <font>Noto Serif Gurmukhi Thin</font>
+    <font>Noto Serif Sinhala Medium</font>
+    <font>Noto Serif Display Condensed ExtraLight</font>
+    <font>Noto Serif Display SemiCondensed Light</font>
+    <font>Noto Serif SemiBold Italic</font>
+    <font>Noto Serif Gurmukhi Bold</font>
+    <font>Noto Serif SemiCondensed SemiBold Italic</font>
+    <font>Noto Serif Sinhala SemiBold</font>
+    <font>Noto Serif Sinhala Condensed ExtraLight</font>
+    <font>Noto Serif Tamil Condensed Black Italic</font>
+    <font>Noto Serif Myanmar SemiCondensed ExtraBold</font>
+    <font>Noto Serif Armenian Condensed ExtraBold</font>
+    <font>Noto Serif Display Condensed Medium Italic</font>
+    <font>Noto Serif Armenian Medium</font>
+    <font>Noto Serif Georgian SemiCondensed ExtraBold</font>
+    <font>Noto Serif Ethiopic Regular</font>
+    <font>Noto Serif Malayalam Bold</font>
+    <font>Noto Serif Lao Thin</font>
+    <font>Noto Serif Display Medium</font>
+    <font>Noto Serif Bold Italic</font>
+    <font>Noto Serif Myanmar SemiCondensed Regular</font>
+    <font>Noto Serif Telugu Medium</font>
+    <font>Noto Serif Lao SemiCondensed Light</font>
+    <font>Noto Serif Hebrew SemiCondensed Black</font>
+    <font>Noto Serif SemiCondensed Bold Italic</font>
+    <font>Noto Serif Lao Condensed Thin</font>
+    <font>Noto Serif Thai SemiCondensed Medium</font>
+    <font>Noto Serif Myanmar SemiCondensed Thin</font>
+    <font>Noto Serif Display Condensed ExtraBold Italic</font>
+    <font>Noto Serif Khmer Regular</font>
+    <font>Noto Serif Tamil Condensed Light Italic</font>
+    <font>Noto Serif Sinhala SemiCondensed Medium</font>
+    <font>Noto Serif Tamil SemiCondensed Light</font>
+    <font>Noto Serif Display SemiCondensed SemiBold Italic</font>
+    <font>Noto Serif Sinhala SemiCondensed Black</font>
+    <font>Noto Serif Georgian Condensed Black</font>
+    <font>Noto Serif Armenian SemiBold</font>
+    <font>Noto Serif Myanmar Condensed Thin</font>
+    <font>Noto Serif Devanagari SemiCondensed Medium</font>
+    <font>Noto Serif Condensed</font>
+    <font>Noto Serif Sinhala SemiCondensed ExtraBold</font>
+    <font>Noto Serif Dogra Regular</font>
+    <font>Noto Serif NP Hmong Regular</font>
+    <font>Noto Serif Georgian SemiCondensed</font>
+    <font>Noto Serif Tibetan Medium</font>
+    <font>Noto Serif SemiCondensed Italic</font>
+    <font>Noto Serif Tamil Thin</font>
+    <font>Noto Serif Tamil Condensed ExtraLight Italic</font>
+    <font>Noto Serif Condensed ExtraLight</font>
+    <font>Noto Serif Tamil Bold</font>
+    <font>Noto Serif Condensed Light Italic</font>
+    <font>Noto Serif Hebrew Condensed ExtraBold</font>
+    <font>Noto Serif Sinhala Thin</font>
+    <font>Noto Serif Bengali SemiCondensed Thin</font>
+    <font>Noto Serif Khojki Regular</font>
+    <font>Noto Serif Thin Italic</font>
+    <font>Noto Serif Tamil SemiBold Italic</font>
+    <font>Noto Serif Sinhala SemiCondensed Bold</font>
+    <font>Noto Serif Condensed Bold</font>
+    <font>Noto Serif Yezidi SemiBold</font>
+    <font>Noto Serif Khmer SemiCondensed Medium</font>
+    <font>Noto Serif Telugu Regular</font>
+    <font>Noto Serif Tamil SemiCondensed ExtraLight</font>
+    <font>Noto Serif Tamil SemiCondensed Thin</font>
+    <font>Noto Serif NP Hmong Bold</font>
+    <font>Noto Serif Bold</font>
+    <font>Noto Serif Display Bold Italic</font>
+    <font>Noto Serif Sinhala SemiCondensed Thin</font>
+    <font>Noto Serif Gurmukhi Regular</font>
+    <font>Noto Serif SemiCondensed ExtraBold Italic</font>
+    <font>Noto Serif Telugu SemiBold</font>
+    <font>Noto Serif Bengali SemiCondensed Light</font>
+    <font>Noto Serif Bengali Condensed Medium</font>
+    <font>Noto Serif Light Italic</font>
+    <font>Noto Serif Thai Condensed ExtraBold</font>
+    <font>Noto Serif Display SemiCondensed Bold</font>
+    <font>Noto Serif Kannada Light</font>
+    <font>Noto Serif Devanagari SemiCondensed ExtraLight</font>
+    <font>Noto Serif Bengali SemiCondensed Regular</font>
+    <font>Noto Serif Sinhala Condensed SemiBold</font>
+    <font>Noto Serif Lao Light</font>
+    <font>Noto Serif Lao Condensed Black</font>
+    <font>Noto Serif Myanmar Thin</font>
+    <font>Noto Serif Devanagari SemiCondensed Bold</font>
+    <font>Noto Serif Khmer SemiCondensed Thin</font>
+    <font>Noto Serif Tamil SemiCondensed Black</font>
+    <font>Noto Serif Condensed Thin</font>
+    <font>Noto Serif Bengali Bold</font>
+    <font>Noto Serif Khmer SemiCondensed SemiBold</font>
+    <font>Noto Serif Georgian SemiCondensed Light</font>
+    <font>Noto Serif Gurmukhi Light</font>
+    <font>Noto Serif Display Condensed Medium</font>
+    <font>Noto Serif Lao Regular</font>
+    <font>Noto Serif Hebrew Condensed Light</font>
+    <font>Noto Serif Khmer Light</font>
+    <font>Noto Serif Thai Medium</font>
+    <font>Noto Serif Tamil SemiCondensed Medium Italic</font>
+    <font>Noto Serif Display Condensed Bold</font>
+    <font>Noto Serif Kannada Bold</font>
+    <font>Noto Serif Myanmar SemiCondensed ExtraLight</font>
+    <font>Noto Serif Tamil SemiCondensed ExtraBold Italic</font>
+    <font>Noto Serif Vithkuqi SemiBold</font>
+    <font>Noto Serif Telugu Bold</font>
+    <font>Noto Serif Display SemiBold Italic</font>
+    <font>Noto Serif Myanmar Bold</font>
+    <font>Noto Serif Hebrew Condensed Medium</font>
+    <font>Noto Serif Sinhala Condensed ExtraBold</font>
+    <font>Noto Serif Gujarati SemiBold</font>
+    <font>Noto Serif Sinhala Light</font>
+    <font>Noto Serif Armenian SemiCondensed ExtraBold</font>
+    <font>Noto Serif Georgian Condensed Thin</font>
+    <font>Noto Serif Devanagari SemiCondensed SemiBold</font>
+    <font>Noto Serif Tamil Bold Italic</font>
+    <font>Noto Serif Georgian Regular</font>
+    <font>Noto Serif Bengali Condensed Regular</font>
+    <font>Noto Serif Display SemiBold</font>
+    <font>Noto Serif Malayalam Medium</font>
+    <font>Noto Serif Armenian SemiCondensed ExtraLight</font>
+    <font>Noto Serif Georgian Condensed Light</font>
+    <font>Noto Serif Oriya Regular</font>
+    <font>Noto Serif Lao Condensed Light</font>
+    <font>Noto Serif Devanagari Condensed Bold</font>
+    <font>Noto Serif Myanmar Condensed Light</font>
+    <font>Noto Serif Lao Bold</font>
+    <font>Noto Serif Lao Condensed SemiBold</font>
+    <font>Noto Serif Armenian SemiCondensed SemiBold</font>
+    <font>Noto Serif Bengali SemiCondensed Black</font>
+    <font>Noto Serif Devanagari Regular</font>
+    <font>Noto Serif Balinese Regular</font>
+    <font>Noto Serif Condensed ExtraBold</font>
+    <font>Noto Serif Condensed SemiBold Italic</font>
+    <font>Noto Serif Georgian Condensed Medium</font>
+    <font>Noto Serif Sinhala SemiCondensed ExtraLight</font>
+    <font>Noto Serif Armenian SemiCondensed Black</font>
+    <font>Noto Serif Bengali SemiCondensed ExtraBold</font>
+    <font>Noto Serif SemiCondensed ExtraLight Italic</font>
+    <font>Noto Serif Condensed Black Italic</font>
+    <font>Noto Serif Hebrew Medium</font>
+    <font>Noto Serif Display Light</font>
+    <font>Noto Serif Display SemiCondensed SemiBold</font>
+    <font>Noto Serif Khmer Condensed ExtraLight</font>
+    <font>Noto Serif Georgian SemiBold</font>
+    <font>Noto Serif Tibetan Light</font>
+    <font>Noto Serif Bengali Condensed ExtraLight</font>
+    <font>Noto Serif Display Condensed ExtraBold</font>
+    <font>Noto Serif Khmer Condensed ExtraBold</font>
+    <font>Noto Serif Tamil SemiCondensed SemiBold Italic</font>
+    <font>Noto Serif Myanmar SemiCondensed Medium</font>
+    <font>Noto Serif Display Regular</font>
+    <font>Noto Serif Display SemiCondensed Medium Italic</font>
+    <font>Noto Serif Ethiopic Condensed Black</font>
+    <font>Noto Serif Lao SemiCondensed Regular</font>
+    <font>Noto Serif Tamil Regular</font>
+    <font>Noto Serif Display SemiCondensed Italic</font>
+    <font>Noto Serif Lao SemiCondensed Thin</font>
+    <font>Noto Serif Thai Condensed Bold</font>
+    <font>Noto Serif Armenian Light</font>
+    <font>Noto Serif Dives Akuru Regular</font>
+    <font>Noto Serif Thai Condensed Black</font>
+    <font>Noto Serif Lao SemiCondensed SemiBold</font>
+    <font>Noto Serif Ahom Regular</font>
+    <font>Noto Serif Bengali SemiBold</font>
+    <font>Noto Serif NP Hmong Medium</font>
+    <font>Noto Serif Sinhala Condensed Thin</font>
+    <font>Noto Serif Myanmar Condensed Bold</font>
+    <font>Noto Serif Display Italic</font>
+    <font>Noto Serif Thai SemiCondensed Thin</font>
+    <font>Noto Serif Ethiopic SemiCondensed ExtraLight</font>
+    <font>Noto Serif Devanagari SemiCondensed Light</font>
+    <font>Noto Serif Georgian Condensed</font>
+    <font>Noto Serif SemiCondensed SemiBold</font>
+    <font>Noto Serif Devanagari SemiCondensed Black</font>
+    <font>Noto Serif Armenian Condensed</font>
+    <font>Noto Serif Condensed Medium Italic</font>
+    <font>Noto Serif Bengali Condensed ExtraBold</font>
+    <font>Noto Serif Yezidi Regular</font>
+    <font>Noto Serif Ethiopic Bold</font>
+    <font>Noto Serif Armenian SemiCondensed Bold</font>
+    <font>Noto Serif Condensed Italic</font>
+    <font>Noto Serif Tibetan SemiBold</font>
+    <font>Noto Serif Khmer SemiCondensed ExtraBold</font>
+    <font>Noto Serif Hebrew SemiBold</font>
+    <font>Noto Serif Oriya Bold</font>
+    <font>Noto Serif Display Thin Italic</font>
+    <font>Noto Serif Thai Condensed Thin</font>
+    <font>Noto Serif SemiCondensed Light Italic</font>
+    <font>Noto Serif Georgian Condensed SemiBold</font>
+    <font>Noto Serif Tamil Italic</font>
+    <font>Noto Serif Hebrew SemiCondensed Bold</font>
+    <font>Noto Serif Malayalam SemiBold</font>
+    <font>Noto Serif Ottoman Siyaq Regular</font>
+    <font>Noto Serif Tamil Condensed Light</font>
+    <font>Noto Serif Khmer Bold</font>
+    <font>Noto Serif Display SemiCondensed Thin Italic</font>
+    <font>Noto Serif Gujarati Thin</font>
+    <font>Noto Serif Ethiopic Thin</font>
+    <font>Noto Serif Khojki Bold</font>
+    <font>Noto Serif Gujarati Regular</font>
+    <font>Noto Serif Myanmar SemiBold</font>
+    <font>Noto Serif Tamil Light Italic</font>
+    <font>Noto Serif Georgian Condensed Bold</font>
+    <font>Noto Serif Myanmar SemiCondensed SemiBold</font>
+    <font>Noto Serif Display Condensed Regular</font>
+    <font>Noto Serif Ethiopic Light</font>
+    <font>Noto Serif Toto Regular</font>
+    <font>Noto Serif Thai SemiCondensed</font>
+    <font>Noto Serif Tamil Condensed ExtraLight</font>
+    <font>Noto Serif Sinhala Condensed Black</font>
+    <font>Noto Serif Tamil Condensed SemiBold</font>
+    <font>Noto Serif Devanagari Condensed SemiBold</font>
+    <font>Noto Serif Ethiopic SemiCondensed Thin</font>
+    <font>Noto Serif Tamil SemiCondensed Regular</font>
+    <font>Noto Serif Tibetan Bold</font>
+    <font>Noto Serif Devanagari Bold</font>
+    <font>Noto Serif Devanagari SemiCondensed ExtraBold</font>
+    <font>Noto Serif Test Regular</font>
+    <font>Noto Serif Malayalam Regular</font>
+    <font>Noto Serif Bengali SemiCondensed Medium</font>
+    <font>Noto Serif Tamil SemiCondensed ExtraBold</font>
+    <font>Noto Serif Georgian Medium</font>
+    <font>Noto Serif Display SemiCondensed ExtraLight Italic</font>
+    <font>Noto Serif Bengali SemiCondensed SemiBold</font>
+    <font>Noto Serif Thai Condensed Medium</font>
+    <font>Noto Serif Tamil Light</font>
+    <font>Noto Serif Ethiopic SemiCondensed Black</font>
+    <font>Noto Serif Condensed Thin Italic</font>
+    <font>Noto Serif Khmer SemiBold</font>
+    <font>Noto Serif Ethiopic Condensed Thin</font>
+    <font>Noto Serif Grantha Regular</font>
+    <font>Noto Serif Georgian SemiCondensed Black</font>
+    <font>Noto Serif Makasar Regular</font>
+    <font>Noto Serif Lao SemiCondensed Bold</font>
+    <font>Noto Serif Thai Light</font>
+    <font>Noto Serif Armenian Condensed Thin</font>
+    <font>Noto Serif Toto Medium</font>
+    <font>Noto Serif Tamil Condensed Medium</font>
+    <font>Noto Serif Tamil Condensed Bold Italic</font>
+    <font>Noto Serif Tamil SemiCondensed Bold Italic</font>
+    <font>Noto Serif Khmer Condensed SemiBold</font>
+    <font>Noto Serif Ethiopic Condensed SemiBold</font>
+    <font>Noto Serif Ethiopic Condensed ExtraLight</font>
+    <font>Noto Serif SemiCondensed Thin Italic</font>
+    <font>Noto Serif Vithkuqi Bold</font>
+    <font>Noto Serif Armenian Condensed Black</font>
+    <font>Noto Serif Tamil Condensed Black</font>
+    <font>Noto Serif Light</font>
+    <font>Noto Serif Malayalam Light</font>
+    <font>Noto Serif Sinhala Condensed Bold</font>
+    <font>Noto Serif Gujarati Medium</font>
+    <font>Noto Serif Thai SemiCondensed SemiBold</font>
+    <font>Noto Serif Medium</font>
+    <font>Noto Serif Khmer SemiCondensed Bold</font>
+    <font>Noto Serif Armenian SemiCondensed Medium</font>
+    <font>Noto Serif Test Bold</font>
+    <font>Noto Serif Display SemiCondensed ExtraBold Italic</font>
+    <font>Noto Serif Regular</font>
+    <font>Noto Serif Display Condensed Italic</font>
+    <font>Noto Serif Display SemiCondensed Regular</font>
+    <font>Noto Serif Sinhala SemiCondensed SemiBold</font>
+  </provides>
 </component>

--- a/packages/n/noto-sans-ttf/package.yml
+++ b/packages/n/noto-sans-ttf/package.yml
@@ -1,11 +1,9 @@
 name       : noto-sans-ttf
 version    : 2025.03.01
-release    : 39
+release    : 40
 source     :
     - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-2025.03.01.tar.gz : 780a43c2c4f607a3e7192b88d1401640b0c041f6c2d7a6313c30157f5367c771
-    - https://github.com/googlefonts/noto-emoji/archive/refs/tags/v2.047.tar.gz : 2cfaf5a427eb26334cdb30d98e4a0c005b660504a339249dc54373e566f09b50
 homepage   : https://fonts.google.com/noto
-extract    : no
 license    : OFL-1.1
 component  :
     - desktop.font
@@ -16,25 +14,15 @@ summary    :
 description: |
     Noto's goal is to provide a beautiful reading experience for all languages. It is a free, professionally-designed, open-source collection of fonts with a harmonious look and feel in multiple weights and styles.
 install    : |
-    #extract it
-    for i in $sources/*.tar.gz; do
-        tar xf ${i}
-    done
-
     install -Ddm00755 $installdir/usr/share/fonts/truetype/noto-sans-ttf
 
-    # Install emoji
-    install -m00644 noto-emoji*/fonts/NotoColorEmoji.ttf $installdir/usr/share/fonts/truetype/noto-sans-ttf
-
     # Install fonts
-    pushd notofonts*/fonts
-    for tff in Noto*/hinted/ttf; do
+    for tff in fonts/Noto*/hinted/ttf; do
         pushd $tff
             rm -f *-{Black,Extra}*.ttf *.ttc
             install -m00644 * $installdir/usr/share/fonts/truetype/noto-sans-ttf
         popd
     done
-    popd
 
     install -Dm00644 $pkgfiles/noto-sans-ttf.metainfo.xml $installdir/usr/share/metainfo/noto-sans-ttf.metainfo.xml
     install -Dm00644 $pkgfiles/noto-serif-ttf.metainfo.xml $installdir/usr/share/metainfo/noto-serif-ttf.metainfo.xml

--- a/packages/n/noto-sans-ttf/pspec_x86_64.xml
+++ b/packages/n/noto-sans-ttf/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>noto-sans-ttf</Name>
         <Homepage>https://fonts.google.com/noto</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>OFL-1.1</License>
         <PartOf>desktop.font</PartOf>
@@ -20,7 +20,6 @@
 </Description>
         <PartOf>desktop.font</PartOf>
         <Files>
-            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoColorEmoji.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoFangsongKSSRotated-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoFangsongKSSVertical-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoKufiArabic-Bold.ttf</Path>
@@ -1537,12 +1536,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="39">
-            <Date>2025-03-05</Date>
+        <Update release="40">
+            <Date>2025-06-08</Date>
             <Version>2025.03.01</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/p/plasma-desktop-branding/package.yml
+++ b/packages/p/plasma-desktop-branding/package.yml
@@ -1,6 +1,6 @@
 name       : plasma-desktop-branding
 version    : 4.6.0
-release    : 72
+release    : 73
 source     :
     # - https://github.com/getsolus/plasma-desktop-branding/releases/download/v4.6.0/plasma-desktop-branding-4.6.0.tar.xz : 929fe7738882541c5ac9b8f97753d900d711c1d6dc09975bde8be5a890209ae4
     - git|https://github.com/getsolus/plasma-desktop-branding.git : c9ec42a18c0d88fdfbcec48d4337600b56a4bf44
@@ -18,6 +18,7 @@ rundeps    :
     - breeze-cursor-theme
     - breeze-light-cursor-theme
     - breeze-gtk-theme
+    - font-noto-emoji
     - noto-sans-ttf
     - noto-serif-ttf
     - solus-artwork-plasma

--- a/packages/p/plasma-desktop-branding/pspec_x86_64.xml
+++ b/packages/p/plasma-desktop-branding/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>plasma-desktop-branding</Name>
         <Homepage>https://github.com/getsolus/plasma-desktop-branding</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>LGPL-2.0-only</License>
@@ -123,12 +123,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="72">
-            <Date>2024-06-12</Date>
+        <Update release="73">
+            <Date>2025-06-08</Date>
             <Version>4.6.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/x/xfce4-desktop-branding/package.yml
+++ b/packages/x/xfce4-desktop-branding/package.yml
@@ -1,6 +1,6 @@
 name       : xfce4-desktop-branding
 version    : 1.1.1
-release    : 17
+release    : 18
 source     :
     - https://github.com/getsolus/xfce4-desktop-branding/archive/refs/tags/v1.1.1.tar.gz : a2e5487d0364f77d3ca7211ca3f5d20cc427553f1c233d2e6df7054b5606dde6
 homepage   : https://github.com/getsolus/xfce4-desktop-branding
@@ -17,6 +17,7 @@ description:
 rundeps    :
     - breeze-cursor-theme
     - font-hack-ttf
+    - font-noto-emoji
     - maliit-keyboard
     - noto-sans-ttf
     - noto-serif-ttf

--- a/packages/x/xfce4-desktop-branding/pspec_x86_64.xml
+++ b/packages/x/xfce4-desktop-branding/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xfce4-desktop-branding</Name>
         <Homepage>https://github.com/getsolus/xfce4-desktop-branding</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>desktop.xfce</PartOf>
@@ -33,19 +33,19 @@
         <Description xml:lang="en">Defaults for the XFCE4 Desktop.</Description>
         <PartOf>desktop.xfce</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="17">xfce4-desktop-branding</Dependency>
+            <Dependency releaseFrom="18">xfce4-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/lightdm/lightdm.conf.d/xfce_config.conf</Path>
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2025-05-13</Date>
+        <Update release="18">
+            <Date>2025-06-08</Date>
             <Version>1.1.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- noto-emoji uses a different source and different versioning it doesn't make sense to contain it within noto
- Our appstream catalog uses the "emoji" icons for the noto-sans package causing confusion, splitting it out will prevent this
- Improve the appstream metainfo for noto-{sans,serif} whilst we're here to pass `appstreamcli validate`
- Add rundep on `font-noto-emoji` to all branding packages to ensure it continues to be installed.

**Test Plan**

Test upgrade paths, test appstream metainfo composition.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
