### PR TITLE
repo-wide: Remove unneccessary PYTHON=/usr/bin/python3 env

### DIFF
--- a/packages/a/apparmor/package.yml
+++ b/packages/a/apparmor/package.yml
@@ -23,9 +23,6 @@ rundeps    :
     - python-notify2
     - python3
 networking : true
-environment: |
-    export PYTHON=/usr/bin/python3
-    export PYTHON_VERSIONS=python3
 setup      : |
     %patch -p1 -i $pkgfiles/0001-Add-stateless-directory-to-default-apparmor-profile.patch
     %patch -p1 -i $pkgfiles/0001-Adjust-paths-to-usr-location.patch

--- a/packages/f/firewalld/package.yml
+++ b/packages/f/firewalld/package.yml
@@ -44,8 +44,7 @@ setup      : |
     autoconf
     automake --add-missing
     %reconfigure --disable-schemas-compile \
-             --disable-sysconfig \
-             PYTHON=/usr/bin/python3
+             --disable-sysconfig
 build      : |
     %make
 install    : |

--- a/packages/g/gstreamer-1.0/package.yml
+++ b/packages/g/gstreamer-1.0/package.yml
@@ -225,7 +225,6 @@ rundeps    :
 clang      : true
 optimize   : thin-lto
 environment: |
-    export PYTHON=/usr/bin/python3
     # Make cargo use system libzstd
     export ZSTD_SYS_USE_PKG_CONFIG=1
 setup      : |

--- a/packages/i/itstool/package.yml
+++ b/packages/i/itstool/package.yml
@@ -13,8 +13,6 @@ builddeps  :
     - docbook-xml
 rundeps    :
     - docbook-xml
-environment: |
-    export PYTHON=/usr/bin/python3
 setup      : |
     %patch -p1 -i $pkgfiles/itstool-2.0.5-fix-crash-wrong-encoding.patch
     %patch -p1 -i $pkgfiles/fix-handling-untranslated-nodes.patch

--- a/packages/l/libkate/package.yml
+++ b/packages/l/libkate/package.yml
@@ -21,8 +21,6 @@ patterns   :
 builddeps  :
     - pkgconfig(libpng)
     - pkgconfig(ogg)
-environment: |
-    export PYTHON=/usr/bin/python3
 setup      : |
     %configure_no_runstatedir --disable-static --disable-doc
 build      : |

--- a/packages/l/libtorrent-rasterbar/package.yml
+++ b/packages/l/libtorrent-rasterbar/package.yml
@@ -17,8 +17,6 @@ builddeps  :
 clang      : true
 optimize   :
     - thin-lto
-environment: |
-    export PYTHON=/usr/bin/python3
 setup      : |
     %cmake_ninja -Dpython-bindings=on -Dpython-egg-info=on -Dpython-install-system-dir=on
 build      : |

--- a/packages/l/libxml2/package.yml
+++ b/packages/l/libxml2/package.yml
@@ -26,7 +26,6 @@ patterns   :
 environment: |
     # set common build options here to avoid copy pasta spam.
     export COMMON_OPTS="--disable-static --with-python --with-legacy --with-ftp --with-icu --with-threads --with-xptr-locs"
-    export PYTHON=/usr/bin/python3
 setup      : |
     %apply_patches
 

--- a/packages/m/mate-utils/package.yml
+++ b/packages/m/mate-utils/package.yml
@@ -24,7 +24,6 @@ builddeps  :
     - pkgconfig(xext)
     - itstool
 setup      : |
-    export PYTHON=/usr/bin/python3
     %configure --disable-static \
         --disable-debug \
         --disable-maintainer-flags \

--- a/packages/m/mesalib/package.yml
+++ b/packages/m/mesalib/package.yml
@@ -65,8 +65,6 @@ optimize   :
     - no-symbolic
     # - thin-lto
 environment: |
-    export PYTHON=/usr/bin/python3
-
     export PE_CODECS=0
     if [[ ! -z $PE_CODECS ]]; then
           export PT_ARGS="-Dvideo-codecs=all"

--- a/packages/py/python-slip/package.yml
+++ b/packages/py/python-slip/package.yml
@@ -15,8 +15,6 @@ builddeps  :
 rundeps    :
     - python-decorator
     - python3-dbus
-environment: |
-    export PYTHON=/usr/bin/python3
 build      : |
     %make
 install    : |

--- a/packages/s/scanmem/package.yml
+++ b/packages/s/scanmem/package.yml
@@ -19,7 +19,6 @@ rundeps    :
 setup      : |
     %patch -p1 -i $pkgfiles/0001-Force-python3.patch
 
-    export PYTHON=/usr/bin/python3
     %autogen --disable-static --enable-gui
 build      : |
     %make


### PR DESCRIPTION
**Summary**
- python now defaults to python3

**Test Plan**

Build a few of these a random, ensure they still compile and use python3 as expected

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
