### PR TITLE
python-maturin: Update to v1.9.3

### DIFF
--- a/packages/py/python-maturin/package.yml
+++ b/packages/py/python-maturin/package.yml
@@ -1,8 +1,8 @@
 name       : python-maturin
-version    : 1.9.2
-release    : 61
+version    : 1.9.3
+release    : 62
 source     :
-    - https://github.com/PyO3/maturin/archive/refs/tags/v1.9.2.tar.gz : ff8f7486f41e23afe305530e10a2c0804ea841151203340505e07d9ea5b74c7b
+    - https://github.com/PyO3/maturin/archive/refs/tags/v1.9.3.tar.gz : 1a4a87224a34a97a4322bd123487e9c6f2d2091bac4fe469618b92a06aad3492
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-maturin/pspec_x86_64.xml
+++ b/packages/py/python-maturin/pspec_x86_64.xml
@@ -22,12 +22,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/maturin</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.2.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.2.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.2.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.2.dist-info/licenses/license-apache</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.2.dist-info/licenses/license-mit</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.2.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.3.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.3.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.3.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.3.dist-info/licenses/license-apache</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.3.dist-info/licenses/license-mit</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.3.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -40,9 +40,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="61">
-            <Date>2025-08-01</Date>
-            <Version>1.9.2</Version>
+        <Update release="62">
+            <Date>2025-08-11</Date>
+            <Version>1.9.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Add support for RISC-V architecture in manylinux
- pyproject.toml: bump setuptools for PEP 639
- Fix PEP 639 support for source distributions
- Fix relative README rewrite in source distributions

**Test Plan**

Successfully built `python-orjson`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
