### PR TITLE
deprecate bzr

### DIFF
--- a/packages/f/flatpak-builder/package.yml
+++ b/packages/f/flatpak-builder/package.yml
@@ -1,6 +1,6 @@
 name       : flatpak-builder
 version    : 1.4.4
-release    : 27
+release    : 28
 source     :
     - https://github.com/flatpak/flatpak-builder/releases/download/1.4.4/flatpak-builder-1.4.4.tar.xz : dc27159394baaa2cb523f52f874472ff50d161983233264ca2a22e850741ec7a
 homepage   : https://flatpak.org
@@ -10,6 +10,7 @@ summary    : Tool to build flatpaks from source
 description: |
     Flatpak-builder is a tool for building flatpaks from sources.
 builddeps  :
+    - pkgconfig(appstream-compose)
     - pkgconfig(flatpak)
     - pkgconfig(json-glib-1.0)
     - pkgconfig(libcap)
@@ -22,7 +23,6 @@ builddeps  :
     - xmlto
 rundeps    :
     - ccache
-    - bzr
     - debugedit
     - elfutils
     - flatpak

--- a/packages/f/flatpak-builder/pspec_x86_64.xml
+++ b/packages/f/flatpak-builder/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>flatpak-builder</Name>
         <Homepage>https://flatpak.org</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>desktop</PartOf>
@@ -23,17 +23,17 @@
             <Path fileType="executable">/usr/bin/flatpak-builder</Path>
             <Path fileType="doc">/usr/share/doc/flatpak-builder/docbook.css</Path>
             <Path fileType="doc">/usr/share/doc/flatpak-builder/flatpak-builder-docs.html</Path>
-            <Path fileType="man">/usr/share/man/man1/flatpak-builder.1</Path>
-            <Path fileType="man">/usr/share/man/man5/flatpak-manifest.5</Path>
+            <Path fileType="man">/usr/share/man/man1/flatpak-builder.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man5/flatpak-manifest.5.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2024-07-31</Date>
+        <Update release="28">
+            <Date>2025-10-07</Date>
             <Version>1.4.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2919,5 +2919,7 @@
 		<Package>gammaray-probe-qt5</Package>
 		<Package>cvassistant</Package>
 		<Package>cvassistant-dbginfo</Package>
+		<Package>bzr</Package>
+		<Package>bzr-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3968,5 +3968,9 @@
 		<Package>cvassistant</Package>
 		<Package>cvassistant-dbginfo</Package>
 
+		<!-- Python 2 -->
+		<Package>bzr</Package>
+		<Package>bzr-dbginfo</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
**Summary**

`bzr` depends on Python 2, so it is time for it to ride off into the sunset.

**Test Plan**

n/a

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
