### PR TITLE
rclone: Update to v1.71.0

### DIFF
--- a/packages/r/rclone/package.yml
+++ b/packages/r/rclone/package.yml
@@ -1,8 +1,8 @@
 name       : rclone
-version    : 1.70.3
-release    : 37
+version    : 1.71.0
+release    : 38
 source     :
-    - https://github.com/rclone/rclone/archive/refs/tags/v1.70.3.tar.gz : 0b25fb9f0cb26883cfa885576ddb34276564a1e224edc5aacab826f9ba22179d
+    - https://github.com/rclone/rclone/archive/refs/tags/v1.71.0.tar.gz : 20eab33e279e7c14a20174db43277de3f5bbdcd248103e014d6e54374b43224a
 license    : MIT
 component  : network.util
 homepage   : https://rclone.org

--- a/packages/r/rclone/pspec_x86_64.xml
+++ b/packages/r/rclone/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>rclone</Name>
         <Homepage>https://rclone.org</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>network.util</PartOf>
@@ -26,17 +26,17 @@
             <Path fileType="doc">/usr/share/doc/rclone/MANUAL.md</Path>
             <Path fileType="doc">/usr/share/doc/rclone/MANUAL.txt</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/rclone.fish</Path>
-            <Path fileType="man">/usr/share/man/man1/rclone.1</Path>
+            <Path fileType="man">/usr/share/man/man1/rclone.1.zst</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_rclone</Path>
         </Files>
     </Package>
     <History>
-        <Update release="37">
-            <Date>2025-07-10</Date>
-            <Version>1.70.3</Version>
+        <Update release="38">
+            <Date>2025-09-21</Date>
+            <Version>1.71.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://rclone.org/changelog/#v1-71-0-2025-08-22).

**Test Plan**
- Checked settings.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
