### PR TITLE
steam: Update to v1.0.0.84

### DIFF
--- a/packages/s/steam/package.yml
+++ b/packages/s/steam/package.yml
@@ -1,8 +1,8 @@
 name       : steam
-version    : 1.0.0.83
-release    : 100
+version    : 1.0.0.84
+release    : 101
 source     :
-    - https://repo.steampowered.com/steam/pool/steam/s/steam/steam_1.0.0.83.tar.gz : 791682b0cc7efd946c7002f917c9dd474d2619b7f9ed00891216a8a6b4ac8f82
+    - https://repo.steampowered.com/steam/pool/steam/s/steam/steam_1.0.0.84.tar.gz : 31fa762d58793f1aa8ea9df0122c3469c253fc8acb6daa7140fb7433fe077b44
 homepage   : https://store.steampowered.com
 license    : Distributable
 component  :

--- a/packages/s/steam/pspec_x86_64.xml
+++ b/packages/s/steam/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>steam</Name>
         <Homepage>https://store.steampowered.com</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>Distributable</License>
         <PartOf>games</PartOf>
@@ -18,7 +18,7 @@
         <Description xml:lang="en">Launcher for the Steam software distribution service</Description>
         <PartOf>games</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="100">steam-devices</Dependency>
+            <Dependency releaseFrom="101">steam-devices</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/steamdeps</Path>
@@ -57,12 +57,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="100">
-            <Date>2025-06-29</Date>
-            <Version>1.0.0.83</Version>
+        <Update release="101">
+            <Date>2025-08-29</Date>
+            <Version>1.0.0.84</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Updated client timestamp 1751405894 (2025-07-01)
- Steam Runtime (scout) version 1.0.20250519.130917
- Remove steam-runtime-supervisor from the bootstrap mini-runtime, no longer required
- Appstream metainfo: Add OARS content rating

**Test Plan**
- Launched Steam
- Messaged a friend
- Installed, played and uninstalled a small game

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
