### PR TITLE
miriway: Update to v25.11

### DIFF
--- a/packages/m/miriway/abi_used_libs
+++ b/packages/m/miriway/abi_used_libs
@@ -2,7 +2,6 @@ libc.so.6
 libgcc_s.so.1
 libm.so.6
 libmiral.so.7
-libmircommon.so.11
 libmircore.so.2
 libmirwayland.so.5
 libstdc++.so.6

--- a/packages/m/miriway/abi_used_symbols
+++ b/packages/m/miriway/abi_used_symbols
@@ -152,6 +152,8 @@ libmiral.so.7:_ZN5miral22WindowManagementPolicy30advise_application_zone_createE
 libmiral.so.7:_ZN5miral22WindowManagementPolicy30advise_application_zone_deleteERKNS_4ZoneE
 libmiral.so.7:_ZN5miral22WindowManagementPolicy30advise_application_zone_updateERKNS_4ZoneES3_
 libmiral.so.7:_ZN5miral22WindowManagementPolicy30advise_removing_from_workspaceERKSt10shared_ptrINS_9WorkspaceEERKSt6vectorINS_6WindowESaIS7_EE
+libmiral.so.7:_ZN5miral25AppendKeyboardEventFilterC1ERKSt8functionIFbPK16MirKeyboardEventEE
+libmiral.so.7:_ZN5miral25AppendKeyboardEventFilterclERN3mir6ServerE
 libmiral.so.7:_ZN5miral25SetWindowManagementPolicyC1ERKSt8functionIFSt10unique_ptrINS_22WindowManagementPolicyESt14default_deleteIS3_EERKNS_18WindowManagerToolsEEE
 libmiral.so.7:_ZN5miral25SetWindowManagementPolicyD1Ev
 libmiral.so.7:_ZN5miral29display_configuration_optionsERN3mir6ServerE
@@ -179,6 +181,9 @@ libmiral.so.7:_ZN5miral7toolkit34mir_input_event_get_keyboard_eventEPK13MirInput
 libmiral.so.7:_ZN5miral8SlowKeysC1ERNS_11live_config5StoreE
 libmiral.so.7:_ZN5miral8SlowKeysclERN3mir6ServerE
 libmiral.so.7:_ZN5miral8pre_initERKNS_19ConfigurationOptionE
+libmiral.so.7:_ZN5miral9Magnifier6enableEb
+libmiral.so.7:_ZN5miral9MagnifierC2ERNS_11live_config5StoreE
+libmiral.so.7:_ZN5miral9MagnifierclERN3mir6ServerE
 libmiral.so.7:_ZN5miral9MirRunner17add_stop_callbackERKSt8functionIFvvEE
 libmiral.so.7:_ZN5miral9MirRunner18add_start_callbackERKSt8functionIFvvEE
 libmiral.so.7:_ZN5miral9MirRunner19register_fd_handlerEN3mir2FdERKSt8functionIFviEE
@@ -202,6 +207,7 @@ libmiral.so.7:_ZNK5miral11CursorScaleclERN3mir6ServerE
 libmiral.so.7:_ZNK5miral11CursorThemeclERN3mir6ServerE
 libmiral.so.7:_ZNK5miral11DecorationsclERN3mir6ServerE
 libmiral.so.7:_ZNK5miral11live_config3Key9to_stringB5cxx11Ev
+libmiral.so.7:_ZNK5miral11live_config3KeyssERKS1_
 libmiral.so.7:_ZNK5miral12IdleListenerclERN3mir6ServerE
 libmiral.so.7:_ZNK5miral12OutputFilterclERN3mir6ServerE
 libmiral.so.7:_ZNK5miral12WaylandTools16for_each_bindingEPN3mir7wayland6ClientERKNS_6OutputERKSt8functionIFvP11wl_resourceEE
@@ -230,7 +236,6 @@ libmiral.so.7:_ZNK5miral6Window8top_leftEv
 libmiral.so.7:_ZNK5miral6WindowcvbEv
 libmiral.so.7:_ZNK5miral9MirRunner11config_fileB5cxx11Ev
 libmiral.so.7:_ZTIN5miral20MinimalWindowManagerE
-libmircommon.so.11:_ZN3mir4logvENS_7logging8SeverityEPKcS3_P13__va_list_tag
 libmircore.so.2:_ZN3mir11fatal_errorE
 libmircore.so.2:_ZN3mir2FdC1Ei
 libmirwayland.so.5:_ZN3mir7wayland15LifetimeTrackerC2Ev
@@ -253,6 +258,7 @@ libmirwayland.so.5:_ZTv0_n24_N3mir7wayland8ResourceD1Ev
 libstdc++.so.6:_ZNKSt10filesystem7__cxx114path5_List13_Impl_deleterclEPNS2_5_ImplE
 libstdc++.so.6:_ZNKSt10filesystem7__cxx114path5_List3endEv
 libstdc++.so.6:_ZNKSt13runtime_error4whatEv
+libstdc++.so.6:_ZNKSt5ctypeIcE13_M_widen_initEv
 libstdc++.so.6:_ZNKSt6locale2id5_M_idEv
 libstdc++.so.6:_ZNKSt6locale4nameB5cxx11Ev
 libstdc++.so.6:_ZNKSt6localeeqERKS_
@@ -294,10 +300,12 @@ libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt20__throw_system_errori
+libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
 libstdc++.so.6:_ZSt25__throw_bad_function_callv
 libstdc++.so.6:_ZSt28_Rb_tree_rebalance_for_erasePSt18_Rb_tree_node_baseRS_
 libstdc++.so.6:_ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_
+libstdc++.so.6:_ZSt4cerr
 libstdc++.so.6:_ZSt8to_charsPcS_d
 libstdc++.so.6:_ZSt8to_charsPcS_dSt12chars_format
 libstdc++.so.6:_ZSt8to_charsPcS_dSt12chars_formati

--- a/packages/m/miriway/package.yml
+++ b/packages/m/miriway/package.yml
@@ -1,8 +1,8 @@
 name       : miriway
-version    : '25.10'
-release    : 3
+version    : '25.11'
+release    : 4
 source     :
-    - https://github.com/Miriway/Miriway/archive/refs/tags/v25.10.tar.gz : 4e0a2a33689397078d4ed69d892dad9a38e19057fc90eef5420cff4e8b97c618
+    - https://github.com/Miriway/Miriway/archive/refs/tags/v25.11.tar.gz : ea7b0669f0ae370d23d6843f6707227e4adfdd33bcf8ce65c4d682cb503e6bb2
 homepage   : https://github.com/Miriway/Miriway
 license    : GPL-3.0-only
 component  :

--- a/packages/m/miriway/pspec_x86_64.xml
+++ b/packages/m/miriway/pspec_x86_64.xml
@@ -43,7 +43,7 @@ Miriway has been tested with shell components from several desktop environments 
 </Description>
         <PartOf>desktop</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="3">miriway</Dependency>
+            <Dependency releaseFrom="4">miriway</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/sddm/sddm.conf.d/miriway.conf</Path>
@@ -58,7 +58,7 @@ Miriway has been tested with shell components from several desktop environments 
 </Description>
         <PartOf>desktop</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="3">miriway</Dependency>
+            <Dependency releaseFrom="4">miriway</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/miriway-session</Path>
@@ -69,9 +69,9 @@ Miriway has been tested with shell components from several desktop environments 
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2025-08-29</Date>
-            <Version>25.10</Version>
+        <Update release="4">
+            <Date>2025-09-26</Date>
+            <Version>25.11</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/Miriway/Miriway/releases/tag/v25.11).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a Budgie Miriway session.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
