### PR TITLE
libarchive: Update to v3.8.1

### DIFF
--- a/packages/l/libarchive/abi_symbols
+++ b/packages/l/libarchive/abi_symbols
@@ -1,5 +1,7 @@
 libarchive.so.13:archive_bzlib_version
 libarchive.so.13:archive_clear_error
+libarchive.so.13:archive_cng_version
+libarchive.so.13:archive_commoncrypto_version
 libarchive.so.13:archive_compression
 libarchive.so.13:archive_compression_name
 libarchive.so.13:archive_copy_error
@@ -100,6 +102,7 @@ libarchive.so.13:archive_entry_set_ctime
 libarchive.so.13:archive_entry_set_dev
 libarchive.so.13:archive_entry_set_devmajor
 libarchive.so.13:archive_entry_set_devminor
+libarchive.so.13:archive_entry_set_digest
 libarchive.so.13:archive_entry_set_fflags
 libarchive.so.13:archive_entry_set_filetype
 libarchive.so.13:archive_entry_set_gid
@@ -177,8 +180,19 @@ libarchive.so.13:archive_filter_name
 libarchive.so.13:archive_format
 libarchive.so.13:archive_format_name
 libarchive.so.13:archive_free
+libarchive.so.13:archive_libacl_version
+libarchive.so.13:archive_libattr_version
+libarchive.so.13:archive_libbsdxml_version
+libarchive.so.13:archive_libexpat_version
+libarchive.so.13:archive_libiconv_version
 libarchive.so.13:archive_liblz4_version
 libarchive.so.13:archive_liblzma_version
+libarchive.so.13:archive_liblzo2_version
+libarchive.so.13:archive_libmd_version
+libarchive.so.13:archive_libpcre2_version
+libarchive.so.13:archive_libpcre_version
+libarchive.so.13:archive_librichacl_version
+libarchive.so.13:archive_libxml2_version
 libarchive.so.13:archive_libzstd_version
 libarchive.so.13:archive_match_exclude_entry
 libarchive.so.13:archive_match_exclude_pattern
@@ -210,6 +224,10 @@ libarchive.so.13:archive_match_path_unmatched_inclusions_next
 libarchive.so.13:archive_match_path_unmatched_inclusions_next_w
 libarchive.so.13:archive_match_set_inclusion_recursion
 libarchive.so.13:archive_match_time_excluded
+libarchive.so.13:archive_mbedtls_version
+libarchive.so.13:archive_nettle_version
+libarchive.so.13:archive_openssl_version
+libarchive.so.13:archive_parse_date
 libarchive.so.13:archive_position_compressed
 libarchive.so.13:archive_position_uncompressed
 libarchive.so.13:archive_read_add_callback_data
@@ -338,6 +356,7 @@ libarchive.so.13:archive_utility_string_sort
 libarchive.so.13:archive_version_details
 libarchive.so.13:archive_version_number
 libarchive.so.13:archive_version_string
+libarchive.so.13:archive_wincrypt_version
 libarchive.so.13:archive_write_add_filter
 libarchive.so.13:archive_write_add_filter_b64encode
 libarchive.so.13:archive_write_add_filter_by_name
@@ -425,6 +444,10 @@ libarchive.so.13:archive_write_set_options
 libarchive.so.13:archive_write_set_passphrase
 libarchive.so.13:archive_write_set_passphrase_callback
 libarchive.so.13:archive_write_set_skip_file
+libarchive.so.13:archive_write_zip_set_compression_bzip2
 libarchive.so.13:archive_write_zip_set_compression_deflate
+libarchive.so.13:archive_write_zip_set_compression_lzma
 libarchive.so.13:archive_write_zip_set_compression_store
+libarchive.so.13:archive_write_zip_set_compression_xz
+libarchive.so.13:archive_write_zip_set_compression_zstd
 libarchive.so.13:archive_zlib_version

--- a/packages/l/libarchive/abi_symbols32
+++ b/packages/l/libarchive/abi_symbols32
@@ -1,5 +1,7 @@
 libarchive.so.13:archive_bzlib_version
 libarchive.so.13:archive_clear_error
+libarchive.so.13:archive_cng_version
+libarchive.so.13:archive_commoncrypto_version
 libarchive.so.13:archive_compression
 libarchive.so.13:archive_compression_name
 libarchive.so.13:archive_copy_error
