### PR TITLE
budgie-desktop-branding: Change default theme to Pocillo-dark

### DIFF
--- a/packages/b/budgie-desktop-branding/files/0001-schemas-Set-Pocillo-dark-as-the-default-GTK-theme.patch
+++ b/packages/b/budgie-desktop-branding/files/0001-schemas-Set-Pocillo-dark-as-the-default-GTK-theme.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Evan Maddock <maddock.evan@vivaldi.net>
+Date: Thu, 2 Oct 2025 13:56:59 -0400
+Subject: [PATCH] schemas: Set Pocillo-dark as the default GTK theme
+
+Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
+---
+ schemas/org.gnome.desktop.interface.gschema.override      | 2 +-
+ schemas/org.gnome.desktop.wm.preferences.gschema.override | 2 +-
+ schemas/x.dm.slick-greeter.gschema.override               | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/schemas/org.gnome.desktop.interface.gschema.override b/schemas/org.gnome.desktop.interface.gschema.override
+index 1462423..633a417 100644
+--- a/schemas/org.gnome.desktop.interface.gschema.override
++++ b/schemas/org.gnome.desktop.interface.gschema.override
+@@ -4,6 +4,6 @@ document-font-name='Noto Sans 9'
+ font-antialiasing='rgba'
+ font-hinting='slight'
+ font-name='Noto Sans 9'
+-gtk-theme='Materia'
++gtk-theme='Pocillo-dark'
+ icon-theme='Papirus'
+ monospace-font-name='Hack 9'
+diff --git a/schemas/org.gnome.desktop.wm.preferences.gschema.override b/schemas/org.gnome.desktop.wm.preferences.gschema.override
+index e842583..bfcf7f0 100644
+--- a/schemas/org.gnome.desktop.wm.preferences.gschema.override
++++ b/schemas/org.gnome.desktop.wm.preferences.gschema.override
+@@ -1,4 +1,4 @@
+ [org.gnome.desktop.wm.preferences]
+ button-layout='appmenu:minimize,maximize,close'
+-theme='Materia'
++theme='Pocillo-dark'
+ titlebar-font='Noto Sans Bold 11'
+diff --git a/schemas/x.dm.slick-greeter.gschema.override b/schemas/x.dm.slick-greeter.gschema.override
+index 4ce30f8..24c8e9e 100644
+--- a/schemas/x.dm.slick-greeter.gschema.override
++++ b/schemas/x.dm.slick-greeter.gschema.override
+@@ -1,5 +1,5 @@
+ [x.dm.slick-greeter]
+ background="/usr/share/backgrounds/budgie/singaporean-cityscape.jpg"
+-theme-name="Materia-dark"
++theme-name="Pocillo-dark"
+ icon-theme-name="Papirus"
+ font-name="Noto Sans 10"

--- a/packages/b/budgie-desktop-branding/package.yml
+++ b/packages/b/budgie-desktop-branding/package.yml
@@ -1,6 +1,6 @@
 name       : budgie-desktop-branding
 version    : '23.1'
-release    : 80
+release    : 81
 source     :
     - https://github.com/getsolus/budgie-desktop-branding/archive/refs/tags/v23.1.tar.gz : e5605da107e5f3a6659c323571d085381ee1021e5c4ce69f53635f651e1a9281
 homepage   : https://github.com/getsolus/budgie-desktop-branding
@@ -29,16 +29,16 @@ rundeps    :
     - font-hack-ttf
     - font-noto-emoji
     - maliit-keyboard
-    - materia-gtk-theme
-    - materia-gtk-theme-dark
     - noto-sans-ttf
     - noto-serif-ttf
     - papirus-icon-theme
+    - pocillo-gtk-theme
     - qtstyleplugins
     - solus-artwork
     - livecd :
         - budgie-desktop-branding
 setup      : |
+    %patch -p1 -i $pkgfiles/0001-schemas-Set-Pocillo-dark-as-the-default-GTK-theme.patch
     %meson_configure
 build      : |
     %ninja_build

--- a/packages/b/budgie-desktop-branding/pspec_x86_64.xml
+++ b/packages/b/budgie-desktop-branding/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>budgie-desktop-branding</Name>
         <Homepage>https://github.com/getsolus/budgie-desktop-branding</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>desktop.budgie</PartOf>
@@ -36,7 +36,7 @@
         <Description xml:lang="en">Budgie LiveCD-specific Configuration</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="80">budgie-desktop-branding</Dependency>
+            <Dependency releaseFrom="81">budgie-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/glib-2.0/schemas/50_budgie_settings.gschema.override</Path>
@@ -44,12 +44,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="80">
-            <Date>2025-06-08</Date>
+        <Update release="81">
+            <Date>2025-10-02</Date>
             <Version>23.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Change default theme to Pocillo-dark

Fixes https://github.com/getsolus/packages/issues/6374

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install, see theme changed, open LibreOffice Calc and see that the sheet entry field thing is readable.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
