### PR TITLE
i3status: Update to v2.15

### DIFF
--- a/packages/i/i3status/MAINTAINERS.md
+++ b/packages/i/i3status/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Ivan Trepakov
+  - Matrix: @liontiger23:matrix.org
+  - Email: liontiger23@gmail.com

--- a/packages/i/i3status/abi_used_symbols
+++ b/packages/i/i3status/abi_used_symbols
@@ -74,6 +74,7 @@ libc.so.6:gettimeofday
 libc.so.6:glob64
 libc.so.6:globfree64
 libc.so.6:if_nametoindex
+libc.so.6:inet_ntop
 libc.so.6:ioctl
 libc.so.6:isatty
 libc.so.6:kill

--- a/packages/i/i3status/package.yml
+++ b/packages/i/i3status/package.yml
@@ -1,8 +1,8 @@
 name       : i3status
-version    : '2.14'
-release    : 15
+version    : '2.15'
+release    : 16
 source     :
-    - https://i3wm.org/i3status/i3status-2.14.tar.xz : 5c4d0273410f9fa3301fd32065deda32e9617fcae8b3cb34793061bf21644924
+    - https://i3wm.org/i3status/i3status-2.15.tar.xz : 6c67f52cae4f139df764ad1cc736562be0f97750791bc212b53f34c06eaf2205
 homepage   : https://i3wm.org/i3status/
 license    : MIT
 component  : desktop.i3

--- a/packages/i/i3status/pspec_x86_64.xml
+++ b/packages/i/i3status/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>i3status</Name>
         <Homepage>https://i3wm.org/i3status/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Ivan Trepakov</Name>
+            <Email>liontiger23@gmail.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>desktop.i3</PartOf>
@@ -22,16 +22,16 @@
         <Files>
             <Path fileType="config">/etc/i3status.conf</Path>
             <Path fileType="executable">/usr/bin/i3status</Path>
-            <Path fileType="man">/usr/share/man/man1/i3status.1</Path>
+            <Path fileType="man">/usr/share/man/man1/i3status.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2024-04-21</Date>
-            <Version>2.14</Version>
+        <Update release="16">
+            <Date>2025-10-22</Date>
+            <Version>2.15</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Ivan Trepakov</Name>
+            <Email>liontiger23@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changelog:

- man: document --run-once flag
- meson: replace bashisms
- update to clang-format-12
- add missing newlines to some error messages
- make maybe_escape_markup() memory-safe
- fix segfault when read_file lacks a path
- ethernet: printer faster speeds in Gbit/s, e.g. 2.5 Gbit/s
- wireless: correctly display bitrates > 2147483647 bps
- ipv6: add support for %iface placeholder
- battery: add status idle (e.g. configured to stop charging)
- battery: increase maximum string size to make space for markup
- *BSD: fix build, use statvfs
- *BSD: use f_bsize for disk_info
- OpenBSD: add CPU spin support
- OpenBSD: properly print wireless signal strength

**Test Plan**

Use `i3status` as status bar in i3 and verify that it shows valid information.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
