### PR TITLE
svtplay-dl: Update to v4.149

### DIFF
--- a/packages/s/svtplay-dl/package.yml
+++ b/packages/s/svtplay-dl/package.yml
@@ -1,8 +1,8 @@
 name       : svtplay-dl
-version    : '4.137'
-release    : 33
+version    : '4.149'
+release    : 34
 source     :
-    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.137.tar.gz : 2f3c027202e4e1f3705064365c6c0a7499fc137b1c3760612a0065da8cd17a48
+    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.149.tar.gz : 153916e9546f48b1ee2baf7481c0e176ea329923b74f7e2380d83d230f09f69f
 homepage   : https://svtplay-dl.se/
 license    : MIT
 component  : network.download

--- a/packages/s/svtplay-dl/pspec_x86_64.xml
+++ b/packages/s/svtplay-dl/pspec_x86_64.xml
@@ -21,12 +21,12 @@
         <PartOf>network.download</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/svtplay-dl</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.137.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.137.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.137.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.137.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.137.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.137.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.149.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.149.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.149.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.149.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.149.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.149.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -243,9 +243,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2025-09-13</Date>
-            <Version>4.137</Version>
+        <Update release="34">
+            <Date>2025-10-23</Date>
+            <Version>4.149</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
- output: format the filename here for everyone
- svtplay: dont format name here
- urplay: fix series page download and filenames
- Urplay: Update JSON parsing to match new format and add more nfo
- svtplay: skip dash-hbbtv format because they seems to not have average bitrate tag
- fetcher.dash: add support for average bitrate

**Test Plan**
- Downloaded a video.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
