### PR TITLE
eopkg: Bump to pick up iksemel changes

### DIFF
--- a/packages/e/eopkg/package.yml
+++ b/packages/e/eopkg/package.yml
@@ -1,6 +1,6 @@
 name       : eopkg
 version    : 4.2.1
-release    : 22
+release    : 23
 source     :
     - https://github.com/getsolus/eopkg/archive/refs/tags/v4.2.1.tar.gz : 5db28176ef8d35c18b7578f4ec240815c58aaf744d0f0f85283e052cd47fd6d9
     - git|https://github.com/getsolus/PackageKit.git : 9b0f17c1ba6addc1c85bff34b64efad6a905ca50

--- a/packages/e/eopkg/pspec_x86_64.xml
+++ b/packages/e/eopkg/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>eopkg</Name>
         <Homepage>https://github.com/getsolus/eopkg</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -35,11 +35,11 @@
             <Path fileType="executable">/usr/bin/eopkg.py3</Path>
             <Path fileType="executable">/usr/bin/lseopkg.py3</Path>
             <Path fileType="executable">/usr/bin/uneopkg.py3</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.2.1.dist-info/AUTHORS</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.2.1.dist-info/METADATA</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.2.1.dist-info/RECORD</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.2.1.dist-info/WHEEL</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.2.1.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.2.1.dist-info/licenses/AUTHORS</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.2.1.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pisi/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pisi/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -449,12 +449,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2025-06-06</Date>
+        <Update release="23">
+            <Date>2025-06-14</Date>
             <Version>4.2.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
`iksemel` recently received an updated patch, which fixes previously-broken unicode output. This bump incorporates that change into `eopkg.bin`.

**Test Plan**
1. Run `eopkg.bin info deja-dup`. Note that the output contains "?" instead of accented characters.
2. Build and install `eopkg` from this PR.
3. Run `eopkg.bin info deja-dup`. Note that the output is now correct, just like `eopkg.py2` is.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
