### PR TITLE
liferea: Update to v1.16.6

### DIFF
--- a/packages/l/liferea/abi_symbols
+++ b/packages/l/liferea/abi_symbols
@@ -55,6 +55,7 @@ liferea:conf_get_bool_value_from_schema
 liferea:conf_get_dark_theme
 liferea:conf_get_default_font
 liferea:conf_get_int_value_from_schema
+liferea:conf_get_settings
 liferea:conf_get_str_value_from_schema
 liferea:conf_get_strv_value_from_schema
 liferea:conf_get_toolbar_style
@@ -117,8 +118,6 @@ liferea:favicon_get_urls
 liferea:favicon_load_from_cache
 liferea:favicon_remove_from_cache
 liferea:favicon_save_from_data
-liferea:feed_enrich_item
-liferea:feed_get_max_item_count
 liferea:feed_get_provider
 liferea:feed_get_subscription_type
 liferea:feed_list_view_add_duplicate_url_subscription
@@ -138,7 +137,6 @@ liferea:feed_list_view_sort_folder
 liferea:feed_list_view_to_iter
 liferea:feed_list_view_update_iter
 liferea:feed_list_view_update_node
-liferea:feed_new
 liferea:feed_parse
 liferea:feed_parser_ctxt_free
 liferea:feed_parser_ctxt_new
@@ -147,6 +145,7 @@ liferea:feed_type_str_to_fhp
 liferea:feedlist
 liferea:feedlist_add_folder
 liferea:feedlist_add_subscription
+liferea:feedlist_add_subscription_by_url
 liferea:feedlist_add_subscription_check_duplicate
 liferea:feedlist_create
 liferea:feedlist_find_node
@@ -188,6 +187,8 @@ liferea:google_source_login
 liferea:google_source_migrate_node
 liferea:google_source_provider_get_type
 liferea:google_source_register
+liferea:gopher_init_feed_handler
+liferea:gopher_process_request
 liferea:html5_init_feed_handler
 liferea:html_auto_discover_feed
 liferea:html_discover_favicon
@@ -273,6 +274,7 @@ liferea:itemview_clear
 liferea:itemview_create
 liferea:itemview_do_zoom
 liferea:itemview_find_unread_item
+liferea:itemview_get_effective_layout
 liferea:itemview_get_layout
 liferea:itemview_get_type
 liferea:itemview_launch_URL
@@ -368,6 +370,7 @@ liferea:liferea_shell_update_item_menu
 liferea:liferea_shell_update_toolbar
 liferea:liferea_web_view_get_type
 liferea:liferea_web_view_new
+liferea:liferea_web_view_print
 liferea:liferea_web_view_scroll_pagedown
 liferea:liferea_web_view_set_dbus_connection
 liferea:liferea_webkit_change_zoom_level
@@ -406,7 +409,6 @@ liferea:network_monitor_set_online
 liferea:network_process_request
 liferea:network_set_proxy
 liferea:network_strerror
-liferea:new_subscription_dialog_get_type
 liferea:newsbin_get_list
 liferea:newsbin_get_provider
 liferea:node_auto_update_subscription
@@ -570,11 +572,13 @@ liferea:social_unregister_bookmark_site
 liferea:subscription_auto_update
 liferea:subscription_cancel_update
 liferea:subscription_dialog_new
+liferea:subscription_enrich_item
 liferea:subscription_export
 liferea:subscription_free
 liferea:subscription_get_default_update_interval
 liferea:subscription_get_filter
 liferea:subscription_get_homepage
+liferea:subscription_get_max_item_count
 liferea:subscription_get_source
 liferea:subscription_get_update_interval
 liferea:subscription_icon_update
@@ -610,7 +614,6 @@ liferea:ui_common_setup_combo_text
 liferea:ui_common_simple_action_group_set_enabled
 liferea:ui_common_treeview_move_cursor
 liferea:ui_common_treeview_move_cursor_to_first
-liferea:ui_complex_subscription_dialog_cb
 liferea:ui_dnd_setup_feedlist
 liferea:ui_folder_add
 liferea:ui_popup_item_menu
