### PR TITLE
runc: Update to v1.2.8

### DIFF
--- a/packages/r/runc/package.yml
+++ b/packages/r/runc/package.yml
@@ -1,8 +1,8 @@
 name       : runc
-version    : 1.2.6
-release    : 37
+version    : 1.2.8
+release    : 38
 source     :
-    - https://github.com/opencontainers/runc/archive/refs/tags/v1.2.6.tar.gz : 19b280702341f33ff353fa254d1dbdb67f6aab2c74395f6d651a17524f68e752
+    - https://github.com/opencontainers/runc/archive/refs/tags/v1.2.8.tar.gz : a7c82d9c5b39f26a596335b26cf8f3a6c96dffa3ed305eca10a0dbfa111c854c
 homepage   : https://opencontainers.org/
 license    : Apache-2.0
 component  : virt

--- a/packages/r/runc/pspec_x86_64.xml
+++ b/packages/r/runc/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>runc</Name>
         <Homepage>https://opencontainers.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>virt</PartOf>
@@ -22,32 +22,32 @@
         <Files>
             <Path fileType="executable">/usr/bin/runc</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/runc</Path>
-            <Path fileType="man">/usr/share/man/man8/runc-checkpoint.8</Path>
-            <Path fileType="man">/usr/share/man/man8/runc-create.8</Path>
-            <Path fileType="man">/usr/share/man/man8/runc-delete.8</Path>
-            <Path fileType="man">/usr/share/man/man8/runc-events.8</Path>
-            <Path fileType="man">/usr/share/man/man8/runc-exec.8</Path>
-            <Path fileType="man">/usr/share/man/man8/runc-kill.8</Path>
-            <Path fileType="man">/usr/share/man/man8/runc-list.8</Path>
-            <Path fileType="man">/usr/share/man/man8/runc-pause.8</Path>
-            <Path fileType="man">/usr/share/man/man8/runc-ps.8</Path>
-            <Path fileType="man">/usr/share/man/man8/runc-restore.8</Path>
-            <Path fileType="man">/usr/share/man/man8/runc-resume.8</Path>
-            <Path fileType="man">/usr/share/man/man8/runc-run.8</Path>
-            <Path fileType="man">/usr/share/man/man8/runc-spec.8</Path>
-            <Path fileType="man">/usr/share/man/man8/runc-start.8</Path>
-            <Path fileType="man">/usr/share/man/man8/runc-state.8</Path>
-            <Path fileType="man">/usr/share/man/man8/runc-update.8</Path>
-            <Path fileType="man">/usr/share/man/man8/runc.8</Path>
+            <Path fileType="man">/usr/share/man/man8/runc-checkpoint.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/runc-create.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/runc-delete.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/runc-events.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/runc-exec.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/runc-kill.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/runc-list.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/runc-pause.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/runc-ps.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/runc-restore.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/runc-resume.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/runc-run.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/runc-spec.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/runc-start.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/runc-state.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/runc-update.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/runc.8.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="37">
-            <Date>2025-03-18</Date>
-            <Version>1.2.6</Version>
+        <Update release="38">
+            <Date>2025-11-05</Date>
+            <Version>1.2.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/opencontainers/runc/releases/tag/v1.2.8).

**Security**
Includes fixes for:
- CVE-2025-31133
- CVE-2025-52565
- CVE-2025-52881

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

I don't actually know how to test this.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
