### PR TITLE
ripgrep: Update to v15.0.0

### DIFF
--- a/packages/r/ripgrep/abi_used_symbols
+++ b/packages/r/ripgrep/abi_used_symbols
@@ -7,6 +7,7 @@ libc.so.6:abort
 libc.so.6:bcmp
 libc.so.6:calloc
 libc.so.6:chdir
+libc.so.6:chroot
 libc.so.6:clock_gettime
 libc.so.6:close
 libc.so.6:closedir

--- a/packages/r/ripgrep/package.yml
+++ b/packages/r/ripgrep/package.yml
@@ -1,8 +1,8 @@
 name       : ripgrep
-version    : 14.1.1
-release    : 18
+version    : 15.0.0
+release    : 19
 source     :
-    - https://github.com/BurntSushi/ripgrep/archive/refs/tags/14.1.1.tar.gz : 4dad02a2f9c8c3c8d89434e47337aa654cb0e2aa50e806589132f186bf5c2b66
+    - https://github.com/BurntSushi/ripgrep/archive/refs/tags/15.0.0.tar.gz : e6b2d35ff79c3327edc0c92a29dc4bb74e82d8ee4b8156fb98e767678716be7a
 homepage   : https://github.com/BurntSushi/ripgrep
 license    : MIT
 component  : programming.tools

--- a/packages/r/ripgrep/pspec_x86_64.xml
+++ b/packages/r/ripgrep/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ripgrep</Name>
         <Homepage>https://github.com/BurntSushi/ripgrep</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.tools</PartOf>
@@ -23,17 +23,17 @@
             <Path fileType="executable">/usr/bin/rg</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/rg</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/rg.fish</Path>
-            <Path fileType="man">/usr/share/man/man1/rg.1</Path>
+            <Path fileType="man">/usr/share/man/man1/rg.1.zst</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_rg</Path>
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2024-11-06</Date>
-            <Version>14.1.1</Version>
+        <Update release="19">
+            <Date>2025-10-18</Date>
+            <Version>15.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://github.com/BurntSushi/ripgrep/releases/tag/15.0.0)

**Test Plan**

- Run some searches on the package repo

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
