### PR TITLE
python-pluggy: Re-enable tests

### DIFF
--- a/packages/py/python-pluggy/package.yml
+++ b/packages/py/python-pluggy/package.yml
@@ -1,6 +1,6 @@
 name       : python-pluggy
 version    : 1.5.0
-release    : 21
+release    : 22
 source     :
     - https://pypi.debian.net/pluggy/pluggy-1.5.0.tar.gz : 2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1
 homepage   : https://github.com/pytest-dev/pluggy
@@ -21,6 +21,5 @@ build      : |
     %python3_setup
 install    : |
     %python3_install
-# todo 3.12
-#check      : |
-#    %python3_test pytest
+check      : |
+    %python3_test pytest -v

--- a/packages/py/python-pluggy/pspec_x86_64.xml
+++ b/packages/py/python-pluggy/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-pluggy</Name>
         <Homepage>https://github.com/pytest-dev/pluggy</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pluggy-1.5.0.dist-info/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pluggy-1.5.0.dist-info/METADATA</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pluggy-1.5.0.dist-info/RECORD</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pluggy-1.5.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pluggy-1.5.0.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pluggy-1.5.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pluggy/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pluggy/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -53,12 +53,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2025-05-15</Date>
+        <Update release="22">
+            <Date>2025-06-17</Date>
             <Version>1.5.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Re-enable test suite

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the test suite passes during build.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
