### PR TITLE
yubikey-manage: update to 5.8.0

### DIFF
--- a/packages/y/yubikey-manager/monitoring.yaml
+++ b/packages/y/yubikey-manager/monitoring.yaml
@@ -1,6 +1,6 @@
 releases:
-  id: 13695
-  rss: https://github.com/Yubico/yubikey-manager/tags.atom
+  id: 67946
+  rss: https://github.com/Yubico/yubikey-manager/releases.atom
 # No known CPE, checked 2024-11-14
 security:
   cpe: ~

--- a/packages/y/yubikey-manager/package.yml
+++ b/packages/y/yubikey-manager/package.yml
@@ -1,8 +1,8 @@
 name       : yubikey-manager
-version    : 5.7.1
-release    : 45
+version    : 5.8.0
+release    : 46
 source     :
-    - https://github.com/Yubico/yubikey-manager/releases/download/5.7.1/yubikey_manager-5.7.1.tar.gz : 0200efca86eb310e19b841a2e365812c83c19f8e65f8c6065e14bbb7b4a58ef3
+    - https://github.com/Yubico/yubikey-manager/releases/download/5.8.0/yubikey_manager-5.8.0.tar.gz : 3af0da65e1fdd46763c94ee74e2da55a4b6e7771da776c197f5f4b4581738560
 homepage   : https://developers.yubico.com/yubikey-manager/
 license    : BSD-2-Clause
 component  : security
@@ -14,16 +14,10 @@ builddeps  :
     - pkgconfig(python3)
     - pcsc-lite
     - python-build
-    - python-click
     - python-fido2
     - python-installer
-    - python-openssl
-    - python-packaging
     - python-poetry
     - python-pyscard
-    - python-pyusb
-    - python-testpath
-    - python-wheel
 rundeps    :
     - ccid
     - python-click
@@ -34,9 +28,24 @@ rundeps    :
     - python-pyscard
 build      : |
     %python3_setup
+
+    # Create shell completions
+    python -m venv --system-site-packages completion-env
+    completion-env/bin/python -m installer dist/*.whl
+    _YKMAN_COMPLETE=bash_source completion-env/bin/ykman > ykman.bash
+    _YKMAN_COMPLETE=zsh_source completion-env/bin/ykman > _ykman
 install    : |
     %python3_install
-
     # Vendor enable pcscd.socket so this works OOTB.
     install -dm00755 $installdir/%libdir%/systemd/system/sockets.target.wants
     ln -sv ../pcscd.socket $installdir/%libdir%/systemd/system/sockets.target.wants/pcscd.socket
+
+    # Manpages
+    install -Dm00644 man/ykman.1 -t "$installdir/usr/share/man/man1/"
+
+    # Install completions
+    install -Dm0644 ykman.bash -t "$installdir/usr/share/bash-completion/completions/"
+    install -Dm0644 _ykman -t "$installdir/usr/share/zsh/site-functions/"
+
+    # Include copyright notice as required by the license
+    install -Dm0644 -t "$installdir/usr/share/licenses/$package/" COPYING 

--- a/packages/y/yubikey-manager/pspec_x86_64.xml
+++ b/packages/y/yubikey-manager/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>yubikey-manager</Name>
         <Homepage>https://developers.yubico.com/yubikey-manager/</Homepage>
         <Packager>
-            <Name>Tracey Clark</Name>
-            <Email>traceyc.dev@tlcnet.info</Email>
+            <Name>Matthias Homann</Name>
+            <Email>palto@mailbox.org</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>security</PartOf>
@@ -103,6 +103,8 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/hid/__pycache__/__init__.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/hid/__pycache__/base.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/hid/__pycache__/base.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/hid/__pycache__/fido.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/hid/__pycache__/fido.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/hid/__pycache__/freebsd.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/hid/__pycache__/freebsd.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/hid/__pycache__/linux.cpython-312.opt-1.pyc</Path>
@@ -112,6 +114,7 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/hid/__pycache__/windows.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/hid/__pycache__/windows.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/hid/base.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/hid/fido.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/hid/freebsd.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/hid/linux.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/hid/macos.py</Path>
@@ -157,11 +160,11 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/scripting.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/settings.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ykman/util.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/yubikey_manager-5.7.1.dist-info/COPYING</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/yubikey_manager-5.7.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/yubikey_manager-5.7.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/yubikey_manager-5.7.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/yubikey_manager-5.7.1.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/yubikey_manager-5.8.0.dist-info/COPYING</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/yubikey_manager-5.8.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/yubikey_manager-5.8.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/yubikey_manager-5.8.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/yubikey_manager-5.8.0.dist-info/entry_points.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/yubikit/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/yubikit/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/yubikit/__pycache__/__init__.cpython-312.pyc</Path>
@@ -209,15 +212,19 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/yubikit/support.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/yubikit/yubiotp.py</Path>
             <Path fileType="library">/usr/lib64/systemd/system/sockets.target.wants/pcscd.socket</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/ykman.bash</Path>
+            <Path fileType="data">/usr/share/licenses/yubikey-manager/COPYING</Path>
+            <Path fileType="man">/usr/share/man/man1/ykman.1.zst</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_ykman</Path>
         </Files>
     </Package>
     <History>
-        <Update release="45">
-            <Date>2025-06-11</Date>
-            <Version>5.7.1</Version>
+        <Update release="46">
+            <Date>2025-11-03</Date>
+            <Version>5.8.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Tracey Clark</Name>
-            <Email>traceyc.dev@tlcnet.info</Email>
+            <Name>Matthias Homann</Name>
+            <Email>palto@mailbox.org</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://github.com/Yubico/yubikey-manager/releases/tag/5.8.0)
- Added man pages
- Added shell completions for bash and zsh
- Include copyright file as required by the license
- Corrected ID in `monitoring.yaml`

**Test Plan**

- YubiKey Manager can be run with `ykman`
- `ykman` info shows a connected YubiKey
- `ykman fido credentials list` asks for PIN code and then shows the expected entries

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
