### PR TITLE
appstream-catalog: Update to latest catalog

### DIFF
--- a/packages/a/appstream-catalog/package.yml
+++ b/packages/a/appstream-catalog/package.yml
@@ -1,13 +1,13 @@
 name       : appstream-catalog
-version    : '20250822'
-release    : 15
+version    : '20250823'
+release    : 16
 source     :
-    - https://appstream.getsol.us/data/unstable/main/Components-x86_64.xml.gz: 8d69349a4d671fd0b8c50d3da1db4190f8f2a4a79084c30902be7e8a471c44eb
-    - https://appstream.getsol.us/data/unstable/main/icons-128x128.tar.gz: 56b8bb9f953670c4985667936ff22282ae4cb4efc5f286249cffc905e767b002
+    - https://appstream.getsol.us/data/unstable/main/Components-x86_64.xml.gz: 9704c90fd2dafcb5d0361f9a4bbe20da928ed81810f8e8d6b9b1d37644664188
+    - https://appstream.getsol.us/data/unstable/main/icons-128x128.tar.gz: 1833d2ab1e176b4ed9f683837e71a43efb3c7ac4f94f21404cab9a8300486adf
     - https://appstream.getsol.us/data/unstable/main/icons-128x128@2.tar.gz: 5cc9b73fddc1d92e7bec96be3585e2784b93465485a2d8b3c46b4ab5bb7fb964
-    - https://appstream.getsol.us/data/unstable/main/icons-48x48.tar.gz: 706af0344970952418f61f19a7d94f29bc0422c51fe46fbc27a74a1f0c625a10
+    - https://appstream.getsol.us/data/unstable/main/icons-48x48.tar.gz: 3a2978375d06ef6af886463d26bb742327c642d452d369782adcc47b280e05a0
     - https://appstream.getsol.us/data/unstable/main/icons-48x48@2.tar.gz: 634c3a8741979b68cb458f5d7c1bbfc64d73f9315e18718524e5dd7fd8497b9a
-    - https://appstream.getsol.us/data/unstable/main/icons-64x64.tar.gz: b2c72c5206ba44650e7569dc102d31d6ee6d4b4a47d624066dcb8473272ea0a2
+    - https://appstream.getsol.us/data/unstable/main/icons-64x64.tar.gz: d0fccff963f36ba7461f5591eb159e53f1f292cf667be239a98ec6d139fde1ff
     - https://appstream.getsol.us/data/unstable/main/icons-64x64@2.tar.gz: 86b8b548aca7c54f6439778af90f806db54ee454a2c422528b1d976c25b1efb4
 homepage   : https://www.freedesktop.org/wiki/Distributions/AppStream/
 license    :

--- a/packages/a/appstream-catalog/pspec_x86_64.xml
+++ b/packages/a/appstream-catalog/pspec_x86_64.xml
@@ -210,6 +210,7 @@
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/font-ubuntu-ttf_ubuntu-regular.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/font-weather-icons_weathericons-regular.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/fontforge_org.fontforge.FontForge.png</Path>
+            <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/fonts-installer_fonts-installer.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/fooyin_org.fooyin.fooyin.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/four-in-a-row_org.gnome.Four-in-a-row.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/fragments_de.haeckerfelix.Fragments.png</Path>
@@ -893,7 +894,6 @@
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/chocolate-doom_chocolate-doom.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/ckb_ckb-next.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/claws-mail_claws-mail.png</Path>
-            <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/cockatrice_cockatrice.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/codelite_codelite.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/collision_dev.geopjr.Collision.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/conky-manager_conky-manager2.png</Path>
@@ -1006,6 +1006,7 @@
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/font-ubuntu-ttf_ubuntu-regular.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/font-weather-icons_weathericons-regular.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/fontforge_org.fontforge.FontForge.png</Path>
+            <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/fonts-installer_fonts-installer.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/fooyin_org.fooyin.fooyin.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/four-in-a-row_org.gnome.Four-in-a-row.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/fragments_de.haeckerfelix.Fragments.png</Path>
@@ -1287,7 +1288,6 @@
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/naev_org.naev.Naev.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/nasc_com.github.parnold_x.nasc.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/nautilus_org.gnome.Nautilus.png</Path>
-            <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/neochat_org.kde.neochat.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/neovim-qt_nvim-qt.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/neovim_nvim.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/network-manager-applet_preferences-system-network.png</Path>
@@ -1838,6 +1838,7 @@
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/font-ubuntu-ttf_ubuntu-regular.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/font-weather-icons_weathericons-regular.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/fontforge_org.fontforge.FontForge.png</Path>
+            <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/fonts-installer_fonts-installer.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/foobillardplus_foobillardplus.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/fooyin_org.fooyin.fooyin.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/fotocx_fotocx.png</Path>
@@ -2540,9 +2541,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2025-08-22</Date>
-            <Version>20250822</Version>
+        <Update release="16">
+            <Date>2025-08-23</Date>
+            <Version>20250823</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**

Update Appstream Catalog

**Test Plan**

Search for Neochat, Cockatrice, and fonts installer in Discover and see that all of them are available from Solus.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
