### PR TITLE
Deprecate mariadb-libs

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2899,5 +2899,6 @@
 		<Package>ldb-devel</Package>
 		<Package>ace</Package>
 		<Package>ace-dbginfo</Package>
+		<Package>mariadb-libs</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3931,5 +3931,8 @@
 		<!-- Very old, no longer packaged by other distros -->
 		<Package>ace</Package>
 		<Package>ace-dbginfo</Package>
+
+		<!-- Replaced by mariadb-common -->
+		<Package>mariadb-libs</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
**Summary**

This subpackage was replaced by `mariadb-common` in https://github.com/getsolus/packages/pull/3327
