### PR TITLE
gnuchess: Update to v6.3.0

### DIFF
--- a/packages/g/gnuchess/abi_used_symbols
+++ b/packages/g/gnuchess/abi_used_symbols
@@ -3,10 +3,10 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_tolower_loc
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
-libc.so.6:__fgets_chk
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_fscanf
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_fscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__longjmp_chk
 libc.so.6:__memcpy_chk
@@ -62,7 +62,6 @@ libc.so.6:pthread_cond_init
 libc.so.6:pthread_cond_signal
 libc.so.6:pthread_cond_wait
 libc.so.6:pthread_create
-libc.so.6:pthread_exit
 libc.so.6:pthread_join
 libc.so.6:pthread_mutex_init
 libc.so.6:pthread_mutex_lock
@@ -83,7 +82,6 @@ libc.so.6:srand
 libc.so.6:stderr
 libc.so.6:stdin
 libc.so.6:stdout
-libc.so.6:stpcpy
 libc.so.6:strcat
 libc.so.6:strchr
 libc.so.6:strcmp
@@ -97,7 +95,6 @@ libc.so.6:strncpy
 libc.so.6:strstr
 libc.so.6:strtod
 libc.so.6:strtok
-libc.so.6:strtol
 libc.so.6:system
 libc.so.6:textdomain
 libc.so.6:time

--- a/packages/g/gnuchess/package.yml
+++ b/packages/g/gnuchess/package.yml
@@ -1,8 +1,8 @@
 name       : gnuchess
-version    : 6.2.9
-release    : 11
+version    : 6.3.0
+release    : 12
 source     :
-    - https://ftp.gnu.org/gnu/chess/gnuchess-6.2.9.tar.gz : ddfcc20bdd756900a9ab6c42c7daf90a2893bf7f19ce347420ce36baebc41890
+    - https://ftpmirror.gnu.org/gnu/chess/gnuchess-6.3.0.tar.gz : 0b37bec2098c2ad695b7443e5d7944dc6dc8284f8d01fcc30bdb94dd033ca23a
 homepage   : https://www.gnu.org/software/chess/
 license    : GPL-3.0-or-later
 component  : games.strategy

--- a/packages/g/gnuchess/pspec_x86_64.xml
+++ b/packages/g/gnuchess/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>gnuchess</Name>
         <Homepage>https://www.gnu.org/software/chess/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>games.strategy</PartOf>
         <Summary xml:lang="en">GNU Chess program</Summary>
         <Description xml:lang="en">GNU Chess lets most modern computers play a full game of chess. It has a terminal interface but supports visual interfaces such as XBoard.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>gnuchess</Name>
@@ -25,9 +25,8 @@
             <Path fileType="executable">/usr/bin/gnuchessx</Path>
             <Path fileType="data">/usr/share/games/plugins/logos/gnuchess.png</Path>
             <Path fileType="data">/usr/share/games/plugins/xboard/gnuchess.eng</Path>
-            <Path fileType="data">/usr/share/gnuchess/gnuchess.ini</Path>
             <Path fileType="data">/usr/share/gnuchess/smallbook.bin</Path>
-            <Path fileType="info">/usr/share/info/gnuchess.info</Path>
+            <Path fileType="info">/usr/share/info/gnuchess.info.zst</Path>
             <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/gnuchess.mo</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/gnuchess.mo</Path>
             <Path fileType="localedata">/usr/share/locale/eo/LC_MESSAGES/gnuchess.mo</Path>
@@ -38,21 +37,22 @@
             <Path fileType="localedata">/usr/share/locale/nb/LC_MESSAGES/gnuchess.mo</Path>
             <Path fileType="localedata">/usr/share/locale/nl/LC_MESSAGES/gnuchess.mo</Path>
             <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/gnuchess.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ro/LC_MESSAGES/gnuchess.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sr/LC_MESSAGES/gnuchess.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/gnuchess.mo</Path>
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/gnuchess.mo</Path>
             <Path fileType="localedata">/usr/share/locale/vi/LC_MESSAGES/gnuchess.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/gnuchess.mo</Path>
-            <Path fileType="man">/usr/share/man/man1/gnuchess.1</Path>
+            <Path fileType="man">/usr/share/man/man1/gnuchess.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2022-03-24</Date>
-            <Version>6.2.9</Version>
+        <Update release="12">
+            <Date>2025-10-30</Date>
+            <Version>6.3.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Look for gnuchess.ini in XDG_CONFIG_HOME or ~/.config/.
- Dynamically configure gnuchess.ini from gnuchess.ini.in.
- Disable engine book on 'book off'.
- Improve style of some help messages.
- More graceful program termination if book does not exist.
- Bug fix in (epd)load command.
- Fix potential buffer overflows in the pipes read/write.

**Test Plan**
- Checked version.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
