### PR TITLE
zsync: Update to 0.6.3

### DIFF
--- a/packages/z/zsync/abi_used_symbols
+++ b/packages/z/zsync/abi_used_symbols
@@ -2,13 +2,16 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
 libc.so.6:__fread_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoll
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__xpg_basename
+libc.so.6:abort
 libc.so.6:access
 libc.so.6:calloc
 libc.so.6:close
@@ -44,7 +47,6 @@ libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset
 libc.so.6:mkstemp
-libc.so.6:mktime
 libc.so.6:optarg
 libc.so.6:optind
 libc.so.6:pclose
@@ -78,9 +80,8 @@ libc.so.6:strncasecmp
 libc.so.6:strptime
 libc.so.6:strrchr
 libc.so.6:strstr
-libc.so.6:strtol
-libc.so.6:strtoll
 libc.so.6:time
+libc.so.6:timegm
 libc.so.6:tmpfile
 libc.so.6:unlink
 libc.so.6:utime

--- a/packages/z/zsync/package.yml
+++ b/packages/z/zsync/package.yml
@@ -1,9 +1,9 @@
 name       : zsync
-version    : 0.6.2
-release    : 4
-homepage   : http://zsync.moria.org.uk/
+version    : 0.6.3
+release    : 5
+homepage   : https://zsync.moria.org.uk/
 source     :
-    - http://zsync.moria.org.uk/download/zsync-0.6.2.tar.bz2 : 0b9d53433387aa4f04634a6c63a5efa8203070f2298af72a705f9be3dda65af2
+    - https://zsync.moria.org.uk/download/zsync-0.6.3.tar.bz2 : 293b6191821641d3ed6248206f8f9df0bf46e6ee2cf8b4dd97cfd1d5909edb9a
 license    : Artistic-2.0
 component  : system.utils
 summary    : zsync is a file transfer program.

--- a/packages/z/zsync/pspec_x86_64.xml
+++ b/packages/z/zsync/pspec_x86_64.xml
@@ -1,17 +1,17 @@
 <PISI>
     <Source>
         <Name>zsync</Name>
-        <Homepage>http://zsync.moria.org.uk/</Homepage>
+        <Homepage>https://zsync.moria.org.uk/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Dariusz Mencel</Name>
+            <Email>dariusz.bajon@gmail.com</Email>
         </Packager>
         <License>Artistic-2.0</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">zsync is a file transfer program.</Summary>
         <Description xml:lang="en">zsync is a file transfer program. It allows you to download a file from a remote server, where you have a copy of an older version of the file on your computer already. zsync downloads only the new parts of the file.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>zsync</Name>
@@ -24,17 +24,17 @@
             <Path fileType="executable">/usr/bin/zsyncmake</Path>
             <Path fileType="doc">/usr/share/doc/zsync/COPYING</Path>
             <Path fileType="doc">/usr/share/doc/zsync/README</Path>
-            <Path fileType="man">/usr/share/man/man1/zsync.1</Path>
-            <Path fileType="man">/usr/share/man/man1/zsyncmake.1</Path>
+            <Path fileType="man">/usr/share/man/man1/zsync.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/zsyncmake.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2021-06-17</Date>
-            <Version>0.6.2</Version>
+        <Update release="5">
+            <Date>2025-10-10</Date>
+            <Version>0.6.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Dariusz Mencel</Name>
+            <Email>dariusz.bajon@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
zsync: Update to 0.6.3
<!-- Info on what this pull request updates/changes/etc -->
Release page:
    - https://zsync.moria.org.uk/downloads

As part of #5522 https link for homepage and source were added
**Test Plan**

Run zsync in console:
<img width="1478" height="532" alt="image" src="https://github.com/user-attachments/assets/3551cba3-3a88-4abc-8c9f-0837a349918b" />


**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
