### PR TITLE
curl: Update to v8.17.0

### DIFF
--- a/packages/c/curl/abi_symbols
+++ b/packages/c/curl/abi_symbols
@@ -56,6 +56,8 @@ libcurl-gnutls.so.4:curl_multi_get_handles
 libcurl-gnutls.so.4:curl_multi_get_offt
 libcurl-gnutls.so.4:curl_multi_info_read
 libcurl-gnutls.so.4:curl_multi_init
+libcurl-gnutls.so.4:curl_multi_notify_disable
+libcurl-gnutls.so.4:curl_multi_notify_enable
 libcurl-gnutls.so.4:curl_multi_perform
 libcurl-gnutls.so.4:curl_multi_poll
 libcurl-gnutls.so.4:curl_multi_remove_handle
@@ -154,6 +156,8 @@ libcurl.so.4:curl_multi_get_handles
 libcurl.so.4:curl_multi_get_offt
 libcurl.so.4:curl_multi_info_read
 libcurl.so.4:curl_multi_init
+libcurl.so.4:curl_multi_notify_disable
+libcurl.so.4:curl_multi_notify_enable
 libcurl.so.4:curl_multi_perform
 libcurl.so.4:curl_multi_poll
 libcurl.so.4:curl_multi_remove_handle

--- a/packages/c/curl/abi_symbols32
+++ b/packages/c/curl/abi_symbols32
@@ -56,6 +56,8 @@ libcurl-gnutls.so.4:curl_multi_get_handles
 libcurl-gnutls.so.4:curl_multi_get_offt
 libcurl-gnutls.so.4:curl_multi_info_read
 libcurl-gnutls.so.4:curl_multi_init
+libcurl-gnutls.so.4:curl_multi_notify_disable
+libcurl-gnutls.so.4:curl_multi_notify_enable
 libcurl-gnutls.so.4:curl_multi_perform
 libcurl-gnutls.so.4:curl_multi_poll
 libcurl-gnutls.so.4:curl_multi_remove_handle
@@ -154,6 +156,8 @@ libcurl.so.4:curl_multi_get_handles
 libcurl.so.4:curl_multi_get_offt
 libcurl.so.4:curl_multi_info_read
 libcurl.so.4:curl_multi_init
+libcurl.so.4:curl_multi_notify_disable
+libcurl.so.4:curl_multi_notify_enable
 libcurl.so.4:curl_multi_perform
 libcurl.so.4:curl_multi_poll
 libcurl.so.4:curl_multi_remove_handle

--- a/packages/c/curl/abi_used_symbols
+++ b/packages/c/curl/abi_used_symbols
@@ -8,9 +8,6 @@ libc.so.6:__fdelt_chk
 libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
-libc.so.6:__pthread_register_cancel
-libc.so.6:__pthread_unregister_cancel
-libc.so.6:__sigsetjmp
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__strcpy_chk
@@ -79,10 +76,8 @@ libc.so.6:memset
 libc.so.6:mkdir
 libc.so.6:open
 libc.so.6:opendir
-libc.so.6:perror
 libc.so.6:pipe
 libc.so.6:poll
-libc.so.6:pthread_cancel
 libc.so.6:pthread_create
 libc.so.6:pthread_detach
 libc.so.6:pthread_join
@@ -90,7 +85,6 @@ libc.so.6:pthread_mutex_destroy
 libc.so.6:pthread_mutex_init
 libc.so.6:pthread_mutex_lock
 libc.so.6:pthread_mutex_unlock
-libc.so.6:pthread_setcancelstate
 libc.so.6:puts
 libc.so.6:qsort
 libc.so.6:read
@@ -122,7 +116,6 @@ libc.so.6:strcmp
 libc.so.6:strcpy
 libc.so.6:strcspn
 libc.so.6:strdup
-libc.so.6:strerror
 libc.so.6:strerror_r
 libc.so.6:strftime
 libc.so.6:strlen
@@ -257,7 +250,6 @@ libcrypto.so.3:PEM_read_bio_PrivateKey
 libcrypto.so.3:PEM_read_bio_X509
 libcrypto.so.3:PEM_read_bio_X509_AUX
 libcrypto.so.3:PEM_write_bio_X509
-libcrypto.so.3:PKCS12_PBE_add
 libcrypto.so.3:PKCS12_free
 libcrypto.so.3:PKCS12_parse
 libcrypto.so.3:RAND_bytes
@@ -638,6 +630,7 @@ libssl.so.3:SSL_set_connect_state
 libssl.so.3:SSL_set_ex_data
 libssl.so.3:SSL_set_incoming_stream_policy
 libssl.so.3:SSL_set_session
+libssl.so.3:SSL_set_value_uint
 libssl.so.3:SSL_shutdown
 libssl.so.3:SSL_shutdown_ex
 libssl.so.3:SSL_stream_conclude

