### PR TITLE
mtdev: Fix https homepage link

### DIFF
--- a/packages/m/mtdev/package.yml
+++ b/packages/m/mtdev/package.yml
@@ -1,9 +1,9 @@
 name       : mtdev
 version    : 1.1.7
-release    : 8
+release    : 9
 source     :
-    - http://bitmath.org/code/mtdev/mtdev-1.1.7.tar.gz : a55bd02a9af4dd266c0042ec608744fff3a017577614c057da09f1f4566ea32c
-homepage   : http://bitmath.org/code/mtdev/
+    - https://bitmath.se/org/code/mtdev/mtdev-1.1.7.tar.gz : a55bd02a9af4dd266c0042ec608744fff3a017577614c057da09f1f4566ea32c
+homepage   : https://bitmath.se/org/code/mtdev/
 license    :
     - MIT
 summary    : Multitouch Protocol Translation Library

--- a/packages/m/mtdev/pspec_x86_64.xml
+++ b/packages/m/mtdev/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>mtdev</Name>
-        <Homepage>http://bitmath.org/code/mtdev/</Homepage>
+        <Homepage>https://bitmath.se/org/code/mtdev/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>xorg.driver</PartOf>
@@ -32,7 +32,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="8">mtdev</Dependency>
+            <Dependency release="9">mtdev</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/mtdev-mapping.h</Path>
@@ -43,12 +43,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2024-05-26</Date>
+        <Update release="9">
+            <Date>2025-10-28</Date>
             <Version>1.1.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fixed https homepage link
- As part of https://github.com/getsolus/packages/issues/5522 secure links for homepages
- Fixed https for source code

**Test Plan**

Installed mtdev. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
