### PR TITLE
eopkg: Update to v4.3.3

### DIFF
--- a/packages/e/eopkg/package.yml
+++ b/packages/e/eopkg/package.yml
@@ -1,8 +1,8 @@
 name       : eopkg
-version    : 4.3.2
-release    : 28
+version    : 4.3.3
+release    : 29
 source     :
-    - https://github.com/getsolus/eopkg/archive/refs/tags/v4.3.2.tar.gz : 34dd252b9ee9a9d807085dd8b8d5503b5ea6c4bc390ed90115081d47e6546308
+    - https://github.com/getsolus/eopkg/archive/refs/tags/v4.3.3.tar.gz : 4e682b58b1465d169a5d4746e5a95b5aa28adea5074cf0e4d56035d5ec10360f
     - git|https://github.com/getsolus/PackageKit.git : 9b0f17c1ba6addc1c85bff34b64efad6a905ca50
 homepage   : https://github.com/getsolus/eopkg
 license    : GPL-2.0-or-later

--- a/packages/e/eopkg/pspec_x86_64.xml
+++ b/packages/e/eopkg/pspec_x86_64.xml
@@ -37,12 +37,12 @@
             <Path fileType="executable">/usr/bin/eopkg.py3</Path>
             <Path fileType="executable">/usr/bin/lseopkg.py3</Path>
             <Path fileType="executable">/usr/bin/uneopkg.py3</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.2.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.2.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.2.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.2.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.2.dist-info/licenses/AUTHORS</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.2.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.3.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.3.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.3.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.3.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.3.dist-info/licenses/AUTHORS</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.3.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pisi/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pisi/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pisi/__pycache__/__init__.cpython-312.pyc</Path>
@@ -451,9 +451,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2025-08-12</Date>
-            <Version>4.3.2</Version>
+        <Update release="29">
+            <Date>2025-08-18</Date>
+            <Version>4.3.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Hans K</Name>
             <Email>hans@communitycomputing.net</Email>


### PR DESCRIPTION
**Summary**
Release notes can be found [here](https://github.com/getsolus/eopkg/releases/v4.3.3)

**Test Plan**
- Build and install eopkg from this PR.
- Make sure eopkg operations still work.
- If you're feeling ambitious, reference the test plan from https://github.com/getsolus/eopkg/pull/175 to come up with a way to test the actual change made in this release.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
