### PR TITLE
desktop-file-utils: Update to v0.28

### DIFF
--- a/packages/d/desktop-file-utils/abi_used_libs
+++ b/packages/d/desktop-file-utils/abi_used_libs
@@ -1,2 +1,3 @@
 libc.so.6
+libgio-2.0.so.0
 libglib-2.0.so.0

--- a/packages/d/desktop-file-utils/abi_used_symbols
+++ b/packages/d/desktop-file-utils/abi_used_symbols
@@ -28,6 +28,7 @@ libc.so.6:strncmp
 libc.so.6:strtoul
 libc.so.6:umask
 libc.so.6:unlink
+libgio-2.0.so.0:g_dbus_is_interface_name
 libglib-2.0.so.0:g_ascii_strcasecmp
 libglib-2.0.so.0:g_ascii_strncasecmp
 libglib-2.0.so.0:g_ascii_table

--- a/packages/d/desktop-file-utils/package.yml
+++ b/packages/d/desktop-file-utils/package.yml
@@ -1,9 +1,9 @@
 name       : desktop-file-utils
-version    : '0.27'
-release    : 12
+version    : '0.28'
+release    : 13
 source     :
-    - https://freedesktop.org/software/desktop-file-utils/releases/desktop-file-utils-0.27.tar.xz : a0817df39ce385b6621880407c56f1f298168c040c2032cedf88d5b76affe836
-homepage   : http://freedesktop.org/wiki/Software/desktop-file-utils
+    - https://freedesktop.org/software/desktop-file-utils/releases/desktop-file-utils-0.28.tar.xz : 4401d4e231d842c2de8242395a74a395ca468cd96f5f610d822df33594898a70
+homepage   : https://freedesktop.org/wiki/Software/desktop-file-utils
 license    : GPL-2.0-or-later
 summary    : Utilities required for working with Desktop entries
 component  : desktop.core

--- a/packages/d/desktop-file-utils/pspec_x86_64.xml
+++ b/packages/d/desktop-file-utils/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>desktop-file-utils</Name>
-        <Homepage>http://freedesktop.org/wiki/Software/desktop-file-utils</Homepage>
+        <Homepage>https://freedesktop.org/wiki/Software/desktop-file-utils</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>reilly@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.core</PartOf>
@@ -25,19 +25,19 @@
             <Path fileType="executable">/usr/bin/desktop-file-validate</Path>
             <Path fileType="executable">/usr/bin/update-desktop-database</Path>
             <Path fileType="data">/usr/share/emacs/site-lisp/desktop-entry-mode.el</Path>
-            <Path fileType="man">/usr/share/man/man1/desktop-file-edit.1</Path>
-            <Path fileType="man">/usr/share/man/man1/desktop-file-install.1</Path>
-            <Path fileType="man">/usr/share/man/man1/desktop-file-validate.1</Path>
-            <Path fileType="man">/usr/share/man/man1/update-desktop-database.1</Path>
+            <Path fileType="man">/usr/share/man/man1/desktop-file-edit.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/desktop-file-install.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/desktop-file-validate.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/update-desktop-database.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2024-02-14</Date>
-            <Version>0.27</Version>
+        <Update release="13">
+            <Date>2025-10-04</Date>
+            <Version>0.28</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>reilly@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Increase GLib requirement to 2.26
- Fix install failing on second run
- Fix use of deprecated Meson feature resulting in a warning Anarki). desktop-file-validate
- Allow groups with the same name as interfaces in Implements
- Add support for the COSMIC environment

**Test Plan**
- Checked a desktop file.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
