### PR TITLE
libunistring: Update to v1.4.1

### DIFF
--- a/packages/l/libunistring/abi_symbols
+++ b/packages/l/libunistring/abi_symbols
@@ -166,11 +166,11 @@ libunistring.so.5:libunistring_c_isspace
 libunistring.so.5:libunistring_c_isupper
 libunistring.so.5:libunistring_c_isxdigit
 libunistring.so.5:libunistring_c_strcasecmp
-libunistring.so.5:libunistring_c_strncasecmp
 libunistring.so.5:libunistring_c_tolower
 libunistring.so.5:libunistring_c_toupper
 libunistring.so.5:libunistring_freea
 libunistring.so.5:libunistring_fseterr
+libunistring.so.5:libunistring_getlocalename_l_unsafe
 libunistring.so.5:libunistring_gl_locale_name
 libunistring.so.5:libunistring_gl_locale_name_default
 libunistring.so.5:libunistring_gl_locale_name_environ
@@ -199,6 +199,7 @@ libunistring.so.5:libunistring_mem_cd_iconveh
 libunistring.so.5:libunistring_mem_iconveh
 libunistring.so.5:libunistring_mem_iconveha
 libunistring.so.5:libunistring_memcmp2
+libunistring.so.5:libunistring_memeq
 libunistring.so.5:libunistring_mmalloca
 libunistring.so.5:libunistring_printf_frexp
 libunistring.so.5:libunistring_printf_frexpl
@@ -211,6 +212,7 @@ libunistring.so.5:libunistring_setlocale_null_unlocked
 libunistring.so.5:libunistring_str_cd_iconveh
 libunistring.so.5:libunistring_str_iconveh
 libunistring.so.5:libunistring_str_iconveha
+libunistring.so.5:libunistring_streq
 libunistring.so.5:libunistring_u16_casemap
 libunistring.so.5:libunistring_u16_is_invariant
 libunistring.so.5:libunistring_u16_possible_linebreaks_loop

--- a/packages/l/libunistring/abi_symbols32
+++ b/packages/l/libunistring/abi_symbols32
@@ -166,11 +166,11 @@ libunistring.so.5:libunistring_c_isspace
 libunistring.so.5:libunistring_c_isupper
 libunistring.so.5:libunistring_c_isxdigit
 libunistring.so.5:libunistring_c_strcasecmp
-libunistring.so.5:libunistring_c_strncasecmp
 libunistring.so.5:libunistring_c_tolower
 libunistring.so.5:libunistring_c_toupper
 libunistring.so.5:libunistring_freea
 libunistring.so.5:libunistring_fseterr
+libunistring.so.5:libunistring_getlocalename_l_unsafe
 libunistring.so.5:libunistring_gl_locale_name
 libunistring.so.5:libunistring_gl_locale_name_default
 libunistring.so.5:libunistring_gl_locale_name_environ
@@ -199,6 +199,7 @@ libunistring.so.5:libunistring_mem_cd_iconveh
 libunistring.so.5:libunistring_mem_iconveh
 libunistring.so.5:libunistring_mem_iconveha
 libunistring.so.5:libunistring_memcmp2
+libunistring.so.5:libunistring_memeq
 libunistring.so.5:libunistring_mmalloca
 libunistring.so.5:libunistring_printf_frexp
 libunistring.so.5:libunistring_printf_frexpl
@@ -211,6 +212,7 @@ libunistring.so.5:libunistring_setlocale_null_unlocked
 libunistring.so.5:libunistring_str_cd_iconveh
 libunistring.so.5:libunistring_str_iconveh
 libunistring.so.5:libunistring_str_iconveha
+libunistring.so.5:libunistring_streq
 libunistring.so.5:libunistring_u16_casemap
 libunistring.so.5:libunistring_u16_is_invariant
 libunistring.so.5:libunistring_u16_possible_linebreaks_loop

--- a/packages/l/libunistring/abi_used_symbols
+++ b/packages/l/libunistring/abi_used_symbols
@@ -39,6 +39,7 @@ libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset
 libc.so.6:nl_langinfo
+libc.so.6:nl_langinfo_l
 libc.so.6:pthread_mutex_init
 libc.so.6:pthread_mutex_lock
 libc.so.6:pthread_mutex_unlock

--- a/packages/l/libunistring/abi_used_symbols32
+++ b/packages/l/libunistring/abi_used_symbols32
@@ -39,6 +39,7 @@ libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset
 libc.so.6:nl_langinfo
+libc.so.6:nl_langinfo_l
 libc.so.6:pthread_mutex_init
 libc.so.6:pthread_mutex_lock
 libc.so.6:pthread_mutex_unlock

--- a/packages/l/libunistring/package.yml
+++ b/packages/l/libunistring/package.yml
@@ -1,9 +1,9 @@
 name       : libunistring
-version    : '1.3'
-release    : 10
+version    : 1.4.1
+release    : 11
 source     :
-    - https://ftp.gnu.org/gnu/libunistring/libunistring-1.3.tar.xz : f245786c831d25150f3dfb4317cda1acc5e3f79a5da4ad073ddca58886569527
-homepage   : http://www.gnu.org/software/libunistring
+    - https://ftpmirror.gnu.org/gnu/libunistring/libunistring-1.4.1.tar.xz : 67d88430892527861903788868c77802a217b0959990f7449f2976126a307763
+homepage   : https://www.gnu.org/software/libunistring
 license    : LGPL-3.0-or-later
 component  : system.base
 summary    : Library for manipulating Unicode strings

--- a/packages/l/libunistring/pspec_x86_64.xml
+++ b/packages/l/libunistring/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>libunistring</Name>
-        <Homepage>http://www.gnu.org/software/libunistring</Homepage>
+        <Homepage>https://www.gnu.org/software/libunistring</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>LGPL-3.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -21,8 +21,8 @@
         <PartOf>system.base</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libunistring.so.5</Path>
-            <Path fileType="library">/usr/lib64/libunistring.so.5.2.0</Path>
-            <Path fileType="info">/usr/share/info/libunistring.info</Path>
+            <Path fileType="library">/usr/lib64/libunistring.so.5.2.1</Path>
+            <Path fileType="info">/usr/share/info/libunistring.info.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -32,11 +32,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">libunistring</Dependency>
+            <Dependency release="11">libunistring</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libunistring.so.5</Path>
-            <Path fileType="library">/usr/lib32/libunistring.so.5.2.0</Path>
+            <Path fileType="library">/usr/lib32/libunistring.so.5.2.1</Path>
         </Files>
     </Package>
     <Package>
@@ -46,8 +46,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">libunistring-devel</Dependency>
-            <Dependency release="10">libunistring-32bit</Dependency>
+            <Dependency release="11">libunistring-32bit</Dependency>
+            <Dependency release="11">libunistring-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libunistring.so</Path>
@@ -60,7 +60,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">libunistring</Dependency>
+            <Dependency release="11">libunistring</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/unicase.h</Path>
@@ -122,12 +122,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2024-10-18</Date>
-            <Version>1.3</Version>
+        <Update release="11">
+            <Date>2025-10-30</Date>
+            <Version>1.4.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- The data tables and algorithms have been updated to Unicode version 17.0.0.
- Fixed a bug: The functions u*_grapheme_next and u*_grapheme_prev did not work right for strings with Indic characters, Emojis, or regional indicators.

**Test Plan**
- Ran tests.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
