### PR TITLE
libvips: Update to v8.17.2

### DIFF
--- a/packages/l/libvips/abi_symbols
+++ b/packages/l/libvips/abi_symbols
@@ -1481,6 +1481,7 @@ libvips.so.42:vips_fwfft
 libvips.so.42:vips_g_cond_free
 libvips.so.42:vips_g_cond_new
 libvips.so.42:vips_g_error
+libvips.so.42:vips_g_input_stream_get_type
 libvips.so.42:vips_g_input_stream_new_from_source
 libvips.so.42:vips_g_mutex_free
 libvips.so.42:vips_g_mutex_new
@@ -2000,6 +2001,7 @@ libvips.so.42:vips_sobel
 libvips.so.42:vips_source_custom_get_type
 libvips.so.42:vips_source_custom_new
 libvips.so.42:vips_source_decode
+libvips.so.42:vips_source_g_input_stream_get_type
 libvips.so.42:vips_source_g_input_stream_new
 libvips.so.42:vips_source_get_type
 libvips.so.42:vips_source_is_file

--- a/packages/l/libvips/package.yml
+++ b/packages/l/libvips/package.yml
@@ -1,8 +1,8 @@
 name       : libvips
-version    : 8.17.1
-release    : 53
+version    : 8.17.2
+release    : 54
 source     :
-    - https://github.com/libvips/libvips/archive/refs/tags/v8.17.1.tar.gz : 79f54d367a485507c1421408ae13768e4734f473edc71af511472645f46dbd08
+    - https://github.com/libvips/libvips/archive/refs/tags/v8.17.2.tar.gz : 66e2c8f0a716a08cf99e46a27535ef4938f1cae110dd9207cf8e992616b36ba7
 homepage   : https://www.libvips.org/
 license    : LGPL-2.1-or-later
 component  :

--- a/packages/l/libvips/pspec_x86_64.xml
+++ b/packages/l/libvips/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libvips</Name>
         <Homepage>https://www.libvips.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>multimedia.library</PartOf>
@@ -26,9 +26,9 @@
             <Path fileType="executable">/usr/bin/vipsthumbnail</Path>
             <Path fileType="library">/usr/lib64/girepository-1.0/Vips-8.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libvips-cpp.so.42</Path>
-            <Path fileType="library">/usr/lib64/libvips-cpp.so.42.19.1</Path>
+            <Path fileType="library">/usr/lib64/libvips-cpp.so.42.19.2</Path>
             <Path fileType="library">/usr/lib64/libvips.so.42</Path>
-            <Path fileType="library">/usr/lib64/libvips.so.42.19.1</Path>
+            <Path fileType="library">/usr/lib64/libvips.so.42.19.2</Path>
             <Path fileType="library">/usr/lib64/vips-modules-8.17/vips-heif.so</Path>
             <Path fileType="library">/usr/lib64/vips-modules-8.17/vips-jxl.so</Path>
             <Path fileType="library">/usr/lib64/vips-modules-8.17/vips-magick.so</Path>
@@ -38,7 +38,6 @@
             <Path fileType="man">/usr/share/man/man1/vips.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/vipsedit.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/vipsheader.1.zst</Path>
-            <Path fileType="man">/usr/share/man/man1/vipsprofile.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/vipsthumbnail.1.zst</Path>
         </Files>
     </Package>
@@ -49,7 +48,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="53">libvips</Dependency>
+            <Dependency release="54">libvips</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/vips/VConnection8.h</Path>
@@ -186,6 +185,7 @@
             <Path fileType="doc">/usr/share/doc/vips/class.Foreign.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/class.ForeignLoad.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/class.ForeignSave.html</Path>
+            <Path fileType="doc">/usr/share/doc/vips/class.GInputStream.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/class.Image.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/class.Interpolate.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/class.Object.html</Path>
@@ -194,6 +194,7 @@
             <Path fileType="doc">/usr/share/doc/vips/class.Sbuf.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/class.Source.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/class.SourceCustom.html</Path>
+            <Path fileType="doc">/usr/share/doc/vips/class.SourceGInputStream.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/class.Target.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/class.TargetCustom.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/class.ThreadState.html</Path>
@@ -285,6 +286,7 @@
             <Path fileType="doc">/usr/share/doc/vips/ctor.ArrayInt.newv.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/ctor.Blob.new.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/ctor.Blob.profile_load.html</Path>
