### PR TITLE
python-maturin: Update to v1.8.7

### DIFF
--- a/packages/py/python-maturin/abi_used_symbols
+++ b/packages/py/python-maturin/abi_used_symbols
@@ -9,6 +9,7 @@ libc.so.6:__errno_location
 libc.so.6:__libc_start_main
 libc.so.6:__register_atfork
 libc.so.6:__res_init
+libc.so.6:__stack_chk_fail
 libc.so.6:__xpg_strerror_r
 libc.so.6:_exit
 libc.so.6:abort

--- a/packages/py/python-maturin/package.yml
+++ b/packages/py/python-maturin/package.yml
@@ -1,8 +1,8 @@
 name       : python-maturin
-version    : 1.8.6
-release    : 57
+version    : 1.8.7
+release    : 58
 source     :
-    - https://github.com/PyO3/maturin/archive/refs/tags/v1.8.6.tar.gz : ab092813266355e08b2feeb0b138c8a47be7cac44a0ed45c9e04722ae94b8bf5
+    - https://github.com/PyO3/maturin/archive/refs/tags/v1.8.7.tar.gz : 7fae57e8f14ea469c904f190774dd3c68a70fbc4c87b6a778b3e950e44cb8c24
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-maturin/pspec_x86_64.xml
+++ b/packages/py/python-maturin/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-maturin</Name>
         <Homepage>https://www.maturin.rs/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>MIT</License>
@@ -22,10 +22,10 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/maturin</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.8.6.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.8.6.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.8.6.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.8.6.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.8.7.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.8.7.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.8.7.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.8.7.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -38,12 +38,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="57">
-            <Date>2025-05-19</Date>
-            <Version>1.8.6</Version>
+        <Update release="58">
+            <Date>2025-06-09</Date>
+            <Version>1.8.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Trim package description
- bootstrap: fix overriden setuptools PEP 517 hooks
- Upgrade cbindgen to 0.29
- Allow specifying compression method and level, in both `build` and `develop` modes
- Upgrade jobserver

**Test Plan**

Successfully built `python-orjson`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
