### PR TITLE
scrcpy: Update to v3.3

### DIFF
--- a/packages/s/scrcpy/abi_used_symbols
+++ b/packages/s/scrcpy/abi_used_symbols
@@ -146,6 +146,7 @@ libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__memmove_chk
 libc.so.6:__printf_chk
+libc.so.6:__recv_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:_exit

--- a/packages/s/scrcpy/package.yml
+++ b/packages/s/scrcpy/package.yml
@@ -1,9 +1,9 @@
 name       : scrcpy
-version    : '3.2'
-release    : 33
+version    : '3.3'
+release    : 34
 source     :
-    - https://github.com/Genymobile/scrcpy/archive/v3.2.tar.gz : 9902a3afd75f9a5da64898ac06ffaf77065dd713a58f47a408630b98f03ba9ce
-    - https://github.com/Genymobile/scrcpy/releases/download/v3.2/scrcpy-server-v3.2 : b920e0ea01936bf2482f4ba2fa985c22c13c621999e3d33b45baa5acfc1ea3d0
+    - https://github.com/Genymobile/scrcpy/archive/v3.3.tar.gz : 6636f97f3a5446e3a1c845545108cf692bbd9cdc02cacfda099a2789ca7f6d56
+    - https://github.com/Genymobile/scrcpy/releases/download/v3.3/scrcpy-server-v3.3 : 351cb2edc7e4c2c75f09a7933fdabcf137be52e2602df154f24ec02db46e9e51
 homepage   : https://github.com/Genymobile/scrcpy
 license    : Apache-2.0
 component  : network.util

--- a/packages/s/scrcpy/pspec_x86_64.xml
+++ b/packages/s/scrcpy/pspec_x86_64.xml
@@ -31,9 +31,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2025-03-30</Date>
-            <Version>3.2</Version>
+        <Update release="34">
+            <Date>2025-06-13</Date>
+            <Version>3.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Associate UHID devices to virtual displays
- Fix audio capture (again) on Android 16
- Fix segfault with --no-window without --no-control
- Fix default locked capture orientation
- Add app name SDL hint
- Report specific error for INJECT_EVENT permission

Full release notes available [here](https://github.com/Genymobile/scrcpy/releases/tag/v3.3)

**Test Plan**

Mirrored my phone's screen and controlled it with mouse and keyboard

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
