### PR TITLE
pisi: Make `eopkg.bin` the default

### DIFF
--- a/packages/p/pisi/actions.py
+++ b/packages/p/pisi/actions.py
@@ -4,12 +4,12 @@ def install():
     pythonmodules.install()
 
     # BEGIN comment these out for the epoch bump build of pisi
-    pisitools.dosym("eopkg.py2", "/usr/bin/eopkg")
-    pisitools.dosym("eopkg.py2", "/usr/bin/eopkg-cli")
-    pisitools.dosym("lseopkg.py2", "/usr/bin/lseopkg")
-    pisitools.dosym("lseopkg.py2", "/usr/bin/lspisi.py2")
-    pisitools.dosym("uneopkg.py2", "/usr/bin/uneopkg")
-    pisitools.dosym("uneopkg.py2", "/usr/bin/unpisi.py2")
+    pisitools.dosym("eopkg.bin", "/usr/bin/eopkg")
+    pisitools.dosym("eopkg.bin", "/usr/bin/eopkg-cli")
+    pisitools.dosym("lseopkg.py3", "/usr/bin/lseopkg")
+    pisitools.dosym("lseopkg.py3", "/usr/bin/lspisi.py2")
+    pisitools.dosym("uneopkg.py3", "/usr/bin/uneopkg")
+    pisitools.dosym("uneopkg.py3", "/usr/bin/unpisi.py2")
     # END comment these out for the epoch bump build of pisi
     pisitools.dodir("/etc/mudur")
     shelltools.echo("%s/etc/mudur/locale" % get.installDIR(), "")

--- a/packages/p/pisi/pspec.xml
+++ b/packages/p/pisi/pspec.xml
@@ -67,6 +67,13 @@
     </Package>
 
     <History>
+        <Update release="119">
+            <Date>06-14-2025</Date>
+            <Version>3.12.5</Version>
+            <Comment>Change eopkg symlink to eopkg.bin and all other symlinks to their py3 equivalents</Comment>
+            <Name>Hans Kelson</Name>
+            <Email>hans@communitycomputing.net</Email>
+        </Update>
         <Update release="118">
             <Date>10-15-2024</Date>
             <Version>3.12.5</Version>


### PR DESCRIPTION
**Summary**
- Makes python3-based `eopkg.bin` the default eopkg.

**Test Plan**
1. Build and install `pisi` from this PR.
2. Note that `file /usr/bin/eopkg` now reports `/usr/bin/eopkg: symbolic link to eopkg.bin`, and other eopkg symlinks are similarly changed.
3. Note that the upgrade didn't blow up.
4. Try some eopkg operations to make sure stuff works.

The above is what I did. This PR will need ***extensive*** testing -- before this hits stable, we need to make sure upgrades from very old ISOs still work, etc. I think we should test this as a PR until next sync, and then advertise in next week's sync notes that this will be landing shortly after sync so people who don't want to test it yet can switch their systems to stable temporarily. 

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
