### PR TITLE
expat: Update to v2.7.3

### DIFF
--- a/packages/e/expat/package.yml
+++ b/packages/e/expat/package.yml
@@ -1,8 +1,8 @@
 name       : expat
-version    : 2.7.2
-release    : 34
+version    : 2.7.3
+release    : 35
 source     :
-    - https://github.com/libexpat/libexpat/releases/download/R_2_7_2/expat-2.7.2.tar.bz2 : 976f6c2d358953c22398d64cd93790ba5abc62e02a1bbc204a3a264adea149b8
+    - https://github.com/libexpat/libexpat/releases/download/R_2_7_3/expat-2.7.3.tar.bz2 : 59c31441fec9a66205307749eccfee551055f2d792f329f18d97099e919a3b2f
 homepage   : https://libexpat.github.io/
 license    : MIT
 component  :

--- a/packages/e/expat/pspec_x86_64.xml
+++ b/packages/e/expat/pspec_x86_64.xml
@@ -22,7 +22,7 @@
         <Files>
             <Path fileType="executable">/usr/bin/xmlwf</Path>
             <Path fileType="library">/usr/lib64/libexpat.so.1</Path>
-            <Path fileType="library">/usr/lib64/libexpat.so.1.11.0</Path>
+            <Path fileType="library">/usr/lib64/libexpat.so.1.11.1</Path>
         </Files>
     </Package>
     <Package>
@@ -32,11 +32,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="34">expat</Dependency>
+            <Dependency release="35">expat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libexpat.so.1</Path>
-            <Path fileType="library">/usr/lib32/libexpat.so.1.11.0</Path>
+            <Path fileType="library">/usr/lib32/libexpat.so.1.11.1</Path>
         </Files>
     </Package>
     <Package>
@@ -46,14 +46,14 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="34">expat-32bit</Dependency>
-            <Dependency release="34">expat-devel</Dependency>
+            <Dependency release="35">expat-32bit</Dependency>
+            <Dependency release="35">expat-devel</Dependency>
         </RuntimeDependencies>
         <Files>
-            <Path fileType="library">/usr/lib32/cmake/expat-2.7.2/expat-config-version.cmake</Path>
-            <Path fileType="library">/usr/lib32/cmake/expat-2.7.2/expat-config.cmake</Path>
-            <Path fileType="library">/usr/lib32/cmake/expat-2.7.2/expat-noconfig.cmake</Path>
-            <Path fileType="library">/usr/lib32/cmake/expat-2.7.2/expat.cmake</Path>
+            <Path fileType="library">/usr/lib32/cmake/expat-2.7.3/expat-config-version.cmake</Path>
+            <Path fileType="library">/usr/lib32/cmake/expat-2.7.3/expat-config.cmake</Path>
+            <Path fileType="library">/usr/lib32/cmake/expat-2.7.3/expat-noconfig.cmake</Path>
+            <Path fileType="library">/usr/lib32/cmake/expat-2.7.3/expat.cmake</Path>
             <Path fileType="library">/usr/lib32/libexpat.so</Path>
             <Path fileType="data">/usr/lib32/pkgconfig/expat.pc</Path>
         </Files>
@@ -65,24 +65,24 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="34">expat</Dependency>
+            <Dependency release="35">expat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/expat.h</Path>
             <Path fileType="header">/usr/include/expat_config.h</Path>
             <Path fileType="header">/usr/include/expat_external.h</Path>
-            <Path fileType="library">/usr/lib64/cmake/expat-2.7.2/expat-config-version.cmake</Path>
-            <Path fileType="library">/usr/lib64/cmake/expat-2.7.2/expat-config.cmake</Path>
-            <Path fileType="library">/usr/lib64/cmake/expat-2.7.2/expat-noconfig.cmake</Path>
-            <Path fileType="library">/usr/lib64/cmake/expat-2.7.2/expat.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/expat-2.7.3/expat-config-version.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/expat-2.7.3/expat-config.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/expat-2.7.3/expat-noconfig.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/expat-2.7.3/expat.cmake</Path>
             <Path fileType="library">/usr/lib64/libexpat.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/expat.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="34">
-            <Date>2025-09-16</Date>
-            <Version>2.7.2</Version>
+        <Update release="35">
+            <Date>2025-09-25</Date>
+            <Version>2.7.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/libexpat/libexpat/blob/R_2_7_3/expat/Changes).

**Security**
Includes fixes for:
- CVE-2024-8176
- CVE-2025-59375

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebuild `gdb`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
