### PR TITLE
mtools: Update to v4.0.49

### DIFF
--- a/packages/m/mtools/abi_used_symbols
+++ b/packages/m/mtools/abi_used_symbols
@@ -6,7 +6,9 @@ libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
 libc.so.6:__fread_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoul
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__memset_chk
@@ -68,6 +70,7 @@ libc.so.6:iswlower
 libc.so.6:iswupper
 libc.so.6:kill
 libc.so.6:localtime
+libc.so.6:lrand48
 libc.so.6:lseek
 libc.so.6:lstat
 libc.so.6:malloc
@@ -88,7 +91,6 @@ libc.so.6:putc
 libc.so.6:putchar
 libc.so.6:puts
 libc.so.6:putwc
-libc.so.6:random
 libc.so.6:read
 libc.so.6:readdir
 libc.so.6:realloc
@@ -100,7 +102,7 @@ libc.so.6:setuid
 libc.so.6:sigaction
 libc.so.6:signal
 libc.so.6:sleep
-libc.so.6:srandom
+libc.so.6:srand48
 libc.so.6:stat
 libc.so.6:stderr
 libc.so.6:stdin
@@ -125,8 +127,6 @@ libc.so.6:strpbrk
 libc.so.6:strrchr
 libc.so.6:strspn
 libc.so.6:strstr
-libc.so.6:strtol
-libc.so.6:strtoul
 libc.so.6:tcflush
 libc.so.6:tcgetattr
 libc.so.6:tcsetattr

--- a/packages/m/mtools/package.yml
+++ b/packages/m/mtools/package.yml
@@ -1,19 +1,14 @@
 name       : mtools
-version    : 4.0.45
-release    : 11
+version    : 4.0.49
+release    : 12
 source     :
-    - https://ftp.gnu.org/gnu/mtools/mtools-4.0.45.tar.gz : eea170403f48f0cd19b3d940e4bd12630a82601e25f944f47654b13d9d7eb5d4
+    - https://ftpmirror.gnu.org/gnu/mtools/mtools-4.0.49.tar.gz : 10cd1111da87bf2400a380c1639a6cba8bfb937a24f9c51f5f88d393ae5f6f76
 license    : GPL-3.0-or-later
 homepage   : https://ftp.gnu.org/gnu/mtools
 component  : system.utils
 summary    : A collection of utilities to access MS-DOS disks without mounting them
 description: |
-    Mtools is a collection of utilities to access MS-DOS disks from GNU and Unix without mounting
-    them. It supports Win'95 style long file names, OS/2 Xdf disks and 2m disks (store up to 1992k
-    on a high density 3 1/2 disk). In addition to file access, it supports many FAT-specific
-    features: volume labels, FAT-specific file attributes (hidden, system, ...), "bad block" map
-    maintenance, access to remote floppy drives, Iomega ZIP disk protection, "secure" erase,
-    display of file's on-disk layout, etc.
+    Mtools is a collection of utilities to access MS-DOS disks from GNU and Unix without mounting them. It supports Win'95 style long file names, OS/2 Xdf disks and 2m disks (store up to 1992k on a high density 3 1/2 disk). In addition to file access, it supports many FAT-specific features: volume labels, FAT-specific file attributes (hidden, system, ...), "bad block" map maintenance, access to remote floppy drives, Iomega ZIP disk protection, "secure" erase, display of file's on-disk layout, etc.
 setup      : |
     %configure
 build      : |

--- a/packages/m/mtools/pspec_x86_64.xml
+++ b/packages/m/mtools/pspec_x86_64.xml
@@ -3,30 +3,20 @@
         <Name>mtools</Name>
         <Homepage>https://ftp.gnu.org/gnu/mtools</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">A collection of utilities to access MS-DOS disks without mounting them</Summary>
-        <Description xml:lang="en">Mtools is a collection of utilities to access MS-DOS disks from GNU and Unix without mounting
-them. It supports Win&apos;95 style long file names, OS/2 Xdf disks and 2m disks (store up to 1992k
-on a high density 3 1/2 disk). In addition to file access, it supports many FAT-specific
-features: volume labels, FAT-specific file attributes (hidden, system, ...), &quot;bad block&quot; map
-maintenance, access to remote floppy drives, Iomega ZIP disk protection, &quot;secure&quot; erase,
-display of file&apos;s on-disk layout, etc.
+        <Description xml:lang="en">Mtools is a collection of utilities to access MS-DOS disks from GNU and Unix without mounting them. It supports Win&apos;95 style long file names, OS/2 Xdf disks and 2m disks (store up to 1992k on a high density 3 1/2 disk). In addition to file access, it supports many FAT-specific features: volume labels, FAT-specific file attributes (hidden, system, ...), &quot;bad block&quot; map maintenance, access to remote floppy drives, Iomega ZIP disk protection, &quot;secure&quot; erase, display of file&apos;s on-disk layout, etc.
 </Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>mtools</Name>
         <Summary xml:lang="en">A collection of utilities to access MS-DOS disks without mounting them</Summary>
