### PR TITLE
python-maturin: Update to v1.9.2

### DIFF
--- a/packages/py/python-maturin/package.yml
+++ b/packages/py/python-maturin/package.yml
@@ -1,8 +1,8 @@
 name       : python-maturin
-version    : 1.9.1
-release    : 60
+version    : 1.9.2
+release    : 61
 source     :
-    - https://github.com/PyO3/maturin/archive/refs/tags/v1.9.1.tar.gz : ad374fbf04340083add2a47f3b3acdd809ceea1275d80cb5918cde80940a2fca
+    - https://github.com/PyO3/maturin/archive/refs/tags/v1.9.2.tar.gz : ff8f7486f41e23afe305530e10a2c0804ea841151203340505e07d9ea5b74c7b
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-maturin/pspec_x86_64.xml
+++ b/packages/py/python-maturin/pspec_x86_64.xml
@@ -22,10 +22,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/maturin</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.2.dist-info/licenses/license-apache</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.2.dist-info/licenses/license-mit</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.2.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -38,9 +40,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="60">
-            <Date>2025-07-08</Date>
-            <Version>1.9.1</Version>
+        <Update release="61">
+            <Date>2025-08-01</Date>
+            <Version>1.9.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Respect PEP 621 dynamic fields when merging Cargo.toml metadata
- Only use all_features=true in sdist when local path dependencies exist
- auditwheel: add manylinux_2_26 policy
- Use user-specified library search paths in RUSTFLAGS in auditwheel
- pyproject.toml: add license-files
- Update manylinux/musllinux policies to the latest main
- Fix PEP 639 implementation, use License-Expression over License

**Test Plan**

Successfully built `python-orjson`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
