### PR TITLE
automake: Update to v1.18.1

### DIFF
--- a/packages/a/automake/package.yml
+++ b/packages/a/automake/package.yml
@@ -1,8 +1,8 @@
 name       : automake
-version    : '1.17'
-release    : 15
+version    : 1.18.1
+release    : 16
 source     :
-    - https://ftp.gnu.org/gnu/automake/automake-1.17.tar.xz : 8920c1fc411e13b90bf704ef9db6f29d540e76d232cb3b2c9f4dc4cc599bd990
+    - https://ftpmirror.gnu.org/gnu/automake/automake-1.18.1.tar.xz : 168aa363278351b89af56684448f525a5bce5079d0b6842bd910fdd3f1646887
 homepage   : https://www.gnu.org/software/automake/
 license    : GPL-2.0-or-later
 component  : system.devel
@@ -16,7 +16,7 @@ build      : |
 install    : |
     %make_install
     # enable legacy eopkg builds (non-ypkg) to reconfigure
-    export main_version="1.17"
+    export main_version="1.18.1"
     ln -s automake-${main_version} $installdir/usr/share/gnuconfig
 check      : |
     %make check

--- a/packages/a/automake/pspec_x86_64.xml
+++ b/packages/a/automake/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>automake</Name>
         <Homepage>https://www.gnu.org/software/automake/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.devel</PartOf>
@@ -21,139 +21,140 @@
         <PartOf>system.devel</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/aclocal</Path>
-            <Path fileType="executable">/usr/bin/aclocal-1.17</Path>
+            <Path fileType="executable">/usr/bin/aclocal-1.18</Path>
             <Path fileType="executable">/usr/bin/automake</Path>
-            <Path fileType="executable">/usr/bin/automake-1.17</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/amversion.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/ar-lib.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/as.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/auxdir.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/cond-if.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/cond.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/depend.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/depout.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/dmalloc.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/extra-recurs.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/gcj.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/init.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/install-sh.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/internal/ac-config-macro-dirs.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/lead-dot.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/lex.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/lispdir.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/maintainer.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/make.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/missing.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/mkdirp.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/obsolete.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/options.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/prog-cc-c-o.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/python.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/rmf.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/runlog.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/sanity.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/silent.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/strip.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/substnot.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/tar.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/upc.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/vala.m4</Path>
-            <Path fileType="data">/usr/share/aclocal-1.17/xargsn.m4</Path>
+            <Path fileType="executable">/usr/bin/automake-1.18</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/amversion.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/ar-lib.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/as.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/auxdir.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/cond-if.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/cond.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/depend.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/depout.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/dmalloc.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/extra-recurs.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/gcj.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/init.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/install-sh.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/internal/ac-config-macro-dirs.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/lead-dot.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/lex.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/lispdir.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/maintainer.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/make.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/missing.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/mkdirp.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/obsolete.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/options.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/prog-cc-c-o.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/python.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/rmf.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/runlog.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/sanity.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/silent.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/strip.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/substnot.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/tar.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/upc.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/vala.m4</Path>
+            <Path fileType="data">/usr/share/aclocal-1.18/xargsn.m4</Path>
             <Path fileType="data">/usr/share/aclocal/README</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/ChannelDefs.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/Channels.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/Condition.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/Config.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/Configure_ac.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/DisjConditions.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/FileUtils.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/General.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/Getopt.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/Item.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/ItemDef.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/Language.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/Location.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/Options.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/Rule.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/RuleDef.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/VarDef.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/Variable.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/Version.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/Wrap.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/Automake/XFile.pm</Path>