@@ -627,7 +630,6 @@ liferea:update_job_get_state
 liferea:update_job_get_type
 liferea:update_job_new
 liferea:update_job_queue_add
-liferea:update_job_queue_finished
 liferea:update_job_queue_get_count
 liferea:update_job_queue_remove
 liferea:update_options_copy

--- a/packages/l/liferea/abi_used_libs
+++ b/packages/l/liferea/abi_used_libs
@@ -3,7 +3,7 @@ libfribidi.so.0
 libgdk-3.so.0
 libgdk_pixbuf-2.0.so.0
 libgio-2.0.so.0
-libgirepository-1.0.so.1
+libgirepository-2.0.so.0
 libglib-2.0.so.0
 libgobject-2.0.so.0
 libgtk-3.so.0

--- a/packages/l/liferea/abi_used_symbols
+++ b/packages/l/liferea/abi_used_symbols
@@ -91,6 +91,7 @@ libgio-2.0.so.0:g_bus_own_name
 libgio-2.0.so.0:g_bus_unown_name
 libgio-2.0.so.0:g_cancellable_cancel
 libgio-2.0.so.0:g_cancellable_new
+libgio-2.0.so.0:g_content_type_guess
 libgio-2.0.so.0:g_credentials_is_same_user
 libgio-2.0.so.0:g_credentials_new
 libgio-2.0.so.0:g_dbus_auth_observer_new
@@ -117,6 +118,7 @@ libgio-2.0.so.0:g_file_move
 libgio-2.0.so.0:g_file_new_for_path
 libgio-2.0.so.0:g_file_new_for_uri
 libgio-2.0.so.0:g_icon_get_type
+libgio-2.0.so.0:g_inet_socket_address_new
 libgio-2.0.so.0:g_io_error_quark
 libgio-2.0.so.0:g_list_model_get_item
 libgio-2.0.so.0:g_list_model_get_n_items
@@ -131,6 +133,8 @@ libgio-2.0.so.0:g_menu_item_set_action_and_target
 libgio-2.0.so.0:g_menu_item_set_label
 libgio-2.0.so.0:g_menu_new
 libgio-2.0.so.0:g_proxy_resolver_get_default
+libgio-2.0.so.0:g_resolver_get_default
+libgio-2.0.so.0:g_resolver_lookup_by_name
 libgio-2.0.so.0:g_resources_lookup_data
 libgio-2.0.so.0:g_settings_bind
 libgio-2.0.so.0:g_settings_get_boolean
@@ -150,6 +154,11 @@ libgio-2.0.so.0:g_settings_set_strv
 libgio-2.0.so.0:g_simple_action_group_new
 libgio-2.0.so.0:g_simple_action_set_enabled
 libgio-2.0.so.0:g_simple_action_set_state
+libgio-2.0.so.0:g_socket_connect
+libgio-2.0.so.0:g_socket_new
+libgio-2.0.so.0:g_socket_receive
+libgio-2.0.so.0:g_socket_send
+libgio-2.0.so.0:g_socket_set_timeout
 libgio-2.0.so.0:g_static_resource_fini
 libgio-2.0.so.0:g_static_resource_get_resource
 libgio-2.0.so.0:g_static_resource_init
@@ -159,9 +168,9 @@ libgio-2.0.so.0:g_task_run_in_thread
 libgio-2.0.so.0:g_task_set_task_data
 libgio-2.0.so.0:g_themed_icon_new
 libgio-2.0.so.0:g_themed_icon_new_with_default_fallbacks
-libgirepository-1.0.so.1:g_irepository_get_default
-libgirepository-1.0.so.1:g_irepository_get_option_group
-libgirepository-1.0.so.1:g_irepository_require_private
+libgirepository-2.0.so.0:gi_repository_dup_default
+libgirepository-2.0.so.0:gi_repository_get_option_group
+libgirepository-2.0.so.0:gi_repository_require_private
 libglib-2.0.so.0:g_array_append_vals
 libglib-2.0.so.0:g_array_free
 libglib-2.0.so.0:g_array_new
