### PR TITLE
deno: Remove extra char in summary

### DIFF
--- a/packages/d/deno/package.yml
+++ b/packages/d/deno/package.yml
@@ -1,12 +1,12 @@
 name       : deno
 version    : 2.5.2
-release    : 21
+release    : 22
 source     :
     - https://github.com/denoland/deno/archive/refs/tags/v2.5.1.tar.gz : 2b9426cf6976444888bb3b5154efa6368753b0cc6e712c12bfebcaf9915cf1da
 homepage   : https://deno.com/
 license    : MIT
 component  : programming.tools
-summary    : AA modern runtime for JavaScript and TypeScript
+summary    : A modern runtime for JavaScript and TypeScript
 description: |
     Deno is a JavaScript, TypeScript, and WebAssembly runtime with secure defaults and a great developer experience. It's built on V8, Rust, and Tokio.
 networking : true

--- a/packages/d/deno/pspec_x86_64.xml
+++ b/packages/d/deno/pspec_x86_64.xml
@@ -3,19 +3,19 @@
         <Name>deno</Name>
         <Homepage>https://deno.com/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.tools</PartOf>
-        <Summary xml:lang="en">AA modern runtime for JavaScript and TypeScript</Summary>
+        <Summary xml:lang="en">A modern runtime for JavaScript and TypeScript</Summary>
         <Description xml:lang="en">Deno is a JavaScript, TypeScript, and WebAssembly runtime with secure defaults and a great developer experience. It&apos;s built on V8, Rust, and Tokio.
 </Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>deno</Name>
-        <Summary xml:lang="en">AA modern runtime for JavaScript and TypeScript</Summary>
+        <Summary xml:lang="en">A modern runtime for JavaScript and TypeScript</Summary>
         <Description xml:lang="en">Deno is a JavaScript, TypeScript, and WebAssembly runtime with secure defaults and a great developer experience. It&apos;s built on V8, Rust, and Tokio.
 </Description>
         <PartOf>programming.tools</PartOf>
@@ -27,12 +27,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
+        <Update release="22">
             <Date>2025-09-25</Date>
             <Version>2.5.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Remove extra character in package summary

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the summary now only has one A.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
