### PR TITLE
libnss: Update to v3.112 and add libfreeblpriv3.so symlink

### DIFF
--- a/packages/l/libnss/package.yml
+++ b/packages/l/libnss/package.yml
@@ -1,8 +1,8 @@
 name       : libnss
-version    : '3.110'
-release    : 71
+version    : '3.112'
+release    : 72
 source     :
-    - https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_110_RTM/src/nss-3.110.tar.gz : 9cd610c40422a07771b9b45166be2d052ea2f00b605a7928129e1f2071b3ae27
+    - https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_112_RTM/src/nss-3.112.tar.gz : 33ae72d43b275957252adc8639e84229d3ae692a57b6191b059d9456b8568a68
 license    :
     - GPL-2.0-or-later
     - LGPL-2.1-or-later
@@ -62,7 +62,7 @@ install    : |
     sed -e 's|\/lib\b|/lib%LIBSUFFIX%|g' -i dist/Linux*/lib/pkgconfig/nss.pc
     install -D -m00644 dist/Linux*/lib/pkgconfig/nss.pc $installdir/%libdir%/pkgconfig/nss.pc
 
-    for f in libcrmf.a libfreebl3.so libnssutil3.so libnss3.so libsmime3.so libnssckbi.so \
+    for f in libcrmf.a libfreebl3.so libfreeblpriv3.so libnssutil3.so libnss3.so libsmime3.so libnssckbi.so \
              libsoftokn3.so libnssdbm3.so libssl3.so libnsssysinit.so; do
         ln -s %libdir%/nss/${f} $installdir/%libdir%/${f}
     done

--- a/packages/l/libnss/pspec_x86_64.xml
+++ b/packages/l/libnss/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libnss</Name>
         <Homepage>https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -29,6 +29,7 @@
             <Path fileType="executable">/usr/bin/signtool</Path>
             <Path fileType="executable">/usr/bin/ssltap</Path>
             <Path fileType="library">/usr/lib64/libfreebl3.so</Path>
+            <Path fileType="library">/usr/lib64/libfreeblpriv3.so</Path>
             <Path fileType="library">/usr/lib64/libnss3.so</Path>
             <Path fileType="library">/usr/lib64/libnssckbi.so</Path>
             <Path fileType="library">/usr/lib64/libnssdbm3.so</Path>
@@ -62,10 +63,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="71">libnss</Dependency>
+            <Dependency release="72">libnss</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libfreebl3.so</Path>
+            <Path fileType="library">/usr/lib32/libfreeblpriv3.so</Path>
             <Path fileType="library">/usr/lib32/libnss3.so</Path>
             <Path fileType="library">/usr/lib32/libnssckbi.so</Path>
             <Path fileType="library">/usr/lib32/libnssdbm3.so</Path>
@@ -99,8 +101,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="71">libnss-devel</Dependency>
-            <Dependency release="71">libnss-32bit</Dependency>
+            <Dependency release="72">libnss-32bit</Dependency>
+            <Dependency release="72">libnss-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libcrmf.a</Path>
@@ -150,7 +152,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="71">libnss</Dependency>
+            <Dependency release="72">libnss</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/nss/alghmac.h</Path>
@@ -450,12 +452,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="71">
-            <Date>2025-04-15</Date>
-            <Version>3.110</Version>
+        <Update release="72">
+            <Date>2025-06-15</Date>
+            <Version>3.112</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Make libfreeblpriv3.so symlink available to e.g. firefox

Changelogs:
- [3.111](https://firefox-source-docs.mozilla.org/security/nss/releases/nss_3_111.html)
- [3.112](https://firefox-source-docs.mozilla.org/security/nss/releases/nss_3_112.html)

Resolves https://github.com/getsolus/packages/issues/5798

**Test Plan**
- Confirmed Clearkey playback in firefox works (https://reference.dashif.org/dash.js/latest/samples/drm/clearkey.html)

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
