### PR TITLE
gzip: Fix https homepage link

### DIFF
--- a/packages/g/gzip/MAINTAINERS.md
+++ b/packages/g/gzip/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Jared Cervantes
+  - Matrix: @jaredy89:matrix.org
+  - Email: jared@jaredcervantes.com

--- a/packages/g/gzip/package.yml
+++ b/packages/g/gzip/package.yml
@@ -1,9 +1,9 @@
 name       : gzip
 version    : '1.14'
-release    : 18
+release    : 19
 source     :
-    - https://ftp.gnu.org/gnu/gzip/gzip-1.14.tar.xz : 01a7b881bd220bfdf615f97b8718f80bdfd3f6add385b993dcf6efd14e8c0ac6
-homepage   : http://www.gzip.org/
+    - https://mirror.team-cymru.com/gnu/gzip/gzip-1.14.tar.gz : 613d6ea44f1248d7370c7ccdeee0dd0017a09e6c39de894b3c6f03f981191c6b
+homepage   : https://www.gnu.org/software/gzip/
 license    : GPL-3.0-or-later
 summary    : gzip (Compression utility)
 component  : system.base

--- a/packages/g/gzip/pspec_x86_64.xml
+++ b/packages/g/gzip/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>gzip</Name>
-        <Homepage>http://www.gzip.org/</Homepage>
+        <Homepage>https://www.gnu.org/software/gzip/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -34,27 +34,27 @@
             <Path fileType="executable">/usr/bin/zless</Path>
             <Path fileType="executable">/usr/bin/zmore</Path>
             <Path fileType="executable">/usr/bin/znew</Path>
-            <Path fileType="info">/usr/share/info/gzip.info</Path>
-            <Path fileType="man">/usr/share/man/man1/gunzip.1</Path>
-            <Path fileType="man">/usr/share/man/man1/gzexe.1</Path>
-            <Path fileType="man">/usr/share/man/man1/gzip.1</Path>
-            <Path fileType="man">/usr/share/man/man1/zcat.1</Path>
-            <Path fileType="man">/usr/share/man/man1/zcmp.1</Path>
-            <Path fileType="man">/usr/share/man/man1/zdiff.1</Path>
-            <Path fileType="man">/usr/share/man/man1/zforce.1</Path>
-            <Path fileType="man">/usr/share/man/man1/zgrep.1</Path>
-            <Path fileType="man">/usr/share/man/man1/zless.1</Path>
-            <Path fileType="man">/usr/share/man/man1/zmore.1</Path>
-            <Path fileType="man">/usr/share/man/man1/znew.1</Path>
+            <Path fileType="info">/usr/share/info/gzip.info.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/gunzip.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/gzexe.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/gzip.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/zcat.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/zcmp.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/zdiff.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/zforce.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/zgrep.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/zless.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/zmore.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/znew.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2025-04-15</Date>
+        <Update release="19">
+            <Date>2025-10-28</Date>
             <Version>1.14</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fixed https homepage link
- As part of https://github.com/getsolus/packages/issues/5522  secure links for homepages
- Replace non-working ftp source code with mirror from gzip website

**Test Plan**

Zip file. Unzip file. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
