### PR TITLE
cython: Remove rundep on python-devel

### DIFF
--- a/packages/c/cython/package.yml
+++ b/packages/c/cython/package.yml
@@ -1,6 +1,6 @@
 name       : cython
 version    : 3.1.2
-release    : 40
+release    : 41
 source     :
     - https://github.com/cython/cython/archive/refs/tags/3.1.2.tar.gz : da72f94262c8948e04784c3e6b2d14417643703af6b7bd27d6c96ae7f02835f1
 homepage   : https://cython.org/
@@ -20,7 +20,6 @@ checkdeps  :
     - python-coverage
     - python-jedi
 rundeps    :
-    - python-devel
     - python3-devel
 build      : |
     %python3_setup

--- a/packages/c/cython/pspec_x86_64.xml
+++ b/packages/c/cython/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>cython</Name>
         <Homepage>https://cython.org/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming</PartOf>
@@ -615,12 +615,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="40">
-            <Date>2025-06-14</Date>
+        <Update release="41">
+            <Date>2025-10-17</Date>
             <Version>3.1.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
This removes a runtime dependency on python 2, which is slated for removal from the repo in the very near future.

**Test Plan**
- Built and installed `cython`  from this PR.
- Tried `cython eopkgBackend.py` (first random .py file I could find). 
- Observed that cython emitted a file `eopkgBackend.c` and returned no errors. 
- No idea how to actually use cython, but it didn't log an error.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
