### PR TITLE
font-overpass-otf: Fix homepage link

### DIFF
--- a/packages/f/font-overpass-otf/package.yml
+++ b/packages/f/font-overpass-otf/package.yml
@@ -1,9 +1,9 @@
 name       : font-overpass-otf
 version    : 3.0.5
-release    : 5
+release    : 6
 source     :
     - https://github.com/RedHatOfficial/Overpass/archive/refs/tags/v3.0.5.tar.gz : beb7528f1e9adf3decf841f02510a3752820561a06842f9097d9f2565fe41f34
-homepage   : http://overpassfont.org/
+homepage   : https://overpassfont.org/
 license    :
     - OFL-1.1
     - LGPL-2.1-or-later

--- a/packages/f/font-overpass-otf/pspec_x86_64.xml
+++ b/packages/f/font-overpass-otf/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>font-overpass-otf</Name>
-        <Homepage>http://overpassfont.org/</Homepage>
+        <Homepage>https://overpassfont.org/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Dariusz Mencel</Name>
+            <Email>dariusz.bajon@gmail.com</Email>
         </Packager>
         <License>OFL-1.1</License>
         <License>LGPL-2.1-or-later</License>
@@ -45,12 +45,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2023-10-13</Date>
+        <Update release="6">
+            <Date>2025-10-31</Date>
             <Version>3.0.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Dariusz Mencel</Name>
+            <Email>dariusz.bajon@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

font-overpass-otf: Fix homepage
Part of: #5522

**Test Plan**
Build and install fonts
<img width="970" height="652" alt="image" src="https://github.com/user-attachments/assets/7512f04b-efc2-4bcf-b18f-34df3f4324b5" />

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
