### PR TITLE
xfce4-panel: Swap Software Center for Discover

### DIFF
--- a/packages/x/xfce4-panel/files/0001-Use-Solus-defaults.patch
+++ b/packages/x/xfce4-panel/files/0001-Use-Solus-defaults.patch
@@ -9,7 +9,7 @@ Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
  1 file changed, 49 insertions(+), 46 deletions(-)
 
 diff --git a/migrate/default.xml.in b/migrate/default.xml.in
-index 24980455..1a3b5821 100644
+index 24980455..923f1397 100644
 --- a/migrate/default.xml.in
 +++ b/migrate/default.xml.in
 @@ -4,14 +4,14 @@
@@ -113,7 +113,7 @@ index 24980455..1a3b5821 100644
 -    <property name="plugin-16" type="string" value="launcher">
 +    <property name="plugin-6" type="string" value="launcher">
 +      <property name="items" type="array">
-+        <value type="string" value="solus-sc.desktop"/>
++        <value type="string" value="org.kde.discover.desktop"/>
 +      </property>
 +    </property>
 +    <property name="plugin-7" type="string" value="launcher">

--- a/packages/x/xfce4-panel/package.yml
+++ b/packages/x/xfce4-panel/package.yml
@@ -1,6 +1,6 @@
 name       : xfce4-panel
 version    : 4.20.4
-release    : 19
+release    : 20
 source     :
     - https://archive.xfce.org/src/xfce/xfce4-panel/4.20/xfce4-panel-4.20.4.tar.bz2 : 695b23af490719e734c8659394821b43cc94d3bee69994bafdc42ef40daa0d2c
 homepage   : https://docs.xfce.org/xfce/xfce4-panel/start

--- a/packages/x/xfce4-panel/pspec_x86_64.xml
+++ b/packages/x/xfce4-panel/pspec_x86_64.xml
@@ -223,7 +223,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="19">xfce4-panel</Dependency>
+            <Dependency release="20">xfce4-panel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/xfce4/libxfce4panel-2.0/libxfce4panel/libxfce4panel-config.h</Path>
@@ -274,8 +274,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2025-07-08</Date>
+        <Update release="20">
+            <Date>2025-09-20</Date>
             <Version>4.20.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
- Swap the Solus Software Center pin for KDE Discover

**Do not merge until after Epoch!**

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

TBD

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
