### PR TITLE
expat: Update to v2.7.2

### DIFF
--- a/packages/e/expat/abi_symbols
+++ b/packages/e/expat/abi_symbols
@@ -27,6 +27,8 @@ libexpat.so.1:XML_ParserCreate_MM
 libexpat.so.1:XML_ParserFree
 libexpat.so.1:XML_ParserReset
 libexpat.so.1:XML_ResumeParser
+libexpat.so.1:XML_SetAllocTrackerActivationThreshold
+libexpat.so.1:XML_SetAllocTrackerMaximumAmplification
 libexpat.so.1:XML_SetAttlistDeclHandler
 libexpat.so.1:XML_SetBase
 libexpat.so.1:XML_SetBillionLaughsAttackProtectionActivationThreshold

--- a/packages/e/expat/abi_symbols32
+++ b/packages/e/expat/abi_symbols32
@@ -27,6 +27,8 @@ libexpat.so.1:XML_ParserCreate_MM
 libexpat.so.1:XML_ParserFree
 libexpat.so.1:XML_ParserReset
 libexpat.so.1:XML_ResumeParser
+libexpat.so.1:XML_SetAllocTrackerActivationThreshold
+libexpat.so.1:XML_SetAllocTrackerMaximumAmplification
 libexpat.so.1:XML_SetAttlistDeclHandler
 libexpat.so.1:XML_SetBase
 libexpat.so.1:XML_SetBillionLaughsAttackProtectionActivationThreshold

--- a/packages/e/expat/abi_used_symbols
+++ b/packages/e/expat/abi_used_symbols
@@ -2,6 +2,7 @@ libc.so.6:__assert_fail
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
 libc.so.6:__isoc23_strtoul
+libc.so.6:__isoc23_strtoull
 libc.so.6:__libc_start_main
 libc.so.6:__stack_chk_fail
 libc.so.6:arc4random_buf
@@ -38,4 +39,3 @@ libc.so.6:strcpy
 libc.so.6:strlen
 libc.so.6:strrchr
 libc.so.6:strtof
-libc.so.6:strtoull

--- a/packages/e/expat/package.yml
+++ b/packages/e/expat/package.yml
@@ -1,8 +1,8 @@
 name       : expat
-version    : 2.7.1
-release    : 33
+version    : 2.7.2
+release    : 34
 source     :
-    - https://github.com/libexpat/libexpat/releases/download/R_2_7_1/expat-2.7.1.tar.gz : 0cce2e6e69b327fc607b8ff264f4b66bdf71ead55a87ffd5f3143f535f15cfa2
+    - https://github.com/libexpat/libexpat/releases/download/R_2_7_2/expat-2.7.2.tar.bz2 : 976f6c2d358953c22398d64cd93790ba5abc62e02a1bbc204a3a264adea149b8
 homepage   : https://libexpat.github.io/
 license    : MIT
 component  :

--- a/packages/e/expat/pspec_x86_64.xml
+++ b/packages/e/expat/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>expat</Name>
         <Homepage>https://libexpat.github.io/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.base</PartOf>
@@ -22,7 +22,7 @@
         <Files>
             <Path fileType="executable">/usr/bin/xmlwf</Path>
             <Path fileType="library">/usr/lib64/libexpat.so.1</Path>
-            <Path fileType="library">/usr/lib64/libexpat.so.1.10.2</Path>
+            <Path fileType="library">/usr/lib64/libexpat.so.1.11.0</Path>
         </Files>
     </Package>
     <Package>
@@ -32,11 +32,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="33">expat</Dependency>
+            <Dependency release="34">expat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libexpat.so.1</Path>
-            <Path fileType="library">/usr/lib32/libexpat.so.1.10.2</Path>
+            <Path fileType="library">/usr/lib32/libexpat.so.1.11.0</Path>
         </Files>
     </Package>
     <Package>
@@ -46,14 +46,14 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="33">expat-32bit</Dependency>
-            <Dependency release="33">expat-devel</Dependency>
+            <Dependency release="34">expat-32bit</Dependency>
+            <Dependency release="34">expat-devel</Dependency>
         </RuntimeDependencies>
         <Files>
-            <Path fileType="library">/usr/lib32/cmake/expat-2.7.1/expat-config-version.cmake</Path>
-            <Path fileType="library">/usr/lib32/cmake/expat-2.7.1/expat-config.cmake</Path>
-            <Path fileType="library">/usr/lib32/cmake/expat-2.7.1/expat-noconfig.cmake</Path>
-            <Path fileType="library">/usr/lib32/cmake/expat-2.7.1/expat.cmake</Path>
+            <Path fileType="library">/usr/lib32/cmake/expat-2.7.2/expat-config-version.cmake</Path>
+            <Path fileType="library">/usr/lib32/cmake/expat-2.7.2/expat-config.cmake</Path>
+            <Path fileType="library">/usr/lib32/cmake/expat-2.7.2/expat-noconfig.cmake</Path>
+            <Path fileType="library">/usr/lib32/cmake/expat-2.7.2/expat.cmake</Path>
             <Path fileType="library">/usr/lib32/libexpat.so</Path>
             <Path fileType="data">/usr/lib32/pkgconfig/expat.pc</Path>
         </Files>
@@ -65,27 +65,27 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="33">expat</Dependency>
+            <Dependency release="34">expat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/expat.h</Path>
             <Path fileType="header">/usr/include/expat_config.h</Path>
             <Path fileType="header">/usr/include/expat_external.h</Path>
-            <Path fileType="library">/usr/lib64/cmake/expat-2.7.1/expat-config-version.cmake</Path>
-            <Path fileType="library">/usr/lib64/cmake/expat-2.7.1/expat-config.cmake</Path>
-            <Path fileType="library">/usr/lib64/cmake/expat-2.7.1/expat-noconfig.cmake</Path>
-            <Path fileType="library">/usr/lib64/cmake/expat-2.7.1/expat.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/expat-2.7.2/expat-config-version.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/expat-2.7.2/expat-config.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/expat-2.7.2/expat-noconfig.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/expat-2.7.2/expat.cmake</Path>
             <Path fileType="library">/usr/lib64/libexpat.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/expat.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2025-04-15</Date>
-            <Version>2.7.1</Version>
+        <Update release="34">
+            <Date>2025-09-16</Date>
+            <Version>2.7.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/libexpat/libexpat/blob/R_2_7_2/expat/Changes).

**Security**
Includes fixes for:
- CVE-2025-59375

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build `gdb` against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
