### PR TITLE
syncthing-gtk:  Patch to work with syncthing 2.x

### DIFF
--- a/packages/s/syncthing-gtk/package.yml
+++ b/packages/s/syncthing-gtk/package.yml
@@ -1,6 +1,6 @@
 name       : syncthing-gtk
 version    : 0.9.4.5
-release    : 25
+release    : 26
 source     :
     - https://github.com/syncthing-gtk/syncthing-gtk/archive/refs/tags/0.9.4.5.tar.gz : 42758c3490a7f2ab1323c2ee6a6bef460ceb13b1f5d412c02f3b9347e798573c
 homepage   : https://syncthing.net/
@@ -27,6 +27,7 @@ rundeps    :
 setup      : |
     %patch -p1 -i $pkgfiles/0001-Fix-status-icon-on-Solus.patch
     %patch -p1 -i $pkgfiles/0001-solus-Set-version-variable.patch
+    %patch -p1 -i $pkgfiles/0002-Update-to-work-with-syncthing-2.0.patch
 build      : |
     ./generate-locales.sh
     %python3_setup

--- a/packages/s/syncthing-gtk/pspec_x86_64.xml
+++ b/packages/s/syncthing-gtk/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>syncthing-gtk</Name>
         <Homepage>https://syncthing.net/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>network.download</PartOf>
@@ -291,12 +291,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="25">
-            <Date>2025-05-08</Date>
+        <Update release="26">
+            <Date>2025-08-29</Date>
             <Version>0.9.4.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Patch flags to have double dashes for compatibility with syncthing 2.x

**Test Plan**

Restarted syncthing-gtk and verified
- it loads with no errors
- Tray icon appears
- UI looks good
- Can restart the daemon from the UI
- Can properly browse shares

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
