### PR TITLE
syncthing-gtk: Patch to work with syncthing 2.x

### DIFF
--- a/packages/s/syncthing-gtk/files/0002-Update-to-work-with-syncthing-2.0.patch
+++ b/packages/s/syncthing-gtk/files/0002-Update-to-work-with-syncthing-2.0.patch
@@ -1,0 +1,30 @@
+From a5539cc04e975c3636425a54345e3c5818cd9aad Mon Sep 17 00:00:00 2001
+From: Tracey Clark <traceyc.dev@tlcnet.info>
+Date: Fri, 29 Aug 2025 17:54:59 -0500
+Subject: [PATCH] Update to work with syncthing 2.0
+
+---
+ syncthing_gtk/app.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/syncthing_gtk/app.py b/syncthing_gtk/app.py
+index bb5909b..e38657e 100644
+--- a/syncthing_gtk/app.py
++++ b/syncthing_gtk/app.py
+@@ -508,11 +508,11 @@ class App(Gtk.Application, TimerManager):
+         Sets self.process, adds related handlers and starts daemon.
+         Just so I don't have to write same code all over the place.
+         """
+-        cmdline = [self.config["syncthing_binary"], "-no-browser"]
++        cmdline = [self.config["syncthing_binary"], "--no-browser"]
+         vars, preargs, args = parse_config_arguments(self.config["syncthing_arguments"])
+         cmdline = preargs + cmdline + args
+         if self.home_dir_override:
+-            cmdline += ["-home", self.home_dir_override]
++            cmdline += ["--home", self.home_dir_override]
+ 
+         self.process = DaemonProcess(cmdline, self.config["daemon_priority"], self.config["max_cpus"], env=vars)
+         self.process.connect("failed", self.cb_daemon_startup_failed)
+-- 
+2.49.1
+

--- a/packages/s/syncthing-gtk/package.yml
+++ b/packages/s/syncthing-gtk/package.yml
@@ -1,6 +1,6 @@
 name       : syncthing-gtk
 version    : 0.9.4.5
-release    : 26
+release    : 27
 source     :
     - https://github.com/syncthing-gtk/syncthing-gtk/archive/refs/tags/0.9.4.5.tar.gz : 42758c3490a7f2ab1323c2ee6a6bef460ceb13b1f5d412c02f3b9347e798573c
 homepage   : https://syncthing.net/

--- a/packages/s/syncthing-gtk/pspec_x86_64.xml
+++ b/packages/s/syncthing-gtk/pspec_x86_64.xml
@@ -291,8 +291,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2025-08-29</Date>
+        <Update release="27">
+            <Date>2025-08-30</Date>
             <Version>0.9.4.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Tracey Clark</Name>


### PR DESCRIPTION
**Summary**
Update flags to work with syncthing 2.x

**Test Plan**

Restarted syncthing-gtk and verified
- it loads with no errors
- Tray icon appears
- UI looks good
- Can restart the daemon from the UI
- Can properly browse shares

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
