### PR TITLE
apostrophe: Update to v3.2

### DIFF
--- a/packages/a/apostrophe/MAINTAINERS.md
+++ b/packages/a/apostrophe/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Muhammad Alfi Syahrin
+  - Matrix: @alfisya:matrix.org
+  - Email: malfisya.dev@hotmail.com

--- a/packages/a/apostrophe/files/305.patch
+++ b/packages/a/apostrophe/files/305.patch
@@ -1,0 +1,62 @@
+From 67ea7fe899f52b7c82528dd7be57dd42e22f296b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ball=C3=B3=20Gy=C3=B6rgy?= <ballogyor@gmail.com>
+Date: Mon, 28 Oct 2024 13:53:39 +0100
+Subject: [PATCH] Make reveal.js optional
+
+If reveal.js is not present on the system, don't set the `revealjs-url`
+variable, so it will be loaded from unpkg.com.
+---
+ apostrophe/export_dialog.py | 7 ++++---
+ meson.build                 | 4 ----
+ 2 files changed, 4 insertions(+), 7 deletions(-)
+
+diff --git a/apostrophe/export_dialog.py b/apostrophe/export_dialog.py
+index 0fd93be0..bf723bcb 100644
+--- a/apostrophe/export_dialog.py
++++ b/apostrophe/export_dialog.py
+@@ -209,6 +209,7 @@ class AdvancedExportDialog(Adw.Dialog):
+ 
+         self.file = file
+         self.text = text
++        self.revealjs = helpers.get_media_path('/libs/reveal.js')
+ 
+         if not self.formats:
+             with open(helpers.get_media_path("/media/formats.json")) as f:
+@@ -303,8 +304,8 @@ class AdvancedExportDialog(Adw.Dialog):
+         def on_response(dialog, response):
+             if self.exports_multiple_files:
+                 folder = export_dialog.get_file()
+-                shutil.copytree(helpers.get_media_path('/libs/reveal.js'),
+-                                os.path.join(folder.get_path(), 'reveal.js'), dirs_exist_ok=True)
++                if self.revealjs:
++                    shutil.copytree(self.revealjs, os.path.join(folder.get_path(), 'reveal.js'), dirs_exist_ok=True)
+                 export_file = folder.get_child(self.file.name + '.' +
+                                 self.formats_list.get_selected_row().item.ext)
+             else:
+@@ -387,7 +388,7 @@ class AdvancedExportDialog(Adw.Dialog):
+             if self.sw_incremental_bullets.get_active():
+                 args.append("--incremental")
+ 
+-        if self.formats_list.get_selected_row().item.to == "revealjs":
++        if self.formats_list.get_selected_row().item.to == "revealjs" and self.revealjs:
+             args.extend(["-V", "revealjs-url=reveal.js"])
+ 
+         return args
+diff --git a/meson.build b/meson.build
+index 6dd4ca89..8b2d1a1e 100644
+--- a/meson.build
++++ b/meson.build
+@@ -60,10 +60,6 @@ pkgdatadir = datadir / meson.project_name()
+ #bindir = join_paths(get_option('prefix'), get_option('bindir'))
+ podir = meson.source_root() / 'po'
+ 
+-if not fs.exists(join_paths(pkgdatadir, 'libs/reveal.js'))
+-  error('No valid reveal.js installation found')
+-endif
+-
+ subdir('data')
+ #subdir('help')
+ subdir('po')
+-- 
+GitLab
+

--- a/packages/a/apostrophe/package.yml
+++ b/packages/a/apostrophe/package.yml
@@ -1,8 +1,8 @@
 name       : apostrophe
-version    : 2.6.3
-release    : 13
+version    : '3.2'
+release    : 14
 source     :
-    - https://gitlab.gnome.org/World/apostrophe/-/archive/v2.6.3/apostrophe-v2.6.3.tar.gz : 6f73c80146af0820ec705ec8b32ec64f0f323f51de6b6a4cfd4d02f0719876f3
+    - https://gitlab.gnome.org/World/apostrophe/-/archive/v3.2/apostrophe-v3.2.tar.gz : 6a69c0e4b7800099396129d5a07a6eb4592897f17c742586c411f17b6fe450d5
 homepage   : https://world.pages.gitlab.gnome.org/apostrophe/
 license    : GPL-3.0-or-later
 component  : office.notes
@@ -12,23 +12,20 @@ description: |
 replaces   :
     - uberwriter
 builddeps  :
-    - pkgconfig(appstream-glib)
-    - pkgconfig(libhandy-1)
-    - desktop-file-utils
-    - sassc
+    - pkgconfig(libadwaita-1)
 rundeps    :
     - font-fira-ttf
-    - gspell
-    - libhandy
-    - libwebkit-gtk
+    - libadwaita
+    - libspelling
+    - libwebkit-gtk6
     - pyenchant
     - python-gobject
     - python-levenshtein
     - python-pypandoc
     - python-regex
 setup      : |
