### PR TITLE
yubikey-manager: Update to v5.7.1

### DIFF
--- a/packages/y/yubikey-manager/package.yml
+++ b/packages/y/yubikey-manager/package.yml
@@ -1,8 +1,8 @@
 name       : yubikey-manager
-version    : 5.5.1
-release    : 44
+version    : 5.7.1
+release    : 45
 source     :
-    - https://github.com/Yubico/yubikey-manager/releases/download/5.5.1/yubikey_manager-5.5.1.tar.gz : 2b1f4e70813973c646eb301c8f2513faf5e4736dd3c564422efdce0349c02afd
+    - https://github.com/Yubico/yubikey-manager/releases/download/5.7.1/yubikey_manager-5.7.1.tar.gz : 0200efca86eb310e19b841a2e365812c83c19f8e65f8c6065e14bbb7b4a58ef3
 homepage   : https://developers.yubico.com/yubikey-manager/
 license    : BSD-2-Clause
 component  : security

--- a/packages/y/yubikey-manager/pspec_x86_64.xml
+++ b/packages/y/yubikey-manager/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>yubikey-manager</Name>
         <Homepage>https://developers.yubico.com/yubikey-manager/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>security</PartOf>
@@ -157,11 +157,11 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/scripting.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/settings.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/util.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/yubikey_manager-5.5.1.dist-info/COPYING</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/yubikey_manager-5.5.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/yubikey_manager-5.5.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/yubikey_manager-5.5.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/yubikey_manager-5.5.1.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/yubikey_manager-5.7.1.dist-info/COPYING</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/yubikey_manager-5.7.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/yubikey_manager-5.7.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/yubikey_manager-5.7.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/yubikey_manager-5.7.1.dist-info/entry_points.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/yubikit/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/yubikit/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/yubikit/__pycache__/__init__.cpython-312.pyc</Path>
@@ -212,12 +212,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="44">
-            <Date>2025-05-08</Date>
-            <Version>5.5.1</Version>
+        <Update release="45">
+            <Date>2025-06-11</Date>
+            <Version>5.7.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Update yubikey-manager

**Changelog:**

**5.7.1**
- Bugfix: Fix OTP connections for YubiKeys with all other USB interfaces deactivated.

**5.7.0**
- Python 3.9 or later is now required.
- PIV: Improve error handling for the Printed data slot.
- PIV: Improve error handling when decompressing malformed certificates.
- Fix incompatibility with pyscard 2.2.2.
- Improve compatibility with NFC readers that don't support extended APDUs.
- Building the project now requires Poetry version 2.0 or later.
- Windows and MacOS installers built with Python 3.13.3

**5.6.1**
- Fix: Version 5.6.0 uses Exclusive smart card connections, which caused connections to fail if another application was accessing the YubiKey. This version adds a fallback to use non-exclusive connections in case of such a failure.
- Bugfix: APDU encoding was slightly incorrect for commands which specify Le, but no data body. This caused issued on some platforms.
- CLI: The "fido info" command now shows the YubiKey AAGUID, when available.

**5.6.0**
- SCP: Add support for specifying Le (needed in OpenPGP get_challenge).
- PIV: When writing a new CHUID, prefer to keep data from the old one if possible.
- CLI: Specifying public-key is now optional when generating a PIV certificate, if a public key can be read from the YubiKey itself.
- CLI: (YK FIPS) Disallow --protect for PIV when not in FIPS approved state.
- CLI: Support specifying Le in "apdu" command.
- CLI: Show OpenPGP key information in "openpgp info" and "openpgp keys info" commands.
- CLI: Detect OpenPGP memory corruption, and correctly factory reset OpenPGP if needed.
- CLI: Don't fail on corrupted configuration files, instead show a warning.
- Require Poetry >= 2.0 for building and packaging of the library.
- Bugfix: CLI - Don't use extended APDUs in the "apdu" command on old YubiKeys which do not support it.

Full release notes available [here](https://github.com/Yubico/yubikey-manager/releases)

**Test Plan**

- YubiKey Manager can be run with `ykman`
- `ykman info` shows a connected YubiKey
- YubiKey recognized, program behaves as expected

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
