### PR TITLE
gstreamer-1.0: Fix dependencies for devel packages

### DIFF
--- a/packages/g/gstreamer-1.0/package.yml
+++ b/packages/g/gstreamer-1.0/package.yml
@@ -1,6 +1,6 @@
 name       : gstreamer-1.0
 version    : 1.26.6
-release    : 117
+release    : 118
 source     :
     - https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/1.26.6/gstreamer-1.26.6.tar.gz : 528842eeb64e181712feebe72318f4c986f481d72d16c84ad9bb0895df106338
 license    : LGPL-2.1-or-later
@@ -205,6 +205,14 @@ rundeps    :
     - ^gstreamer-1.0-plugins-bad-devel :
         - gstreamer-1.0-plugins-bad
         - gstreamer-1.0-plugins-bad-extras
+    - ^gstreamer-1.0-plugins-base-32bit-devel :
+        - gstreamer-1.0-plugins-base-32bit
+    - ^gstreamer-1.0-plugins-base-devel :
+        - gstreamer-1.0-plugins-base
+    - ^gstreamer-1.0-plugins-good-devel :
+        - gstreamer-1.0-plugins-good
+    - ^gstreamer-1.0-plugins-ugly-devel :
+        - gstreamer-1.0-plugins-ugly
     - ^gstreamer-editing-services :
         - python-gstreamer
     - ^gstreamer-editing-services-devel :

--- a/packages/g/gstreamer-1.0/pspec_x86_64.xml
+++ b/packages/g/gstreamer-1.0/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gstreamer-1.0</Name>
         <Homepage>https://gstreamer.freedesktop.org/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>multimedia.gstreamer</PartOf>
@@ -103,7 +103,7 @@
         <Description xml:lang="en">GStreamer is a streaming media framework that enables applications to share a common set of plugins for things like video encoding and decoding, audio encoding and decoding, audio and video filters, audio visualisation, web streaming and anything else that streams in real-time or otherwise. This package only provides base functionality and libraries. You may need at least gst-plugins-base and one of Good, Bad, Ugly or Libav plugins.</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0</Dependency>
+            <Dependency release="118">gstreamer-1.0</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/gstreamer-1.0/gstreamer-1.0/gst-completion-helper</Path>
@@ -130,8 +130,8 @@
         <Description xml:lang="en">GStreamer is a streaming media framework that enables applications to share a common set of plugins for things like video encoding and decoding, audio encoding and decoding, audio and video filters, audio visualisation, web streaming and anything else that streams in real-time or otherwise. This package only provides base functionality and libraries. You may need at least gst-plugins-base and one of Good, Bad, Ugly or Libav plugins.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0-32bit</Dependency>
-            <Dependency release="117">gstreamer-1.0-devel</Dependency>
+            <Dependency release="118">gstreamer-1.0-32bit</Dependency>
+            <Dependency release="118">gstreamer-1.0-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libgstbase-1.0.so</Path>
@@ -152,8 +152,8 @@
         <Description xml:lang="en">GStreamer FFmpeg/LibAV plugin</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0-plugins-base</Dependency>
-            <Dependency release="117">gstreamer-1.0</Dependency>
+            <Dependency release="118">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="118">gstreamer-1.0</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstlibav.so</Path>
@@ -168,8 +168,8 @@
         <Description xml:lang="en">GStreamer &quot;bad&quot; plugins OpenCV plugin</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0</Dependency>
-            <Dependency release="117">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="118">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="118">gstreamer-1.0</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstopencv.so</Path>
@@ -186,7 +186,7 @@
         <Description xml:lang="en">Development files for gstreamer-1.0-plugins-opencv</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="117">gstreamer-1.0-plugin-opencv</Dependency>
+            <Dependency releaseFrom="118">gstreamer-1.0-plugin-opencv</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gstreamer-1.0/gst/opencv/gstopencvutils.h</Path>
@@ -204,9 +204,9 @@
         <Description xml:lang="en">GStreamer streaming media framework &quot;bad&quot; plugins</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0</Dependency>
-            <Dependency release="117">gstreamer-1.0-plugins-base</Dependency>
-            <Dependency release="117">gstreamer-1.0-plugins-bad-libs</Dependency>
+            <Dependency release="118">gstreamer-1.0-plugins-bad-libs</Dependency>
+            <Dependency release="118">gstreamer-1.0</Dependency>
+            <Dependency release="118">gstreamer-1.0-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/gst-transcoder-1.0</Path>
@@ -408,11 +408,11 @@
         <Description xml:lang="en">Development files for gstreamer-1.0-plugins-bad</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0-devel</Dependency>
