### PR TITLE
qutebrowser: Update to v3.6.0

### DIFF
--- a/packages/q/qutebrowser/MAINTAINERS.md
+++ b/packages/q/qutebrowser/MAINTAINERS.md
@@ -1,4 +1,0 @@
-This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
-
-- Jakob Gezelius 
-  - Email: jakob@knugen.nu 

--- a/packages/q/qutebrowser/package.yml
+++ b/packages/q/qutebrowser/package.yml
@@ -1,8 +1,8 @@
 name       : qutebrowser
-version    : 3.5.1
-release    : 51
+version    : 3.6.0
+release    : 52
 source     :
-    - https://github.com/qutebrowser/qutebrowser/releases/download/v3.5.1/qutebrowser-3.5.1.tar.gz : 826bba328a08357248d5e5a86faab0a73655497439ad54d269e212055926b38e
+    - https://github.com/qutebrowser/qutebrowser/releases/download/v3.6.0/qutebrowser-3.6.0.tar.gz : 5c1b518c0881bd2311170756d5164ad99427c708737637cae4ee9266b1d467bc
 homepage   : https://qutebrowser.org
 license    : GPL-3.0-or-later
 component  : network.web.browser

--- a/packages/q/qutebrowser/pspec_x86_64.xml
+++ b/packages/q/qutebrowser/pspec_x86_64.xml
@@ -21,13 +21,13 @@
         <PartOf>network.web.browser</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/qutebrowser</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.1-py3.12.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.1-py3.12.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.1-py3.12.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.1-py3.12.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.1-py3.12.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.1-py3.12.egg-info/top_level.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.5.1-py3.12.egg-info/zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.0-py3.12.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.0-py3.12.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.0-py3.12.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.0-py3.12.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.0-py3.12.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.0-py3.12.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.0-py3.12.egg-info/zip-safe</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -581,6 +581,8 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/misc/__pycache__/throttle.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/misc/__pycache__/utilcmds.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/misc/__pycache__/utilcmds.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/misc/__pycache__/wmname.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/misc/__pycache__/wmname.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/misc/autoupdate.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/misc/backendproblem.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/misc/binparsing.py</Path>
@@ -611,6 +613,7 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/misc/sql.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/misc/throttle.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/misc/utilcmds.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/misc/wmname.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/qt/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/qt/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/qt/__pycache__/__init__.cpython-312.pyc</Path>
@@ -731,7 +734,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/512x512/apps/qutebrowser.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/qutebrowser.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/qutebrowser.svg</Path>
-            <Path fileType="man">/usr/share/man/man1/qutebrowser.1</Path>
+            <Path fileType="man">/usr/share/man/man1/qutebrowser.1.zst</Path>
             <Path fileType="data">/usr/share/metainfo/org.qutebrowser.qutebrowser.appdata.xml</Path>
             <Path fileType="data">/usr/share/qutebrowser/scripts/cycle-inputs.js</Path>
             <Path fileType="data">/usr/share/qutebrowser/scripts/dictcli.py</Path>
@@ -772,9 +775,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="51">
-            <Date>2025-06-05</Date>
-            <Version>3.5.1</Version>
+        <Update release="52">
+            <Date>2025-10-24</Date>
+            <Version>3.6.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/qutebrowser/qutebrowser/blob/main/doc/changelog.asciidoc#v360-2025-10-24).

**Test Plan**
- Surfed the web.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
