### PR TITLE
budgie-extras: Add patch to add metainfo files

### DIFF
--- a/packages/b/budgie-extras/abi_used_symbols
+++ b/packages/b/budgie-extras/abi_used_symbols
@@ -7,6 +7,7 @@ libbudgie-plugin.so.0:budgie_popover_get_type
 libbudgie-plugin.so.0:budgie_popover_manager_register_popover
 libbudgie-plugin.so.0:budgie_popover_manager_show_popover
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__stack_chk_fail
 libc.so.6:bind_textdomain_codeset
@@ -22,7 +23,6 @@ libc.so.6:strchr
 libc.so.6:strcmp
 libc.so.6:strlen
 libc.so.6:strstr
-libc.so.6:strtol
 libc.so.6:textdomain
 libcairo.so.2:cairo_create
 libcairo.so.2:cairo_destroy

--- a/packages/b/budgie-extras/files/0001-Add-AppStream-metainfo-files-for-all-applets.patch
+++ b/packages/b/budgie-extras/files/0001-Add-AppStream-metainfo-files-for-all-applets.patch
@@ -1,0 +1,1534 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Evan Maddock <maddock.evan@vivaldi.net>
+Date: Fri, 31 Oct 2025 14:14:20 -0400
+Subject: [PATCH] Add AppStream metainfo files for all applets
+
+It would be great for these applets to be shown in software centers like
+GNOME Software and KDE Discover. Adding these files should accomplish
+that.
+
+Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
+---
+ budgie-app-launcher/data/meson.build          |  3 +
+ .../org.ubuntubudgie.applauncher.metainfo.xml | 52 ++++++++++++++
+ budgie-app-launcher/meson.build               |  1 +
+ budgie-brightness-controller/data/meson.build |  3 +
+ ...tubudgie.brightnesscontroller.metainfo.xml | 57 ++++++++++++++++
+ budgie-brightness-controller/meson.build      |  1 +
+ budgie-clockworks/data/meson.build            |  3 +
+ .../org.ubuntubudgie.clockworks.metainfo.xml  | 56 +++++++++++++++
+ budgie-clockworks/meson.build                 |  2 +
+ budgie-countdown/data/meson.build             |  3 +
+ .../org.ubuntubudgie.countdown.metainfo.xml   | 59 ++++++++++++++++
+ budgie-countdown/meson.build                  |  2 +
+ budgie-dropby/data/meson.build                |  3 +
+ .../data/org.ubuntubudgie.dropby.metainfo.xml | 59 ++++++++++++++++
+ budgie-dropby/meson.build                     |  2 +
+ budgie-fuzzyclock/data/meson.build            |  3 +
+ .../org.ubuntubudgie.fuzzyclock.metainfo.xml  | 52 ++++++++++++++
+ budgie-fuzzyclock/meson.build                 |  1 +
+ budgie-hotcorners/misc/meson.build            |  4 ++
+ .../org.ubuntubudgie.hotcorners.metainfo.xml  | 56 +++++++++++++++
+ budgie-kangaroo/data/meson.build              |  3 +
+ .../org.ubuntubudgie.kangaroo.metainfo.xml    | 53 +++++++++++++++
+ budgie-kangaroo/meson.build                   |  2 +
+ budgie-keyboard-autoswitch/data/meson.build   |  3 +
+ ...untubudgie.keyboardautoswitch.metainfo.xml | 68 +++++++++++++++++++
+ budgie-keyboard-autoswitch/meson.build        |  2 +
+ budgie-quicknote/data/meson.build             |  4 ++
+ .../org.ubuntubudgie.quicknote.metainfo.xml   | 53 +++++++++++++++
+ budgie-quicknote/meson.build                  |  2 +
+ budgie-recentlyused/data/meson.build          |  3 +
+ ...org.ubuntubudgie.recentlyused.metainfo.xml | 52 ++++++++++++++
+ budgie-recentlyused/meson.build               |  1 +
+ budgie-rotation-lock/data/meson.build         |  3 +
+ ...org.ubuntubudgie.rotationlock.metainfo.xml | 53 +++++++++++++++
+ budgie-rotation-lock/meson.build              |  2 +
+ budgie-showtime/data/meson.build              |  3 +
+ .../org.ubuntubudgie.showtime.metainfo.xml    | 53 +++++++++++++++
+ budgie-showtime/meson.build                   |  1 +
+ budgie-takeabreak/data/meson.build            |  3 +
+ .../org.ubuntubudgie.takeabreak.metainfo.xml  | 59 ++++++++++++++++
+ budgie-takeabreak/meson.build                 |  2 +
+ budgie-visualspace/data/meson.build           |  4 ++
+ .../org.ubuntubudgie.visualspace.metainfo.xml | 53 +++++++++++++++
+ budgie-weathershow/data/meson.build           |  3 +
+ .../org.ubuntubudgie.weathershow.metainfo.xml | 53 +++++++++++++++
+ budgie-weathershow/meson.build                |  1 +
+ budgie-workspace-stopwatch/data/meson.build   |  3 +
+ ...untubudgie.workspacestopwatch.metainfo.xml | 62 +++++++++++++++++
+ budgie-workspace-stopwatch/meson.build        |  2 +
+ budgie-wswitcher/data/meson.build             |  4 ++
+ .../org.ubuntubudgie.wswitcher.metainfo.xml   | 47 +++++++++++++
+ 51 files changed, 1079 insertions(+)
+ create mode 100644 budgie-app-launcher/data/meson.build
+ create mode 100644 budgie-app-launcher/data/org.ubuntubudgie.applauncher.metainfo.xml
+ create mode 100644 budgie-brightness-controller/data/meson.build
+ create mode 100644 budgie-brightness-controller/data/org.ubuntubudgie.brightnesscontroller.metainfo.xml
+ create mode 100644 budgie-clockworks/data/meson.build
+ create mode 100644 budgie-clockworks/data/org.ubuntubudgie.clockworks.metainfo.xml
+ create mode 100644 budgie-countdown/data/meson.build
+ create mode 100644 budgie-countdown/data/org.ubuntubudgie.countdown.metainfo.xml
+ create mode 100644 budgie-dropby/data/meson.build
+ create mode 100644 budgie-dropby/data/org.ubuntubudgie.dropby.metainfo.xml
+ create mode 100644 budgie-fuzzyclock/data/meson.build
+ create mode 100644 budgie-fuzzyclock/data/org.ubuntubudgie.fuzzyclock.metainfo.xml
+ create mode 100644 budgie-hotcorners/misc/org.ubuntubudgie.hotcorners.metainfo.xml
+ create mode 100644 budgie-kangaroo/data/meson.build
+ create mode 100644 budgie-kangaroo/data/org.ubuntubudgie.kangaroo.metainfo.xml
+ create mode 100644 budgie-keyboard-autoswitch/data/meson.build
+ create mode 100644 budgie-keyboard-autoswitch/data/org.ubuntubudgie.keyboardautoswitch.metainfo.xml
+ create mode 100644 budgie-quicknote/data/meson.build
+ create mode 100644 budgie-quicknote/data/org.ubuntubudgie.quicknote.metainfo.xml
+ create mode 100644 budgie-recentlyused/data/meson.build
+ create mode 100644 budgie-recentlyused/data/org.ubuntubudgie.recentlyused.metainfo.xml
+ create mode 100644 budgie-rotation-lock/data/meson.build
+ create mode 100644 budgie-rotation-lock/data/org.ubuntubudgie.rotationlock.metainfo.xml
+ create mode 100644 budgie-showtime/data/meson.build
+ create mode 100644 budgie-showtime/data/org.ubuntubudgie.showtime.metainfo.xml
+ create mode 100644 budgie-takeabreak/data/meson.build
+ create mode 100644 budgie-takeabreak/data/org.ubuntubudgie.takeabreak.metainfo.xml
+ create mode 100644 budgie-visualspace/data/org.ubuntubudgie.visualspace.metainfo.xml
+ create mode 100644 budgie-weathershow/data/meson.build
+ create mode 100644 budgie-weathershow/data/org.ubuntubudgie.weathershow.metainfo.xml
+ create mode 100644 budgie-workspace-stopwatch/data/meson.build
+ create mode 100644 budgie-workspace-stopwatch/data/org.ubuntubudgie.workspacestopwatch.metainfo.xml
+ create mode 100644 budgie-wswitcher/data/org.ubuntubudgie.wswitcher.metainfo.xml
+
+diff --git a/budgie-app-launcher/data/meson.build b/budgie-app-launcher/data/meson.build
+new file mode 100644
+index 0000000..6026b8a
+--- /dev/null
++++ b/budgie-app-launcher/data/meson.build
+@@ -0,0 +1,3 @@
++install_data('org.ubuntubudgie.applauncher.metainfo.xml',
++    install_dir: join_paths(datadir, 'metainfo')
++)
+diff --git a/budgie-app-launcher/data/org.ubuntubudgie.applauncher.metainfo.xml b/budgie-app-launcher/data/org.ubuntubudgie.applauncher.metainfo.xml
+new file mode 100644
+index 0000000..c6a7dff
+--- /dev/null
++++ b/budgie-app-launcher/data/org.ubuntubudgie.applauncher.metainfo.xml
+@@ -0,0 +1,52 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
++<component type="addon">
++  <id>org.ubuntubudgie.applauncher</id>
++  <extends>com.solus-project.budgie-desktop</extends>
++  <metadata_license>FSFAP</metadata_license>
++  <project_license>GPL-3.0-or-later</project_license>
++  <name>Budgie App Launcher</name>
++  <summary>App Launcher is a Budgie Desktop applet for productivity</summary>
++  <update_contact>admin@ubuntubudgie.org</update_contact>
++  <description>
++    <p>
++      App Launcher is a Budgie Desktop applet for productivity. This applet lists your favourite apps.
++    </p>
++  </description>
++  <categories>
++    <category>Utility</category>
++  </categories>
++  <screenshots>
++    <screenshot type="default">
++      <caption>The app launcher popover</caption>
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-app-launcher/screenshots/screenshot1.gif</image>
++    </screenshot>
++  </screenshots>
++  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
++  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
++  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
++  <url type="donation">https://ubuntubudgie.org/donate</url>
++  <project_group>Ubuntu Budgie</project_group>
++  <content_rating type="oars-1.0">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++  </content_rating>
++</component>
+diff --git a/budgie-app-launcher/meson.build b/budgie-app-launcher/meson.build
+index 839d87f..ffa42e0 100644
+--- a/budgie-app-launcher/meson.build
++++ b/budgie-app-launcher/meson.build
+@@ -8,3 +8,4 @@ conf.set('PROJECT_NAME', meson.project_name())
+ message('Installing applet...')
+ 
+ subdir('src')
++subdir('data')
+diff --git a/budgie-brightness-controller/data/meson.build b/budgie-brightness-controller/data/meson.build
+new file mode 100644
+index 0000000..d55689c
+--- /dev/null
++++ b/budgie-brightness-controller/data/meson.build
+@@ -0,0 +1,3 @@
++install_data('org.ubuntubudgie.brightnesscontroller.metainfo.xml',
++    install_dir: join_paths(datadir, 'metainfo')
++)
+diff --git a/budgie-brightness-controller/data/org.ubuntubudgie.brightnesscontroller.metainfo.xml b/budgie-brightness-controller/data/org.ubuntubudgie.brightnesscontroller.metainfo.xml
+new file mode 100644
+index 0000000..3ce375b
+--- /dev/null
++++ b/budgie-brightness-controller/data/org.ubuntubudgie.brightnesscontroller.metainfo.xml
+@@ -0,0 +1,57 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
++<component type="addon">
++  <id>org.ubuntubudgie.brightnesscontroller</id>
++  <extends>com.solus-project.budgie-desktop</extends>
++  <metadata_license>FSFAP</metadata_license>
++  <project_license>GPL-3.0-or-later</project_license>
++  <name>Budgie Brightness Controller</name>
++  <summary>Brightness Controller is a Budgie Desktop applet for productivity</summary>
++  <update_contact>admin@ubuntubudgie.org</update_contact>
++  <description>
++    <p>
++      Brightness Controller is a Budgie Desktop applet for productivity.
++    </p>
++  </description>
++  <categories>
++    <category>Utility</category>
++  </categories>
++  <screenshots>
++    <screenshot type="default">
++      <caption>Brightness controller light theme</caption>
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-brightness-controller/screenshots/screenshot1.png</image>
++    </screenshot>
++    <screenshot>
++      <caption>Brightness controller dark theme</caption>
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-brightness-controller/screenshots/screenshot2.png</image>
++    </screenshot>
++  </screenshots>
++  <icon type="stock">budgie-brightness-controller-1-symbolic</icon>
++  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
++  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
++  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
++  <url type="donation">https://ubuntubudgie.org/donate</url>
++  <project_group>Ubuntu Budgie</project_group>
++  <content_rating type="oars-1.0">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++  </content_rating>
++</component>
+diff --git a/budgie-brightness-controller/meson.build b/budgie-brightness-controller/meson.build
+index f837d8e..847c323 100644
+--- a/budgie-brightness-controller/meson.build
++++ b/budgie-brightness-controller/meson.build
+@@ -13,4 +13,5 @@ DEPENDENCY_BUDGIE = budgie_dep
+ message('Installing applet...')
+ 
+ subdir('src')
++subdir('data')
+ subdir('icons')
+diff --git a/budgie-clockworks/data/meson.build b/budgie-clockworks/data/meson.build
+new file mode 100644
+index 0000000..79a50bf
+--- /dev/null
++++ b/budgie-clockworks/data/meson.build
+@@ -0,0 +1,3 @@
++install_data('org.ubuntubudgie.clockworks.metainfo.xml',
++    install_dir: join_paths(datadir, 'metainfo')
++)
+diff --git a/budgie-clockworks/data/org.ubuntubudgie.clockworks.metainfo.xml b/budgie-clockworks/data/org.ubuntubudgie.clockworks.metainfo.xml
+new file mode 100644
+index 0000000..ae090ee
+--- /dev/null
++++ b/budgie-clockworks/data/org.ubuntubudgie.clockworks.metainfo.xml
+@@ -0,0 +1,56 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
++<component type="addon">
++  <id>org.ubuntubudgie.clockworks</id>
++  <extends>com.solus-project.budgie-desktop</extends>
++  <metadata_license>FSFAP</metadata_license>
++  <project_license>GPL-3.0-or-later</project_license>
++  <name>Budgie App Launcher</name>
++  <summary>A multi-clock applet to show the time across multiple timezones</summary>
++  <update_contact>admin@ubuntubudgie.org</update_contact>
++  <description>
++    <p>
++      A multi- clock applet to show the time across multiple timezones. Clocks can be created and deleted in a single click, and easily be (re-) named. Timezones can be looked up from the applet's popup menu.
++    </p>
++    <p>
++      The applet's colors are fully customizable from Budgie Settings.
++    </p>
++  </description>
++  <categories>
++    <category>Utility</category>
++  </categories>
++  <screenshots>
++    <screenshot type="default">
++      <caption>The main applet window</caption>
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-clockworks/applet.png</image>
++    </screenshot>
++  </screenshots>
++  <icon type="stock">budgie-clockworks-symbolic</icon>
++  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
++  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
++  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
++  <url type="donation">https://ubuntubudgie.org/donate</url>
++  <project_group>Ubuntu Budgie</project_group>
++  <content_rating type="oars-1.0">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++  </content_rating>
++</component>
+diff --git a/budgie-clockworks/meson.build b/budgie-clockworks/meson.build
+index af47185..c795ff3 100644
+--- a/budgie-clockworks/meson.build
++++ b/budgie-clockworks/meson.build
+@@ -24,4 +24,6 @@ install_data('schema/org.ubuntubudgie.plugins.budgie-clockworks.gschema.xml',
+     install_dir: '/usr/share/glib-2.0/schemas'
+ )
+ 
++subdir('data')
++
+ meson.add_install_script('meson_post_install.py')
+diff --git a/budgie-countdown/data/meson.build b/budgie-countdown/data/meson.build
+new file mode 100644
+index 0000000..b66bdcd
+--- /dev/null
++++ b/budgie-countdown/data/meson.build
+@@ -0,0 +1,3 @@
++install_data('org.ubuntubudgie.countdown.metainfo.xml',
++    install_dir: join_paths(datadir, 'metainfo')
++)
+diff --git a/budgie-countdown/data/org.ubuntubudgie.countdown.metainfo.xml b/budgie-countdown/data/org.ubuntubudgie.countdown.metainfo.xml
+new file mode 100644
+index 0000000..ced0b34
+--- /dev/null
++++ b/budgie-countdown/data/org.ubuntubudgie.countdown.metainfo.xml
+@@ -0,0 +1,59 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
++<component type="addon">
++  <id>org.ubuntubudgie.countdown</id>
++  <extends>com.solus-project.budgie-desktop</extends>
++  <metadata_license>FSFAP</metadata_license>
++  <project_license>GPL-3.0-or-later</project_license>
++  <name>Budgie Countdown</name>
++  <summary>A count down applet with many different options</summary>
++  <update_contact>admin@ubuntubudgie.org</update_contact>
++  <description>
++    <p>
++      A count down applet with the following options: ring a bell, flash the (panel) icon, display a message window or run a (any) command. The applet also offers the option to overrule possible user settings on suspend, to keep the clock going while time is running.
++    </p>
++    <p>
++      The panel icon switches color, depending on remaining time; green, yellow (&lt; 5 minutes left) or red (&lt; 1 minute left).
++    </p>
++    <p>
++      The countdown label will be invisible until the clock starts running.
++    </p>
++  </description>
++  <categories>
++    <category>Utility</category>
++  </categories>
++  <screenshots>
++    <screenshot type="default">
++      <caption>The main applet window</caption>
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-countdown/applet.png</image>
++    </screenshot>
++  </screenshots>
++  <icon type="stock">budgie-countdown-symbolic</icon>
++  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
++  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
++  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
++  <url type="donation">https://ubuntubudgie.org/donate</url>
++  <project_group>Ubuntu Budgie</project_group>
++  <content_rating type="oars-1.0">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++  </content_rating>
++</component>
+diff --git a/budgie-countdown/meson.build b/budgie-countdown/meson.build
+index 3ffa7f8..3e5ead3 100644
+--- a/budgie-countdown/meson.build
++++ b/budgie-countdown/meson.build
+@@ -30,4 +30,6 @@ install_data('schema/org.ubuntubudgie.plugins.budgie-countdown.gschema.xml',
+     install_dir: '/usr/share/glib-2.0/schemas'
+ )
+ 
++subdir('data')
++
+ meson.add_install_script('meson_post_install.py')
+diff --git a/budgie-dropby/data/meson.build b/budgie-dropby/data/meson.build
+new file mode 100644
+index 0000000..ed5226a
+--- /dev/null
++++ b/budgie-dropby/data/meson.build
+@@ -0,0 +1,3 @@
++install_data('org.ubuntubudgie.dropby.metainfo.xml',
++    install_dir: join_paths(datadir, 'metainfo')
++)
+diff --git a/budgie-dropby/data/org.ubuntubudgie.dropby.metainfo.xml b/budgie-dropby/data/org.ubuntubudgie.dropby.metainfo.xml
+new file mode 100644
+index 0000000..5bfe945
+--- /dev/null
++++ b/budgie-dropby/data/org.ubuntubudgie.dropby.metainfo.xml
+@@ -0,0 +1,59 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
++<component type="addon">
++  <id>org.ubuntubudgie.dropby</id>
++  <extends>com.solus-project.budgie-desktop</extends>
++  <metadata_license>FSFAP</metadata_license>
++  <project_license>GPL-3.0-or-later</project_license>
++  <name>Budgie DropBy</name>
++  <summary>The DropBy applet pops up on the occasion of connecting a usb device</summary>
++  <update_contact>admin@ubuntubudgie.org</update_contact>
++  <description>
++    <p>
++      The DropBy applet pops up on the occasion of connecting a usb device. The applet subsequently offers the option(s) to mount, unmount/eject, and, in case of a flash drive, to make a local copy of the drive's content. The info shows the free space on the volume.
++    </p>
++    <p>
++      The applet is context-sensitive, meaning: it only shows its icon in the panel if, and as long as, any usb drive is connected.
++    </p>
++  </description>
++  <categories>
++    <category>Utility</category>
++  </categories>
++  <screenshots>
++    <screenshot type="default">
++      <caption>The main applet window</caption>
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-dropby/dropby_copy.png</image>
++    </screenshot>
++    <screenshot>
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-dropby/dropby_open.png</image>
++    </screenshot>
++  </screenshots>
++  <icon type="stock">budgie-dropby-symbolic</icon>
++  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
++  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
++  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
++  <url type="donation">https://ubuntubudgie.org/donate</url>
++  <project_group>Ubuntu Budgie</project_group>
++  <content_rating type="oars-1.0">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++  </content_rating>
++</component>
+diff --git a/budgie-dropby/meson.build b/budgie-dropby/meson.build
+index 8f2e189..0eabae0 100644
+--- a/budgie-dropby/meson.build
++++ b/budgie-dropby/meson.build
+@@ -25,4 +25,6 @@ install_data('schema/org.ubuntubudgie.plugins.budgie-dropby.gschema.xml',
+     install_dir: '/usr/share/glib-2.0/schemas'
+ )
+ 
++subdir('data')
++
+ meson.add_install_script('meson_post_install.py')
+diff --git a/budgie-fuzzyclock/data/meson.build b/budgie-fuzzyclock/data/meson.build
+new file mode 100644
+index 0000000..8e1918d
+--- /dev/null
++++ b/budgie-fuzzyclock/data/meson.build
+@@ -0,0 +1,3 @@
++install_data('org.ubuntubudgie.fuzzyclock.metainfo.xml',
++    install_dir: join_paths(datadir, 'metainfo')
++)
+diff --git a/budgie-fuzzyclock/data/org.ubuntubudgie.fuzzyclock.metainfo.xml b/budgie-fuzzyclock/data/org.ubuntubudgie.fuzzyclock.metainfo.xml
+new file mode 100644
+index 0000000..4b13d02
+--- /dev/null
++++ b/budgie-fuzzyclock/data/org.ubuntubudgie.fuzzyclock.metainfo.xml
+@@ -0,0 +1,52 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
++<component type="addon">
++  <id>org.ubuntubudgie.fuzzyclock</id>
++  <extends>com.solus-project.budgie-desktop</extends>
++  <metadata_license>FSFAP</metadata_license>
++  <project_license>GPL-3.0-or-later</project_license>
++  <name>Budgie Fuzzy Clock</name>
++  <summary>Shows the time in a Fuzzy Way</summary>
++  <update_contact>admin@ubuntubudgie.org</update_contact>
++  <description>
++    <p>
++      Shows the time in a Fuzzy Way. It supports 24-hour format, dates, and horizontal panels.
++    </p>
++  </description>
++  <categories>
++    <category>Utility</category>
++  </categories>
++  <screenshots>
++    <screenshot type="default">
++      <caption>The main applet window</caption>
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-fuzzyclock/menu.png</image>
++    </screenshot>
++  </screenshots>
++  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
++  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
++  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
++  <url type="donation">https://ubuntubudgie.org/donate</url>
++  <project_group>Ubuntu Budgie</project_group>
++  <content_rating type="oars-1.0">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++  </content_rating>
++</component>
+diff --git a/budgie-fuzzyclock/meson.build b/budgie-fuzzyclock/meson.build
+index 0774aa9..9003593 100644
+--- a/budgie-fuzzyclock/meson.build
++++ b/budgie-fuzzyclock/meson.build
+@@ -5,3 +5,4 @@ LIB_INSTALL_DIR = join_paths(prefix, libdir, 'budgie-desktop', 'plugins', PLUGIN
+ message('Installing applet...')
+ 
+ subdir('src')
++subdir('data')
+diff --git a/budgie-hotcorners/misc/meson.build b/budgie-hotcorners/misc/meson.build
+index aa7a559..4bf2a54 100644
+--- a/budgie-hotcorners/misc/meson.build
++++ b/budgie-hotcorners/misc/meson.build
+@@ -38,3 +38,7 @@ custom_target('desktop-file-hotcorners',
+     command : [intltool, '--desktop-style', podir, '@INPUT@', '@OUTPUT@'],
+     install : true,
+     install_dir : join_paths(datadir, 'applications'))
++
++install_data('org.ubuntubudgie.hotcorners.metainfo.xml',
++    install_dir: join_paths(datadir, 'metainfo')
++)
+diff --git a/budgie-hotcorners/misc/org.ubuntubudgie.hotcorners.metainfo.xml b/budgie-hotcorners/misc/org.ubuntubudgie.hotcorners.metainfo.xml
+new file mode 100644
+index 0000000..27dcde6
+--- /dev/null
++++ b/budgie-hotcorners/misc/org.ubuntubudgie.hotcorners.metainfo.xml
+@@ -0,0 +1,56 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
++<component type="addon">
++  <id>org.ubuntubudgie.hotcorners</id>
++  <extends>com.solus-project.budgie-desktop</extends>
++  <metadata_license>FSFAP</metadata_license>
++  <project_license>GPL-3.0-or-later</project_license>
++  <name>Budgie HotCorners</name>
++  <summary>Budgie Hotcorners offers the option to set corner actions for any of the corners or screen edges</summary>
++  <update_contact>admin@ubuntubudgie.org</update_contact>
++  <description>
++    <p>
++        Budgie Hotcorners offers the option to set corner actions for any of the corners or screen edges, from presets or custom commands.
++    </p>
++    <p>
++      Budgie Hotcorners is (as of now) a mini-app and can be accessed from the main menu. Additionally, an applet is available for quick access, switch on/off or edit actions.
++    </p>
++  </description>
++  <categories>
++    <category>Utility</category>
++  </categories>
++  <screenshots>
++    <screenshot type="default">
++      <caption>The main applet window</caption>
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-hotcorners/applet.png</image>
++    </screenshot>
++  </screenshots>
++  <icon type="stock">org.ubuntubudgie.budgie-extras.hotcorners</icon>
++  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
++  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
++  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
++  <url type="donation">https://ubuntubudgie.org/donate</url>
++  <project_group>Ubuntu Budgie</project_group>
++  <content_rating type="oars-1.0">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++  </content_rating>
++</component>
+diff --git a/budgie-kangaroo/data/meson.build b/budgie-kangaroo/data/meson.build
+new file mode 100644
+index 0000000..7944151
+--- /dev/null
++++ b/budgie-kangaroo/data/meson.build
+@@ -0,0 +1,3 @@
++install_data('org.ubuntubudgie.kangaroo.metainfo.xml',
++    install_dir: join_paths(datadir, 'metainfo')
++)
+diff --git a/budgie-kangaroo/data/org.ubuntubudgie.kangaroo.metainfo.xml b/budgie-kangaroo/data/org.ubuntubudgie.kangaroo.metainfo.xml
+new file mode 100644
+index 0000000..17caaeb
+--- /dev/null
++++ b/budgie-kangaroo/data/org.ubuntubudgie.kangaroo.metainfo.xml
+@@ -0,0 +1,53 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
++<component type="addon">
++  <id>org.ubuntubudgie.kangaroo</id>
++  <extends>com.solus-project.budgie-desktop</extends>
++  <metadata_license>FSFAP</metadata_license>
++  <project_license>GPL-3.0-or-later</project_license>
++  <name>Budgie Kangaroo</name>
++  <summary>Kangaroo is an applet for quick &amp; easy browsing, across (possibly) many directory layers</summary>
++  <update_contact>admin@ubuntubudgie.org</update_contact>
++  <description>
++    <p>
++      Kangaroo is an applet for quick &amp; easy browsing, across (possibly) many directory layers, without having to do a single mouse click.
++    </p>
++  </description>
++  <categories>
++    <category>Utility</category>
++  </categories>
++  <screenshots>
++    <screenshot type="default">
++      <caption>The main applet window</caption>
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-kangaroo/screenshot.png</image>
++    </screenshot>
++  </screenshots>
++  <icon type="stock">budgie-foldertrack-symbolic</icon>
++  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
++  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
++  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
++  <url type="donation">https://ubuntubudgie.org/donate</url>
++  <project_group>Ubuntu Budgie</project_group>
++  <content_rating type="oars-1.0">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++  </content_rating>
++</component>
+diff --git a/budgie-kangaroo/meson.build b/budgie-kangaroo/meson.build
+index 835442b..6ca5f49 100644
+--- a/budgie-kangaroo/meson.build
++++ b/budgie-kangaroo/meson.build
+@@ -20,3 +20,5 @@ install_data(
+     'budgie-foldertrack-symbolic.svg',
+     install_dir: PIXMAPS_DIR
+ )
++
++subdir('data')
+diff --git a/budgie-keyboard-autoswitch/data/meson.build b/budgie-keyboard-autoswitch/data/meson.build
+new file mode 100644
+index 0000000..9d52651
+--- /dev/null
++++ b/budgie-keyboard-autoswitch/data/meson.build
+@@ -0,0 +1,3 @@
++install_data('org.ubuntubudgie.keyboardautoswitch.metainfo.xml',
++    install_dir: join_paths(datadir, 'metainfo')
++)
+diff --git a/budgie-keyboard-autoswitch/data/org.ubuntubudgie.keyboardautoswitch.metainfo.xml b/budgie-keyboard-autoswitch/data/org.ubuntubudgie.keyboardautoswitch.metainfo.xml
+new file mode 100644
+index 0000000..859e922
+--- /dev/null
++++ b/budgie-keyboard-autoswitch/data/org.ubuntubudgie.keyboardautoswitch.metainfo.xml
+@@ -0,0 +1,68 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
++<component type="addon">
++  <id>org.ubuntubudgie.keyboardautoswitch</id>
++  <extends>com.solus-project.budgie-desktop</extends>
++  <metadata_license>FSFAP</metadata_license>
++  <project_license>GPL-3.0-or-later</project_license>
++  <name>Budgie Keyboard Autoswitch</name>
++  <summary>Keyboard Auto Switch is an applet to use a different input keyboard layout per application</summary>
++  <update_contact>admin@ubuntubudgie.org</update_contact>
++  <description>
++    <p>
++      Keyboard Auto Switch is an applet to use a different input keyboard layout per application. Simply set a default layout to be used in general. Subsequently, simply set a different layout, with the application's window in front, and an exception for that specific application is remembered.
++    </p>
++    <p>
++      Exceptions can be removed at any time, either from the applet's menu or by setting the application's layout, again, with its window in front.
++    </p>
++  </description>
++  <categories>
++    <category>Utility</category>
++  </categories>
++  <screenshots>
++    <screenshot type="default">
++      <caption>The main applet window</caption>
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-keyboard-autoswitch/applet.png</image>
++    </screenshot>
++    <screenshot>
++      <caption>Settings window</caption>
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-keyboard-autoswitch/settings.png</image>
++    </screenshot>
++    <screenshot>
++      <caption>Languages window</caption>
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-keyboard-autoswitch/languages.png</image>
++    </screenshot>
++    <screenshot>
++      <caption>Exceptions window</caption>
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-keyboard-autoswitch/exceptions.png</image>
++    </screenshot>
++  </screenshots>
++  <icon type="stock">budgie-keyboard-autoswitch-symbolic</icon>
++  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
++  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
++  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
++  <url type="donation">https://ubuntubudgie.org/donate</url>
++  <project_group>Ubuntu Budgie</project_group>
++  <content_rating type="oars-1.0">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++  </content_rating>
++</component>
+diff --git a/budgie-keyboard-autoswitch/meson.build b/budgie-keyboard-autoswitch/meson.build
+index e0d303d..8edf651 100644
+--- a/budgie-keyboard-autoswitch/meson.build
++++ b/budgie-keyboard-autoswitch/meson.build
+@@ -12,3 +12,5 @@ install_data(
+     'budgie-keyboard-autoswitch-symbolic.svg',
+     install_dir: PIXMAPS_DIR
+ )
++
++subdir('data')
+diff --git a/budgie-quicknote/data/meson.build b/budgie-quicknote/data/meson.build
+new file mode 100644
+index 0000000..c78ea0a
+--- /dev/null
++++ b/budgie-quicknote/data/meson.build
+@@ -0,0 +1,4 @@
++install_data(
++  'org.ubuntubudgie.quicknote.metainfo.xml',
++  install_dir: join_paths(datadir, 'metainfo'),
++)
+diff --git a/budgie-quicknote/data/org.ubuntubudgie.quicknote.metainfo.xml b/budgie-quicknote/data/org.ubuntubudgie.quicknote.metainfo.xml
+new file mode 100644
+index 0000000..cdaf6af
+--- /dev/null
++++ b/budgie-quicknote/data/org.ubuntubudgie.quicknote.metainfo.xml
+@@ -0,0 +1,53 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
++<component type="addon">
++  <id>org.ubuntubudgie.quicknote</id>
++  <extends>com.solus-project.budgie-desktop</extends>
++  <metadata_license>FSFAP</metadata_license>
++  <project_license>GPL-3.0-or-later</project_license>
++  <name>Budgie Quicknote</name>
++  <summary>An applet to provide the easiest possible way to make small notes</summary>
++  <update_contact>admin@ubuntubudgie.org</update_contact>
++  <description>
++    <p>
++      Budgie Quicknote is is an applet to provide the easiest possible way to make small notes. Just click the icon and write down your notes. QuickNote autosaves the text while writing, and comes with a ten- level undo/redo function.
++    </p>
++  </description>
++  <categories>
++    <category>Utility</category>
++  </categories>
++  <screenshots>
++    <screenshot type="default">
++      <caption>The main applet window</caption>
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-quicknote/quicknote.png</image>
++    </screenshot>
++  </screenshots>
++  <icon type="stock">budgie-quicknote-symbolic</icon>
++  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
++  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
++  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
++  <url type="donation">https://ubuntubudgie.org/donate</url>
++  <project_group>Ubuntu Budgie</project_group>
++  <content_rating type="oars-1.0">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++  </content_rating>
++</component>
+diff --git a/budgie-quicknote/meson.build b/budgie-quicknote/meson.build
+index d96a257..55f647b 100644
+--- a/budgie-quicknote/meson.build
++++ b/budgie-quicknote/meson.build
+@@ -54,4 +54,6 @@ install_data(
+     install_dir: join_paths(datadir, 'glib-2.0', 'schemas'),
+ )
+ 
++subdir('data')
++
+ meson.add_install_script('meson_post_install.py')
+diff --git a/budgie-recentlyused/data/meson.build b/budgie-recentlyused/data/meson.build
+new file mode 100644
+index 0000000..1eab743
+--- /dev/null
++++ b/budgie-recentlyused/data/meson.build
+@@ -0,0 +1,3 @@
++install_data('org.ubuntubudgie.recentlyused.metainfo.xml',
++    install_dir: join_paths(datadir, 'metainfo')
++)
+diff --git a/budgie-recentlyused/data/org.ubuntubudgie.recentlyused.metainfo.xml b/budgie-recentlyused/data/org.ubuntubudgie.recentlyused.metainfo.xml
+new file mode 100644
+index 0000000..86f539a
+--- /dev/null
++++ b/budgie-recentlyused/data/org.ubuntubudgie.recentlyused.metainfo.xml
+@@ -0,0 +1,52 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
++<component type="addon">
++  <id>org.ubuntubudgie.recentlyused</id>
++  <extends>com.solus-project.budgie-desktop</extends>
++  <metadata_license>FSFAP</metadata_license>
++  <project_license>GPL-3.0-or-later</project_license>
++  <name>Budgie Recently Used</name>
++  <summary>Show (Gtk applications') recently used items in a menu</summary>
++  <update_contact>admin@ubuntubudgie.org</update_contact>
++  <description>
++    <p>
++      Show (Gtk applications') recently used items in a menu.
++    </p>
++  </description>
++  <categories>
++    <category>Utility</category>
++  </categories>
++  <screenshots>
++    <screenshot type="default">
++      <caption>The main applet window</caption>
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-recentlyused/menu.png</image>
++    </screenshot>
++  </screenshots>
++  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
++  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
++  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
++  <url type="donation">https://ubuntubudgie.org/donate</url>
++  <project_group>Ubuntu Budgie</project_group>
++  <content_rating type="oars-1.0">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++  </content_rating>
++</component>
+diff --git a/budgie-recentlyused/meson.build b/budgie-recentlyused/meson.build
+index 98284be..8583268 100644
+--- a/budgie-recentlyused/meson.build
++++ b/budgie-recentlyused/meson.build
+@@ -10,5 +10,6 @@ LIB_INSTALL_DIR = join_paths(prefix, libdir, 'budgie-desktop', 'plugins', PLUGIN
+ message('Installing applet...')
+ 
+ subdir('src')
++subdir('data')
+ 
+ meson.add_install_script('meson_post_install.py')
+diff --git a/budgie-rotation-lock/data/meson.build b/budgie-rotation-lock/data/meson.build
+new file mode 100644
+index 0000000..b2695bd
+--- /dev/null
++++ b/budgie-rotation-lock/data/meson.build
+@@ -0,0 +1,3 @@
++install_data('org.ubuntubudgie.rotationlock.metainfo.xml',
++    install_dir: join_paths(datadir, 'metainfo')
++)
+diff --git a/budgie-rotation-lock/data/org.ubuntubudgie.rotationlock.metainfo.xml b/budgie-rotation-lock/data/org.ubuntubudgie.rotationlock.metainfo.xml
+new file mode 100644
+index 0000000..a6baa44
+--- /dev/null
++++ b/budgie-rotation-lock/data/org.ubuntubudgie.rotationlock.metainfo.xml
+@@ -0,0 +1,53 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
++<component type="addon">
++  <id>org.ubuntubudgie.rotationlock</id>
++  <extends>com.solus-project.budgie-desktop</extends>
++  <metadata_license>FSFAP</metadata_license>
++  <project_license>GPL-3.0-or-later</project_license>
++  <name>Budgie RotationLock</name>
++  <summary>A simple applet that lets you toggle the "Rotation Lock" feature for Budgie</summary>
++  <update_contact>admin@ubuntubudgie.org</update_contact>
++  <description>
++    <p>
++      RotationLock is a simple applet that lets you toggle the "Rotation Lock" feature for Budgie.
++    </p>
++  </description>
++  <categories>
++    <category>Utility</category>
++  </categories>
++  <screenshots>
++    <screenshot type="default">
++      <caption>The main applet window</caption>
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-rotationlock/rotationlock.png</image>
++    </screenshot>
++  </screenshots>
++  <icon type="stock">budgie-rotation-button-symbolic</icon>
++  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
++  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
++  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
++  <url type="donation">https://ubuntubudgie.org/donate</url>
++  <project_group>Ubuntu Budgie</project_group>
++  <content_rating type="oars-1.0">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++  </content_rating>
++</component>
+diff --git a/budgie-rotation-lock/meson.build b/budgie-rotation-lock/meson.build
+index f93a95d..bbba67b 100644
+--- a/budgie-rotation-lock/meson.build
++++ b/budgie-rotation-lock/meson.build
+@@ -13,3 +13,5 @@ install_data(
+     'budgie-rotation-lock-button-symbolic.svg',
+     install_dir: PIXMAPS_DIR
+ )
++
++subdir('data')
+diff --git a/budgie-showtime/data/meson.build b/budgie-showtime/data/meson.build
+new file mode 100644
+index 0000000..0289064
+--- /dev/null
++++ b/budgie-showtime/data/meson.build
+@@ -0,0 +1,3 @@
++install_data('org.ubuntubudgie.showtime.metainfo.xml',
++    install_dir: join_paths(datadir, 'metainfo')
++)
+diff --git a/budgie-showtime/data/org.ubuntubudgie.showtime.metainfo.xml b/budgie-showtime/data/org.ubuntubudgie.showtime.metainfo.xml
+new file mode 100644
+index 0000000..e74adbc
+--- /dev/null
++++ b/budgie-showtime/data/org.ubuntubudgie.showtime.metainfo.xml
+@@ -0,0 +1,53 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
++<component type="addon">
++  <id>org.ubuntubudgie.showtime</id>
++  <extends>com.solus-project.budgie-desktop</extends>
++  <metadata_license>FSFAP</metadata_license>
++  <project_license>GPL-3.0-or-later</project_license>
++  <name>Budgie ShowTime</name>
++  <summary>Budgie Showtime is a digital desktop clock, showing time, and optionally, date</summary>
++  <update_contact>admin@ubuntubudgie.org</update_contact>
++  <description>
++    <p>
++      Budgie Showtime is a digital desktop clock, showing time, and optionally, date. Textcolor of both can be set separately from the applet's menu.
++    </p>
++    <p>
++      Settings from Budgie Settings include text alignment, -color, -size, temporarily make the applet dragable for custom positioning, 12 hrs format, custom data formatting
++    </p>
++    <p>
++      Furthermore, gsettings overrides can be done for font (-family), left or right bottom positioning.
++    </p>
++  </description>
++  <categories>
++    <category>Utility</category>
++  </categories>
++  <icon type="stock">showtimenew-symbolic</icon>
++  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
++  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
++  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
++  <url type="donation">https://ubuntubudgie.org/donate</url>
++  <project_group>Ubuntu Budgie</project_group>
++  <content_rating type="oars-1.0">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++  </content_rating>
++</component>
+diff --git a/budgie-showtime/meson.build b/budgie-showtime/meson.build
+index d18029c..979755a 100644
+--- a/budgie-showtime/meson.build
++++ b/budgie-showtime/meson.build
+@@ -9,6 +9,7 @@ LIB_INSTALL_DIR = join_paths(prefix, libdir, 'budgie-desktop', 'plugins', PLUGIN
+ message('Installing applet...')
+ 
+ subdir('src')
++subdir('data')
+ subdir('icons')
+ 
+ meson.add_install_script('meson_post_install.py')
+diff --git a/budgie-takeabreak/data/meson.build b/budgie-takeabreak/data/meson.build
+new file mode 100644
+index 0000000..18063bf
+--- /dev/null
++++ b/budgie-takeabreak/data/meson.build
+@@ -0,0 +1,3 @@
++install_data('org.ubuntubudgie.takeabreak.metainfo.xml',
++    install_dir: join_paths(datadir, 'metainfo')
++)
+diff --git a/budgie-takeabreak/data/org.ubuntubudgie.takeabreak.metainfo.xml b/budgie-takeabreak/data/org.ubuntubudgie.takeabreak.metainfo.xml
+new file mode 100644
+index 0000000..43ce5be
+--- /dev/null
++++ b/budgie-takeabreak/data/org.ubuntubudgie.takeabreak.metainfo.xml
+@@ -0,0 +1,59 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
++<component type="addon">
++  <id>org.ubuntubudgie.takeabreak</id>
++  <extends>com.solus-project.budgie-desktop</extends>
++  <metadata_license>FSFAP</metadata_license>
++  <project_license>GPL-3.0-or-later</project_license>
++  <name>Budgie TakeABreak</name>
++  <summary>A pomodoro-like applet, to make sure to take regular breaks from working</summary>
++  <update_contact>admin@ubuntubudgie.org</update_contact>
++  <description>
++    <p>
++      Budgie TakeaBreak is a pomodoro- like applet, to make sure to take regular breaks from working. Options from Budgie Settings include turning the screen upside down, dim the screen, lock screen or show a countdown message on break time. The applet can be accessed quickly from the panel to temporarily switch it off.
++    </p>
++  </description>
++  <categories>
++    <category>Utility</category>
++  </categories>
++  <screenshots>
++    <screenshot type="default">
++      <caption>The main applet window</caption>
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-takeabreak/switch1.png</image>
++    </screenshot>
++    <screenshot type="default">
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-takeabreak/switch2.png</image>
++    </screenshot>
++    <screenshot type="default">
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-takeabreak/options.png</image>
++    </screenshot>
++  </screenshots>
++  <icon type="stock">takeabreak-symbolic</icon>
++  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
++  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
++  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
++  <url type="donation">https://ubuntubudgie.org/donate</url>
++  <project_group>Ubuntu Budgie</project_group>
++  <content_rating type="oars-1.0">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++  </content_rating>
++</component>
+diff --git a/budgie-takeabreak/meson.build b/budgie-takeabreak/meson.build
+index 1b456a4..5208370 100644
+--- a/budgie-takeabreak/meson.build
++++ b/budgie-takeabreak/meson.build
+@@ -28,4 +28,6 @@ install_data('schema/org.ubuntubudgie.plugins.takeabreak.gschema.xml',
+     install_dir: '/usr/share/glib-2.0/schemas'
+ )
+ 
++subdir('data')
++
+ meson.add_install_script('meson_post_install.py')
+diff --git a/budgie-visualspace/data/meson.build b/budgie-visualspace/data/meson.build
+index 2eb22f9..144250b 100644
+--- a/budgie-visualspace/data/meson.build
++++ b/budgie-visualspace/data/meson.build
+@@ -4,6 +4,10 @@ install_data(
+     install_dir: PIXMAPS_DIR
+ )
+ 
++install_data('org.ubuntubudgie.visualspace.metainfo.xml',
++    install_dir: join_paths(datadir, 'metainfo')
++)
++
+ substprog = find_program('subst.py')
+ 
+ mytarget = custom_target('autoworkspace',
+diff --git a/budgie-visualspace/data/org.ubuntubudgie.visualspace.metainfo.xml b/budgie-visualspace/data/org.ubuntubudgie.visualspace.metainfo.xml
+new file mode 100644
+index 0000000..589e355
+--- /dev/null
++++ b/budgie-visualspace/data/org.ubuntubudgie.visualspace.metainfo.xml
+@@ -0,0 +1,53 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
++<component type="addon">
++  <id>org.ubuntubudgie.visualspace</id>
++  <extends>com.solus-project.budgie-desktop</extends>
++  <metadata_license>FSFAP</metadata_license>
++  <project_license>GPL-3.0-or-later</project_license>
++  <name>Budgie VisualSpace</name>
++  <summary>Shows the current workspaces, as bullets</summary>
++  <update_contact>admin@ubuntubudgie.org</update_contact>
++  <description>
++    <p>
++      Budgie VisualSpace shows the current workspace(s), as bullet(s). The applet includes a menu to navigate to either one of the windows or their corresponding workspace.
++    </p>
++  </description>
++  <categories>
++    <category>Utility</category>
++  </categories>
++  <screenshots>
++    <screenshot type="default">
++      <caption>The main applet window</caption>
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-visualspace/visualspace.png</image>
++    </screenshot>
++  </screenshots>
++  <icon type="stock">visualspace-symbolic</icon>
++  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
++  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
++  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
++  <url type="donation">https://ubuntubudgie.org/donate</url>
++  <project_group>Ubuntu Budgie</project_group>
++  <content_rating type="oars-1.0">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++  </content_rating>
++</component>
+diff --git a/budgie-weathershow/data/meson.build b/budgie-weathershow/data/meson.build
+new file mode 100644
+index 0000000..fe55dbd
+--- /dev/null
++++ b/budgie-weathershow/data/meson.build
+@@ -0,0 +1,3 @@
++install_data('org.ubuntubudgie.weathershow.metainfo.xml',
++    install_dir: join_paths(datadir, 'metainfo')
++)
+diff --git a/budgie-weathershow/data/org.ubuntubudgie.weathershow.metainfo.xml b/budgie-weathershow/data/org.ubuntubudgie.weathershow.metainfo.xml
+new file mode 100644
+index 0000000..74da013
+--- /dev/null
++++ b/budgie-weathershow/data/org.ubuntubudgie.weathershow.metainfo.xml
+@@ -0,0 +1,53 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
++<component type="addon">
++  <id>org.ubuntubudgie.weathershow</id>
++  <extends>com.solus-project.budgie-desktop</extends>
++  <metadata_license>FSFAP</metadata_license>
++  <project_license>GPL-3.0-or-later</project_license>
++  <name>Budgie WeatherShow II</name>
++  <summary>A completely rewritten version of the existing python WeatherShow applet</summary>
++  <update_contact>admin@ubuntubudgie.org</update_contact>
++  <description>
++    <p>
++      WeatherShowII is a completely rewritten version of the existing python WeatherShow applet. It merges the functionality of Budgie Weather applet (showing weather in the panel) and WeatherShow. Each of the modules: weather forecast, weather in the panel and weather on the desktop can be switched on and of.
++    </p>
++    <p>
++      The applet includes many technical improvements under the hood. Weather forecast now has its own thread, therefore the panel should not suffer in any way from possible possible delays or issues in fetching the forecast (e.g. in case of network- related problems). Furthermore, the applet adapts (in three steps) to the monitor's size, for better scaling on high resolutions.
++    </p>
++    <p>
++      WeatherShow uses an OWM key with permission of Open Weather Map. Permission was granted to UbuntuBudgie developers. Please don't copy!
++    </p>
++  </description>
++  <categories>
++    <category>Utility</category>
++  </categories>
++  <icon type="stock">budgie-wticon-symbolic</icon>
++  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
++  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
++  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
++  <url type="donation">https://ubuntubudgie.org/donate</url>
++  <project_group>Ubuntu Budgie</project_group>
++  <content_rating type="oars-1.0">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++  </content_rating>
++</component>
+diff --git a/budgie-weathershow/meson.build b/budgie-weathershow/meson.build
+index 0ba69de..c987cc4 100644
+--- a/budgie-weathershow/meson.build
++++ b/budgie-weathershow/meson.build
+@@ -25,5 +25,6 @@ message('Installing applet...')
+ subdir('src')
+ subdir('weather_icons')
+ subdir('icons_for_pixmaps')
++subdir('data')
+ 
+ meson.add_install_script('meson_post_install.py')
+diff --git a/budgie-workspace-stopwatch/data/meson.build b/budgie-workspace-stopwatch/data/meson.build
+new file mode 100644
+index 0000000..5c3788f
+--- /dev/null
++++ b/budgie-workspace-stopwatch/data/meson.build
+@@ -0,0 +1,3 @@
++install_data('org.ubuntubudgie.workspacestopwatch.metainfo.xml',
++    install_dir: join_paths(datadir, 'metainfo')
++)
+diff --git a/budgie-workspace-stopwatch/data/org.ubuntubudgie.workspacestopwatch.metainfo.xml b/budgie-workspace-stopwatch/data/org.ubuntubudgie.workspacestopwatch.metainfo.xml
+new file mode 100644
+index 0000000..9478e75
+--- /dev/null
++++ b/budgie-workspace-stopwatch/data/org.ubuntubudgie.workspacestopwatch.metainfo.xml
+@@ -0,0 +1,62 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
++<component type="addon">
++  <id>org.ubuntubudgie.workspacestopwatch</id>
++  <extends>com.solus-project.budgie-desktop</extends>
++  <metadata_license>FSFAP</metadata_license>
++  <project_license>GPL-3.0-or-later</project_license>
++  <name>Budgie Workspace Stopwatch</name>
++  <summary>An applet to keep track of usage per workspace</summary>
++  <update_contact>admin@ubuntubudgie.org</update_contact>
++  <description>
++    <p>
++      Workspace Timer Applet is an applet to keep track of usage per workspace, e.g. to find out how much minutes/hours were actually spent on a job.
++    </p>
++    <p>
++      Workspaces can be freely named, custom names and all data are remembered, also after logout/restart, until the RESET button is pressed.
++    </p>
++    <p>
++      The log file is updated on workspace switch/clicking the icon for popup or else every 30 seconds.
++    </p>
++    <p>
++      Time during suspend is automatically retracted from a workspace' time.
++    </p>
++  </description>
++  <categories>
++    <category>Utility</category>
++  </categories>
++  <screenshots>
++    <screenshot type="default">
++      <caption>The main applet window</caption>
++      <image>https://github.com/UbuntuBudgie/budgie-extras/raw/master/budgie-workspace-stopwatch/screenshot.png</image>
++    </screenshot>
++  </screenshots>
++  <icon type="stock">budgie-wstopwatch-symbolic</icon>
++  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
++  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
++  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
++  <url type="donation">https://ubuntubudgie.org/donate</url>
++  <project_group>Ubuntu Budgie</project_group>
++  <content_rating type="oars-1.0">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++  </content_rating>
++</component>
+diff --git a/budgie-workspace-stopwatch/meson.build b/budgie-workspace-stopwatch/meson.build
+index fb06877..a25e008 100644
+--- a/budgie-workspace-stopwatch/meson.build
++++ b/budgie-workspace-stopwatch/meson.build
+@@ -12,3 +12,5 @@ install_data(
+     'budgie-wstopwatch-symbolic.svg',
+     install_dir: PIXMAPS_DIR
+ )
++
++subdir('data')
+diff --git a/budgie-wswitcher/data/meson.build b/budgie-wswitcher/data/meson.build
+index 26634f6..e87e4ba 100644
+--- a/budgie-wswitcher/data/meson.build
++++ b/budgie-wswitcher/data/meson.build
+@@ -3,3 +3,7 @@ install_data(
+     'budgie-wsw-symbolic.svg',
+     install_dir: PIXMAPS_DIR
+ )
++
++install_data('org.ubuntubudgie.wswitcher.metainfo.xml',
++    install_dir: join_paths(datadir, 'metainfo')
++)
+diff --git a/budgie-wswitcher/data/org.ubuntubudgie.wswitcher.metainfo.xml b/budgie-wswitcher/data/org.ubuntubudgie.wswitcher.metainfo.xml
+new file mode 100644
+index 0000000..e0b42da
+--- /dev/null
++++ b/budgie-wswitcher/data/org.ubuntubudgie.wswitcher.metainfo.xml
+@@ -0,0 +1,47 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
++<component type="addon">
++  <id>org.ubuntubudgie.wswitcher</id>
++  <extends>com.solus-project.budgie-desktop</extends>
++  <metadata_license>FSFAP</metadata_license>
++  <project_license>GPL-3.0-or-later</project_license>
++  <name>Budgie Wallpaper Workspace Switcher</name>
++  <summary>An applet to show a different wallpaper on each of the workspaces</summary>
++  <update_contact>admin@ubuntubudgie.org</update_contact>
++  <description>
++    <p>
++      Budgie Wallpaper Workspace Switcher is an application (applet) to show a different wallpaper on each of the workspaces. Usage is simple: add the applet to the panel and set wallpapers on each of the workspaces in the way you are used to. The applet will remember what wallpaper was set on each of the workspaces.
++    </p>
++  </description>
++  <categories>
++    <category>Utility</category>
++  </categories>
++  <icon type="stock">budgie-wsw-symbolic</icon>
++  <url type="homepage">https://github.com/UbuntuBudgie/budgie-extras</url>
++  <url type="bugtracker">https://github.com/UbuntuBudgie/budgie-extras/issues</url>
++  <url type="translate">https://www.transifex.com/ubuntu-budgie/ubuntu-budgie-extras</url>
++  <url type="donation">https://ubuntubudgie.org/donate</url>
++  <project_group>Ubuntu Budgie</project_group>
++  <content_rating type="oars-1.0">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++  </content_rating>
++</component>

--- a/packages/b/budgie-extras/files/series
+++ b/packages/b/budgie-extras/files/series
@@ -2,3 +2,4 @@
 0001-hardcode-libexecdir.patch
 0001-fix-budgie-hotcorners-settingswindow.patch
 0001-budgie-hotcorners-Fix-formatting-of-defaults-file-JSON.patch
+0001-Add-AppStream-metainfo-files-for-all-applets.patch

--- a/packages/b/budgie-extras/package.yml
+++ b/packages/b/budgie-extras/package.yml
@@ -1,6 +1,6 @@
 name       : budgie-extras
 version    : 1.9.0
-release    : 31
+release    : 32
 source     :
     - https://github.com/UbuntuBudgie/budgie-extras/releases/download/v1.9.0/budgie-extras-1.9.0.tar.xz : baab2b16f4d366cd2bc2a2702cf30b837ea81e6759aca377d1737f00b99dce1d
 homepage   : https://github.com/UbuntuBudgie/budgie-extras
@@ -50,10 +50,12 @@ description:
 patterns   :
     - ^budgie-brightness-controller-applet :
         - /usr/lib64/budgie-desktop/plugins/budgie-brightness-controller
+        - /usr/share/metainfo/org.ubuntubudgie.brightnesscontroller.metainfo.xml
         - /usr/share/pixmaps/budgie-brightness-controller-1-symbolic.svg
     - ^budgie-countdown-applet :
         - /usr/lib64/budgie-desktop/plugins/budgie-countdown
         - /usr/share/glib-2.0/schemas/org.ubuntubudgie.plugins.budgie-countdown.gschema.xml
+        - /usr/share/metainfo/org.ubuntubudgie.countdown.metainfo.xml
         - /usr/share/pixmaps/budgie-countdown-symbolic.svg
         - /usr/share/pixmaps/cr*
     - ^budgie-extras-daemon :
@@ -61,12 +63,13 @@ patterns   :
         - /usr/lib64/budgie-extras-daemon/invoke.py
         - /usr/share/budgie-desktop/layouts
         - /usr/share/budgie-extras-daemon
-        - /usr/share/man/man1/budgie-extras-daemon.1
+        - /usr/share/man/man1/budgie-extras-daemon.1*
         - /usr/share/xdg/autostart/budgie-extras-daemon.desktop
     - ^budgie-hotcorners-applet :
         - /usr/lib64/budgie-desktop/plugins/budgie-hotcorners
         - /usr/lib64/budgie-extras/budgie-hotcorners*
         - /usr/share/applications/org.ubuntubudgie.budgie-extras.HotCorners*
+        - /usr/share/metainfo/org.ubuntubudgie.hotcorners.metainfo.xml
         - /usr/share/pixmaps/budgie-hot*
         - /usr/share/budgie-hotcorners*
         - /usr/share/glib-2.0/schemas/org.ubuntubudgie.budgie-extras.HotCorners*
@@ -74,6 +77,7 @@ patterns   :
         - /usr/share/xdg/autostart/org.ubuntubudgie.budgie-extras.HotCorners-autostart.desktop
     - ^budgie-kangaroo-applet :
         - /usr/lib64/budgie-desktop/plugins/budgie-kangaroo
+        - /usr/share/metainfo/org.ubuntubudgie.kangaroo.metainfo.xml
         - /usr/share/pixmaps/budgie-foldertrack-symbolic.svg
     - ^budgie-previews :
         - /usr/lib64/budgie-previews
@@ -88,24 +92,29 @@ patterns   :
     - ^budgie-quicknote-applet :
         - /usr/lib64/budgie-desktop/plugins/budgie-quicknote
         - /usr/share/glib-2.0/schemas/org.ubuntubudgie.plugins.quicknote.gschema.xml
+        - /usr/share/metainfo/org.ubuntubudgie.quicknote.metainfo.xml
         - /usr/share/pixmaps/budgie-quicknote-symbolic.svg
     - ^budgie-showtime-applet :
         - /usr/lib64/budgie-desktop/plugins/budgie-showtime
         - /usr/share/glib-2.0/schemas/org.ubuntubudgie.plugins.budgie-showtime.gschema.xml
+        - /usr/share/metainfo/org.ubuntubudgie.showtime.metainfo.xml
         - /usr/share/pixmaps/showtimenew-symbolic.svg
     - ^budgie-takeabreak-applet :
         - /usr/lib64/budgie-desktop/plugins/budgie-takeabreak
         - /usr/share/glib-2.0/schemas/org.ubuntubudgie.plugins.takeabreak.gschema.xml
+        - /usr/share/metainfo/org.ubuntubudgie.takeabreak.metainfo.xml
         - /usr/share/pixmaps/takeabreak*
     - ^budgie-visualspace-applet :
         - /usr/lib64/budgie-desktop/plugins/budgie-visualspace
         - /usr/share/glib-2.0/schemas/org.ubuntubudgie.plugins.budgie-visualspace.gschema.xml
+        - /usr/share/metainfo/org.ubuntubudgie.visualspace.metainfo.xml
         - /usr/share/pixmaps/visualspace-symbolic.svg
         - /usr/share/xdg/autostart/visualspace-autostart.desktop
     - ^budgie-weathershow-applet :
         - /usr/lib64/budgie-desktop/plugins/budgie-weathershow
         - /usr/share/glib-2.0/schemas/org.ubuntubudgie.plugins.weathershow.gschema.xml
         - /usr/share/budgie-desktop/budgie-weathershow*
+        - /usr/share/metainfo/org.ubuntubudgie.weathershow.metainfo.xml
         - /usr/share/pixmaps/budgie-wticon-symbolic.svg
     - ^budgie-window-shuffler :
         - /usr/lib64/budgie-window-shuffler

--- a/packages/b/budgie-extras/pspec_x86_64.xml
+++ b/packages/b/budgie-extras/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>budgie-extras</Name>
         <Homepage>https://github.com/UbuntuBudgie/budgie-extras</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop.budgie</PartOf>
@@ -47,11 +47,12 @@
         <Description xml:lang="en">The brightness controller applet allows controlling of the screen levels via xrandr (fallback) or via gnome-settings-daemon (if available).</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="31">budgie-extras</Dependency>
+            <Dependency releaseFrom="32">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-brightness-controller/brightnesscontroller.plugin</Path>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-brightness-controller/libbrightnesscontroller.so</Path>
+            <Path fileType="data">/usr/share/metainfo/org.ubuntubudgie.brightnesscontroller.metainfo.xml</Path>
             <Path fileType="data">/usr/share/pixmaps/budgie-brightness-controller-1-symbolic.svg</Path>
         </Files>
     </Package>
@@ -61,12 +62,13 @@
         <Description xml:lang="en">A count down applet with the following options; ring a bell, flash the (panel) icon, display a message window or run a (any) command.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="31">budgie-extras</Dependency>
+            <Dependency releaseFrom="32">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-countdown/CountDown.plugin</Path>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-countdown/budgie-countdown.py</Path>
             <Path fileType="data">/usr/share/glib-2.0/schemas/org.ubuntubudgie.plugins.budgie-countdown.gschema.xml</Path>
+            <Path fileType="data">/usr/share/metainfo/org.ubuntubudgie.countdown.metainfo.xml</Path>
             <Path fileType="data">/usr/share/pixmaps/budgie-countdown-symbolic.svg</Path>
             <Path fileType="data">/usr/share/pixmaps/cr_green.png</Path>
             <Path fileType="data">/usr/share/pixmaps/cr_grey.png</Path>
@@ -81,7 +83,7 @@
         <Description xml:lang="en">This on logon process manages keyboard shortcuts delivered via .bde files for various extras-plugins.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="31">budgie-extras</Dependency>
+            <Dependency releaseFrom="32">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/budgie-extras-daemon</Path>
@@ -95,7 +97,7 @@
             <Path fileType="data">/usr/share/budgie-desktop/layouts/traditional.layout</Path>
             <Path fileType="data">/usr/share/budgie-desktop/layouts/ubuntubudgie.layout</Path>
             <Path fileType="data">/usr/share/budgie-extras-daemon/example.bde</Path>
-            <Path fileType="man">/usr/share/man/man1/budgie-extras-daemon.1</Path>
+            <Path fileType="man">/usr/share/man/man1/budgie-extras-daemon.1.zst</Path>
             <Path fileType="data">/usr/share/xdg/autostart/budgie-extras-daemon.desktop</Path>
         </Files>
     </Package>
@@ -105,8 +107,8 @@
         <Description xml:lang="en">The hotcorners applet allow user defined commands to be executed when the mouse cursor is pushed into a corner of the main desktop.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="31">budgie-previews</Dependency>
-            <Dependency releaseFrom="31">budgie-window-shuffler</Dependency>
+            <Dependency releaseFrom="32">budgie-previews</Dependency>
+            <Dependency releaseFrom="32">budgie-window-shuffler</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-hotcorners/HotCorners.plugin</Path>
@@ -117,6 +119,7 @@
             <Path fileType="data">/usr/share/budgie-hotcorners/defaults</Path>
             <Path fileType="data">/usr/share/glib-2.0/schemas/org.ubuntubudgie.budgie-extras.HotCorners.gschema.xml</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/org.ubuntubudgie.budgie-extras.hotcorners.svg</Path>
+            <Path fileType="data">/usr/share/metainfo/org.ubuntubudgie.hotcorners.metainfo.xml</Path>
             <Path fileType="data">/usr/share/pixmaps/budgie-hotcgui-edit-red.svg</Path>
             <Path fileType="data">/usr/share/pixmaps/budgie-hotcgui-edit-symbolic.svg</Path>
             <Path fileType="data">/usr/share/pixmaps/budgie-hotcgui-red.svg</Path>
@@ -131,11 +134,12 @@
         <Description xml:lang="en">The kangaroo applet allows for quick and easy browsing, across (possibly) many directory layers, without having to do a single mouse click.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="31">budgie-extras</Dependency>
+            <Dependency releaseFrom="32">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-kangaroo/BudgieKangaroo.plugin</Path>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-kangaroo/budgie_kangaroo.py</Path>
+            <Path fileType="data">/usr/share/metainfo/org.ubuntubudgie.kangaroo.metainfo.xml</Path>
             <Path fileType="data">/usr/share/pixmaps/budgie-foldertrack-symbolic.svg</Path>
         </Files>
     </Package>
@@ -145,7 +149,7 @@
         <Description xml:lang="en">Set previews to show an overview of windows in an expose like way.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="31">budgie-extras-daemon</Dependency>
+            <Dependency releaseFrom="32">budgie-extras-daemon</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-previews/previews_controls</Path>
@@ -178,12 +182,13 @@
         <Description xml:lang="en">The quicknote applet allows a user to record a text based note. The applet autosaves the text while writing and supports multiple undo and redo capabilities.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="31">budgie-extras</Dependency>
+            <Dependency releaseFrom="32">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-quicknote/QuickNoteApplet.plugin</Path>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-quicknote/libquicknoteapplet.so</Path>
             <Path fileType="data">/usr/share/glib-2.0/schemas/org.ubuntubudgie.plugins.quicknote.gschema.xml</Path>
+            <Path fileType="data">/usr/share/metainfo/org.ubuntubudgie.quicknote.metainfo.xml</Path>
             <Path fileType="data">/usr/share/pixmaps/budgie-quicknote-symbolic.svg</Path>
         </Files>
     </Package>
@@ -193,13 +198,14 @@
         <Description xml:lang="en">Budgie Showtime is a digital desktop clock, showing time, and optionally, date. Text color of both can be set separately from the applet&apos;s menu.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="31">budgie-extras</Dependency>
+            <Dependency releaseFrom="32">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-showtime/ShowTime.plugin</Path>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-showtime/libbudgieshowtime.so</Path>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-showtime/showtime_desktop</Path>
             <Path fileType="data">/usr/share/glib-2.0/schemas/org.ubuntubudgie.plugins.budgie-showtime.gschema.xml</Path>
+            <Path fileType="data">/usr/share/metainfo/org.ubuntubudgie.showtime.metainfo.xml</Path>
             <Path fileType="data">/usr/share/pixmaps/showtimenew-symbolic.svg</Path>
         </Files>
     </Package>
@@ -209,7 +215,7 @@
         <Description xml:lang="en">Budgie TakeaBreak is a pomodoro like applet, to make sure to take regular breaks from working. Options from Budgie Settings include turning the screen upside down, dim the screen, lock screen or show a countdown message on break time. The applet can be accessed quickly from the panel to temporarily switch it off.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="31">budgie-extras</Dependency>
+            <Dependency releaseFrom="32">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-takeabreak/BudgieTakeaBreak.plugin</Path>
@@ -217,6 +223,7 @@
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-takeabreak/message_window</Path>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-takeabreak/takeabreak_run</Path>
             <Path fileType="data">/usr/share/glib-2.0/schemas/org.ubuntubudgie.plugins.takeabreak.gschema.xml</Path>
+            <Path fileType="data">/usr/share/metainfo/org.ubuntubudgie.takeabreak.metainfo.xml</Path>
             <Path fileType="data">/usr/share/pixmaps/takeabreak-symbolic.svg</Path>
             <Path fileType="data">/usr/share/pixmaps/takeabreakpaused-symbolic.svg</Path>
         </Files>
@@ -227,13 +234,14 @@
         <Description xml:lang="en">The visualspace applet shows as a stylish compact workspace on the budgie panel. Choosing windows in the applet popup moves to the workspace where the window is located and gives it focus. The number of Workspace can also be changed though the applet popup.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="31">budgie-extras</Dependency>
+            <Dependency releaseFrom="32">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-visualspace/VisualSpace.plugin</Path>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-visualspace/auto_workspace</Path>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-visualspace/libvisualspace.so</Path>
             <Path fileType="data">/usr/share/glib-2.0/schemas/org.ubuntubudgie.plugins.budgie-visualspace.gschema.xml</Path>
+            <Path fileType="data">/usr/share/metainfo/org.ubuntubudgie.visualspace.metainfo.xml</Path>
             <Path fileType="data">/usr/share/pixmaps/visualspace-symbolic.svg</Path>
             <Path fileType="data">/usr/share/xdg/autostart/visualspace-autostart.desktop</Path>
         </Files>
@@ -244,7 +252,7 @@
         <Description xml:lang="en">The weathershow applet displays daily and three hourly weather forecasts on both the desktop and a Popover.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="31">budgie-extras</Dependency>
+            <Dependency releaseFrom="32">budgie-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-weathershow/WeatherShow.plugin</Path>
@@ -320,6 +328,7 @@
             <Path fileType="data">/usr/share/budgie-desktop/budgie-weathershow/weather_icons/804n-overcast-clouds.svg</Path>
             <Path fileType="data">/usr/share/budgie-desktop/budgie-weathershow/weather_icons/error_icon.svg</Path>
             <Path fileType="data">/usr/share/glib-2.0/schemas/org.ubuntubudgie.plugins.weathershow.gschema.xml</Path>
+            <Path fileType="data">/usr/share/metainfo/org.ubuntubudgie.weathershow.metainfo.xml</Path>
             <Path fileType="data">/usr/share/pixmaps/budgie-wticon-symbolic.svg</Path>
         </Files>
     </Package>
@@ -329,7 +338,7 @@
         <Description xml:lang="en">The window shuffler is an easy to use windows tiling capability driven primarily through the keyboard to place and move window in a grid format.</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="31">budgie-extras-daemon</Dependency>
+            <Dependency releaseFrom="32">budgie-extras-daemon</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/budgie-window-shuffler/ShufflerAPplet.plugin</Path>
@@ -407,12 +416,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2025-03-12</Date>
+        <Update release="32">
+            <Date>2025-10-31</Date>
             <Version>1.9.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Add AppStream metainfo files for all applets.

See https://github.com/UbuntuBudgie/budgie-extras/pull/495

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that every applet has a metainfo file.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