-            <Dependency release="117">gstreamer-1.0-plugins-base-devel</Dependency>
-            <Dependency release="117">gstreamer-1.0-plugins-bad-libs</Dependency>
-            <Dependency releaseFrom="117">gstreamer-1.0-plugins-bad</Dependency>
-            <Dependency releaseFrom="117">gstreamer-1.0-plugins-bad-extras</Dependency>
+            <Dependency release="118">gstreamer-1.0-plugins-base-devel</Dependency>
+            <Dependency release="118">gstreamer-1.0-devel</Dependency>
+            <Dependency release="118">gstreamer-1.0-plugins-bad-libs</Dependency>
+            <Dependency releaseFrom="118">gstreamer-1.0-plugins-bad</Dependency>
+            <Dependency releaseFrom="118">gstreamer-1.0-plugins-bad-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gstreamer-1.0/gst/analytics/analytics-meta-prelude.h</Path>
@@ -661,9 +661,9 @@
         <Description xml:lang="en">GStreamer streaming media framework &quot;bad&quot; plugins</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0-plugins-bad-libs</Dependency>
-            <Dependency release="117">gstreamer-1.0</Dependency>
-            <Dependency release="117">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="118">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="118">gstreamer-1.0-plugins-bad-libs</Dependency>
+            <Dependency release="118">gstreamer-1.0</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstaom.so</Path>
@@ -682,8 +682,8 @@
         <Description xml:lang="en">GStreamer streaming media framework &quot;bad&quot; plugins - libs</Description>
         <PartOf>programming.library</PartOf>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0</Dependency>
-            <Dependency release="117">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="118">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="118">gstreamer-1.0</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/girepository-1.0/CudaGst-1.0.typelib</Path>
@@ -756,7 +756,7 @@
         <Description xml:lang="en">GStreamer streaming media framework base plugins</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0</Dependency>
+            <Dependency release="118">gstreamer-1.0</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/gst-device-monitor-1.0</Path>
@@ -883,7 +883,7 @@
         <Description xml:lang="en">GStreamer is a streaming media framework that enables applications to share a common set of plugins for things like video encoding and decoding, audio encoding and decoding, audio and video filters, audio visualisation, web streaming and anything else that streams in real-time or otherwise. This package only provides base functionality and libraries. You may need at least gst-plugins-base and one of Good, Bad, Ugly or Libav plugins.</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0-32bit</Dependency>
+            <Dependency release="118">gstreamer-1.0-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/gstreamer-1.0/libgstadder.so</Path>
@@ -950,7 +950,8 @@
         <Description xml:lang="en">GStreamer is a streaming media framework that enables applications to share a common set of plugins for things like video encoding and decoding, audio encoding and decoding, audio and video filters, audio visualisation, web streaming and anything else that streams in real-time or otherwise. This package only provides base functionality and libraries. You may need at least gst-plugins-base and one of Good, Bad, Ugly or Libav plugins.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0-32bit-devel</Dependency>
+            <Dependency release="118">gstreamer-1.0-32bit-devel</Dependency>
+            <Dependency releaseFrom="118">gstreamer-1.0-plugins-base-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/gstreamer-1.0/include/gst/gl/gstglconfig.h</Path>
@@ -991,7 +992,8 @@
         <Description xml:lang="en">Development files for gstreamer-1.0-plugins-base</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0-devel</Dependency>
+            <Dependency release="118">gstreamer-1.0-devel</Dependency>
+            <Dependency releaseFrom="118">gstreamer-1.0-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gstreamer-1.0/gst/allocators/allocators-prelude.h</Path>
@@ -1246,8 +1248,8 @@
         <Description xml:lang="en">GStreamer streaming media framework &quot;good&quot; plugins</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0</Dependency>
-            <Dependency release="117">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="118">gstreamer-1.0</Dependency>
+            <Dependency release="118">gstreamer-1.0-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgst1394.so</Path>
@@ -1380,8 +1382,8 @@
         <Summary xml:lang="en">Streaming media framework</Summary>
         <Description xml:lang="en">GStreamer is a streaming media framework that enables applications to share a common set of plugins for things like video encoding and decoding, audio encoding and decoding, audio and video filters, audio visualisation, web streaming and anything else that streams in real-time or otherwise. This package only provides base functionality and libraries. You may need at least gst-plugins-base and one of Good, Bad, Ugly or Libav plugins.</Description>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0</Dependency>
