### PR TITLE
starship: Add completions and AerynOS preset

### DIFF
--- a/packages/s/starship/files/50-starship.sh
+++ b/packages/s/starship/files/50-starship.sh
@@ -1,0 +1,21 @@
+##
+## Initialises starship prompt for interactive shells
+## Removing starship package will also remove this initialisation
+##
+
+# Check for interactive shell the POSIX sh way
+[ -t 0 ] || return 0
+
+# The linux console terminal emulator can't show the default starship prompt...
+case "$TERM" in
+    "linux") return 0;;
+esac
+
+# For bash
+[ -n "$BASH_VERSION" ]  && eval "$(starship init bash)"
+
+# For zsh
+[ -n "$ZSH_VERSION" ] && eval "$(starship init zsh)"
+
+# For fish
+[ -n "$FISH_VERSION" ] && eval "$(starship init fish)"

--- a/packages/s/starship/files/aeryn-os.toml
+++ b/packages/s/starship/files/aeryn-os.toml
@@ -1,0 +1,83 @@
+format = """
+[░▒▓](#a3aed2)\
+[ 󰌽 ](bg:#a3aed2 fg:#090c0c)\
+$username\
+$hostname\
+[](bg:#769ff0 fg:#a3aed2)\
+$directory\
+[](fg:#769ff0 bg:#394260)\
+$git_branch\
+$git_status\
+[](fg:#394260 bg:#212736)\
+$nodejs\
+$rust\
+$golang\
+$php\
+[](fg:#212736 bg:#1d2230)\
+$time\
+[ ](fg:#1d2230)\
+\n$character"""
+
+
+[directory]
+style = "fg:#e3e5e5 bg:#769ff0"
+format = "[ $path ]($style)"
+truncation_length = 3
+truncation_symbol = "…/"
+
+[directory.substitutions]
+"Desktop" = " "
+"Documents" = "󰈙 "
+"Downloads" = " "
+"Music" = " "
+"Pictures" = " "
+"Videos" = " "
+
+[username]
+show_always = true
+style_user = "bg:#a3aed2 fg:#090c0c"
+style_root = "bg:#a3aed2 fg:#090c0c"
+format = '[$user]($style)'
+disabled = false
+
+[hostname]
+ssh_only = false
+format = '[@$hostname $ssh_symbol ]($style)'
+ssh_symbol = "󰄙"
+style = "bg:#a3aed2 fg:#090c0c"
+disabled = false
+
+[git_branch]
+symbol = ""
+style = "bg:#394260"
+format = '[[ $symbol $branch ](fg:#769ff0 bg:#394260)]($style)'
+
+[git_status]
+style = "bg:#394260"
+format = '[[($all_status$ahead_behind )](fg:#769ff0 bg:#394260)]($style)'
+
+[nodejs]
+symbol = ""
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[rust]
+symbol = ""
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[golang]
+symbol = ""
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[php]
+symbol = ""
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[time]
+disabled = false
+time_format = "%R" # Hour:Minute Format
+style = "bg:#1d2230"
+format = '[[  $time ](fg:#a0a9cb bg:#1d2230)]($style)'

--- a/packages/s/starship/package.yml
+++ b/packages/s/starship/package.yml
@@ -1,6 +1,6 @@
 name       : starship
 version    : 1.24.0
-release    : 24
+release    : 25
 source     :
     - https://github.com/starship/starship/archive/refs/tags/v1.24.0.tar.gz : 3d98e2c57dcfea36c6035e2ad812f91cfe33099e4b67f6ea7728e2294f02ca61
 homepage   : https://starship.rs/
@@ -19,11 +19,25 @@ builddeps  :
 checkdeps  :
     - git
 setup      : |
+    cp $pkgfiles/aeryn-os.toml docs/public/presets/toml/aeryn-os.toml
+
     %cargo_fetch
 build      : |
     %cargo_build
 install    : |
     %cargo_install
+
+    # Install completions
+    install -dm00755 $installdir/usr/share/bash-completion/completions
+    install -dm00755 $installdir/usr/share/zsh/site-functions
+    install -dm00755 $installdir/usr/share/fish/vendor_completions.d
+
+    target/release/starship completions bash > $installdir/usr/share/bash-completion/completions/starship.bash
+    target/release/starship completions zsh > $installdir/usr/share/zsh/site-functions/_starship
+    target/release/starship completions fish > $installdir/usr/share/fish/vendor_completions.d/starship.fish
+
+    # Default initialization
+    install -Dm00644 $pkgfiles/50-starship.sh $installdir/usr/share/defaults/etc/profile.d/50-starship.sh
 check      : |
     export TERM=xterm-256color
     %cargo_test -- --skip "modules::username::tests::show_always_false"

--- a/packages/s/starship/pspec_x86_64.xml
+++ b/packages/s/starship/pspec_x86_64.xml
@@ -29,11 +29,15 @@ Every little detail is customizable to your liking, to make this prompt as minim
         <PartOf>system.utils</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/starship</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/starship.bash</Path>
+            <Path fileType="data">/usr/share/defaults/etc/profile.d/50-starship.sh</Path>
+            <Path fileType="data">/usr/share/fish/vendor_completions.d/starship.fish</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_starship</Path>
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2025-10-25</Date>
+        <Update release="25">
+            <Date>2025-10-31</Date>
             <Version>1.24.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
- Add shell completions for bash, zsh, and fish
- Add the AerynOS prompt preset
- Start Starship automatically when installed
  - Only works with Bash, since we only source scripts in `profile.d` in
    Bash

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new session with Fish.
Start a new session with Bash.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
