### PR TITLE
pspp: Switch to mirror source, fix build

### DIFF
--- a/packages/p/pspp/abi_used_symbols
+++ b/packages/p/pspp/abi_used_symbols
@@ -6,6 +6,7 @@ libc.so.6:__cxa_atexit
 libc.so.6:__environ
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
+libc.so.6:__fread_unlocked_chk
 libc.so.6:__isoc23_sscanf
 libc.so.6:__isoc23_strtol
 libc.so.6:__isoc23_strtoull
@@ -1239,6 +1240,7 @@ libm.so.6:sin
 libm.so.6:sincos
 libm.so.6:sqrt
 libm.so.6:tan
+libm.so.6:trunc
 libpango-1.0.so.0:pango_attr_font_desc_new
 libpango-1.0.so.0:pango_attr_list_insert
 libpango-1.0.so.0:pango_attr_list_new

--- a/packages/p/pspp/package.yml
+++ b/packages/p/pspp/package.yml
@@ -1,8 +1,8 @@
 name       : pspp
 version    : 2.0.1
-release    : 12
+release    : 13
 source     :
-    - https://ftp.gnu.org/gnu/pspp/pspp-2.0.1.tar.gz : 8edbb0f09e8cf8010cad9e0559e0230d7fc5aae4721c756c350554df33024c00
+    - https://ftpmirror.gnu.org/gnu/pspp/pspp-2.0.1.tar.gz : 8edbb0f09e8cf8010cad9e0559e0230d7fc5aae4721c756c350554df33024c00
 homepage   : https://www.gnu.org/software/pspp/
 license    : GPL-3.0-or-later
 component  : office.maths
@@ -19,7 +19,9 @@ setup      : |
     # See http://savannah.gnu.org/bugs/?65892, remove all .png related docs
     %patch -p1 -i $pkgfiles/disable-png.patch
 
-    %reconfigure --disable-static
+    # FIXME: reconfigure macro doesn't pick up -I
+    autoreconf -vfi -I /usr/share/gettext/m4
+    %configure --disable-static
 build      : |
     %make
 install    : |

--- a/packages/p/pspp/pspec_x86_64.xml
+++ b/packages/p/pspp/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pspp</Name>
         <Homepage>https://www.gnu.org/software/pspp/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>office.maths</PartOf>
@@ -64,11 +64,11 @@
             <Path fileType="data">/usr/share/icons/hicolor/96x96/mimetypes</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/org.gnu.pspp.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/mimetypes</Path>
-            <Path fileType="info">/usr/share/info/pspp-dev.info</Path>
-            <Path fileType="info">/usr/share/info/pspp.info</Path>
-            <Path fileType="info">/usr/share/info/pspp.info-1</Path>
-            <Path fileType="info">/usr/share/info/pspp.info-2</Path>
-            <Path fileType="info">/usr/share/info/pspp.info-3</Path>
+            <Path fileType="info">/usr/share/info/pspp-dev.info.zst</Path>
+            <Path fileType="info">/usr/share/info/pspp.info-1.zst</Path>
+            <Path fileType="info">/usr/share/info/pspp.info-2.zst</Path>
+            <Path fileType="info">/usr/share/info/pspp.info-3.zst</Path>
+            <Path fileType="info">/usr/share/info/pspp.info.zst</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/pspp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/pspp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/pspp.mo</Path>
@@ -89,11 +89,11 @@
             <Path fileType="localedata">/usr/share/locale/tr/LC_MESSAGES/pspp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/pspp.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/pspp.mo</Path>
-            <Path fileType="man">/usr/share/man/man1/pspp-convert.1</Path>
-            <Path fileType="man">/usr/share/man/man1/pspp-dump-sav.1</Path>
-            <Path fileType="man">/usr/share/man/man1/pspp-output.1</Path>
-            <Path fileType="man">/usr/share/man/man1/pspp.1</Path>
-            <Path fileType="man">/usr/share/man/man1/psppire.1</Path>
+            <Path fileType="man">/usr/share/man/man1/pspp-convert.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/pspp-dump-sav.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/pspp-output.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/pspp.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/psppire.1.zst</Path>
             <Path fileType="data">/usr/share/metainfo/org.gnu.pspp.metainfo.xml</Path>
             <Path fileType="data">/usr/share/mime/packages/org.gnu.pspp.xml</Path>
             <Path fileType="data">/usr/share/pspp/actions</Path>
@@ -166,12 +166,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2024-11-12</Date>
+        <Update release="13">
+            <Date>2025-10-31</Date>
             <Version>2.0.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Switch to better gnu source, dodge autotool jank

Resolves https://github.com/getsolus/packages/issues/6688

**Test Plan**

- Built, started pspp REPL

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
