### PR TITLE
python-pathspec: Re-enable tests

### DIFF
--- a/packages/py/python-pathspec/package.yml
+++ b/packages/py/python-pathspec/package.yml
@@ -1,6 +1,6 @@
 name       : python-pathspec
 version    : 0.12.1
-release    : 10
+release    : 11
 source     :
     - https://github.com/cpburnz/python-pathspec/archive/refs/tags/v0.12.1.tar.gz : dd47a400b58c965c93e1ee6723b8ac562ade44ebfcc12421075ebc8dbe7030a7
 homepage   : https://github.com/cpburnz/python-path-specification
@@ -19,6 +19,5 @@ build      : |
     %python3_setup
 install    : |
     %python3_install
-# todo 3.12
-#check      : |
-#    %python3_test
+check      : |
+    %python3_test

--- a/packages/py/python-pathspec/pspec_x86_64.xml
+++ b/packages/py/python-pathspec/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-pathspec</Name>
         <Homepage>https://github.com/cpburnz/python-path-specification</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MPL-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -52,12 +52,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2025-05-15</Date>
+        <Update release="11">
+            <Date>2025-06-17</Date>
             <Version>0.12.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Re-enable test suite

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the test suite passes during build.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
