### PR TITLE
eopkg: Add jeepney dependency to python-eopkg

### DIFF
--- a/packages/e/eopkg/package.yml
+++ b/packages/e/eopkg/package.yml
@@ -1,6 +1,6 @@
 name       : eopkg
 version    : 4.3.1
-release    : 26
+release    : 27
 source     :
     - https://github.com/getsolus/eopkg/archive/refs/tags/v4.3.1.tar.gz : e456bcdc194c195176ee1681968ada4ba578b0c956af7df77657d10cc5e3fb13
     - git|https://github.com/getsolus/PackageKit.git : 9b0f17c1ba6addc1c85bff34b64efad6a905ca50
@@ -41,6 +41,7 @@ builddeps  :
 rundeps    :
     - ^python-eopkg :
         - iksemel
+        - python-jeepney
         - python-ordered-set
         - python-xattr
     - glibc

--- a/packages/e/eopkg/pspec_x86_64.xml
+++ b/packages/e/eopkg/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>eopkg</Name>
         <Homepage>https://github.com/getsolus/eopkg</Homepage>
         <Packager>
-            <Name>Hans K</Name>
-            <Email>hans@communitycomputing.net</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -451,12 +451,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2025-08-09</Date>
+        <Update release="27">
+            <Date>2025-08-11</Date>
             <Version>4.3.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Hans K</Name>
-            <Email>hans@communitycomputing.net</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Necessary for `ypkg` functionality

Without it e.g. yupdate prints the following error

```
 yupdate 2.59 https://sourceforge.net/projects/keepass/files/KeePass%202.x/2.59/KeePass-2.59-Source.zip                    
Traceback (most recent call last):
  File "/usr/bin/yupdate", line 18, in <module>
    import pisi.version
  File "/usr/lib/python3.12/site-packages/pisi/__init__.py", line 62, in <module>
    import pisi.api
  File "/usr/lib/python3.12/site-packages/pisi/api.py", line 8, in <module>
    from . import fetcher
  File "/usr/lib/python3.12/site-packages/pisi/fetcher.py", line 22, in <module>
    import pisi.util as util
  File "/usr/lib/python3.12/site-packages/pisi/util.py", line 21, in <module>
    from jeepney import MessageType
ModuleNotFoundError: No module named 'jeepney'
```

**Test Plan**

Successfully yupdated and built `keepass` 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
