### PR TITLE
xsel: fix homepage link

### DIFF
--- a/packages/x/xsel/abi_used_symbols
+++ b/packages/x/xsel/abi_used_symbols
@@ -22,6 +22,7 @@ libX11.so.6:XStoreName
 libX11.so.6:XSync
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__longjmp_chk
 libc.so.6:__printf_chk
@@ -64,5 +65,4 @@ libc.so.6:strdup
 libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncpy
-libc.so.6:strtol
 libc.so.6:umask

--- a/packages/x/xsel/package.yml
+++ b/packages/x/xsel/package.yml
@@ -1,9 +1,9 @@
 name       : xsel
 version    : 1.2.1
-release    : 2
+release    : 3
 source     :
     - https://github.com/kfish/xsel/archive/refs/tags/1.2.1.tar.gz : 18487761f5ca626a036d65ef2db8ad9923bf61685e06e7533676c56d7d60eb14
-homepage   : http://www.kfish.org/software/xsel/ 
+homepage   : https://vergenet.net/~conrad/software/xsel/
 license    : MIT
 component  : xorg.apps
 summary    : Manipulate the X selection

--- a/packages/x/xsel/pspec_x86_64.xml
+++ b/packages/x/xsel/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>xsel</Name>
-        <Homepage>http://www.kfish.org/software/xsel/</Homepage>
+        <Homepage>https://vergenet.net/~conrad/software/xsel/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Dariusz Mencel</Name>
+            <Email>dariusz.bajon@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>xorg.apps</PartOf>
@@ -21,16 +21,16 @@
         <PartOf>xorg.apps</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/xsel</Path>
-            <Path fileType="man">/usr/share/man/man1/xsel.1x</Path>
+            <Path fileType="man">/usr/share/man/man1/xsel.1x.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-03-13</Date>
+        <Update release="3">
+            <Date>2025-10-13</Date>
             <Version>1.2.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Dariusz Mencel</Name>
+            <Email>dariusz.bajon@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Adjusted homepage for xsel with secure link - https as part of #5522

**Test Plan**
Run xsel from shell
<img width="1477" height="923" alt="image" src="https://github.com/user-attachments/assets/6e443b40-910c-4dcf-b1ab-ed61614ebcdc" />

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
