### PR TITLE
libde265: Update to v1.0.16

### DIFF
--- a/packages/l/libde265/abi_symbols
+++ b/packages/l/libde265/abi_symbols
@@ -341,6 +341,9 @@ libde265.so.0:_ZN10NAL_ParserC1Ev
 libde265.so.0:_ZN10NAL_ParserC2Ev
 libde265.so.0:_ZN10NAL_ParserD1Ev
 libde265.so.0:_ZN10NAL_ParserD2Ev
+libde265.so.0:_ZN10PacketSinkD0Ev
+libde265.so.0:_ZN10PacketSinkD1Ev
+libde265.so.0:_ZN10PacketSinkD2Ev
 libde265.so.0:_ZN10alloc_pool10delete_objEPv
 libde265.so.0:_ZN10alloc_pool16add_memory_blockEv
 libde265.so.0:_ZN10alloc_pool7new_objEm
@@ -371,8 +374,12 @@ libde265.so.0:_ZN10slice_unitD1Ev
 libde265.so.0:_ZN10slice_unitD2Ev
 libde265.so.0:_ZN11ImageSourceC1Ev
 libde265.so.0:_ZN11ImageSourceC2Ev
+libde265.so.0:_ZN11ImageSourceD0Ev
+libde265.so.0:_ZN11ImageSourceD1Ev
+libde265.so.0:_ZN11ImageSourceD2Ev
 libde265.so.0:_ZN11de265_image10copy_imageEPKS_
 libde265.so.0:_ZN11de265_image10fill_imageEiii
+libde265.so.0:_ZN11de265_image10fill_planeEii
 libde265.so.0:_ZN11de265_image10thread_runEPK11thread_task
 libde265.so.0:_ZN11de265_image11alloc_imageEii12de265_chromaSt10shared_ptrIK17seq_parameter_setEbP15decoder_contextlPvb
 libde265.so.0:_ZN11de265_image11set_mv_infoEiiiiRK8PBMotion
@@ -417,6 +424,8 @@ libde265.so.0:_ZN13CABAC_encoder21write_CABAC_TU_bypassEii
 libde265.so.0:_ZN13CTBTreeMatrix5allocEiii
 libde265.so.0:_ZN13ImageSink_YUV10send_imageEPK11de265_image
 libde265.so.0:_ZN13ImageSink_YUV12set_filenameEPKc
+libde265.so.0:_ZN13ImageSink_YUVC1Ev
+libde265.so.0:_ZN13ImageSink_YUVC2Ev
 libde265.so.0:_ZN13ImageSink_YUVD0Ev
 libde265.so.0:_ZN13ImageSink_YUVD1Ev
 libde265.so.0:_ZN13ImageSink_YUVD2Ev
@@ -669,6 +678,9 @@ libde265.so.0:_ZN8NAL_unitC1Ev
 libde265.so.0:_ZN8NAL_unitC2Ev
 libde265.so.0:_ZN8NAL_unitD1Ev
 libde265.so.0:_ZN8NAL_unitD2Ev
+libde265.so.0:_ZN9ImageSinkD0Ev
+libde265.so.0:_ZN9ImageSinkD1Ev
+libde265.so.0:_ZN9ImageSinkD2Ev
 libde265.so.0:_ZNK10nal_header5writeER13CABAC_encoder
 libde265.so.0:_ZNK10option_int12getTypeDescrB5cxx11Ev
 libde265.so.0:_ZNK10option_int18get_default_stringB5cxx11Ev
@@ -683,6 +695,8 @@ libde265.so.0:_ZNK13CTBTreeMatrix5getCBEii
 libde265.so.0:_ZNK13CTBTreeMatrix5getPBEii
 libde265.so.0:_ZNK13CTBTreeMatrix5getTBEii
 libde265.so.0:_ZNK13PixelAccessor11copyToImageEP11de265_imagei
