### PR TITLE
asciidoc: Update to v10.2.1

### DIFF
--- a/packages/a/asciidoc/package.yml
+++ b/packages/a/asciidoc/package.yml
@@ -1,21 +1,23 @@
 name       : asciidoc
-version    : 9.1.1
-release    : 12
+version    : 10.2.1
+release    : 13
 source     :
-    - https://github.com/asciidoc-py/asciidoc-py/releases/download/9.1.1/asciidoc-9.1.1.tar.gz : ea39760ac2739496c14002902571592dc2ae2fa673296ec141a9e491d9c11fca
+    - https://github.com/asciidoc-py/asciidoc-py/releases/download/10.2.1/asciidoc-10.2.1.tar.gz : aa7be8ae894f6cc1e67784d76ffa6c6b9e9f96efdc695db43c6bd63820e5072b
 license    : GPL-2.0-or-later
-homepage   : http://asciidoc.org/
+homepage   : https://asciidoc-py.github.io/
 component  : office
 summary    : AsciiDoc is a text document format for writing notes, documentation, and more.
 description: |
     AsciiDoc is a text document format for writing notes, documentation, and more.
+networking : yes
 builddeps  :
     - pkgconfig(libxslt)
     - docbook-xml
+    - pip
 rundeps    :
     - docbook-xml
-    - libxslt
     - fop
+    - libxslt
 setup      : |
     # It otherwise installs its assets into etc
     %reconfigure --sysconfdir=/usr/share

--- a/packages/a/asciidoc/pspec_x86_64.xml
+++ b/packages/a/asciidoc/pspec_x86_64.xml
@@ -1,17 +1,17 @@
 <PISI>
     <Source>
         <Name>asciidoc</Name>
-        <Homepage>http://asciidoc.org/</Homepage>
+        <Homepage>https://asciidoc-py.github.io/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>office</PartOf>
         <Summary xml:lang="en">AsciiDoc is a text document format for writing notes, documentation, and more.</Summary>
         <Description xml:lang="en">AsciiDoc is a text document format for writing notes, documentation, and more.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>asciidoc</Name>
@@ -21,111 +21,154 @@
         <PartOf>office</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/a2x</Path>
-            <Path fileType="executable">/usr/bin/a2x.py</Path>
             <Path fileType="executable">/usr/bin/asciidoc</Path>
