### PR TITLE
halloy: Update to v2025.9

### DIFF
--- a/packages/h/halloy/abi_used_libs
+++ b/packages/h/halloy/abi_used_libs
@@ -5,3 +5,4 @@ libcrypto.so.3
 libgcc_s.so.1
 libm.so.6
 libssl.so.3
+libxcb.so.1

--- a/packages/h/halloy/abi_used_symbols
+++ b/packages/h/halloy/abi_used_symbols
@@ -67,6 +67,7 @@ libc.so.6:bcmp
 libc.so.6:bind
 libc.so.6:calloc
 libc.so.6:chdir
+libc.so.6:chroot
 libc.so.6:clock_gettime
 libc.so.6:close
 libc.so.6:closedir
@@ -306,3 +307,11 @@ libssl.so.3:SSL_set_verify
 libssl.so.3:SSL_shutdown
 libssl.so.3:SSL_write_ex
 libssl.so.3:TLS_method
+libxcb.so.1:xcb_connect
+libxcb.so.1:xcb_connection_has_error
+libxcb.so.1:xcb_disconnect
+libxcb.so.1:xcb_get_extension_data
+libxcb.so.1:xcb_get_setup
+libxcb.so.1:xcb_prefetch_extension_data
+libxcb.so.1:xcb_send_request64
+libxcb.so.1:xcb_wait_for_reply64

--- a/packages/h/halloy/package.yml
+++ b/packages/h/halloy/package.yml
@@ -1,8 +1,8 @@
 name       : halloy
-version    : '2025.8'
-release    : 3
+version    : '2025.9'
+release    : 4
 source     :
-    - https://github.com/squidowl/halloy/archive/refs/tags/2025.8.tar.gz : 3d05105457408f63046bf7108a1938e8bac5b8e3017457da94873025e4550ea5
+    - https://github.com/squidowl/halloy/archive/refs/tags/2025.9.tar.gz : ac907172069035ab3058675f32a6c33419a8d77a5f8b5cfdae19f0ebf769a68e
 homepage   : https://halloy.squidowl.org/
 license    : GPL-3.0-or-later
 component  : network.im
@@ -12,6 +12,7 @@ description: |
 networking : true
 builddeps  :
     - pkgconfig(alsa)
+    - pkgconfig(xcb)
     - rust
 setup      : |
     %cargo_fetch

--- a/packages/h/halloy/pspec_x86_64.xml
+++ b/packages/h/halloy/pspec_x86_64.xml
@@ -35,9 +35,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2025-08-01</Date>
-            <Version>2025.8</Version>
+        <Update release="4">
+            <Date>2025-09-17</Date>
+            <Version>2025.9</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://github.com/squidowl/halloy/releases/tag/2025.9)

**Test Plan**

- Join a liberachat server

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
