### PR TITLE
caddy: Update to v2.10.2

### DIFF
--- a/packages/c/caddy/package.yml
+++ b/packages/c/caddy/package.yml
@@ -1,9 +1,9 @@
 name       : caddy
-version    : 2.10.1
-release    : 22
+version    : 2.10.2
+release    : 23
 source     :
-    - https://github.com/caddyserver/caddy/archive/refs/tags/v2.10.1.tar.gz : 944ab8ba4a8a497827b16b51a39b45dc6e69c32e49d39486d9da198a7727b8be
-    # Commit hash for version: 2.10.1
+    - https://github.com/caddyserver/caddy/archive/refs/tags/v2.10.2.tar.gz : f63f46b7ae68ced0a5c2e31df1b6dfc7656117d162a1bc7fed4bd4afd14ddc8f
+    # Commit hash for version: 2.10.2
     - git|https://github.com/caddyserver/dist.git : 80b2cdc3f7b307fe45dadb7795136b25500fbbd1
 homepage   : https://caddyserver.com
 license    : Apache-2.0

--- a/packages/c/caddy/pspec_x86_64.xml
+++ b/packages/c/caddy/pspec_x86_64.xml
@@ -34,9 +34,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2025-08-22</Date>
-            <Version>2.10.1</Version>
+        <Update release="23">
+            <Date>2025-08-23</Date>
+            <Version>2.10.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- http: Make logger first, before TLS provisioning
- httpcaddyfile: Fix acme_dns regression
- caddyfile: Fix importing nested tokens for `{block}`

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start and stop a Caddy server.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
