### PR TITLE
libquotient: Update to v0.9.5

### DIFF
--- a/packages/l/libquotient/package.yml
+++ b/packages/l/libquotient/package.yml
@@ -1,8 +1,8 @@
 name       : libquotient
-version    : 0.9.4
-release    : 20
+version    : 0.9.5
+release    : 21
 source     :
-    - https://github.com/quotient-im/libQuotient/archive/refs/tags/0.9.4.tar.gz : f5dfd8dd7652161e6699baef6cd7e8ded5c91bd2ceb691b7ba4379e9fe319502
+    - https://github.com/quotient-im/libQuotient/archive/refs/tags/0.9.5.tar.gz : 24366dd59aca7b991756e45c3c8823c43fc6a8fdb161ea6dcce5b666c6300766
 homepage   : https://quotient-im.github.io/libQuotient/
 license    : LGPL-2.1-or-later
 component  : programming.library

--- a/packages/l/libquotient/pspec_x86_64.xml
+++ b/packages/l/libquotient/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libquotient</Name>
         <Homepage>https://quotient-im.github.io/libQuotient/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>programming.library</PartOf>
@@ -20,7 +20,7 @@
         <Files>
             <Path fileType="executable">/usr/bin/quotest</Path>
             <Path fileType="library">/usr/lib64/libQuotientQt6.so.0.9</Path>
-            <Path fileType="library">/usr/lib64/libQuotientQt6.so.0.9.4</Path>
+            <Path fileType="library">/usr/lib64/libQuotientQt6.so.0.9.5</Path>
         </Files>
     </Package>
     <Package>
@@ -29,7 +29,7 @@
         <Description xml:lang="en">A Qt library to write cross-platform clients for Matrix</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="20">libquotient</Dependency>
+            <Dependency release="21">libquotient</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/Quotient/accountregistry.h</Path>
@@ -205,12 +205,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2025-08-27</Date>
-            <Version>0.9.4</Version>
+        <Update release="21">
+            <Date>2025-09-26</Date>
+            <Version>0.9.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/n/neochat/package.yml
+++ b/packages/n/neochat/package.yml
@@ -1,6 +1,6 @@
 name       : neochat
 version    : 25.08.1
-release    : 46
+release    : 47
 source     :
     - https://download.kde.org/stable/release-service/25.08.1/src/neochat-25.08.1.tar.xz : 9ad75d279b7f28538e81a1ec25d1bb867c4409c4636d9d3facbfed219ef5e9b6
 homepage   : https://apps.kde.org/neochat/

--- a/packages/n/neochat/pspec_x86_64.xml
+++ b/packages/n/neochat/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>neochat</Name>
         <Homepage>https://apps.kde.org/neochat/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <License>GPL-2.0-or-later</License>
@@ -91,12 +91,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="46">
-            <Date>2025-09-11</Date>
+        <Update release="47">
+            <Date>2025-09-26</Date>
             <Version>25.08.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/quotient-im/libQuotient/releases/tag/0.9.5).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start NeoChat after installing this version, see that NeoChat still functions.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
