### PR TITLE
grim: Update to v1.5.0

### DIFF
--- a/packages/g/grim/abi_used_symbols
+++ b/packages/g/grim/abi_used_symbols
@@ -96,8 +96,10 @@ libwayland-client.so.0:wl_display_roundtrip
 libwayland-client.so.0:wl_list_empty
 libwayland-client.so.0:wl_list_init
 libwayland-client.so.0:wl_list_insert
+libwayland-client.so.0:wl_list_length
 libwayland-client.so.0:wl_list_remove
 libwayland-client.so.0:wl_output_interface
+libwayland-client.so.0:wl_pointer_interface
 libwayland-client.so.0:wl_proxy_add_listener
 libwayland-client.so.0:wl_proxy_destroy
 libwayland-client.so.0:wl_proxy_get_version

--- a/packages/g/grim/monitoring.yaml
+++ b/packages/g/grim/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 20169
+  rss: https://gitlab.freedesktop.org//-/releases.atom
+ # No known CPE, checked 2025-07-09
+security:
+  cpe: ~

--- a/packages/g/grim/package.yml
+++ b/packages/g/grim/package.yml
@@ -1,8 +1,8 @@
 name       : grim
-version    : 1.4.1
-release    : 3
+version    : 1.5.0
+release    : 4
 source     :
-    - https://git.sr.ht/~emersion/grim/archive/v1.4.1.tar.gz : 5ed8e70fcd83a7e203e92d34dbb82a1342d3f13ad98a6b0310cc97e1a9342ded
+    - https://gitlab.freedesktop.org/emersion/grim/-/archive/v1.5.0/grim-v1.5.0.tar.gz : 9e72a98f7621b1f5741b405b8dbd447acf7d300ddb12667ec526db1ce6154eaa
 license    : MIT
 homepage   : https://wayland.emersion.fr/grim/
 component  : multimedia.graphics

--- a/packages/g/grim/pspec_x86_64.xml
+++ b/packages/g/grim/pspec_x86_64.xml
@@ -11,7 +11,7 @@
         <Summary xml:lang="en">Grab images from a Wayland compositor</Summary>
         <Description xml:lang="en">Grab images from a Wayland compositor
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>grim</Name>
@@ -25,9 +25,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2023-06-21</Date>
-            <Version>1.4.1</Version>
+        <Update release="4">
+            <Date>2025-07-09</Date>
+            <Version>1.5.0</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- grim has moved to gitlab.freedesktop.org
- Add support for ext-image-copy-capture-v1
- Add support for toplevel capture via -T

**Test Plan**

- Take screenshots in Sway

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
