### PR TITLE
librecad: Update to v2.2.1.2 and fix translations

### DIFF
--- a/packages/l/librecad/abi_used_symbols
+++ b/packages/l/librecad/abi_used_symbols
@@ -28,7 +28,6 @@ libQt5Core.so.5:_ZN11QMetaObject10ConnectionD1Ev
 libQt5Core.so.5:_ZN11QMetaObject14normalizedTypeEPKc
 libQt5Core.so.5:_ZN11QMetaObject18connectSlotsByNameEP7QObject
 libQt5Core.so.5:_ZN11QMetaObject8activateEP7QObjectPKS_iPPv
-libQt5Core.so.5:_ZN11QTextStream5flushEv
 libQt5Core.so.5:_ZN11QTextStream7readAllEv
 libQt5Core.so.5:_ZN11QTextStream8readLineEx
 libQt5Core.so.5:_ZN11QTextStream8setCodecEP10QTextCodec
@@ -297,6 +296,7 @@ libQt5Core.so.5:_ZN9QListData6appendEv
 libQt5Core.so.5:_ZN9QListData6detachEi
 libQt5Core.so.5:_ZN9QListData6insertEi
 libQt5Core.so.5:_ZN9QListData6removeEi
+libQt5Core.so.5:_ZN9QListData6removeEii
 libQt5Core.so.5:_ZN9QListData7disposeEPNS_4DataE
 libQt5Core.so.5:_ZN9QListData7prependEv
 libQt5Core.so.5:_ZN9QListData7reallocEi
@@ -1279,6 +1279,7 @@ libQt5Widgets.so.5:_ZN9QGroupBox8setTitleERK7QString
 libQt5Widgets.so.5:_ZN9QGroupBoxC1EP7QWidget
 libQt5Widgets.so.5:_ZN9QGroupBoxC1ERK7QStringP7QWidget
 libQt5Widgets.so.5:_ZN9QLineEdit10paintEventEP11QPaintEvent
+libQt5Widgets.so.5:_ZN9QLineEdit10textEditedERK7QString
 libQt5Widgets.so.5:_ZN9QLineEdit11changeEventEP6QEvent
 libQt5Widgets.so.5:_ZN9QLineEdit11qt_metacallEN11QMetaObject4CallEiPPv
 libQt5Widgets.so.5:_ZN9QLineEdit11qt_metacastEPKc
@@ -1790,7 +1791,6 @@ libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T
 libstdc++.so.6:_ZSt16__throw_bad_castv
 libstdc++.so.6:_ZSt17__throw_bad_allocv
 libstdc++.so.6:_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
-libstdc++.so.6:_ZSt18_Rb_tree_incrementPKSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
@@ -1809,6 +1809,7 @@ libstdc++.so.6:_ZSt7nothrow
 libstdc++.so.6:_ZSt9terminatev
 libstdc++.so.6:_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
 libstdc++.so.6:_ZStrsIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EE
+libstdc++.so.6:_ZTIPKc
 libstdc++.so.6:_ZTISt12domain_error
 libstdc++.so.6:_ZTISt12out_of_range
 libstdc++.so.6:_ZTISt13runtime_error

--- a/packages/l/librecad/package.yml
+++ b/packages/l/librecad/package.yml
@@ -1,8 +1,8 @@
 name       : librecad
-version    : 2.2.1
-release    : 16
+version    : 2.2.1.2
+release    : 17
 source     :
-    - https://github.com/LibreCAD/LibreCAD/archive/refs/tags/v2.2.1.tar.gz : 7d1b5d1c8bb537e4f855e7e8a3663f2f1cb8a0d70ee3c7f18481a80471b9029e
+    - https://github.com/LibreCAD/LibreCAD/archive/refs/tags/v2.2.1.2.tar.gz : 2b961cb916a7415d97f427f824c1830e06d4832cc376fea38b27cb456ee95a8e
 homepage   : https://librecad.org/
 license    : GPL-2.0-or-later
 summary    : LibreCAD is a free Open Source CAD application for Windows, Apple and Linux
