### PR TITLE
usysconf-epoch: Enable transition by default

### DIFF
--- a/packages/u/usysconf-epoch/files/epoch.sh
+++ b/packages/u/usysconf-epoch/files/epoch.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 shopt -s nullglob
 
-EPOCH_ENABLE="${EPOCH_ENABLE:=no}"
+EPOCH_ENABLE="${EPOCH_ENABLE:=yes}"
 
 STATE_DIR="${STATE_DIR:=/var/solus/usr-merge}"
 MERGE_FLAG_FILE="${MERGE_FLAG_FILE:=${STATE_DIR}/merge-complete}"

--- a/packages/u/usysconf-epoch/package.yml
+++ b/packages/u/usysconf-epoch/package.yml
@@ -1,6 +1,6 @@
 name       : usysconf-epoch
 version    : 1.0.0
-release    : 23
+release    : 24
 source     :
     # We need something for a source
     - https://getsol.us/sources/hotspot.txt : a12b7cb43c9d9134b5bb1b35e9096b66775d9e92e7611d1cc92b02edd6782a87

--- a/packages/u/usysconf-epoch/pspec_x86_64.xml
+++ b/packages/u/usysconf-epoch/pspec_x86_64.xml
@@ -29,7 +29,7 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
+        <Update release="24">
             <Date>2025-10-24</Date>
             <Version>1.0.0</Version>
             <Comment>Packaging update</Comment>


### PR DESCRIPTION
**Summary**

Enable the epoch transition by default. This should make all users transition to the new epoch after the next reboot.

**Test Plan**

- Make sure your installation is unepoched. For example:
  ```
  sudo eopkg install solus-sc
  sudo eopkg add-repo Stable https://cdn.getsol.us/repo/shannon/eopkg-index.xml.xz
  sudo rm -f /etc/sysconfig/epoch
  ```
- Install package.
- Reboot or run `sudo systemctl restart epoch`.
- Wait for notification that you are transitioned.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
