### PR TITLE
python-moddb: Update to v0.13.0

### DIFF
--- a/packages/py/python-moddb/package.yml
+++ b/packages/py/python-moddb/package.yml
@@ -1,8 +1,8 @@
 name       : python-moddb
-version    : 0.12.0
-release    : 8
+version    : 0.13.0
+release    : 9
 source     :
-    - https://files.pythonhosted.org/packages/source/m/moddb/moddb-0.12.0.tar.gz : 75ac2f1c37860bfb28302527bb58529bd35a408e86d01dc82323b672fae5278c
+    - https://files.pythonhosted.org/packages/source/m/moddb/moddb-0.13.0.tar.gz : f505c5cbbd89e08176ec5955460e710bd9d6e4e1d7a86b08f1ffcf2b32b47fa9
 homepage   : https://github.com/ClementJ18/moddb
 license    : MIT
 component  : programming.python

--- a/packages/py/python-moddb/pspec_x86_64.xml
+++ b/packages/py/python-moddb/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-moddb</Name>
         <Homepage>https://github.com/ClementJ18/moddb</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,11 +20,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/moddb-0.12.0.dist-info/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/moddb-0.12.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/moddb-0.12.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/moddb-0.12.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/moddb-0.12.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/moddb-0.13.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/moddb-0.13.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/moddb-0.13.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/moddb-0.13.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/moddb-0.13.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/moddb/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/moddb/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/moddb/__pycache__/__init__.cpython-312.pyc</Path>
@@ -91,12 +91,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2025-05-17</Date>
-            <Version>0.12.0</Version>
+        <Update release="9">
+            <Date>2025-06-27</Date>
+            <Version>0.13.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Renamed `base.search` `category` parameter to `search_category` to avoid conflict with filters
- Fixed the way IDs are retrieved
- Fixed a bug where saving files and medias would not stream the response
- Fixed issue where the front page would sometimes fail to parse
- `File` and `Addon` now have a `location` value that contains the location list of the entity
- `File.save`, `Addon.save` and `Media.save` can now take `chunk_size` as a keyword parameter to define the size of the chunks to stream in

Note: Not updating to 0.14.0 yet because that version introduces a whole bunch of new dependencies, among which a weird custom curl build

**Test Plan**

Ran some code examples from the project's documentation

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