@@ -100,6 +102,7 @@ libarchive.so.13:archive_entry_set_ctime
 libarchive.so.13:archive_entry_set_dev
 libarchive.so.13:archive_entry_set_devmajor
 libarchive.so.13:archive_entry_set_devminor
+libarchive.so.13:archive_entry_set_digest
 libarchive.so.13:archive_entry_set_fflags
 libarchive.so.13:archive_entry_set_filetype
 libarchive.so.13:archive_entry_set_gid
@@ -177,8 +180,19 @@ libarchive.so.13:archive_filter_name
 libarchive.so.13:archive_format
 libarchive.so.13:archive_format_name
 libarchive.so.13:archive_free
+libarchive.so.13:archive_libacl_version
+libarchive.so.13:archive_libattr_version
+libarchive.so.13:archive_libbsdxml_version
+libarchive.so.13:archive_libexpat_version
+libarchive.so.13:archive_libiconv_version
 libarchive.so.13:archive_liblz4_version
 libarchive.so.13:archive_liblzma_version
+libarchive.so.13:archive_liblzo2_version
+libarchive.so.13:archive_libmd_version
+libarchive.so.13:archive_libpcre2_version
+libarchive.so.13:archive_libpcre_version
+libarchive.so.13:archive_librichacl_version
+libarchive.so.13:archive_libxml2_version
 libarchive.so.13:archive_libzstd_version
 libarchive.so.13:archive_match_exclude_entry
 libarchive.so.13:archive_match_exclude_pattern
@@ -210,6 +224,10 @@ libarchive.so.13:archive_match_path_unmatched_inclusions_next
 libarchive.so.13:archive_match_path_unmatched_inclusions_next_w
 libarchive.so.13:archive_match_set_inclusion_recursion
 libarchive.so.13:archive_match_time_excluded
+libarchive.so.13:archive_mbedtls_version
+libarchive.so.13:archive_nettle_version
+libarchive.so.13:archive_openssl_version
+libarchive.so.13:archive_parse_date
 libarchive.so.13:archive_position_compressed
 libarchive.so.13:archive_position_uncompressed
 libarchive.so.13:archive_read_add_callback_data
@@ -338,6 +356,7 @@ libarchive.so.13:archive_utility_string_sort
 libarchive.so.13:archive_version_details
 libarchive.so.13:archive_version_number
 libarchive.so.13:archive_version_string
+libarchive.so.13:archive_wincrypt_version
 libarchive.so.13:archive_write_add_filter
 libarchive.so.13:archive_write_add_filter_b64encode
 libarchive.so.13:archive_write_add_filter_by_name
@@ -425,6 +444,10 @@ libarchive.so.13:archive_write_set_options
 libarchive.so.13:archive_write_set_passphrase
 libarchive.so.13:archive_write_set_passphrase_callback
 libarchive.so.13:archive_write_set_skip_file
+libarchive.so.13:archive_write_zip_set_compression_bzip2
 libarchive.so.13:archive_write_zip_set_compression_deflate
+libarchive.so.13:archive_write_zip_set_compression_lzma
 libarchive.so.13:archive_write_zip_set_compression_store
+libarchive.so.13:archive_write_zip_set_compression_xz
+libarchive.so.13:archive_write_zip_set_compression_zstd
 libarchive.so.13:archive_zlib_version

--- a/packages/l/libarchive/abi_used_symbols
+++ b/packages/l/libarchive/abi_used_symbols
@@ -119,6 +119,7 @@ libc.so.6:lchown
 libc.so.6:lgetxattr
 libc.so.6:linkat
 libc.so.6:listxattr
+libc.so.6:lldiv
 libc.so.6:llistxattr
 libc.so.6:localtime
 libc.so.6:localtime_r
@@ -245,6 +246,7 @@ liblz4.so.1:LZ4_loadDictHC
 liblz4.so.1:LZ4_resetStreamHC
 liblz4.so.1:LZ4_saveDict
 liblz4.so.1:LZ4_saveDictHC
+liblz4.so.1:LZ4_versionString
 liblzma.so.5:lzma_alone_decoder
 liblzma.so.5:lzma_alone_encoder
 liblzma.so.5:lzma_code
