### PR TITLE
soundtouch: Update to v2.4.0

### DIFF
--- a/packages/s/soundtouch/package.yml
+++ b/packages/s/soundtouch/package.yml
@@ -1,9 +1,9 @@
 name       : soundtouch
-version    : 2.3.3
-release    : 6
+version    : 2.4.0
+release    : 7
 source     :
-    - https://www.surina.net/soundtouch/soundtouch-2.3.3.tar.gz : 43b23dfac2f64a3aff55d64be096ffc7b73842c3f5665caff44975633a975a99
-homepage   : http://surina.net/soundtouch/index.html
+    - https://codeberg.org/soundtouch/soundtouch/archive/2.4.0.tar.gz : 3dda3c9ab1e287f15028c010a66ab7145fa855dfa62763538f341e70b4d10abd
+homepage   : https://surina.net/soundtouch/index.html
 license    : LGPL-2.1-or-later
 summary    : Audio processing library.
 component  : multimedia.library

--- a/packages/s/soundtouch/pspec_x86_64.xml
+++ b/packages/s/soundtouch/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>soundtouch</Name>
-        <Homepage>http://surina.net/soundtouch/index.html</Homepage>
+        <Homepage>https://surina.net/soundtouch/index.html</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>multimedia.library</PartOf>
@@ -36,7 +36,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="6">soundtouch</Dependency>
+            <Dependency release="7">soundtouch</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libSoundTouch.so.1</Path>
@@ -52,8 +52,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="6">soundtouch-32bit</Dependency>
-            <Dependency release="6">soundtouch-devel</Dependency>
+            <Dependency release="7">soundtouch-32bit</Dependency>
+            <Dependency release="7">soundtouch-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libSoundTouch.so</Path>
@@ -68,7 +68,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="6">soundtouch</Dependency>
+            <Dependency release="7">soundtouch</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/SoundTouchDLL.h</Path>
@@ -85,12 +85,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2024-04-25</Date>
-            <Version>2.3.3</Version>
+        <Update release="7">
+            <Date>2025-11-02</Date>
+            <Version>2.4.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Release notes can be found [here](https://soundtouch.surina.net/README.html#changehistory). 
Fix homepage link. Part of https://github.com/getsolus/packages/issues/5522

**Test Plan**

Installed soundtouch

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
