### PR TITLE
eopkg: Remove git tag reference from version string

### DIFF
--- a/packages/e/eopkg/package.yml
+++ b/packages/e/eopkg/package.yml
@@ -1,6 +1,6 @@
 name       : eopkg
 version    : 4.2.1
-release    : 23
+release    : 24
 source     :
     - https://github.com/getsolus/eopkg/archive/refs/tags/v4.2.1.tar.gz : 5db28176ef8d35c18b7578f4ec240815c58aaf744d0f0f85283e052cd47fd6d9
     - git|https://github.com/getsolus/PackageKit.git : 9b0f17c1ba6addc1c85bff34b64efad6a905ca50
@@ -44,17 +44,18 @@ rundeps    :
         - python-xattr
     - glibc
 setup      : |
-    # get rid of any existing lines w/git ref version info
-    sed "/__version__ += /d" -i pisi/__init__.py
-    # Show clean version info
-    grep -Hn version pisi/__init__.py
-    # append the git ref to __version__ on a new line
-    gawk -i inplace \
-        'BEGIN { "git rev-parse --short HEAD" | getline gitref } { print };
-         /__version__ = / { printf "%s %s\n", $1, "+= \" (" gitref ")\"" };' \
-        pisi/__init__.py
-    # Verify added git ref version info for build introspection purposes
-    grep -Hn version pisi/__init__.py
+    # Uncomment the following in case of future extended testing with a git ref:
+    # # get rid of any existing lines w/git ref version info
+    # sed "/__version__ += /d" -i pisi/__init__.py
+    # # Show clean version info
+    # grep -Hn version pisi/__init__.py
+    # # append the git ref to __version__ on a new line
+    # gawk -i inplace \
+    #     'BEGIN { "git rev-parse --short HEAD" | getline gitref } { print };
+    #      /__version__ = / { printf "%s %s\n", $1, "+= \" (" gitref ")\"" };' \
+    #     pisi/__init__.py
+    # # Verify added git ref version info for build introspection purposes
+    # grep -Hn version pisi/__init__.py
 
     %python3_setup
 build      : |

--- a/packages/e/eopkg/pspec_x86_64.xml
+++ b/packages/e/eopkg/pspec_x86_64.xml
@@ -449,8 +449,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2025-06-14</Date>
+        <Update release="24">
+            <Date>2025-06-28</Date>
             <Version>4.2.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Hans K</Name>


### PR DESCRIPTION
**Summary**
This was very useful when testing rapid `eopkg` changes, but is no longer necessary (and is confusing) now that we deploy `eopkg` using a proper tarball. Leaving the git tag logic commented out in case we want to use it for future development testing.

**Test Plan**

1. Run `eopkg --version`. Note the output: `eopkg 4.2.1 ()`.
2. Build and install `eopkg` from this PR.
3. Run `eopkg --version` again. Note that the output no longer contains `()`. 

Fixes https://github.com/getsolus/eopkg/issues/136.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
