### PR TITLE
noto-sans-ttf: Update to v2025.06.01

### DIFF
--- a/packages/n/noto-sans-ttf/package.yml
+++ b/packages/n/noto-sans-ttf/package.yml
@@ -1,15 +1,15 @@
 name       : noto-sans-ttf
-version    : 2025.03.01
-release    : 41
+version    : 2025.06.01
+release    : 42
 source     :
-    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-2025.03.01.tar.gz : 780a43c2c4f607a3e7192b88d1401640b0c041f6c2d7a6313c30157f5367c771
+    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-2025.06.01.tar.gz : e90aef554bb484cd0042e7b60cd29f3b0b60eb1bf508d69263427bc6883e0aa7
 homepage   : https://fonts.google.com/noto
 license    : OFL-1.1
 component  :
     - desktop.font
     - ^noto-serif-ttf : desktop.font
 summary    :
-    - Noto Sans Fonts (Multi-lingual and Emoji)
+    - Noto Sans Fonts (Multi-lingual)
     - ^noto-serif-ttf : Noto Serif Fonts (Multi-lingual)
 description: |
     Noto's goal is to provide a beautiful reading experience for all languages. It is a free, professionally-designed, open-source collection of fonts with a harmonious look and feel in multiple weights and styles.

--- a/packages/n/noto-sans-ttf/pspec_x86_64.xml
+++ b/packages/n/noto-sans-ttf/pspec_x86_64.xml
@@ -3,19 +3,19 @@
         <Name>noto-sans-ttf</Name>
         <Homepage>https://fonts.google.com/noto</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>OFL-1.1</License>
         <PartOf>desktop.font</PartOf>
-        <Summary xml:lang="en">Noto Sans Fonts (Multi-lingual and Emoji)</Summary>
+        <Summary xml:lang="en">Noto Sans Fonts (Multi-lingual)</Summary>
         <Description xml:lang="en">Noto&apos;s goal is to provide a beautiful reading experience for all languages. It is a free, professionally-designed, open-source collection of fonts with a harmonious look and feel in multiple weights and styles.
 </Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>noto-sans-ttf</Name>
-        <Summary xml:lang="en">Noto Sans Fonts (Multi-lingual and Emoji)</Summary>
+        <Summary xml:lang="en">Noto Sans Fonts (Multi-lingual)</Summary>
         <Description xml:lang="en">Noto&apos;s goal is to provide a beautiful reading experience for all languages. It is a free, professionally-designed, open-source collection of fonts with a harmonious look and feel in multiple weights and styles.
 </Description>
         <PartOf>desktop.font</PartOf>
@@ -1536,12 +1536,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="41">
-            <Date>2025-06-08</Date>
-            <Version>2025.03.01</Version>
+        <Update release="42">
+            <Date>2025-06-21</Date>
+            <Version>2025.06.01</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

No changelog available

Full commit log available [here](https://github.com/notofonts/notofonts.github.io/compare/noto-monthly-release-2025.03.01...noto-monthly-release-2025.06.01)

**Test Plan**
- Tested the Noto Sans/Serif in LibreOffice Writer
- Confirmed default Noto Sans system font looked alright in my session

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
