### PR TITLE
python-hatch-vcs: Re-enable tests

### DIFF
--- a/packages/py/python-hatch-vcs/package.yml
+++ b/packages/py/python-hatch-vcs/package.yml
@@ -1,6 +1,6 @@
 name       : python-hatch-vcs
 version    : 0.4.0
-release    : 7
+release    : 8
 source     :
     - https://files.pythonhosted.org/packages/source/h/hatch_vcs/hatch_vcs-0.4.0.tar.gz : 093810748fe01db0d451fabcf2c1ac2688caefd232d4ede967090b1c1b07d9f7
 homepage   : https://github.com/ofek/hatch-vcs
@@ -24,6 +24,5 @@ build      : |
     %python3_setup
 install    : |
     %python3_install
-# todo 3.12
-#check      : |
-#    %python3_test pytest -v
+check      : |
+    %python3_test pytest -v

--- a/packages/py/python-hatch-vcs/pspec_x86_64.xml
+++ b/packages/py/python-hatch-vcs/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-hatch-vcs</Name>
         <Homepage>https://github.com/ofek/hatch-vcs</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -49,12 +49,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2025-05-15</Date>
+        <Update release="8">
+            <Date>2025-06-17</Date>
             <Version>0.4.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Re-enable test suite

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the test suite passes during build.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
