### PR TITLE
httpd: Update to v2.4.64

### DIFF
--- a/packages/h/httpd/abi_symbols
+++ b/packages/h/httpd/abi_symbols
@@ -950,6 +950,7 @@ httpd:ap_hack_ap_set_server_protocol
 httpd:ap_hack_ap_set_string_slot
 httpd:ap_hack_ap_set_string_slot_lower
 httpd:ap_hack_ap_set_sub_req_protocol
+httpd:ap_hack_ap_set_time_process_request
 httpd:ap_hack_ap_setup_auth_internal
 httpd:ap_hack_ap_setup_client_block
 httpd:ap_hack_ap_setup_listeners
@@ -976,6 +977,7 @@ httpd:ap_hack_ap_ssl_ocsp_get_resp
 httpd:ap_hack_ap_ssl_ocsp_prime
 httpd:ap_hack_ap_ssl_var_lookup
 httpd:ap_hack_ap_start_lingering_close
+httpd:ap_hack_ap_stat_check
 httpd:ap_hack_ap_state_query
 httpd:ap_hack_ap_str2_alnum
 httpd:ap_hack_ap_str_tolower
@@ -2417,6 +2419,7 @@ httpd:ap_set_server_protocol
 httpd:ap_set_string_slot
 httpd:ap_set_string_slot_lower
 httpd:ap_set_sub_req_protocol
+httpd:ap_set_time_process_request
 httpd:ap_setup_auth_internal
 httpd:ap_setup_client_block
 httpd:ap_setup_listeners
@@ -2445,6 +2448,7 @@ httpd:ap_ssl_ocsp_get_resp
 httpd:ap_ssl_ocsp_prime
 httpd:ap_ssl_var_lookup
 httpd:ap_start_lingering_close
+httpd:ap_stat_check
 httpd:ap_state_query
 httpd:ap_str2_alnum
 httpd:ap_str_tolower
@@ -2605,6 +2609,7 @@ mod_dav.so:dav_find_child_ns
 mod_dav.so:dav_find_next_ns
 mod_dav.so:dav_finish_multistatus
 mod_dav.so:dav_get_allprops
+mod_dav.so:dav_get_base_path
 mod_dav.so:dav_get_binding_hooks
 mod_dav.so:dav_get_depth
 mod_dav.so:dav_get_liveprop_element

--- a/packages/h/httpd/abi_used_symbols
+++ b/packages/h/httpd/abi_used_symbols
@@ -924,6 +924,7 @@ libc.so.6:getpid
 libc.so.6:getpwnam
 libc.so.6:getpwuid
 libc.so.6:getrlimit
+libc.so.6:getsockname
 libc.so.6:gettid
 libc.so.6:inet_ntoa
 libc.so.6:initgroups
@@ -1256,6 +1257,7 @@ libm.so.6:sqrt
 libnghttp2.so.14:nghttp2_is_fatal
 libnghttp2.so.14:nghttp2_option_del
 libnghttp2.so.14:nghttp2_option_new
+libnghttp2.so.14:nghttp2_option_set_max_send_header_block_length
 libnghttp2.so.14:nghttp2_option_set_no_auto_window_update
 libnghttp2.so.14:nghttp2_option_set_no_closed_streams
 libnghttp2.so.14:nghttp2_option_set_no_rfc9113_leading_and_trailing_ws_validation
@@ -1266,6 +1268,7 @@ libnghttp2.so.14:nghttp2_session_callbacks_new
 libnghttp2.so.14:nghttp2_session_callbacks_set_before_frame_send_callback
 libnghttp2.so.14:nghttp2_session_callbacks_set_on_begin_headers_callback
 libnghttp2.so.14:nghttp2_session_callbacks_set_on_data_chunk_recv_callback
+libnghttp2.so.14:nghttp2_session_callbacks_set_on_frame_not_send_callback
 libnghttp2.so.14:nghttp2_session_callbacks_set_on_frame_recv_callback
 libnghttp2.so.14:nghttp2_session_callbacks_set_on_frame_send_callback
 libnghttp2.so.14:nghttp2_session_callbacks_set_on_header_callback
@@ -1416,7 +1419,6 @@ libssl.so.3:SSL_read
 libssl.so.3:SSL_renegotiate
 libssl.so.3:SSL_session_reused
 libssl.so.3:SSL_set_SSL_CTX
-libssl.so.3:SSL_set_accept_state
 libssl.so.3:SSL_set_alpn_protos
 libssl.so.3:SSL_set_bio
 libssl.so.3:SSL_set_cipher_list

--- a/packages/h/httpd/package.yml
+++ b/packages/h/httpd/package.yml
@@ -1,8 +1,8 @@
 name       : httpd
-version    : 2.4.63
-release    : 32
+version    : 2.4.64
+release    : 33
 source     :
-    - https://dlcdn.apache.org/httpd/httpd-2.4.63.tar.gz : 1fdf1667ebe313a04e9f4d35ea9f043a4e0ebb62ba5a3047abcad824224c3867
+    - https://dlcdn.apache.org/httpd/httpd-2.4.64.tar.gz : 5802224a30846f1471d19451a21f0274ad7f193169b9dc01ac56e53e554f63a3
 homepage   : https://httpd.apache.org/
 license    : Apache-2.0
 component  : programming

--- a/packages/h/httpd/pspec_x86_64.xml
+++ b/packages/h/httpd/pspec_x86_64.xml
@@ -1616,7 +1616,7 @@ Based on the the public domain HTTP daemon devloped by Rob McCool at the Nationa
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="32">httpd</Dependency>
+            <Dependency release="33">httpd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/httpd/ap_compat.h</Path>
@@ -1687,9 +1687,9 @@ Based on the the public domain HTTP daemon devloped by Rob McCool at the Nationa
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2025-01-28</Date>
-            <Version>2.4.63</Version>
+        <Update release="33">
+            <Date>2025-07-19</Date>
+            <Version>2.4.64</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Changelog [here](https://downloads.apache.org/httpd/CHANGES_2.4.64)

**Security**

- CVE-2025-53020
- CVE-2025-49812
- CVE-2025-49630
- CVE-2025-23048
- CVE-2024-47252
- CVE-2024-43204
- CVE-2024-42516

**Test Plan**

- Installed, nothing blew up. Very few user-facing rev-deps

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
