### PR TITLE
jasper: Update to v4.2.8

### DIFF
--- a/packages/j/jasper/abi_used_libs
+++ b/packages/j/jasper/abi_used_libs
@@ -1,6 +1,5 @@
 ld-linux-x86-64.so.2
 libGLU.so.1
-libGLX.so.0
 libOpenGL.so.0
 libc.so.6
 libglut.so.3

--- a/packages/j/jasper/package.yml
+++ b/packages/j/jasper/package.yml
@@ -1,8 +1,8 @@
 name       : jasper
-version    : 4.2.5
-release    : 17
+version    : 4.2.8
+release    : 18
 source     :
-    - https://github.com/jasper-software/jasper/releases/download/version-4.2.5/jasper-4.2.5.tar.gz : 6e49075b47204a9879600f85628a248cdb19abc1bb74d0b7a2177bcdb87c95eb
+    - https://github.com/jasper-software/jasper/releases/download/version-4.2.8/jasper-4.2.8.tar.gz : 98058a94fbff57ec6e31dcaec37290589de0ba6f47c966f92654681a56c71fae
 homepage   : https://ece.engr.uvic.ca/~frodo/jasper/
 license    : JasPer-2.0
 component  : multimedia.library

--- a/packages/j/jasper/pspec_x86_64.xml
+++ b/packages/j/jasper/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>jasper</Name>
         <Homepage>https://ece.engr.uvic.ca/~frodo/jasper/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>JasPer-2.0</License>
         <PartOf>multimedia.library</PartOf>
@@ -26,10 +26,10 @@
             <Path fileType="executable">/usr/bin/jiv</Path>
             <Path fileType="library">/usr/lib64/libjasper.so.7</Path>
             <Path fileType="library">/usr/lib64/libjasper.so.7.0.0</Path>
-            <Path fileType="man">/usr/share/man/man1/imgcmp.1</Path>
-            <Path fileType="man">/usr/share/man/man1/imginfo.1</Path>
-            <Path fileType="man">/usr/share/man/man1/jasper.1</Path>
-            <Path fileType="man">/usr/share/man/man1/jiv.1</Path>
+            <Path fileType="man">/usr/share/man/man1/imgcmp.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/imginfo.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/jasper.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/jiv.1.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -39,7 +39,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="17">jasper</Dependency>
+            <Dependency release="18">jasper</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/jasper/jas_cm.h</Path>
@@ -70,12 +70,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2025-06-18</Date>
-            <Version>4.2.5</Version>
+        <Update release="18">
+            <Date>2025-09-20</Date>
+            <Version>4.2.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- [4.2.8](https://github.com/jasper-software/jasper/releases/tag/version-4.2.8)
- [4.2.7](https://github.com/jasper-software/jasper/releases/tag/version-4.2.7)
- [4.2.6](https://github.com/jasper-software/jasper/releases/tag/version-4.2.6)

**Security**

- CVE-2025-8837 (moderate)

**Test Plan**

- Use digikam, a revdep

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
