### PR TITLE
uv: update to 0.9.6

### DIFF
--- a/packages/u/uv/package.yml
+++ b/packages/u/uv/package.yml
@@ -1,8 +1,8 @@
 name       : uv
-version    : 0.9.5
-release    : 2
+version    : 0.9.6
+release    : 3
 source     :
-    - https://github.com/astral-sh/uv/archive/refs/tags/0.9.5.tar.gz : 9fd1dd030b37b51dcf79b582ea77a911eeb4015a00669bd3047d3b6adea37ba8
+    - https://github.com/astral-sh/uv/archive/refs/tags/0.9.6.tar.gz : c32470f9f1c2903304fa6538fea3f153a9995a7f26da8024f4617bf1ad042936
 homepage   : https://docs.astral.sh/uv
 license    :
     - Apache-2.0
@@ -36,3 +36,6 @@ install    : |
     install -Dm0644 "completions/$package.bash" -t "$installdir/usr/share/bash-completion/completions/"
     install -Dm0644 "completions/$package.fish" -t "$installdir/usr/share/fish/vendor_completions.d/"
     install -Dm0644 "completions/_$package" -t "$installdir/usr/share/zsh/site-functions/"
+check      : |
+    # Run smoke tests
+    "$installdir/usr/bin/uv" run "$workdir/scripts/smoke-test"

--- a/packages/u/uv/pspec_x86_64.xml
+++ b/packages/u/uv/pspec_x86_64.xml
@@ -32,9 +32,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2025-10-23</Date>
-            <Version>0.9.5</Version>
+        <Update release="3">
+            <Date>2025-10-30</Date>
+            <Version>0.9.6</Version>
             <Comment>Packaging update</Comment>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>


### PR DESCRIPTION
**Summary**

- Release notes:
  - [v0.9.6](https://github.com/astral-sh/uv/releases/tag/0.9.6)

**Security**

Address ZIP parsing differentials ([GHSA-pqhf-p39g-3x64](https://github.com/astral-sh/uv/security/advisories/GHSA-pqhf-p39g-3x64))

**Test Plan**

- Added smoke tests from source package in packaging check.
- Installed and tried locally.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
