### PR TITLE
eza: Update to v0.23.1

### DIFF
--- a/packages/e/eza/package.yml
+++ b/packages/e/eza/package.yml
@@ -1,8 +1,8 @@
 name       : eza
-version    : 0.23.0
-release    : 55
+version    : 0.23.1
+release    : 56
 source     :
-    - https://github.com/eza-community/eza/archive/refs/tags/v0.23.0.tar.gz : 119973d58aef7490f6c553f818cfde142998f5e93205f53f94981a9631b50310
+    - https://github.com/eza-community/eza/archive/refs/tags/v0.23.1.tar.gz : 4c49f3ee6fc76ef45c489cd664eb2c68d96cda31b427605a48b074bcf269ee05
 homepage   : https://github.com/eza-community/eza
 license    : EUPL-1.2
 component  : system.utils

--- a/packages/e/eza/pspec_x86_64.xml
+++ b/packages/e/eza/pspec_x86_64.xml
@@ -33,9 +33,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="55">
-            <Date>2025-07-19</Date>
-            <Version>0.23.0</Version>
+        <Update release="56">
+            <Date>2025-09-01</Date>
+            <Version>0.23.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- Restore unsafe blocks for libc major/minor device id
- `cargo deb` metadata to `LICENSE.txt`

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

List files and folders in a directory.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