-            <Path fileType="executable">/usr/bin/asciidoc.py</Path>
-            <Path fileType="data">/usr/share/asciidoc/asciidoc.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/dblatex/asciidoc-dblatex.sty</Path>
-            <Path fileType="data">/usr/share/asciidoc/dblatex/asciidoc-dblatex.xsl</Path>
-            <Path fileType="data">/usr/share/asciidoc/docbook-xsl/chunked.xsl</Path>
-            <Path fileType="data">/usr/share/asciidoc/docbook-xsl/common.xsl</Path>
-            <Path fileType="data">/usr/share/asciidoc/docbook-xsl/epub.xsl</Path>
-            <Path fileType="data">/usr/share/asciidoc/docbook-xsl/fo.xsl</Path>
-            <Path fileType="data">/usr/share/asciidoc/docbook-xsl/htmlhelp.xsl</Path>
-            <Path fileType="data">/usr/share/asciidoc/docbook-xsl/manpage.xsl</Path>
-            <Path fileType="data">/usr/share/asciidoc/docbook-xsl/text.xsl</Path>
-            <Path fileType="data">/usr/share/asciidoc/docbook-xsl/xhtml.xsl</Path>
-            <Path fileType="data">/usr/share/asciidoc/docbook45.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/docbook5.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/filters/code/code-filter.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/filters/code/code-filter.py</Path>
-            <Path fileType="data">/usr/share/asciidoc/filters/graphviz/graphviz-filter.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/filters/graphviz/graphviz2png.py</Path>
-            <Path fileType="data">/usr/share/asciidoc/filters/latex/latex-filter.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/filters/latex/latex2img.py</Path>
-            <Path fileType="data">/usr/share/asciidoc/filters/music/music-filter.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/filters/music/music2png.py</Path>
-            <Path fileType="data">/usr/share/asciidoc/filters/source/source-highlight-filter.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/filters/unwraplatex.py</Path>
-            <Path fileType="data">/usr/share/asciidoc/help.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/html4.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/html5.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/README</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/callouts/1.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/callouts/10.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/callouts/11.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/callouts/12.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/callouts/13.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/callouts/14.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/callouts/15.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/callouts/2.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/callouts/3.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/callouts/4.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/callouts/5.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/callouts/6.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/callouts/7.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/callouts/8.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/callouts/9.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/caution.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/example.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/home.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/important.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/next.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/note.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/prev.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/tip.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/up.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/images/icons/warning.png</Path>
-            <Path fileType="data">/usr/share/asciidoc/javascripts/ASCIIMathML.js</Path>
-            <Path fileType="data">/usr/share/asciidoc/javascripts/LaTeXMathML.js</Path>
-            <Path fileType="data">/usr/share/asciidoc/javascripts/asciidoc.js</Path>
-            <Path fileType="data">/usr/share/asciidoc/javascripts/slidy.js</Path>
-            <Path fileType="data">/usr/share/asciidoc/javascripts/toc.js</Path>
-            <Path fileType="data">/usr/share/asciidoc/lang-ca.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/lang-cs.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/lang-de.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/lang-el.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/lang-en.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/lang-es.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/lang-fi.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/lang-fr.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/lang-hu.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/lang-id.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/lang-it.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/lang-ja.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/lang-nl.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/lang-pl.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/lang-pt-BR.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/lang-ro.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/lang-ru.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/lang-sv.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/lang-uk.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/lang-zh-CN.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/latex.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/slidy.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/stylesheets/asciidoc.css</Path>
-            <Path fileType="data">/usr/share/asciidoc/stylesheets/docbook-xsl.css</Path>
-            <Path fileType="data">/usr/share/asciidoc/stylesheets/pygments.css</Path>
-            <Path fileType="data">/usr/share/asciidoc/stylesheets/slidy.css</Path>
-            <Path fileType="data">/usr/share/asciidoc/stylesheets/toc2.css</Path>
-            <Path fileType="data">/usr/share/asciidoc/stylesheets/xhtml11-quirks.css</Path>
-            <Path fileType="data">/usr/share/asciidoc/text.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/themes/flask/flask.css</Path>
-            <Path fileType="data">/usr/share/asciidoc/themes/volnitsky/volnitsky.css</Path>
-            <Path fileType="data">/usr/share/asciidoc/xhtml11-quirks.conf</Path>
-            <Path fileType="data">/usr/share/asciidoc/xhtml11.conf</Path>
-            <Path fileType="man">/usr/share/man/man1/a2x.1</Path>
-            <Path fileType="man">/usr/share/man/man1/asciidoc.1</Path>
-            <Path fileType="man">/usr/share/man/man1/testasciidoc.1</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc-10.2.1.dist-info/INSTALLER</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc-10.2.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc-10.2.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc-10.2.1.dist-info/REQUESTED</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc-10.2.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc-10.2.1.dist-info/direct_url.json</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc-10.2.1.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc-10.2.1.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc-10.2.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/__main__.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/__metadata__.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/__pycache__/__init__.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/__pycache__/__main__.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/__pycache__/__metadata__.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/__pycache__/a2x.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/__pycache__/api.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/__pycache__/asciidoc.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/__pycache__/attrs.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/__pycache__/collections.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/__pycache__/exceptions.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/__pycache__/message.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/__pycache__/plugin.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/__pycache__/utils.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/a2x.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/api.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/asciidoc.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/attrs.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/blocks/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/blocks/__pycache__/__init__.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/blocks/__pycache__/table.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/blocks/table.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/collections.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/exceptions.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/message.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/plugin.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/asciidoc.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/dblatex/asciidoc-dblatex.sty</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/dblatex/asciidoc-dblatex.xsl</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/dblatex/dblatex-readme.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/docbook-xsl/asciidoc-docbook-xsl.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/docbook-xsl/chunked.xsl</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/docbook-xsl/common.xsl</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/docbook-xsl/epub.xsl</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/docbook-xsl/fo.xsl</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/docbook-xsl/htmlhelp.xsl</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/docbook-xsl/manpage.xsl</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/docbook-xsl/text.xsl</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/docbook-xsl/xhtml.xsl</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/docbook45.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/docbook5.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/filters/__pycache__/unwraplatex.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/filters/code/__pycache__/code-filter.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/filters/code/code-filter-readme.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/filters/code/code-filter-test.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/filters/code/code-filter.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/filters/code/code-filter.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/filters/graphviz/__pycache__/graphviz2png.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/filters/graphviz/asciidoc-graphviz-sample.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/filters/graphviz/graphviz-filter.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/filters/graphviz/graphviz2png.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/filters/latex/__pycache__/latex2img.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/filters/latex/latex-filter.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/filters/latex/latex2img.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/filters/music/__pycache__/music2png.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/filters/music/music-filter-test.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/filters/music/music-filter.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/filters/music/music2png.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/filters/source/source-highlight-filter-test.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/filters/source/source-highlight-filter.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/filters/unwraplatex.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/help.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/html4.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/html5.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/callouts/1.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/callouts/10.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/callouts/11.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/callouts/12.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/callouts/13.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/callouts/14.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/callouts/15.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/callouts/2.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/callouts/3.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/callouts/4.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/callouts/5.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/callouts/6.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/callouts/7.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/callouts/8.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/callouts/9.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/caution.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/example.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/home.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/important.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/next.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/note.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/prev.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/tip.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/up.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/icons/warning.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/javascripts/ASCIIMathML.js</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/javascripts/LaTeXMathML.js</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/javascripts/asciidoc.js</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/javascripts/slidy.js</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/javascripts/toc.js</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/lang-ca.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/lang-cs.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/lang-de.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/lang-el.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/lang-en.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/lang-es.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/lang-fi.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/lang-fr.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/lang-hu.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/lang-id.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/lang-it.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/lang-ja.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/lang-nl.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/lang-pl.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/lang-pt-BR.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/lang-ro.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/lang-ru.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/lang-sv.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/lang-uk.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/lang-zh-CN.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/latex.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/slidy.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/stylesheets/asciidoc.css</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/stylesheets/docbook-xsl.css</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/stylesheets/pygments.css</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/stylesheets/slidy.css</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/stylesheets/toc2.css</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/stylesheets/xhtml11-quirks.css</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/text.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/themes/flask/flask.css</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/themes/volnitsky/volnitsky.css</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/xhtml11-quirks.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/resources/xhtml11.conf</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/asciidoc/utils.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2021-11-30</Date>
-            <Version>9.1.1</Version>
+        <Update release="13">
+            <Date>2025-07-03</Date>
+            <Version>10.2.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Breaking Changes
AsciiDoc.py has been rewritten to be a proper Python package, installable via pip.
- Full changelog [here](https://github.com/asciidoc-py/asciidoc-py/blob/main/CHANGELOG.adoc#version-1021-2024-07-16)

**Test Plan**
- Converted an AsciiDoc to HTML

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
