### PR TITLE
python-helpdev: Re-enable tests

### DIFF
--- a/packages/py/python-helpdev/package.yml
+++ b/packages/py/python-helpdev/package.yml
@@ -1,6 +1,6 @@
 name       : python-helpdev
 version    : 0.7.1
-release    : 9
+release    : 10
 source     :
     - https://gitlab.com/dpizetta/helpdev/-/archive/v0.7.1/helpdev-v0.7.1.tar.bz2 : b52f83d6d3935500da42b434747569660d526cd36e88069bd67a8747cca488fc
 homepage   : https://gitlab.com/dpizetta/helpdev
@@ -12,7 +12,7 @@ description: |
 builddeps  :
     - python-setuptools
 checkdeps  :
-    # pip
+    - pip
     - python-pytest
 rundeps    :
     - python-psutil
@@ -20,6 +20,5 @@ build      : |
     %python3_setup
 install    : |
     %python3_install
-# todo 3.12
-#check      : |
-#    %python3_test py.test3
+check      : |
+    %python3_test py.test3

--- a/packages/py/python-helpdev/pspec_x86_64.xml
+++ b/packages/py/python-helpdev/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-helpdev</Name>
         <Homepage>https://gitlab.com/dpizetta/helpdev</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -34,12 +34,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2025-05-17</Date>
+        <Update release="10">
+            <Date>2025-06-17</Date>
             <Version>0.7.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Re-enable test suite

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the test suite passes during build.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
