### PR TITLE
libogg: Use cmake instead of autotools

### DIFF
--- a/packages/l/libogg/package.yml
+++ b/packages/l/libogg/package.yml
@@ -1,25 +1,32 @@
 name       : libogg
 version    : 1.3.5
-release    : 12
+release    : 13
 source     :
     - https://github.com/xiph/ogg/archive/v1.3.5.tar.gz : f6f1b04cfa4e98b70ffe775d5e302d9c6b98541f05159af6de2d6617817ed7d6
 homepage   : https://www.xiph.org/ogg/
 license    : BSD-3-Clause
 component  : multimedia.codecs
-patterns   :
-    - docs : /usr/share/doc
-emul32     : true
-optimize   : speed
 summary    : Ogg format library
 description: |
     The libogg package contains the Ogg file structure. This is useful for creating (encoding) or playing (decoding) a single physical bit stream.
+emul32     : true
+optimize   : speed
 setup      : |
-    %reconfigure --disable-static
+    if [[ ! -z $EMUL32BUILD ]]; then
+        %cmake_ninja \
+            -DCMAKE_INSTALL_LIBDIR=lib32 \
+            -DBUILD_SHARED_LIBS=ON
+    else
+        %cmake_ninja \
+            -DBUILD_SHARED_LIBS=ON
+    fi
 build      : |
-    %make
+    %ninja_build
 install    : |
-    %make_install
+    %ninja_install
 profile    : |
-    %make check
+    %ninja_check
 check      : |
-    %make check
+    %ninja_check
+patterns   :
+    - docs : /usr/share/doc

--- a/packages/l/libogg/pspec_x86_64.xml
+++ b/packages/l/libogg/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libogg</Name>
         <Homepage>https://www.xiph.org/ogg/</Homepage>
         <Packager>
-            <Name>Domen Skamlic</Name>
-            <Email>domen@skamlic.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>multimedia.codecs</PartOf>
@@ -31,7 +31,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="12">libogg</Dependency>
+            <Dependency release="13">libogg</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libogg.so.0</Path>
@@ -45,10 +45,14 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="12">libogg-32bit</Dependency>
-            <Dependency release="12">libogg-devel</Dependency>
+            <Dependency release="13">libogg-32bit</Dependency>
+            <Dependency release="13">libogg-devel</Dependency>
         </RuntimeDependencies>
         <Files>
+            <Path fileType="library">/usr/lib32/cmake/Ogg/OggConfig.cmake</Path>
+            <Path fileType="library">/usr/lib32/cmake/Ogg/OggConfigVersion.cmake</Path>
+            <Path fileType="library">/usr/lib32/cmake/Ogg/OggTargets-relwithdebinfo.cmake</Path>
+            <Path fileType="library">/usr/lib32/cmake/Ogg/OggTargets.cmake</Path>
             <Path fileType="library">/usr/lib32/libogg.so</Path>
             <Path fileType="data">/usr/lib32/pkgconfig/ogg.pc</Path>
         </Files>
@@ -60,15 +64,18 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="12">libogg</Dependency>
+            <Dependency release="13">libogg</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/ogg/config_types.h</Path>
             <Path fileType="header">/usr/include/ogg/ogg.h</Path>
             <Path fileType="header">/usr/include/ogg/os_types.h</Path>
+            <Path fileType="library">/usr/lib64/cmake/Ogg/OggConfig.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/Ogg/OggConfigVersion.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/Ogg/OggTargets-relwithdebinfo.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/Ogg/OggTargets.cmake</Path>
             <Path fileType="library">/usr/lib64/libogg.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/ogg.pc</Path>
-            <Path fileType="data">/usr/share/aclocal/ogg.m4</Path>
         </Files>
     </Package>
     <Package>
@@ -78,98 +85,99 @@
 </Description>
         <PartOf>programming.docs</PartOf>
         <Files>
