### PR TITLE
Update python cffi https

### DIFF
--- a/packages/py/python-cffi/package.yml
+++ b/packages/py/python-cffi/package.yml
@@ -1,6 +1,6 @@
 name       : python-cffi
 version    : 1.17.1
-release    : 21
+release    : 20
 source     :
     - https://pypi.io/packages/source/c/cffi/cffi-1.17.1.tar.gz : 1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824
 homepage   : https://cffi.readthedocs.io

--- a/packages/py/python-cffi/pspec_x86_64.xml
+++ b/packages/py/python-cffi/pspec_x86_64.xml
@@ -88,7 +88,7 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
+        <Update release="20">
             <Date>2025-11-05</Date>
             <Version>1.17.1</Version>
             <Comment>Packaging update</Comment>


### PR DESCRIPTION
 python-cffi: Update Homepage

**Summary**
    Changed homepage in  package.yaml to https and the direct link. The old link redirects to the .io page.

**Test Plan**

installed updated package successfully. 

