### PR TITLE
fping: Update to v5.4

### DIFF
--- a/packages/f/fping/abi_used_symbols
+++ b/packages/f/fping/abi_used_symbols
@@ -2,7 +2,8 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__memset_chk
@@ -60,7 +61,7 @@ libc.so.6:strchr
 libc.so.6:strcmp
 libc.so.6:strdup
 libc.so.6:strerror
+libc.so.6:strftime
 libc.so.6:strlen
 libc.so.6:strstr
 libc.so.6:strtod
-libc.so.6:strtol

--- a/packages/f/fping/package.yml
+++ b/packages/f/fping/package.yml
@@ -1,8 +1,8 @@
 name       : fping
-version    : '5.2'
-release    : 5
+version    : '5.4'
+release    : 6
 source     :
-    - https://fping.org/dist/fping-5.2.tar.gz : a7692d10d73fb0bb76e1f7459aa7f19bbcdbfc5adbedef02f468974b18b0e42f
+    - https://www.fping.org/dist/fping-5.4.tar.gz : be320771f075e47dd7e5704b485e9bdc7dd11107884345c0f7c18749357f668d
 homepage   : https://fping.org/
 license    : BSD-3-Clause
 component  : network.util

--- a/packages/f/fping/pspec_x86_64.xml
+++ b/packages/f/fping/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>fping</Name>
         <Homepage>https://fping.org/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>network.util</PartOf>
@@ -21,16 +21,16 @@
         <PartOf>network.util</PartOf>
         <Files>
             <Path fileType="executable">/usr/sbin/fping</Path>
-            <Path fileType="man">/usr/share/man/man8/fping.8</Path>
+            <Path fileType="man">/usr/share/man/man8/fping.8.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2024-05-13</Date>
-            <Version>5.2</Version>
+        <Update release="6">
+            <Date>2025-09-20</Date>
+            <Version>5.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Memory allocation safety checks for event storage
- Fix off-by-one boundary check in seqmap code
- The minimum value for the period (-p flag) is now 0.001 milliseconds, since it probably never makes sense to use a smaller value, and to avoid doing a very large memory allocation for event storage.

**Test Plan**
- fping google.se

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
