### PR TITLE
openrct2: Update to v0.4.28

### DIFF
--- a/packages/o/openrct2/abi_used_symbols
+++ b/packages/o/openrct2/abi_used_symbols
@@ -135,6 +135,7 @@ libc.so.6:__stack_chk_fail
 libc.so.6:__strcpy_chk
 libc.so.6:__vfprintf_chk
 libc.so.6:__vsnprintf_chk
+libc.so.6:_exit
 libc.so.6:_setjmp
 libc.so.6:abort
 libc.so.6:accept
@@ -147,6 +148,8 @@ libc.so.6:connect
 libc.so.6:difftime
 libc.so.6:dlclose
 libc.so.6:dlopen
+libc.so.6:dup2
+libc.so.6:execvp
 libc.so.6:exit
 libc.so.6:fclose
 libc.so.6:fcntl64
@@ -154,6 +157,7 @@ libc.so.6:fflush
 libc.so.6:fileno
 libc.so.6:fnmatch
 libc.so.6:fopen64
+libc.so.6:fork
 libc.so.6:fputc
 libc.so.6:fputs
 libc.so.6:fread
@@ -198,8 +202,7 @@ libc.so.6:memset
 libc.so.6:mktime
 libc.so.6:nanosleep
 libc.so.6:open64
-libc.so.6:pclose
-libc.so.6:popen
+libc.so.6:pipe
 libc.so.6:pthread_mutex_lock
 libc.so.6:pthread_mutex_unlock
 libc.so.6:pthread_once
@@ -249,6 +252,7 @@ libc.so.6:toupper
 libc.so.6:unsetenv
 libc.so.6:usleep
 libc.so.6:vsnprintf
+libc.so.6:waitpid
 libc.so.6:wmemcpy
 libc.so.6:wmemset
 libc.so.6:write

--- a/packages/o/openrct2/package.yml
+++ b/packages/o/openrct2/package.yml
@@ -1,8 +1,8 @@
 name       : openrct2
-version    : 0.4.27
-release    : 60
+version    : 0.4.28
+release    : 61
 source     :
-    - git|https://github.com/OpenRCT2/OpenRCT2.git : v0.4.27
+    - git|https://github.com/OpenRCT2/OpenRCT2.git : v0.4.28
     - https://github.com/OpenRCT2/title-sequences/releases/download/v0.4.26/title-sequences.zip : dabb9787b1576342fca4dd9f64b3f8cfa04a7e6ce9c2bb9610f47b762905c858
     - https://github.com/OpenRCT2/objects/releases/download/v1.7.3/objects.zip : c81029264578706ed1db88665e12a70a583e71dc4d3eb4db262535d2f0589eab
     - https://github.com/OpenRCT2/OpenSoundEffects/releases/download/v1.0.6/opensound.zip : 06b90f3e19c216752df441d551b26a9e3e1ba7755bdd2102504b73bf993608be

--- a/packages/o/openrct2/pspec_x86_64.xml
+++ b/packages/o/openrct2/pspec_x86_64.xml
@@ -2726,9 +2726,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="60">
-            <Date>2025-10-04</Date>
-            <Version>0.4.27</Version>
+        <Update release="61">
+            <Date>2025-11-01</Date>
+            <Version>0.4.28</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- *Mr Creosote*
- Release notes [here](https://github.com/OpenRCT2/OpenRCT2/releases/tag/v0.4.28)

**Test Plan**

- Play a scenario

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
