### PR TITLE
python-yapsy: Add patch to remove deprecated APIs

### DIFF
--- a/packages/py/python-yapsy/files/remove-deprecated-apis.patch
+++ b/packages/py/python-yapsy/files/remove-deprecated-apis.patch
@@ -1,0 +1,135 @@
+From 29286320673f9e853559cf20aeb3456e541afbd4 Mon Sep 17 00:00:00 2001
+From: Ameya Vikram Singh <ameya.v.singh@gmail.com>
+Date: Mon, 6 Feb 2023 13:31:23 +0530
+Subject: [PATCH] Remove Deprecated API's
+
+* Replaced packaging.version instead of distutils.version
+* Replaced imp module to importlib
+
+**Note:** Probably Deprecates Python 2.7 supports, and maybe some initial versions of Python 3.x.
+
+Signed-off-by: Ameya Vikram Singh <ameya.v.singh@gmail.com>
+---
+ package/test/test_PluginInfo.py         |  3 ++-
+ package/yapsy/PluginInfo.py             |  6 +++---
+ package/yapsy/PluginManager.py          | 17 ++++++++++-------
+ package/yapsy/VersionedPluginManager.py |  8 ++++----
+ 4 files changed, 19 insertions(+), 15 deletions(-)
+
+diff --git a/package/test/test_PluginInfo.py b/package/test/test_PluginInfo.py
+index 0863671..29c736a 100644
+--- a/package/test/test_PluginInfo.py
++++ b/package/test/test_PluginInfo.py
+@@ -6,6 +6,7 @@
+ 
+ 
+ from yapsy.PluginInfo import PluginInfo
++from packaging.version import Version
+ 
+ 
+ class PluginInfoTest(unittest.TestCase):
+@@ -20,7 +21,7 @@ def testDefaultValuesAndAccessors(self):
+ 		self.assertEqual(None,pi.plugin_object)
+ 		self.assertEqual([],pi.categories)
+ 		self.assertEqual(None,pi.error)
+-		self.assertEqual("0.0",pi.version)
++		self.assertEqual(Version("0.0"),pi.version)
+ 		self.assertEqual("Unknown",pi.author)
+ 		self.assertEqual("Unknown",pi.copyright)
+ 		self.assertEqual("None",pi.website)
+diff --git a/package/yapsy/PluginInfo.py b/package/yapsy/PluginInfo.py
+index 69d220e..700374e 100644
+--- a/package/yapsy/PluginInfo.py
++++ b/package/yapsy/PluginInfo.py
+@@ -12,7 +12,7 @@
+ """
+ 
+ from yapsy.compat import ConfigParser
+-from distutils.version import StrictVersion
++from packaging.version import Version
+ 
+ 
+ class PluginInfo(object):
+@@ -105,7 +105,7 @@ def __setPath(self,path):
+ 
+ 	
+ 	def __getVersion(self):
+-		return StrictVersion(self.details.get("Documentation","Version"))
++		return Version(self.details.get("Documentation","Version"))
+ 	
+ 	def setVersion(self, vstring):
+ 		"""
+@@ -114,7 +114,7 @@ def setVersion(self, vstring):
+ 		Used by subclasses to provide different handling of the
+ 		version number.
+ 		"""
+-		if isinstance(vstring,StrictVersion):
++		if isinstance(vstring,Version):
+ 			vstring = str(vstring)
+ 		if not self.details.has_section("Documentation"):
+ 			self.details.add_section("Documentation")
+diff --git a/package/yapsy/PluginManager.py b/package/yapsy/PluginManager.py
+index 81a7c2b..b72de93 100644
+--- a/package/yapsy/PluginManager.py
++++ b/package/yapsy/PluginManager.py
+@@ -128,10 +128,7 @@
+ 
+ import sys
+ import os
+-try:
+-	import importlib.abc.Loader as imp
+-except ImportError:
+-	import imp
++import importlib
+ 
+ from yapsy import log
+ from yapsy import NormalizePluginNameForModuleName
+@@ -577,11 +574,17 @@ def _importModule(plugin_module_name, candidate_filepath):
+ 		.. note:: Isolated and provided to be reused, but not to be reimplemented !
+ 		"""
+ 		# use imp to correctly load the plugin as a module
++		candidate_module = None
+ 		if os.path.isdir(candidate_filepath):
+-			candidate_module = imp.load_module(plugin_module_name,None,candidate_filepath,("py","r",imp.PKG_DIRECTORY))
++			if (spec := importlib.util.spec_from_file_location(candidate_filepath.split('/')[-1], candidate_filepath + "/__init__.py")) is not None:
++				candidate_module = importlib.util.module_from_spec(spec)
++				sys.modules[plugin_module_name] = candidate_module
++				spec.loader.exec_module(candidate_module)
+ 		else:
+-			with open(candidate_filepath+".py","r") as plugin_file:
+-				candidate_module = imp.load_module(plugin_module_name,plugin_file,candidate_filepath+".py",("py","r",imp.PY_SOURCE))
++			if (spec := importlib.util.spec_from_file_location(candidate_filepath.split('/')[-1], candidate_filepath + ".py")) is not None:
++				candidate_module = importlib.util.module_from_spec(spec)
++				sys.modules[plugin_module_name] = candidate_module
++				spec.loader.exec_module(candidate_module)
+ 		return candidate_module
+ 	
+ 	def instanciateElementWithImportInfo(self, element, element_name,
+diff --git a/package/yapsy/VersionedPluginManager.py b/package/yapsy/VersionedPluginManager.py
+index 83ad4fd..686a52a 100644
+--- a/package/yapsy/VersionedPluginManager.py
++++ b/package/yapsy/VersionedPluginManager.py
+@@ -12,7 +12,7 @@
+ """
+ 
+ 
+-from distutils.version import StrictVersion
++from packaging.version import Version
+ 
+ from yapsy.PluginInfo import PluginInfo
+ from yapsy.IPlugin import IPlugin
+@@ -27,11 +27,11 @@ class VersionedPluginInfo(PluginInfo):
+ 	
+ 	def __init__(self, plugin_name, plugin_path):
+ 		PluginInfo.__init__(self, plugin_name, plugin_path)
+-		# version number is now required to be a StrictVersion object
+-		self.version	= StrictVersion("0.0")
++		# version number is now required to be a Version object
++		self.version	= Version("0.0")
+ 
+ 	def setVersion(self, vstring):
+-		self.version = StrictVersion(vstring)
++		self.version = Version(vstring)
+ 
+ 
+ class VersionedPluginManager(PluginManagerDecorator):

--- a/packages/py/python-yapsy/package.yml
+++ b/packages/py/python-yapsy/package.yml
@@ -1,6 +1,6 @@
 name       : python-yapsy
 version    : 1.12.2
-release    : 4
+release    : 5
 source     :
     - https://files.pythonhosted.org/packages/source/Y/Yapsy/Yapsy-1.12.2.tar.gz : d8113d9f9c74eacf65b4663c9c037d278c9cb273b5eee5f0e1803baeedb23f8b
 license    : BSD-2-Clause-FreeBSD
@@ -14,10 +14,11 @@ builddeps  :
     - python-installer
     - python-setuptools
     - python-wheel
+setup      : |
+    %patch -p2 -i $pkgfiles/remove-deprecated-apis.patch
 build      : |
     %python3_setup
 install    : |
     %python3_install
-# todo 3.12
-#check      : |
-#    %python3_test
+check      : |
+    %python3_test

--- a/packages/py/python-yapsy/pspec_x86_64.xml
+++ b/packages/py/python-yapsy/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-yapsy</Name>
         <Homepage>https://yapsy.sourceforge.net/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>BSD-2-Clause-FreeBSD</License>
         <PartOf>programming.python</PartOf>
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/yapsy-1.12.2.dist-info/LICENSE.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/yapsy-1.12.2.dist-info/METADATA</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/yapsy-1.12.2.dist-info/RECORD</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/yapsy-1.12.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/yapsy-1.12.2.dist-info/licenses/LICENSE.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/yapsy-1.12.2.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/yapsy/AutoInstallPluginManager.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/yapsy/ConfigurablePluginManager.py</Path>
@@ -79,12 +79,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2025-05-20</Date>
+        <Update release="5">
+            <Date>2025-07-04</Date>
             <Version>1.12.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

This fixes, among other things, issues with importlib

Resolves https://github.com/getsolus/packages/issues/5965

**Test Plan**
- Successfully launched `gradience`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