--- a/packages/c/curl/abi_used_symbols32
+++ b/packages/c/curl/abi_used_symbols32
@@ -7,9 +7,6 @@ libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__isoc23_strtol
 libc.so.6:__memcpy_chk
-libc.so.6:__pthread_register_cancel
-libc.so.6:__pthread_unregister_cancel
-libc.so.6:__sigsetjmp
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__strcpy_chk
@@ -67,9 +64,7 @@ libc.so.6:memrchr
 libc.so.6:memset
 libc.so.6:open64
 libc.so.6:opendir
-libc.so.6:perror
 libc.so.6:poll
-libc.so.6:pthread_cancel
 libc.so.6:pthread_create
 libc.so.6:pthread_detach
 libc.so.6:pthread_join
@@ -77,7 +72,6 @@ libc.so.6:pthread_mutex_destroy
 libc.so.6:pthread_mutex_init
 libc.so.6:pthread_mutex_lock
 libc.so.6:pthread_mutex_unlock
-libc.so.6:pthread_setcancelstate
 libc.so.6:qsort
 libc.so.6:read
 libc.so.6:readdir64
@@ -230,7 +224,6 @@ libcrypto.so.3:PEM_read_bio_PrivateKey
 libcrypto.so.3:PEM_read_bio_X509
 libcrypto.so.3:PEM_read_bio_X509_AUX
 libcrypto.so.3:PEM_write_bio_X509
-libcrypto.so.3:PKCS12_PBE_add
 libcrypto.so.3:PKCS12_free
 libcrypto.so.3:PKCS12_parse
 libcrypto.so.3:RAND_bytes

