### PR TITLE
nginx: Update to v1.29.1

### DIFF
--- a/packages/n/nginx/abi_symbols
+++ b/packages/n/nginx/abi_symbols
@@ -289,7 +289,6 @@ nginx:ngx_http_parse_uri
 nginx:ngx_http_post_request
 nginx:ngx_http_postpone_filter_module
 nginx:ngx_http_process_request
-nginx:ngx_http_process_request_header
 nginx:ngx_http_process_request_uri
 nginx:ngx_http_proxy_module
 nginx:ngx_http_range_body_filter_module
@@ -614,6 +613,7 @@ nginx:ngx_ssl_cache_connection_fetch
 nginx:ngx_ssl_cache_fetch
 nginx:ngx_ssl_cache_init
 nginx:ngx_ssl_certificate
+nginx:ngx_ssl_certificate_compression
 nginx:ngx_ssl_certificate_name_index
 nginx:ngx_ssl_certificates
 nginx:ngx_ssl_check_host

--- a/packages/n/nginx/abi_used_symbols
+++ b/packages/n/nginx/abi_used_symbols
@@ -318,6 +318,7 @@ libssl.so.3:SSL_CONF_cmd
 libssl.so.3:SSL_CONF_cmd_value_type
 libssl.so.3:SSL_CTX_callback_ctrl
 libssl.so.3:SSL_CTX_clear_options
+libssl.so.3:SSL_CTX_compress_certs
 libssl.so.3:SSL_CTX_ctrl
 libssl.so.3:SSL_CTX_free
 libssl.so.3:SSL_CTX_get_cert_store

--- a/packages/n/nginx/package.yml
+++ b/packages/n/nginx/package.yml
@@ -1,8 +1,8 @@
 name       : nginx
-version    : 1.29.0
-release    : 51
+version    : 1.29.1
+release    : 52
 source     :
-    - https://github.com/nginx/nginx/releases/download/release-1.29.0/nginx-1.29.0.tar.gz : 109754dfe8e5169a7a0cf0db6718e7da2db495753308f933f161e525a579a664
+    - https://github.com/nginx/nginx/releases/download/release-1.29.1/nginx-1.29.1.tar.gz : c589f7e7ed801ddbd904afbf3de26ae24eb0cce27c7717a2e94df7fb12d6ad27
 homepage   : https://nginx.org/
 license    : BSD-2-Clause
 component  : programming

--- a/packages/n/nginx/pspec_x86_64.xml
+++ b/packages/n/nginx/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nginx</Name>
         <Homepage>https://nginx.org/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>programming</PartOf>
@@ -49,12 +49,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="51">
-            <Date>2025-07-16</Date>
-            <Version>1.29.0</Version>
+        <Update release="52">
+            <Date>2025-08-26</Date>
+            <Version>1.29.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://github.com/nginx/nginx/releases/tag/release-1.29.1)

**Security**

- CVE-2025-53859

**Test Plan**

- See nginx running as a service

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