@@ -171,11 +180,11 @@ libglib-2.0.so.0:g_ascii_strtoull
 libglib-2.0.so.0:g_ascii_table
 libglib-2.0.so.0:g_assertion_message
 libglib-2.0.so.0:g_assertion_message_expr
-libglib-2.0.so.0:g_async_queue_new
-libglib-2.0.so.0:g_async_queue_push
-libglib-2.0.so.0:g_async_queue_try_pop
-libglib-2.0.so.0:g_async_queue_unref
+libglib-2.0.so.0:g_base64_encode
 libglib-2.0.so.0:g_build_filename
+libglib-2.0.so.0:g_byte_array_append
+libglib-2.0.so.0:g_byte_array_new
+libglib-2.0.so.0:g_byte_array_unref
 libglib-2.0.so.0:g_bytes_get_data
 libglib-2.0.so.0:g_bytes_get_size
 libglib-2.0.so.0:g_bytes_new
@@ -201,6 +210,7 @@ libglib-2.0.so.0:g_dir_read_name
 libglib-2.0.so.0:g_direct_equal
 libglib-2.0.so.0:g_direct_hash
 libglib-2.0.so.0:g_error_free
+libglib-2.0.so.0:g_error_matches
 libglib-2.0.so.0:g_error_new
 libglib-2.0.so.0:g_file_get_contents
 libglib-2.0.so.0:g_file_set_contents
@@ -256,6 +266,7 @@ libglib-2.0.so.0:g_malloc
 libglib-2.0.so.0:g_malloc0
 libglib-2.0.so.0:g_markup_escape_text
 libglib-2.0.so.0:g_markup_printf_escaped
+libglib-2.0.so.0:g_memdup2
 libglib-2.0.so.0:g_mkdir_with_parents
 libglib-2.0.so.0:g_mkstemp
 libglib-2.0.so.0:g_once_impl
@@ -346,6 +357,9 @@ libglib-2.0.so.0:g_strv_builder_new
 libglib-2.0.so.0:g_strv_builder_unref
 libglib-2.0.so.0:g_strv_contains
 libglib-2.0.so.0:g_strv_length
+libglib-2.0.so.0:g_thread_pool_free
+libglib-2.0.so.0:g_thread_pool_new
+libglib-2.0.so.0:g_thread_pool_push
 libglib-2.0.so.0:g_time_zone_new_identifier
 libglib-2.0.so.0:g_time_zone_new_utc
 libglib-2.0.so.0:g_time_zone_unref
@@ -645,7 +659,6 @@ libgtk-3.so.0:gtk_widget_get_style_context
 libgtk-3.so.0:gtk_widget_get_type
 libgtk-3.so.0:gtk_widget_get_visible
 libgtk-3.so.0:gtk_widget_get_window
-libgtk-3.so.0:gtk_widget_grab_default
 libgtk-3.so.0:gtk_widget_grab_focus
 libgtk-3.so.0:gtk_widget_hide
 libgtk-3.so.0:gtk_widget_insert_action_group
@@ -667,7 +680,6 @@ libgtk-3.so.0:gtk_window_get_size
 libgtk-3.so.0:gtk_window_maximize
 libgtk-3.so.0:gtk_window_move
 libgtk-3.so.0:gtk_window_present
-libgtk-3.so.0:gtk_window_resize
 libgtk-3.so.0:gtk_window_set_application
 libgtk-3.so.0:gtk_window_set_default_icon_name
 libgtk-3.so.0:gtk_window_set_focus
@@ -783,6 +795,8 @@ libwebkit2gtk-4.1.so.0:webkit_navigation_policy_decision_get_navigation_action
 libwebkit2gtk-4.1.so.0:webkit_policy_decision_download
 libwebkit2gtk-4.1.so.0:webkit_policy_decision_get_type
 libwebkit2gtk-4.1.so.0:webkit_policy_decision_ignore
