### PR TITLE
python-socketio: Add missing checkdeps

### DIFF
--- a/packages/py/python-socketio/package.yml
+++ b/packages/py/python-socketio/package.yml
@@ -1,6 +1,6 @@
 name       : python-socketio
 version    : 5.13.0
-release    : 8
+release    : 9
 source     :
     - https://github.com/miguelgrinberg/python-socketio/archive/refs/tags/v5.13.0.tar.gz : 42b2e11a8e0ebd74fd355d585a4236afa4309c900b24f26ad79c0c88d2bfc095
 homepage   : https://github.com/miguelgrinberg/python-socketio
@@ -15,12 +15,14 @@ builddeps  :
     - python-setuptools
     - python-wheel
 checkdeps  :
+    - python-aiohttp
     - python-bidict
     - python-engineio
     - python-msgpack
     - python-pytest
     - python-pytest-asyncio
     - python-uvicorn
+    - python-websocket-client
 rundeps    :
     - python-bidict
     - python-engineio

--- a/packages/py/python-socketio/pspec_x86_64.xml
+++ b/packages/py/python-socketio/pspec_x86_64.xml
@@ -121,8 +121,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2025-06-07</Date>
+        <Update release="9">
+            <Date>2025-06-08</Date>
             <Version>5.13.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
- Add missing checkdeps

Not sure how these got missed. Looks to be working now, though. Remember to push `onionshare-cli` after this.

Ref https://github.com/getsolus/packages/pull/5776

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the test suite passed during build.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
