### PR TITLE
libwebkit-gtk41: Add patch to disable DMABuf on NVIDIA

### DIFF
--- a/packages/l/libwebkit-gtk41/abi_used_symbols
+++ b/packages/l/libwebkit-gtk41/abi_used_symbols
@@ -3296,7 +3296,7 @@ libstdc++.so.6:_ZNKSt5ctypeIcE13_M_widen_initEv
 libstdc++.so.6:_ZNKSt6locale2id5_M_idEv
 libstdc++.so.6:_ZNKSt6locale4nameB5cxx11Ev
 libstdc++.so.6:_ZNKSt8__detail20_Prime_rehash_policy14_M_need_rehashEmmm
-libstdc++.so.6:_ZNKSt9basic_iosIcSt11char_traitsIcEE4fillEv
+libstdc++.so.6:_ZNKSt9basic_iosIcSt11char_traitsIcEE5widenEc
 libstdc++.so.6:_ZNSi10_M_extractIdEERSiRT_
 libstdc++.so.6:_ZNSi10_M_extractIfEERSiRT_
 libstdc++.so.6:_ZNSi10_M_extractIjEERSiRT_
@@ -3379,9 +3379,7 @@ libstdc++.so.6:_ZSt15__once_callable
 libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
 libstdc++.so.6:_ZSt16__throw_bad_castv
 libstdc++.so.6:_ZSt17__throw_bad_allocv
-libstdc++.so.6:_ZSt18_Rb_tree_decrementPKSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
-libstdc++.so.6:_ZSt18_Rb_tree_incrementPKSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc

