### PR TITLE
hyprland-protocols: Update to 0.7.0

### DIFF
--- a/packages/h/hyprland-protocols/package.yml
+++ b/packages/h/hyprland-protocols/package.yml
@@ -1,8 +1,8 @@
 name       : hyprland-protocols
-version    : 0.6.4
-release    : 5
+version    : 0.7.0
+release    : 6
 source     :
-    - https://github.com/hyprwm/hyprland-protocols/archive/refs/tags/v0.6.4.tar.gz : 0d4f99abc21b04fc126dd754e306bb84cd334131d542ff2e0c172190c6570384
+    - https://github.com/hyprwm/hyprland-protocols/archive/refs/tags/v0.7.0.tar.gz : ee419006d7cd20927b9b7c8b5fc430571c151b0385d600508de1a7957294498c
 homepage   : https://github.com/hyprwm/hyprland-protocols
 license    : BSD-3-Clause
 component  : desktop.hyprland

--- a/packages/h/hyprland-protocols/pspec_x86_64.xml
+++ b/packages/h/hyprland-protocols/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>hyprland-protocols</Name>
         <Homepage>https://github.com/hyprwm/hyprland-protocols</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Dariusz Mencel</Name>
+            <Email>dariusz.bajon@gmail.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>desktop.hyprland</PartOf>
@@ -23,6 +23,7 @@
             <Path fileType="data">/usr/share/hyprland-protocols/protocols/hyprland-ctm-control-v1.xml</Path>
             <Path fileType="data">/usr/share/hyprland-protocols/protocols/hyprland-focus-grab-v1.xml</Path>
             <Path fileType="data">/usr/share/hyprland-protocols/protocols/hyprland-global-shortcuts-v1.xml</Path>
+            <Path fileType="data">/usr/share/hyprland-protocols/protocols/hyprland-input-capture-v1.xml</Path>
             <Path fileType="data">/usr/share/hyprland-protocols/protocols/hyprland-lock-notify-v1.xml</Path>
             <Path fileType="data">/usr/share/hyprland-protocols/protocols/hyprland-surface-v1.xml</Path>
             <Path fileType="data">/usr/share/hyprland-protocols/protocols/hyprland-toplevel-export-v1.xml</Path>
@@ -36,19 +37,19 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="5">hyprland-protocols</Dependency>
+            <Dependency release="6">hyprland-protocols</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/pkgconfig/hyprland-protocols.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2025-04-05</Date>
-            <Version>0.6.4</Version>
+        <Update release="6">
+            <Date>2025-10-13</Date>
+            <Version>0.7.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Dariusz Mencel</Name>
+            <Email>dariusz.bajon@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
hyprland-protocols: Update to 0.7.0
New release with a new EIS protocol
Changes:
- added build instructions 
- Hyprland protocol expension for the Input Capture Desktop Portal

**Test Plan**
Ran hyprland session
<img width="1474" height="919" alt="image" src="https://github.com/user-attachments/assets/827b765a-0d60-4f74-a299-c2a0972a9002" />

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
