### PR TITLE
python-django: Update to v5.2.8

### DIFF
--- a/packages/py/python-django/package.yml
+++ b/packages/py/python-django/package.yml
@@ -1,8 +1,8 @@
 name       : python-django
-version    : 5.2.7
-release    : 28
+version    : 5.2.8
+release    : 29
 source     :
-    - https://files.pythonhosted.org/packages/source/d/django/django-5.2.7.tar.gz : e0f6f12e2551b1716a95a63a1366ca91bbcd7be059862c1b18f989b1da356cdd
+    - https://files.pythonhosted.org/packages/source/d/django/django-5.2.8.tar.gz : 23254866a5bb9a2cfa6004e8b809ec6246eba4b58a7589bc2772f1bcc8456c7f
 homepage   : https://www.djangoproject.com
 license    : BSD-3-Clause
 component  : programming.python

--- a/packages/py/python-django/pspec_x86_64.xml
+++ b/packages/py/python-django/pspec_x86_64.xml
@@ -21,14 +21,13 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/django-admin</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/django-5.2.7.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/django-5.2.7.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/django-5.2.7.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/django-5.2.7.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/django-5.2.7.dist-info/licenses/AUTHORS</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/django-5.2.7.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/django-5.2.7.dist-info/licenses/LICENSE.python</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/django-5.2.7.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/django-5.2.8.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/django-5.2.8.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/django-5.2.8.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/django-5.2.8.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/django-5.2.8.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/django-5.2.8.dist-info/licenses/LICENSE.python</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/django-5.2.8.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/django/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/django/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/django/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -5458,9 +5457,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2025-10-01</Date>
-            <Version>5.2.7</Version>
+        <Update release="29">
+            <Date>2025-11-05</Date>
+            <Version>5.2.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://docs.djangoproject.com/en/5.2/releases/5.2.8/).

**Security**
Includes fixes for:
- CVE-2025-64458
- CVE-2025-64459

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Hoping for verification from @sheepman.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
