### PR TITLE
eopkg: Update to v4.3.4

### DIFF
--- a/packages/e/eopkg/package.yml
+++ b/packages/e/eopkg/package.yml
@@ -1,8 +1,8 @@
 name       : eopkg
-version    : 4.3.3
-release    : 31
+version    : 4.3.4
+release    : 32
 source     :
-    - https://github.com/getsolus/eopkg/archive/refs/tags/v4.3.3.tar.gz : 4e682b58b1465d169a5d4746e5a95b5aa28adea5074cf0e4d56035d5ec10360f
+    - https://github.com/getsolus/eopkg/archive/refs/tags/v4.3.4.tar.gz : 7a7d8565dec51a70e40921316e3f11f1a4a38331bf21750b0c7b89fa414200e4
     - git|https://github.com/getsolus/PackageKit.git : 9b0f17c1ba6addc1c85bff34b64efad6a905ca50
 homepage   : https://github.com/getsolus/eopkg
 license    : GPL-2.0-or-later

--- a/packages/e/eopkg/pspec_x86_64.xml
+++ b/packages/e/eopkg/pspec_x86_64.xml
@@ -49,12 +49,12 @@
             <Path fileType="executable">/usr/bin/eopkg.py3</Path>
             <Path fileType="executable">/usr/bin/lseopkg.py3</Path>
             <Path fileType="executable">/usr/bin/uneopkg.py3</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.3.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.3.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.3.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.3.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.3.dist-info/licenses/AUTHORS</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.3.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.4.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.4.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.4.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.4.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.4.dist-info/licenses/AUTHORS</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.3.4.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pisi/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pisi/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pisi/__pycache__/__init__.cpython-312.pyc</Path>
@@ -463,9 +463,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2025-10-08</Date>
-            <Version>4.3.3</Version>
+        <Update release="32">
+            <Date>2025-10-20</Date>
+            <Version>4.3.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Hans K</Name>
             <Email>hans@communitycomputing.net</Email>


### PR DESCRIPTION
**Summary**
Release notes can be found [here](https://github.com/getsolus/eopkg/releases/tag/v4.3.4)

**Test Plan**
- Build and install `eopkg` from this PR.
- Make sure it still works.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
