### PR TITLE
python-babel: Fix tests

### DIFF
--- a/packages/py/python-babel/package.yml
+++ b/packages/py/python-babel/package.yml
@@ -1,9 +1,10 @@
 name       : python-babel
 version    : 2.17.0
-release    : 25
+release    : 26
 source     :
     - https://github.com/python-babel/babel/archive/refs/tags/v2.17.0.tar.gz : a52696499d9da7860726444c170f3481dc7409398392f3500783d01c07221bbf
     - https://unicode.org/Public/cldr/46/cldr-common-46.0.zip : fbce9c2275862ad26668fb34783fe6c339f3d92ddfeb5a10a1775fb58181a15d
+    - https://unicode.org/Public/cldr/46/core.zip#cldr-core-46.zip : fbce9c2275862ad26668fb34783fe6c339f3d92ddfeb5a10a1775fb58181a15d
 homepage   : https://babel.pocoo.org
 license    : BSD-3-Clause
 component  : programming.python
@@ -18,14 +19,26 @@ checkdeps  :
     - python-freezegun
     - python-pytest
     - python-pytz
+rundeps    :
+    - python-pytz
 setup      : |
     cp $sources/cldr-common-46.0.zip $workdir/cldr/cldr-common-46.0.zip
-    # todo 3.12
-    rm pyproject.toml setup.cfg
+    cp $sources/cldr-core-46.zip $workdir/cldr/cldr-core-46.zip
+
+    # These files confuse our Python macros, but we need
+    # them later for the test suite. Let's rename them for now.
+    mv pyproject.toml pyproject.toml.bak
+    mv setup.cfg setup.cfg.bak
 build      : |
     %python3_setup import_cldr
 install    : |
     %python3_install
-# todo 3.12
-#check      : |
-#    %python3_test pytest
+check      : |
+    # Rename these back to the test suite works.
+    mv pyproject.toml.bak pyproject.toml
+    mv setup.cfg.bak setup.cfg
+
+    # The tests fail if running in the wrong timezone:
+    # https://github.com/python-babel/babel/issues/757
+    export TZ=UTC
+    %python3_test pytest -vk 'not test_setuptools_commands'

--- a/packages/py/python-babel/pspec_x86_64.xml
+++ b/packages/py/python-babel/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-babel</Name>
         <Homepage>https://babel.pocoo.org</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -1155,12 +1155,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="25">
-            <Date>2025-05-15</Date>
+        <Update release="26">
+            <Date>2025-06-17</Date>
             <Version>2.17.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fix test suite

I really wish we had separate macros for PEP517 projects and setup.py projects...

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the test suite passes during build.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
