### PR TITLE
zellij: Update to v0.43.1

### DIFF
--- a/packages/z/zellij/package.yml
+++ b/packages/z/zellij/package.yml
@@ -1,8 +1,8 @@
 name       : zellij
-version    : 0.43.0
-release    : 13
+version    : 0.43.1
+release    : 14
 source     :
-    - https://github.com/zellij-org/zellij/archive/refs/tags/v0.43.0.tar.gz : fd1cb54df0453f7f1340bb293a2682bbeacbd307156aab919acdf715e36b6ee1
+    - https://github.com/zellij-org/zellij/archive/refs/tags/v0.43.1.tar.gz : e9fd24190869be6e9e8d731df2ccd0b3b1dd368ae9dbb9d620ec905b83e325ec
 homepage   : https://zellij.dev
 license    : MIT
 component  : system.utils

--- a/packages/z/zellij/pspec_x86_64.xml
+++ b/packages/z/zellij/pspec_x86_64.xml
@@ -31,9 +31,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2025-08-05</Date>
-            <Version>0.43.0</Version>
+        <Update release="14">
+            <Date>2025-08-08</Date>
+            <Version>0.43.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- fix: pane rename backspace regression
- fix: Zellij Web login issue with safari
- fix: terminal title regression
- fix: resurrection listing regression
- fix: tooltip keybinding backgrounds
- fix: default to session name for window/tab title in Zellij Web
- fix: handle omitted flags in the push sequence of the KKP

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new Zellij session, open and close floating panes.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
