### PR TITLE
ypkg update

### DIFF
--- a/packages/s/solbuild/abi_used_symbols
+++ b/packages/s/solbuild/abi_used_symbols
@@ -19,10 +19,10 @@ libc.so.6:pthread_attr_destroy
 libc.so.6:pthread_attr_getstack
 libc.so.6:pthread_attr_getstacksize
 libc.so.6:pthread_attr_init
+libc.so.6:pthread_attr_setdetachstate
 libc.so.6:pthread_cond_broadcast
 libc.so.6:pthread_cond_wait
 libc.so.6:pthread_create
-libc.so.6:pthread_detach
 libc.so.6:pthread_getattr_np
 libc.so.6:pthread_key_create
 libc.so.6:pthread_mutex_lock

--- a/packages/s/solbuild/package.yml
+++ b/packages/s/solbuild/package.yml
@@ -1,8 +1,8 @@
 name       : solbuild
-version    : 1.7.1
-release    : 57
+version    : 1.8.1
+release    : 58
 source     :
-    - https://github.com/getsolus/solbuild/archive/refs/tags/v1.7.1.tar.gz : b09fa99975b4fab0269e877b342a7e721405976a35c701aa735cd2fa6cfc5815
+    - https://github.com/getsolus/solbuild/releases/download/v1.8.1/solbuild-1.8.1.tar.xz : 347169adc6ae677e6ef3b0ef6dd69bebe7e14551064367d6300316c531665c5a
 homepage   : https://github.com/getsolus/solbuild
 license    : Apache-2.0
 component  :

--- a/packages/s/solbuild/pspec_x86_64.xml
+++ b/packages/s/solbuild/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>solbuild</Name>
         <Homepage>https://github.com/getsolus/solbuild</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.tools</PartOf>
@@ -23,9 +23,9 @@
             <Path fileType="executable">/usr/bin/solbuild</Path>
             <Path fileType="library">/usr/lib64/tmpfiles.d/solbuild.conf</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/solbuild</Path>
-            <Path fileType="man">/usr/share/man/man1/solbuild.1</Path>
-            <Path fileType="man">/usr/share/man/man5/solbuild.conf.5</Path>
-            <Path fileType="man">/usr/share/man/man5/solbuild.profile.5</Path>
+            <Path fileType="man">/usr/share/man/man1/solbuild.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man5/solbuild.conf.5.zst</Path>
+            <Path fileType="man">/usr/share/man/man5/solbuild.profile.5.zst</Path>
             <Path fileType="data">/usr/share/solbuild/00_solbuild.conf</Path>
             <Path fileType="data">/usr/share/solbuild/main-x86_64.profile</Path>
             <Path fileType="data">/usr/share/solbuild/unstable-x86_64.profile</Path>
@@ -38,7 +38,7 @@
 </Description>
         <PartOf>programming.tools</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="57">solbuild</Dependency>
+            <Dependency releaseFrom="58">solbuild</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/solbuild/local-unstable-x86_64.profile</Path>
@@ -51,19 +51,19 @@
 </Description>
         <PartOf>programming.tools</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="57">solbuild</Dependency>
+            <Dependency releaseFrom="58">solbuild</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/solbuild/99_unstable.conf</Path>
         </Files>
     </Package>
     <History>
-        <Update release="57">
-            <Date>2025-01-09</Date>
-            <Version>1.7.1</Version>
+        <Update release="58">
+            <Date>2025-09-06</Date>
+            <Version>1.8.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/y/ypkg/package.yml
+++ b/packages/y/ypkg/package.yml
@@ -1,8 +1,8 @@
 name       : ypkg
-version    : '34'
-release    : 208
+version    : 35.0.0
+release    : 209
 source     :
-    - git|https://github.com/getsolus/ypkg.git : cf4745a723e6909c77aad85003769a6a7dec1dda
+    - https://github.com/getsolus/ypkg/archive/refs/tags/v35.0.0.tar.gz : 8939f09d2453627e7873a9ddf2a9ee95e76d787374059b4f88350f6d32ef0e1c
 homepage   : https://github.com/getsolus/ypkg
 license    : GPL-3.0-or-later
 component  : system.devel
@@ -18,13 +18,23 @@ builddeps  :
     - pkgconfig(python3)
     - nuitka
     - patchelf
+    - python-build
     - python-eopkg
+    - python-hatchling
+    - python-humanize
+    - python-installer
     - python-setuptools
+    - python-typer
+    - python-typing-extensions
+    - python-wheel
     - python-xattr
     - python-zstandard
     - tree
 rundeps    :
     - python-eopkg
+    - python-humanize
+    - python-typer
+    - python-typing-extensions
     - python-xattr
     - pyyaml
     - ruamel_yaml
@@ -32,29 +42,15 @@ clang      : yes
 environment: |
     # ensure our nuitka build doesn't pull in -v3 hwcaps libs
     export GLIBC_TUNABLES=glibc.cpu.hwcaps=-AVX
-setup      : |
-    %patch -p1 -i $pkgfiles/python312-compat.patch
-
-    %python3_setup
 build      : |
-    # build static bins from ypkg
-    # --include-package-data=ypkg is necessary to get rc.yml included (will include all non-py files actually)
-    time nuitka3 --onefile --include-module=dbm.gnu --show-scons --lto=yes --no-deployment-flag=self-execution --main=ypkg --main=ypkg-build --main=ypkg-install-deps --main=ypkg-gen-history --include-package-data=ypkg2 --jobs=%YJOBS%
+    %python3_setup
 install    : |
     %python3_install
+
+    # build static bins from ypkg
+    time nuitka3 --onefile --include-module=dbm.gnu --show-scons --lto=yes --no-deployment-flag=self-execution --main=$installdir/usr/bin/ypkg --jobs=%YJOBS%
 
     # Install main ypkg binary
     mv $installdir/usr/bin/ypkg $installdir/usr/bin/ypkg.py
     install -Dm0755 $workdir/ypkg.bin -t $installdir/usr/bin/
     ln -srvf $installdir/usr/bin/ypkg.bin $installdir/usr/bin/ypkg
-
-    # Create symlinks for the other binaries
-    for b in ypkg-build ypkg-install-deps ypkg-gen-history
-    do
-        mv $installdir/usr/bin/$b $installdir/usr/bin/$b.py
-        # this can be used to switch the used version between the nuitka .bin ones and the pure .py ones
-        #ln -srvf $installdir/usr/bin/$b.py $installdir/usr/bin/$b
-        ln -srvf $installdir/usr/bin/ypkg $installdir/usr/bin/$b
-    done
-    # show the current symlink targets for convenience
-    tree -P 'y*' $installdir/usr/bin/

--- a/packages/y/ypkg/pspec_x86_64.xml
+++ b/packages/y/ypkg/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ypkg</Name>
         <Homepage>https://github.com/getsolus/ypkg</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.devel</PartOf>
@@ -26,61 +26,98 @@ Simply put, it is a tool to convert a build process into a packaging operation.
         <Files>
             <Path fileType="executable">/usr/bin/ybump</Path>
             <Path fileType="executable">/usr/bin/ypkg</Path>
-            <Path fileType="executable">/usr/bin/ypkg-build</Path>
-            <Path fileType="executable">/usr/bin/ypkg-build.py</Path>
-            <Path fileType="executable">/usr/bin/ypkg-gen-history</Path>
-            <Path fileType="executable">/usr/bin/ypkg-gen-history.py</Path>
-            <Path fileType="executable">/usr/bin/ypkg-install-deps</Path>
-            <Path fileType="executable">/usr/bin/ypkg-install-deps.py</Path>
             <Path fileType="executable">/usr/bin/ypkg.bin</Path>
             <Path fileType="executable">/usr/bin/ypkg.py</Path>
             <Path fileType="executable">/usr/bin/yupdate</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2-31.0.0-py3.12.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2-31.0.0-py3.12.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2-31.0.0-py3.12.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2-31.0.0-py3.12.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2-35.0.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2-35.0.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2-35.0.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2-35.0.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2-35.0.0.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/__init__.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/build.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/build.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/compressdoc.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/compressdoc.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/dependencies.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/dependencies.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/examine.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/examine.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/history.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/history.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/main.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/main.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/metadata.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/metadata.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/packages.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/packages.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/scripts.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/scripts.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/sources.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/sources.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/stringglob.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/stringglob.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/ui.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/ui.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/util.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/util.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/yamlhelper.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/yamlhelper.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/ypkgcontext.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/ypkgcontext.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/ypkgspec.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/ypkgspec.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/build.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/cli/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/cli/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/cli/__pycache__/__init__.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/cli/__pycache__/bump.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/cli/__pycache__/bump.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/cli/__pycache__/update.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/cli/__pycache__/update.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/cli/bump.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/cli/update.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/compressdoc.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/dependencies.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/examine.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/history.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/main.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/metadata.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/packages.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/rc.yml</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/scripts.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/sources.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/stringglob.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/ui.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/util.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/yamlhelper.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/ypkgcontext.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/ypkgspec.py</Path>
-            <Path fileType="man">/usr/share/man/man1/ypkg-build.1.gz</Path>
-            <Path fileType="man">/usr/share/man/man1/ypkg-install-deps.1.gz</Path>
-            <Path fileType="man">/usr/share/man/man1/ypkg.1.gz</Path>
-            <Path fileType="man">/usr/share/man/man5/package.yml.5.gz</Path>
+            <Path fileType="man">/usr/share/man/man1/ypkg.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man5/package.yml.5.zst</Path>
+            <Path fileType="data">/usr/share/ypkg/macros/actions/autotools.yaml</Path>
+            <Path fileType="data">/usr/share/ypkg/macros/actions/cargo.yaml</Path>
+            <Path fileType="data">/usr/share/ypkg/macros/actions/cmake.yaml</Path>
+            <Path fileType="data">/usr/share/ypkg/macros/actions/haskell.yaml</Path>
+            <Path fileType="data">/usr/share/ypkg/macros/actions/meson.yaml</Path>
+            <Path fileType="data">/usr/share/ypkg/macros/actions/misc.yaml</Path>
+            <Path fileType="data">/usr/share/ypkg/macros/actions/ninja.yaml</Path>
+            <Path fileType="data">/usr/share/ypkg/macros/actions/perl.yaml</Path>
+            <Path fileType="data">/usr/share/ypkg/macros/actions/pgo.yaml</Path>
+            <Path fileType="data">/usr/share/ypkg/macros/actions/python.yaml</Path>
+            <Path fileType="data">/usr/share/ypkg/macros/actions/qt-kde.yaml</Path>
+            <Path fileType="data">/usr/share/ypkg/macros/actions/ruby.yaml</Path>
+            <Path fileType="data">/usr/share/ypkg/macros/actions/waf.yaml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="208">
-            <Date>2025-06-05</Date>
-            <Version>34</Version>
+        <Update release="209">
+            <Date>2025-09-05</Date>
+            <Version>35.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- **solbuild: Update to 1.8.1**
- **ypkg: Update to 35.0.0**

This PR updates both `solbuild` and `ypkg` to the latest releases. Please see the individual release notes for more details.

**Test Plan**

- Build and install `solbuild`
  ```bash
  go-task build-localcp
  sudo eopkg it ./solbuild-*.eopkg
  ```
- Build and install `ypkg`
  ```bash
  go-task build-localcp
  sudo eopkg it ./ypkg-*.eopkg
  ```
- Build a package like `nano`
  ```bash
  gotopkg nano
  go-task build-local
  ```

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
