### PR TITLE
ghc: fix build errors with gcc 15

### DIFF
--- a/packages/g/ghc/abi_used_symbols
+++ b/packages/g/ghc/abi_used_symbols
@@ -269,7 +269,6 @@ libc.so.6:strncpy
 libc.so.6:strnlen
 libc.so.6:strrchr
 libc.so.6:strtod
-libc.so.6:strtol
 libc.so.6:symlink
 libc.so.6:syscall
 libc.so.6:sysconf

--- a/packages/g/ghc/files/0001-fix-gcc15-c23-error.patch
+++ b/packages/g/ghc/files/0001-fix-gcc15-c23-error.patch
@@ -1,0 +1,100 @@
+From f983a00ffc97b779eb52b10e69e254ec107f8311 Mon Sep 17 00:00:00 2001
+From: Jens Petersen <juhpetersen@gmail.com>
+Date: Tue, 21 Jan 2025 13:04:52 +0000
+Subject: [PATCH] hp2ps/Utilities.c: add extern parameter types for malloc and
+ realloc for C23
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fix build with gcc-15 which defaults to C23 standard (-std=gnu23)
+Fixes #25662
+```
+utils/hp2ps/Utilities.c:6:14: error:
+     warning: conflicting types for built-in function ‘malloc’; expected ‘void *(long unsigned int)’ [-Wbuiltin-declaration-mismatch]
+        6 | extern void* malloc();
+          |              ^~~~~~
+  |
+6 | extern void* malloc();
+  |              ^
+utils/hp2ps/Utilities.c:5:1: error:
+     note: ‘malloc’ is declared in header ‘<stdlib.h>’
+        4 | #include "Error.h"
+      +++ |+#include <stdlib.h>
+        5 |
+  |
+5 |
+  | ^
+utils/hp2ps/Utilities.c: In function ‘xmalloc’:
+utils/hp2ps/Utilities.c:80:17: error:
+     error: too many arguments to function ‘malloc’; expected 0, have 1
+       80 |     r = (void*) malloc(n);
+          |                 ^~~~~~ ~
+   |
+80 |     r = (void*) malloc(n);
+   |                 ^
+utils/hp2ps/Utilities.c:6:14: error:
+     note: declared here
+        6 | extern void* malloc();
+          |              ^~~~~~
+  |
+6 | extern void* malloc();
+  |              ^
+utils/hp2ps/Utilities.c: In function ‘xrealloc’:
+utils/hp2ps/Utilities.c:92:18: error:
+     warning: conflicting types for built-in function ‘realloc’; expected ‘void *(void *, long unsigned int)’ [-Wbuiltin-declaration-mismatch]
+       92 |     extern void *realloc();
+          |                  ^~~~~~~
+   |
+92 |     extern void *realloc();
+   |                  ^
+utils/hp2ps/Utilities.c:92:18: error:
+     note: ‘realloc’ is declared in header ‘<stdlib.h>’
+   |
+92 |     extern void *realloc();
+   |                  ^
+utils/hp2ps/Utilities.c:94:9: error:
+     error: too many arguments to function ‘realloc’; expected 0, have 2
+       94 |     r = realloc(p, n);
+          |         ^~~~~~~ ~
+   |
+94 |     r = realloc(p, n);
+   |         ^
+utils/hp2ps/Utilities.c:92:18: error:
+     note: declared here
+       92 |     extern void *realloc();
+          |                  ^~~~~~~
+   |
+92 |     extern void *realloc();
+   |                  ^
+```
+---
+ utils/hp2ps/Utilities.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/utils/hp2ps/Utilities.c b/utils/hp2ps/Utilities.c
+index 5139144d5357..c26d75423e9e 100644
+--- a/utils/hp2ps/Utilities.c
++++ b/utils/hp2ps/Utilities.c
+@@ -3,7 +3,7 @@
+ #include <string.h>
+ #include "Error.h"
+ 
+-extern void* malloc();
++extern void* malloc(long unsigned int);
+ 
+ char*
+ Basename(char *name)
+@@ -89,7 +89,7 @@ void *
+ xrealloc(void *p, size_t n)
+ {
+     void *r;
+-    extern void *realloc();
++    extern void *realloc(void *, long unsigned int);
+ 
+     r = realloc(p, n);
+     if (!r) {
+-- 
+GitLab
+
+

--- a/packages/g/ghc/package.yml
+++ b/packages/g/ghc/package.yml
@@ -1,6 +1,6 @@
 name       : ghc
 version    : 9.4.8
-release    : 13
+release    : 14
 source     :
     - https://downloads.haskell.org/~ghc/9.4.8/ghc-9.4.8-src.tar.xz : 0bf407eb67fe3e3c24b0f4c8dea8cb63e07f63ca0f76cf2058565143507ab85e
     - https://downloads.haskell.org/~ghc/9.4.8/ghc-9.4.8-testsuite.tar.xz : ac45dd44b097707a2717058ab2cfff22777ec0f31bfa3f54bf60e18b2dd63c95
@@ -26,6 +26,8 @@ environment: |
     }
 setup      : |
     tar xvf $sources/ghc-$version-testsuite.tar.xz  --strip 1
+
+    %patch -p1 -i $pkgfiles/0001-fix-gcc15-c23-error.patch
 
     cabal v2-update
 

--- a/packages/g/ghc/pspec_x86_64.xml
+++ b/packages/g/ghc/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ghc</Name>
         <Homepage>https://www.haskell.org/ghc/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Ivan Trepakov</Name>
+            <Email>liontiger23@gmail.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.haskell</PartOf>
@@ -5183,12 +5183,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2024-12-13</Date>
+        <Update release="14">
+            <Date>2025-10-19</Date>
             <Version>9.4.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Ivan Trepakov</Name>
+            <Email>liontiger23@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Backport [bugfix](https://gitlab.haskell.org/ghc/ghc/-/issues/25662) for building with gcc 15

**Test Plan**

Build `pandoc` and `pandoc-crossref` and verify that it works as expected.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