@@ -261,6 +263,7 @@ liblzma.so.5:lzma_raw_encoder
 liblzma.so.5:lzma_stream_decoder
 liblzma.so.5:lzma_stream_encoder
 liblzma.so.5:lzma_stream_encoder_mt
+liblzma.so.5:lzma_version_string
 liblzo2.so.2:__lzo_init_v2
 liblzo2.so.2:lzo1x_1_15_compress
 liblzo2.so.2:lzo1x_1_compress
@@ -269,7 +272,6 @@ liblzo2.so.2:lzo1x_decompress_safe
 liblzo2.so.2:lzo_adler32
 liblzo2.so.2:lzo_version
 liblzo2.so.2:lzo_version_string
-libxml2.so.2:UTF8Toisolat1
 libxml2.so.2:xmlBufferCreate
 libxml2.so.2:xmlBufferFree
 libxml2.so.2:xmlCleanupParser
@@ -292,8 +294,8 @@ libxml2.so.2:xmlTextWriterStartDocument
 libxml2.so.2:xmlTextWriterStartElement
 libxml2.so.2:xmlTextWriterWriteAttribute
 libxml2.so.2:xmlTextWriterWriteBase64
-libxml2.so.2:xmlTextWriterWriteFormatAttribute
 libxml2.so.2:xmlTextWriterWriteString
+libxml2.so.2:xmlTextWriterWriteVFormatAttribute
 libz.so.1:adler32
 libz.so.1:crc32
 libz.so.1:deflate
@@ -307,12 +309,14 @@ libz.so.1:inflateInit2_
 libz.so.1:inflateInit_
 libz.so.1:inflateReset
 libz.so.1:inflateSetDictionary
+libz.so.1:zlibVersion
 libzstd.so.1:ZSTD_CCtx_reset
 libzstd.so.1:ZSTD_CCtx_setParameter
 libzstd.so.1:ZSTD_CStreamOutSize
 libzstd.so.1:ZSTD_DStreamOutSize
 libzstd.so.1:ZSTD_cParam_getBounds
 libzstd.so.1:ZSTD_compressStream
+libzstd.so.1:ZSTD_compressStream2
 libzstd.so.1:ZSTD_createCStream
 libzstd.so.1:ZSTD_createDStream
 libzstd.so.1:ZSTD_decompressStream
@@ -326,3 +330,4 @@ libzstd.so.1:ZSTD_isError
 libzstd.so.1:ZSTD_maxCLevel
 libzstd.so.1:ZSTD_minCLevel
 libzstd.so.1:ZSTD_versionNumber
+libzstd.so.1:ZSTD_versionString

--- a/packages/l/libarchive/abi_used_symbols32
+++ b/packages/l/libarchive/abi_used_symbols32
@@ -90,6 +90,7 @@ libc.so.6:lchown
 libc.so.6:lgetxattr
 libc.so.6:linkat
 libc.so.6:listxattr
+libc.so.6:lldiv
 libc.so.6:llistxattr
 libc.so.6:localtime_r
 libc.so.6:lseek64
@@ -199,6 +200,7 @@ liblzma.so.5:lzma_raw_encoder
 liblzma.so.5:lzma_stream_decoder
 liblzma.so.5:lzma_stream_encoder
 liblzma.so.5:lzma_stream_encoder_mt
+liblzma.so.5:lzma_version_string
 liblzo2.so.2:__lzo_init_v2
 liblzo2.so.2:lzo1x_1_15_compress
 liblzo2.so.2:lzo1x_1_compress
@@ -207,7 +209,6 @@ liblzo2.so.2:lzo1x_decompress_safe
 liblzo2.so.2:lzo_adler32
 liblzo2.so.2:lzo_version
 liblzo2.so.2:lzo_version_string
-libxml2.so.2:UTF8Toisolat1
 libxml2.so.2:xmlBufferCreate
 libxml2.so.2:xmlBufferFree
 libxml2.so.2:xmlCleanupParser
@@ -230,8 +231,8 @@ libxml2.so.2:xmlTextWriterStartDocument
 libxml2.so.2:xmlTextWriterStartElement
 libxml2.so.2:xmlTextWriterWriteAttribute
 libxml2.so.2:xmlTextWriterWriteBase64
