### PR TITLE
gnome-desktop-branding: Swap Software Center for GNOME Software

### DIFF
--- a/packages/g/gnome-desktop-branding/files/0001-schemas-Swap-solus-sc-for-GNOME-Software.patch
+++ b/packages/g/gnome-desktop-branding/files/0001-schemas-Swap-solus-sc-for-GNOME-Software.patch
@@ -1,0 +1,19 @@
+From 4876001d32e660cc7c6f3d5c09f94074a7270092 Mon Sep 17 00:00:00 2001
+From: Evan Maddock <maddock.evan@vivaldi.net>
+Date: Fri, 19 Sep 2025 21:00:32 -0400
+Subject: [PATCH] schemas: Swap solus-sc for GNOME Software
+
+Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
+---
+ schemas/org.gnome.shell.gschema.override | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/schemas/org.gnome.shell.gschema.override b/schemas/org.gnome.shell.gschema.override
+index b9cbcfe..4b77ab5 100644
+--- a/schemas/org.gnome.shell.gschema.override
++++ b/schemas/org.gnome.shell.gschema.override
+@@ -1,3 +1,3 @@
+ [org.gnome.shell]
+ enabled-extensions=['user-theme@gnome-shell-extensions.gcampax.github.com', 'appindicatorsupport@rgcjonas.gmail.com', 'drive-menu@gnome-shell-extensions.gcampax.github.com', 'speedinator@liam.moe']
+-favorite-apps=['solus-sc.desktop','org.gnome.Nautilus.desktop','firefox.desktop','io.github.celluloid_player.Celluloid.desktop','org.gnome.Rhythmbox3.desktop']
++favorite-apps=['org.gnome.Software.desktop','org.gnome.Nautilus.desktop','firefox.desktop','io.github.celluloid_player.Celluloid.desktop','org.gnome.Rhythmbox3.desktop']

--- a/packages/g/gnome-desktop-branding/package.yml
+++ b/packages/g/gnome-desktop-branding/package.yml
@@ -1,6 +1,6 @@
 name       : gnome-desktop-branding
 version    : '19'
-release    : 57
+release    : 58
 source     :
     - git|https://github.com/getsolus/gnome-desktop-branding.git : 1c99fc38c128017ed5e80396d73e1bfdd3c5e964
 homepage   : https://github.com/getsolus/gnome-desktop-branding
@@ -47,6 +47,7 @@ rundeps    :
     - livecd :
         - gnome-desktop-branding
 setup      : |
+    %patch -p1 -i $pkgfiles/0001-schemas-Swap-solus-sc-for-GNOME-Software.patch
     %meson_configure
 build      : |
     %ninja_build

--- a/packages/g/gnome-desktop-branding/pspec_x86_64.xml
+++ b/packages/g/gnome-desktop-branding/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-desktop-branding</Name>
         <Homepage>https://github.com/getsolus/gnome-desktop-branding</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>desktop.gnome</PartOf>
@@ -36,19 +36,19 @@
         <Description xml:lang="en">Solus 4.0 LiveCD configuration.</Description>
         <PartOf>desktop.gnome</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="57">gnome-desktop-branding</Dependency>
+            <Dependency releaseFrom="58">gnome-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/glib-2.0/schemas/50_gnome_livecd.gschema.override</Path>
         </Files>
     </Package>
     <History>
-        <Update release="57">
-            <Date>2025-06-08</Date>
+        <Update release="58">
+            <Date>2025-10-24</Date>
             <Version>19</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Swap the Solus Software Center pin for GNOME Software

**Do not merge until after epoch!**

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install the package on a GNOME system on Polaris, and relog.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
