### PR TITLE
brlaser: Update to v6.2.8

### DIFF
--- a/packages/b/brlaser/abi_used_symbols
+++ b/packages/b/brlaser/abi_used_symbols
@@ -32,7 +32,6 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_assignER
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createERmm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9push_backEc
 libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
-libstdc++.so.6:_ZSt17__throw_bad_allocv
 libstdc++.so.6:_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt21ios_base_library_initv

--- a/packages/b/brlaser/package.yml
+++ b/packages/b/brlaser/package.yml
@@ -1,8 +1,8 @@
 name       : brlaser
-version    : 6.2.7
-release    : 5
+version    : 6.2.8
+release    : 6
 source     :
-    - https://github.com/Owl-Maintain/brlaser/archive/refs/tags/v6.2.7.tar.gz : e67c5726fc1fe53574c2e8b5f72634f1359d0f53586a555eb2489fafd7c81640
+    - https://github.com/Owl-Maintain/brlaser/archive/refs/tags/v6.2.8.tar.gz : 16dae855aa7fff0eef0c05398fab37678243d7d610fa5f9af0d3a2cc9bf08cb0
 homepage   : https://github.com/Owl-Maintain/brlaser
 license    : GPL-2.0-or-later
 component  : drivers.printer

--- a/packages/b/brlaser/pspec_x86_64.xml
+++ b/packages/b/brlaser/pspec_x86_64.xml
@@ -25,9 +25,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2025-01-22</Date>
-            <Version>6.2.7</Version>
+        <Update release="6">
+            <Date>2025-10-15</Date>
+            <Version>6.2.8</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Added new printer models
- Implemented support for all 1200dpi modes
- Add toner density adjustment option
- Release notes [here](https://github.com/Owl-Maintain/brlaser/releases/tag/v6.2.8)

**Test Plan**

- Print a page on a brother printer

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
