### PR TITLE
exercism-cli: Update to v3.5.8

### DIFF
--- a/packages/e/exercism-cli/package.yml
+++ b/packages/e/exercism-cli/package.yml
@@ -1,8 +1,8 @@
 name       : exercism-cli
-version    : 3.5.7
-release    : 13
+version    : 3.5.8
+release    : 14
 source     :
-    - https://github.com/exercism/cli/archive/refs/tags/v3.5.7.tar.gz : dc8f06d9390a8ff11b24b251644287453e73f0f71eb4277f8fb53dca1825140a
+    - https://github.com/exercism/cli/archive/refs/tags/v3.5.8.tar.gz : 386cee0117c42a0ead45b6f636f96c2fc20cc5f64f802fcda93c7a0778330f3c
 homepage   : https://exercism.org/
 license    : MIT
 component  : programming

--- a/packages/e/exercism-cli/pspec_x86_64.xml
+++ b/packages/e/exercism-cli/pspec_x86_64.xml
@@ -24,9 +24,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2025-07-18</Date>
-            <Version>3.5.7</Version>
+        <Update release="14">
+            <Date>2025-10-19</Date>
+            <Version>3.5.8</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://github.com/exercism/cli/releases/tag/v3.5.8)

**Test Plan**

- Download and exercise

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
