### PR TITLE
python-binaryornot: Fix tests

### DIFF
--- a/packages/py/python-binaryornot/package.yml
+++ b/packages/py/python-binaryornot/package.yml
@@ -1,6 +1,6 @@
 name       : python-binaryornot
 version    : 0.4.4
-release    : 5
+release    : 6
 source     :
     - https://github.com/audreyfeldroy/binaryornot/archive/refs/tags/0.4.4.tar.gz : 8cca04876a5e9d01f0dda79390e99089da87f3c1948ab2720661ba379d1b23f2
 homepage   : https://github.com/audreyfeldroy/binaryornot
@@ -26,6 +26,5 @@ build      : |
     %python3_setup
 install    : |
     %python3_install
-# todo 3.12
-#check      : |
-#    pytest
+check      : |
+    %python3_test

--- a/packages/py/python-binaryornot/pspec_x86_64.xml
+++ b/packages/py/python-binaryornot/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-binaryornot</Name>
         <Homepage>https://github.com/audreyfeldroy/binaryornot</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -20,11 +20,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/binaryornot-0.4.4.dist-info/AUTHORS.rst</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/binaryornot-0.4.4.dist-info/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/binaryornot-0.4.4.dist-info/METADATA</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/binaryornot-0.4.4.dist-info/RECORD</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/binaryornot-0.4.4.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/binaryornot-0.4.4.dist-info/licenses/AUTHORS.rst</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/binaryornot-0.4.4.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/binaryornot-0.4.4.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/binaryornot/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/binaryornot/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -38,12 +38,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2025-05-15</Date>
+        <Update release="6">
+            <Date>2025-06-17</Date>
             <Version>0.4.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fix test suite

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the test suite passes during build.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
