### PR TITLE
usysconf-epoch: Improve timeout behaviour

### DIFF
--- a/packages/u/usysconf-epoch/files/epoch.service
+++ b/packages/u/usysconf-epoch/files/epoch.service
@@ -9,7 +9,7 @@ ExecStart=/usr/lib64/usysconf/epoch.sh
 Type=notify
 
 RemainAfterExit=yes
-TimeoutStartSec=60s
+TimeoutStartSec=15 min
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/u/usysconf-epoch/package.yml
+++ b/packages/u/usysconf-epoch/package.yml
@@ -1,6 +1,6 @@
 name       : usysconf-epoch
 version    : 1.0.0
-release    : 21
+release    : 22
 source     :
     # We need something for a source
     - https://getsol.us/sources/hotspot.txt : a12b7cb43c9d9134b5bb1b35e9096b66775d9e92e7611d1cc92b02edd6782a87

--- a/packages/u/usysconf-epoch/pspec_x86_64.xml
+++ b/packages/u/usysconf-epoch/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>usysconf-epoch</Name>
         <Homepage>https://github.com/getsolus/usysconf/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>system.base</PartOf>
@@ -29,12 +29,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2025-10-10</Date>
+        <Update release="22">
+            <Date>2025-10-19</Date>
             <Version>1.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Improve how the epoch transition service deals with timeouts or slow network connections by:

- Waiting for a network connection.
- Increasing the startup timeout to 15 minutes.

Additionally, quiet a warning about `$NOTIFY_SOCKET` when running the script directly.

**Test Plan**

- Break networking.
- (Re)start `epoch.service`
- Fix networking.
- See that `epoch.service` has completed successfully.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
