### PR TITLE
smartmontools: Update to v7.5 and add monitoring.yaml

### DIFF
--- a/packages/s/smartmontools/abi_used_symbols
+++ b/packages/s/smartmontools/abi_used_symbols
@@ -23,6 +23,7 @@ libc.so.6:asctime_r
 libc.so.6:calloc
 libc.so.6:chdir
 libc.so.6:close
+libc.so.6:close_range
 libc.so.6:closedir
 libc.so.6:closelog
 libc.so.6:dup
@@ -58,7 +59,6 @@ libc.so.6:lstat
 libc.so.6:malloc
 libc.so.6:memcmp
 libc.so.6:memcpy
-libc.so.6:memmove
 libc.so.6:memset
 libc.so.6:mknod
 libc.so.6:open
@@ -123,7 +123,6 @@ libcap-ng.so.0:capng_clear
 libcap-ng.so.0:capng_updatev
 libgcc_s.so.1:_Unwind_Resume
 libgcc_s.so.1:__udivmodti4
-libgcc_s.so.1:__udivti3
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE16find_last_not_ofEPKcmm
 libstdc++.so.6:_ZNSt11logic_errorC1EPKc
 libstdc++.so.6:_ZNSt11logic_errorD1Ev
@@ -143,12 +142,10 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_mutateEm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt9bad_allocD1Ev
 libstdc++.so.6:_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
-libstdc++.so.6:_ZSt18_Rb_tree_incrementPKSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
-libstdc++.so.6:_ZSt28__throw_bad_array_new_lengthv
 libstdc++.so.6:_ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_
 libstdc++.so.6:_ZTISt11logic_error
 libstdc++.so.6:_ZTISt13runtime_error

--- a/packages/s/smartmontools/monitoring.yaml
+++ b/packages/s/smartmontools/monitoring.yaml
@@ -1,0 +1,7 @@
+releases:
+  id: 4835
+  rss: https://sourceforge.net/projects/smartmontools/rss?limit=200
+security:
+  cpe:
+    - vendor: smartmontools
+      product: smartmontools

--- a/packages/s/smartmontools/package.yml
+++ b/packages/s/smartmontools/package.yml
@@ -1,8 +1,8 @@
 name       : smartmontools
-version    : '7.4'
-release    : 8
+version    : '7.5'
+release    : 9
 source     :
-    - https://sourceforge.net/projects/smartmontools/files/smartmontools/7.4/smartmontools-7.4.tar.gz : e9a61f641ff96ca95319edfb17948cd297d0cd3342736b2c49c99d4716fb993d
+    - https://sourceforge.net/projects/smartmontools/files/smartmontools/7.5/smartmontools-7.5.tar.gz : 690b83ca331378da9ea0d9d61008c4b22dde391387b9bbad7f29387f2595f76e
 homepage   : https://www.smartmontools.org/
 license    : GPL-2.0-or-later
 component  : system.utils

--- a/packages/s/smartmontools/pspec_x86_64.xml
+++ b/packages/s/smartmontools/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>smartmontools</Name>
         <Homepage>https://www.smartmontools.org/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -48,19 +48,19 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="8">smartmontools</Dependency>
+            <Dependency release="9">smartmontools</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/drivedb.h</Path>
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2024-06-08</Date>
-            <Version>7.4</Version>
+        <Update release="9">
+            <Date>2025-06-27</Date>
+            <Version>7.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Release notes available [here](https://github.com/smartmontools/smartmontools/releases/tag/RELEASE_7_5)

**Test Plan**
- Checked SMART values for all my drives using `smartctl`
- Looked at detailed drive info in `gsmartcontrol`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
