### PR TITLE
ninja: Add downstream patch to report execution progress to terminal

### DIFF
--- a/packages/n/ninja/abi_used_symbols
+++ b/packages/n/ninja/abi_used_symbols
@@ -122,13 +122,11 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_assignER
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createERmm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_mutateEmmPKcm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1EOS4_
-libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1ERKS4_
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEaSEOS4_
 libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
 libstdc++.so.6:_ZSt16__throw_bad_castv
 libstdc++.so.6:_ZSt17__throw_bad_allocv
 libstdc++.so.6:_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
-libstdc++.so.6:_ZSt18_Rb_tree_incrementPKSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc

--- a/packages/n/ninja/files/0001-Print-OSC-9-4-ANSI-sequence-progress-report-during-e.patch
+++ b/packages/n/ninja/files/0001-Print-OSC-9-4-ANSI-sequence-progress-report-during-e.patch
@@ -1,0 +1,71 @@
+From 1748cd6a4c4f7befd9f85095818a340ae349e36c Mon Sep 17 00:00:00 2001
+From: Joey Riches <josephriches@gmail.com>
+Date: Tue, 10 Jun 2025 22:50:55 +0100
+Subject: [PATCH 1/1] Print OSC 9;4 ANSI sequence progress report during
+ execution
+
+---
+ src/status.cc           | 15 ++++++++++++++-
+ src/subprocess-posix.cc |  6 +++++-
+ 2 files changed, 19 insertions(+), 2 deletions(-)
+
+diff --git a/src/status.cc b/src/status.cc
+index 06f3c20..0f0555a 100644
+--- a/src/status.cc
++++ b/src/status.cc
+@@ -45,7 +45,7 @@ StatusPrinter::StatusPrinter(const BuildConfig& config)
+ 
+   progress_status_format_ = getenv("NINJA_STATUS");
+   if (!progress_status_format_)
+-    progress_status_format_ = "[%f/%t] ";
++    progress_status_format_ = "[%f/%t%n] ";
+ }
+ 
+ void StatusPrinter::EdgeAddedToPlan(const Edge* edge) {
+@@ -399,6 +399,19 @@ string StatusPrinter::FormatProgressStatus(const char* progress_status_format,
+         break;
+       }
+ 
++      case 'n': {
++          // OSC 9;4 ANSI Sequences
++          int percent = 0;
++          if (finished_edges_ != 0 && total_edges_ != 0)
++            percent = (100 * finished_edges_) / total_edges_;
++          if (percent > 0)
++            snprintf(buf, sizeof(buf), "\033]9;4;1;%i\e\\", percent);
++          if (percent == 100)
++            snprintf(buf, sizeof(buf), "\033]9;4;0\e\\");
++          out += buf;
++          break;
++      }
++
+       default:
+         Fatal("unknown placeholder '%%%c' in $NINJA_STATUS", *s);
+         return "";
+diff --git a/src/subprocess-posix.cc b/src/subprocess-posix.cc
+index 8e78540..aca6063 100644
+--- a/src/subprocess-posix.cc
++++ b/src/subprocess-posix.cc
+@@ -164,14 +164,18 @@ ExitStatus Subprocess::Finish() {
+   }
+ #endif
+ 
++  // Always reset OSC 9;4 progress status on exit
++  printf("\033]9;4;0\e\\");
++
+   if (WIFEXITED(status)) {
+     int exit = WEXITSTATUS(status);
+     if (exit == 0)
+       return ExitSuccess;
+   } else if (WIFSIGNALED(status)) {
+     if (WTERMSIG(status) == SIGINT || WTERMSIG(status) == SIGTERM
+-        || WTERMSIG(status) == SIGHUP)
++        || WTERMSIG(status) == SIGHUP) {
+       return ExitInterrupted;
++    }
+   }
+   return ExitFailure;
+ }
+-- 
+2.49.0
+

--- a/packages/n/ninja/package.yml
+++ b/packages/n/ninja/package.yml
@@ -1,6 +1,6 @@
 name       : ninja
 version    : 1.12.1
-release    : 11
+release    : 12
 source     :
     - https://github.com/ninja-build/ninja/archive/refs/tags/v1.12.1.tar.gz : 821bdff48a3f683bc4bb3b6f0b5fe7b2d647cf65d52aeb63328c91a6c6df285a
 license    : Apache-2.0
@@ -15,6 +15,9 @@ builddeps  :
 checkdeps  :
     - pkgconfig(gtest)
 setup      : |
+    # downstream only for now
+    %patch -p1 -i $pkgfiles/0001-Print-OSC-9-4-ANSI-sequence-progress-report-during-e.patch
+
     %cmake_ninja
 build      : |
     %ninja_build

--- a/packages/n/ninja/pspec_x86_64.xml
+++ b/packages/n/ninja/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ninja</Name>
         <Homepage>https://ninja-build.org</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.tools</PartOf>
@@ -24,12 +24,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2024-06-26</Date>
+        <Update release="12">
+            <Date>2025-06-10</Date>
             <Version>1.12.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Supported terminals will display the progress
- Unsupported terminals will simply ignore it

**Test Plan**

Run in ptyxis verify the progress is displayed
Run in konsole verify no bad side effects

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
