### PR TITLE
github-cli: Update to v2.76.2

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.76.0
-release    : 78
+version    : 2.76.2
+release    : 79
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.76.0.tar.gz : 101acc7ca272bf3b0e2e5fb39afe7a980afae53656f1d09d5630a57473d9f7db
+    - https://github.com/cli/cli/archive/refs/tags/v2.76.2.tar.gz : 6aee5afebdabd33f4c5e8604a9b7fa55e5bbac2a5cd36101cc221c990320c8b3
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -232,9 +232,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="78">
-            <Date>2025-07-17</Date>
-            <Version>2.76.0</Version>
+        <Update release="79">
+            <Date>2025-08-01</Date>
+            <Version>2.76.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Fixes regressions related to `gh pr create`.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
