### PR TITLE
cemu: Update to 2.6

### DIFF
--- a/packages/c/cemu/abi_used_libs
+++ b/packages/c/cemu/abi_used_libs
@@ -2,6 +2,7 @@ UNKNOWN
 libOpenGL.so.0
 libSDL2-2.0.so.0
 libX11.so.6
+libbluetooth.so.3
 libboost_program_options.so.1.83.0
 libc.so.6
 libcrypto.so.3

--- a/packages/c/cemu/abi_used_symbols
+++ b/packages/c/cemu/abi_used_symbols
@@ -44,6 +44,12 @@ libSDL2-2.0.so.0:SDL_UnlockJoysticks
 libSDL2-2.0.so.0:SDL_WaitEvent
 libSDL2-2.0.so.0:SDL_WasInit
 libX11.so.6:XInitThreads
+libbluetooth.so.3:bt_free
+libbluetooth.so.3:hci_close_dev
+libbluetooth.so.3:hci_get_route
+libbluetooth.so.3:hci_inquiry
+libbluetooth.so.3:hci_open_dev
+libbluetooth.so.3:hci_read_remote_name
 libboost_program_options.so.1.83.0:_ZN5boost15program_options10validators22check_first_occurrenceERKNS_3anyE
 libboost_program_options.so.1.83.0:_ZN5boost15program_options11to_internalERKNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEEE
 libboost_program_options.so.1.83.0:_ZN5boost15program_options13variables_mapC1Ev
@@ -243,6 +249,7 @@ libc.so.6:strcat
 libc.so.6:strchr
 libc.so.6:strcmp
 libc.so.6:strcpy
+libc.so.6:strerror
 libc.so.6:strerror_r
 libc.so.6:strlen
 libc.so.6:strncmp
@@ -609,6 +616,7 @@ libstdc++.so.6:_ZNSt5ctypeIwE2idE
 libstdc++.so.6:_ZNSt6chrono3_V212steady_clock3nowEv
 libstdc++.so.6:_ZNSt6chrono3_V212system_clock3nowEv
 libstdc++.so.6:_ZNSt6locale5facetD2Ev
+libstdc++.so.6:_ZNSt6locale7classicEv
 libstdc++.so.6:_ZNSt6localeC1ERKS_
 libstdc++.so.6:_ZNSt6localeC1Ev
 libstdc++.so.6:_ZNSt6localeD1Ev
@@ -762,7 +770,6 @@ libstdc++.so.6:__cxa_throw_bad_array_new_length
 libstdc++.so.6:__dynamic_cast
 libstdc++.so.6:__gxx_personality_v0
 libstdc++.so.6:__once_proxy
-libusb-1.0.so.0:libusb_bulk_transfer
 libusb-1.0.so.0:libusb_claim_interface
 libusb-1.0.so.0:libusb_close
 libusb-1.0.so.0:libusb_control_transfer
@@ -784,10 +791,10 @@ libusb-1.0.so.0:libusb_has_capability
 libusb-1.0.so.0:libusb_hotplug_deregister_callback
 libusb-1.0.so.0:libusb_hotplug_register_callback
 libusb-1.0.so.0:libusb_init
+libusb-1.0.so.0:libusb_interrupt_transfer
 libusb-1.0.so.0:libusb_kernel_driver_active
 libusb-1.0.so.0:libusb_open
 libusb-1.0.so.0:libusb_release_interface
-libusb-1.0.so.0:libusb_set_configuration
 libusb-1.0.so.0:libusb_strerror
 libwayland-client.so.0:wl_display_roundtrip
 libwayland-client.so.0:wl_proxy_add_listener

