### PR TITLE
xfce4-panel: Backport patch for systray on Wayland

### DIFF
--- a/packages/x/xfce4-panel/abi_used_symbols
+++ b/packages/x/xfce4-panel/abi_used_symbols
@@ -1169,6 +1169,8 @@ libgtk-layer-shell.so.0:gtk_layer_set_keyboard_mode
 libgtk-layer-shell.so.0:gtk_layer_set_layer
 libgtk-layer-shell.so.0:gtk_layer_set_margin
 libgtk-layer-shell.so.0:gtk_layer_set_monitor
+libm.so.6:ceil
+libm.so.6:floor
 libm.so.6:round
 libm.so.6:sincos
 libpango-1.0.so.0:pango_attr_font_desc_new

--- a/packages/x/xfce4-panel/files/wayland-wrapper-Prevent-plugin-allocation-blocking.patch
+++ b/packages/x/xfce4-panel/files/wayland-wrapper-Prevent-plugin-allocation-blocking.patch
@@ -1,0 +1,28 @@
+From 25e28174821a9d7d3fae5894bb3040f5dbf8cb08 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ga=C3=ABl=20Bonithon?= <gael@xfce.org>
+Date: Wed, 14 Aug 2024 19:19:32 +0200
+Subject: [PATCH] wayland: wrapper: Prevent plugin allocation blocking
+
+Fixes: #849
+---
+ wrapper/wrapper-plug-wayland.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/wrapper/wrapper-plug-wayland.c b/wrapper/wrapper-plug-wayland.c
+index f385d03a7..23f65821c 100644
+--- a/wrapper/wrapper-plug-wayland.c
++++ b/wrapper/wrapper-plug-wayland.c
+@@ -166,6 +166,10 @@ wrapper_plug_wayland_init (WrapperPlugWayland *plug)
+   plug->geometry.width = 1;
+   plug->geometry.height = 1;
+ 
++  /* set a minimum size to start with so as not to block plugin allocation (e.g. for systray,
++   * see #849); this will then correct itself through geometry exchanges between socket and plug */
++  gtk_widget_set_size_request (GTK_WIDGET (plug), 16, 16);
++
+   /* add panel css classes so they apply to external plugins as they do to internal ones */
+   context = gtk_widget_get_style_context (GTK_WIDGET (plug));
+   gtk_style_context_add_class (context, "panel");
+-- 
+GitLab
+

--- a/packages/x/xfce4-panel/package.yml
+++ b/packages/x/xfce4-panel/package.yml
@@ -1,6 +1,6 @@
 name       : xfce4-panel
 version    : 4.20.4
-release    : 18
+release    : 19
 source     :
     - https://archive.xfce.org/src/xfce/xfce4-panel/4.20/xfce4-panel-4.20.4.tar.bz2 : 695b23af490719e734c8659394821b43cc94d3bee69994bafdc42ef40daa0d2c
 homepage   : https://docs.xfce.org/xfce/xfce4-panel/start
@@ -22,6 +22,7 @@ rundeps    :
     - network-manager-applet
 setup      : |
     %patch -p1 -i $pkgfiles/0001-Use-Solus-defaults.patch
+    %patch -p1 -i $pkgfiles/wayland-wrapper-Prevent-plugin-allocation-blocking.patch
 
     %configure \
         --sysconfdir=/usr/share

--- a/packages/x/xfce4-panel/pspec_x86_64.xml
+++ b/packages/x/xfce4-panel/pspec_x86_64.xml
@@ -223,7 +223,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="18">xfce4-panel</Dependency>
+            <Dependency release="19">xfce4-panel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/xfce4/libxfce4panel-2.0/libxfce4panel/libxfce4panel-config.h</Path>
@@ -274,8 +274,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2025-03-24</Date>
+        <Update release="19">
+            <Date>2025-07-08</Date>
             <Version>4.20.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
- Fix system tray not appearing sometimes on Wayland

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Restarted the panel while the tray was broken with `xfce4-panel -r`, and see that the tray immediately appeared.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
