### PR TITLE
budgie-screensaver: Enable fingerprint unlocking

### DIFF
--- a/packages/b/budgie-screensaver/abi_used_symbols
+++ b/packages/b/budgie-screensaver/abi_used_symbols
@@ -264,8 +264,8 @@ libglib-2.0.so.0:g_markup_printf_escaped
 libglib-2.0.so.0:g_mutex_clear
 libglib-2.0.so.0:g_mutex_lock
 libglib-2.0.so.0:g_mutex_unlock
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_option_context_add_main_entries
 libglib-2.0.so.0:g_option_context_free
 libglib-2.0.so.0:g_option_context_new

--- a/packages/b/budgie-screensaver/files/budgie-fingerprint
+++ b/packages/b/budgie-screensaver/files/budgie-fingerprint
@@ -1,0 +1,12 @@
+#%PAM-1.0
+
+auth       required     pam_shells.so
+auth       requisite    pam_nologin.so
+auth       requisite    pam_faillock.so      preauth
+-auth      sufficient   pam_fprintd.so
+auth       include      system-auth
+auth       optional     pam_gnome_keyring.so
+
+account    include      system-local-login
+password   include      pam_deny.so
+session    include      system-local-login

--- a/packages/b/budgie-screensaver/package.yml
+++ b/packages/b/budgie-screensaver/package.yml
@@ -1,6 +1,6 @@
 name       : budgie-screensaver
 version    : 5.1.0
-release    : 28
+release    : 29
 source     :
     - https://github.com/BuddiesOfBudgie/budgie-screensaver/releases/download/v5.1.0/budgie-screensaver-v5.1.0.tar.xz : 563ac3f845729e9e6d184d2dbf036ab3f51ff244c27f5b286cfcb89acc147f0c
 license    :
@@ -32,3 +32,5 @@ install    : |
     rm -rf $installdir/etc/xdg
     install -d $installdir/usr/share/defaults
     mv $installdir/etc $installdir/usr/share/defaults/etc/
+    # Enable fingerprint unlocking
+    install -Dm0644 $pkgfiles/budgie-fingerprint $installdir/usr/share/defaults/etc/pam.d/budgie-screensaver

--- a/packages/b/budgie-screensaver/pspec_x86_64.xml
+++ b/packages/b/budgie-screensaver/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>budgie-screensaver</Name>
         <Homepage>https://github.com/BuddiesOfBudgie/budgie-screensaver</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <License>LGPL-2.0-only</License>
@@ -125,12 +125,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2023-11-13</Date>
+        <Update release="29">
+            <Date>2025-08-21</Date>
             <Version>5.1.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Allow unlocking the screensaver using fingerprints if any are enabled.

**Test Plan**

Tested on both a system with and without a fingerprint reader:

1. Install package
2. Lock screen
3. Unlock using either fingerprint or password

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
