### PR TITLE
Fix taskfile: clean-local fails if there are no packages in the local…

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -256,7 +256,7 @@ tasks:
     dir: '{{ .TASKFILE_DIR }}'
     prompt: This will delete ALL .eopkgs found in the solbuild local repository. Continue?
     cmds:
-      - sudo rm /var/lib/solbuild/local/*.eopkg
+      - sudo rm -f /var/lib/solbuild/local/*.eopkg
 
   list-local:
     desc: List all .eopkgs in the local repo (/var/lib/solbuild/local/*.eopkg)


### PR DESCRIPTION
**Summary**
- Fix taskfile: clean-local fails if there are no packages in the local repository
- Resolves https://github.com/getsolus/packages/issues/3135

**Test Plan**
- Ran go-task and got no failures.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
