### PR TITLE
libcdio-paranoia: Update to v10.2.2.0.2

### DIFF
--- a/packages/l/libcdio-paranoia/abi_used_symbols
+++ b/packages/l/libcdio-paranoia/abi_used_symbols
@@ -6,7 +6,6 @@ libc.so.6:__libc_start_main
 libc.so.6:__snprintf_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
-libc.so.6:__strcat_chk
 libc.so.6:__strncat_chk
 libc.so.6:calloc
 libc.so.6:clock_gettime

--- a/packages/l/libcdio-paranoia/package.yml
+++ b/packages/l/libcdio-paranoia/package.yml
@@ -1,8 +1,8 @@
 name       : libcdio-paranoia
-version    : 10.2.2.0.1
-release    : 8
+version    : 10.2.2.0.2
+release    : 9
 source     :
-    - https://ftp.gnu.org/gnu/libcdio/libcdio-paranoia-10.2+2.0.1.tar.gz : 28d7d00e4a83d0221acda0fd2eb3e3240bf094db4c00a85998922201939fa952
+    - https://github.com/libcdio/libcdio-paranoia/releases/download/release-10.2%2B2.0.2/libcdio-paranoia-10.2+2.0.2.tar.bz2 : 186892539dedd661276014d71318c8c8f97ecb1250a86625256abd4defbf0d0c
 homepage   : https://www.gnu.org/software/libcdio/
 license    : GPL-3.0-or-later
 component  : multimedia.library

--- a/packages/l/libcdio-paranoia/pspec_x86_64.xml
+++ b/packages/l/libcdio-paranoia/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libcdio-paranoia</Name>
         <Homepage>https://www.gnu.org/software/libcdio/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>multimedia.library</PartOf>
@@ -26,8 +26,8 @@
             <Path fileType="library">/usr/lib64/libcdio_cdda.so.2.0.0</Path>
             <Path fileType="library">/usr/lib64/libcdio_paranoia.so.2</Path>
             <Path fileType="library">/usr/lib64/libcdio_paranoia.so.2.0.0</Path>
-            <Path fileType="man">/usr/share/man/jp/man1/cd-paranoia.1</Path>
-            <Path fileType="man">/usr/share/man/man1/cd-paranoia.1</Path>
+            <Path fileType="man">/usr/share/man/ja/man1/cd-paranoia.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/cd-paranoia.1.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -37,7 +37,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="8">libcdio-paranoia</Dependency>
+            <Dependency release="9">libcdio-paranoia</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/cdio/paranoia/cdda.h</Path>
@@ -50,12 +50,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2024-05-26</Date>
-            <Version>10.2.2.0.1</Version>
+        <Update release="9">
+            <Date>2025-10-30</Date>
+            <Version>10.2.2.0.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- A 6-year-old bug seen primarily by Whipper users concerning adjustment of CD-drives with large or negative sample offsets has been fixed
- Added test on LSN for span check errors with improved error messages
- Removed dead code after exit
- Fixed Japanese manpage

**Test Plan**
- Ran tests.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
