### PR TITLE
gsl: fix https homepage link

### DIFF
--- a/packages/g/gsl/abi_used_symbols
+++ b/packages/g/gsl/abi_used_symbols
@@ -1,7 +1,9 @@
 libc.so.6:__assert_fail
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_fscanf
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_fscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoul
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__stack_chk_fail
@@ -34,18 +36,18 @@ libc.so.6:strchr
 libc.so.6:strcmp
 libc.so.6:strlen
 libc.so.6:strtod
-libc.so.6:strtol
-libc.so.6:strtoul
 libm.so.6:acos
 libm.so.6:acosh
 libm.so.6:asin
 libm.so.6:atan
 libm.so.6:atan2
 libm.so.6:atanh
+libm.so.6:ceil
 libm.so.6:cos
 libm.so.6:cosh
 libm.so.6:exp
 libm.so.6:expm1
+libm.so.6:floor
 libm.so.6:fmod
 libm.so.6:frexp
 libm.so.6:hypot
@@ -60,3 +62,4 @@ libm.so.6:sinh
 libm.so.6:sqrt
 libm.so.6:tan
 libm.so.6:tanh
+libm.so.6:trunc

--- a/packages/g/gsl/package.yml
+++ b/packages/g/gsl/package.yml
@@ -1,9 +1,9 @@
 name       : gsl
 version    : '2.7'
-release    : 8
+release    : 9
 source     :
-    - https://ftp.gnu.org/gnu/gsl/gsl-2.7.tar.gz : efbbf3785da0e53038be7907500628b466152dbc3c173a87de1b5eba2e23602b
-homepage   : http://www.gnu.org/software/gsl
+    - https://ftpmirror.gnu.org/gnu/gsl/gsl-2.7.tar.gz : efbbf3785da0e53038be7907500628b466152dbc3c173a87de1b5eba2e23602b
+homepage   : https://www.gnu.org/software/gsl/
 license    : GPL-3.0-only
 component  : programming.library
 summary    : Numerical library for C and C++

--- a/packages/g/gsl/pspec_x86_64.xml
+++ b/packages/g/gsl/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>gsl</Name>
-        <Homepage>http://www.gnu.org/software/gsl</Homepage>
+        <Homepage>https://www.gnu.org/software/gsl/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <PartOf>programming.library</PartOf>
@@ -31,10 +31,10 @@
             <Path fileType="library">/usr/lib64/libgsl.so.25.1.0</Path>
             <Path fileType="library">/usr/lib64/libgslcblas.so.0</Path>
             <Path fileType="library">/usr/lib64/libgslcblas.so.0.0.0</Path>
-            <Path fileType="info">/usr/share/info/gsl-ref.info</Path>
-            <Path fileType="man">/usr/share/man/man1/gsl-config.1</Path>
-            <Path fileType="man">/usr/share/man/man1/gsl-histogram.1</Path>
-            <Path fileType="man">/usr/share/man/man1/gsl-randist.1</Path>
+            <Path fileType="info">/usr/share/info/gsl-ref.info.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/gsl-config.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/gsl-histogram.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/gsl-randist.1.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -44,7 +44,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="8">gsl</Dependency>
+            <Dependency release="9">gsl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gsl/gsl_blas.h</Path>
@@ -317,16 +317,16 @@
             <Path fileType="library">/usr/lib64/libgslcblas.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/gsl.pc</Path>
             <Path fileType="data">/usr/share/aclocal/gsl.m4</Path>
-            <Path fileType="man">/usr/share/man/man3/gsl.3</Path>
+            <Path fileType="man">/usr/share/man/man3/gsl.3.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2023-10-04</Date>
+        <Update release="9">
+            <Date>2025-10-29</Date>
             <Version>2.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://www.gnu.org/software/gsl/#releases).
- Fixed https homepage link
- As part of Packages with insecure http or dead link as homepage getsolus#5522 secure links for homepages

**Test Plan**

Open gsl

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
