### PR TITLE
borg: Update to v1.4.1, fix upstream python-msgpack dep issue

### DIFF
--- a/packages/b/borg/abi_used_symbols
+++ b/packages/b/borg/abi_used_symbols
@@ -122,6 +122,7 @@ UNKNOWN:PyNumber_InPlaceAdd
 UNKNOWN:PyNumber_InPlaceOr
 UNKNOWN:PyNumber_InPlaceSubtract
 UNKNOWN:PyNumber_Index
+UNKNOWN:PyNumber_Invert
 UNKNOWN:PyNumber_Long
 UNKNOWN:PyNumber_Lshift
 UNKNOWN:PyNumber_Multiply

--- a/packages/b/borg/files/0001-All-python-msgpack111.patch
+++ b/packages/b/borg/files/0001-All-python-msgpack111.patch
@@ -1,0 +1,39 @@
+From 2406e0994064c06f124fd65b90a5faaa711b5e54 Mon Sep 17 00:00:00 2001
+From: David Harder <david@davidjharder.ca>
+Date: Sat, 25 Oct 2025 14:06:01 -0500
+Subject: [PATCH] All-python-msgpack111
+
+---
+ pyproject.toml              | 2 +-
+ src/borg/helpers/msgpack.py | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index c5457ed4..65b3eb1d 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -35,7 +35,7 @@ dependencies = [
+     # Please note:
+     # using any other msgpack version is not supported by borg development and
+     # any feedback related to issues caused by this will be ignored.
+-    "msgpack >=1.0.3, <=1.1.0",
++    "msgpack >=1.0.3, <=1.1.1",
+     "packaging",
+ ]
+ 
+diff --git a/src/borg/helpers/msgpack.py b/src/borg/helpers/msgpack.py
+index 5c8cedde..5c0d1a02 100644
+--- a/src/borg/helpers/msgpack.py
++++ b/src/borg/helpers/msgpack.py
+@@ -137,7 +137,7 @@ def is_slow_msgpack():
+ def is_supported_msgpack():
+     # DO NOT CHANGE OR REMOVE! See also requirements and comments in pyproject.toml.
+     import msgpack
+-    return (1, 0, 3) <= msgpack.version <= (1, 1, 0) and \
++    return (1, 0, 3) <= msgpack.version <= (1, 1, 1) and \
+            msgpack.version not in []  # < add bad releases here to deny list
+ 
+ 
+-- 
+2.51.0
+

--- a/packages/b/borg/package.yml
+++ b/packages/b/borg/package.yml
@@ -1,8 +1,8 @@
 name       : borg
-version    : 1.4.0
-release    : 45
+version    : 1.4.1
+release    : 46
 source     :
-    - https://github.com/borgbackup/borg/releases/download/1.4.0/borgbackup-1.4.0.tar.gz : c54c45155643fa66fed7f9ff2d134ea0a58d0ac197c18781ddc2fb236bf6ed29
+    - https://github.com/borgbackup/borg/releases/download/1.4.1/borgbackup-1.4.1.tar.gz : b8fbf8f1c19d900b6b32a5a1dc131c5d8665a7c7eea409e9095209100b903839
 homepage   : https://www.borgbackup.org/
 license    : BSD-3-Clause
 component  : system.utils
@@ -36,6 +36,9 @@ rundeps    :
     - python-llfuse
     - python-msgpack
     - python-packaging
+setup      : |
+    # https://github.com/borgbackup/borg/pull/ 8904
+    %patch -p1 -i $pkgfiles/0001-All-python-msgpack111.patch
 build      : |
     %python3_setup
 install    : |

--- a/packages/b/borg/pspec_x86_64.xml
+++ b/packages/b/borg/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>borg</Name>
         <Homepage>https://www.borgbackup.org/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>system.utils</PartOf>
@@ -300,61 +300,61 @@ The authenticated encryption technique makes it suitable for backups to not full
             <Path fileType="library">/usr/lib/python3.12/site-packages/borg/upgrader.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/borg/version.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/borg/xattr.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/borgbackup-1.4.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/borgbackup-1.4.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/borgbackup-1.4.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/borgbackup-1.4.0.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/borgbackup-1.4.0.dist-info/licenses/AUTHORS</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/borgbackup-1.4.0.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/borgbackup-1.4.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/borgbackup-1.4.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/borgbackup-1.4.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/borgbackup-1.4.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/borgbackup-1.4.1.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/borgbackup-1.4.1.dist-info/licenses/AUTHORS</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/borgbackup-1.4.1.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/borgbackup-1.4.1.dist-info/top_level.txt</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/borg</Path>
             <Path fileType="data">/usr/share/fish/completions/borg.fish</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-benchmark-crud.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-benchmark.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-break-lock.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-change-passphrase.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-check.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-common.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-compact.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-compression.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-config.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-create.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-delete.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-diff.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-export-tar.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-extract.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-import-tar.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-info.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-init.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-key-change-passphrase.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-key-export.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-key-import.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-key-migrate-to-repokey.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-key.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-list.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-mount.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-patterns.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-placeholders.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-prune.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-recreate.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-rename.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-serve.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-umount.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-upgrade.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-version.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg-with-lock.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borg.1</Path>
-            <Path fileType="man">/usr/share/man/man1/borgfs.1</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-benchmark-crud.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-benchmark.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-break-lock.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-change-passphrase.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-check.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-common.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-compact.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-compression.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-config.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-create.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-delete.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-diff.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-export-tar.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-extract.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-import-tar.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-info.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-init.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-key-change-passphrase.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-key-export.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-key-import.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-key-migrate-to-repokey.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-key.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-list.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-mount.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-patterns.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-placeholders.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-prune.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-recreate.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-rename.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-serve.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-umount.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-upgrade.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-version.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg-with-lock.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borg.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/borgfs.1.zst</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_borg</Path>
         </Files>
     </Package>
     <History>
-        <Update release="45">
-            <Date>2025-06-14</Date>
-            <Version>1.4.0</Version>
+        <Update release="46">
+            <Date>2025-10-25</Date>
+            <Version>1.4.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://github.com/borgbackup/borg/releases/tag/1.4.1)
- Resolves https://github.com/getsolus/packages/issues/6629

**Test Plan**

- Initialize a test borg repo

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
