### PR TITLE
dotnet-cli: deprecate

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -2935,6 +2935,7 @@
 		<Package>openssl-11-dbginfo</Package>
 		<Package>openssl-11-devel</Package>
 		<Package>python-d2to1</Package>
+		<Package>dotnet-cli</Package>
 		<Package>python-setuptools-scm-git-archive</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -3996,6 +3996,9 @@
 		<!-- Dead upstream -->
 		<Package>python-d2to1</Package>
 
+		<!-- Intermediary package, no longer needed -->
+		<Package>dotnet-cli</Package>
+
 		<!-- Declared upstream, This plugin is obsolete -->
 		<Package>python-setuptools-scm-git-archive</Package>
 


### PR DESCRIPTION
This package was part of the build to split dotnet to its component packages, and is no longer needed.