### PR TITLE
opensnitch: Fix packaging

### DIFF
--- a/packages/o/opensnitch/package.yml
+++ b/packages/o/opensnitch/package.yml
@@ -1,6 +1,6 @@
 name       : opensnitch
 version    : 1.6.8
-release    : 4
+release    : 5
 source     :
     - https://github.com/evilsocket/opensnitch/archive/refs/tags/v1.6.8.tar.gz : 3c44f585a6a78f63c86f331da099bd001cd199b3c907c262cc6645bf9b3a1825
 homepage   : https://github.com/evilsocket/opensnitch
@@ -33,6 +33,7 @@ rundeps    :
     - python-grpcio
     - python-inotify
     - python-notify2
+    - python-packaging
     - python-protobuf
     - python-qt-material
     - python-slugify

--- a/packages/o/opensnitch/pspec_x86_64.xml
+++ b/packages/o/opensnitch/pspec_x86_64.xml
@@ -181,8 +181,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2025-06-13</Date>
+        <Update release="5">
+            <Date>2025-08-10</Date>
             <Version>1.6.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Robert Gonzalez</Name>


### PR DESCRIPTION
**Summary**
- add missing dependency

**Test Plan**

python packaging was already installed on my machine but python says it was missing a module per issue

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->

Solves https://github.com/getsolus/packages/issues/6135
