### PR TITLE
caddy: Update to v2.10.1

### DIFF
--- a/packages/c/caddy/package.yml
+++ b/packages/c/caddy/package.yml
@@ -1,9 +1,10 @@
 name       : caddy
-version    : 2.10.0
-release    : 21
+version    : 2.10.1
+release    : 22
 source     :
-    - https://github.com/caddyserver/caddy/archive/refs/tags/v2.10.0.tar.gz : e07e2747c394a6549751950ec8f7457ed346496f131ee38538ae39cf89ebcc68
-    - git|https://github.com/caddyserver/dist.git : v2.10.0
+    - https://github.com/caddyserver/caddy/archive/refs/tags/v2.10.1.tar.gz : 944ab8ba4a8a497827b16b51a39b45dc6e69c32e49d39486d9da198a7727b8be
+    # Commit hash for version: 2.10.1
+    - git|https://github.com/caddyserver/dist.git : 80b2cdc3f7b307fe45dadb7795136b25500fbbd1
 homepage   : https://caddyserver.com
 license    : Apache-2.0
 component  : programming

--- a/packages/c/caddy/pspec_x86_64.xml
+++ b/packages/c/caddy/pspec_x86_64.xml
@@ -34,9 +34,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2025-04-19</Date>
-            <Version>2.10.0</Version>
+        <Update release="22">
+            <Date>2025-08-22</Date>
+            <Version>2.10.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/caddyserver/caddy/releases/tag/v2.10.1).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start and stop a basic Caddy server, see that it responds to `curl` traffic.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
