### PR TITLE
eopkg: Update to v4.3.1

### DIFF
--- a/packages/e/eopkg/package.yml
+++ b/packages/e/eopkg/package.yml
@@ -1,8 +1,8 @@
 name       : eopkg
-version    : 4.3.0
-release    : 25
+version    : 4.3.1
+release    : 26
 source     :
-    - https://github.com/getsolus/eopkg/archive/refs/tags/v4.3.0.tar.gz : 48237aa78b1d1f269f8963f0ed1fd94f1f537f96ae5e8617acfcedfee9c8dead
+    - https://github.com/getsolus/eopkg/archive/refs/tags/v4.3.1.tar.gz : e456bcdc194c195176ee1681968ada4ba578b0c956af7df77657d10cc5e3fb13
     - git|https://github.com/getsolus/PackageKit.git : 9b0f17c1ba6addc1c85bff34b64efad6a905ca50
 homepage   : https://github.com/getsolus/eopkg
 license    : GPL-2.0-or-later

--- a/packages/e/eopkg/pspec_x86_64.xml
+++ b/packages/e/eopkg/pspec_x86_64.xml
@@ -451,9 +451,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="25">
+        <Update release="26">
             <Date>2025-08-09</Date>
-            <Version>4.3.0</Version>
+            <Version>4.3.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Hans K</Name>
             <Email>hans@communitycomputing.net</Email>


### PR DESCRIPTION
**Summary**
Release notes can be found [here](https://github.com/getsolus/eopkg/releases/tag/v4.3.1). See #6163 for full notes.

**Test Plan**
See test plan at https://github.com/getsolus/eopkg/pull/170.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
