### PR TITLE
labwc: Update to v0.9.1

### DIFF
--- a/packages/l/labwc/package.yml
+++ b/packages/l/labwc/package.yml
@@ -1,8 +1,8 @@
 name       : labwc
-version    : 0.9.0
-release    : 11
+version    : 0.9.1
+release    : 12
 source     :
-    - https://github.com/labwc/labwc/archive/refs/tags/0.9.0.tar.gz : d06f89fb2bbd4be73e7bba9fb57017054d61868fe24db361d1ded87470329e63
+    - https://github.com/labwc/labwc/archive/refs/tags/0.9.1.tar.gz : bf7a245d5fc5665329b3f5c9cb589eb33e658b8eb638cf4f4c9ad68f4b5979f0
 homepage   : https://labwc.github.io/
 license    : GPL-2.0-or-later
 component  : desktop

--- a/packages/l/labwc/pspec_x86_64.xml
+++ b/packages/l/labwc/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>labwc</Name>
         <Homepage>https://labwc.github.io/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop</PartOf>
@@ -73,7 +73,7 @@
         <Summary xml:lang="en">Labwc session</Summary>
         <Description xml:lang="en">Labwc session</Description>
         <RuntimeDependencies>
-            <Dependency releaseFrom="11">labwc</Dependency>
+            <Dependency releaseFrom="12">labwc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/labwc-symbolic.svg</Path>
@@ -82,12 +82,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2025-07-12</Date>
-            <Version>0.9.0</Version>
+        <Update release="12">
+            <Date>2025-08-02</Date>
+            <Version>0.9.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Prevent interaction with un-initialized xdg-shell windows after unmap to fix a bug exposed by `wlroots-0.19.0` resulting in a compositor crash in certain (unusual) circumstances
- Fix double-free in `img_svg_render()` failure path
- Fix swapped width/height in XWayland client `_NET_WM_ICON` stride calculation

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new session with Xfce using labwc, and see that I have a working compositor.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
