### PR TITLE
github-cli: Update to v2.78.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.76.2
-release    : 79
+version    : 2.78.0
+release    : 80
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.76.2.tar.gz : 6aee5afebdabd33f4c5e8604a9b7fa55e5bbac2a5cd36101cc221c990320c8b3
+    - https://github.com/cli/cli/archive/refs/tags/v2.78.0.tar.gz : 9eeb969222a92bdad47dded2527649cd467a6e2321643cc30e1f12d00490befe
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -232,9 +232,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="79">
-            <Date>2025-08-01</Date>
-            <Version>2.76.2</Version>
+        <Update release="80">
+            <Date>2025-08-21</Date>
+            <Version>2.78.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelogs:

- [2.77.0](https://github.com/cli/cli/releases/tag/v2.77.0)
- [2.78.0](https://github.com/cli/cli/releases/tag/v2.78.0)

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
