### PR TITLE
python-orjson: Update to v3.11.2

### DIFF
--- a/packages/py/python-orjson/package.yml
+++ b/packages/py/python-orjson/package.yml
@@ -1,8 +1,8 @@
 name       : python-orjson
-version    : 3.11.0
-release    : 52
+version    : 3.11.2
+release    : 53
 source     :
-    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.11.0.tar.gz : 2e4c129da624f291bcc607016a99e7f04a353f6874f3bd8d9b47b88597d5f700
+    - https://files.pythonhosted.org/packages/source/o/orjson/orjson-3.11.2.tar.gz : 91bdcf5e69a8fd8e8bdb3de32b31ff01d2bd60c1e8d5fe7d5afabdcf19920309
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-orjson/pspec_x86_64.xml
+++ b/packages/py/python-orjson/pspec_x86_64.xml
@@ -21,11 +21,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/orjson-3.11.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/orjson-3.11.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/orjson-3.11.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/orjson-3.11.0.dist-info/licenses/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/orjson-3.11.0.dist-info/licenses/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/orjson-3.11.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/orjson-3.11.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/orjson-3.11.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/orjson-3.11.2.dist-info/licenses/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/orjson-3.11.2.dist-info/licenses/LICENSE-MIT</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/orjson/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/orjson/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/orjson/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -35,9 +35,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="52">
-            <Date>2025-07-16</Date>
-            <Version>3.11.0</Version>
+        <Update release="53">
+            <Date>2025-08-12</Date>
+            <Version>3.11.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fix build using Rust 1.89 on amd64
- Build now depends on Rust 1.85 or later instead of 1.82
- Fix str on big-endian architectures

**Test Plan**

Ran some examples from the project's README

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
