### PR TITLE
libwebp: Update to v1.5.0

### DIFF
--- a/packages/l/libwebp/abi_used_symbols
+++ b/packages/l/libwebp/abi_used_symbols
@@ -20,7 +20,9 @@ libGL.so.1:glScissor
 libGL.so.1:glViewport
 libc.so.6:__ctype_b_loc
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoul
 libc.so.6:__libc_start_main
 libc.so.6:__longjmp_chk
 libc.so.6:__memcpy_chk
@@ -71,8 +73,6 @@ libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strtod
 libc.so.6:strtok
-libc.so.6:strtol
-libc.so.6:strtoul
 libgif.so.7:DGifCloseFile
 libgif.so.7:DGifGetExtension
 libgif.so.7:DGifGetExtensionNext
@@ -108,7 +108,9 @@ libjpeg.so.8:jpeg_resync_to_restart
 libjpeg.so.8:jpeg_save_markers
 libjpeg.so.8:jpeg_start_decompress
 libjpeg.so.8:jpeg_std_error
+libm.so.6:ceilf
 libm.so.6:expf
+libm.so.6:floorf
 libm.so.6:log
 libm.so.6:log10
 libm.so.6:logf

--- a/packages/l/libwebp/abi_used_symbols32
+++ b/packages/l/libwebp/abi_used_symbols32
@@ -7,6 +7,7 @@ libc.so.6:calloc
 libc.so.6:free
 libc.so.6:fwrite
 libc.so.6:malloc
+libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset
@@ -22,6 +23,7 @@ libc.so.6:pthread_mutex_lock
 libc.so.6:pthread_mutex_unlock
 libc.so.6:qsort
 libc.so.6:stderr
+libm.so.6:ceilf
 libm.so.6:expf
 libm.so.6:floorf
 libm.so.6:log

--- a/packages/l/libwebp/package.yml
+++ b/packages/l/libwebp/package.yml
@@ -1,8 +1,8 @@
 name       : libwebp
-version    : 1.4.0
-release    : 27
+version    : 1.5.0
+release    : 28
 source     :
-    - https://github.com/webmproject/libwebp/archive/refs/tags/v1.4.0.tar.gz : 12af50c45530f0a292d39a88d952637e43fb2d4ab1883c44ae729840f7273381
+    - https://github.com/webmproject/libwebp/archive/refs/tags/v1.5.0.tar.gz : 668c9aba45565e24c27e17f7aaf7060a399f7f31dba6c97a044e1feacb930f37
 homepage   : https://developers.google.com/speed/webp/
 license    : BSD-3-Clause
 component  : multimedia.codecs

--- a/packages/l/libwebp/pspec_x86_64.xml
+++ b/packages/l/libwebp/pspec_x86_64.xml
@@ -28,17 +28,17 @@
             <Path fileType="executable">/usr/bin/webpinfo</Path>
             <Path fileType="executable">/usr/bin/webpmux</Path>
             <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libwebp.so.7</Path>
-            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libwebp.so.7.1.9</Path>
+            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libwebp.so.7.1.10</Path>
             <Path fileType="library">/usr/lib64/libsharpyuv.so.0</Path>
-            <Path fileType="library">/usr/lib64/libsharpyuv.so.0.1.0</Path>
+            <Path fileType="library">/usr/lib64/libsharpyuv.so.0.1.1</Path>
             <Path fileType="library">/usr/lib64/libwebp.so.7</Path>
-            <Path fileType="library">/usr/lib64/libwebp.so.7.1.9</Path>
+            <Path fileType="library">/usr/lib64/libwebp.so.7.1.10</Path>
             <Path fileType="library">/usr/lib64/libwebpdecoder.so.3</Path>
-            <Path fileType="library">/usr/lib64/libwebpdecoder.so.3.1.9</Path>
+            <Path fileType="library">/usr/lib64/libwebpdecoder.so.3.1.10</Path>
             <Path fileType="library">/usr/lib64/libwebpdemux.so.2</Path>
-            <Path fileType="library">/usr/lib64/libwebpdemux.so.2.0.15</Path>
+            <Path fileType="library">/usr/lib64/libwebpdemux.so.2.0.16</Path>
             <Path fileType="library">/usr/lib64/libwebpmux.so.3</Path>
-            <Path fileType="library">/usr/lib64/libwebpmux.so.3.1.0</Path>
+            <Path fileType="library">/usr/lib64/libwebpmux.so.3.1.1</Path>
         </Files>
     </Package>
     <Package>
@@ -48,19 +48,19 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="27">libwebp</Dependency>
+            <Dependency release="28">libwebp</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libsharpyuv.so.0</Path>
-            <Path fileType="library">/usr/lib32/libsharpyuv.so.0.1.0</Path>
+            <Path fileType="library">/usr/lib32/libsharpyuv.so.0.1.1</Path>
             <Path fileType="library">/usr/lib32/libwebp.so.7</Path>
-            <Path fileType="library">/usr/lib32/libwebp.so.7.1.9</Path>
+            <Path fileType="library">/usr/lib32/libwebp.so.7.1.10</Path>
             <Path fileType="library">/usr/lib32/libwebpdecoder.so.3</Path>
-            <Path fileType="library">/usr/lib32/libwebpdecoder.so.3.1.9</Path>
+            <Path fileType="library">/usr/lib32/libwebpdecoder.so.3.1.10</Path>
             <Path fileType="library">/usr/lib32/libwebpdemux.so.2</Path>
-            <Path fileType="library">/usr/lib32/libwebpdemux.so.2.0.15</Path>
+            <Path fileType="library">/usr/lib32/libwebpdemux.so.2.0.16</Path>
             <Path fileType="library">/usr/lib32/libwebpmux.so.3</Path>
-            <Path fileType="library">/usr/lib32/libwebpmux.so.3.1.0</Path>
+            <Path fileType="library">/usr/lib32/libwebpmux.so.3.1.1</Path>
         </Files>
     </Package>
     <Package>
@@ -70,8 +70,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="27">libwebp-32bit</Dependency>
-            <Dependency release="27">libwebp-devel</Dependency>
+            <Dependency release="28">libwebp-32bit</Dependency>
+            <Dependency release="28">libwebp-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libsharpyuv.so</Path>
@@ -93,7 +93,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="27">libwebp</Dependency>
+            <Dependency release="28">libwebp</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/webp/decode.h</Path>
@@ -124,9 +124,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2024-06-09</Date>
-            <Version>1.4.0</Version>
+        <Update release="28">
+            <Date>2025-06-25</Date>
+            <Version>1.5.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

This is a binary compatible release

Changes:
- `cross_color_transform_bits` added to WebPAuxStats
- minor lossless encoder speed and compression improvements
- lossless encoding does not use floats anymore
- additional Arm optimizations for lossy & lossless + general code generation improvements
- improvements to WASM performance
- improvements and corrections in webp-container-spec.txt and webp-lossless-bitstream-spec.txt
- further security related hardening and increased fuzzing coverage w/fuzztest
- miscellaneous warning, bug & build fixes
- gif2webp: add -sharp_yuv & -near_lossless
- img2webp: add -exact & -noexact
- exit codes normalized; running an example program with no arguments will output its help and exit with an error

**Test Plan**
- Opened and edited some webp files with `eog`, `drawing` and GIMP
- Converted images and gifs to webp using `img2webp` and `gif2webp`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
