### PR TITLE
Added luksGeneration: "luks2"

### DIFF
--- a/packages/c/calamares/files/install/modules/partition.conf
+++ b/packages/c/calamares/files/install/modules/partition.conf
@@ -19,6 +19,8 @@ userSwapChoices:
     # - reuse     # Re-use existing swap, but don't create any (unsupported right now)
     # - file      # To swap file instead of partition
 
+luksGeneration:                     "luks2" #Should set the default luks to luks2 if encryption is selected
+
 defaultFileSystemType:              "ext4"
 
 availableFileSystemTypes:           ["ext4","btrfs","f2fs"]


### PR DESCRIPTION

**Summary**

Adding `luksGeneration: "luks2"` should set the default luks version to luks2 if encryption is enabled. This would be more for the 4.8 ISO unless the 4.7 ISO is updated.

**Test Plan**

Created live 4.7 usb. 

**First Test: Current / Non-Modified with Encryption** 

- Tested with default / current settings in partition.conf
- Performed the install with encryption enabled.
- Verified on Calamares review that it was listed as LUKS (not LUKS2).
![Default-LUKS-test-ss](https://github.com/user-attachments/assets/1a38bf8b-770a-47cd-81af-076c52f3af13)


**Second Test: Encryption test with modified parition.conf**

- Modified /usr/share/calamares/modules/partition.conf and added: luksGeneration: "luks2"
- Performed the install with encryption enabled.
- Verified on Calamares review that it was listed as LUKS2.
![LUKS2-test-ss](https://github.com/user-attachments/assets/3028f96c-802a-40f2-9466-2c2b43c13563)


**Third Test: Test non-encrypted install with the modified parition.conf**

-  Modified /usr/share/calamares/modules/partition.conf and added: luksGeneration: "luks2"
- Performed the install with encryption not enabled.
- Verified on Calamares review that it was not listed with encryption.
- Rebooted check luksDump
![No-LUKS-test-ss](https://github.com/user-attachments/assets/a42d379e-4060-47d1-bb0b-340ce090799e)



**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
