### PR TITLE
python-maturin: Update to v1.9.6

### DIFF
--- a/packages/py/python-maturin/package.yml
+++ b/packages/py/python-maturin/package.yml
@@ -1,8 +1,8 @@
 name       : python-maturin
-version    : 1.9.4
-release    : 63
+version    : 1.9.6
+release    : 64
 source     :
-    - https://github.com/PyO3/maturin/archive/refs/tags/v1.9.4.tar.gz : c052ec18498b6dafc727696610a4df49afac54fee29f8020857e301ce2c5f5e0
+    - https://github.com/PyO3/maturin/archive/refs/tags/v1.9.6.tar.gz : c8aef8af6cd3d5b3331191b21191ec92d7b4ee0633e0799351a01af1c5ea2a6c
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-maturin/pspec_x86_64.xml
+++ b/packages/py/python-maturin/pspec_x86_64.xml
@@ -22,12 +22,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/maturin</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.4.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.4.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.4.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.4.dist-info/licenses/license-apache</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.4.dist-info/licenses/license-mit</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.4.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.6.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.6.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.6.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.6.dist-info/licenses/license-apache</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.6.dist-info/licenses/license-mit</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.6.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -40,9 +40,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="63">
-            <Date>2025-09-07</Date>
-            <Version>1.9.4</Version>
+        <Update release="64">
+            <Date>2025-10-17</Date>
+            <Version>1.9.6</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Trim platform details on Windows detection
- Make PythonInterpreter::check_executable aware of windows arch
- search_lib_dir: Only recurse into build* if it is a directory
- Add freebsd 14.2 amd64 sysconfig
- Only select Windows Python interpreters with matching CPU pointer widths and architectures

**Test Plan**

Successfully built `python-orjson`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