-            <Dependency release="117">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="118">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="118">gstreamer-1.0</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgsta52dec.so</Path>
@@ -1447,9 +1449,9 @@
         <Description xml:lang="en">GStreamer editing services</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0-plugins-base</Dependency>
-            <Dependency release="117">gstreamer-1.0</Dependency>
-            <Dependency releaseFrom="117">python-gstreamer</Dependency>
+            <Dependency release="118">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="118">gstreamer-1.0</Dependency>
+            <Dependency releaseFrom="118">python-gstreamer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/ges-launch-1.0</Path>
@@ -1470,9 +1472,9 @@
         <Description xml:lang="en">Development files for gstreamer-editing-services</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0-devel</Dependency>
-            <Dependency release="117">gstreamer-1.0-plugins-base-devel</Dependency>
-            <Dependency releaseFrom="117">gstreamer-editing-services</Dependency>
+            <Dependency release="118">gstreamer-1.0-devel</Dependency>
+            <Dependency release="118">gstreamer-1.0-plugins-base-devel</Dependency>
+            <Dependency releaseFrom="118">gstreamer-editing-services</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gstreamer-1.0/ges/ges-asset.h</Path>
@@ -1552,8 +1554,8 @@
         <Description xml:lang="en">GStreamer&apos;s RTSP server (gst-rtsp-server) is a featureful and easy-to-use library that allows applications to implement a complete RTSP server with just a couple of lines of code.</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0-plugins-base</Dependency>
-            <Dependency release="117">gstreamer-1.0</Dependency>
+            <Dependency release="118">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="118">gstreamer-1.0</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/girepository-1.0/GstRtspServer-1.0.typelib</Path>
@@ -1570,11 +1572,11 @@
         <Description xml:lang="en">Development files for gstreamer-1.0-plugins-ugly</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0-plugins-base-devel</Dependency>
-            <Dependency release="117">gstreamer-1.0</Dependency>
-            <Dependency release="117">gstreamer-1.0-plugins-base</Dependency>
-            <Dependency release="117">gstreamer-rtsp-server</Dependency>
-            <Dependency release="117">gstreamer-1.0-devel</Dependency>
+            <Dependency release="118">gstreamer-1.0-plugins-base-devel</Dependency>
+            <Dependency release="118">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="118">gstreamer-1.0-devel</Dependency>
+            <Dependency release="118">gstreamer-rtsp-server</Dependency>
+            <Dependency release="118">gstreamer-1.0</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gstreamer-1.0/gst/rtsp-server/rtsp-address-pool.h</Path>
@@ -1617,9 +1619,9 @@
         <Description xml:lang="en">GStreamer VA API library</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0</Dependency>
-            <Dependency release="117">gstreamer-1.0-plugins-base</Dependency>
-            <Dependency release="117">gstreamer-1.0-plugins-bad-libs</Dependency>
+            <Dependency release="118">gstreamer-1.0</Dependency>
+            <Dependency release="118">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="118">gstreamer-1.0-plugins-bad-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstvaapi.so</Path>
@@ -1631,9 +1633,9 @@
         <Description xml:lang="en">GStreamer python overrides for the gobject-introspection-based pygst bindings.</Description>
         <PartOf>programming.python</PartOf>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0-plugins-bad-libs</Dependency>
-            <Dependency release="117">gstreamer-1.0</Dependency>
-            <Dependency releaseFrom="117">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="118">gstreamer-1.0-plugins-bad-libs</Dependency>
+            <Dependency release="118">gstreamer-1.0</Dependency>
+            <Dependency releaseFrom="118">gstreamer-1.0-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib/python3.12/site-packages/gi/overrides/Gst.py</Path>
@@ -1662,7 +1664,7 @@
         <Description xml:lang="en">GStreamer is a streaming media framework that enables applications to share a common set of plugins for things like video encoding and decoding, audio encoding and decoding, audio and video filters, audio visualisation, web streaming and anything else that streams in real-time or otherwise. This package only provides base functionality and libraries. You may need at least gst-plugins-base and one of Good, Bad, Ugly or Libav plugins.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="117">gstreamer-1.0</Dependency>
+            <Dependency release="118">gstreamer-1.0</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gstreamer-1.0/gst/base/base-prelude.h</Path>
@@ -1814,12 +1816,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="117">
-            <Date>2025-10-01</Date>
+        <Update release="118">
+            <Date>2025-10-16</Date>
             <Version>1.26.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Make sure that the `-devel` packages depend on the corresponding non-devel package.

**Test Plan**

Successfully rebuild VLC.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
