### PR TITLE
zelda-roth-se: Rebuild after homepage link fix

### DIFF
--- a/packages/z/zelda-roth-se/package.yml
+++ b/packages/z/zelda-roth-se/package.yml
@@ -1,9 +1,9 @@
 name       : zelda-roth-se
 version    : 1.2.1
-release    : 8
+release    : 9
 source     :
     - https://gitlab.com/solarus-games/games/zelda-roth-se/-/archive/v1.2.1/zelda-roth-se-v1.2.1.tar.bz2 : 1cff44fe97eab1327a0c0d11107ca10ea983a652c4780487f00f2660a6ab23c0
-homepage   : http://www.zeldaroth.fr/us/
+homepage   : https://www.zeldaroth.fr/us/
 license    :
     - CC-BY-SA-3.0
     - GPL-2.0-or-later

--- a/packages/z/zelda-roth-se/pspec_x86_64.xml
+++ b/packages/z/zelda-roth-se/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>zelda-roth-se</Name>
-        <Homepage>http://www.zeldaroth.fr/us/</Homepage>
+        <Homepage>https://www.zeldaroth.fr/us/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Dariusz Mencel</Name>
+            <Email>dariusz.bajon@gmail.com</Email>
         </Packager>
         <License>CC-BY-SA-3.0</License>
         <License>GPL-2.0-or-later</License>
@@ -41,12 +41,12 @@ This new version was developed with the Solarus engine by Christopho, Mymy and V
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2024-07-14</Date>
+        <Update release="9">
+            <Date>2025-10-10</Date>
             <Version>1.2.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Dariusz Mencel</Name>
+            <Email>dariusz.bajon@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fixed https homepage link
- As part of #5522 secure links for homepages

**Test Plan**

Ran game localy:
<img width="655" height="525" alt="image" src="https://github.com/user-attachments/assets/4b192029-6a6a-4424-98f0-a04d6682365d" />

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
