### PR TITLE
Remove libgeocode-glib from builddeps

### DIFF
--- a/packages/g/gnome-clocks/abi_used_symbols
+++ b/packages/g/gnome-clocks/abi_used_symbols
@@ -47,6 +47,7 @@ libadwaita-1.so.0:adw_view_stack_page_set_needs_attention
 libadwaita-1.so.0:adw_view_stack_set_visible_child
 libadwaita-1.so.0:adw_view_stack_set_visible_child_name
 libadwaita-1.so.0:adw_view_switcher_bar_get_type
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__stack_chk_fail
 libc.so.6:bind_textdomain_codeset
@@ -61,7 +62,6 @@ libc.so.6:setlocale
 libc.so.6:strcmp
 libc.so.6:strlen
 libc.so.6:strstr
-libc.so.6:strtol
 libc.so.6:textdomain
 libgeoclue-2.so.0:gclue_location_get_type
 libgeoclue-2.so.0:gclue_simple_get_location
@@ -458,7 +458,9 @@ libgweather-4.so.0:gweather_location_next_child
 libgweather-4.so.0:gweather_location_serialize
 libm.so.6:acos
 libm.so.6:asin
+libm.so.6:ceil
 libm.so.6:cos
+libm.so.6:floor
 libm.so.6:fmod
 libm.so.6:round
 libm.so.6:sin

--- a/packages/g/gnome-clocks/package.yml
+++ b/packages/g/gnome-clocks/package.yml
@@ -1,6 +1,6 @@
 name       : gnome-clocks
 version    : '48.0'
-release    : 22
+release    : 23
 source     :
     - https://download.gnome.org/sources/gnome-clocks/48/gnome-clocks-48.0.tar.xz : 616ee1fb75300b1f26b9766219e954751360ca0fa0f491311bcf83bf38087c62
 homepage   : https://apps.gnome.org/Clocks/
@@ -12,7 +12,6 @@ description: |
 optimize   :
     - lto
 builddeps  :
-    - pkgconfig(geocode-glib-1.0)
     - pkgconfig(gnome-desktop-4)
     - pkgconfig(gweather4)
     - pkgconfig(libadwaita-1)

--- a/packages/g/gnome-clocks/pspec_x86_64.xml
+++ b/packages/g/gnome-clocks/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-clocks</Name>
         <Homepage>https://apps.gnome.org/Clocks/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.gnome</PartOf>
@@ -383,12 +383,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2025-04-04</Date>
+        <Update release="23">
+            <Date>2025-06-29</Date>
             <Version>48.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/g/gnome-contacts/package.yml
+++ b/packages/g/gnome-contacts/package.yml
@@ -1,6 +1,6 @@
 name       : gnome-contacts
 version    : '48.0'
-release    : 22
+release    : 23
 source     :
     - https://download.gnome.org/sources/gnome-contacts/48/gnome-contacts-48.0.tar.xz : a2762995b59427ec3f185f28b5594e37077b72a70cd7c19217ed634637ecc1b5
 homepage   : https://apps.gnome.org/Contacts/
@@ -16,7 +16,6 @@ builddeps  :
     - pkgconfig(clutter-gtk-1.0)
     - pkgconfig(folks)
     - pkgconfig(gee-0.8)
-    - pkgconfig(geocode-glib-1.0)
     - pkgconfig(gnome-desktop-3.0)
     - pkgconfig(goa-1.0)
     - pkgconfig(gobject-introspection-1.0)

--- a/packages/g/gnome-contacts/pspec_x86_64.xml
+++ b/packages/g/gnome-contacts/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-contacts</Name>
         <Homepage>https://apps.gnome.org/Contacts/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>office</PartOf>
@@ -113,12 +113,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2025-04-04</Date>
+        <Update release="23">
+            <Date>2025-06-29</Date>
             <Version>48.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- gnome-clocks: Remove libgeocode-glib from builddeps                                                           
- gnome-contacts: Remove libgeocode-glib from builddeps 

I think we can remove libsoup-2.4 build of geocode-glib

**Test Plan**

<!-- Short description of how the package was tested -->
Launch the apps and make sure it functions properly

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
