### PR TITLE
noto-sans-ttf: Update to v2025.08.01

### DIFF
--- a/packages/n/noto-sans-ttf/files/noto-sans-ttf.metainfo.xml
+++ b/packages/n/noto-sans-ttf/files/noto-sans-ttf.metainfo.xml
@@ -1043,5 +1043,21 @@
     <font>Noto Sans Kannada UI Condensed Thin</font>
     <font>Noto Sans Arabic UI SemiCondensed ExtraBold</font>
     <font>Noto Sans Sunuwar Regular</font>
+    <font>Noto Sans Bengali Condensed Black</font>
+    <font>Noto Sans Bengali Condensed Bold</font>
+    <font>Noto Sans Bengali Condensed ExtraBold</font>
+    <font>Noto Sans Bengali Condensed ExtraLight</font>
+    <font>Noto Sans Bengali Condensed Light</font>
+    <font>Noto Sans Bengali Condensed Medium</font>
+    <font>Noto Sans Bengali Condensed SemiBold</font>
+    <font>Noto Sans Bengali Condensed Thin</font>
+    <font>Noto Sans Bengali SemiCondensed Black</font>
+    <font>Noto Sans Bengali SemiCondensed Bold</font>
+    <font>Noto Sans Bengali SemiCondensed ExtraBold</font>
+    <font>Noto Sans Bengali SemiCondensed ExtraLight</font>
+    <font>Noto Sans Bengali SemiCondensed Light</font>
+    <font>Noto Sans Bengali SemiCondensed Medium</font>
+    <font>Noto Sans Bengali SemiCondensed SemiBold</font>
+    <font>Noto Sans Bengali SemiCondensed Thin</font>
   </provides>
 </component>

--- a/packages/n/noto-sans-ttf/package.yml
+++ b/packages/n/noto-sans-ttf/package.yml
@@ -1,8 +1,8 @@
 name       : noto-sans-ttf
-version    : 2025.07.01
-release    : 43
+version    : 2025.08.01
+release    : 44
 source     :
-    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-2025.07.01.tar.gz : 8f28bfde2d44c80c989c27e5d119f29f082916b13c1420fab6a975a47bcb1cd6
+    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-2025.08.01.tar.gz : b1e2ce44aacc1773a18c2fb7345c3c710cb269684747a68d2a97c0a8b180b652
 homepage   : https://fonts.google.com/noto
 license    : OFL-1.1
 component  :

--- a/packages/n/noto-sans-ttf/pspec_x86_64.xml
+++ b/packages/n/noto-sans-ttf/pspec_x86_64.xml
@@ -186,11 +186,27 @@
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBatak-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-Bold.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-Condensed.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-CondensedBlack.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-CondensedBold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-CondensedExtraBold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-CondensedExtraLight.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-CondensedLight.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-CondensedMedium.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-CondensedSemiBold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-CondensedThin.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-Light.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-Medium.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-SemiBold.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-SemiCondensed.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-SemiCondensedBlack.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-SemiCondensedBold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-SemiCondensedExtraBold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-SemiCondensedExtraLight.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-SemiCondensedLight.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-SemiCondensedMedium.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-SemiCondensedSemiBold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-SemiCondensedThin.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengali-Thin.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengaliUI-Bold.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansBengaliUI-Condensed.ttf</Path>
@@ -1537,9 +1553,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="43">
-            <Date>2025-07-03</Date>
-            <Version>2025.07.01</Version>
+        <Update release="44">
+            <Date>2025-08-01</Date>
+            <Version>2025.08.01</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

No changelog available.

Full commit log available [here](https://github.com/notofonts/notofonts.github.io/compare/noto-monthly-release-2025.07.01...noto-monthly-release-2025.08.01)

**Test Plan**
- Wrote some text using Noto Sans/Serif in LibreOffice
- Confirmed UI with Noto Sans system font looked alright

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