-    # Fix export to HTML
-    sed -i 's|/app/share/fonts|/usr/share/fonts/truetype/fira|' data/media/css/web/base.css
+    # Make reveal.js optional
+    %patch -p1 -i $pkgfiles/305.patch
 
     %meson_configure
 build      : |

--- a/packages/a/apostrophe/pspec_x86_64.xml
+++ b/packages/a/apostrophe/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>apostrophe</Name>
         <Homepage>https://world.pages.gitlab.gnome.org/apostrophe/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>office.notes</PartOf>
@@ -25,7 +25,9 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/__init__.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/application.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/bottombar.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/config.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/editor.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/export_dialog.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/fix_table.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/headerbars.cpython-312.pyc</Path>
@@ -35,28 +37,32 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/latex_to_PNG.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/main_window.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/markup_regex.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/movable_bin.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/open_popover.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/panels.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/preferences_dialog.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/preview_converter.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/preview_handler.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/preview_layout_switcher.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/preview_renderer.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/preview_security.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/preview_web_view.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/preview_window.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/pride.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/search_and_replace.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/settings.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/stats_counter.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/stats_handler.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/table_input.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/text_buffer.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/text_view.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/text_view_drag_drop_handler.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/text_view_format_inserter.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/text_view_markup_handler.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/text_view_scroller.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/text_view_undo_redo_handler.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/theme_switcher.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/__pycache__/tweener.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/application.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/bottombar.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/config.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/editor.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/export_dialog.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/fix_table.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/headerbars.py</Path>
@@ -66,42 +72,35 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/latex_to_PNG.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/main_window.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/markup_regex.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/movable_bin.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/open_popover.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/panels.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/preferences_dialog.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/preview_converter.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/preview_handler.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/preview_layout_switcher.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/preview_renderer.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/preview_security.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/preview_web_view.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/preview_window.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/pride.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/search_and_replace.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/settings.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/stats_counter.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/stats_handler.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/table_input.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/text_buffer.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/text_view.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/text_view_drag_drop_handler.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/text_view_format_inserter.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/text_view_markup_handler.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/text_view_scroller.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/text_view_undo_redo_handler.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/theme_switcher.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/apostrophe/tweener.py</Path>
             <Path fileType="data">/usr/share/apostrophe/apostrophe.gresource</Path>
             <Path fileType="data">/usr/share/apostrophe/lua/relative_to_absolute.lua</Path>
-            <Path fileType="data">/usr/share/apostrophe/lua/task-list.lua</Path>
             <Path fileType="data">/usr/share/apostrophe/media/apostrophe_markdown.md</Path>
-            <Path fileType="data">/usr/share/apostrophe/media/css/gtk/Adwaita-dark-hc.scss</Path>
-            <Path fileType="data">/usr/share/apostrophe/media/css/gtk/Adwaita-dark.scss</Path>
-            <Path fileType="data">/usr/share/apostrophe/media/css/gtk/Adwaita-hc.scss</Path>
-            <Path fileType="data">/usr/share/apostrophe/media/css/gtk/Adwaita-sepia-hc.scss</Path>
-            <Path fileType="data">/usr/share/apostrophe/media/css/gtk/Adwaita-sepia.scss</Path>
-            <Path fileType="data">/usr/share/apostrophe/media/css/gtk/Adwaita.scss</Path>
-            <Path fileType="data">/usr/share/apostrophe/media/css/gtk/_base.scss</Path>
-            <Path fileType="data">/usr/share/apostrophe/media/css/gtk/_definitions.scss</Path>
-            <Path fileType="data">/usr/share/apostrophe/media/css/gtk/_drawing.scss</Path>
-            <Path fileType="data">/usr/share/apostrophe/media/css/gtk/_recoloring.scss</Path>
-            <Path fileType="data">/usr/share/apostrophe/media/css/gtk/bindings.css</Path>
-            <Path fileType="data">/usr/share/apostrophe/media/css/gtk/meson.build</Path>
+            <Path fileType="data">/usr/share/apostrophe/media/css/gtk/style-dark.css</Path>
+            <Path fileType="data">/usr/share/apostrophe/media/css/gtk/style-hc.css</Path>
+            <Path fileType="data">/usr/share/apostrophe/media/css/gtk/style-sepia.css</Path>
+            <Path fileType="data">/usr/share/apostrophe/media/css/gtk/style.css</Path>
             <Path fileType="data">/usr/share/apostrophe/media/css/web/adwaita-sepia.css</Path>
             <Path fileType="data">/usr/share/apostrophe/media/css/web/adwaita.css</Path>
             <Path fileType="data">/usr/share/apostrophe/media/css/web/base.css</Path>
@@ -109,18 +108,27 @@
             <Path fileType="data">/usr/share/apostrophe/media/css/web/highcontrast_inverse.css</Path>
             <Path fileType="data">/usr/share/apostrophe/media/formats.json</Path>
             <Path fileType="data">/usr/share/apostrophe/media/icons/checkmark-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/apostrophe/media/icons/code-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/apostrophe/media/icons/format-text-heading-symbolic.svg</Path>
             <Path fileType="data">/usr/share/apostrophe/media/icons/preview-layout-full-width-symbolic.svg</Path>
             <Path fileType="data">/usr/share/apostrophe/media/icons/preview-layout-half-height-symbolic.svg</Path>
             <Path fileType="data">/usr/share/apostrophe/media/icons/preview-layout-half-width-symbolic.svg</Path>
             <Path fileType="data">/usr/share/apostrophe/media/icons/preview-layout-windowed-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/apostrophe/media/markdown-mark.svg</Path>
