### PR TITLE
usysconf-epoch: Temporarily don't link epoch script

### DIFF
--- a/packages/u/usysconf-epoch/package.yml
+++ b/packages/u/usysconf-epoch/package.yml
@@ -1,6 +1,6 @@
 name       : usysconf-epoch
 version    : 1.0.0
-release    : 19
+release    : 20
 source     :
     # We need something for a source
     - https://getsol.us/sources/hotspot.txt : a12b7cb43c9d9134b5bb1b35e9096b66775d9e92e7611d1cc92b02edd6782a87
@@ -15,6 +15,7 @@ install    : |
     install -Dm00755 -t $installdir/usr/lib64/usysconf/      $pkgfiles/*.sh
     install -Dm00644 -t $installdir/%libdir%/systemd/system/ $pkgfiles/*.service
 
-    install -Ddm00755 $installdir/%libdir%/systemd/system/{sysinit,multi-user}.target.wants
+    # install -Ddm00755 $installdir/%libdir%/systemd/system/{sysinit,multi-user}.target.wants
+    install -Ddm00755 $installdir/%libdir%/systemd/system/sysinit.target.wants
     ln -srv $installdir/%libdir%/systemd/system/usr-merge.service $installdir/%libdir%/systemd/system/sysinit.target.wants/usr-merge.service
-    ln -srv $installdir/%libdir%/systemd/system/epoch.service     $installdir/%libdir%/systemd/system/multi-user.target.wants/epoch.service
+    # ln -srv $installdir/%libdir%/systemd/system/epoch.service     $installdir/%libdir%/systemd/system/multi-user.target.wants/epoch.service

--- a/packages/u/usysconf-epoch/pspec_x86_64.xml
+++ b/packages/u/usysconf-epoch/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>usysconf-epoch</Name>
         <Homepage>https://github.com/getsolus/usysconf/</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>system.base</PartOf>
@@ -21,7 +21,6 @@
         <PartOf>system.base</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/systemd/system/epoch.service</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/multi-user.target.wants/epoch.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/sysinit.target.wants/usr-merge.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/usr-merge.service</Path>
             <Path fileType="library">/usr/lib64/usysconf/epoch.sh</Path>
@@ -29,12 +28,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2025-10-08</Date>
+        <Update release="20">
+            <Date>2025-10-10</Date>
             <Version>1.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Our timeline shifted by a week.

**Test Plan**

<img width="782" height="152" alt="image" src="https://github.com/user-attachments/assets/592e6d97-febf-4faf-81fb-96d428a2bc0d" />


**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
