### PR TITLE
python3: Symlink binaries without the 3 suffix

### DIFF
--- a/packages/py/python3/package.yml
+++ b/packages/py/python3/package.yml
@@ -1,6 +1,6 @@
 name       : python3
 version    : 3.12.11
-release    : 76
+release    : 77
 source     :
     - https://www.python.org/ftp/python/3.12.11/Python-3.12.11.tar.xz : c30bb24b7f1e9a19b11b55a546434f74e739bb4c271a3e3a80ff4380d49f7adb
 homepage   : https://www.python.org/
@@ -42,6 +42,9 @@ patterns   :
         - /usr/lib/python3.*/test
     - tkinter :
         - /usr/lib64/python3.*/lib-dynload/_tkinter.cpython-3*-x86_64-linux-gnu.so*
+environment: |
+    # stolen from Arch's PKGBUILD
+    export _pybasever=${version%.*}
 setup      : |
     %patch -p1 -i $pkgfiles/Try-to-load-so.avx2-libs-first-if-they-exist-and-cpu.patch
 
@@ -62,7 +65,12 @@ install    : |
     %make_install
 
     install -Dm00644 Tools/gdb/libpython.py $installdir/usr/share/gdb/auto-load/usr/lib64/libpython3.12.so.1.0-gdb.py
-    rm $installdir/usr/bin/2to3
 
     # Unneeded on Linux
     find "$installdir" -name '*.exe' -print -delete
+
+    ln -s python3               $installdir/usr/bin/python
+    ln -s python3-config        $installdir/usr/bin/python-config
+    ln -s idle3                 $installdir/usr/bin/idle
+    ln -s pydoc3                $installdir/usr/bin/pydoc
+    ln -s python${_pybasever}.1 $installdir/usr/share/man/man1/python.1

--- a/packages/py/python3/pspec_x86_64.xml
+++ b/packages/py/python3/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python3</Name>
         <Homepage>https://www.python.org/</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>Python-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -20,11 +20,15 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
+            <Path fileType="executable">/usr/bin/2to3</Path>
             <Path fileType="executable">/usr/bin/2to3-3.12</Path>
+            <Path fileType="executable">/usr/bin/idle</Path>
             <Path fileType="executable">/usr/bin/idle3</Path>
             <Path fileType="executable">/usr/bin/idle3.12</Path>
+            <Path fileType="executable">/usr/bin/pydoc</Path>
             <Path fileType="executable">/usr/bin/pydoc3</Path>
             <Path fileType="executable">/usr/bin/pydoc3.12</Path>
+            <Path fileType="executable">/usr/bin/python</Path>
             <Path fileType="executable">/usr/bin/python3</Path>
             <Path fileType="executable">/usr/bin/python3.12</Path>
             <Path fileType="library">/usr/lib/python3.12/LICENSE.txt</Path>
@@ -3170,8 +3174,9 @@
             <Path fileType="library">/usr/lib64/python3.12/lib-dynload/xxsubtype.cpython-312-x86_64-linux-gnu.so</Path>
             <Path fileType="library">/usr/lib64/python3.12/lib-dynload/zlib.cpython-312-x86_64-linux-gnu.so</Path>
             <Path fileType="data">/usr/share/gdb/auto-load/usr/lib64/libpython3.12.so.1.0-gdb.py</Path>
+            <Path fileType="man">/usr/share/man/man1/python.1</Path>
             <Path fileType="man">/usr/share/man/man1/python3.1</Path>
-            <Path fileType="man">/usr/share/man/man1/python3.12.1</Path>
+            <Path fileType="man">/usr/share/man/man1/python3.12.1.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -3181,9 +3186,10 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="76">python3</Dependency>
+            <Dependency release="77">python3</Dependency>
         </RuntimeDependencies>
         <Files>
+            <Path fileType="executable">/usr/bin/python-config</Path>
             <Path fileType="executable">/usr/bin/python3-config</Path>
             <Path fileType="executable">/usr/bin/python3.12-config</Path>
             <Path fileType="header">/usr/include/python3.12/Python.h</Path>
@@ -3416,7 +3422,7 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="76">python3</Dependency>
+            <Dependency releaseFrom="77">python3</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib/python3.12/test/Sine-1000Hz-300ms.aif</Path>
@@ -8091,19 +8097,19 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="76">python3</Dependency>
+            <Dependency releaseFrom="77">python3</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/python3.12/lib-dynload/_tkinter.cpython-312-x86_64-linux-gnu.so</Path>
         </Files>
     </Package>
     <History>
-        <Update release="76">
-            <Date>2025-07-01</Date>
+        <Update release="77">
+            <Date>2025-10-25</Date>
             <Version>3.12.11</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Now that python2 is deprecated we do not need the 3 suffix on binaries e.g. python3 -> python
- Reintroduce 2to3 binary now that python2 is deprecated

**Test Plan**

`python --version`
`man python`

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