--- a/packages/c/cemu/files/fix-nonascii-filename.patch
+++ b/packages/c/cemu/files/fix-nonascii-filename.patch
@@ -1,0 +1,15 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Thomas Staudinger <Staudi.Kaos@gmail.com>
+Date: Tue, 8 Jul 2025 22:57:47 +0200
+Subject: [PATCH] ar: Remove invisible control characters from file name
+
+Signed-off-by: Thomas Staudinger <Staudi.Kaos@gmail.com>
+---
+ .../resources/ar/cemu.mo                            | Bin
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+ rename "bin/resources/ar/\342\200\217\342\200\217cemu.mo" => bin/resources/ar/cemu.mo (100%)
+
+diff --git "a/bin/resources/ar/\342\200\217\342\200\217cemu.mo" b/bin/resources/ar/cemu.mo
+similarity index 100%
+rename from "bin/resources/ar/\342\200\217\342\200\217cemu.mo"
+rename to bin/resources/ar/cemu.mo

--- a/packages/c/cemu/package.yml
+++ b/packages/c/cemu/package.yml
@@ -1,8 +1,8 @@
 name       : cemu
-version    : '2.4'
-release    : 15
+version    : '2.6'
+release    : 16
 source     :
-    - git|https://github.com/cemu-project/Cemu : v2.4
+    - git|https://github.com/cemu-project/Cemu : v2.6
 homepage   : https://cemu.info/
 license    : MPL-2.0
 component  : games.emulator
@@ -11,10 +11,13 @@ description: |
     Cemu is an emulator for the Nintendo Wii U console. It is capable of running and debugging homebrew applications, as well as many commercial games.
 builddeps  :
     - pkgconfig(RapidJSON)
+    - pkgconfig(bluez)
     - pkgconfig(fmt)
+    - pkgconfig(gamemode)
     - pkgconfig(glm)
     - pkgconfig(glu)
     - pkgconfig(gtk+-3.0)
+    - pkgconfig(libcrypto)
     - pkgconfig(libcurl)
     - pkgconfig(libpng)
     - pkgconfig(libusb-1.0)
@@ -29,6 +32,8 @@ builddeps  :
     - libboost-devel
     - wxwidgets-devel
 setup      : |
+    patch -p1 -i $pkgfiles/fix-nonascii-filename.patch
+
     # glm fix
     sed -i 's/glm::glm/glm/' src/Common/CMakeLists.txt src/input/CMakeLists.txt
 
@@ -38,8 +43,8 @@ setup      : |
 
     %cmake_ninja \
         -DCMAKE_BUILD_TYPE=Release \
-        -DENABLE_VCPKG=OFF \
-        -DPORTABLE=OFF
+        -DALLOW_PORTABLE=OFF \
+        -DENABLE_VCPKG=OFF
 build      : |
     %ninja_build
 install    : |

--- a/packages/c/cemu/pspec_x86_64.xml
+++ b/packages/c/cemu/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>cemu</Name>
         <Homepage>https://cemu.info/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Packager>
         <License>MPL-2.0</License>
         <PartOf>games.emulator</PartOf>
@@ -259,6 +259,7 @@
             <Path fileType="data">/usr/share/cemu/gameProfiles/default/0005000C1012BE00.ini</Path>
             <Path fileType="data">/usr/share/cemu/gameProfiles/default/0005000e1019c800.ini</Path>
             <Path fileType="data">/usr/share/cemu/gameProfiles/default/000500c01017cd00.ini</Path>
+            <Path fileType="data">/usr/share/cemu/resources/ar/cemu.mo</Path>
             <Path fileType="data">/usr/share/cemu/resources/ca/cemu.mo</Path>
             <Path fileType="data">/usr/share/cemu/resources/de/cemu.mo</Path>
             <Path fileType="data">/usr/share/cemu/resources/es/cemu.mo</Path>
@@ -286,12 +287,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2025-06-06</Date>
-            <Version>2.4</Version>
+        <Update release="16">
+            <Date>2025-08-10</Date>
+            <Version>2.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Enhancements
- Numerous graphics fixes for Vulkan
- Add workarounds for shaders which contain infinite loops
- Add support for connecting Wiimotes via L2CAP
- Fix a number of crashes and regressions

The full changelog is available [here](github.com/cemu-project/Cemu/compare/v2.4...v2.6).

**Test Plan**

Launch a game, load some graphics packs, and make sure things generally work correctly.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
