### PR TITLE
Fix package name prefix and monitoring search for python package creation

### DIFF
--- a/common/Scripts/release_monitoring.py
+++ b/common/Scripts/release_monitoring.py
@@ -190,7 +190,7 @@ def get_release_monitoring(package_name: str, tarball_src: str) -> ReleaseMonito
         search_name = package_name[len("python-"):]
     else:
         search_name = package_name
-    response = _get_release_exact_match(package_name, tarball_uri)
+    response = _get_release_exact_match(search_name, tarball_uri)
     return ReleaseMonitoring(
         YamlData(
             releases=Releases(

--- a/common/Scripts/yauto.py
+++ b/common/Scripts/yauto.py
@@ -163,9 +163,10 @@ class AutoPackage:
                     or "setup.cfg" in file
                 ):
                     # this is a python module.
-                    known_types.append(PYTHON_MODULES)
-                    self.component = "programming.python"
-                    self.package_name = f"python-{self.package_name}"
+                    if PYTHON_MODULES not in known_types:
+                        known_types.append(PYTHON_MODULES)
+                        self.component = "programming.python"
+                        self.package_name = f"python-{self.package_name}"
                 # Handle python modules respecting PEP517.
                 if "pyproject.toml" in file or "setup.cfg" in file:
                     if PEP517 not in known_types:


### PR DESCRIPTION
**Summary**

The previous change to `yauto` could lead to the "python-" prefix being applied to the package name several times. This makes sure it's only done once.

Fix a small oversight in the `generate_monitoring` code that caused the prefix to not be stripped for the anitya search.

**Test Plan**

- `RELEASE_MONITORING_TOKEN=<insert-token-here> go-task new -- python-mypy-protobuf https://files.pythonhosted.org/packages/4d/6f/282d64d66bf48ce60e38a6560753f784e0f88ab245ac2fb5e93f701a36cd/mypy-protobuf-3.6.0.tar.gz`
- Confirmed `monitoring.yaml` is correctly filled in
- Confirmed `package.yaml` has proper name (one prefix)

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
