### PR TITLE
util-linux: Activate fstrim.timer by default

### DIFF
--- a/packages/u/util-linux/package.yml
+++ b/packages/u/util-linux/package.yml
@@ -1,6 +1,6 @@
 name       : util-linux
 version    : 2.40.4
-release    : 52
+release    : 53
 source     :
     - https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.40/util-linux-2.40.4.tar.xz : 5c1daf733b04e9859afdc3bd87cc481180ee0f88b5c0946b16fdec931975fb79
 homepage   : https://github.com/util-linux/util-linux
@@ -105,10 +105,15 @@ install    : |
         mv $installdir/usr/lib/* $installdir/usr/lib64
         rmdir $installdir/usr/lib
 
+        # Create necessary systemd directories
+        install -D -d -m 00755 $installdir/%libdir%/systemd/system/{sockets,timers}.target.wants
+
         # Ensure that uuid daemon works
         install -Dm00644 $pkgfiles/util-linux.sysusers $installdir/%libdir%/sysusers.d/util-linux.conf
-        install -D -d -m 00755 $installdir/%libdir%/systemd/system/sockets.target.wants
         ln -sv ../uuidd.socket -t $installdir/%libdir%/systemd/system/sockets.target.wants
+
+        # Enable fstrim.timer by default
+        ln -sv ../fstrim.timer $installdir/%libdir%/systemd/system/timers.target.wants/fstrim.timer
 
         # PAM
         install -dm00755 $installdir/usr/share/defaults/etc/pam.d

--- a/packages/u/util-linux/pspec_x86_64.xml
+++ b/packages/u/util-linux/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>util-linux</Name>
         <Homepage>https://github.com/util-linux/util-linux</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Hans Kelson</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>BSD-4-Clause-UC</License>
@@ -264,6 +264,7 @@
             <Path fileType="library">/usr/lib64/systemd/system/fstrim.timer</Path>
             <Path fileType="library">/usr/lib64/systemd/system/lastlog2-import.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/sockets.target.wants/uuidd.socket</Path>
+            <Path fileType="library">/usr/lib64/systemd/system/timers.target.wants/fstrim.timer</Path>
             <Path fileType="library">/usr/lib64/systemd/system/uuidd.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/uuidd.socket</Path>
             <Path fileType="library">/usr/lib64/sysusers.d/util-linux.conf</Path>
@@ -616,7 +617,7 @@
         <Description xml:lang="en">Util-linux is a suite of essential tools for any Linux system, such as chsh, kill, cfdisk, mkfs, mount, and more.</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="52">util-linux</Dependency>
+            <Dependency release="53">util-linux</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libblkid.so.1</Path>
@@ -637,8 +638,8 @@
         <Description xml:lang="en">Util-linux is a suite of essential tools for any Linux system, such as chsh, kill, cfdisk, mkfs, mount, and more.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="52">util-linux-32bit</Dependency>
-            <Dependency release="52">util-linux-devel</Dependency>
+            <Dependency release="53">util-linux-32bit</Dependency>
+            <Dependency release="53">util-linux-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/lib_fdisk.a</Path>
@@ -677,7 +678,7 @@
         <Description xml:lang="en">Util-linux is a suite of essential tools for any Linux system, such as chsh, kill, cfdisk, mkfs, mount, and more.</Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="52">util-linux</Dependency>
+            <Dependency release="53">util-linux</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/blkid/blkid.h</Path>
@@ -726,12 +727,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="52">
-            <Date>2025-05-08</Date>
+        <Update release="53">
+            <Date>2025-07-29</Date>
             <Version>2.40.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Hans Kelson</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Resolves https://github.com/getsolus/packages/issues/5374

**Test Plan**

- Boot latest snapshot ISO in a VM.
- Run `systemctl status fstrim.timer`. See that it is disabled and inactive.
- Run `systemctl list-timers --all`. See that `fstrim.timer` is not active.
- Build util-linux from this PR, copying it to your local repo (`go-task localcp`).
- Create a smoketest ISO (I used plasma, but this is DE-independent).
- Boot the new smoketest ISO in a VM.
- Run `systemctl status fstrim.timer`. See that the timer shows "active (waiting)" where previously it said "dead". 
> [!NOTE]
> We do not actually want this timer to be **enabled**. As far as I can tell, "disabled" in yellow means the timer *will* be triggered at the appropriate time, but will *not* be triggered on every system startup. 
- Run `systemctl list-timers --all`. See that now, `fstrim.timer` is listed.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
