### PR TITLE
blueprint-compiler: Update to v0.18.0

### DIFF
--- a/packages/b/blueprint-compiler/package.yml
+++ b/packages/b/blueprint-compiler/package.yml
@@ -1,8 +1,8 @@
 name       : blueprint-compiler
-version    : 0.16.0
-release    : 9
+version    : 0.18.0
+release    : 10
 source     :
-    - https://gitlab.gnome.org/GNOME/blueprint-compiler/-/archive/v0.16.0/blueprint-compiler-v0.16.0.tar.gz : 01feb8263fe7a450b0a9fed0fd54cf88947aaf00f86cc7da345f8b39a0e7bd30
+    - https://gitlab.gnome.org/GNOME/blueprint-compiler/-/archive/v0.18.0/blueprint-compiler-v0.18.0.tar.gz : 703c7ccd23cb6f77a8fe9c8cae0f91de9274910ca953de77135b6e79dbff1fc3
 license    : GPL-3.0-or-later
 homepage   : https://jwestman.pages.gitlab.gnome.org/blueprint-compiler/
 component  : programming.tools

--- a/packages/b/blueprint-compiler/pspec_x86_64.xml
+++ b/packages/b/blueprint-compiler/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>blueprint-compiler</Name>
         <Homepage>https://jwestman.pages.gitlab.gnome.org/blueprint-compiler/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Marcus L&#xf6;nnqvist</Name>
+            <Email>marlonn.dev@proton.me</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>programming.tools</PartOf>
@@ -126,12 +126,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2025-05-21</Date>
-            <Version>0.16.0</Version>
+        <Update release="10">
+            <Date>2025-07-27</Date>
+            <Version>0.18.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Marcus L&#xf6;nnqvist</Name>
+            <Email>marlonn.dev@proton.me</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Updated blueprint compiler to version 0.18.0

**Test Plan**

Build and run bazaar flatpak frontend (requires version 0.18.0)

**Checklist**

- [ x ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
