### PR TITLE
ypkg: Add python-zstandard to the runtime dependencies

### DIFF
--- a/packages/y/ypkg/package.yml
+++ b/packages/y/ypkg/package.yml
@@ -1,6 +1,6 @@
 name       : ypkg
 version    : 35.0.0
-release    : 209
+release    : 210
 source     :
     - https://github.com/getsolus/ypkg/archive/refs/tags/v35.0.0.tar.gz : 8939f09d2453627e7873a9ddf2a9ee95e76d787374059b4f88350f6d32ef0e1c
 homepage   : https://github.com/getsolus/ypkg
@@ -29,13 +29,13 @@ builddeps  :
     - python-wheel
     - python-xattr
     - python-zstandard
-    - tree
 rundeps    :
     - python-eopkg
     - python-humanize
     - python-typer
     - python-typing-extensions
     - python-xattr
+    - python-zstandard
     - pyyaml
     - ruamel_yaml
 clang      : yes

--- a/packages/y/ypkg/pspec_x86_64.xml
+++ b/packages/y/ypkg/pspec_x86_64.xml
@@ -112,8 +112,8 @@ Simply put, it is a tool to convert a build process into a packaging operation.
         </Files>
     </Package>
     <History>
-        <Update release="209">
-            <Date>2025-09-05</Date>
+        <Update release="210">
+            <Date>2025-09-10</Date>
             <Version>35.0.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**

Add `python-zstandard` to the runtime dependencies, and remove `tree` from the build dependencies.

**Test Plan**

Inspect the .eopkg metadata and see that `python-zstandard` was added to the dependency list.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
