### PR TITLE
spyder3: drop unneccessary dep on importlib-metadata

### DIFF
--- a/packages/s/spyder3/files/0001-Don-t-require-importlib_metadata-on-python-3.10.patch
+++ b/packages/s/spyder3/files/0001-Don-t-require-importlib_metadata-on-python-3.10.patch
@@ -1,0 +1,61 @@
+From 9aa04686907762659144e7dbc9e9cc15536c60c5 Mon Sep 17 00:00:00 2001
+From: Joey Riches <josephriches@gmail.com>
+Date: Sun, 6 Jul 2025 17:10:15 +0100
+Subject: [PATCH 1/1] Don't require importlib_metadata on python >= 3.10
+
+---
+ setup.py               | 4 +---
+ spyder/dependencies.py | 8 ++++++--
+ 2 files changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 17f6418b6..07fcfd8fc 100644
+--- a/setup.py
++++ b/setup.py
+@@ -276,9 +276,7 @@ def run(self):
+     'cloudpickle>=0.5.0',
+     'cookiecutter>=1.6.0',
+     'diff-match-patch>=20181111',
+-    # While this is only required for python <3.10, it is safe enough to
+-    # install in all cases and helps the tests to pass.
+-    'importlib-metadata>=4.6.0',
++    'importlib-metadata>=4.6.0;python_version<"3.10"',
+     'intervaltree>=3.0.2',
+     'ipython>=8.13.0,<9.0.0,!=8.17.1',
+     'ipython_pygments_lexers>=1.0',
+diff --git a/spyder/dependencies.py b/spyder/dependencies.py
+index ec5e9aada..51d3f0ed9 100644
+--- a/spyder/dependencies.py
++++ b/spyder/dependencies.py
+@@ -18,6 +18,9 @@
+ 
+ HERE = osp.dirname(osp.abspath(__file__))
+ 
++# Python 3.10
++PY310 = sys.version_info[:2] < (3, 10)
++
+ # =============================================================================
+ # Kind of dependency
+ # =============================================================================
+@@ -39,7 +42,7 @@
+ CLOUDPICKLE_REQVER = '>=0.5.0'
+ COOKIECUTTER_REQVER = '>=1.6.0'
+ DIFF_MATCH_PATCH_REQVER = '>=20181111'
+-IMPORTLIB_METADATA_REQVER = '>=4.6.0'
++IMPORTLIB_METADATA_REQVER = '>=4.6.0' if PY310 else None
+ INTERVALTREE_REQVER = '>=3.0.2'
+ IPYTHON_REQVER = ">=8.13.0,<9.0.0,!=8.17.1"
+ IPYTHON_PYGMENTS_LEXERS_REQVER = ">=1.0"
+@@ -135,7 +138,8 @@
+     {'modname': 'importlib_metadata',
+      'package_name': 'importlib-metadata',
+      'features': _('Access the metadata for a Python package'),
+-     'required_version': IMPORTLIB_METADATA_REQVER},
++     'required_version': IMPORTLIB_METADATA_REQVER,
++     'display': IMPORTLIB_METADATA_REQVER is not None},
+     {'modname': "intervaltree",
+      'package_name': "intervaltree",
+      'features': _("Compute folding range nesting levels"),
+-- 
+2.49.0
+

--- a/packages/s/spyder3/package.yml
+++ b/packages/s/spyder3/package.yml
@@ -1,6 +1,6 @@
 name       : spyder3
 version    : 6.0.7
-release    : 42
+release    : 43
 source     :
     - https://github.com/spyder-ide/spyder/archive/refs/tags/v6.0.7.tar.gz : a917307482500b4bfbebcbd17ab4e672e0df91ba82e1e00d5203e700052348eb
 homepage   : https://www.spyder-ide.org/
@@ -34,7 +34,6 @@ rundeps    :
     - python-bcrypt
     - python-chardet
     - python-cookiecutter
-    - python-importlib-metadata
     - python-intervaltree
     - python-jellyfish
     - python-keyring
@@ -62,6 +61,8 @@ rundeps    :
     - pyxdg
     - scipy
     - sympy
+setup      : |
+    %patch -p1 -i $pkgfiles/0001-Don-t-require-importlib_metadata-on-python-3.10.patch
 build      : |
     %python3_setup
 install    : |

--- a/packages/s/spyder3/pspec_x86_64.xml
+++ b/packages/s/spyder3/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>spyder3</Name>
         <Homepage>https://www.spyder-ide.org/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>CC-BY-2.5</License>
@@ -2745,12 +2745,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="42">
-            <Date>2025-07-05</Date>
+        <Update release="43">
+            <Date>2025-07-06</Date>
             <Version>6.0.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

This dep is not required on python >= 3.10, don't complain if its not installed

**Test Plan**

Run Help->Dependencies confirm importlib-metadata is no longer required
run pip check

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
