### PR TITLE
hyprlock: Update to 0.9.2

### DIFF
--- a/packages/h/hyprlock/abi_symbols
+++ b/packages/h/hyprlock/abi_symbols
@@ -6,6 +6,7 @@ hyprlock:wl_data_device_manager_interface
 hyprlock:wl_data_offer_interface
 hyprlock:wl_data_source_interface
 hyprlock:wl_display_interface
+hyprlock:wl_fixes_interface
 hyprlock:wl_keyboard_interface
 hyprlock:wl_output_interface
 hyprlock:wl_pointer_interface

--- a/packages/h/hyprlock/abi_used_symbols
+++ b/packages/h/hyprlock/abi_used_symbols
@@ -3,6 +3,7 @@ libEGL.so.1:eglCreateContext
 libEGL.so.1:eglCreateImage
 libEGL.so.1:eglDestroyContext
 libEGL.so.1:eglDestroyImage
+libEGL.so.1:eglDestroySurface
 libEGL.so.1:eglGetError
 libEGL.so.1:eglGetProcAddress
 libEGL.so.1:eglInitialize

--- a/packages/h/hyprlock/package.yml
+++ b/packages/h/hyprlock/package.yml
@@ -1,8 +1,8 @@
 name       : hyprlock
-version    : 0.9.1
-release    : 12
+version    : 0.9.2
+release    : 13
 source     :
-    - https://github.com/hyprwm/hyprlock/archive/refs/tags/v0.9.1.tar.gz : 03f26ceba049546767a903a5e5bcd78fa4d261a5d116febd45633b88b9f16a97
+    - https://github.com/hyprwm/hyprlock/archive/refs/tags/v0.9.2.tar.gz : d4a8ef9115232b3545dd517e96f1251f91022765eb272b5e7057c20e3e7e8837
 homepage   : https://github.com/hyprwm/hyprlock
 license    : BSD-3-Clause
 component  : desktop.hyprland

--- a/packages/h/hyprlock/pspec_x86_64.xml
+++ b/packages/h/hyprlock/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>hyprlock</Name>
         <Homepage>https://github.com/hyprwm/hyprlock</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Dariusz Mencel</Name>
+            <Email>dariusz.bajon@gmail.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>desktop.hyprland</PartOf>
@@ -26,12 +26,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2025-08-11</Date>
-            <Version>0.9.1</Version>
+        <Update release="13">
+            <Date>2025-10-03</Date>
+            <Version>0.9.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Dariusz Mencel</Name>
+            <Email>dariusz.bajon@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
A new patch release with some fixes :)

Release notes link:
- https://github.com/hyprwm/hyprlock/releases/tag/v0.9.2

Changes:
- Make detection of PAM library more portable
- background: monitor transforms fixups
- core: remove dmabuf listeners after we are done with Screencopy
- renderer: move asyncResourceGatherer out of the rendere
- core: monitor replug workaround for nvidia
- lock-surface: remove redundant sendDestroy calls
- Refactor asset management to use shared_ptr
- renderer: fix nvidia workaround

**Test Plan**

Run hyprlock with hyprland and wlogout (configured for locking with hyprlock)

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
