### PR TITLE
ed: Update to v1.22.2

### DIFF
--- a/packages/e/ed/abi_used_symbols
+++ b/packages/e/ed/abi_used_symbols
@@ -1,5 +1,6 @@
 libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__stack_chk_fail
 libc.so.6:_setjmp
@@ -21,6 +22,7 @@ libc.so.6:ftell
 libc.so.6:fwrite
 libc.so.6:getc
 libc.so.6:getenv
+libc.so.6:getpid
 libc.so.6:ioctl
 libc.so.6:isatty
 libc.so.6:longjmp
@@ -38,18 +40,19 @@ libc.so.6:regcomp
 libc.so.6:regerror
 libc.so.6:regexec
 libc.so.6:regfree
+libc.so.6:remove
 libc.so.6:setlocale
 libc.so.6:setvbuf
 libc.so.6:sigaction
 libc.so.6:sigaddset
 libc.so.6:sigemptyset
 libc.so.6:sigprocmask
+libc.so.6:snprintf
 libc.so.6:strchr
 libc.so.6:strcmp
 libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strncpy
-libc.so.6:strtol
 libc.so.6:system
 libc.so.6:tmpfile

--- a/packages/e/ed/package.yml
+++ b/packages/e/ed/package.yml
@@ -1,8 +1,8 @@
 name       : ed
-version    : '1.20.2'
-release    : 11
+version    : 1.22.2
+release    : 12
 source     :
-    - https://ftp.gnu.org/gnu/ed/ed-1.20.2.tar.lz : 65fec7318f48c2ca17f334ac0f4703defe62037bb13cc23920de077b5fa24523
+    - https://ftpmirror.gnu.org/gnu/ed/ed-1.22.2.tar.lz : f58d15242056e15af76f13f34c60d890fa2a2d5cb0abef91c115e4d83794ffe3
 homepage   : https://www.gnu.org/software/ed/
 license    : GPL-2.0-or-later
 component  : editor
@@ -16,3 +16,5 @@ build      : |
 install    : |
     %make_install
     %make_install install-man
+check      : |
+    %make check

--- a/packages/e/ed/pspec_x86_64.xml
+++ b/packages/e/ed/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ed</Name>
         <Homepage>https://www.gnu.org/software/ed/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>editor</PartOf>
@@ -22,18 +22,18 @@
         <Files>
             <Path fileType="executable">/usr/bin/ed</Path>
             <Path fileType="executable">/usr/bin/red</Path>
-            <Path fileType="info">/usr/share/info/ed.info</Path>
-            <Path fileType="man">/usr/share/man/man1/ed.1</Path>
+            <Path fileType="info">/usr/share/info/ed.info.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/ed.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/red.1</Path>
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2024-04-26</Date>
-            <Version>1.20.2</Version>
+        <Update release="12">
+            <Date>2025-10-29</Date>
+            <Version>1.22.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Newline characters are no longer allowed in file names even when '--unsafe-names' is specified.
- The file name is now printed escaped also when replaced into a shell command.

**Test Plan**
- edited a file.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
