### PR TITLE
common/Scripts: update CVE search URL

### DIFF
--- a/common/Scripts/release_monitoring.py
+++ b/common/Scripts/release_monitoring.py
@@ -85,7 +85,7 @@ class ReleaseMonitoring:
         else:
             lines.insert(
                 3,
-                "# Verify successful cpe hits by visiting https://cve.circl.lu/search/$VENDOR/$PRODUCT",
+                "# Verify successful cpe hits by visiting https://cve.circl.lu/search?vendor=$VENDOR&product=$PRODUCT",
             )
 
         with open(filename, "w") as f:


### PR DESCRIPTION
**Summary**

https://cve.circl.lu/ seem to have changed their search query. 
Using the currently suggested double-check URL in the monitoring.yaml leads to a 404 page. This PR updates the comment to the new query format.

**Test Plan**

- Checked if the new url worked for a known vendor/product pair

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
