### PR TITLE
noto-sans-ttf: Update to v2025.07.01

### DIFF
--- a/packages/n/noto-sans-ttf/files/noto-sans-ttf.metainfo.xml
+++ b/packages/n/noto-sans-ttf/files/noto-sans-ttf.metainfo.xml
@@ -1042,5 +1042,6 @@
     <font>Noto Sans Myanmar Condensed Black</font>
     <font>Noto Sans Kannada UI Condensed Thin</font>
     <font>Noto Sans Arabic UI SemiCondensed ExtraBold</font>
+    <font>Noto Sans Sunuwar Regular</font>
   </provides>
 </component>

--- a/packages/n/noto-sans-ttf/package.yml
+++ b/packages/n/noto-sans-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : noto-sans-ttf
-version    : 2025.06.01
-release    : 42
+version    : 2025.07.01
+release    : 43
 source     :
-    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-2025.06.01.tar.gz : e90aef554bb484cd0042e7b60cd29f3b0b60eb1bf508d69263427bc6883e0aa7
+    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-2025.07.01.tar.gz : 8f28bfde2d44c80c989c27e5d119f29f082916b13c1420fab6a975a47bcb1cd6
 homepage   : https://fonts.google.com/noto
 license    : OFL-1.1
 component  :

--- a/packages/n/noto-sans-ttf/pspec_x86_64.xml
+++ b/packages/n/noto-sans-ttf/pspec_x86_64.xml
@@ -838,6 +838,7 @@
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansSundanese-Medium.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansSundanese-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansSundanese-SemiBold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansSunuwar-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansSylotiNagri-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansSymbols-Bold.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansSymbols-Light.ttf</Path>
@@ -1536,9 +1537,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="42">
-            <Date>2025-06-21</Date>
-            <Version>2025.06.01</Version>
+        <Update release="43">
+            <Date>2025-07-03</Date>
+            <Version>2025.07.01</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

No changelog available

Full commit log available [here](https://github.com/notofonts/notofonts.github.io/compare/noto-monthly-release-2025.06.01...noto-monthly-release-2025.07.01)

**Test Plan**
- Wrote some text using Noto Sans/Serif in LibreOffice
- Confirmed UI with Noto Sans system font looked alright

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
