### PR TITLE
gcstar: Update to 1.8.0 + updates until 2025-07-02

### DIFF
--- a/packages/g/gcstar/monitoring.yaml
+++ b/packages/g/gcstar/monitoring.yaml
@@ -2,4 +2,4 @@ releases:
   id: 358017
   rss: https://gitlab.com/GCstar/GCstar/-/releases.atom
 security:
-  cpe: ~ # Last checked 2025-04-03
+  cpe: ~ # Last checked 2025-07-05

--- a/packages/g/gcstar/package.yml
+++ b/packages/g/gcstar/package.yml
@@ -1,10 +1,10 @@
 name       : gcstar
-version    : 1.8.0.2025.04.29
-release    : 4
+version    : 1.8.0.2025.07.02
+release    : 5
 source     :
     # - https://gitlab.com/GCstar/GCstar/-/archive/v1.8.0/GCstar-v1.8.0.tar.gz : 0c790f61a69d0aa2eadc5ef35c45cbfee71beedf
-    - git|https://gitlab.com/GCstar/GCstar.git : 909cd2f3f0c358abb3643635952709c1bda20d2e
-homepage   : https://gcstar.gitlab.io/
+    - git|https://gitlab.com/GCstar/GCstar.git : 0fb82c5cb169d0f1eb4934935cb407a29810bc46
+homepage   : https://gcstar.gitlab.io/gcstar_docs/en/
 license    : GPL-2.0-or-later
 component  : office
 summary    : GCstar is a free open source application for managing your collections.

--- a/packages/g/gcstar/pspec_x86_64.xml
+++ b/packages/g/gcstar/pspec_x86_64.xml
@@ -1,7 +1,7 @@
 <PISI>
     <Source>
         <Name>gcstar</Name>
-        <Homepage>https://gcstar.gitlab.io/</Homepage>
+        <Homepage>https://gcstar.gitlab.io/gcstar_docs/en/</Homepage>
         <Packager>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>
@@ -1448,9 +1448,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2025-05-04</Date>
-            <Version>1.8.0.2025.04.29</Version>
+        <Update release="5">
+            <Date>2025-07-05</Date>
+            <Version>1.8.0.2025.07.02</Version>
             <Comment>Packaging update</Comment>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>


### PR DESCRIPTION
**Summary**

Intermediate version to incorporate updates since 2025-04-29.

Enhancements:

- The images associated to items can be rotated

Full release notes:

- [1.8.1 pre-release](https://gitlab.com/GCstar/GCstar/-/raw/main/gcstar/CHANGELOG)

Package:

- Fix homepage link

**Test Plan**

- Opened library and edited some entries.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged 
