### PR TITLE
yauto: Add json schema hint to generated file

### DIFF
--- a/common/Scripts/yauto.py
+++ b/common/Scripts/yauto.py
@@ -335,7 +335,7 @@ component  : %(COMPONENT)s\n"""
             )
 
             if self.networking:
-                tmp += "\nnetworking : yes\n"
+                tmp += "\nnetworking : true\n"
 
             tmp += """summary    : PLEASE FILL ME IN
 

--- a/common/Scripts/yauto.py
+++ b/common/Scripts/yauto.py
@@ -322,7 +322,8 @@ class AutoPackage:
             }
 
             tmp = (
-                """name       : %(NAME)s
+                """# yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
+name       : %(NAME)s
 version    : %(VERSION)s
 release    : 1
 source     :


### PR DESCRIPTION
**Summary**

As discussed in https://github.com/getsolus/ypkg/pull/121, this PR adds a hint for the yaml-language-server to the autogenerated package.yml. 

There was also one more yes -> true conversion to be found in the script. 

**Test Plan**
- Have the JSON schema from https://github.com/getsolus/ypkg/pull/121 installed in  /usr/share/ypkg/schema/schema.json
- Have a yaml language server setup in your editor
- Create a new package with `go-task new`
- Check that the schema is picked up and you get LSP hints

**Checklist**

- [ ] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
