### PR TITLE
pandoc-crossref: Add runtime dependency on pandoc

### DIFF
--- a/packages/p/pandoc-crossref/package.yml
+++ b/packages/p/pandoc-crossref/package.yml
@@ -1,6 +1,6 @@
 name       : pandoc-crossref
 version    : 0.3.20
-release    : 6
+release    : 7
 source     :
     - https://github.com/lierdakil/pandoc-crossref/archive/refs/tags/v0.3.20.tar.gz : 935d66e4b52323aba625b2bfa90abfea774816ccf4feb959e8271beac6d9b453
 homepage   : https://lierdakil.github.io/pandoc-crossref/
@@ -12,6 +12,8 @@ description: |
 builddeps  :
     - ghc
     - haskell-cabal-install
+rundeps    :
+    - pandoc
 networking : true
 setup      : |
     rm $workdir/cabal.project.freeze

--- a/packages/p/pandoc-crossref/pspec_x86_64.xml
+++ b/packages/p/pandoc-crossref/pspec_x86_64.xml
@@ -25,8 +25,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2025-10-18</Date>
+        <Update release="7">
+            <Date>2025-10-20</Date>
             <Version>0.3.20</Version>
             <Comment>Packaging update</Comment>
             <Name>Ivan Trepakov</Name>


### PR DESCRIPTION
**Summary**

When updating `pandoc` or `pandoc-crossref` we must ensure that
`pandoc-crossref` is built against the same version of `pandoc`
despite not directly using it as build dependency.
Otherwise, if versions are mismatched `pandoc-crossref` will report a warning:
```
WARNING: pandoc-crossref was compiled with pandoc 3.7.0.2 but is being run through 3.6.3.
This is not supported. Strange things may (and likely will) happen silently.
```

So since `pandoc-crossref` is meant to be used only with fixed version
of `pandoc` from repos, it makes sense to add runtime dependency between
them.

**Test Plan**

- Build pandoc-crossref [demo](https://github.com/lierdakil/pandoc-crossref/tree/v0.3.20/docs/demo) with `make`
- Check that all references resolve correctly

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
