### PR TITLE
python-maturin: Update to v1.9.0

### DIFF
--- a/packages/py/python-maturin/abi_used_symbols
+++ b/packages/py/python-maturin/abi_used_symbols
@@ -196,14 +196,9 @@ libgcc_s.so.1:_Unwind_SetIP
 liblzma.so.5:lzma_code
 liblzma.so.5:lzma_end
 liblzma.so.5:lzma_stream_decoder
-libm.so.6:ceil
-libm.so.6:fmod
 libm.so.6:log
 libm.so.6:log2f
 libm.so.6:pow
-libm.so.6:round
-libm.so.6:trunc
-libm.so.6:truncf
 libssl.so.3:OPENSSL_init_ssl
 libssl.so.3:SSL_CTX_ctrl
 libssl.so.3:SSL_CTX_free

--- a/packages/py/python-maturin/package.yml
+++ b/packages/py/python-maturin/package.yml
@@ -1,8 +1,8 @@
 name       : python-maturin
-version    : 1.8.7
-release    : 58
+version    : 1.9.0
+release    : 59
 source     :
-    - https://github.com/PyO3/maturin/archive/refs/tags/v1.8.7.tar.gz : 7fae57e8f14ea469c904f190774dd3c68a70fbc4c87b6a778b3e950e44cb8c24
+    - https://github.com/PyO3/maturin/archive/refs/tags/v1.9.0.tar.gz : 84a74988960a19f4e6ffa6f3a349803403496ced10dd3ff83baf4feed88c3fd8
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-maturin/pspec_x86_64.xml
+++ b/packages/py/python-maturin/pspec_x86_64.xml
@@ -22,10 +22,10 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/maturin</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.8.7.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.8.7.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.8.7.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.8.7.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -38,9 +38,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="58">
-            <Date>2025-06-09</Date>
-            <Version>1.8.7</Version>
+        <Update release="59">
+            <Date>2025-06-23</Date>
+            <Version>1.9.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Update pyproject-toml to 0.13.5
- Fix clippy lints
- `ZipWriter` requires a compression level of `None` for the `stored` method
- Implement PEP 639 Support
- Don't go through Display for platform tag to policy
- Add `--compatibility pypi` to avoid building for unsupported architectures
- Fix self bootstrap without Rust installed

**Test Plan**

Successfully built `python-orjson`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