-            <Path fileType="data">/usr/share/automake-1.17/COPYING</Path>
-            <Path fileType="data">/usr/share/automake-1.17/INSTALL</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/check.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/check2.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/clean-hdr.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/clean.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/compile.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/configure.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/data.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/dejagnu.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/depend.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/depend2.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/distdir.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/footer.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/header-vars.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/header.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/inst-vars.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/install.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/java.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/lang-compile.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/lex.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/library.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/libs.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/libtool.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/lisp.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/ltlib.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/ltlibrary.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/mans-vars.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/mans.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/program.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/progs.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/python.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/remake-hdr.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/scripts.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/subdirs.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/tags.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/texi-vers.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/texibuild.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/texinfos.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/vala.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/am/yacc.am</Path>
-            <Path fileType="data">/usr/share/automake-1.17/ar-lib</Path>
-            <Path fileType="data">/usr/share/automake-1.17/compile</Path>
-            <Path fileType="data">/usr/share/automake-1.17/config.guess</Path>
-            <Path fileType="data">/usr/share/automake-1.17/config.sub</Path>
-            <Path fileType="data">/usr/share/automake-1.17/depcomp</Path>
-            <Path fileType="data">/usr/share/automake-1.17/install-sh</Path>
-            <Path fileType="data">/usr/share/automake-1.17/mdate-sh</Path>
-            <Path fileType="data">/usr/share/automake-1.17/missing</Path>
-            <Path fileType="data">/usr/share/automake-1.17/mkinstalldirs</Path>
-            <Path fileType="data">/usr/share/automake-1.17/py-compile</Path>
-            <Path fileType="data">/usr/share/automake-1.17/tap-driver.sh</Path>
-            <Path fileType="data">/usr/share/automake-1.17/test-driver</Path>
-            <Path fileType="data">/usr/share/automake-1.17/texinfo.tex</Path>
-            <Path fileType="data">/usr/share/automake-1.17/ylwrap</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/ChannelDefs.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/Channels.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/Condition.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/Config.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/Configure_ac.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/DisjConditions.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/FileUtils.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/General.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/Getopt.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/Item.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/ItemDef.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/Language.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/Location.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/Options.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/Rule.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/RuleDef.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/VarDef.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/Variable.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/Version.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/Wrap.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/Automake/XFile.pm</Path>
+            <Path fileType="data">/usr/share/automake-1.18/COPYING</Path>
+            <Path fileType="data">/usr/share/automake-1.18/INSTALL</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/check.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/check2.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/clean-hdr.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/clean.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/compile.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/configure.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/data.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/dejagnu.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/depend.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/depend2.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/distdir.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/footer.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/header-vars.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/header.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/inst-vars.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/install.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/java.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/lang-compile.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/lex.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/library.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/libs.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/libtool.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/lisp.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/ltlib.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/ltlibrary.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/mans-vars.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/mans.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/program.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/progs.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/python.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/remake-hdr.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/scripts.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/subdirs.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/tags.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/texi-vers.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/texibuild.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/texinfos.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/vala.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/am/yacc.am</Path>
+            <Path fileType="data">/usr/share/automake-1.18/ar-lib</Path>
+            <Path fileType="data">/usr/share/automake-1.18/compile</Path>
+            <Path fileType="data">/usr/share/automake-1.18/config.guess</Path>
+            <Path fileType="data">/usr/share/automake-1.18/config.sub</Path>
+            <Path fileType="data">/usr/share/automake-1.18/depcomp</Path>
+            <Path fileType="data">/usr/share/automake-1.18/install-sh</Path>
+            <Path fileType="data">/usr/share/automake-1.18/mdate-sh</Path>
+            <Path fileType="data">/usr/share/automake-1.18/missing</Path>
+            <Path fileType="data">/usr/share/automake-1.18/mkinstalldirs</Path>
+            <Path fileType="data">/usr/share/automake-1.18/py-compile</Path>
+            <Path fileType="data">/usr/share/automake-1.18/tap-driver.sh</Path>
+            <Path fileType="data">/usr/share/automake-1.18/test-driver</Path>
+            <Path fileType="data">/usr/share/automake-1.18/texinfo.tex</Path>
+            <Path fileType="data">/usr/share/automake-1.18/ylwrap</Path>
             <Path fileType="doc">/usr/share/doc/automake/amhello-1.0.tar.gz</Path>
-            <Path fileType="info">/usr/share/info/automake-history.info</Path>
-            <Path fileType="info">/usr/share/info/automake.info</Path>
-            <Path fileType="info">/usr/share/info/automake.info-1</Path>
-            <Path fileType="info">/usr/share/info/automake.info-2</Path>
-            <Path fileType="man">/usr/share/man/man1/aclocal-1.17.1</Path>
-            <Path fileType="man">/usr/share/man/man1/aclocal.1</Path>
-            <Path fileType="man">/usr/share/man/man1/automake-1.17.1</Path>
-            <Path fileType="man">/usr/share/man/man1/automake.1</Path>
+            <Path fileType="data">/usr/share/gnuconfig</Path>
+            <Path fileType="info">/usr/share/info/automake-history.info.zst</Path>
+            <Path fileType="info">/usr/share/info/automake.info-1.zst</Path>
+            <Path fileType="info">/usr/share/info/automake.info-2.zst</Path>
+            <Path fileType="info">/usr/share/info/automake.info.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/aclocal-1.18.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/aclocal.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/automake-1.18.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/automake.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2024-10-18</Date>
-            <Version>1.17</Version>
+        <Update release="16">
+            <Date>2025-10-31</Date>
+            <Version>1.18.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Undo change to mdate-sh; once again, it does not look at SOURCE_DATE_EPOCH. This change was a misunderstanding that causes problems, not fixes, for reproducible builds.
- Improve debuggability of installcheck failures.

**Test Plan**
- Ran tests.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
