### PR TITLE
zpaq: Rebuild after homepage link fix

### DIFF
--- a/packages/z/zpaq/abi_used_symbols
+++ b/packages/z/zpaq/abi_used_symbols
@@ -1,5 +1,6 @@
 libc.so.6:__fprintf_chk
 libc.so.6:__fread_chk
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__stack_chk_fail
@@ -55,12 +56,10 @@ libc.so.6:strlen
 libc.so.6:strncat
 libc.so.6:strrchr
 libc.so.6:strstr
-libc.so.6:strtol
 libc.so.6:time
 libc.so.6:truncate64
 libc.so.6:utime
 libgcc_s.so.1:_Unwind_Resume
-libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7compareEPKc
 libstdc++.so.6:_ZNSt13runtime_errorC1EPKc
 libstdc++.so.6:_ZNSt13runtime_errorD1Ev
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_disposeEv
@@ -74,16 +73,12 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_assignER
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createERmm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_mutateEmmPKcm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1EOS4_
-libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1ERKS4_
 libstdc++.so.6:_ZNSt9bad_allocD1Ev
-libstdc++.so.6:_ZSt17__throw_bad_allocv
 libstdc++.so.6:_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
-libstdc++.so.6:_ZSt18_Rb_tree_incrementPKSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
-libstdc++.so.6:_ZSt28__throw_bad_array_new_lengthv
 libstdc++.so.6:_ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_
 libstdc++.so.6:_ZTISt13runtime_error
 libstdc++.so.6:_ZTISt9bad_alloc

--- a/packages/z/zpaq/package.yml
+++ b/packages/z/zpaq/package.yml
@@ -1,9 +1,9 @@
 name       : zpaq
 version    : '7.15'
-release    : 5
+release    : 6
 source     :
     - https://github.com/zpaq/zpaq/archive/7.15.tar.gz : 64280d86cd38ad5ebc1c6415b17eb09ee292078d772176b90e16287687191efe
-homepage   : http://mattmahoney.net/dc/zpaq.html
+homepage   : https://mattmahoney.net/dc/zpaq.html
 license    :
     - MIT
     - Unlicense

--- a/packages/z/zpaq/pspec_x86_64.xml
+++ b/packages/z/zpaq/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>zpaq</Name>
-        <Homepage>http://mattmahoney.net/dc/zpaq.html</Homepage>
+        <Homepage>https://mattmahoney.net/dc/zpaq.html</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Dariusz Mencel</Name>
+            <Email>dariusz.bajon@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <License>Unlicense</License>
@@ -24,16 +24,16 @@ zpaq is faster and compresses better than most other popular archivers and backu
         <PartOf>system.utils</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/zpaq</Path>
-            <Path fileType="man">/usr/share/man/man1/zpaq.1</Path>
+            <Path fileType="man">/usr/share/man/man1/zpaq.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2023-10-10</Date>
+        <Update release="6">
+            <Date>2025-10-10</Date>
             <Version>7.15</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Dariusz Mencel</Name>
+            <Email>dariusz.bajon@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- zpaq: Rebuild after insecure homepage link adjustment
- As part of #5522 https link for homepage fixed

**Test plan**
- run zpaq in console
<img width="787" height="615" alt="image" src="https://github.com/user-attachments/assets/49d66b77-2368-427e-bd52-bee1095ec425" />

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
