### PR TITLE
usysconf-epoch: Fix service failing when disabled

### DIFF
--- a/packages/u/usysconf-epoch/files/epoch.sh
+++ b/packages/u/usysconf-epoch/files/epoch.sh
@@ -123,22 +123,27 @@ function _notify-send() {
     done
 }
 
+function _exit() {
+    systemd-notify --ready
+    exit "$@"
+}
+
 if [[ "${EPOCH_ENABLE}" != "yes" ]]
 then
     echo "Not enabled, refusing to transition"
-    exit 0
+    _exit 0
 fi
 
 if [[ ! -e "${MERGE_FLAG_FILE}" ]]
 then
     echo "Not ready: not usr-merged"
-    exit 1
+    _exit 1
 fi
 
 if [[ "$(readlink /usr/bin/eopkg)" != "eopkg.bin" ]]
 then
     echo "Not ready: eopkg is not python3"
-    exit 1
+    _exit 1
 fi
 
 desktop=""

--- a/packages/u/usysconf-epoch/package.yml
+++ b/packages/u/usysconf-epoch/package.yml
@@ -1,6 +1,6 @@
 name       : usysconf-epoch
 version    : 1.0.0
-release    : 18
+release    : 19
 source     :
     # We need something for a source
     - https://getsol.us/sources/hotspot.txt : a12b7cb43c9d9134b5bb1b35e9096b66775d9e92e7611d1cc92b02edd6782a87

--- a/packages/u/usysconf-epoch/pspec_x86_64.xml
+++ b/packages/u/usysconf-epoch/pspec_x86_64.xml
@@ -29,8 +29,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2025-10-04</Date>
+        <Update release="19">
+            <Date>2025-10-08</Date>
             <Version>1.0.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Silke Hofstra</Name>


### PR DESCRIPTION
**Summary**

Fix `epoch.service` failing when the user has not opted-in.

**Test Plan**

- Install on a system that has not opted in.
- Check that the service has not failed using `systemctl status epoch`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
