### PR TITLE
fix hyprpolkitagent

### DIFF
--- a/packages/h/hyprpolkitagent/package.yml
+++ b/packages/h/hyprpolkitagent/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : hyprpolkitagent
 version    : 0.1.3
-release    : 1
+release    : 2
 source     :
     - https://github.com/hyprwm/hyprpolkitagent/archive/refs/tags/v0.1.3.tar.gz : a8fa714b92d47331f056b608cb731dd1f5cc3845a9109cb22c6e6eb55b4eac84
 homepage   : https://github.com/hyprwm/hyprpolkitagent
@@ -19,6 +19,8 @@ builddeps  :
     - pkgconfig(hyprutils)
     - pkgconfig(polkit-qt6-1)
     - qt6-base-private-devel
+rundeps    :
+    - hyprland-qt-support
 setup      : |
     %cmake_ninja
 build      : |

--- a/packages/h/hyprpolkitagent/pspec_x86_64.xml
+++ b/packages/h/hyprpolkitagent/pspec_x86_64.xml
@@ -32,8 +32,8 @@ Wiki: https://wiki.hypr.land/Hypr-Ecosystem/hyprpolkitagent/
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2025-10-05</Date>
+        <Update release="2">
+            <Date>2025-10-07</Date>
             <Version>0.1.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Dariusz Mencel</Name>


### PR DESCRIPTION
**hyprpolkitagent: Fix run dependency for hyprpolkitagent**

**Summary**
Added:
rundeps    :
    - hyprland-qt-support

**Test Plan**
Discovered on new/clean hyprland install that hyprpolkitagent is missing hyprland-qt-support
<img width="1276" height="793" alt="image" src="https://github.com/user-attachments/assets/dee3b75f-5bf7-4b8d-b49c-abc6ef76cd32" />

For testing:
- installed hyprpolkitagent -> run dependency installed
- run hyprpolkitagent -> without any errors

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
