### PR TITLE
magic-wormhole: Update to v0.21.1

### DIFF
--- a/packages/m/magic-wormhole/package.yml
+++ b/packages/m/magic-wormhole/package.yml
@@ -1,8 +1,8 @@
 name       : magic-wormhole
-version    : 0.21.0
-release    : 15
+version    : 0.21.1
+release    : 16
 source     :
-    - https://github.com/magic-wormhole/magic-wormhole/archive/refs/tags/0.21.0.tar.gz : e31bbb2cfbe3c9ba32b614fce70f5d8c4ed6898d7581c13a1fcc81752b894189
+    - https://github.com/magic-wormhole/magic-wormhole/archive/refs/tags/0.21.1.tar.gz : f8f02fe786720c0cc086046117f04740fe4a4d76023c8ca35a3f7d25e6bb5e9e
 homepage   : https://github.com/magic-wormhole/magic-wormhole
 license    : MIT
 component  : network

--- a/packages/m/magic-wormhole/pspec_x86_64.xml
+++ b/packages/m/magic-wormhole/pspec_x86_64.xml
@@ -22,12 +22,12 @@
         <Files>
             <Path fileType="executable">/usr/bin/magic-wormhole</Path>
             <Path fileType="executable">/usr/bin/wormhole</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/magic_wormhole-0.21.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/magic_wormhole-0.21.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/magic_wormhole-0.21.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/magic_wormhole-0.21.0.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/magic_wormhole-0.21.0.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/magic_wormhole-0.21.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/magic_wormhole-0.21.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/magic_wormhole-0.21.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/magic_wormhole-0.21.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/magic_wormhole-0.21.1.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/magic_wormhole-0.21.1.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/magic_wormhole-0.21.1.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/wormhole/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/wormhole/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/wormhole/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -301,9 +301,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2025-10-24</Date>
-            <Version>0.21.0</Version>
+        <Update release="16">
+            <Date>2025-10-31</Date>
+            <Version>0.21.1</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Exclude autobahn 25.10.2 due to Windows breakage

**Test Plan**

- Transfer a file

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
