### PR TITLE
miriway: Update to v25.12

### DIFF
--- a/packages/m/miriway/abi_used_symbols
+++ b/packages/m/miriway/abi_used_symbols
@@ -44,6 +44,8 @@ libmiral.so.7:_ZN5miral11Decorations10always_ssdEv
 libmiral.so.7:_ZN5miral11Decorations10prefer_csdEv
 libmiral.so.7:_ZN5miral11Decorations10prefer_ssdEv
 libmiral.so.7:_ZN5miral11live_config3KeyC1ESt16initializer_listIKSt17basic_string_viewIcSt11char_traitsIcEEE
+libmiral.so.7:_ZN5miral11live_config5StoreC2Ev
+libmiral.so.7:_ZN5miral11live_config5StoreD2Ev
 libmiral.so.7:_ZN5miral11live_config7IniFile9load_fileERSiRKNSt10filesystem7__cxx114pathE
 libmiral.so.7:_ZN5miral11live_config7IniFileC1Ev
 libmiral.so.7:_ZN5miral11live_config7IniFileD1Ev
@@ -235,6 +237,7 @@ libmiral.so.7:_ZNK5miral6Window4sizeEv
 libmiral.so.7:_ZNK5miral6Window8top_leftEv
 libmiral.so.7:_ZNK5miral6WindowcvbEv
 libmiral.so.7:_ZNK5miral9MirRunner11config_fileB5cxx11Ev
+libmiral.so.7:_ZTIN5miral11live_config5StoreE
 libmiral.so.7:_ZTIN5miral20MinimalWindowManagerE
 libmircore.so.2:_ZN3mir11fatal_errorE
 libmircore.so.2:_ZN3mir2FdC1Ei

--- a/packages/m/miriway/package.yml
+++ b/packages/m/miriway/package.yml
@@ -1,8 +1,8 @@
 name       : miriway
-version    : '25.11'
-release    : 4
+version    : '25.12'
+release    : 5
 source     :
-    - https://github.com/Miriway/Miriway/archive/refs/tags/v25.11.tar.gz : ea7b0669f0ae370d23d6843f6707227e4adfdd33bcf8ce65c4d682cb503e6bb2
+    - https://github.com/Miriway/Miriway/archive/refs/tags/v25.12.tar.gz : a4077e23a10744d32a533da5ca508c8f499f69e9b86166a862e205e0348136db
 homepage   : https://github.com/Miriway/Miriway
 license    : GPL-3.0-only
 component  :

--- a/packages/m/miriway/pspec_x86_64.xml
+++ b/packages/m/miriway/pspec_x86_64.xml
@@ -43,7 +43,7 @@ Miriway has been tested with shell components from several desktop environments 
 </Description>
         <PartOf>desktop</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="4">miriway</Dependency>
+            <Dependency releaseFrom="5">miriway</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/sddm/sddm.conf.d/miriway.conf</Path>
@@ -58,7 +58,7 @@ Miriway has been tested with shell components from several desktop environments 
 </Description>
         <PartOf>desktop</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="4">miriway</Dependency>
+            <Dependency releaseFrom="5">miriway</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/miriway-session</Path>
@@ -69,9 +69,9 @@ Miriway has been tested with shell components from several desktop environments 
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2025-09-26</Date>
-            <Version>25.11</Version>
+        <Update release="5">
+            <Date>2025-11-03</Date>
+            <Version>25.12</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/Miriway/Miriway/releases/tag/v25.12).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a Budgie Miriway session.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
