### PR TITLE
usysconf-epoch: Check and set flag file

### DIFF
--- a/packages/u/usysconf-epoch/files/epoch.sh
+++ b/packages/u/usysconf-epoch/files/epoch.sh
@@ -4,8 +4,10 @@ shopt -s nullglob
 
 EPOCH_ENABLE="${EPOCH_ENABLE:=yes}"
 
-STATE_DIR="${STATE_DIR:=/var/solus/usr-merge}"
-MERGE_FLAG_FILE="${MERGE_FLAG_FILE:=${STATE_DIR}/merge-complete}"
+STATE_DIR="${STATE_DIR:=/var/solus}"
+MERGE_FLAG_FILE="${MERGE_FLAG_FILE:=${STATE_DIR}/usr-merge/merge-complete}"
+EPOCH_STATE_DIR="${EPOCH_STATE_DIR:=${STATE_DIR}/epoch}"
+EPOCH_FLAG_FILE="${EPOCH_FLAG_FILE:=${EPOCH_STATE_DIR}/epoch-complete}"
 
 OLD_REPO="https://cdn.getsol.us/repo/shannon/eopkg-index.xml.xz"
 NEW_REPO="https://cdn.getsol.us/repo/polaris/eopkg-index.xml.xz"
@@ -193,6 +195,12 @@ then
     _exit 0
 fi
 
+if [[ -e "${EPOCH_FLAG_FILE}" ]]
+then
+    echo "This system is running on the new epoch"
+    _exit 0
+fi
+
 if [[ ! -e "${MERGE_FLAG_FILE}" ]]
 then
     echo "Not ready: not usr-merged"
@@ -244,6 +252,9 @@ do
     echo "Failed to check repository, will retry."
     sleep 10
 done
+
+mkdir -p "${EPOCH_STATE_DIR}"
+touch "${EPOCH_FLAG_FILE}"
 
 echo "Finished! Welcome to the new epoch."
 _systemd-notify --ready

--- a/packages/u/usysconf-epoch/package.yml
+++ b/packages/u/usysconf-epoch/package.yml
@@ -1,6 +1,6 @@
 name       : usysconf-epoch
 version    : 1.0.0
-release    : 24
+release    : 25
 source     :
     # We need something for a source
     - https://getsol.us/sources/hotspot.txt : a12b7cb43c9d9134b5bb1b35e9096b66775d9e92e7611d1cc92b02edd6782a87

--- a/packages/u/usysconf-epoch/pspec_x86_64.xml
+++ b/packages/u/usysconf-epoch/pspec_x86_64.xml
@@ -29,8 +29,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2025-10-24</Date>
+        <Update release="25">
+            <Date>2025-10-27</Date>
             <Version>1.0.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Silke Hofstra</Name>


### PR DESCRIPTION
**Summary**

Write a flag file after the epoch is switched.
This allows users to change or remove the software centers after installation.

Resolves #6626

**Test Plan**

1. Install package.
2. Restart `epoch.service`.
3. Check if flag file exists as `/var/solus/epoch/epoch-complete`.
4. Restart `epoch.service` again.
5. Verify that it logged `This system is running on the new epoch` to the journal.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