+libde265.so.0:_ZNK15ImageSource_YUV10get_heightEv
+libde265.so.0:_ZNK15ImageSource_YUV9get_widthEv
 libde265.so.0:_ZNK15decoder_context15get_highest_TIDEv
 libde265.so.0:_ZNK17config_parameters11find_optionEPKc
 libde265.so.0:_ZNK17config_parameters12print_paramsEv

--- a/packages/l/libde265/abi_used_symbols
+++ b/packages/l/libde265/abi_used_symbols
@@ -1,5 +1,4 @@
 UNKNOWN:_ZTV10option_int
-UNKNOWN:_ZTV13ImageSink_YUV
 UNKNOWN:_ZTV13option_string
 libc.so.6:__assert_fail
 libc.so.6:__cxa_atexit
@@ -53,7 +52,6 @@ libc.so.6:realloc
 libc.so.6:stat
 libc.so.6:stderr
 libc.so.6:stdout
-libc.so.6:strcasecmp
 libc.so.6:strcmp
 libc.so.6:strcpy
 libc.so.6:strlen
@@ -106,13 +104,11 @@ libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE4initEPSt15basic_streambufIcS
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE5clearESt12_Ios_Iostate
 libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
 libstdc++.so.6:_ZSt16__throw_bad_castv
-libstdc++.so.6:_ZSt17__throw_bad_allocv
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt20__throw_system_errori
 libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
-libstdc++.so.6:_ZSt28__throw_bad_array_new_lengthv
 libstdc++.so.6:_ZSt4cerr
 libstdc++.so.6:_ZSt4cout
 libstdc++.so.6:_ZSt7getlineIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EES4_

--- a/packages/l/libde265/package.yml
+++ b/packages/l/libde265/package.yml
@@ -1,8 +1,8 @@
 name       : libde265
-version    : 1.0.15
-release    : 12
+version    : 1.0.16
+release    : 13
 source     :
-    - https://github.com/strukturag/libde265/releases/download/v1.0.15/libde265-1.0.15.tar.gz : 00251986c29d34d3af7117ed05874950c875dd9292d016be29d3b3762666511d
+    - https://github.com/strukturag/libde265/releases/download/v1.0.16/libde265-1.0.16.tar.gz : b92beb6b53c346db9a8fae968d686ab706240099cdd5aff87777362d668b0de7
 homepage   : https://www.libde265.org/
 license    : LGPL-3.0-or-later
 component  : multimedia.codecs

--- a/packages/l/libde265/pspec_x86_64.xml
+++ b/packages/l/libde265/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libde265</Name>
         <Homepage>https://www.libde265.org/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>LGPL-3.0-or-later</License>
         <PartOf>multimedia.codecs</PartOf>
@@ -20,7 +20,6 @@
 </Description>
         <PartOf>multimedia.codecs</PartOf>
         <Files>
-            <Path fileType="executable">/usr/bin/de265-acceleration_speed</Path>
             <Path fileType="executable">/usr/bin/de265-bjoentegaard</Path>
             <Path fileType="executable">/usr/bin/de265-block-rate-estim</Path>
             <Path fileType="executable">/usr/bin/de265-enc265</Path>
@@ -29,7 +28,7 @@
             <Path fileType="executable">/usr/bin/de265-tests</Path>
             <Path fileType="executable">/usr/bin/de265-yuv-distortion</Path>
             <Path fileType="library">/usr/lib64/libde265.so.0</Path>
-            <Path fileType="library">/usr/lib64/libde265.so.0.1.8</Path>
+            <Path fileType="library">/usr/lib64/libde265.so.0.1.9</Path>
         </Files>
     </Package>
     <Package>
@@ -39,7 +38,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="12">libde265</Dependency>
+            <Dependency release="13">libde265</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libde265/de265-version.h</Path>
@@ -49,12 +48,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2023-12-26</Date>
-            <Version>1.0.15</Version>
+        <Update release="13">
+            <Date>2025-10-26</Date>
+            <Version>1.0.16</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- This release fixes some rare decoding errors and some build issues

**Test Plan**

- Watch an x265 video

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
