### PR TITLE
python-beautifulsoup4: Update to v4.13.4

### DIFF
--- a/packages/py/python-beautifulsoup4/package.yml
+++ b/packages/py/python-beautifulsoup4/package.yml
@@ -1,8 +1,8 @@
 name       : python-beautifulsoup4
-version    : 4.13.3
-release    : 23
+version    : 4.13.4
+release    : 24
 source     :
-    - https://files.pythonhosted.org/packages/source/b/beautifulsoup4/beautifulsoup4-4.13.3.tar.gz : 1bd32405dacc920b42b83ba01644747ed77456a65760e285fbc47633ceddaf8b
+    - https://files.pythonhosted.org/packages/source/b/beautifulsoup4/beautifulsoup4-4.13.4.tar.gz : dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195
 homepage   : https://www.crummy.com/software/BeautifulSoup/
 license    : MIT
 component  : programming.python

--- a/packages/py/python-beautifulsoup4/pspec_x86_64.xml
+++ b/packages/py/python-beautifulsoup4/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-beautifulsoup4</Name>
         <Homepage>https://www.crummy.com/software/BeautifulSoup/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,11 +20,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/beautifulsoup4-4.13.3.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/beautifulsoup4-4.13.3.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/beautifulsoup4-4.13.3.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/beautifulsoup4-4.13.3.dist-info/licenses/AUTHORS</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/beautifulsoup4-4.13.3.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/beautifulsoup4-4.13.4.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/beautifulsoup4-4.13.4.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/beautifulsoup4-4.13.4.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/beautifulsoup4-4.13.4.dist-info/licenses/AUTHORS</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/beautifulsoup4-4.13.4.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/bs4/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/bs4/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/bs4/__pycache__/__init__.cpython-312.pyc</Path>
@@ -143,12 +143,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2025-05-15</Date>
-            <Version>4.13.3</Version>
+        <Update release="24">
+            <Date>2025-06-27</Date>
+            <Version>4.13.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- If you pass a function as the first argument to a find* method, the function will only ever be called once per tag, with the Tag object as the argument. Starting in 4.13.0, there were cases where the function would be called with a Tag object and then called again with the name of the tag.
- Added a passthrough implementation for NavigableString.__getitem__ which gives a more helpful exception if the user tries to treat it as a Tag and access its HTML attributes.
- Fixed a bug that caused an exception when unpickling the result of parsing certain invalid markup with lxml as the tree builder.
- Converted the AUTHORS file to UTF-8 for PEP8 compliance.

**Test Plan**
- Ran a bunch of examples from the project's documentation
- Confirmed `anki` works correctly

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
