### PR TITLE
scrcpy: Update to v3.3.2

### DIFF
--- a/packages/s/scrcpy/package.yml
+++ b/packages/s/scrcpy/package.yml
@@ -1,9 +1,9 @@
 name       : scrcpy
-version    : 3.3.1
-release    : 35
+version    : 3.3.2
+release    : 36
 source     :
-    - https://github.com/Genymobile/scrcpy/archive/v3.3.1.tar.gz : 9999d2ff3605e1c5d1efb0b737ed6e240a93a928091ab356ba07199c92f52ace
-    - https://github.com/Genymobile/scrcpy/releases/download/v3.3.1/scrcpy-server-v3.3.1 : a0f70b20aa4998fbf658c94118cd6c8dab6abbb0647a3bdab344d70bc1ebcbb8
+    - https://github.com/Genymobile/scrcpy/archive/v3.3.2.tar.gz : 08bc272ac8decf364fbefb8865eaf074ba600969494ea8ade08736a6a2e3c39a
+    - https://github.com/Genymobile/scrcpy/releases/download/v3.3.2/scrcpy-server-v3.3.2 : 2ee5ca0863ef440f5b7c75856bb475c5283d0a8359cb370b1c161314fd29dfd9
 homepage   : https://github.com/Genymobile/scrcpy
 license    : Apache-2.0
 component  : network.util

--- a/packages/s/scrcpy/pspec_x86_64.xml
+++ b/packages/s/scrcpy/pspec_x86_64.xml
@@ -25,15 +25,15 @@
             <Path fileType="data">/usr/share/applications/scrcpy.desktop</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/scrcpy</Path>
             <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/scrcpy.png</Path>
-            <Path fileType="man">/usr/share/man/man1/scrcpy.1</Path>
+            <Path fileType="man">/usr/share/man/man1/scrcpy.1.zst</Path>
             <Path fileType="data">/usr/share/scrcpy/scrcpy-server</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_scrcpy</Path>
         </Files>
     </Package>
     <History>
-        <Update release="35">
-            <Date>2025-06-21</Date>
-            <Version>3.3.1</Version>
+        <Update release="36">
+            <Date>2025-09-07</Date>
+            <Version>3.3.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fix virtual display after Android 16 upgrade
- Workaround clipboard issue on Samsung devices
- Various technical fixes

Full release notes available [here](https://github.com/Genymobile/scrcpy/releases/tag/v3.3.2)

**Test Plan**
- Mirrored my phone's display
- Controlled my phone with mouse and keyboard

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