+            <Path fileType="doc">/usr/share/doc/vips/ctor.GInputStream.new_from_source.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/ctor.Image.analyzeload.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/ctor.Image.black.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/ctor.Image.csvload.html</Path>
@@ -400,6 +402,7 @@
             <Path fileType="doc">/usr/share/doc/vips/ctor.Source.new_from_options.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/ctor.Source.new_from_target.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/ctor.SourceCustom.new.html</Path>
+            <Path fileType="doc">/usr/share/doc/vips/ctor.SourceGInputStream.new.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/ctor.Target.new_temp.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/ctor.Target.new_to_descriptor.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/ctor.Target.new_to_file.html</Path>
@@ -656,7 +659,6 @@
             <Path fileType="doc">/usr/share/doc/vips/func.format_sizeof.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/func.format_sizeof_unsafe.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/func.g_error.html</Path>
-            <Path fileType="doc">/usr/share/doc/vips/func.g_input_stream_new_from_source.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/func.g_thread_new.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/func.get_argv0.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/func.get_disc_threshold.html</Path>
@@ -1368,6 +1370,7 @@
             <Path fileType="doc">/usr/share/doc/vips/property.ForeignSave.page-height.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/property.ForeignSave.profile.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/property.ForeignSave.strip.html</Path>
+            <Path fileType="doc">/usr/share/doc/vips/property.GInputStream.input.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/property.Image.bands.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/property.Image.coding.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/property.Image.demand.html</Path>
@@ -1388,6 +1391,7 @@
             <Path fileType="doc">/usr/share/doc/vips/property.Object.nickname.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/property.Sbuf.input.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/property.Source.blob.html</Path>
+            <Path fileType="doc">/usr/share/doc/vips/property.SourceGInputStream.stream.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/property.Target.blob.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/property.Target.memory.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/search.js</Path>
@@ -1421,15 +1425,11 @@
             <Path fileType="doc">/usr/share/doc/vips/struct.Blob.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/struct.Buf.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/struct.Dbuf.html</Path>
-            <Path fileType="doc">/usr/share/doc/vips/struct.GInputStream.html</Path>
-            <Path fileType="doc">/usr/share/doc/vips/struct.GInputStreamClass.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/struct.Progress.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/struct.Rect.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/struct.RefString.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/struct.SaveString.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/struct.Semaphore.html</Path>
-            <Path fileType="doc">/usr/share/doc/vips/struct.SourceGInputStream.html</Path>
-            <Path fileType="doc">/usr/share/doc/vips/struct.SourceGInputStreamClass.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/style.css</Path>
             <Path fileType="doc">/usr/share/doc/vips/tn_owl.jpg</Path>
             <Path fileType="doc">/usr/share/doc/vips/type_func.Area.free_cb.html</Path>
@@ -1474,7 +1474,6 @@
             <Path fileType="doc">/usr/share/doc/vips/type_func.Object.summary_class.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/type_func.Operation.block_set.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/type_func.Progress.set.html</Path>
-            <Path fileType="doc">/usr/share/doc/vips/type_func.Source.g_input_stream_new.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/type_func.ThreadState.set.html</Path>
             <Path fileType="doc">/usr/share/doc/vips/urlmap.js</Path>
             <Path fileType="doc">/usr/share/doc/vips/using-from-c.html</Path>
@@ -1525,12 +1524,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="53">
-            <Date>2025-09-17</Date>
-            <Version>8.17.1</Version>
+        <Update release="54">
+            <Date>2025-09-21</Date>
+            <Version>8.17.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- rank: fix an off-by-one error
- popplerload, svgload: validate page size
- pdfiumload: allow both dpi and scale to be set
- svgload: honor DPI when scaling elements with non-pixel units
- disable redundant Highway AVX512 targets
- openslideload_source: flag operation as "nocache"
- remove vipsprofile.1 man page from install
- tiffload: ensure processing halts for memory-related errors
- tiffload: increase memory limit from 20MB to 50MB
- fix vapi build
- tiffsave: include sample format when copying tiff data

**Test Plan**

Edited a bunch of images using `vip`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