-libxml2.so.2:xmlTextWriterWriteFormatAttribute
 libxml2.so.2:xmlTextWriterWriteString
+libxml2.so.2:xmlTextWriterWriteVFormatAttribute
 libz.so.1:adler32
 libz.so.1:crc32
 libz.so.1:deflate
@@ -245,12 +246,14 @@ libz.so.1:inflateInit2_
 libz.so.1:inflateInit_
 libz.so.1:inflateReset
 libz.so.1:inflateSetDictionary
+libz.so.1:zlibVersion
 libzstd.so.1:ZSTD_CCtx_reset
 libzstd.so.1:ZSTD_CCtx_setParameter
 libzstd.so.1:ZSTD_CStreamOutSize
 libzstd.so.1:ZSTD_DStreamOutSize
 libzstd.so.1:ZSTD_cParam_getBounds
 libzstd.so.1:ZSTD_compressStream
+libzstd.so.1:ZSTD_compressStream2
 libzstd.so.1:ZSTD_createCStream
 libzstd.so.1:ZSTD_createDStream
 libzstd.so.1:ZSTD_decompressStream
@@ -264,3 +267,4 @@ libzstd.so.1:ZSTD_isError
 libzstd.so.1:ZSTD_maxCLevel
 libzstd.so.1:ZSTD_minCLevel
 libzstd.so.1:ZSTD_versionNumber
+libzstd.so.1:ZSTD_versionString

--- a/packages/l/libarchive/package.yml
+++ b/packages/l/libarchive/package.yml
@@ -1,8 +1,8 @@
 name       : libarchive
-version    : 3.7.8
-release    : 56
+version    : 3.8.1
+release    : 57
 source     :
-    - https://github.com/libarchive/libarchive/releases/download/v3.7.8/libarchive-3.7.8.tar.xz : 32a51747527e01f50d0e06abad0fe0b95b6fa40b8fc173c48b8bd97d0f743330
+    - https://github.com/libarchive/libarchive/releases/download/v3.8.1/libarchive-3.8.1.tar.xz : 19f917d42d530f98815ac824d90c7eaf648e9d9a50e4f309c812457ffa5496b5
 homepage   : http://www.libarchive.org/
 license    : BSD-2-Clause
 component  :

--- a/packages/l/libarchive/pspec_x86_64.xml
+++ b/packages/l/libarchive/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libarchive</Name>
         <Homepage>http://www.libarchive.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>programming.library</PartOf>
@@ -21,7 +21,7 @@
         <PartOf>programming.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libarchive.so.13</Path>
-            <Path fileType="library">/usr/lib64/libarchive.so.13.7.8</Path>
+            <Path fileType="library">/usr/lib64/libarchive.so.13.8.1</Path>
         </Files>
     </Package>
     <Package>
@@ -31,11 +31,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="56">libarchive</Dependency>
+            <Dependency release="57">libarchive</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libarchive.so.13</Path>
-            <Path fileType="library">/usr/lib32/libarchive.so.13.7.8</Path>
+            <Path fileType="library">/usr/lib32/libarchive.so.13.8.1</Path>
         </Files>
     </Package>
     <Package>
@@ -45,8 +45,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="56">libarchive-devel</Dependency>
-            <Dependency release="56">libarchive-32bit</Dependency>
+            <Dependency release="57">libarchive-devel</Dependency>
+            <Dependency release="57">libarchive-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libarchive.so</Path>
@@ -60,7 +60,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="56">libarchive</Dependency>
+            <Dependency release="57">libarchive</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/bsdcat</Path>
@@ -84,7 +84,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="56">libarchive</Dependency>
+            <Dependency release="57">libarchive</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/archive.h</Path>
@@ -131,12 +131,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="56">
-            <Date>2025-03-20</Date>
-            <Version>3.7.8</Version>
+        <Update release="57">
+            <Date>2025-08-16</Date>
+            <Version>3.8.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- [3.8.0 Changelog](https://github.com/libarchive/libarchive/releases/tag/v3.8.0)
- [3.8.1 Changelog](https://github.com/libarchive/libarchive/releases/tag/v3.8.1)

**Security**
- CVE-2025-5918
- CVE-2025-5914
- CVE-2025-5915
- CVE-2025-5916
- CVE-2025-5917

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Open zip files and compressed tar files with File Roller.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
