### PR TITLE
attract: fix https homepage link

### DIFF
--- a/packages/a/attract/abi_symbols
+++ b/packages/a/attract/abi_symbols
@@ -3173,7 +3173,6 @@ attract:_ZNK9tu_string13utf8_to_upperEv
 attract:_ZNK9tu_string14utf8_substringEii
 attract:_ZSt4cerr
 attract:_ZSt4cout
-attract:_ZSt7nothrow
 attract:_ZThn16_N7gameswf11as_mcloaderD0Ev
 attract:_ZThn16_N7gameswf11as_mcloaderD1Ev
 attract:_ZThn16_N7gameswf11as_propertyD0Ev

--- a/packages/a/attract/abi_used_symbols
+++ b/packages/a/attract/abi_used_symbols
@@ -486,7 +486,6 @@ libsfml-window.so.2.6:_ZNK2sf10WindowBase8hasFocusEv
 libstdc++.so.6:_ZNKSt12__basic_fileIcE7is_openEv
 libstdc++.so.6:_ZNKSt5ctypeIcE13_M_widen_initEv
 libstdc++.so.6:_ZNKSt6locale4nameB5cxx11Ev
-libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12find_last_ofEPKcm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12find_last_ofEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE13find_first_ofEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE16find_last_not_ofEPKcmm
@@ -532,8 +531,6 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_assignER
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createERmm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_mutateEmmPKcm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1EOS4_
-libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1ERKS4_
-libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1ERKS4_mm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEED1Ev
@@ -547,9 +544,7 @@ libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE4initEPSt15basic_streambufIcS
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE5clearESt12_Ios_Iostate
 libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
 libstdc++.so.6:_ZSt16__throw_bad_castv
-libstdc++.so.6:_ZSt17__throw_bad_allocv
 libstdc++.so.6:_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
-libstdc++.so.6:_ZSt18_Rb_tree_incrementPKSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
@@ -557,7 +552,6 @@ libstdc++.so.6:_ZSt20__throw_system_errori
 libstdc++.so.6:_ZSt21ios_base_library_initv
 libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
 libstdc++.so.6:_ZSt28_Rb_tree_rebalance_for_erasePSt18_Rb_tree_node_baseRS_
-libstdc++.so.6:_ZSt28__throw_bad_array_new_lengthv
 libstdc++.so.6:_ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_
 libstdc++.so.6:_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
 libstdc++.so.6:_ZSt7getlineIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EES4_

--- a/packages/a/attract/package.yml
+++ b/packages/a/attract/package.yml
@@ -1,9 +1,9 @@
 name       : attract
 version    : 2.7.0
-release    : 20
+release    : 21
 source     :
     - https://github.com/mickelson/attract/archive/v2.7.0.tar.gz : 497bc9d4d5846cb0eee71eaed2352d2350f789df3a913f423a3d6eed9ba428e8
-homepage   : http://attractmode.org/
+homepage   : https://attractmode.org/
 license    : GPL-3.0-or-later
 component  : games.emulator
 summary    : A graphical front-end for command line emulators that hides the underlying operating system and is intended to be controlled with a joystick or gamepad.

--- a/packages/a/attract/pspec_x86_64.xml
+++ b/packages/a/attract/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>attract</Name>
-        <Homepage>http://attractmode.org/</Homepage>
+        <Homepage>https://attractmode.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>games.emulator</PartOf>
@@ -238,12 +238,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2024-11-15</Date>
+        <Update release="21">
+            <Date>2025-10-28</Date>
             <Version>2.7.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fixed https homepage link
- As part of https://github.com/getsolus/packages/issues/5522 secure links for homepages

**Test Plan**

Installed attract. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
