### PR TITLE
svtplay-dl: Update to v4.127

### DIFF
--- a/packages/s/svtplay-dl/package.yml
+++ b/packages/s/svtplay-dl/package.yml
@@ -1,8 +1,8 @@
 name       : svtplay-dl
-version    : '4.113'
-release    : 29
+version    : '4.127'
+release    : 30
 source     :
-    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.113.tar.gz : b13e50c4e61974ca0e0c5f749077b9ab0838a8ba8f5b808eca66e7dab0d450f2
+    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.127.tar.gz : fbff3d44b4e4feda5d66393b859ef05a0166a2f4ce91ef0a70279cc2682cfb49
 homepage   : https://svtplay-dl.se/
 license    : MIT
 component  : network.download

--- a/packages/s/svtplay-dl/pspec_x86_64.xml
+++ b/packages/s/svtplay-dl/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>svtplay-dl</Name>
         <Homepage>https://svtplay-dl.se/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>network.download</PartOf>
@@ -21,12 +21,12 @@
         <PartOf>network.download</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/svtplay-dl</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.113.dist-info/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.113.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.113.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.113.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.113.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.113.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.127.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.127.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.127.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.127.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.127.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.127.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -243,12 +243,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="29">
-            <Date>2025-05-29</Date>
-            <Version>4.113</Version>
+        <Update release="30">
+            <Date>2025-07-02</Date>
+            <Version>4.127</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- subtitle: add support for name and fix unicode encoding
- hls: subtitle name support
- fetcher: fix print class repr
- svtplay: fixed a crash on some series with -A
- sr: fix getting some audio files
- svtplay: fix a crash on videos not available
- hls: add a message about we cant access the key
- subtitle: show a message if we have to download a lot of files.
- aftonbladet: improve strategy for private videos

**Test Plan**
- Checked some commands.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
