### PR TITLE
rustup: Add conflict for rust-devel

### DIFF
--- a/packages/r/rustup/package.yml
+++ b/packages/r/rustup/package.yml
@@ -1,6 +1,6 @@
 name       : rustup
 version    : 1.28.2
-release    : 28
+release    : 29
 source     :
     - https://github.com/rust-lang/rustup/archive/1.28.2.tar.gz : 5987dcb828068a4a5e29ba99ab26f2983ac0c6e2e4dc3e5b3a3c0fafb69abbc0
 homepage   : https://rust-lang.github.io/rustup/
@@ -17,6 +17,7 @@ builddeps  :
     - rust
 conflicts  :
     - rust
+    - rust-devel
 networking : yes
 environment: |
     # Force use of system libs

--- a/packages/r/rustup/pspec_x86_64.xml
+++ b/packages/r/rustup/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>rustup</Name>
         <Homepage>https://rust-lang.github.io/rustup/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>MIT</License>
@@ -40,15 +40,16 @@
         </Files>
         <Conflicts>
             <Package>rust</Package>
+            <Package>rust-devel</Package>
         </Conflicts>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2025-07-15</Date>
+        <Update release="29">
+            <Date>2025-07-26</Date>
             <Version>1.28.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Resolves https://github.com/getsolus/packages/issues/6105

**Test Plan**

- rustup now warns of conflict when rust-devel is already installed

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
