### PR TITLE
apostrophe: Update to v3.4

### DIFF
--- a/packages/a/apostrophe/package.yml
+++ b/packages/a/apostrophe/package.yml
@@ -1,8 +1,8 @@
 name       : apostrophe
-version    : '3.3'
-release    : 15
+version    : '3.4'
+release    : 16
 source     :
-    - https://gitlab.gnome.org/World/apostrophe/-/archive/v3.3/apostrophe-v3.3.tar.gz : cff3260e221a5c2edad76c84c6eb531995ffcd7256428ab8d491b569130d119d
+    - https://gitlab.gnome.org/World/apostrophe/-/archive/v3.4/apostrophe-v3.4.tar.gz : daee484d02f67e03d9c46a0f3ce1ae7828afc7b9946868f6b057267ed591918a
 homepage   : https://world.pages.gitlab.gnome.org/apostrophe/
 license    : GPL-3.0-or-later
 component  : office.notes

--- a/packages/a/apostrophe/pspec_x86_64.xml
+++ b/packages/a/apostrophe/pspec_x86_64.xml
@@ -138,6 +138,7 @@
             <Path fileType="localedata">/usr/share/locale/hi/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/hr/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/hu/LC_MESSAGES/apostrophe.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ia/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ie/LC_MESSAGES/apostrophe.mo</Path>
             <Path fileType="localedata">/usr/share/locale/is/LC_MESSAGES/apostrophe.mo</Path>
@@ -169,9 +170,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2025-09-11</Date>
-            <Version>3.3</Version>
+        <Update release="16">
+            <Date>2025-11-01</Date>
+            <Version>3.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
             <Email>malfisya.dev@hotmail.com</Email>


### PR DESCRIPTION
**Summary**

Full release note can be read [here](https://gitlab.gnome.org/World/apostrophe/-/raw/v3.4/NEWS?ref_type=tags)

**Test Plan**

<!-- Short description of how the package was tested -->
Launch the app, create new markdown document and open old document

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
