### PR TITLE
gnubg: Update to v1.08.003

### DIFF
--- a/packages/g/gnubg/package.yml
+++ b/packages/g/gnubg/package.yml
@@ -1,8 +1,8 @@
 name       : gnubg
-version    : 1.08.001
-release    : 13
+version    : 1.08.003
+release    : 14
 source     :
-    - https://ftp.gnu.org/gnu/gnubg/gnubg-release-1.08.001-sources.tar.gz : 1e15f9be4594e0d53261ce03bb339058393b01cd6a1b2c4e7c259bee7eaf662d
+    - https://ftpmirror.gnu.org/gnu/gnubg/gnubg-release-1.08.003-sources.tar.gz : 6f7d969b13cfff786fba90ff8cc5e5d564b97f4f0aa69afe4f3838f18c445979
 homepage   : https://www.gnu.org/software/gnubg/
 license    : GPL-3.0-or-later
 component  : games.strategy

--- a/packages/g/gnubg/pspec_x86_64.xml
+++ b/packages/g/gnubg/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnubg</Name>
         <Homepage>https://www.gnu.org/software/gnubg/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>games.strategy</PartOf>
@@ -265,12 +265,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2025-05-22</Date>
-            <Version>1.08.001</Version>
+        <Update release="14">
+            <Date>2025-10-30</Date>
+            <Version>1.08.003</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Added po-debconf Catalan translation

**Test Plan**

<img width="476" height="365" alt="Snapshot_2025-10-30_10-09-24" src="https://github.com/user-attachments/assets/804e293a-dd11-4ce5-a69c-dae294ce90a0" />


**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
