### PR TITLE
syncthing: Update to v1.30.0

### DIFF
--- a/packages/s/syncthing/package.yml
+++ b/packages/s/syncthing/package.yml
@@ -1,9 +1,9 @@
 name       : syncthing
-version    : 1.29.7
-release    : 102
+version    : 1.30.0
+release    : 103
 homepage   : https://syncthing.net
 source     :
-    - https://github.com/syncthing/syncthing/archive/refs/tags/v1.29.7.tar.gz : 0e2f2574334fc65220977156caffc521314298c43b361a669ea3ea0507267652
+    - https://github.com/syncthing/syncthing/archive/refs/tags/v1.30.0.tar.gz : 1e9eb93be73960f748fe85d2738793b5a11c88e63839254057d4fd86cd4321a3
 license    : MPL-2.0
 component  : network.util
 networking : yes

--- a/packages/s/syncthing/pspec_x86_64.xml
+++ b/packages/s/syncthing/pspec_x86_64.xml
@@ -50,9 +50,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="102">
-            <Date>2025-06-06</Date>
-            <Version>1.29.7</Version>
+        <Update release="103">
+            <Date>2025-07-14</Date>
+            <Version>1.30.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Tracey Clark</Name>
             <Email>traceyc.dev@tlcnet.info</Email>


### PR DESCRIPTION
**Summary**

**Syncthing 2 is coming**

Syncthing version 1.x will soon be replaced by Syncthing version 2.x. Version 2 brings a new database format and various cleanups, but remains protocol compatible with Syncthing 1.

More detailed information about Syncthing 2 can be found in the release notes at [https://github.com/syncthing/syncthing/releases](https://github.com/syncthing/syncthing/releases).

- fix(protocol): avoid deadlock with concurrent connection start and close
- fix(syncthing): avoid writing panic log to nil fd

- feat(config): expose folder and device info as metrics

- build: properly propagate build tags to Debian build
- chore(protocol): don't start connection routines a second time
- chore(protocol): only allow enc. password changes on cluster config

Full changelog available [here](https://github.com/syncthing/syncthing/releases/)

**Test Plan**

- Restart Syncthing-GTK, use it to restart syncthing, verify all folders sync
- View syncthing gui in web browser, ensure everything looks good

**Checklist**

- [x] pkg was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
