### PR TITLE
msmtp: Update to 1.8.31

### DIFF
--- a/packages/m/msmtp/package.yml
+++ b/packages/m/msmtp/package.yml
@@ -1,8 +1,8 @@
 name       : msmtp
-version    : 1.8.30
-release    : 12
+version    : 1.8.31
+release    : 13
 source     :
-    - https://marlam.de/msmtp/releases/msmtp-1.8.30.tar.xz : f826a3c500c4dfeed814685097cead9b2b3dca5a2ec3897967cb9032570fa9ab
+    - https://marlam.de/msmtp/releases/msmtp-1.8.31.tar.xz : c262b11762d8582a3c6d6ca8d8b2cca2b1605497324ca27cc57fdc145a27119f
 homepage   : https://marlam.de/msmtp
 license    : GPL-3.0-or-later
 component  : network.clients

--- a/packages/m/msmtp/pspec_x86_64.xml
+++ b/packages/m/msmtp/pspec_x86_64.xml
@@ -22,7 +22,7 @@
         <Files>
             <Path fileType="executable">/usr/bin/msmtp</Path>
             <Path fileType="executable">/usr/bin/msmtpd</Path>
-            <Path fileType="info">/usr/share/info/msmtp.info</Path>
+            <Path fileType="info">/usr/share/info/msmtp.info.zst</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/msmtp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/eo/LC_MESSAGES/msmtp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/msmtp.mo</Path>
@@ -35,14 +35,14 @@
             <Path fileType="localedata">/usr/share/locale/ta/LC_MESSAGES/msmtp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/msmtp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/msmtp.mo</Path>
-            <Path fileType="man">/usr/share/man/man1/msmtp.1</Path>
-            <Path fileType="man">/usr/share/man/man1/msmtpd.1</Path>
+            <Path fileType="man">/usr/share/man/man1/msmtp.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/msmtpd.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2025-06-02</Date>
-            <Version>1.8.30</Version>
+        <Update release="13">
+            <Date>2025-09-07</Date>
+            <Version>1.8.31</Version>
             <Comment>Packaging update</Comment>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>


### PR DESCRIPTION
**Summary**

Bugfixes:

- Fixed check of error conditions with the --read-envelope-from option
- Fixed handling of null bytes in the input by msmtpd (msmtp handled them correctly)
- Fixed handling of very long OAuth tokens

Full release notes:

- [News](https://marlam.de/msmtp/news/)

**Test Plan**

- Build and installed locally
- Sent test email

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged
