### PR TITLE
budgie-cputemp-applet: Add metainfo file

### DIFF
--- a/packages/b/budgie-cputemp-applet/abi_used_symbols
+++ b/packages/b/budgie-cputemp-applet/abi_used_symbols
@@ -6,13 +6,13 @@ libbudgie-plugin.so.0:budgie_plugin_get_type
 libbudgie-plugin.so.0:budgie_popover_manager_register_popover
 libbudgie-plugin.so.0:budgie_popover_manager_show_popover
 libbudgie-plugin.so.0:budgie_popover_new
+libc.so.6:__isoc23_strtol
 libc.so.6:__stack_chk_fail
 libc.so.6:fclose
 libc.so.6:fgets
 libc.so.6:fopen64
 libc.so.6:fread
 libc.so.6:strlen
-libc.so.6:strtol
 libgio-2.0.so.0:g_settings_bind
 libgio-2.0.so.0:g_settings_get_boolean
 libgio-2.0.so.0:g_settings_get_string

--- a/packages/b/budgie-cputemp-applet/files/0001-assets-Add-AppStream-metainfo-file.patch
+++ b/packages/b/budgie-cputemp-applet/files/0001-assets-Add-AppStream-metainfo-file.patch
@@ -1,0 +1,93 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Evan Maddock <maddock.evan@vivaldi.net>
+Date: Fri, 31 Oct 2025 15:46:16 -0400
+Subject: [PATCH] assets: Add AppStream metainfo file
+
+Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
+---
+ ....tarkah.budgie-cputemp-applet.metainfo.xml | 52 +++++++++++++++++++
+ assets/meson.build                            |  3 ++
+ meson.build                                   |  3 +-
+ 3 files changed, 57 insertions(+), 1 deletion(-)
+ create mode 100644 assets/io.github.tarkah.budgie-cputemp-applet.metainfo.xml
+ create mode 100644 assets/meson.build
+
+diff --git a/assets/io.github.tarkah.budgie-cputemp-applet.metainfo.xml b/assets/io.github.tarkah.budgie-cputemp-applet.metainfo.xml
+new file mode 100644
+index 0000000..db51acf
+--- /dev/null
++++ b/assets/io.github.tarkah.budgie-cputemp-applet.metainfo.xml
+@@ -0,0 +1,52 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!-- Copyright 2022 Ubuntu Budgie Developers <admin@ubuntubudgie.org> -->
++<component type="addon">
++  <id>io.github.tarkah.budgie-cputemp-applet</id>
++  <extends>com.solus-project.budgie-desktop</extends>
++  <metadata_license>FSFAP</metadata_license>
++  <project_license>GPL-3.0-or-later</project_license>
++  <name>Budgie CPUTemp</name>
++  <summary>A CPU temperature applet for Budgie Desktop</summary>
++  <update_contact>admin@ubuntubudgie.org</update_contact>
++  <description>
++    <p>
++      A CPU temperature applet for Budgie Desktop. Available sensors are inherited from hwmon.
++    </p>
++  </description>
++  <categories>
++    <category>Utility</category>
++  </categories>
++  <screenshots>
++    <screenshot type="default">
++      <image>https://github.com/tarkah/budgie-cputemp-applet/raw/master/assets/applet.gif</image>
++    </screenshot>
++  </screenshots>
++  <url type="homepage">https://github.com/tarkah/budgie-cputemp-applet</url>
++  <url type="bugtracker">https://github.com/tarkah/budgie-cputemp-applet/issues</url>
++  <developer id="io.github.tarkah">
++    <name>Corey Forsstrom</name>
++    <url>https://github.com/tarkah</url>
++  </developer>
++  <content_rating type="oars-1.0">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++  </content_rating>
++</component>
+diff --git a/assets/meson.build b/assets/meson.build
+new file mode 100644
+index 0000000..d3c4cc6
+--- /dev/null
++++ b/assets/meson.build
+@@ -0,0 +1,3 @@
++install_data('io.github.tarkah.budgie-cputemp-applet.metainfo.xml',
++    install_dir: join_paths(datadir, 'metainfo')
++)
+diff --git a/meson.build b/meson.build
+index 79abf39..18592a6 100644
+--- a/meson.build
++++ b/meson.build
+@@ -49,4 +49,5 @@ config_h = configure_file(
+ 	configuration: conf
+ )
+ 
+-subdir('plugin')
+\ No newline at end of file
++subdir('assets')
++subdir('plugin')

--- a/packages/b/budgie-cputemp-applet/package.yml
+++ b/packages/b/budgie-cputemp-applet/package.yml
@@ -1,6 +1,6 @@
 name       : budgie-cputemp-applet
 version    : 1.2.0
-release    : 3
+release    : 4
 source     :
     - https://github.com/tarkah/budgie-cputemp-applet/archive/refs/tags/1.2.0.tar.gz : f3c897dc47a08398f1da0b1bb020d7fe07d01b93666ea6f48623990184a8325a
 homepage   : https://github.com/tarkah/budgie-cputemp-applet
@@ -13,6 +13,8 @@ builddeps  :
     - pkgconfig(budgie-1.0)
     - vala
 setup      : |
+    %patch -p1 -i $pkgfiles/0001-assets-Add-AppStream-metainfo-file.patch
+
     %meson_configure --sysconfdir=/usr/share
 build      : |
     %ninja_build

--- a/packages/b/budgie-cputemp-applet/pspec_x86_64.xml
+++ b/packages/b/budgie-cputemp-applet/pspec_x86_64.xml
@@ -23,12 +23,13 @@
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/cpu-temp/CpuTempApplet.plugin</Path>
             <Path fileType="library">/usr/lib64/budgie-desktop/plugins/cpu-temp/libcputempapplet.so</Path>
             <Path fileType="data">/usr/share/glib-2.0/schemas/com.github.tarkah.budgie-cputemp-applet.gschema.xml</Path>
+            <Path fileType="data">/usr/share/metainfo/io.github.tarkah.budgie-cputemp-applet.metainfo.xml</Path>
             <Path fileType="data">/usr/share/pixmaps/chip-cpu-symbolic.svg</Path>
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2023-10-18</Date>
+        <Update release="4">
+            <Date>2025-10-31</Date>
             <Version>1.2.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
Add AppStream metainfo file.

See https://github.com/tarkah/budgie-cputemp-applet/pull/9

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that a metainfo file is now installed.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
