### PR TITLE
git: Update to v2.49.1

### DIFF
--- a/packages/g/git/abi_used_symbols
+++ b/packages/g/git/abi_used_symbols
@@ -218,7 +218,6 @@ libc.so.6:strrchr
 libc.so.6:strspn
 libc.so.6:strstr
 libc.so.6:strtod
-libc.so.6:strtol
 libc.so.6:symlink
 libc.so.6:sync_file_range
 libc.so.6:sysconf

--- a/packages/g/git/package.yml
+++ b/packages/g/git/package.yml
@@ -1,8 +1,8 @@
 name       : git
-version    : 2.49.0
-release    : 136
+version    : 2.49.1
+release    : 137
 source     :
-    - https://www.kernel.org/pub/software/scm/git/git-2.49.0.tar.gz : f8047f572f665bebeb637fd5f14678f31b3ca5d2ff9a18f20bd925bd48f75d3c
+    - https://www.kernel.org/pub/software/scm/git/git-2.49.1.tar.gz : 84a8383ffc77146133bc128a544450cf8ce5166cbea5056c98033d2f0c454794
 license    :
     - GPL-2.0-only
     - LGPL-2.1-or-later

--- a/packages/g/git/pspec_x86_64.xml
+++ b/packages/g/git/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>git</Name>
         <Homepage>https://git-scm.com/</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <License>LGPL-2.1-or-later</License>
@@ -569,12 +569,12 @@ and full access to internals.
         </Files>
     </Package>
     <History>
-        <Update release="136">
-            <Date>2025-04-02</Date>
-            <Version>2.49.0</Version>
+        <Update release="137">
+            <Date>2025-07-08</Date>
+            <Version>2.49.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- [2.49.1](https://github.com/git/git/blob/master/Documentation/RelNotes/2.49.1.adoc)

**Security**

- CVE-2025-27613
- CVE-2025-27614
- CVE-2025-46334
- CVE-2025-46835
- CVE-2025-48384
- CVE-2025-48385
- CVE-2025-48386

**Test Plan**

- Clone a repo
- Make some commits

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
