### PR TITLE
gdm: Install gdm.sysuser back

### DIFF
--- a/packages/g/gdm/package.yml
+++ b/packages/g/gdm/package.yml
@@ -1,6 +1,6 @@
 name       : gdm
 version    : '49.1'
-release    : 82
+release    : 83
 source     :
     - https://download.gnome.org/sources/gdm/49/gdm-49.1.tar.xz : 69da5d1319dc2c68adf5cd394ad59bec99bb2e24f284045a1bb4acd7740044e5
 homepage   : https://projects.gnome.org/gdm/
@@ -50,7 +50,7 @@ install    : |
 
     # Ensure we have sysusers + tmpfiles
     install -D -m 00644 $pkgfiles/gdm.tmpfiles $installdir/%libdir%/tmpfiles.d/gdm.conf
-
+    install -D -m 00644 $pkgfiles/gdm.sysusers $installdir/%libdir%/sysusers.d/gdm.conf
     install -Dm00644 $pkgfiles/gdm.group $installdir/%libdir%/userdb/gdm.group
     ln -s gdm.group $installdir/%libdir%/userdb/21.group
     install -Dm00644 $pkgfiles/gdm.user $installdir/%libdir%/userdb/gdm.user

--- a/packages/g/gdm/pspec_x86_64.xml
+++ b/packages/g/gdm/pspec_x86_64.xml
@@ -41,6 +41,7 @@
             <Path fileType="library">/usr/lib64/libgdm.so.1</Path>
             <Path fileType="library">/usr/lib64/libgdm.so.1.0.0</Path>
             <Path fileType="library">/usr/lib64/security/pam_gdm.so</Path>
+            <Path fileType="library">/usr/lib64/sysusers.d/gdm.conf</Path>
             <Path fileType="library">/usr/lib64/tmpfiles.d/gdm.conf</Path>
             <Path fileType="library">/usr/lib64/userdb/21.group</Path>
             <Path fileType="library">/usr/lib64/userdb/21.user</Path>
@@ -245,7 +246,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="82">gdm</Dependency>
+            <Dependency release="83">gdm</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gdm/gdm-choice-list-pam-extension.h</Path>
@@ -263,8 +264,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="82">
-            <Date>2025-11-03</Date>
+        <Update release="83">
+            <Date>2025-11-06</Date>
             <Version>49.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>


### PR DESCRIPTION
**Summary**

<!-- Info on what this pull request updates/changes/etc -->
Install gdm.sysuser back. This fixes ISO generation on GNOME Edition.

**Test Plan**

<!-- Short description of how the package was tested -->
Spin a smoketest GNOME ISO

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