@@ -12,6 +12,7 @@ description: |
 builddeps  :
     - pkgconfig(ImageMagick)
     - pkgconfig(Qt5Svg)
+    - pkgconfig(Qt5UiTools)
     - pkgconfig(freetype2)
     - pkgconfig(gl)
     - pkgconfig(muparser)

--- a/packages/l/librecad/pspec_x86_64.xml
+++ b/packages/l/librecad/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>librecad</Name>
         <Homepage>https://librecad.org/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>office</PartOf>
@@ -1350,6 +1350,7 @@
             <Path fileType="data">/usr/share/librecad/library/sheets/A4_2_text.dxf</Path>
             <Path fileType="data">/usr/share/librecad/library/templates/empty.dxf</Path>
             <Path fileType="data">/usr/share/librecad/patterns/angle.dxf</Path>
+            <Path fileType="data">/usr/share/librecad/patterns/angle45.dxf</Path>
             <Path fileType="data">/usr/share/librecad/patterns/ansi31.dxf</Path>
             <Path fileType="data">/usr/share/librecad/patterns/ar-b816.dxf</Path>
             <Path fileType="data">/usr/share/librecad/patterns/ar-b816c.dxf</Path>
@@ -1412,18 +1413,137 @@
             <Path fileType="data">/usr/share/librecad/patterns/square.dxf</Path>
             <Path fileType="data">/usr/share/librecad/patterns/triangle_a.dxf</Path>
             <Path fileType="data">/usr/share/librecad/patterns/triangle_b.dxf</Path>
-            <Path fileType="data">/usr/share/librecad/qm</Path>
-            <Path fileType="man">/usr/share/man/man1/librecad.1</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_ar.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_ca.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_cs.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_da.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_de.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_el.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_en.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_en_au.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_es.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_es_ar.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_es_bo.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_es_cl.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_es_co.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_es_cr.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_es_do.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_es_ec.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_es_gt.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_es_hn.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_es_mx.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_es_ni.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_es_pa.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_es_pe.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_es_pr.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_es_py.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_es_sv.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_es_us.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_es_uy.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_es_ve.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_et.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_eu.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_fi.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_fr.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_gl.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_he.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_hi.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_hu.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_id_ID.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_it.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_ja.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_ka.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_ko.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_lv.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_mk.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_nl.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_no.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_pa.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_pl.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_pt_br.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_pt_pt.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_ro_ro.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_ru.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_sk.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_sl.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_sq_al.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_sr.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_sv.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_ta.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_th.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_tr.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_uk.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_zh_cn.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/librecad_zh_tw.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_ar.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_ca.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_cs.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_da.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_de.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_el.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_en.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_en_au.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_es.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_es_ar.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_es_bo.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_es_cl.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_es_co.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_es_cr.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_es_do.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_es_ec.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_es_gt.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_es_hn.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_es_mx.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_es_ni.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_es_pa.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_es_pe.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_es_pr.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_es_py.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_es_sv.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_es_us.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_es_uy.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_es_ve.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_et.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_eu.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_fi.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_fr.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_gl.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_hi.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_hu.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_id_ID.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_it.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_ja.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_ko.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_lv.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_mk.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_nl.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_no.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_pa.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_pl.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_pt_br.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_pt_pt.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_ro_ro.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_ru.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_sk.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_sl.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_sq_al.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_sv.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_ta.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_tr.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_uk.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_zh_cn.qm</Path>
+            <Path fileType="data">/usr/share/librecad/qm/plugins_zh_tw.qm</Path>
+            <Path fileType="man">/usr/share/man/man1/librecad.1.zst</Path>
             <Path fileType="data">/usr/share/metainfo/org.librecad.librecad.appdata.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2025-01-25</Date>
-            <Version>2.2.1</Version>
+        <Update release="17">
+            <Date>2025-09-18</Date>
+            <Version>2.2.1.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Release note can be read [here](https://github.com/LibreCAD/LibreCAD/releases/tag/v2.2.1.2)
- Add missing builddeps, so translations is generated properly

**Test Plan**

<!-- Short description of how the package was tested -->
Launch the app and make sure translations is there

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
