### PR TITLE
repo_data: Deprecate hexchat-theme-manager

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2900,5 +2900,6 @@
 		<Package>ace</Package>
 		<Package>ace-dbginfo</Package>
 		<Package>mariadb-libs</Package>
+		<Package>hexchat-theme-manager</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3934,5 +3934,8 @@
 
 		<!-- Replaced by mariadb-common -->
 		<Package>mariadb-libs</Package>
+
+		<!-- Hexchat has been deprecated -->
+		<Package>hexchat-theme-manager</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
**Summary**

Hexchat was deprecated in June 2025 see getsolus/packages#5775