### PR TITLE
httrack: Update to v3.49.6

### DIFF
--- a/packages/h/httrack/abi_used_symbols
+++ b/packages/h/httrack/abi_used_symbols
@@ -3,10 +3,11 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__printf_chk
+libc.so.6:__recv_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail

--- a/packages/h/httrack/package.yml
+++ b/packages/h/httrack/package.yml
@@ -1,8 +1,8 @@
 name       : httrack
-version    : 3.49.5
-release    : 8
+version    : 3.49.6
+release    : 9
 source     :
-    - git|https://github.com/xroche/httrack.git : ce2d2ce810cb1bbaf1c587a3947c31adb47d5244
+    - git|https://github.com/xroche/httrack.git : 748c35de7858ead963daf1393ad023d75b7820c2
 homepage   : http://www.httrack.com/
 license    : GPL-3.0-or-later
 component  : network.download

--- a/packages/h/httrack/pspec_x86_64.xml
+++ b/packages/h/httrack/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>httrack</Name>
         <Homepage>http://www.httrack.com/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.download</PartOf>
@@ -245,7 +245,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="8">httrack</Dependency>
+            <Dependency release="9">httrack</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/httrack/config.h</Path>
@@ -267,12 +267,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2024-05-19</Date>
-            <Version>3.49.5</Version>
+        <Update release="9">
+            <Date>2025-05-28</Date>
+            <Version>3.49.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Fixed CVE-2017-14062

**Test Plan**

- Mirror a test site

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
