### PR TITLE
tinc: Fix https homepage link

### DIFF
--- a/packages/t/tinc/package.yml
+++ b/packages/t/tinc/package.yml
@@ -1,9 +1,9 @@
 name       : tinc
 version    : 1.0.36
-release    : 7
+release    : 8
 source     :
     - https://github.com/gsliepen/tinc/archive/release-1.0.36.tar.gz : 04d87f81335ca32f00a5be1fc94d13fae9d8ae3a65452b76df259cb44a1afa78
-homepage   : http://tinc-vpn.org/
+homepage   : https://tinc-vpn.org/
 license    : GPL-2.0-or-later
 component  : network.clients
 summary    : tinc is a Virtual Private Network (VPN) daemon that uses tunnelling and encryption to create a secure private network between hosts on the Internet.

--- a/packages/t/tinc/pspec_x86_64.xml
+++ b/packages/t/tinc/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>tinc</Name>
-        <Homepage>http://tinc-vpn.org/</Homepage>
+        <Homepage>https://tinc-vpn.org/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>network.clients</PartOf>
@@ -21,18 +21,18 @@
         <PartOf>network.clients</PartOf>
         <Files>
             <Path fileType="executable">/usr/sbin/tincd</Path>
-            <Path fileType="info">/usr/share/info/tinc.info</Path>
-            <Path fileType="man">/usr/share/man/man5/tinc.conf.5</Path>
-            <Path fileType="man">/usr/share/man/man8/tincd.8</Path>
+            <Path fileType="info">/usr/share/info/tinc.info.zst</Path>
+            <Path fileType="man">/usr/share/man/man5/tinc.conf.5.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/tincd.8.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2024-06-22</Date>
+        <Update release="8">
+            <Date>2025-10-29</Date>
             <Version>1.0.36</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fixed https homepage link
- As part of Packages with insecure http or dead link as homepage getsolus#5522 secure links for homepages

**Test Plan**

Install tinc

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
