### PR TITLE
gamescope: Update to v3.16.17

### DIFF
--- a/packages/g/gamescope/abi_used_symbols
+++ b/packages/g/gamescope/abi_used_symbols
@@ -597,6 +597,7 @@ libm.so.6:logf
 libm.so.6:modff
 libm.so.6:powf
 libm.so.6:rintf
+libm.so.6:round
 libm.so.6:roundf
 libopenvr_api.so:VR_GetGenericInterface
 libopenvr_api.so:VR_GetInitToken

--- a/packages/g/gamescope/monitoring.yaml
+++ b/packages/g/gamescope/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 242438
+  rss: https://github.com/ValveSoftware/gamescope/releases.atom
+ # No known CPE, checked 2025-10-04
+security:
+  cpe: ~

--- a/packages/g/gamescope/package.yml
+++ b/packages/g/gamescope/package.yml
@@ -1,8 +1,8 @@
 name       : gamescope
-version    : 3.16.14
-release    : 43
+version    : 3.16.17
+release    : 44
 source     :
-    - git|https://github.com/ValveSoftware/gamescope.git : 3.16.14
+    - git|https://github.com/ValveSoftware/gamescope.git : 3.16.17
 license    : BSD-2-Clause
 component  : system.utils
 homepage   : https://github.com/ValveSoftware/gamescope

--- a/packages/g/gamescope/pspec_x86_64.xml
+++ b/packages/g/gamescope/pspec_x86_64.xml
@@ -25,6 +25,12 @@
             <Path fileType="executable">/usr/bin/gamescopereaper</Path>
             <Path fileType="executable">/usr/bin/gamescopestream</Path>
             <Path fileType="library">/usr/lib64/libVkLayer_FROG_gamescope_wsi_x86_64.so</Path>
+            <Path fileType="data">/usr/share/gamescope/looks/cb_deut_g22.cube</Path>
+            <Path fileType="data">/usr/share/gamescope/looks/cb_deut_pq.cube</Path>
+            <Path fileType="data">/usr/share/gamescope/looks/cb_prot_g22.cube</Path>
+            <Path fileType="data">/usr/share/gamescope/looks/cb_prot_pq.cube</Path>
+            <Path fileType="data">/usr/share/gamescope/looks/cb_trit_g22.cube</Path>
+            <Path fileType="data">/usr/share/gamescope/looks/cb_trit_pq.cube</Path>
             <Path fileType="data">/usr/share/gamescope/looks/grayscale_g22.cube</Path>
             <Path fileType="data">/usr/share/gamescope/looks/grayscale_pq.cube</Path>
             <Path fileType="data">/usr/share/gamescope/looks/invertbrightness_g22.cube</Path>
@@ -46,9 +52,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="43">
-            <Date>2025-07-13</Date>
-            <Version>3.16.14</Version>
+        <Update release="44">
+            <Date>2025-10-04</Date>
+            <Version>3.16.17</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
- steamcompmgr: Hold wlserver_lock around handle_presented_xdg
- Resolves https://github.com/getsolus/packages/issues/6373

**Test Plan**
- Checked version.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
