### PR TITLE
darkly: Update to v0.5.23

### DIFF
--- a/packages/d/darkly/MAINTAINERS.md
+++ b/packages/d/darkly/MAINTAINERS.md
@@ -1,5 +1,5 @@
 This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
 
-- Hurican Solas
+- Hurican Dev
   - Matrix: @hurican:matrix.org
   - Email: hurican@keemail.me

--- a/packages/d/darkly/package.yml
+++ b/packages/d/darkly/package.yml
@@ -1,8 +1,8 @@
 name       : darkly
-version    : 0.5.22
-release    : 9
+version    : 0.5.23
+release    : 10
 source     :
-    - https://github.com/Bali10050/Darkly/archive/refs/tags/v0.5.22.tar.gz : cd6a34ee054dacba6ee8cad15a969dd83d7ab3653eb2665c261d441b21092ace
+    - https://github.com/Bali10050/Darkly/archive/refs/tags/v0.5.23.tar.gz : a897784e4e43fe7947afe65fd91e796f98f8eec6beec7f94a04f3c102c5d5577
 homepage   : https://github.com/Bali10050/Darkly
 license    : GPL-2.0-or-later
 component  : desktop.theme

--- a/packages/d/darkly/pspec_x86_64.xml
+++ b/packages/d/darkly/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>darkly</Name>
         <Homepage>https://github.com/Bali10050/Darkly</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Hurican Dev</Name>
+            <Email>hurican@keemail.me</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.theme</PartOf>
@@ -41,7 +41,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="9">darkly</Dependency>
+            <Dependency release="10">darkly</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/cmake/Darkly/DarklyConfig.cmake</Path>
@@ -49,12 +49,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2025-10-01</Date>
-            <Version>0.5.22</Version>
+        <Update release="10">
+            <Date>2025-10-05</Date>
+            <Version>0.5.23</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Hurican Dev</Name>
+            <Email>hurican@keemail.me</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Updated Darkly to the latest version.
Release notes can be found [here](https://github.com/Bali10050/Darkly/releases/tag/v0.5.23).

**Test Plan**

Installed the package and everything continued to work as it should.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
