### PR TITLE
nano: Update to v8.6

### DIFF
--- a/packages/n/nano/package.yml
+++ b/packages/n/nano/package.yml
@@ -1,8 +1,8 @@
 name       : nano
-version    : '8.5'
-release    : 205
+version    : '8.6'
+release    : 206
 source     :
-    - https://www.nano-editor.org/dist/v8/nano-8.5.tar.xz : 000b011d339c141af9646d43288f54325ff5c6e8d39d6e482b787bbc6654c26a
+    - https://www.nano-editor.org/dist/v8/nano-8.6.tar.xz : f7abfbf0eed5f573ab51bd77a458f32d82f9859c55e9689f819d96fe1437a619
 homepage   : https://www.nano-editor.org
 license    : GPL-3.0-or-later
 component  : system.devel

--- a/packages/n/nano/pspec_x86_64.xml
+++ b/packages/n/nano/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nano</Name>
         <Homepage>https://www.nano-editor.org</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.devel</PartOf>
@@ -117,12 +117,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="205">
-            <Date>2025-06-12</Date>
-            <Version>8.5</Version>
+        <Update release="206">
+            <Date>2025-08-22</Date>
+            <Version>8.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- *reason alone was a defective compass*
- The GotoLine menu accepts the prefixes ++ and -- for jumping a number of lines forward or backward.
- Anchors are not forgotten when a line number is given on the command line.

**Test Plan**

- Edit a text file

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
