### PR TITLE
vlc: Fix AppStream metainfo to be consistent with Flathub

### DIFF
--- a/packages/v/vlc/abi_used_symbols
+++ b/packages/v/vlc/abi_used_symbols
@@ -4321,7 +4321,6 @@ libssl.so.3:SSL_write
 libssl.so.3:TLS_client_method
 libssl.so.3:TLS_server_method
 libstdc++.so.6:_ZNKSt12__basic_fileIcE7is_openEv
-libstdc++.so.6:_ZNKSt5ctypeIcE13_M_widen_initEv
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE13find_first_ofEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE16find_last_not_ofEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE17find_first_not_ofEPKcmm
@@ -4392,10 +4391,8 @@ libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE5clearESt12_Ios_Iostate
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE5imbueERKSt6locale
 libstdc++.so.6:_ZSt11_Hash_bytesPKvmm
 libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
-libstdc++.so.6:_ZSt16__throw_bad_castv
 libstdc++.so.6:_ZSt17__throw_bad_allocv
 libstdc++.so.6:_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
-libstdc++.so.6:_ZSt18_Rb_tree_incrementPKSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc

--- a/packages/v/vlc/package.yml
+++ b/packages/v/vlc/package.yml
@@ -1,6 +1,6 @@
 name       : vlc
 version    : 3.0.21
-release    : 187
+release    : 188
 source     :
     - https://download.videolan.org/pub/videolan/vlc/3.0.21/vlc-3.0.21.tar.xz : 24dbbe1d7dfaeea0994d5def0bbde200177347136dbfe573f5b6a4cee25afbb0
 homepage   : https://www.videolan.org/
@@ -82,6 +82,12 @@ clang      : yes
 setup      : |
     export BUILDCC="$CC"
     %apply_patches
+
+    # sync appstream app-id with Flathub
+    # https: https://code.videolan.org/videolan/vlc/-/merge_requests/1555 (4.0)
+    sed -e 's|org\.videolan\.vlc|org.videolan.VLC|' \
+        -e 's|http:|https:|g' \
+        -i share/vlc.appdata.xml.in.in
 
     %reconfigure \
         --disable-rpath \

--- a/packages/v/vlc/pspec_x86_64.xml
+++ b/packages/v/vlc/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>vlc</Name>
         <Homepage>https://www.videolan.org/</Homepage>
         <Packager>
-            <Name>Rune Morling</Name>
-            <Email>ermo@serpentos.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -19,7 +19,7 @@
         <Description xml:lang="en">VLC is a free and open source cross-platform multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.</Description>
         <PartOf>multimedia.video</PartOf>
         <RuntimeDependencies>
-            <Dependency release="187">vlc-core</Dependency>
+            <Dependency release="188">vlc-core</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/cvlc</Path>
@@ -667,8 +667,8 @@
         <Description xml:lang="en">VLC is a free and open source cross-platform multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="187">vlc</Dependency>
-            <Dependency release="187">vlc-core</Dependency>
+            <Dependency release="188">vlc</Dependency>
+            <Dependency release="188">vlc-core</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/vlc/deprecated.h</Path>
@@ -817,12 +817,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="187">
-            <Date>2024-10-31</Date>
+        <Update release="188">
+            <Date>2025-06-27</Date>
             <Version>3.0.21</Version>
             <Comment>Packaging update</Comment>
-            <Name>Rune Morling</Name>
-            <Email>ermo@serpentos.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Make AppStream app-id consistent with Flathub

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Inspected the built eopkg file, and opened the metainfo file; saw that it uses uppercase VLC as the ID.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
