### PR TITLE
obs-vkcapture: Update to v1.5.3

### DIFF
--- a/packages/o/obs-vkcapture/abi_used_symbols32
+++ b/packages/o/obs-vkcapture/abi_used_symbols32
@@ -31,6 +31,7 @@ libc.so.6:socket
 libc.so.6:stderr
 libc.so.6:strcmp
 libc.so.6:strerror
+libc.so.6:strncmp
 libc.so.6:strncpy
 libc.so.6:strtol
 libc.so.6:unsetenv

--- a/packages/o/obs-vkcapture/package.yml
+++ b/packages/o/obs-vkcapture/package.yml
@@ -1,8 +1,8 @@
 name       : obs-vkcapture
-version    : 1.5.2
-release    : 12
+version    : 1.5.3
+release    : 13
 source     :
-    - https://github.com/nowrep/obs-vkcapture/archive/refs/tags/v1.5.2.tar.gz : 2bc00d2848fdb00fb00bfe34a3cde8dc7f0cec4e7c37c69f75957290bc5c2bc5
+    - https://github.com/nowrep/obs-vkcapture/archive/refs/tags/v1.5.3.tar.gz : 33ac77427ba30f8d4bdd0921b04ad47385afcf2d52575e7023047c7b17ddd858
 license    : GPL-2.0-or-later
 homepage   : https://github.com/nowrep/obs-vkcapture
 component  : multimedia.video

--- a/packages/o/obs-vkcapture/pspec_x86_64.xml
+++ b/packages/o/obs-vkcapture/pspec_x86_64.xml
@@ -48,7 +48,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="12">obs-vkcapture</Dependency>
+            <Dependency release="13">obs-vkcapture</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libVkLayer_obs_vkcapture.so</Path>
@@ -56,9 +56,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2025-05-20</Date>
-            <Version>1.5.2</Version>
+        <Update release="13">
+            <Date>2025-09-07</Date>
+            <Version>1.5.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fixed GL capture with recent Wine versions
- Fixed dark image when used together with certain filters
- Disabled GL capture with zink

**Test Plan**

Recorded some footage of the Steam game "b"

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
