### PR TITLE
wordgrinder: Fix https homepage link

### DIFF
--- a/packages/w/wordgrinder/package.yml
+++ b/packages/w/wordgrinder/package.yml
@@ -1,9 +1,9 @@
 name       : wordgrinder
 version    : '0.8'
-release    : 7
+release    : 8
 source     :
     - https://github.com/davidgiven/wordgrinder/archive/refs/tags/0.8.tar.gz : 856cbed2b4ccd5127f61c4997a30e642d414247970f69932f25b4b5a81b18d3f
-homepage   : http://cowlark.com/wordgrinder/
+homepage   : https://cowlark.com/wordgrinder/
 license    : MIT
 component  : office
 summary    : WordGrinder is a simple, Unicode-aware word processor that runs on the console

--- a/packages/w/wordgrinder/pspec_x86_64.xml
+++ b/packages/w/wordgrinder/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>wordgrinder</Name>
-        <Homepage>http://cowlark.com/wordgrinder/</Homepage>
+        <Homepage>https://cowlark.com/wordgrinder/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>office</PartOf>
@@ -24,19 +24,19 @@
             <Path fileType="executable">/usr/bin/xwordgrinder</Path>
             <Path fileType="data">/usr/share/applications/wordgrinder.desktop</Path>
             <Path fileType="doc">/usr/share/doc/wordgrinder/README.wg</Path>
-            <Path fileType="man">/usr/share/man/man1/wordgrinder.1</Path>
-            <Path fileType="man">/usr/share/man/man1/xwordgrinder.1</Path>
+            <Path fileType="man">/usr/share/man/man1/wordgrinder.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/xwordgrinder.1.zst</Path>
             <Path fileType="data">/usr/share/mime-info/wordgrinder.mime</Path>
             <Path fileType="data">/usr/share/pixmaps/wordgrinder.png</Path>
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2024-04-14</Date>
+        <Update release="8">
+            <Date>2025-10-29</Date>
             <Version>0.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fixed https homepage link
- As part of Packages with insecure http or dead link as homepage getsolus#5522 secure links for homepages

**Test Plan**

Opened wordgrinder

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
