### PR TITLE
docker-compose: Update to v2.38.2

### DIFF
--- a/packages/d/docker-compose/package.yml
+++ b/packages/d/docker-compose/package.yml
@@ -1,8 +1,8 @@
 name       : docker-compose
-version    : 2.34.0
-release    : 58
+version    : 2.38.2
+release    : 59
 source     :
-    - https://github.com/docker/compose/archive/refs/tags/v2.34.0.tar.gz : 3612fa592658bfaaf646bf3c05289396af954bbbc6299d5bcddec5b0424589be
+    - https://github.com/docker/compose/archive/refs/tags/v2.38.2.tar.gz : 250e087aeb614c762e3cb7c5b0cacb964acfa90f3f1d158942fc06d22d5e1044
 homepage   : https://docs.docker.com/compose/
 license    : Apache-2.0
 component  : virt

--- a/packages/d/docker-compose/pspec_x86_64.xml
+++ b/packages/d/docker-compose/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>docker-compose</Name>
         <Homepage>https://docs.docker.com/compose/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>iisteev</Name>
+            <Email>isteevan.shetoo@is-info.fr</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>virt</PartOf>
@@ -27,12 +27,12 @@ With Compose, you use a Compose file to configure your application&#x2019;s serv
         </Files>
     </Package>
     <History>
-        <Update release="58">
-            <Date>2025-03-19</Date>
-            <Version>2.34.0</Version>
+        <Update release="59">
+            <Date>2025-07-13</Date>
+            <Version>2.38.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>iisteev</Name>
+            <Email>isteevan.shetoo@is-info.fr</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- docker-compose now uses bake for builds (introduced in v2.37.0) by default
- external binaries as service provider to extend compose behavior
- various bug fixes, improvements and new features

Release notes can be found [here](https://github.com/docker/compose/releases)

Notable release notes:
- https://github.com/docker/compose/releases/tag/v2.38.0
- https://github.com/docker/compose/releases/tag/v2.37.0
- https://github.com/docker/compose/releases/tag/v2.36.0

**Test Plan**

<!-- Short description of how the package was tested -->

did run builds and few containers with docker-compose

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
