### PR TITLE
solus-sc: Prevent bad markdown conversion breaking functionality

### DIFF
--- a/packages/s/solus-sc/files/0001-Add-exception-handling-to-markdown-conversion.patch
+++ b/packages/s/solus-sc/files/0001-Add-exception-handling-to-markdown-conversion.patch
@@ -1,0 +1,52 @@
+From 3ae06a4d45fe154e44d8df3f0c5fabb6c134ce7a Mon Sep 17 00:00:00 2001
+From: Troy Harvey <harveydevel@gmail.com>
+Date: Fri, 22 Aug 2025 14:37:53 +1000
+Subject: [PATCH] Add exception handling to markdown conversion
+
+Signed-off-by: Troy Harvey <harveydevel@gmail.com>
+---
+ solus_sc/changelog.py | 28 ++++++++++++++++------------
+ 1 file changed, 16 insertions(+), 12 deletions(-)
+
+diff --git a/solus_sc/changelog.py b/solus_sc/changelog.py
+index 58dd2be..54c6d20 100755
+--- a/solus_sc/changelog.py
++++ b/solus_sc/changelog.py
+@@ -81,18 +81,22 @@ class ScChangelogEntry(Gtk.EventBox):
+                 r = r.split(id)[1].strip()
+                 break
+ 
+-            r = MARKUP_URI_HIT.sub(r'<a href="\2">\1</a>', r)
+-            r = MARKUP_CODE_HIT.sub(r'<tt>\1</tt>', r)
+-            r = MARKUP_BOLD_HIT.sub(r'<b>\1</b>', r)
+-            r = MARKUP_ITALIC_HIT.sub(r'<i>\1</i>', r)
+-            r = MARKUP_GITHUB_CHECKED_TASK_HIT.sub(r'&#x1F5F9; \1', r)
+-            r = MARKUP_GITHUB_UNCHECKED_TASK_HIT.sub(r'&#x2610; \1', r)
+-            r = MARKUP_GITHUB_TITLE_HIT.sub(r'<i>\1</i>\n', r)
+-            r = MARKUP_SIGNED_OFF_BY_HIT.sub(r'<small><b>{}</b> <i>\1</i></small>'.format(GIT_SIGNED_OFF_BY_LINE), r)
+-            r = CVE_HIT.sub(r' <a href="{}\1">\1</a>'.format(CVE_URI), r)
+-            r = BUG_HIT.sub(r' <a href="{}/T\1">T\1</a>'.format(PHAB_URI), r)
+-            r = DIFF_HIT.sub(r' <a href="{}/D\1">D\1</a>'.format(PHAB_URI), r)
+-            r = GITHUB_ISSUE_HIT.sub(r'<a href="{}/issues/\1">#\1</a>'.format(GITHUB_URI), r)
++            try:
++                r = MARKUP_URI_HIT.sub(r'<a href="\2">\1</a>', r)
++                r = MARKUP_CODE_HIT.sub(r'<tt>\1</tt>', r)
++                r = MARKUP_BOLD_HIT.sub(r'<b>\1</b>', r)
++                r = MARKUP_ITALIC_HIT.sub(r'<i>\1</i>', r)
++                r = MARKUP_GITHUB_CHECKED_TASK_HIT.sub(r'&#x1F5F9; \1', r)
++                r = MARKUP_GITHUB_UNCHECKED_TASK_HIT.sub(r'&#x2610; \1', r)
++                r = MARKUP_GITHUB_TITLE_HIT.sub(r'<i>\1</i>\n', r)
++                r = MARKUP_SIGNED_OFF_BY_HIT.sub(r'<small><b>{}</b> <i>\1</i></small>'.format(GIT_SIGNED_OFF_BY_LINE), r)
++                r = CVE_HIT.sub(r' <a href="{}\1">\1</a>'.format(CVE_URI), r)
++                r = BUG_HIT.sub(r' <a href="{}/T\1">T\1</a>'.format(PHAB_URI), r)
++                r = DIFF_HIT.sub(r' <a href="{}/D\1">D\1</a>'.format(PHAB_URI), r)
++                r = GITHUB_ISSUE_HIT.sub(r'<a href="{}/issues/\1">#\1</a>'.format(GITHUB_URI), r)
++            except Exception as e:
++                print "Problem with line:", r
++                print "Error:", e
+ 
+             # Check if this is a bullet point
+             if (r.startswith("- ") or r.startswith("* ")) and len(r) > 2:
+-- 
+2.49.1
+

--- a/packages/s/solus-sc/package.yml
+++ b/packages/s/solus-sc/package.yml
@@ -1,6 +1,6 @@
 name       : solus-sc
 version    : '23'
-release    : 56
+release    : 57
 source     :
     - git|https://github.com/getsolus/solus-sc.git : 1f2faa14fb9cd5ac920275aea49ee561a0354051
 homepage   : https://getsol.us
@@ -24,6 +24,7 @@ replaces   :
 setup      : |
     %patch -p1 -i $pkgfiles/0001-Remove-repo_data-files-from-POTFILES.in.patch
     %patch -p1 -i $pkgfiles/0001-Convert-from-appstream-glib-to-appstream.patch
+    %patch -p1 -i $pkgfiles/0001-Add-exception-handling-to-markdown-conversion.patch
 build      : |
     %python_setup
 install    : |

--- a/packages/s/solus-sc/pspec_x86_64.xml
+++ b/packages/s/solus-sc/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>solus-sc</Name>
         <Homepage>https://getsol.us</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>desktop</PartOf>
@@ -158,12 +158,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="56">
-            <Date>2025-05-31</Date>
+        <Update release="57">
+            <Date>2025-08-22</Date>
             <Version>23</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

A user reported that clicking on libgudev in solus-sc does nothing. Which means no install/remove for it or packages split from it.

This is due to this commit in the package history containing a single underscore.
https://github.com/getsolus/packages/commit/f76fd93ed5e42b0f41a1bf05e65f3cfa5a2985cb

Our markdown italics conversion breaks when there is only one underscore.
https://github.com/getsolus/solus-sc/commit/b8aeda06792a2a75387569a397aecd3b179a25ed

No telling how many other packages are affected by this sort of issue.

By adding exception handling we prevent any markdown conversion from breaking functionality for this and every other package. Instead we get this when launched from the terminal.
```
Problem with line: - Clarify that _get_sysfs_attr() functions are cached
Error: unmatched group
```

Given solus-sc will be deprecated soon this "fix" is good enough.

**Test Plan**

- Check I can interact with libgudev
- Install libgudev-32bit-devel
- Remove libgudev-32bit-devel

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
