### PR TITLE
libvips: Update to v8.17.1

### DIFF
--- a/packages/l/libvips/abi_used_symbols
+++ b/packages/l/libvips/abi_used_symbols
@@ -151,6 +151,9 @@ libc.so.6:ungetc
 libc.so.6:write
 libcairo.so.2:cairo_create
 libcairo.so.2:cairo_destroy
+libcairo.so.2:cairo_font_options_create
+libcairo.so.2:cairo_font_options_destroy
+libcairo.so.2:cairo_font_options_set_antialias
 libcairo.so.2:cairo_image_surface_create_for_data
 libcairo.so.2:cairo_scale
 libcairo.so.2:cairo_status_to_string
@@ -545,6 +548,7 @@ libheif.so.1:heif_context_get_image_handle
 libheif.so.1:heif_context_get_list_of_top_level_image_IDs
 libheif.so.1:heif_context_get_number_of_top_level_images
 libheif.so.1:heif_context_get_primary_image_ID
+libheif.so.1:heif_context_get_security_limits
 libheif.so.1:heif_context_read_from_reader
 libheif.so.1:heif_context_set_maximum_image_size_limit
 libheif.so.1:heif_context_set_primary_image
@@ -725,6 +729,7 @@ libpango-1.0.so.0:pango_layout_set_spacing
 libpango-1.0.so.0:pango_layout_set_width
 libpango-1.0.so.0:pango_layout_set_wrap
 libpango-1.0.so.0:pango_parse_markup
+libpangocairo-1.0.so.0:pango_cairo_context_set_font_options
 libpangocairo-1.0.so.0:pango_cairo_font_map_new
 libpangocairo-1.0.so.0:pango_cairo_font_map_set_resolution
 libpangocairo-1.0.so.0:pango_cairo_show_layout

--- a/packages/l/libvips/package.yml
+++ b/packages/l/libvips/package.yml
@@ -1,13 +1,13 @@
 name       : libvips
-version    : 8.17.0
-release    : 51
+version    : 8.17.1
+release    : 52
 source     :
-    - https://github.com/libvips/libvips/archive/refs/tags/v8.17.0.tar.gz : 41dd9d302dc58d956b62aa991fc2a803b1757fe764a7e1c096ead7c1127fb568
+    - https://github.com/libvips/libvips/archive/refs/tags/v8.17.1.tar.gz : 79f54d367a485507c1421408ae13768e4734f473edc71af511472645f46dbd08
 homepage   : https://www.libvips.org/
 license    : LGPL-2.1-or-later
 component  :
     - multimedia.library
-    - doc: programming.docs
+    - doc : programming.docs
 summary    :
     - A fast image processing library with low memory needs
     - doc : Documentation for libvips
@@ -41,4 +41,4 @@ install    : |
 check      : |
     %ninja_check
 patterns   :
-    - doc  : /usr/share/doc/
+    - doc : /usr/share/doc/

--- a/packages/l/libvips/pspec_x86_64.xml
+++ b/packages/l/libvips/pspec_x86_64.xml
@@ -26,9 +26,9 @@
             <Path fileType="executable">/usr/bin/vipsthumbnail</Path>
             <Path fileType="library">/usr/lib64/girepository-1.0/Vips-8.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libvips-cpp.so.42</Path>
-            <Path fileType="library">/usr/lib64/libvips-cpp.so.42.19.0</Path>
+            <Path fileType="library">/usr/lib64/libvips-cpp.so.42.19.1</Path>
             <Path fileType="library">/usr/lib64/libvips.so.42</Path>
-            <Path fileType="library">/usr/lib64/libvips.so.42.19.0</Path>
+            <Path fileType="library">/usr/lib64/libvips.so.42.19.1</Path>
             <Path fileType="library">/usr/lib64/vips-modules-8.17/vips-heif.so</Path>
             <Path fileType="library">/usr/lib64/vips-modules-8.17/vips-jxl.so</Path>
             <Path fileType="library">/usr/lib64/vips-modules-8.17/vips-magick.so</Path>
@@ -49,7 +49,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="51">libvips</Dependency>
+            <Dependency release="52">libvips</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/vips/VConnection8.h</Path>
@@ -1525,9 +1525,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="51">
-            <Date>2025-06-07</Date>
-            <Version>8.17.0</Version>
+        <Update release="52">
+            <Date>2025-07-08</Date>
+            <Version>8.17.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- fix API docs build with meson < 0.60
- improve function checks in meson
- tiff: use correct log domain in threadsafe warning handlers
- shift 16-bit output down to 8-bit when unsupported by saver
- text: prevent use of rgba subpixel anti-aliasing
- tiffsave: always apply resolution unit conversion
- cache: suppress invalidation errors in release builds
- dzsave: IIIF: use named region of 'full' when no crop takes place
- pdfload: fix potential crash with pdfium < 6633

**Test Plan**

Edited a bunch of images using `vips`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