-        <Description xml:lang="en">Mtools is a collection of utilities to access MS-DOS disks from GNU and Unix without mounting
-them. It supports Win&apos;95 style long file names, OS/2 Xdf disks and 2m disks (store up to 1992k
-on a high density 3 1/2 disk). In addition to file access, it supports many FAT-specific
-features: volume labels, FAT-specific file attributes (hidden, system, ...), &quot;bad block&quot; map
-maintenance, access to remote floppy drives, Iomega ZIP disk protection, &quot;secure&quot; erase,
-display of file&apos;s on-disk layout, etc.
+        <Description xml:lang="en">Mtools is a collection of utilities to access MS-DOS disks from GNU and Unix without mounting them. It supports Win&apos;95 style long file names, OS/2 Xdf disks and 2m disks (store up to 1992k on a high density 3 1/2 disk). In addition to file access, it supports many FAT-specific features: volume labels, FAT-specific file attributes (hidden, system, ...), &quot;bad block&quot; map maintenance, access to remote floppy drives, Iomega ZIP disk protection, &quot;secure&quot; erase, display of file&apos;s on-disk layout, etc.
 </Description>
         <PartOf>system.utils</PartOf>
         <Files>
@@ -42,6 +32,7 @@ display of file&apos;s on-disk layout, etc.
             <Path fileType="executable">/usr/bin/mdel</Path>
             <Path fileType="executable">/usr/bin/mdeltree</Path>
             <Path fileType="executable">/usr/bin/mdir</Path>
+            <Path fileType="executable">/usr/bin/mdoctorfat</Path>
             <Path fileType="executable">/usr/bin/mdu</Path>
             <Path fileType="executable">/usr/bin/mformat</Path>
             <Path fileType="executable">/usr/bin/minfo</Path>
@@ -62,44 +53,45 @@ display of file&apos;s on-disk layout, etc.
             <Path fileType="executable">/usr/bin/mzip</Path>
             <Path fileType="executable">/usr/bin/tgz</Path>
             <Path fileType="executable">/usr/bin/uz</Path>
-            <Path fileType="info">/usr/share/info/mtools.info</Path>
-            <Path fileType="man">/usr/share/man/man1/floppyd.1</Path>
-            <Path fileType="man">/usr/share/man/man1/floppyd_installtest.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mattrib.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mbadblocks.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mcat.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mcd.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mcopy.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mdel.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mdeltree.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mdir.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mdu.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mformat.1</Path>
-            <Path fileType="man">/usr/share/man/man1/minfo.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mkmanifest.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mlabel.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mmd.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mmount.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mmove.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mpartition.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mrd.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mren.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mshortname.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mshowfat.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mtools.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mtoolstest.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mtype.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mzip.1</Path>
-            <Path fileType="man">/usr/share/man/man5/mtools.5</Path>
+            <Path fileType="info">/usr/share/info/mtools.info.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/floppyd.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/floppyd_installtest.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mattrib.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mbadblocks.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mcat.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mcd.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mcopy.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mdel.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mdeltree.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mdir.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mdoctorfat.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mdu.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mformat.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/minfo.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mkmanifest.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mlabel.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mmd.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mmount.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mmove.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mpartition.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mrd.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mren.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mshortname.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mshowfat.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mtools.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mtoolstest.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mtype.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mzip.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man5/mtools.5.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2024-10-02</Date>
-            <Version>4.0.45</Version>
+        <Update release="12">
+            <Date>2025-10-28</Date>
+            <Version>4.0.49</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Correctly detect overlong file names, especially when multibyte (UTF-8) strings are concerned
- Fix off-by-one error in 2 calls to native_to_wchar
- When changing disk label, ignore any plain file which would match label
- Added missing newlines in error messages about disk geometry
- Do not print error message if getting geometry is simply not supported by device type (such as for loop devices)
- If full geometry of a device is not available (such as for loop devices), at least make use of the size

**Test Plan**
- Ran tests.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
