### PR TITLE
appstream-catalog: Update to latest catalog

### DIFF
--- a/packages/a/appstream-catalog/package.yml
+++ b/packages/a/appstream-catalog/package.yml
@@ -1,13 +1,13 @@
 name       : appstream-catalog
-version    : '20250613'
-release    : 7
+version    : '20250620'
+release    : 8
 source     :
-    - https://appstream.getsol.us/data/unstable/main/Components-x86_64.xml.gz: 29e5d9545cf967909e18e56163be7ee4cfa89503e465049999e9249d2aef756e
-    - https://appstream.getsol.us/data/unstable/main/icons-128x128.tar.gz: 854779b279022d79708b1af50a42901bdfc28c6ab689001f2ffa51058138f2dc
+    - https://appstream.getsol.us/data/unstable/main/Components-x86_64.xml.gz: e8398b06aec98497e8fbbd7d7082f18a60e09131b88f2028e368d17a34f07ee2
+    - https://appstream.getsol.us/data/unstable/main/icons-128x128.tar.gz: 9f269f45f178e63d2c9865b268ce9dad10e38512d3d73e8aa5ae29c85ea71701
     - https://appstream.getsol.us/data/unstable/main/icons-128x128@2.tar.gz: 5a00c5ec8aecf041b6f6fb68c6efe3490f0d75fd57d0d4eb5a56e7376ebaa398
-    - https://appstream.getsol.us/data/unstable/main/icons-48x48.tar.gz: afd04eea6413bb28d2e0e4ff6550a729da3bb32435e8b58252dc88adadcca69e
+    - https://appstream.getsol.us/data/unstable/main/icons-48x48.tar.gz: 2c2ccaf72db6439dd0ac4f568cbbcf42f286b0afeef426de854ecd3239b8f881
     - https://appstream.getsol.us/data/unstable/main/icons-48x48@2.tar.gz: f0546f9c9dd47bc796687fef47dbaf7e122fad59bb60721d81f801d1c32f08c2
-    - https://appstream.getsol.us/data/unstable/main/icons-64x64.tar.gz: 23f4b7dd21eed05681dd84ad5f6c467d9856ca76f12152a69f8bc4a70ff5914a
+    - https://appstream.getsol.us/data/unstable/main/icons-64x64.tar.gz: 7b0666170f50c69205a45c66694b11d7906814df21e81ddc42ee158a02c43495
     - https://appstream.getsol.us/data/unstable/main/icons-64x64@2.tar.gz: 99abdbff2354a50a30db937130b4414e8a29d830b07e94771e3c4ea7d00aea10
 homepage   : https://www.freedesktop.org/wiki/Distributions/AppStream/
 license    :

--- a/packages/a/appstream-catalog/pspec_x86_64.xml
+++ b/packages/a/appstream-catalog/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>appstream-catalog</Name>
         <Homepage>https://www.freedesktop.org/wiki/Distributions/AppStream/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>CC-BY-SA-3.0</License>
         <License>CC-BY-SA-4.0</License>
@@ -313,7 +313,6 @@
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/helix_helix.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/helvum_org.pipewire.Helvum.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/heroic-games-launcher_com.heroicgameslauncher.hgl.png</Path>
-            <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/hexchat_io.github.Hexchat.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/homebank_homebank.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/horizon-eda_org.horizon_eda.HorizonEDA.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/hplip_hp-logo.png</Path>
@@ -322,7 +321,7 @@
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/hugin_ptbatcher.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/hydrogen_org.hydrogenmusic.Hydrogen.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/inkscape_org.inkscape.Inkscape.png</Path>
-            <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/input-leap_io.github.input_leap.InputLeap.png</Path>
+            <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/input-leap_io.github.input_leap.input-leap.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/input-remapper_input-remapper.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/insomnia_rest.insomnia.Insomnia.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/inxi_utilities-terminal.png</Path>
@@ -1111,7 +1110,6 @@
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/hatari_hatari.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/heaptrack_heaptrack.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/helvum_org.pipewire.Helvum.png</Path>
-            <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/hexchat_io.github.Hexchat.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/homebank_homebank.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/horizon-eda_org.horizon_eda.HorizonEDA.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/hplip_hp-logo.png</Path>
@@ -1121,7 +1119,7 @@
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/hugin_ptbatcher.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/hydrogen_org.hydrogenmusic.Hydrogen.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/inkscape_org.inkscape.Inkscape.png</Path>
-            <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/input-leap_io.github.input_leap.InputLeap.png</Path>
+            <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/input-leap_io.github.input_leap.input-leap.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/input-remapper_input-remapper.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/insomnia_rest.insomnia.Insomnia.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/inxi_utilities-terminal.png</Path>
@@ -1959,7 +1957,6 @@
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/helix_helix.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/helvum_org.pipewire.Helvum.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/heroic-games-launcher_com.heroicgameslauncher.hgl.png</Path>
-            <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/hexchat_io.github.Hexchat.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/homebank_homebank.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/horizon-eda_org.horizon_eda.HorizonEDA.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/hplip_hp-logo.png</Path>
@@ -1969,7 +1966,7 @@
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/hugin_ptbatcher.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/hydrogen_org.hydrogenmusic.Hydrogen.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/inkscape_org.inkscape.Inkscape.png</Path>
-            <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/input-leap_io.github.input_leap.InputLeap.png</Path>
+            <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/input-leap_io.github.input_leap.input-leap.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/input-remapper_input-remapper.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/insomnia_rest.insomnia.Insomnia.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/inxi_utilities-terminal.png</Path>
@@ -2539,12 +2536,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2025-06-13</Date>
-            <Version>20250613</Version>
+        <Update release="8">
+            <Date>2025-06-20</Date>
+            <Version>20250620</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Update Appstream Catalog

**Test Plan**

Search for Hexchat, see it is no longer available from the Solus repository.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
