### PR TITLE
python-pytest-relaxed: Update to v2.0.2

### DIFF
--- a/packages/py/python-pytest-relaxed/monitoring.yaml
+++ b/packages/py/python-pytest-relaxed/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 317561
+  rss: https://pypi.org/rss/project/pytest-relaxed/releases.xml
+# No known CPE, checked 2025-06-17
+security:
+  cpe: ~

--- a/packages/py/python-pytest-relaxed/package.yml
+++ b/packages/py/python-pytest-relaxed/package.yml
@@ -1,8 +1,8 @@
 name       : python-pytest-relaxed
-version    : 2.0.1
-release    : 8
+version    : 2.0.2
+release    : 9
 source     :
-    - https://github.com/bitprophet/pytest-relaxed/archive/2.0.1.tar.gz : caf4a7da34e922c0cd26fbf37b9aca1bc099a02668bcf83ebf6fe6717687e844
+    - https://github.com/bitprophet/pytest-relaxed/archive/refs/tags/2.0.2.tar.gz : aba10bf2dd25ef25b0a6e116e5ee10e43852fe285f66a4092984c87cbfcf5b18
 homepage   : https://github.com/bitprophet/pytest-relaxed
 license    : BSD-2-Clause
 component  : programming.python
@@ -21,6 +21,5 @@ build      : |
     %python3_setup
 install    : |
     %python3_install
-# todo 3.12
-#check      : |
-#    %python3_test pytest -v
+check      : |
+    %python3_test pytest -v

--- a/packages/py/python-pytest-relaxed/pspec_x86_64.xml
+++ b/packages/py/python-pytest-relaxed/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-pytest-relaxed</Name>
         <Homepage>https://github.com/bitprophet/pytest-relaxed</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -20,20 +20,27 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed-2.0.1-py3.12.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed-2.0.1-py3.12.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed-2.0.1-py3.12.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed-2.0.1-py3.12.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed-2.0.1-py3.12.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed-2.0.1-py3.12.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed-2.0.2-py3.12.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed-2.0.2-py3.12.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed-2.0.2-py3.12.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed-2.0.2-py3.12.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed-2.0.2-py3.12.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed-2.0.2-py3.12.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed/__pycache__/__init__.cpython-312-pytest-8.3.5.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed/__pycache__/__init__.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed/__pycache__/_version.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed/__pycache__/classes.cpython-312-pytest-8.3.5.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed/__pycache__/classes.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed/__pycache__/fixtures.cpython-312-pytest-8.3.5.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed/__pycache__/fixtures.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed/__pycache__/plugin.cpython-312-pytest-8.3.5.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed/__pycache__/plugin.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed/__pycache__/raises.cpython-312-pytest-8.3.5.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed/__pycache__/raises.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed/__pycache__/reporter.cpython-312-pytest-8.3.5.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed/__pycache__/reporter.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed/__pycache__/trap.cpython-312-pytest-8.3.5.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed/__pycache__/trap.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed/_version.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pytest_relaxed/classes.py</Path>
@@ -45,12 +52,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2025-05-15</Date>
-            <Version>2.0.1</Version>
+        <Update release="9">
+            <Date>2025-06-17</Date>
+            <Version>2.0.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fix dangling compatibility issues with pytest version 8.x

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the test suite passes during build.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
