### PR TITLE
protontricks: Update to v1.13.0

### DIFF
--- a/packages/p/protontricks/package.yml
+++ b/packages/p/protontricks/package.yml
@@ -1,8 +1,8 @@
 name       : protontricks
-version    : 1.12.1
-release    : 30
+version    : 1.13.0
+release    : 31
 source     :
-    - https://files.pythonhosted.org/packages/source/p/protontricks/protontricks-1.12.1.tar.gz : 72629218eaa1d2edf9892f6c2d641d8ab66f54584db59f03e3b8a9cafd60ec9c
+    - https://files.pythonhosted.org/packages/source/p/protontricks/protontricks-1.13.0.tar.gz : c1351e9ebeb7a640147eaf53051137491a8a0a5bd6d5fdd0b962f78d11e7420c
 homepage   : https://github.com/Matoking/protontricks
 license    : GPL-3.0-or-later
 component  : virt

--- a/packages/p/protontricks/pspec_x86_64.xml
+++ b/packages/p/protontricks/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>protontricks</Name>
         <Homepage>https://github.com/Matoking/protontricks</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Marcus L&#xf6;nnqvist</Name>
+            <Email>marlonn.dev@proton.me</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>virt</PartOf>
@@ -23,12 +23,12 @@
             <Path fileType="executable">/usr/bin/protontricks</Path>
             <Path fileType="executable">/usr/bin/protontricks-desktop-install</Path>
             <Path fileType="executable">/usr/bin/protontricks-launch</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.12.1.dist-info/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.12.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.12.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.12.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.12.1.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.12.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.13.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.13.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.13.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.13.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.13.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.13.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/__pycache__/__init__.cpython-312.pyc</Path>
@@ -63,11 +63,23 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/cli/main.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/cli/util.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/config.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/data/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/data/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/data/__pycache__/__init__.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/data/data/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/data/data/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/data/data/__pycache__/__init__.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/data/data/icon_placeholder.png</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/data/scripts/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/data/scripts/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/data/scripts/__pycache__/__init__.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/data/scripts/bwrap_launcher.sh</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/data/scripts/wine_launch.sh</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/data/scripts/wineserver_keepalive.bat</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/data/scripts/wineserver_keepalive.sh</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/data/share/applications/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/data/share/applications/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/data/share/applications/__pycache__/__init__.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/data/share/applications/protontricks-launch.desktop</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/data/share/applications/protontricks.desktop</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/flatpak.py</Path>
@@ -81,12 +93,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="30">
-            <Date>2025-05-08</Date>
-            <Version>1.12.1</Version>
+        <Update release="31">
+            <Date>2025-08-18</Date>
+            <Version>1.13.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Marcus L&#xf6;nnqvist</Name>
+            <Email>marlonn.dev@proton.me</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

[1.13.0] - 2025-08-11
Added
 - Improve compatibility by setting additional Proton related environment variables when applicable
Changed
 - Fixed locale is now used for SteamOS 3, not only Steam Deck

**Test Plan**

* Started protontricks gui
* Install dotnet48 on a prefix

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
