### PR TITLE
syncthing: Update to v2.0.3

### DIFF
--- a/packages/s/syncthing/package.yml
+++ b/packages/s/syncthing/package.yml
@@ -1,9 +1,9 @@
 name       : syncthing
-version    : 1.30.0
-release    : 103
+version    : 2.0.3
+release    : 104
 homepage   : https://syncthing.net
 source     :
-    - https://github.com/syncthing/syncthing/archive/refs/tags/v1.30.0.tar.gz : 1e9eb93be73960f748fe85d2738793b5a11c88e63839254057d4fd86cd4321a3
+    - https://github.com/syncthing/syncthing/archive/refs/tags/v2.0.3.tar.gz : ccb5524e27f0c19c225275603bf2390bb0a1663ae63863f766303204a62cdce0
 license    : MPL-2.0
 component  : network.util
 networking : yes

--- a/packages/s/syncthing/pspec_x86_64.xml
+++ b/packages/s/syncthing/pspec_x86_64.xml
@@ -50,9 +50,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="103">
-            <Date>2025-07-14</Date>
-            <Version>1.30.0</Version>
+        <Update release="104">
+            <Date>2025-08-23</Date>
+            <Version>2.0.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Tracey Clark</Name>
             <Email>traceyc.dev@tlcnet.info</Email>


### PR DESCRIPTION
**Summary**

The 2.0 update has changed the database backend from LevelDB to SQLite. The logging format has also changed.

**Major changes in 2.0**

- Database backend switched from LevelDB to SQLite. There is a migration on first launch which can be lengthy for larger setups. The new database is easier to understand and maintain and, hopefully, less buggy.

- The logging format has changed to use structured log entries (a message plus several key-value pairs). Additionally, we can now control the log level per package, and a new log level WARNING has been inserted between INFO and ERROR (which was previously known as WARNING...). The INFO level has become more verbose, indicating the sync actions taken by Syncthing. A new command line flag `--log-level` sets the default log level for all packages, and the `STTRACE` environment variable and GUI has been updated to set log levels per package. The `--verbose` and `--logflags` command line options have been removed and will be ignored if given.

- Deleted items are no longer kept forever in the database, instead they are forgotten after six months. If your use case require deletes to take effect after more than a six month delay, set the `--db-delete-retention-interval` command line option or corresponding environment variable to zero, or a longer time interval of your choosing.

- Modernised command line options parsing. Old single-dash long options are no longer supported, e.g. `-home` must be given as `--home`. Some options have been renamed, others have become subcommands. All serve options are now also accepted as environment variables. See `syncthing --help` and `syncthing serve --help` for details.

- Rolling hash detection of shifted data is no longer supported as this effectively never helped. Instead, scanning and syncing is faster and more efficient without it.

- A "default folder" is no longer created on first startup.

- Multiple connections are now used by default between v2 devices. The new default value is to use three connections: one for index metadata and two for data exchange.

- The handling of conflict resolution involving deleted files has changed. A delete can now be the winning outcome of conflict resolution, resulting in  the deleted file being moved to a conflict copy.

Various fixes and enhancements.

Full changelog available [here](https://github.com/syncthing/syncthing/releases/)

**Test Plan**

- Restart Syncthing-GTK, use it to restart syncthing, verify all folders sync
- View syncthing gui in web browser, ensure everything looks good

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged
