### PR TITLE
sqlite3: Update to v3.50.4

### DIFF
--- a/packages/s/sqlite3/abi_symbols
+++ b/packages/s/sqlite3/abi_symbols
@@ -198,6 +198,7 @@ libsqlite3.so.0:sqlite3_set_authorizer
 libsqlite3.so.0:sqlite3_set_auxdata
 libsqlite3.so.0:sqlite3_set_clientdata
 libsqlite3.so.0:sqlite3_set_last_insert_rowid
+libsqlite3.so.0:sqlite3_setlk_timeout
 libsqlite3.so.0:sqlite3_shutdown
 libsqlite3.so.0:sqlite3_sleep
 libsqlite3.so.0:sqlite3_snprintf

--- a/packages/s/sqlite3/abi_symbols32
+++ b/packages/s/sqlite3/abi_symbols32
@@ -198,6 +198,7 @@ libsqlite3.so.0:sqlite3_set_authorizer
 libsqlite3.so.0:sqlite3_set_auxdata
 libsqlite3.so.0:sqlite3_set_clientdata
 libsqlite3.so.0:sqlite3_set_last_insert_rowid
+libsqlite3.so.0:sqlite3_setlk_timeout
 libsqlite3.so.0:sqlite3_shutdown
 libsqlite3.so.0:sqlite3_sleep
 libsqlite3.so.0:sqlite3_snprintf

--- a/packages/s/sqlite3/abi_used_symbols
+++ b/packages/s/sqlite3/abi_used_symbols
@@ -53,7 +53,6 @@ libc.so.6:isatty
 libc.so.6:localtime_r
 libc.so.6:lstat64
 libc.so.6:malloc
-libc.so.6:malloc_usable_size
 libc.so.6:memchr
 libc.so.6:memcmp
 libc.so.6:memcpy
@@ -92,7 +91,6 @@ libc.so.6:rewind
 libc.so.6:rmdir
 libc.so.6:setvbuf
 libc.so.6:signal
-libc.so.6:sprintf
 libc.so.6:stat64
 libc.so.6:stderr
 libc.so.6:stdin
@@ -109,6 +107,7 @@ libc.so.6:strspn
 libc.so.6:strstr
 libc.so.6:strtod
 libc.so.6:strtol
+libc.so.6:strtoll
 libc.so.6:symlink
 libc.so.6:sysconf
 libc.so.6:system

--- a/packages/s/sqlite3/abi_used_symbols32
+++ b/packages/s/sqlite3/abi_used_symbols32
@@ -24,7 +24,6 @@ libc.so.6:gettimeofday
 libc.so.6:localtime_r
 libc.so.6:lstat64
 libc.so.6:malloc
-libc.so.6:malloc_usable_size
 libc.so.6:memchr
 libc.so.6:memcmp
 libc.so.6:memcpy
@@ -54,6 +53,7 @@ libc.so.6:readlink
 libc.so.6:realloc
 libc.so.6:rmdir
 libc.so.6:stat64
+libc.so.6:strchr
 libc.so.6:strchrnul
 libc.so.6:strcmp
 libc.so.6:strcspn

--- a/packages/s/sqlite3/package.yml
+++ b/packages/s/sqlite3/package.yml
@@ -1,8 +1,8 @@
 name       : sqlite3
-version    : 3.49.2
-release    : 63
+version    : 3.50.4
+release    : 64
 source     :
-    - https://sqlite.org/2025/sqlite-src-3490200.zip : c3101978244669a43bc09f44fa21e47a4e25cdf440f1829e9eff176b9a477862
+    - https://sqlite.org/2025/sqlite-src-3500400.zip : b7b4dc060f36053902fb65b344bbbed592e64b2291a26ac06fe77eec097850e9
 license    : Public-Domain
 component  :
     - system.base
@@ -30,12 +30,13 @@ setup      : |
         --enable-fts3 \
         --enable-fts4 \
         --enable-fts5 \
+        --enable-geopoly \
         --enable-rtree \
         --enable-threadsafe \
         $ex_opts \
         --disable-tcl \
         --soname=legacy \
-        CFLAGS="$CFLAGS \
+        CPPFLAGS="$CPPFLAGS \
         -DSQLITE_ENABLE_COLUMN_METADATA=1 \
         -DSQLITE_ENABLE_DBPAGE_VTAB=1 \
         -DSQLITE_ENABLE_DBSTAT_VTAB=1 \
@@ -58,7 +59,6 @@ install    : |
     install -Dm00644 lempar.c -t $installdir/usr/share/lemon/
     install -Dm00755 lemon $installdir/usr/bin
     popd
-
 patterns   :
     - lemon :
         - /usr/bin/lemon

--- a/packages/s/sqlite3/pspec_x86_64.xml
+++ b/packages/s/sqlite3/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>sqlite3</Name>
         <Homepage>https://www.sqlite.org</Homepage>
         <Packager>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Public-Domain</License>
         <PartOf>system.base</PartOf>
@@ -20,8 +20,8 @@
         <Files>
             <Path fileType="executable">/usr/bin/sqlite3</Path>
             <Path fileType="library">/usr/lib64/libsqlite3.so.0</Path>
-            <Path fileType="library">/usr/lib64/libsqlite3.so.3.49.2</Path>
-            <Path fileType="man">/usr/share/man/man1/sqlite3.1</Path>
+            <Path fileType="library">/usr/lib64/libsqlite3.so.3.50.4</Path>
+            <Path fileType="man">/usr/share/man/man1/sqlite3.1.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -30,11 +30,11 @@
         <Description xml:lang="en">The SQLite package is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="63">sqlite3</Dependency>
+            <Dependency release="64">sqlite3</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libsqlite3.so.0</Path>
-            <Path fileType="library">/usr/lib32/libsqlite3.so.3.49.2</Path>
+            <Path fileType="library">/usr/lib32/libsqlite3.so.3.50.4</Path>
         </Files>
     </Package>
     <Package>
@@ -43,8 +43,8 @@
         <Description xml:lang="en">The SQLite package is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="63">sqlite3-32bit</Dependency>
-            <Dependency release="63">sqlite3-devel</Dependency>
+            <Dependency release="64">sqlite3-32bit</Dependency>
+            <Dependency release="64">sqlite3-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libsqlite3.so</Path>
@@ -57,7 +57,7 @@
         <Description xml:lang="en">The SQLite package is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="63">sqlite3</Dependency>
+            <Dependency release="64">sqlite3</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/sqlite3.h</Path>
@@ -77,12 +77,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="63">
-            <Date>2025-05-10</Date>
-            <Version>3.49.2</Version>
+        <Update release="64">
+            <Date>2025-09-06</Date>
+            <Version>3.50.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fix two long-standings cases of the use of uninitialized variables in obscure circumstances
- Fix a possible memory error that can occur if a query is made against against FTS5 index that has been deliberately corrupted in a very specific way
- Fix the parser so that it ignored SQL comments in all places of a CREATE TRIGGER statement
- Fix an incorrect answer due to over-optimization of an AND operator

Full changelog available [here](https://sqlite.org/changes.html).

**Security**
Includes fixes for:
- CVE-2025-6965
- CVE-2025-7709

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Create a new sqlite database, and create a table in that datebase.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
