### PR TITLE
python-proton-vpn-local-agent: Use %python3_version% macro

### DIFF
--- a/packages/py/python-proton-vpn-local-agent/package.yml
+++ b/packages/py/python-proton-vpn-local-agent/package.yml
@@ -1,6 +1,6 @@
 name       : python-proton-vpn-local-agent
 version    : 1.4.5
-release    : 5
+release    : 6
 source     :
     - https://github.com/ProtonVPN/local-agent-rs/archive/refs/tags/1.4.5.tar.gz : 6d2fc6e0517d1559c6ddfab386b3138721afc44c8a827b8395138d88564ba284
 homepage   : https://github.com/ProtonVPN/local-agent-rs
@@ -21,4 +21,4 @@ build      : |
     %cargo_build
     popd
 install    : |
-    install -Dm00755 $workdir/python-proton-vpn-local-agent/target/release/libpython_proton_vpn_local_agent.so $installdir/usr/lib/python3.12/site-packages/proton/vpn/local_agent.abi3.so
+    install -Dm00755 $workdir/python-proton-vpn-local-agent/target/release/libpython_proton_vpn_local_agent.so $installdir/usr/lib/python%python3_version%/site-packages/proton/vpn/local_agent.abi3.so

--- a/packages/py/python-proton-vpn-local-agent/pspec_x86_64.xml
+++ b/packages/py/python-proton-vpn-local-agent/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-proton-vpn-local-agent</Name>
         <Homepage>https://github.com/ProtonVPN/local-agent-rs</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>programming.python</PartOf>
@@ -24,12 +24,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
+        <Update release="6">
             <Date>2025-06-12</Date>
             <Version>1.4.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Use the %python3_version% macro to make the build automatically use the correct site-packages directory after Python updates/rebuilds

**Test Plan**

Confirmed the correct symlink gets created using the macro

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