-            <Path fileType="doc">/usr/share/doc/libogg/fish_xiph_org.png</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/framing.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/index.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/bitpacking.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/datastructures.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/decoding.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/encoding.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/general.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/index.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_iovec_t.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_packet.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_packet_clear.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_page.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_page_bos.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_page_checksum_set.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_page_continued.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_page_eos.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_page_granulepos.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_page_packets.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_page_pageno.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_page_serialno.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_page_version.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_stream_check.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_stream_clear.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_stream_destroy.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_stream_eos.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_stream_flush.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_stream_flush_fill.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_stream_init.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_stream_iovecin.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_stream_packetin.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_stream_packetout.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_stream_packetpeek.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_stream_pagein.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_stream_pageout.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_stream_pageout_fill.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_stream_reset.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_stream_reset_serialno.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_stream_state.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_sync_buffer.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_sync_check.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_sync_clear.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_sync_destroy.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_sync_init.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_sync_pageout.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_sync_pageseek.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_sync_reset.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_sync_state.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/ogg_sync_wrote.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/oggpack_adv.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/oggpack_adv1.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/oggpack_bits.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/oggpack_buffer.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/oggpack_bytes.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/oggpack_get_buffer.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/oggpack_look.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/oggpack_look1.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/oggpack_read.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/oggpack_read1.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/oggpack_readinit.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/oggpack_reset.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/oggpack_write.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/oggpack_writealign.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/oggpack_writecheck.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/oggpack_writeclear.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/oggpack_writecopy.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/oggpack_writeinit.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/oggpack_writetrunc.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/overview.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/reference.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/libogg/style.css</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/multiplex1.png</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/ogg-multiplex.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/oggstream.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/packets.png</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/pages.png</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/rfc3533.txt</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/rfc5334.txt</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/skeleton.html</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/stream.png</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/vorbisword2.png</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/white-ogg.png</Path>
-            <Path fileType="doc">/usr/share/doc/libogg/white-xifish.png</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/fish_xiph_org.png</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/framing.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/index.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/Makefile.am</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/bitpacking.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/datastructures.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/decoding.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/encoding.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/general.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/index.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_iovec_t.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_packet.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_packet_clear.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_page.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_page_bos.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_page_checksum_set.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_page_continued.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_page_eos.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_page_granulepos.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_page_packets.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_page_pageno.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_page_serialno.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_page_version.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_stream_check.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_stream_clear.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_stream_destroy.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_stream_eos.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_stream_flush.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_stream_flush_fill.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_stream_init.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_stream_iovecin.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_stream_packetin.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_stream_packetout.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_stream_packetpeek.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_stream_pagein.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_stream_pageout.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_stream_pageout_fill.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_stream_reset.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_stream_reset_serialno.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_stream_state.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_sync_buffer.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_sync_check.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_sync_clear.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_sync_destroy.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_sync_init.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_sync_pageout.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_sync_pageseek.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_sync_reset.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_sync_state.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/ogg_sync_wrote.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/oggpack_adv.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/oggpack_adv1.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/oggpack_bits.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/oggpack_buffer.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/oggpack_bytes.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/oggpack_get_buffer.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/oggpack_look.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/oggpack_look1.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/oggpack_read.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/oggpack_read1.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/oggpack_readinit.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/oggpack_reset.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/oggpack_write.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/oggpack_writealign.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/oggpack_writecheck.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/oggpack_writeclear.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/oggpack_writecopy.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/oggpack_writeinit.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/oggpack_writetrunc.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/overview.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/reference.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/libogg/style.css</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/multiplex1.png</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/ogg-multiplex.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/oggstream.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/packets.png</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/pages.png</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/rfc3533.txt</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/rfc5334.txt</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/skeleton.html</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/stream.png</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/vorbisword2.png</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/white-ogg.png</Path>
+            <Path fileType="doc">/usr/share/doc/libogg/html/white-xifish.png</Path>
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2024-07-04</Date>
+        <Update release="13">
+            <Date>2025-10-07</Date>
             <Version>1.3.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Domen Skamlic</Name>
-            <Email>domen@skamlic.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

<!-- Info on what this pull request updates/changes/etc -->
Convert recipe to use cmake instead of autotools

**Test Plan**

<!-- Short description of how the package was tested -->
Build `endless-sky` against this package

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
