### PR TITLE
libheif: Update to v1.20.2

### DIFF
--- a/packages/l/libheif/abi_used_symbols
+++ b/packages/l/libheif/abi_used_symbols
@@ -208,6 +208,7 @@ libstdc++.so.6:_ZNKSt10filesystem7__cxx114path5_List3endEv
 libstdc++.so.6:_ZNKSt5ctypeIcE13_M_widen_initEv
 libstdc++.so.6:_ZNKSt6locale2id5_M_idEv
 libstdc++.so.6:_ZNKSt8__detail20_Prime_rehash_policy14_M_need_rehashEmmm
+libstdc++.so.6:_ZNSdC2Ev
 libstdc++.so.6:_ZNSdD2Ev
 libstdc++.so.6:_ZNSi10_M_extractIlEERSiRT_
 libstdc++.so.6:_ZNSi4readEPcl

--- a/packages/l/libheif/package.yml
+++ b/packages/l/libheif/package.yml
@@ -1,8 +1,8 @@
 name       : libheif
-version    : 1.20.1
-release    : 51
+version    : 1.20.2
+release    : 52
 source     :
-    - https://github.com/strukturag/libheif/releases/download/v1.20.1/libheif-1.20.1.tar.gz : 55cc76b77c533151fc78ba58ef5ad18562e84da403ed749c3ae017abaf1e2090
+    - https://github.com/strukturag/libheif/releases/download/v1.20.2/libheif-1.20.2.tar.gz : 68ac9084243004e0ef3633f184eeae85d615fe7e4444373a0a21cebccae9d12a
 license    :
     - LGPL-3.0-or-later
     - MIT # /usr/include/libheif/heif_cxx.h

--- a/packages/l/libheif/pspec_x86_64.xml
+++ b/packages/l/libheif/pspec_x86_64.xml
@@ -31,7 +31,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
             <Path fileType="library">/usr/lib64/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-heif.so</Path>
             <Path fileType="library">/usr/lib64/libheif</Path>
             <Path fileType="library">/usr/lib64/libheif.so.1</Path>
-            <Path fileType="library">/usr/lib64/libheif.so.1.20.1</Path>
+            <Path fileType="library">/usr/lib64/libheif.so.1.20.2</Path>
             <Path fileType="man">/usr/share/man/man1/heif-dec.1</Path>
             <Path fileType="man">/usr/share/man/man1/heif-enc.1</Path>
             <Path fileType="man">/usr/share/man/man1/heif-info.1</Path>
@@ -47,7 +47,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="51">libheif</Dependency>
+            <Dependency release="52">libheif</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libheif/heif.h</Path>
@@ -82,9 +82,9 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
         </Files>
     </Package>
     <History>
-        <Update release="51">
-            <Date>2025-07-03</Date>
-            <Version>1.20.1</Version>
+        <Update release="52">
+            <Date>2025-08-11</Date>
+            <Version>1.20.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- When opening tiled images, do not check against maximum image size immediately to allow for tile-based decoding of very large images
- Several smaller fixes in writing image sequences
- CMake option to disable building of heif-view, which pulls in dependency on SDL
- Fixes reading/writing of GIMI content IDs
- Some build fixes

**Test Plan**

Encoded and decoded a bunch of images

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
