### PR TITLE
github-cli: Update to v2.74.1

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.74.0
-release    : 74
+version    : 2.74.1
+release    : 75
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.74.0.tar.gz : b13e60f114388cbc20ba410d57b43f262814dec7d3e37363accfd525c6885d3b
+    - https://github.com/cli/cli/archive/refs/tags/v2.74.1.tar.gz : ac894d0f16f78db34818c396aad542b1512a776b925a7639d5d5a30d205a103b
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -232,9 +232,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="74">
-            <Date>2025-05-31</Date>
-            <Version>2.74.0</Version>
+        <Update release="75">
+            <Date>2025-06-13</Date>
+            <Version>2.74.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Document support for `@copilot` in `gh [pr|issue] edit --add-assignee` and `--remove-assignee`
- Fix pr edit when URL is provided
- Fix const in PR finder tests

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