+libwebkit2gtk-4.1.so.0:webkit_print_operation_new
+libwebkit2gtk-4.1.so.0:webkit_print_operation_run_dialog
 libwebkit2gtk-4.1.so.0:webkit_response_policy_decision_get_type
 libwebkit2gtk-4.1.so.0:webkit_response_policy_decision_is_mime_type_supported
 libwebkit2gtk-4.1.so.0:webkit_script_world_get_default
@@ -794,6 +808,7 @@ libwebkit2gtk-4.1.so.0:webkit_uri_request_get_uri
 libwebkit2gtk-4.1.so.0:webkit_uri_scheme_request_finish
 libwebkit2gtk-4.1.so.0:webkit_uri_scheme_request_finish_error
 libwebkit2gtk-4.1.so.0:webkit_uri_scheme_request_get_path
+libwebkit2gtk-4.1.so.0:webkit_uri_scheme_request_get_uri
 libwebkit2gtk-4.1.so.0:webkit_user_content_manager_add_style_sheet
 libwebkit2gtk-4.1.so.0:webkit_user_content_manager_remove_all_style_sheets
 libwebkit2gtk-4.1.so.0:webkit_user_style_sheet_new

--- a/packages/l/liferea/package.yml
+++ b/packages/l/liferea/package.yml
@@ -1,8 +1,8 @@
 name       : liferea
-version    : 1.16.2
-release    : 35
+version    : 1.16.6
+release    : 36
 source     :
-    - https://github.com/lwindolf/liferea/archive/refs/tags/v1.16.2.tar.gz : a7a37eaa0cbf831085b885f8ae418bd251e3ac67dc4467eebf6b31661af2d8fb
+    - https://github.com/lwindolf/liferea/releases/download/v1.16.6/liferea-1.16.6.tar.bz2 : 0fd9919a0d62c129726160ae626303cc29215308330c0ff50c4823e3d079f4b7
 license    : GPL-2.0-or-later
 homepage   : https://lzone.de/liferea
 component  : network.news
@@ -22,7 +22,7 @@ rundeps    :
 environment: |
     export WEBKIT_DISABLE_COMPOSITING_MODE=1 # temp workaround: https://github.com/lwindolf/liferea/issues/767
 setup      : |
-    %autogen --disable-static --disable-schemas-compile
+    %configure --disable-static
 build      : |
     %make
 install    : |

--- a/packages/l/liferea/pspec_x86_64.xml
+++ b/packages/l/liferea/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>liferea</Name>
         <Homepage>https://lzone.de/liferea</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>network.news</PartOf>
@@ -133,7 +133,6 @@
             <Path fileType="data">/usr/share/liferea/mark_read_dialog.ui</Path>
             <Path fileType="data">/usr/share/liferea/new_folder.ui</Path>
             <Path fileType="data">/usr/share/liferea/new_newsbin.ui</Path>
-            <Path fileType="data">/usr/share/liferea/new_subscription.ui</Path>
             <Path fileType="data">/usr/share/liferea/node_source.ui</Path>
             <Path fileType="data">/usr/share/liferea/opml/feedlist_bg.opml</Path>
             <Path fileType="data">/usr/share/liferea/opml/feedlist_ca.opml</Path>
@@ -215,18 +214,18 @@
             <Path fileType="localedata">/usr/share/locale/vi/LC_MESSAGES/liferea.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/liferea.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/liferea.mo</Path>
-            <Path fileType="man">/usr/share/man/it/man1/liferea.1</Path>
-            <Path fileType="man">/usr/share/man/man1/liferea.1</Path>
+            <Path fileType="man">/usr/share/man/it/man1/liferea.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/liferea.1.zst</Path>
             <Path fileType="data">/usr/share/metainfo/net.sourceforge.liferea.appdata.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="35">
-            <Date>2025-08-31</Date>
-            <Version>1.16.2</Version>
+        <Update release="36">
+            <Date>2025-11-02</Date>
+            <Version>1.16.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/lwindolf/liferea/releases/tag/v1.16.6).

Part of making everything depend on girepository-2.0.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Open Liferea and browse some news feeds.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
