### PR TITLE
solseek: Add at v0.2.0

### DIFF
--- a/packages/s/solseek/MAINTAINERS.md
+++ b/packages/s/solseek/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Name Surname
+  - Matrix: @clintre:matrix.org
+  - Email: clint@original-syn.com

--- a/packages/s/solseek/monitoring.yaml
+++ b/packages/s/solseek/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: ~
+  rss: https://github.com/clintre/solseek/tags.atom
+ # No known CPE, checked 2025-10-25
+security:
+  cpe: ~

--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
+name       : solseek
+version    : 0.2.0
+release    : 1
+source     :
+    - https://github.com/clintre/solseek/archive/refs/tags/v0.2.0.tar.gz : 93b9f2a19b85c6d6483619fd829e495349887415743d1ef6fcb2c8e45e552ddc
+homepage   : https://github.com/clintre/solseek
+license    : GPL-3.0-or-later
+component  : systtem.utils
+summary    : A TUI Package Manager for Solus
+description: |
+    Solseek is a simple terminal user interface that allows you to browse, search, and manage packages from the Solus packages.
+rundeps:
+    - fzf
+install    : |
+    install -Dm00755 $workdir/package/bin/solseek $installdir/usr/bin/solseek
+    install -dm00755 $installdir/usr/share
+    cp -r $workdir/package/share/solseek $installdir/usr/share/
+    install -Dm00644 $workdir/package/share/applications/Solseek.desktop $installdir/usr/share/applications/Solseek.desktop
+    install -Dm00644 $workdir/package/share/icons/hicolor/scalable/apps/solseek.svg $installdir/usr/share/icons/hicolor/scalable/apps/solseek.svg

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -1,0 +1,47 @@
+<PISI>
+    <Source>
+        <Name>solseek</Name>
+        <Homepage>https://github.com/clintre/solseek</Homepage>
+        <Packager>
+            <Name>clintre</Name>
+            <Email>clint@eschberger.info</Email>
+        </Packager>
+        <License>GPL-3.0-or-later</License>
+        <PartOf>systtem.utils</PartOf>
+        <Summary xml:lang="en">A TUI Package Manager for Solus</Summary>
+        <Description xml:lang="en">Solseek is a simple terminal user interface that allows you to browse, search, and manage packages from the Solus packages.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>solseek</Name>
+        <Summary xml:lang="en">A TUI Package Manager for Solus</Summary>
+        <Description xml:lang="en">Solseek is a simple terminal user interface that allows you to browse, search, and manage packages from the Solus packages.
+</Description>
+        <PartOf>systtem.utils</PartOf>
+        <Files>
+            <Path fileType="executable">/usr/bin/solseek</Path>
+            <Path fileType="data">/usr/share/applications/Solseek.desktop</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/solseek.svg</Path>
+            <Path fileType="data">/usr/share/solseek/LICENSE-solseek.txt</Path>
+            <Path fileType="data">/usr/share/solseek/lang/en/_dictionary.lang</Path>
+            <Path fileType="data">/usr/share/solseek/lang/en/eopkg_check.txt</Path>
+            <Path fileType="data">/usr/share/solseek/lang/en/help.txt</Path>
+            <Path fileType="data">/usr/share/solseek/lang/en/history.txt</Path>
+            <Path fileType="data">/usr/share/solseek/lang/en/information.txt</Path>
+            <Path fileType="data">/usr/share/solseek/lang/en/list.txt</Path>
+            <Path fileType="data">/usr/share/solseek/lang/en/package_action.txt</Path>
+            <Path fileType="data">/usr/share/solseek/lang/en/update_system.txt</Path>
+            <Path fileType="data">/usr/share/solseek/lang/en/welcome.txt</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2025-10-28</Date>
+            <Version>0.2.0</Version>
+            <Comment>Packaging update</Comment>
+            <Name>clintre</Name>
+            <Email>clint@eschberger.info</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**
Add Solseek package manager to Solus repository
Resolves getsolus/packages#6637

**Summary**

Adds a TUI based lightweight package manager to Solus

**Test Plan**

Has been tested by users straight from the original repository.
I have tested the eopkg install on a clean Solus install across, all DEs.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
