### PR TITLE
github-cli: Update to v2.82.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,8 +1,8 @@
 name       : github-cli
-version    : 2.81.0
-release    : 83
+version    : 2.82.0
+release    : 84
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.81.0.tar.gz : 11550fd0e06043f29d03fd973dd67cb77b2fee462a76084e0812c2099c6689dc
+    - https://github.com/cli/cli/archive/refs/tags/v2.82.0.tar.gz : c282c0bf2a2c694c99dd7d6da1ac13b3e87c1a511186ec66f0144d8b0ac94a49
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -238,9 +238,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="83">
-            <Date>2025-10-02</Date>
-            <Version>2.81.0</Version>
+        <Update release="84">
+            <Date>2025-10-16</Date>
+            <Version>2.82.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/cli/cli/releases/tag/v2.82.0).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `gh status`, `gh pr list`, and create this Pull Request.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
