### PR TITLE
fix more booleans

### DIFF
--- a/packages/c/cnijfilter2/package.yml
+++ b/packages/c/cnijfilter2/package.yml
@@ -63,7 +63,7 @@ description: |
     Canon PIXMA TS9180
     Canon PIXMA XK50
     Canon PIXMA XK70
-libsplit   : no
+libsplit   : false
 builddeps  :
     - pkgconfig(cups)
     - pkgconfig(libusb-1.0)

--- a/packages/o/owncloud-client/package.yml
+++ b/packages/o/owncloud-client/package.yml
@@ -7,7 +7,7 @@ license    : GPL-2.0-or-later
 component  : network.download
 homepage   : https://owncloud.org
 summary    : The ownCloud Desktop Client is a tool to synchronize files from ownCloud Server with your computer
-libsplit   : no
+libsplit   : false
 description: |
     The ownCloud Desktop Client is a tool to synchronize files from ownCloud Server with your computer.
 builddeps  :

--- a/packages/v/vscode/package.yml
+++ b/packages/v/vscode/package.yml
@@ -11,9 +11,9 @@ component  : programming.ide
 summary    : Visual Studio Code (open source version) is a new type of tool that combines the simplicity of a code editor with what developers need for their core edit-build-debug cycle.
 description: |
     Visual Studio Code (open source version) is a new type of tool that combines the simplicity of a code editor with what developers need for their core edit-build-debug cycle.
-networking : yes
-debug      : no
-strip      : no
+networking : true
+debug      : false
+strip      : false
 builddeps  :
     - pkgconfig(alsa)
     - pkgconfig(gbm)


### PR DESCRIPTION
**Summary**

- **[NFC] cnijfilter2: Use `false` instead of `no`**
- **[NFC] vscode: Use `true`/`false` instead of `yes`/`no`**
- **[NFC] owncloud-client: Use `false` instead of `no`**

**Test Plan**

n/a

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
