### PR TITLE
eopkg: Add translations to nuitka-compiled version

### DIFF
--- a/packages/e/eopkg/package.yml
+++ b/packages/e/eopkg/package.yml
@@ -1,6 +1,6 @@
 name       : eopkg
 version    : 4.3.3
-release    : 29
+release    : 30
 source     :
     - https://github.com/getsolus/eopkg/archive/refs/tags/v4.3.3.tar.gz : 4e682b58b1465d169a5d4746e5a95b5aa28adea5074cf0e4d56035d5ec10360f
     - git|https://github.com/getsolus/PackageKit.git : 9b0f17c1ba6addc1c85bff34b64efad6a905ca50
@@ -73,7 +73,7 @@ build      : |
     #       ca-certs to be able to check https connections.
 
     # We're not actually using self-execution. In this case, eopkg is using the -c flag as shorthand for --component, rather than for passing the program as a string (as is default python behavior).
-    nuitka3 --onefile --include-module=dbm.gnu --show-scons --no-deployment-flag=self-execution eopkg.py3
+    nuitka3 --onefile --include-module=dbm.gnu --include-data-dir=build/lib/pisi/data/locale=pisi/data/locale --show-scons --no-deployment-flag=self-execution eopkg.py3
     nuitka3 --onefile --include-module=dbm.gnu $sources/PackageKit.git/backends/eopkg/eopkgBackend.py
 install    : |
     # install the normal pure py3 stuff

--- a/packages/e/eopkg/pspec_x86_64.xml
+++ b/packages/e/eopkg/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>eopkg</Name>
         <Homepage>https://github.com/getsolus/eopkg</Homepage>
         <Packager>
-            <Name>Hans K</Name>
-            <Email>hans@communitycomputing.net</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -451,12 +451,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="29">
-            <Date>2025-08-18</Date>
+        <Update release="30">
+            <Date>2025-09-10</Date>
             <Version>4.3.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Hans K</Name>
-            <Email>hans@communitycomputing.net</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Resolves getsolus/packages#6292

**Test Plan**

- Run env LANG=fr_FR.UTF-8 eopkg --help and make sure French translations load.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