--- a/packages/l/libwebkit-gtk41/files/disable-dmabuf-nvidia.patch
+++ b/packages/l/libwebkit-gtk41/files/disable-dmabuf-nvidia.patch
@@ -1,0 +1,81 @@
+From a6f223a530ddd008f17cd610ce462971d835bff9 Mon Sep 17 00:00:00 2001
+From: Carlos Garcia Campos <cgarcia@igalia.com>
+Date: Thu, 5 Jun 2025 10:51:07 +0200
+Subject: [PATCH] Disable DMABuf renderer for NVIDIA proprietary drivers
+
+Bug: https://bugs.webkit.org/show_bug.cgi?id=262607
+Bug-Debian: https://bugs.debian.org/1039720
+Origin: https://github.com/WebKit/WebKit/pull/18614
+
+===================================================================
+
+Gbp-Pq: Name disable-nvidia-dmabuf.patch
+---
+ .../gtk/AcceleratedBackingStoreDMABuf.cpp     | 33 +++++++++++++++++++
+ 1 file changed, 33 insertions(+)
+
+diff --git a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+index 461ce4fddb..5592675a0e 100644
+--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
++++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+@@ -39,6 +39,7 @@
+ #include <WebCore/NativeImage.h>
+ #include <WebCore/NotImplemented.h>
+ #include <WebCore/PlatformDisplay.h>
++#include <WebCore/PlatformDisplaySurfaceless.h>
+ #include <WebCore/RefPtrCairo.h>
+ #include <WebCore/ShareableBitmap.h>
+ #include <WebCore/SharedMemory.h>
+@@ -53,6 +54,7 @@
+ 
+ #if USE(GBM)
+ #include <WebCore/DRMDeviceManager.h>
++#include <WebCore/PlatformDisplayGBM.h>
+ #include <gbm.h>
+ 
+ static constexpr uint64_t s_dmabufInvalidModifier = DRM_FORMAT_MOD_INVALID;
+@@ -77,6 +79,34 @@ namespace WebKit {
+ 
+ WTF_MAKE_TZONE_ALLOCATED_IMPL(AcceleratedBackingStoreDMABuf);
+ 
++static bool isNVIDIA()
++{
++    const char* forceDMABuf = getenv("WEBKIT_FORCE_DMABUF_RENDERER");
++    if (forceDMABuf && strcmp(forceDMABuf, "0"))
++        return false;
++
++    std::unique_ptr<WebCore::PlatformDisplay> platformDisplay;
++#if USE(GBM)
++    const char* disableGBM = getenv("WEBKIT_DMABUF_RENDERER_DISABLE_GBM");
++    if (!disableGBM || !strcmp(disableGBM, "0")) {
++
++        auto& manager = WebCore::DRMDeviceManager::singleton();
++        if (!manager.isInitialized())
++            manager.initializeMainDevice(drmRenderNodeDevice());
++        if (auto* device = manager.mainGBMDeviceNode(WebCore::DRMDeviceManager::NodeType::Render))
++            platformDisplay = WebCore::PlatformDisplayGBM::create(device);
++    }
++#endif
++    if (!platformDisplay)
++        platformDisplay = WebCore::PlatformDisplaySurfaceless::create();
++
++    WebCore::GLContext::ScopedGLContext glContext(WebCore::GLContext::createOffscreen(platformDisplay ? *platformDisplay : WebCore::PlatformDisplay::sharedDisplay()));
++    const char* glVendor = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
++    if (glVendor && strstr(glVendor, "NVIDIA"))
++        return true;
++    return false;
++}
++
+ OptionSet<RendererBufferTransportMode> AcceleratedBackingStoreDMABuf::rendererBufferTransportMode()
+ {
+     static OptionSet<RendererBufferTransportMode> mode;
+@@ -92,6 +122,9 @@ OptionSet<RendererBufferTransportMode> AcceleratedBackingStoreDMABuf::rendererBu
+             return;
+         }
+ 
++        if (isNVIDIA())
++            return;
++
+         mode.add(RendererBufferTransportMode::SharedMemory);
+ 
+         const char* forceSHM = getenv("WEBKIT_DMABUF_RENDERER_FORCE_SHM");

--- a/packages/l/libwebkit-gtk41/package.yml
+++ b/packages/l/libwebkit-gtk41/package.yml
@@ -1,6 +1,6 @@
 name       : libwebkit-gtk41
 version    : 2.48.1
-release    : 42
+release    : 43
 source     :
     - https://webkitgtk.org/releases/webkitgtk-2.48.1.tar.xz : 98efdf21c4cdca0fe0b73ab5a8cb52093b5aa52d9b1b016a93f71dbfa1eb258f
 homepage   : https://webkitgtk.org
@@ -48,6 +48,7 @@ rundeps    :
     - bubblewrap
     - xdg-dbus-proxy
 setup      : |
+    %patch -p1 -i $pkgfiles/disable-dmabuf-nvidia.patch
     %cmake_ninja \
                  -DENABLE_DOCUMENTATION=OFF \
                  -DENABLE_SPEECH_SYNTHESIS=OFF \

--- a/packages/l/libwebkit-gtk41/pspec_x86_64.xml
+++ b/packages/l/libwebkit-gtk41/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libwebkit-gtk41</Name>
         <Homepage>https://webkitgtk.org</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>LGPL-2.1-only</License>
         <PartOf>desktop.web</PartOf>
@@ -93,7 +93,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="42">libwebkit-gtk41</Dependency>
+            <Dependency release="43">libwebkit-gtk41</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/webkitgtk-4.1/JavaScriptCore/JSBase.h</Path>
@@ -327,12 +327,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="42">
-            <Date>2025-04-09</Date>
+        <Update release="43">
+            <Date>2025-07-11</Date>
             <Version>2.48.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

This adds a patch to disable the DMABuf renderer when using the proprietary NVIDIA driver.

Fixes rendering/launch issues with, for example, `yelp` and `neohtop`
(see for example recent discussion on the forums here: https://discuss.getsol.us/d/11773-sync-updates-for-week-28-2025/26)

Related to https://github.com/getsolus/packages/issues/621

**Test Plan**

Successfully launched both `yelp` and `neohtop` without workarounds

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
