### PR TITLE
github-cli: Update to v2.74.2

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.74.1
-release    : 75
+version    : 2.74.2
+release    : 76
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.74.1.tar.gz : ac894d0f16f78db34818c396aad542b1512a776b925a7639d5d5a30d205a103b
+    - https://github.com/cli/cli/archive/refs/tags/v2.74.2.tar.gz : 58d383e75e1a6f3eb5e5694f232d1ed6f7f53681fda9c6a997e6e1be344edd94
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -232,9 +232,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="75">
-            <Date>2025-06-13</Date>
-            <Version>2.74.1</Version>
+        <Update release="76">
+            <Date>2025-06-23</Date>
+            <Version>2.74.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Fix assignees being dropped from `gh pr edit`
- Add accurate context when run rerun fails
- Avoid requesting PR reviewer twice
- Quote filenames suggested at the end of worklow run

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