-            <Path fileType="data">/usr/share/apostrophe/media/raw/raw_icons.svg</Path>
-            <Path fileType="data">/usr/share/apostrophe/media/reveal.js.zip</Path>
+            <Path fileType="data">/usr/share/apostrophe/media/icons/quotation-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/apostrophe/media/icons/table-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/apostrophe/media/js/scroll.js</Path>
             <Path fileType="data">/usr/share/apostrophe/reference_files/reference-a4.docx</Path>
             <Path fileType="data">/usr/share/apostrophe/reference_files/reference-a4.odt</Path>
+            <Path fileType="data">/usr/share/apostrophe/styles/dark.xml</Path>
+            <Path fileType="data">/usr/share/apostrophe/styles/light.xml</Path>
+            <Path fileType="data">/usr/share/apostrophe/styles/sepia.xml</Path>
             <Path fileType="data">/usr/share/apostrophe/ui/About.ui.in</Path>
+            <Path fileType="data">/usr/share/apostrophe/ui/AboutHemingway.ui</Path>
+            <Path fileType="data">/usr/share/apostrophe/ui/BottomBar.ui</Path>
+            <Path fileType="data">/usr/share/apostrophe/ui/Editor.ui</Path>
             <Path fileType="data">/usr/share/apostrophe/ui/Export.ui</Path>
             <Path fileType="data">/usr/share/apostrophe/ui/Headerbar.ui</Path>
+            <Path fileType="data">/usr/share/apostrophe/ui/Panels.ui</Path>
             <Path fileType="data">/usr/share/apostrophe/ui/Preferences.ui</Path>
             <Path fileType="data">/usr/share/apostrophe/ui/PreviewLayoutSwitcher.ui</Path>
             <Path fileType="data">/usr/share/apostrophe/ui/PreviewLayoutSwitcherItem.ui</Path>
@@ -128,35 +136,49 @@
             <Path fileType="data">/usr/share/apostrophe/ui/Recents.ui</Path>
             <Path fileType="data">/usr/share/apostrophe/ui/SearchBar.ui</Path>
             <Path fileType="data">/usr/share/apostrophe/ui/Shortcuts.ui</Path>
+            <Path fileType="data">/usr/share/apostrophe/ui/Statsbar.ui</Path>
+            <Path fileType="data">/usr/share/apostrophe/ui/TableInput.ui</Path>
             <Path fileType="data">/usr/share/apostrophe/ui/TexliveWarning.ui</Path>
             <Path fileType="data">/usr/share/apostrophe/ui/TextView.ui</Path>
             <Path fileType="data">/usr/share/apostrophe/ui/ThemeSwitcher.ui</Path>
+            <Path fileType="data">/usr/share/apostrophe/ui/Toolbar.ui</Path>
             <Path fileType="data">/usr/share/apostrophe/ui/Window.ui</Path>
             <Path fileType="data">/usr/share/applications/org.gnome.gitlab.somas.Apostrophe.desktop</Path>
             <Path fileType="data">/usr/share/glib-2.0/schemas/org.gnome.gitlab.somas.Apostrophe.gschema.xml</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/org.gnome.gitlab.somas.Apostrophe.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/symbolic/apps/org.gnome.gitlab.somas.Apostrophe-symbolic.svg</Path>
+            <Path fileType="localedata">/usr/share/locale/bg/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/apostrophe.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/el/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/en_GB/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/eu/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fa/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fi/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/apostrophe.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/fur/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/gl/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/he/LC_MESSAGES/apostrophe.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/hi/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/hr/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/hu/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/apostrophe.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ie/LC_MESSAGES/apostrophe.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/is/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/apostrophe.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/apostrophe.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/kab/LC_MESSAGES/apostrophe.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/nb/LC_MESSAGES/apostrophe.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ne/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/nl/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/oc/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pl/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/apostrophe.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ro/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ru/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/si/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sl/LC_MESSAGES/apostrophe.mo</Path>
@@ -174,12 +196,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2025-05-21</Date>
-            <Version>2.6.3</Version>
+        <Update release="14">
+            <Date>2025-08-23</Date>
+            <Version>3.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Port to GTK4 and more. Here are the release notes:
- [3.2](https://gitlab.gnome.org/World/apostrophe/-/releases/v3.2)
- [3.1](https://gitlab.gnome.org/World/apostrophe/-/releases/v3.1)
- [3.0](https://gitlab.gnome.org/World/apostrophe/-/releases/v3.0)

Resolves #6231 

**Test Plan**

<!-- Short description of how the package was tested -->
Launch and create note

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
