### PR TITLE
eza: Update to v0.22.0

### DIFF
--- a/packages/e/eza/package.yml
+++ b/packages/e/eza/package.yml
@@ -1,8 +1,8 @@
 name       : eza
-version    : 0.21.6
-release    : 52
+version    : 0.22.0
+release    : 53
 source     :
-    - https://github.com/eza-community/eza/archive/refs/tags/v0.21.6.tar.gz : 8433260eff7be158cfdfafc7dffd620d878c1470b937a88f8a20117591990c67
+    - https://github.com/eza-community/eza/archive/refs/tags/v0.22.0.tar.gz : 9ff08a8e82e558d596291a15fcf89f7f7259d8fe3968cbf26e23315c982cf3e8
 homepage   : https://github.com/eza-community/eza
 license    : EUPL-1.2
 component  : system.utils

--- a/packages/e/eza/pspec_x86_64.xml
+++ b/packages/e/eza/pspec_x86_64.xml
@@ -33,9 +33,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="52">
-            <Date>2025-06-27</Date>
-            <Version>0.21.6</Version>
+        <Update release="53">
+            <Date>2025-07-05</Date>
+            <Version>0.22.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**

**Breaking Change:** The behavior of the `-d` flag has been refined to be more
consistent with `ls`. Its long flag has been changed to `--treat-dirs-as-files`
for clarity, while `--list-dirs` is retained as a backward-compatible alias to be
removed in a future release.

- Replace default_input_path check with "." check

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

List files and folders in a directory.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
