### PR TITLE
msmtp: Update to 1.8.32

### DIFF
--- a/packages/m/msmtp/package.yml
+++ b/packages/m/msmtp/package.yml
@@ -1,8 +1,8 @@
 name       : msmtp
-version    : 1.8.31
-release    : 13
+version    : 1.8.32
+release    : 14
 source     :
-    - https://marlam.de/msmtp/releases/msmtp-1.8.31.tar.xz : c262b11762d8582a3c6d6ca8d8b2cca2b1605497324ca27cc57fdc145a27119f
+    - https://marlam.de/msmtp/releases/msmtp-1.8.32.tar.xz : 20cd58b58dd007acf7b937fa1a1e21f3afb3e9ef5bbcfb8b4f5650deadc64db4
 homepage   : https://marlam.de/msmtp
 license    : GPL-3.0-or-later
 component  : network.clients

--- a/packages/m/msmtp/pspec_x86_64.xml
+++ b/packages/m/msmtp/pspec_x86_64.xml
@@ -40,9 +40,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2025-09-07</Date>
-            <Version>1.8.31</Version>
+        <Update release="14">
+            <Date>2025-10-14</Date>
+            <Version>1.8.32</Version>
             <Comment>Packaging update</Comment>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>


### PR DESCRIPTION
**Summary**

Improvements:

- Uses the SMTPUTF8 extension only when really necessary, to avoid problems further down the delivery line.

Full release notes:

- [News](https://marlam.de/msmtp/news/)

**Test Plan**

Installed locally and sent test email.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
