### PR TITLE
tidy-html5: Fix https homepage link

### DIFF
--- a/packages/t/tidy-html5/MAINTAINERS.md
+++ b/packages/t/tidy-html5/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Jared Cervantes
+  - Matrix: @jaredy89:matrix.org
+  - Email: jared@jaredcervantes.com

--- a/packages/t/tidy-html5/abi_used_symbols
+++ b/packages/t/tidy-html5/abi_used_symbols
@@ -2,7 +2,8 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_tolower_loc
 libc.so.6:__cxa_atexit
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
@@ -51,5 +52,4 @@ libc.so.6:strncmp
 libc.so.6:strncpy
 libc.so.6:strstr
 libc.so.6:strtok
-libc.so.6:strtol
 libc.so.6:utime

--- a/packages/t/tidy-html5/package.yml
+++ b/packages/t/tidy-html5/package.yml
@@ -1,9 +1,9 @@
 name       : tidy-html5
 version    : 5.8.0
-release    : 5
+release    : 6
 source     :
     - https://github.com/htacg/tidy-html5/archive/5.8.0.tar.gz : 59c86d5b2e452f63c5cdb29c866a12a4c55b1741d7025cf2f3ce0cde99b0660e
-homepage   : http://www.html-tidy.org/
+homepage   : https://www.html-tidy.org/
 license    : Zlib
 component  : programming.tools
 summary    : tidy-html5 corrects and cleans up HTML and XML documents by fixing markup errors and upgrading legacy code to modern standards.

--- a/packages/t/tidy-html5/pspec_x86_64.xml
+++ b/packages/t/tidy-html5/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>tidy-html5</Name>
-        <Homepage>http://www.html-tidy.org/</Homepage>
+        <Homepage>https://www.html-tidy.org/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Zlib</License>
         <PartOf>programming.tools</PartOf>
@@ -23,7 +23,7 @@
             <Path fileType="executable">/usr/bin/tidy</Path>
             <Path fileType="library">/usr/lib/libtidy.so.5.8.0</Path>
             <Path fileType="library">/usr/lib/libtidy.so.58</Path>
-            <Path fileType="man">/usr/share/man/man1/tidy.1</Path>
+            <Path fileType="man">/usr/share/man/man1/tidy.1.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -33,7 +33,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="5">tidy-html5</Dependency>
+            <Dependency release="6">tidy-html5</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/tidy.h</Path>
@@ -45,12 +45,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2024-06-22</Date>
+        <Update release="6">
+            <Date>2025-10-28</Date>
             <Version>5.8.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fixed https homepage link
- As part of https://github.com/getsolus/packages/issues/5522 secure links for homepages

**Test Plan**

Installed tidy, tested with messy html file and correctly displayed messages.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
