### PR TITLE
font-firago: Update to v1.001

### DIFF
--- a/packages/f/font-firago/package.yml
+++ b/packages/f/font-firago/package.yml
@@ -1,17 +1,16 @@
 name       : font-firago
-version    : '1.000'
-release    : 5
+version    : 1.001
+release    : 6
 source     :
-    - https://github.com/bBoxType/FiraGO/archive/1.000.tar.gz : b2f97f1ee02921ca1776903fa0e6f1358b017bf854c0e8776b6b8512e3c9d4a1
-homepage   : https://bboxtype.com/typefaces/FiraGO/
+    - https://carrois.com/downloads/FiraGO/Download_Folder_FiraGO_1001.zip : d3866120498c496931265a7b199dc0a54f44330170dde1178bb982fffcc6bb52
+homepage   : https://carrois.com/fira/
 license    : OFL-1.1
 component  : desktop.font
 summary    : An independent Open Source typeface — FiraGO
-description:
-    An independent Open Source typeface — FiraGO
+description: An independent Open Source typeface — FiraGO
 install    : |
     for cat in Italic Roman; do
-        install -D -m00644 Fonts/FiraGO_OTF/${cat}/*.otf -t $installdir/usr/share/fonts/opentype/firago/
+        install -D -m00644 Fonts/FiraGO_OTF_1001/${cat}/*.otf -t $installdir/usr/share/fonts/opentype/firago/
     done
     install -Dm00644 $pkgfiles/firago.metainfo.xml -t $installdir/usr/share/metainfo/
 replaces   :

--- a/packages/f/font-firago/pspec_x86_64.xml
+++ b/packages/f/font-firago/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>font-firago</Name>
-        <Homepage>https://bboxtype.com/typefaces/FiraGO/</Homepage>
+        <Homepage>https://carrois.com/fira/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>OFL-1.1</License>
         <PartOf>desktop.font</PartOf>
@@ -56,12 +56,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2024-11-06</Date>
-            <Version>1.000</Version>
+        <Update release="6">
+            <Date>2025-07-14</Date>
+            <Version>1.001</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- change be.loclBGR to ve.loclBGR
- introduce clear names for stylistic sets
- separate stylistic variant a and g (a=ss04, g=ss05)
- change shape of /longs according to /f and /germandbls in Italic
- optimize anchor position of /zeta
- add rfn-notice to copyright: with Reserved Font Name "Fira"
- Moved ligatures f_f, f_f_i, f_f_j, f_j, f_f_l to liga-feature
- add alternative /four accessible via ss06
- make loclBGR/SRB work

**Test Plan**
- Checked font was still present.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
