### PR TITLE
python-maturin: Update to v1.9.4

### DIFF
--- a/packages/py/python-maturin/abi_used_symbols
+++ b/packages/py/python-maturin/abi_used_symbols
@@ -18,6 +18,7 @@ libc.so.6:calloc
 libc.so.6:cfmakeraw
 libc.so.6:chdir
 libc.so.6:chmod
+libc.so.6:chroot
 libc.so.6:clock_gettime
 libc.so.6:close
 libc.so.6:closedir

--- a/packages/py/python-maturin/package.yml
+++ b/packages/py/python-maturin/package.yml
@@ -1,8 +1,8 @@
 name       : python-maturin
-version    : 1.9.3
-release    : 62
+version    : 1.9.4
+release    : 63
 source     :
-    - https://github.com/PyO3/maturin/archive/refs/tags/v1.9.3.tar.gz : 1a4a87224a34a97a4322bd123487e9c6f2d2091bac4fe469618b92a06aad3492
+    - https://github.com/PyO3/maturin/archive/refs/tags/v1.9.4.tar.gz : c052ec18498b6dafc727696610a4df49afac54fee29f8020857e301ce2c5f5e0
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-maturin/pspec_x86_64.xml
+++ b/packages/py/python-maturin/pspec_x86_64.xml
@@ -22,12 +22,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/maturin</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.3.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.3.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.3.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.3.dist-info/licenses/license-apache</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.3.dist-info/licenses/license-mit</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.3.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.4.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.4.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.4.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.4.dist-info/licenses/license-apache</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.4.dist-info/licenses/license-mit</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.4.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -40,9 +40,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="62">
-            <Date>2025-08-11</Date>
-            <Version>1.9.3</Version>
+        <Update release="63">
+            <Date>2025-09-07</Date>
+            <Version>1.9.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Downgrade manylinux version for riscv64
- Fix calculation of platform tag for FreeBSD
- Add builtin sysconfigs for GraalPy
- Add use-base-python option to pyproject.toml
- Fix clippy warnings
- Fix Target::get_python_arch comment
- Set `PYO3_BUILD_EXTENSION_MODULE` env var when building pyo3 extension modules

**Test Plan**

Successfully built `python-orjson`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
