### PR TITLE
openxr: Update to v1.1.51

### DIFF
--- a/packages/o/openxr/abi_libs
+++ b/packages/o/openxr/abi_libs
@@ -1,5 +1,6 @@
 hello_xr
 libXrApiLayer_api_dump.so
+libXrApiLayer_best_practices_validation.so
 libXrApiLayer_core_validation.so
 libopenxr_loader.so.1
 openxr_runtime_list

--- a/packages/o/openxr/abi_symbols
+++ b/packages/o/openxr/abi_symbols
@@ -4,6 +4,7 @@ hello_xr:_ZSt4cout
 hello_xr:__libc_single_threaded
 hello_xr:stdin
 libXrApiLayer_api_dump.so:xrNegotiateLoaderApiLayerInterface
+libXrApiLayer_best_practices_validation.so:xrNegotiateLoaderApiLayerInterface
 libXrApiLayer_core_validation.so:xrNegotiateLoaderApiLayerInterface
 libopenxr_loader.so.1:xrAcquireSwapchainImage
 libopenxr_loader.so.1:xrApplyHapticFeedback

--- a/packages/o/openxr/abi_used_symbols
+++ b/packages/o/openxr/abi_used_symbols
@@ -259,6 +259,7 @@ libvulkan.so.1:vkDestroyFence
 libvulkan.so.1:vkDestroyFramebuffer
 libvulkan.so.1:vkDestroyImage
 libvulkan.so.1:vkDestroyImageView
+libvulkan.so.1:vkDestroyPipeline
 libvulkan.so.1:vkDestroyPipelineLayout
 libvulkan.so.1:vkDestroyRenderPass
 libvulkan.so.1:vkDestroyShaderModule

--- a/packages/o/openxr/package.yml
+++ b/packages/o/openxr/package.yml
@@ -1,8 +1,8 @@
 name       : openxr
-version    : 1.1.49
-release    : 1
+version    : 1.1.51
+release    : 2
 source     :
-    - https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-1.1.49/OpenXR-SDK-Source-release-1.1.49.tar.gz : 207452a51ec9d730742c385adb5af21fb266fa7be8090b251f76c0bd2b433c61
+    - https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-1.1.51/OpenXR-SDK-Source-release-1.1.51.tar.gz : 0efacfbaada35f877d6be1d283d381717536b2743c24697c1145409377a6da2c
 homepage   : https://www.khronos.org/openxr/
 license    : Apache-2.0
 component  : multimedia.library

--- a/packages/o/openxr/pspec_x86_64.xml
+++ b/packages/o/openxr/pspec_x86_64.xml
@@ -24,12 +24,13 @@
             <Path fileType="executable">/usr/bin/openxr_runtime_list</Path>
             <Path fileType="executable">/usr/bin/openxr_runtime_list_json</Path>
             <Path fileType="library">/usr/lib64/libopenxr_loader.so.1</Path>
-            <Path fileType="library">/usr/lib64/libopenxr_loader.so.1.1.49</Path>
+            <Path fileType="library">/usr/lib64/libopenxr_loader.so.1.1.51</Path>
             <Path fileType="doc">/usr/share/doc/openxr/LICENSE</Path>
             <Path fileType="man">/usr/share/man/man1/hello_xr.1</Path>
             <Path fileType="man">/usr/share/man/man1/openxr_runtime_list.1</Path>
             <Path fileType="man">/usr/share/man/man1/openxr_runtime_list_json.1</Path>
             <Path fileType="data">/usr/share/openxr/1/api_layers/explicit.d/XrApiLayer_api_dump.json</Path>
+            <Path fileType="data">/usr/share/openxr/1/api_layers/explicit.d/XrApiLayer_best_practices_validation.json</Path>
             <Path fileType="data">/usr/share/openxr/1/api_layers/explicit.d/XrApiLayer_core_validation.json</Path>
         </Files>
     </Package>
@@ -40,7 +41,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="1">openxr</Dependency>
+            <Dependency release="2">openxr</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/openxr/openxr.h</Path>
@@ -55,15 +56,16 @@
             <Path fileType="library">/usr/lib64/cmake/openxr/OpenXRTargets-relwithdebinfo.cmake</Path>
             <Path fileType="library">/usr/lib64/cmake/openxr/OpenXRTargets.cmake</Path>
             <Path fileType="library">/usr/lib64/libXrApiLayer_api_dump.so</Path>
+            <Path fileType="library">/usr/lib64/libXrApiLayer_best_practices_validation.so</Path>
             <Path fileType="library">/usr/lib64/libXrApiLayer_core_validation.so</Path>
             <Path fileType="library">/usr/lib64/libopenxr_loader.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/openxr.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2025-07-08</Date>
-            <Version>1.1.49</Version>
+        <Update release="2">
+            <Date>2025-08-29</Date>
+            <Version>1.1.51</Version>
             <Comment>Packaging update</Comment>
             <Name>Hurican Solas</Name>
             <Email>hurican@keemail.me</Email>


### PR DESCRIPTION

**Summary**

Updated to v1.1.51
Release notes: 
[1.1.50
](https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/tag/release-1.1.50) [1.1.51](https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/tag/release-1.1.51)

**Test Plan**

Installed package alongside the dev version and built an envision profile

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
