### PR TITLE
jq: Update to v1.8.0

### DIFF
--- a/packages/j/jq/abi_symbols
+++ b/packages/j/jq/abi_symbols
@@ -124,8 +124,10 @@ libjq.so.1:jv_mem_strdup_unguarded
 libjq.so.1:jv_nomem_handler
 libjq.so.1:jv_null
 libjq.so.1:jv_number
+libjq.so.1:jv_number_abs
 libjq.so.1:jv_number_get_literal
 libjq.so.1:jv_number_has_literal
+libjq.so.1:jv_number_negate
 libjq.so.1:jv_number_value
 libjq.so.1:jv_number_with_literal
 libjq.so.1:jv_object
@@ -167,6 +169,7 @@ libjq.so.1:jv_string_implode
 libjq.so.1:jv_string_indexes
 libjq.so.1:jv_string_length_bytes
 libjq.so.1:jv_string_length_codepoints
+libjq.so.1:jv_string_repeat
 libjq.so.1:jv_string_sized
 libjq.so.1:jv_string_slice
 libjq.so.1:jv_string_split
@@ -175,3 +178,4 @@ libjq.so.1:jv_string_vfmt
 libjq.so.1:jv_true
 libjq.so.1:jv_tsd_dec_ctx_fini
 libjq.so.1:jv_tsd_dec_ctx_init
+libjq.so.1:jv_unique

--- a/packages/j/jq/abi_used_symbols
+++ b/packages/j/jq/abi_used_symbols
@@ -4,6 +4,7 @@ libc.so.6:__cxa_atexit
 libc.so.6:__environ
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
+libc.so.6:__fread_chk
 libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
@@ -44,6 +45,7 @@ libc.so.6:memcpy
 libc.so.6:memmem
 libc.so.6:memmove
 libc.so.6:memset
+libc.so.6:mktime
 libc.so.6:open
 libc.so.6:pathconf
 libc.so.6:perror
@@ -79,7 +81,6 @@ libc.so.6:strncpy
 libc.so.6:strptime
 libc.so.6:strrchr
 libc.so.6:strspn
-libc.so.6:strstr
 libc.so.6:time
 libc.so.6:timegm
 libm.so.6:acos
@@ -90,6 +91,7 @@ libm.so.6:atan
 libm.so.6:atan2
 libm.so.6:atanh
 libm.so.6:cbrt
+libm.so.6:ceil
 libm.so.6:cos
 libm.so.6:cosh
 libm.so.6:drem
@@ -100,6 +102,7 @@ libm.so.6:exp10
 libm.so.6:exp2
 libm.so.6:expm1
 libm.so.6:fdim
+libm.so.6:floor
 libm.so.6:fma
 libm.so.6:fmax
 libm.so.6:fmin
@@ -134,6 +137,7 @@ libm.so.6:sqrt
 libm.so.6:tan
 libm.so.6:tanh
 libm.so.6:tgamma
+libm.so.6:trunc
 libm.so.6:y0
 libm.so.6:y1
 libm.so.6:yn

--- a/packages/j/jq/package.yml
+++ b/packages/j/jq/package.yml
@@ -1,8 +1,8 @@
 name       : jq
-version    : '1.7.1'
-release    : 10
+version    : 1.8.0
+release    : 11
 source     :
-    - https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-1.7.1.tar.gz : 478c9ca129fd2e3443fe27314b455e211e0d8c60bc8ff7df703873deeee580c2
+    - https://github.com/jqlang/jq/releases/download/jq-1.8.0/jq-1.8.0.tar.gz : 91811577f91d9a6195ff50c2bffec9b72c8429dc05ec3ea022fd95c06d2b319c
 homepage   : https://stedolan.github.io/jq/
 license    : MIT
 component  : programming.tools

--- a/packages/j/jq/pspec_x86_64.xml
+++ b/packages/j/jq/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>jq</Name>
         <Homepage>https://stedolan.github.io/jq/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.tools</PartOf>
@@ -37,7 +37,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">jq</Dependency>
+            <Dependency release="11">jq</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/jq.h</Path>
@@ -47,12 +47,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2023-12-17</Date>
-            <Version>1.7.1</Version>
+        <Update release="11">
+            <Date>2025-06-20</Date>
+            <Version>1.8.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/jqlang/jq/releases/tag/jq-1.8.0).
- This release includes a number of improvements since the last version. Note that some changes may introduce breaking changes to existing scripts, so be sure to read the release notes carefully.

**Security**
Includes fixes for:
- CVE-2024-23337
- CVE-2024-53427
- CVE-2025-48060

**Test Plan**
- echo '{"foo": "bar"}' | jq '.foo'

**Checklist**

- [X] Package was built and tested against unstable
- [X] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
