### PR TITLE
tv-lite: Update to v0.7.8

### DIFF
--- a/packages/t/tv-lite/abi_used_symbols
+++ b/packages/t/tv-lite/abi_used_symbols
@@ -47,7 +47,6 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE9_M_appendEP
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE9_M_assignERKS4_
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE9_M_createERmm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE9_M_mutateEmmPKwm
-libstdc++.so.6:_ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEEC1ERKS4_
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt21ios_base_library_initv
@@ -307,7 +306,6 @@ libwx_baseu-3.2.so.0:_ZTV12wxMBConvUTF8
 libwx_baseu-3.2.so.0:_ZTV13wxThreadEvent
 libwx_baseu-3.2.so.0:_ZTV14wxProcessEvent
 libwx_baseu-3.2.so.0:_ZTV15wxStandardPaths
-libwx_baseu-3.2.so.0:_ZTV5wxURI
 libwx_baseu-3.2.so.0:_ZTV7wxTimer
 libwx_baseu-3.2.so.0:_ZTV8wxLocale
 libwx_baseu-3.2.so.0:_ZTV8wxObject

--- a/packages/t/tv-lite/package.yml
+++ b/packages/t/tv-lite/package.yml
@@ -1,8 +1,8 @@
 name       : TV-Lite
-version    : 0.7.7
-release    : 5
+version    : 0.7.8
+release    : 6
 source     :
-    - https://gitlab.com/cburneci/tv-lite/-/archive/0.7.7/tv-lite-0.7.7.tar.bz2 : b24637cb20361def591f6f41ac35b7044b8625797cde95fbdd51c92a82c03e99
+    - https://gitlab.com/cburneci/tv-lite/-/archive/0.7.8/tv-lite-0.7.8.tar.gz : 282f528c962b072e1f032cd53bbaeea8413f4b39a76ec2eff075631eda74a36c
 homepage   : https://tv-lite.com
 license    : GPL-2.0-or-later
 component  : multimedia.video

--- a/packages/t/tv-lite/pspec_x86_64.xml
+++ b/packages/t/tv-lite/pspec_x86_64.xml
@@ -37,9 +37,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2025-01-07</Date>
-            <Version>0.7.7</Version>
+        <Update release="6">
+            <Date>2025-07-22</Date>
+            <Version>0.7.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
- Some build fixes
- Fixed VLC options behavior
- Remember highlighted position in lists
- Work on Wayland

**Test Plan**
- Watched tv.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