--- a/packages/c/curl/files/524f7e733237cd26553dfd.patch
+++ b/packages/c/curl/files/524f7e733237cd26553dfd.patch
@@ -1,0 +1,81 @@
+From 524f7e733237cd26553dfd76adda521d3150d852 Mon Sep 17 00:00:00 2001
+From: Samuel Henrique <samueloph@debian.org>
+Date: Sun, 12 Oct 2025 14:39:46 +0100
+Subject: [PATCH] Don't percent-decode '/' and '\' in output file name
+
+Co-Authored-by: Sergio Durigan Junior <sergiodj@sergiodj.net>
+---
+ tests/tests.sh |  7 +++++++
+ wcurl          | 26 ++++++++++++++++++++++++--
+ 2 files changed, 31 insertions(+), 2 deletions(-)
+
+diff --git a/tests/tests.sh b/tests/tests.sh
+index 30ac37b..b4636c0 100755
+--- a/tests/tests.sh
++++ b/tests/tests.sh
+@@ -200,6 +200,13 @@ testUrlDecodingWhitespaceTrailingSlash()
+     assertContains "Verify whether 'wcurl' successfully uses the default filename when the URL ends with a slash" "${ret}" 'index.html'
+ }
+ 
++testUrlDecodingBackslashes()
++{
++    url='example.com/filename%5Cwith%2Fbackslashes%5c%2f'
++    ret=$(${WCURL_CMD} ${url} 2>&1)
++    assertContains "Verify whether 'wcurl' successfully uses the default filename when the URL ends with a slash" "${ret}" 'filename%5Cwith%2Fbackslashes%5c%2f'
++}
++
+ # Test decoding a bunch of different languages (that don't use the latin
+ # alphabet), we could split each language on its own test, but for now it
+ # doesn't make a difference.
+diff --git a/wcurl b/wcurl
+index 66ce954..b1a06ef 100755
+--- a/wcurl
++++ b/wcurl
+@@ -113,6 +113,13 @@ readonly PER_URL_PARAMETERS="\
+     --remote-time \
+     --retry 5 "
+ 
++# Valid percent-encode codes that are considered unsafe to be decoded.
++# This is a list of space-separated percent-encoded uppercase
++# characters.
++# 2F = /
++# 5C = \
++readonly UNSAFE_PERCENT_ENCODE="2F 5C"
++
+ # Whether to invoke curl or not.
+ DRY_RUN="false"
+ 
+@@ -137,6 +144,20 @@ is_subset_of()
+     esac
+ }
+ 
++# Indicate via exit code whether the HTML code given in the first
++# parameter is safe to be decoded.
++is_safe_percent_encode()
++{
++    upper_str=$(printf "%s" "${1}" | tr "[:lower:]" "[:upper:]")
++    for unsafe in ${UNSAFE_PERCENT_ENCODE}; do
++        if [ "${unsafe}" = "${upper_str}" ]; then
++            return 1
++        fi
++    done
++
++    return 0
++}
++
+ # Print the given string percent-decoded.
+ percent_decode()
+ {
+@@ -151,9 +172,10 @@ percent_decode()
+                 decode_out="${decode_out}${decode_hex2}"
+                 # Skip decoding if this is a control character (00-1F).
+                 # Skip decoding if DECODE_FILENAME is not "true".
+-                if is_subset_of "${decode_hex1}" "23456789abcdefABCDEF" \
++                if [ "${DECODE_FILENAME}" = "true" ] \
++                    && is_subset_of "${decode_hex1}" "23456789abcdefABCDEF" \
+                     && is_subset_of "${decode_hex2}" "0123456789abcdefABCDEF" \
+-                    && [ "${DECODE_FILENAME}" = "true" ]; then
++                    && is_safe_percent_encode "${decode_out}"; then
+                     # Use printf to decode it into octal and then decode it to the final format.
+                     decode_out="$(printf "%b" "\\$(printf %o "0x${decode_hex1}${decode_hex2}")")"
+                 fi

--- a/packages/c/curl/package.yml
+++ b/packages/c/curl/package.yml
@@ -1,8 +1,8 @@
 name       : curl
-version    : 8.16.0
-release    : 110
+version    : 8.17.0
+release    : 111
 source     :
-    - https://github.com/curl/curl/releases/download/curl-8_16_0/curl-8.16.0.tar.bz2 : 9459180ab4933b30d0778ddd71c91fe2911fab731c46e59b3f4c8385b1596c91
+    - https://github.com/curl/curl/releases/download/curl-8_17_0/curl-8.17.0.tar.bz2 : 230032528ce5f85594d4f3eace63364c4244ccc3c801b7f8db1982722f2761f4
 extract    : false
 homepage   : https://curl.se
 license    : MIT

--- a/packages/c/curl/pspec_x86_64.xml
+++ b/packages/c/curl/pspec_x86_64.xml
@@ -36,7 +36,7 @@
         <Description xml:lang="en">curl is a client to get files from servers using any of the supported protocols. The command is designed to work without user interaction or any kind of interactivity. curl offers a busload of useful tricks like proxy support, user authentication, ftp upload, HTTP post, file transfer resume and more.</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="110">curl</Dependency>
+            <Dependency release="111">curl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libcurl.so.4</Path>
@@ -49,8 +49,8 @@
         <Description xml:lang="en">curl is a client to get files from servers using any of the supported protocols. The command is designed to work without user interaction or any kind of interactivity. curl offers a busload of useful tricks like proxy support, user authentication, ftp upload, HTTP post, file transfer resume and more.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="110">curl-32bit</Dependency>
-            <Dependency release="110">curl-devel</Dependency>
+            <Dependency release="111">curl-32bit</Dependency>
+            <Dependency release="111">curl-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libcurl.so</Path>
@@ -63,7 +63,7 @@
         <Description xml:lang="en">curl is a client to get files from servers using any of the supported protocols. The command is designed to work without user interaction or any kind of interactivity. curl offers a busload of useful tricks like proxy support, user authentication, ftp upload, HTTP post, file transfer resume and more.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="110">curl</Dependency>
+            <Dependency release="111">curl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/curl/curl.h</Path>
@@ -171,6 +171,8 @@
             <Path fileType="man">/usr/share/man/man3/CURLMOPT_MAX_PIPELINE_LENGTH.3.zst</Path>
             <Path fileType="man">/usr/share/man/man3/CURLMOPT_MAX_TOTAL_CONNECTIONS.3.zst</Path>
             <Path fileType="man">/usr/share/man/man3/CURLMOPT_NETWORK_CHANGED.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/CURLMOPT_NOTIFYDATA.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/CURLMOPT_NOTIFYFUNCTION.3.zst</Path>
             <Path fileType="man">/usr/share/man/man3/CURLMOPT_PIPELINING.3.zst</Path>
             <Path fileType="man">/usr/share/man/man3/CURLMOPT_PIPELINING_SERVER_BL.3.zst</Path>
             <Path fileType="man">/usr/share/man/man3/CURLMOPT_PIPELINING_SITE_BL.3.zst</Path>
@@ -548,6 +550,8 @@
             <Path fileType="man">/usr/share/man/man3/curl_multi_get_offt.3.zst</Path>
             <Path fileType="man">/usr/share/man/man3/curl_multi_info_read.3.zst</Path>
             <Path fileType="man">/usr/share/man/man3/curl_multi_init.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/curl_multi_notify_disable.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/curl_multi_notify_enable.3.zst</Path>
             <Path fileType="man">/usr/share/man/man3/curl_multi_perform.3.zst</Path>
             <Path fileType="man">/usr/share/man/man3/curl_multi_poll.3.zst</Path>
             <Path fileType="man">/usr/share/man/man3/curl_multi_remove_handle.3.zst</Path>
@@ -619,9 +623,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="110">
-            <Date>2025-09-10</Date>
-            <Version>8.16.0</Version>
+        <Update release="111">
+            <Date>2025-11-05</Date>
+            <Version>8.17.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://daniel.haxx.se/blog/2025/11/05/curl-8-17-0/).

**Security**
Includes fixes for:
- CVE-2025-10966

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Use `curl` to download a file.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
