### PR TITLE
macchanger: Fix homepage link

### DIFF
--- a/packages/m/macchanger/abi_used_symbols
+++ b/packages/m/macchanger/abi_used_symbols
@@ -1,4 +1,5 @@
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtoul
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__sprintf_chk
@@ -31,4 +32,3 @@ libc.so.6:strdup
 libc.so.6:strlen
 libc.so.6:strncpy
 libc.so.6:strstr
-libc.so.6:strtoul

--- a/packages/m/macchanger/package.yml
+++ b/packages/m/macchanger/package.yml
@@ -1,9 +1,9 @@
 name       : macchanger
 version    : 1.7.0
-release    : 3
+release    : 4
 source     :
     - https://github.com/alobbs/macchanger/releases/download/1.7.0/macchanger-1.7.0.tar.gz : dae2717c270fd5f62d790dbf80c19793c651b1b26b62c101b82d5fdf25a845bf
-homepage   : http://www.gnu.org/software/macchanger
+homepage   : https://github.com/alobbs/macchanger
 license    : GPL-3.0-or-later
 component  : network.util
 summary    : GNU MAC Changer is an utility that makes the maniputation of MAC addresses of network interfaces easier

--- a/packages/m/macchanger/pspec_x86_64.xml
+++ b/packages/m/macchanger/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>macchanger</Name>
-        <Homepage>http://www.gnu.org/software/macchanger</Homepage>
+        <Homepage>https://github.com/alobbs/macchanger</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.util</PartOf>
@@ -21,19 +21,19 @@
         <PartOf>network.util</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/macchanger</Path>
-            <Path fileType="info">/usr/share/info/macchanger.info</Path>
+            <Path fileType="info">/usr/share/info/macchanger.info.zst</Path>
             <Path fileType="data">/usr/share/macchanger/OUI.list</Path>
             <Path fileType="data">/usr/share/macchanger/wireless.list</Path>
-            <Path fileType="man">/usr/share/man/man1/macchanger.1</Path>
+            <Path fileType="man">/usr/share/man/man1/macchanger.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-05-10</Date>
+        <Update release="4">
+            <Date>2025-11-07</Date>
             <Version>1.7.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Part of https://github.com/getsolus/packages/issues/5522
Dead link. Linked to github repo. 

**Test Plan**

Installed macchanger

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
