### PR TITLE
ncdu: Update to v2.9.2

### DIFF
--- a/packages/n/ncdu/package.yml
+++ b/packages/n/ncdu/package.yml
@@ -1,8 +1,8 @@
 name       : ncdu
-version    : 2.9.1
-release    : 25
+version    : 2.9.2
+release    : 26
 source     :
-    - https://dev.yorhel.nl/download/ncdu-2.9.1.tar.gz : bfd1094e1400ee89cfd59200eab940f025ccdc0c238067105c984a3c4857bf7e
+    - https://dev.yorhel.nl/download/ncdu-2.9.2.tar.gz : e91135281cb66569f2ca4c0bac277246991e7e52524c0ca8cba3de5c8e81cec9
 homepage   : https://dev.yorhel.nl/ncdu
 license    : MIT
 component  : system.utils

--- a/packages/n/ncdu/pspec_x86_64.xml
+++ b/packages/n/ncdu/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ncdu</Name>
         <Homepage>https://dev.yorhel.nl/ncdu</Homepage>
         <Packager>
-            <Name>Marcus Mellor</Name>
-            <Email>infinitymdm@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -25,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="25">
-            <Date>2025-09-22</Date>
-            <Version>2.9.1</Version>
+        <Update release="26">
+            <Date>2025-10-24</Date>
+            <Version>2.9.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Marcus Mellor</Name>
-            <Email>infinitymdm@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Still requires Zig 0.14 or 0.15
- Fix hang on loading config file when compiled with Zig 0.15.2

**Test Plan**

- Look at a directory

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
