### PR TITLE
accountsservice: Add patch to fix build

### DIFF
--- a/packages/a/accountsservice/abi_used_symbols
+++ b/packages/a/accountsservice/abi_used_symbols
@@ -306,6 +306,7 @@ libglib-2.0.so.0:g_variant_builder_add
 libglib-2.0.so.0:g_variant_builder_clear
 libglib-2.0.so.0:g_variant_builder_end
 libglib-2.0.so.0:g_variant_builder_init
+libglib-2.0.so.0:g_variant_builder_init_static
 libglib-2.0.so.0:g_variant_builder_new
 libglib-2.0.so.0:g_variant_builder_unref
 libglib-2.0.so.0:g_variant_equal

--- a/packages/a/accountsservice/files/0001-build-Add-option-to-disable-tests.patch
+++ b/packages/a/accountsservice/files/0001-build-Add-option-to-disable-tests.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Evan Maddock <maddock.evan@vivaldi.net>
+Date: Mon, 27 Oct 2025 13:53:11 -0400
+Subject: [PATCH] build: Add option to disable tests
+
+We currently need this for Solus because we're building packages as root
+because fakeroot is broken with our setup or something, I don't remember
+the details.
+
+Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
+---
+ meson.build       | 4 +++-
+ meson_options.txt | 1 +
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 4a509e7..845f7f3 100644
+--- a/meson.build
++++ b/meson.build
+@@ -232,7 +232,9 @@ if get_option('gtk_doc')
+   subdir('doc/libaccountsservice')
+ endif
+ 
+-subdir('tests')
++if get_option('tests') and meson.can_run_host_binaries()
++  subdir('tests')
++endif
+ 
+ configure_file(
+   output: 'config.h',
+diff --git a/meson_options.txt b/meson_options.txt
+index b34a0fa..67db09b 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -13,3 +13,4 @@ option('vapi', type: 'boolean', value: true, description : 'Enable Vala bindings
+ 
+ option('docbook', type: 'boolean', value: false, description: 'build documentation (requires xmlto)')
+ option('gtk_doc', type: 'boolean', value: false, description: 'use gtk-doc to build documentation')
++option('tests',   type: 'boolean', value: true, description: 'run accountservice tests if possible')

--- a/packages/a/accountsservice/files/0001-tests-Drop-check-format-test.patch
+++ b/packages/a/accountsservice/files/0001-tests-Drop-check-format-test.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
+Date: Sun, 23 Jun 2024 03:29:43 +0200
+Subject: [PATCH] tests: Drop check-format test
+
+It modifies the Git tree and prevents patches from being applied
+correctly.
+
+This really should be part of a pre-commit check, not a Meson test. The
+source directory should not be modified.
+---
+ tests/meson.build | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/tests/meson.build b/tests/meson.build
+index ff9004d6ad75..178a2f09f1aa 100644
+--- a/tests/meson.build
++++ b/tests/meson.build
+@@ -1,4 +1,3 @@
+-test('check-format', find_program('check-format.sh'))
+ 
+ libmocklibc = subproject('mocklibc').get_variable('libmocklibc')
+ 
+

--- a/packages/a/accountsservice/package.yml
+++ b/packages/a/accountsservice/package.yml
@@ -1,9 +1,9 @@
 name       : accountsservice
 version    : 23.13.9
-release    : 36
+release    : 37
 source     :
     - https://www.freedesktop.org/software/accountsservice/accountsservice-23.13.9.tar.xz : adda4cdeae24fa0992e7df3ffff9effa7090be3ac233a3edfdf69d5a9c9b924f
-homepage   : http://www.freedesktop.org/wiki/Software/AccountsService
+homepage   : https://www.freedesktop.org/wiki/Software/AccountsService
 license    : GPL-3.0-or-later
 component  : desktop.core
 summary    : D-Bus service for accessing user accounts and information
@@ -21,12 +21,18 @@ setup      : |
     %patch -p1 -i $pkgfiles/0001-daemon-Add-support-for-default-user-groups.patch
     %patch -p1 -i $pkgfiles/assume-gdm-for-compat.patch
     %patch -p1 -i $pkgfiles/gcc-14.patch
+    %patch -p1 -i $pkgfiles/0001-tests-Drop-check-format-test.patch
+
+    # We need this because the tests cannot be run as root,
+    # but our fakeroot stuff is broken or something.
+    %patch -p1 -i $pkgfiles/0001-build-Add-option-to-disable-tests.patch
 
     %meson_configure --sysconfdir=/usr/share \
         -Dadmin_group=sudo \
         -Dextra_admin_groups="adm,lpadmin" \
         -Ddefault_user_groups="audio,video,cdrom,dialout,fuse,users,sambashares" \
-        -Dgtk_doc=true
+        -Dgtk_doc=true \
+        -Dtests=false
 build      : |
     %ninja_build
 install    : |
@@ -39,6 +45,7 @@ install    : |
              $installdir/var/lib/AccountsService/ \
              $installdir/var/lib/ \
              $installdir/var/
-check      : |
-    unset LD_PRELOAD
-    %ninja_check
+# Tests cannot be run as root
+# check      : |
+#     unset LD_PRELOAD
+#     %ninja_check

--- a/packages/a/accountsservice/pspec_x86_64.xml
+++ b/packages/a/accountsservice/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>accountsservice</Name>
-        <Homepage>http://www.freedesktop.org/wiki/Software/AccountsService</Homepage>
+        <Homepage>https://www.freedesktop.org/wiki/Software/AccountsService</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop.core</PartOf>
@@ -32,7 +32,6 @@
             <Path fileType="data">/usr/share/dbus-1/interfaces/org.freedesktop.Accounts.xml</Path>
             <Path fileType="data">/usr/share/dbus-1/system-services/org.freedesktop.Accounts.service</Path>
             <Path fileType="data">/usr/share/dbus-1/system.d/org.freedesktop.Accounts.conf</Path>
-            <Path fileType="data">/usr/share/gir-1.0/AccountsService-1.0.gir</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/accounts-service.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/accounts-service.mo</Path>
             <Path fileType="localedata">/usr/share/locale/as/LC_MESSAGES/accounts-service.mo</Path>
@@ -117,7 +116,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="36">accountsservice</Dependency>
+            <Dependency release="37">accountsservice</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/accountsservice-1.0/act/act-user-enum-types.h</Path>
@@ -126,6 +125,7 @@
             <Path fileType="header">/usr/include/accountsservice-1.0/act/act.h</Path>
             <Path fileType="library">/usr/lib64/libaccountsservice.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/accountsservice.pc</Path>
+            <Path fileType="data">/usr/share/gir-1.0/AccountsService-1.0.gir</Path>
             <Path fileType="data">/usr/share/vala/vapi/accountsservice.deps</Path>
             <Path fileType="data">/usr/share/vala/vapi/accountsservice.vapi</Path>
         </Files>
@@ -157,12 +157,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2024-08-19</Date>
+        <Update release="37">
+            <Date>2025-10-28</Date>
             <Version>23.13.9</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
We currently need this for Solus because we're building packages as root because fakeroot is broken with our setup or something, I don't remember the details.

Fixes https://github.com/getsolus/packages/issues/6616

Part of https://github.com/getsolus/packages/issues/5522

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the package builds.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
