### PR TITLE
mp3gain: Fix https homepage link

### DIFF
--- a/packages/m/mp3gain/abi_used_symbols
+++ b/packages/m/mp3gain/abi_used_symbols
@@ -1,6 +1,8 @@
 libc.so.6:__ctype_toupper_loc
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__fread_chk
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__memmove_chk
@@ -38,8 +40,8 @@ libc.so.6:strcat
 libc.so.6:strlen
 libc.so.6:strncpy
 libc.so.6:strtod
-libc.so.6:strtol
 libc.so.6:utime
+libm.so.6:ceil
 libm.so.6:floor
 libm.so.6:log10
 libm.so.6:pow

--- a/packages/m/mp3gain/package.yml
+++ b/packages/m/mp3gain/package.yml
@@ -1,9 +1,9 @@
 name       : mp3gain
 version    : 1.6.2
-release    : 5
+release    : 6
 source     :
     - https://sourceforge.net/projects/mp3gain/files/mp3gain/1.6.2/mp3gain-1_6_2-src.zip : 5cc04732ef32850d5878b28fbd8b85798d979a025990654aceeaa379bcc9596d
-homepage   : http://mp3gain.sourceforge.net/
+homepage   : https://mp3gain.sourceforge.net/
 license    : LGPL-2.1-or-later
 component  : multimedia.audio
 summary    : Adjusts mp3 files to play at the same volume

--- a/packages/m/mp3gain/pspec_x86_64.xml
+++ b/packages/m/mp3gain/pspec_x86_64.xml
@@ -1,17 +1,17 @@
 <PISI>
     <Source>
         <Name>mp3gain</Name>
-        <Homepage>http://mp3gain.sourceforge.net/</Homepage>
+        <Homepage>https://mp3gain.sourceforge.net/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>multimedia.audio</PartOf>
         <Summary xml:lang="en">Adjusts mp3 files to play at the same volume</Summary>
         <Description xml:lang="en">MP3Gain analyzes and adjusts mp3 files to play at the same volume.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>mp3gain</Name>
@@ -24,12 +24,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2022-10-30</Date>
+        <Update release="6">
+            <Date>2025-10-28</Date>
             <Version>1.6.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fixed https homepage link
- As part of https://github.com/getsolus/packages/issues/5522 secure links for homepages

**Test Plan**

Installed mp3gain. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
