### PR TITLE
libmicrohttpd: Update to v1.0.2

### DIFF
--- a/packages/l/libmicrohttpd/abi_used_symbols
+++ b/packages/l/libmicrohttpd/abi_used_symbols
@@ -1,8 +1,9 @@
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
-libc.so.6:__fprintf_chk
 libc.so.6:__memcpy_chk
 libc.so.6:__memmove_chk
+libc.so.6:__poll_chk
+libc.so.6:__read_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__vfprintf_chk
 libc.so.6:abort

--- a/packages/l/libmicrohttpd/package.yml
+++ b/packages/l/libmicrohttpd/package.yml
@@ -1,8 +1,8 @@
 name       : libmicrohttpd
-version    : 1.0.1
-release    : 11
+version    : 1.0.2
+release    : 12
 source     :
-    - https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-1.0.1.tar.gz : a89e09fc9b4de34dde19f4fcb4faaa1ce10299b9908db1132bbfa1de47882b94
+    - https://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-1.0.2.tar.gz : df324fcd0834175dab07483133902d9774a605bfa298025f69883288fd20a8c7
 homepage   : https://www.gnu.org/software/libmicrohttpd/
 license    : LGPL-2.1-or-later
 component  : network.web
@@ -11,8 +11,6 @@ description: |
     GNU libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application.
 builddeps  :
     - pkgconfig(gnutls)
-checkdeps  :
-    - pkgconfig(libcurl) # extended checks
 clang      : true
 setup      : |
     %configure --disable-static

--- a/packages/l/libmicrohttpd/pspec_x86_64.xml
+++ b/packages/l/libmicrohttpd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libmicrohttpd</Name>
         <Homepage>https://www.gnu.org/software/libmicrohttpd/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>network.web</PartOf>
@@ -21,7 +21,7 @@
         <PartOf>network.web</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libmicrohttpd.so.12</Path>
-            <Path fileType="library">/usr/lib64/libmicrohttpd.so.12.62.1</Path>
+            <Path fileType="library">/usr/lib64/libmicrohttpd.so.12.62.2</Path>
         </Files>
     </Package>
     <Package>
@@ -31,22 +31,22 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="11">libmicrohttpd</Dependency>
+            <Dependency release="12">libmicrohttpd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/microhttpd.h</Path>
             <Path fileType="library">/usr/lib64/libmicrohttpd.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/libmicrohttpd.pc</Path>
-            <Path fileType="man">/usr/share/man/man3/libmicrohttpd.3</Path>
+            <Path fileType="man">/usr/share/man/man3/libmicrohttpd.3.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2024-02-24</Date>
-            <Version>1.0.1</Version>
+        <Update release="12">
+            <Date>2025-10-30</Date>
+            <Version>1.0.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- add d/patches/test_get_close_for_curl_8.16.patch to fix FTBFS with curl 8.16.

**Test Plan**
- Ran tests.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->

**Packaging notes**
- Tests fail with curl so dropped the dependency.
