### PR TITLE
eopkg: Update to v4.3.0

### DIFF
--- a/packages/e/eopkg/package.yml
+++ b/packages/e/eopkg/package.yml
@@ -1,8 +1,8 @@
 name       : eopkg
-version    : 4.2.1
-release    : 24
+version    : 4.3.0
+release    : 25
 source     :
-    - https://github.com/getsolus/eopkg/archive/refs/tags/v4.2.1.tar.gz : 5db28176ef8d35c18b7578f4ec240815c58aaf744d0f0f85283e052cd47fd6d9
+    - https://github.com/getsolus/eopkg/archive/refs/tags/v4.3.0.tar.gz : 48237aa78b1d1f269f8963f0ed1fd94f1f537f96ae5e8617acfcedfee9c8dead
     - git|https://github.com/getsolus/PackageKit.git : 9b0f17c1ba6addc1c85bff34b64efad6a905ca50
 homepage   : https://github.com/getsolus/eopkg
 license    : GPL-2.0-or-later
@@ -30,6 +30,7 @@ builddeps  :
     - patchelf
     - python-build
     - python-installer
+    - python-jeepney
     - python-magic
     - python-ordered-set
     - python-packaging
@@ -91,6 +92,12 @@ install    : |
     # Install the usr-merge marker file
     install -dm0755 $installdir/var/solus/usr-merge
     touch $installdir/var/solus/usr-merge/eopkg-ready
+
+    # Install Bash completions
+    install -Dm0755 $workdir/dist/completions/bash/eopkg $installdir/usr/share/bash-completion/completions/eopkg
+
+    # Install Zsh completions
+    install -Dm0755 $workdir/dist/completions/zsh/_eopkg $installdir/usr/share/zsh/site-functions/_eopkg
 
     ## BEGIN post epoch ownership changes
     # This makes eopkg.bin the default package manager on Solus

--- a/packages/e/eopkg/pspec_x86_64.xml
+++ b/packages/e/eopkg/pspec_x86_64.xml
@@ -20,6 +20,8 @@
         <Files>
             <Path fileType="executable">/usr/bin/eopkg.bin</Path>
             <Path fileType="data">/usr/share/PackageKit/helpers/eopkg/eopkgBackend.bin</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/eopkg</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_eopkg</Path>
             <Path fileType="data">/var/solus/usr-merge/eopkg-ready</Path>
         </Files>
         <Replaces>
@@ -35,12 +37,12 @@
             <Path fileType="executable">/usr/bin/eopkg.py3</Path>
             <Path fileType="executable">/usr/bin/lseopkg.py3</Path>
             <Path fileType="executable">/usr/bin/uneopkg.py3</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.2.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.2.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.2.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.2.1.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.2.1.dist-info/licenses/AUTHORS</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.2.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.0.dist-info/licenses/AUTHORS</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pisi/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pisi/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pisi/__pycache__/__init__.cpython-312.pyc</Path>
@@ -449,9 +451,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2025-06-28</Date>
-            <Version>4.2.1</Version>
+        <Update release="25">
+            <Date>2025-08-09</Date>
+            <Version>4.3.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Hans K</Name>
             <Email>hans@communitycomputing.net</Email>


### PR DESCRIPTION
**Summary**
Release notes can be found [here](https://github.com/getsolus/eopkg/releases/v4.3.0).

> [!WARNING]
> This PR depends on #6162. Land that first.

For sync notes: 
This week, enjoy a newly-released version of `eopkg`! Version 4.3.0 contains systemd-inhibit support, Zsh completions, usability improvements, general bugfixes, and more. This is another step towards modernization of Solus infrastructure and tooling, including the eventual removal of Python 2.  Read the full changelog [here](https://github.com/getsolus/eopkg/releases/v4.3.0).

**Test Plan**
Give special attention to testing `eopkg` operations in general during the week following this PR landing. 
There was one specific packaging change for this version, which should be tested specially:
- Check out #6162 and follow its test plan.
- Check out this PR.
- Build and install `eopkg` from this PR. 
- Re-exec `bash` or restart your terminal.
- Note that `eopkg [tab]` once again shows completions available.
- Run `zsh`. 
- Note that `eopkg [tab]` now additionally shows Zsh completions.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
