### PR TITLE
python-typer: Add at v0.17.3

### DIFF
--- a/packages/py/python-typer/monitoring.yaml
+++ b/packages/py/python-typer/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 58739
+  rss: https://pypi.org/rss/project/typer/releases.xml
+ # No known CPE, checked 2025-08-29
+security:
+  cpe: ~

--- a/packages/py/python-typer/package.yml
+++ b/packages/py/python-typer/package.yml
@@ -1,0 +1,57 @@
+name       : python-typer
+version    : 0.17.3
+release    : 1
+source     :
+    - https://files.pythonhosted.org/packages/source/t/typer/typer-0.16.1.tar.gz : d358c65a464a7a90f338e3bb7ff0c74ac081449e53884b12ba658cbd72990614
+homepage   : https://pypi.org/project/typer
+license    : MIT
+component  : programming.python
+summary    : Build great CLIs
+description: |
+    Typer is a library for building CLI applications that users will love using and developers will love creating. Based on Python type hints.
+builddeps  :
+    - python-build
+    - python-installer
+    - python-pdm-backend
+    - python-setuptools
+checkdeps  :
+    - python-click
+    - python-pytest
+    - python-rich
+    - python-shellingham
+    - python-typing-extensions
+rundeps    :
+    - python-click
+    - python-rich
+    - python-shellingham
+    - python-typing-extensions
+build      : |
+    %python3_setup
+install    : |
+    %python3_install
+
+    # /usr/bin/typer conflicts with the erlang
+    # package, so rename the binary here.
+    mv $installdir/usr/bin/typer $installdir/usr/bin/python-typer
+check      : |
+    # See scripts/test.sh. We do not run the linters (scripts/lint.sh, i.e.,
+    # mypy/black/isort).
+    export TERMINAL_WIDTH=3000
+    export _TYPER_FORCE_DISABLE_TERMINAL=1
+    export _TYPER_RUN_INSTALL_COMPLETION_TESTS=1
+
+    # These cannot find the typer package because the tests override PYTHONPATH.
+    ignore="${ignore-} --ignore=tests/test_tutorial/test_subcommands/test_tutorial001.py"
+    ignore="${ignore-} --ignore=tests/test_tutorial/test_subcommands/test_tutorial003.py"
+
+    mkdir _stub
+    cat > _stub/coverage.py <<'EOF'
+    from subprocess import run
+    from sys import argv, executable, exit
+    if len(argv) < 3 or argv[1] != "run":
+        exit(f"Unsupported arguments: {argv!r}")
+    exit(run([executable] + argv[2:]).returncode)
+    EOF
+    export PYTHONPATH="${PWD}/_stub:$installdir/usr/lib/python%python3_version%/site-packages"
+
+    %python3_test pytest -k "${k-}" ${ignore} -v -rs

--- a/packages/py/python-typer/pspec_x86_64.xml
+++ b/packages/py/python-typer/pspec_x86_64.xml
@@ -1,0 +1,89 @@
+<PISI>
+    <Source>
+        <Name>python-typer</Name>
+        <Homepage>https://pypi.org/project/typer</Homepage>
+        <Packager>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
+        </Packager>
+        <License>MIT</License>
+        <PartOf>programming.python</PartOf>
+        <Summary xml:lang="en">Build great CLIs</Summary>
+        <Description xml:lang="en">Typer is a library for building CLI applications that users will love using and developers will love creating. Based on Python type hints.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>python-typer</Name>
+        <Summary xml:lang="en">Build great CLIs</Summary>
+        <Description xml:lang="en">Typer is a library for building CLI applications that users will love using and developers will love creating. Based on Python type hints.
+</Description>
+        <PartOf>programming.python</PartOf>
+        <Files>
+            <Path fileType="executable">/usr/bin/python-typer</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer-0.16.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer-0.16.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer-0.16.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer-0.16.1.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer-0.16.1.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__main__.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/__init__.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/__main__.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/__main__.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/_completion_classes.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/_completion_classes.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/_completion_shared.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/_completion_shared.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/_types.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/_types.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/_typing.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/_typing.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/cli.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/cli.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/colors.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/colors.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/completion.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/completion.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/core.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/core.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/main.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/main.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/models.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/models.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/params.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/params.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/rich_utils.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/rich_utils.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/testing.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/testing.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/utils.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/__pycache__/utils.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/_completion_classes.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/_completion_shared.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/_types.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/_typing.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/cli.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/colors.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/completion.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/core.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/main.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/models.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/params.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/py.typed</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/rich_utils.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/testing.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/typer/utils.py</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2025-09-01</Date>
+            <Version>0.17.3</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**
Initial inclusion of python-typer.

Having this included in the repository now will make my life way easier in regards to testing ypkg, which will be using `typer`. This might also be of help to Hans for `eopkg` work.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Check that basic functionality works. The real test will be when ypkg uses it.

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
