### PR TITLE
openrct2: Update to v0.4.26

### DIFF
--- a/packages/o/openrct2/abi_used_libs
+++ b/packages/o/openrct2/abi_used_libs
@@ -16,3 +16,4 @@ libstdc++.so.6
 libvorbisfile.so.3
 libz.so.1
 libzip.so.5
+libzstd.so.1

--- a/packages/o/openrct2/abi_used_symbols
+++ b/packages/o/openrct2/abi_used_symbols
@@ -635,3 +635,17 @@ libzip.so.5:zip_source_buffer
 libzip.so.5:zip_source_free
 libzip.so.5:zip_stat_index
 libzip.so.5:zip_strerror
+libzstd.so.1:ZSTD_CCtx_setParameter
+libzstd.so.1:ZSTD_CCtx_setPledgedSrcSize
+libzstd.so.1:ZSTD_CStreamInSize
+libzstd.so.1:ZSTD_CStreamOutSize
+libzstd.so.1:ZSTD_DStreamInSize
+libzstd.so.1:ZSTD_DStreamOutSize
+libzstd.so.1:ZSTD_compressStream2
+libzstd.so.1:ZSTD_createCCtx
+libzstd.so.1:ZSTD_createDCtx
+libzstd.so.1:ZSTD_decompressStream
+libzstd.so.1:ZSTD_freeCCtx
+libzstd.so.1:ZSTD_freeDCtx
+libzstd.so.1:ZSTD_getErrorName
+libzstd.so.1:ZSTD_isError

--- a/packages/o/openrct2/package.yml
+++ b/packages/o/openrct2/package.yml
@@ -1,8 +1,8 @@
 name       : openrct2
-version    : 0.4.25
-release    : 58
+version    : 0.4.26
+release    : 59
 source     :
-    - git|https://github.com/OpenRCT2/OpenRCT2.git : v0.4.25
+    - git|https://github.com/OpenRCT2/OpenRCT2.git : v0.4.26
     - https://github.com/OpenRCT2/title-sequences/releases/download/v0.4.14/title-sequences.zip : 140df714e806fed411cc49763e7f16b0fcf2a487a57001d1e50fce8f9148a9f3
     - https://github.com/OpenRCT2/objects/releases/download/v1.7.3/objects.zip : c81029264578706ed1db88665e12a70a583e71dc4d3eb4db262535d2f0589eab
     - https://github.com/OpenRCT2/OpenSoundEffects/releases/download/v1.0.6/opensound.zip : 06b90f3e19c216752df441d551b26a9e3e1ba7755bdd2102504b73bf993608be

--- a/packages/o/openrct2/pspec_x86_64.xml
+++ b/packages/o/openrct2/pspec_x86_64.xml
@@ -42,8 +42,8 @@
             <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/openrct2.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/96x96/apps/openrct2.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/openrct2.svg</Path>
-            <Path fileType="man">/usr/share/man/man6/openrct2-cli.6</Path>
-            <Path fileType="man">/usr/share/man/man6/openrct2.6</Path>
+            <Path fileType="man">/usr/share/man/man6/openrct2-cli.6.zst</Path>
+            <Path fileType="man">/usr/share/man/man6/openrct2.6.zst</Path>
             <Path fileType="data">/usr/share/metainfo/openrct2.appdata.xml</Path>
             <Path fileType="data">/usr/share/mime/packages/openrct2.xml</Path>
             <Path fileType="data">/usr/share/openrct2/assetpack/openrct2.music.alternative.parkap</Path>
@@ -2726,9 +2726,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="58">
-            <Date>2025-08-12</Date>
-            <Version>0.4.25</Version>
+        <Update release="59">
+            <Date>2025-09-07</Date>
+            <Version>0.4.26</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- *Climbing the North Face of the Uxbridge Road*
- Release notes [here](https://github.com/OpenRCT2/OpenRCT2/releases/tag/v0.4.26)

**Test Plan**

- Start a new scenario

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
