### PR TITLE
plasma-desktop: Swap solus-sc for KDE Discover

### DIFF
--- a/packages/p/plasma-desktop/files/branding/0001-Add-KDE-Discover-to-Favorites.patch
+++ b/packages/p/plasma-desktop/files/branding/0001-Add-KDE-Discover-to-Favorites.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Justin Zobel <justin.zobel@gmail.com>
+Date: Tue, 16 Jan 2024 10:55:02 +1030
+Subject: [PATCH 1/6] Add KDE Discover to Favorites
+
+---
+ applets/kicker/package/contents/config/main.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/applets/kicker/package/contents/config/main.xml b/applets/kicker/package/contents/config/main.xml
+index ba637e5e2..0493230ca 100644
+--- a/applets/kicker/package/contents/config/main.xml
++++ b/applets/kicker/package/contents/config/main.xml
+@@ -38,7 +38,7 @@
+     </entry>
+     <entry name="favoriteApps" type="StringList">
+       <label>List of general favorites. Supported values are menu id's (usually .desktop file names), special URLs that expand into default applications (e.g. preferred://browser), document URLs and KPeople contact URIs.</label>
+-      <default>preferred://browser,org.kde.kontact.desktop,systemsettings.desktop,org.kde.dolphin.desktop,org.kde.discover</default>
++      <default>preferred://browser,org.kde.discover.desktop,systemsettings.desktop,org.kde.dolphin.desktop,org.kde.neochat.desktop,org.kde.kate.desktop</default>
+     </entry>
+     <entry name="favoriteSystemActions" type="StringList">
+       <label>List of system action favorites.</label>

--- a/packages/p/plasma-desktop/files/branding/0002-Add-Solus-Kickoff-favorites.patch
+++ b/packages/p/plasma-desktop/files/branding/0002-Add-Solus-Kickoff-favorites.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Justin Zobel <justin.zobel@gmail.com>
+Date: Tue, 16 Jan 2024 11:01:01 +1030
+Subject: [PATCH 2/6] Add KDE Discover to Kickoff favorites
+
+---
+ applets/kickoff/package/contents/config/main.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/applets/kickoff/package/contents/config/main.xml b/applets/kickoff/package/contents/config/main.xml
+index be17a59cb..153b20e3a 100644
+--- a/applets/kickoff/package/contents/config/main.xml
++++ b/applets/kickoff/package/contents/config/main.xml
+@@ -15,7 +15,7 @@
+         </entry>
+         <entry name="favorites" type="StringList">
+             <label>List of general favorites. Supported values are menu id's (usually .desktop file names), special URLs that expand into default applications (e.g. preferred://browser), document URLs and KPeople contact URIs.</label>
+-            <default>preferred://browser,org.kde.kontact.desktop,systemsettings.desktop,org.kde.dolphin.desktop,org.kde.discover.desktop</default>
++            <default>preferred://browser,org.kde.discover.desktop,systemsettings.desktop,org.kde.dolphin.desktop,org.kde.neochat.desktop,org.kde.kate.desktop</default>
+         </entry>
+         <entry name="systemFavorites" type="StringList">
+             <label>List of system action favorites.</label>

--- a/packages/p/plasma-desktop/files/branding/0003-Solus-tweaks-to-default-taskmanager.patch
+++ b/packages/p/plasma-desktop/files/branding/0003-Solus-tweaks-to-default-taskmanager.patch
@@ -3,11 +3,10 @@ From: "F. von Gellhorn" <flinux@vongellhorn.ch>
 Date: Sat, 27 Mar 2021 17:25:40 +0100
 Subject: [PATCH 3/6] Solus tweaks to default taskmanager
 
-- set Souls-sc, preffered FM and Browser as default
 - set grouped icons to show tooltips
 ---
  applets/taskmanager/package/contents/config/main.xml | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ 1 file changed, 1 insertions(+), 1 deletions(-)
 
 diff --git a/applets/taskmanager/package/contents/config/main.xml b/applets/taskmanager/package/contents/config/main.xml
 index 6bb27695d..658593525 100644
@@ -22,12 +21,3 @@ index 6bb27695d..658593525 100644
      </entry>
      <entry name="groupPopups" type="Bool">
        <label>Whether groups are to be reduced to a single task button and expand into a popup or task buttons are grouped on the widget itself.</label>
-@@ -85,7 +85,7 @@
-     </entry>
-     <entry name="launchers" type="StringList">
-       <label>The list of launcher tasks on the widget. Usually .desktop file or executable URLs. Special URLs such as preferred://browser that expand to default applications are supported.</label>
--      <default>applications:systemsettings.desktop,applications:org.kde.discover.desktop,preferred://filemanager,preferred://browser</default>
-+       <default>applications:systemsettings.desktop,applications:solus-sc.desktop,preferred://filemanager,preferred://browser</default>
-     </entry>
-     <entry name="middleClickAction" type="Enum">
-       <label>What to do on middle-mouse click on a task button.</label>

--- a/packages/p/plasma-desktop/package.yml
+++ b/packages/p/plasma-desktop/package.yml
@@ -1,6 +1,6 @@
 name       : plasma-desktop
 version    : 6.4.5
-release    : 163
+release    : 164
 source     :
     - https://download.kde.org/stable/plasma/6.4.5/plasma-desktop-6.4.5.tar.xz : 7552e4c7c7ccbf5b7756726bb9aaabd344630977aaf13f5f305b4477caa17bb7
 homepage   : https://www.kde.org/workspaces/plasmadesktop/

--- a/packages/p/plasma-desktop/pspec_x86_64.xml
+++ b/packages/p/plasma-desktop/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>plasma-desktop</Name>
         <Homepage>https://www.kde.org/workspaces/plasmadesktop/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <License>GPL-2.0-or-later</License>
@@ -3531,12 +3531,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="163">
-            <Date>2025-10-01</Date>
+        <Update release="164">
+            <Date>2025-10-24</Date>
             <Version>6.4.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Swap the Solus Software Center for KDE Discover in Kickoff, Favorites, and the task manager.

**Do not merge until after Epoch!**

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install in a VM, reboot, and see that the old Software Center icon is now the KDE Discover icon.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
