### PR TITLE
python-constantly: Re-enable tests

### DIFF
--- a/packages/py/python-constantly/package.yml
+++ b/packages/py/python-constantly/package.yml
@@ -1,6 +1,6 @@
 name       : python-constantly
 version    : 23.10.4
-release    : 9
+release    : 10
 source     :
     - https://github.com/twisted/constantly/archive/refs/tags/23.10.4.tar.gz : c158c7a71ced2a77471ae851089b4ea15c15fce968d3f0105a15819666cd641a
 homepage   : https://github.com/twisted/constantly
@@ -21,6 +21,5 @@ build      : |
     %python3_setup
 install    : |
     %python3_install
-# todo 3.12
-#check      : |
-#    %python3_test pytest -v
+check      : |
+    %python3_test pytest -v

--- a/packages/py/python-constantly/pspec_x86_64.xml
+++ b/packages/py/python-constantly/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-constantly</Name>
         <Homepage>https://github.com/twisted/constantly</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/constantly-23.10.4.dist-info/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/constantly-23.10.4.dist-info/METADATA</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/constantly-23.10.4.dist-info/RECORD</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/constantly-23.10.4.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/constantly-23.10.4.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/constantly-23.10.4.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/constantly/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/constantly/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -43,12 +43,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2025-05-15</Date>
+        <Update release="10">
+            <Date>2025-06-17</Date>
             <Version>23.10.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Re-enable tests

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the test suite passes during build.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
