### PR TITLE
keepassxc: Add wl-clipboard runtime dependency

### DIFF
--- a/packages/k/keepassxc/abi_used_symbols
+++ b/packages/k/keepassxc/abi_used_symbols
@@ -9,8 +9,6 @@ UNKNOWN:_ZTVN5Botan14RSA_PrivateKeyE
 UNKNOWN:_ZTVN5Botan16ECDSA_PrivateKeyE
 UNKNOWN:_ZTVN5Botan17DataSource_MemoryE
 UNKNOWN:_ZTVN5Botan18Ed25519_PrivateKeyE
-UNKNOWN:_ZTVN5Botan19AlgorithmIdentifierE
-UNKNOWN:_ZTVN5Botan3OIDE
 libQt5Concurrent.so.5:_ZN12QtConcurrent16ThreadEngineBase10isCanceledEv
 libQt5Concurrent.so.5:_ZN12QtConcurrent16ThreadEngineBase11startThreadEv
 libQt5Concurrent.so.5:_ZN12QtConcurrent16ThreadEngineBase13waitForResumeEv
@@ -3075,7 +3073,6 @@ libstdc++.so.6:_ZNSolsEi
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_disposeEv
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createERmm
 libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
-libstdc++.so.6:_ZSt17__throw_bad_allocv
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt21ios_base_library_initv

--- a/packages/k/keepassxc/package.yml
+++ b/packages/k/keepassxc/package.yml
@@ -1,6 +1,6 @@
 name       : keepassxc
 version    : 2.7.10
-release    : 49
+release    : 50
 homepage   : https://keepassxc.org
 source     :
     - https://github.com/keepassxreboot/keepassxc/releases/download/2.7.10/keepassxc-2.7.10-src.tar.xz : 5ce76d6440986c24842585f019d5f3cadc166fa71fc911a4fe97b8bbc4819dfa
@@ -34,6 +34,8 @@ builddeps  :
     - pkgconfig(xtst)
     - asciidoctor
     - libyubikey-devel
+rundeps    :
+    - wl-clipboard
 setup      : |
     %cmake_ninja -DWITH_TESTS=OFF -DWITH_CCACHE=ON -DWITH_XC_ALL=ON -DWITH_XC_UPDATECHECK=OFF -DWITH_XC_DOCS=OFF
 build      : |

--- a/packages/k/keepassxc/pspec_x86_64.xml
+++ b/packages/k/keepassxc/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>keepassxc</Name>
         <Homepage>https://keepassxc.org</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <License>BSD-3-Clause</License>
@@ -95,12 +95,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="49">
-            <Date>2025-03-26</Date>
+        <Update release="50">
+            <Date>2025-08-10</Date>
             <Version>2.7.10</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

This allows the "Clear clipboard after" functionality to work under Wayland

Resolves https://github.com/getsolus/packages/issues/6170

**Test Plan**

Confirmed clipboard gets cleared after the time interval set in options

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
