### PR TITLE
python-orjson: Update to v3.11.0

### DIFF
--- a/packages/py/python-orjson/abi_used_symbols
+++ b/packages/py/python-orjson/abi_used_symbols
@@ -6,7 +6,6 @@ UNKNOWN:PyByteArray_Type
 UNKNOWN:PyBytes_FromStringAndSize
 UNKNOWN:PyBytes_Type
 UNKNOWN:PyCMethod_New
-UNKNOWN:PyCallable_Check
 UNKNOWN:PyCapsule_Import
 UNKNOWN:PyDict_New
 UNKNOWN:PyDict_Type
@@ -40,8 +39,8 @@ UNKNOWN:PyModule_AddObjectRef
 UNKNOWN:PyObject_GenericGetDict
 UNKNOWN:PyObject_GetAttr
 UNKNOWN:PyObject_HasAttr
+UNKNOWN:PyObject_Vectorcall
 UNKNOWN:PyObject_VectorcallMethod
-UNKNOWN:PyThreadState_Get
 UNKNOWN:PyTuple_New
 UNKNOWN:PyTuple_Type
 UNKNOWN:PyType_GetDict
@@ -58,8 +57,6 @@ UNKNOWN:_PyDict_NewPresized
 UNKNOWN:_PyDict_Next
 UNKNOWN:_PyDict_SetItem_KnownHash
 UNKNOWN:_PyLong_AsByteArray
-UNKNOWN:_PyObject_MakeTpCall
-UNKNOWN:_Py_CheckFunctionResult
 UNKNOWN:_Py_Dealloc
 UNKNOWN:_Py_FalseStruct
 UNKNOWN:_Py_HashBytes

--- a/packages/py/python-orjson/package.yml
+++ b/packages/py/python-orjson/package.yml
@@ -1,8 +1,8 @@
 name       : python-orjson
-version    : 3.10.18
-release    : 51
+version    : 3.11.0
+release    : 52
 source     :
-    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.10.18.tar.gz : e8da3947d92123eda795b68228cafe2724815621fe35e8e320a9e9593a4bcd53
+    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.11.0.tar.gz : 2e4c129da624f291bcc607016a99e7f04a353f6874f3bd8d9b47b88597d5f700
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-orjson/pspec_x86_64.xml
+++ b/packages/py/python-orjson/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-orjson</Name>
         <Homepage>https://github.com/ijl/orjson</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>MIT</License>
@@ -21,11 +21,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/orjson-3.10.18.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/orjson-3.10.18.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/orjson-3.10.18.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/orjson-3.10.18.dist-info/licenses/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/orjson-3.10.18.dist-info/licenses/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/orjson-3.11.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/orjson-3.11.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/orjson-3.11.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/orjson-3.11.0.dist-info/licenses/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/orjson-3.11.0.dist-info/licenses/LICENSE-MIT</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/orjson/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/orjson/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/orjson/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -35,12 +35,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="51">
-            <Date>2025-05-17</Date>
-            <Version>3.10.18</Version>
+        <Update release="52">
+            <Date>2025-07-16</Date>
+            <Version>3.11.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Use a deserialization buffer allocated per request instead of a shared buffer allocated on import
- ABI compatibility with CPython 3.14 beta 4

**Test Plan**

Ran some examples from the project's README

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
