### PR TITLE
nvidia-vaapi-driver: Update to v0.0.14

### DIFF
--- a/packages/n/nvidia-vaapi-driver/package.yml
+++ b/packages/n/nvidia-vaapi-driver/package.yml
@@ -1,9 +1,9 @@
 name       : nvidia-vaapi-driver
-version    : 0.0.13
-release    : 17
+version    : 0.0.14
+release    : 18
 homepage   : https://github.com/elFarto/nvidia-vaapi-driver
 source     :
-    - https://github.com/elFarto/nvidia-vaapi-driver/archive/refs/tags/v0.0.13.tar.gz : 0bd10013b183eeef1676f99213f449482b86cbb9cd8883e7fb3801f6f59de231
+    - https://github.com/elFarto/nvidia-vaapi-driver/archive/refs/tags/v0.0.14.tar.gz : 4ded132ec4164f3e05656061675dffce677327e4af0d8da33da5f8527609ad2a
 license    : MIT
 component  : xorg.display
 summary    : A VA-API implemention using NVIDIA's NVDEC as the backend (UNSUPPORTED)

--- a/packages/n/nvidia-vaapi-driver/pspec_x86_64.xml
+++ b/packages/n/nvidia-vaapi-driver/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Conflicts>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2024-11-03</Date>
-            <Version>0.0.13</Version>
+        <Update release="18">
+            <Date>2025-06-09</Date>
+            <Version>0.0.14</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fixed to work with newer NVIDIA drivers
- Reworked decoder cleanup to attempt to prevent simultaneous destroys
- Reverted single plane export
- Dial in the log2GobsPerBlockY threshold a bit more
- Implement log2GobsPerBlockY values for even smaller images
- Round up surface sizes and display area for subsampled chroma videos
- Fix some potential deadlocks and H.264 video decode error when seeking
- Fix 545.29 driver version check
- Fixed crashes caused by invalid concurrent writes to `drv->nextObjId`
- Fix "possibly uninitialized" warning
- Fix 32-bit issues

**Test Plan**
`
Confirmed video acceleration in `firefox` works with the `nvidia-beta-driver

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
