### PR TITLE
deno: Update to v2.5.2

### DIFF
--- a/packages/d/deno/MAINTAINERS.md
+++ b/packages/d/deno/MAINTAINERS.md
@@ -1,5 +1,0 @@
-This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
-
-- Peter Reisz
-  - Email: peter.reisz@mozaiq.app
-

--- a/packages/d/deno/abi_used_symbols
+++ b/packages/d/deno/abi_used_symbols
@@ -49,6 +49,7 @@ libc.so.6:catopen
 libc.so.6:chdir
 libc.so.6:chmod
 libc.so.6:chown
+libc.so.6:chroot
 libc.so.6:clock_gettime
 libc.so.6:close
 libc.so.6:closedir

--- a/packages/d/deno/package.yml
+++ b/packages/d/deno/package.yml
@@ -1,8 +1,8 @@
 name       : deno
-version    : 2.4.1
-release    : 20
+version    : 2.5.2
+release    : 21
 source     :
-    - https://github.com/denoland/deno/archive/refs/tags/v2.4.1.tar.gz : 746d4cc54fdd3c11eb9616988c941c0d756fc3f1030e18df92d10c8a949dc807
+    - https://github.com/denoland/deno/archive/refs/tags/v2.5.1.tar.gz : 2b9426cf6976444888bb3b5154efa6368753b0cc6e712c12bfebcaf9915cf1da
 homepage   : https://deno.com/
 license    : MIT
 component  : programming.tools

--- a/packages/d/deno/pspec_x86_64.xml
+++ b/packages/d/deno/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>deno</Name>
         <Homepage>https://deno.com/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.tools</PartOf>
@@ -27,12 +27,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2025-07-08</Date>
-            <Version>2.4.1</Version>
+        <Update release="21">
+            <Date>2025-09-25</Date>
+            <Version>2.5.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

**Changelogs:**

- [2.4.2](https://github.com/denoland/deno/releases/tag/v2.4.2)
- [2.4.3](https://github.com/denoland/deno/releases/tag/v2.4.3)
- [2.4.4](https://github.com/denoland/deno/releases/tag/v2.4.4)
- [2.4.5](https://github.com/denoland/deno/releases/tag/v2.4.5)
- [2.5.0](https://github.com/denoland/deno/releases/tag/v2.5.0)
- [2.5.1](https://github.com/denoland/deno/releases/tag/v2.5.1)
- [2.5.2](https://github.com/denoland/deno/releases/tag/v2.5.2)

Read what is new in the 2.5 series [here](https://deno.com/blog/v2.5)

**Test Plan**
- Successfully built and ran the default `fresh` template project.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
