### PR TITLE
openjazz: Update to v20240919

### DIFF
--- a/packages/o/openjazz/abi_used_symbols
+++ b/packages/o/openjazz/abi_used_symbols
@@ -1,4 +1,6 @@
-libSDL2-2.0.so.0:SDL_CloseAudio
+libSDL2-2.0.so.0:SDL_BuildAudioCVT
+libSDL2-2.0.so.0:SDL_CloseAudioDevice
+libSDL2-2.0.so.0:SDL_ConvertAudio
 libSDL2-2.0.so.0:SDL_CreateRGBSurface
 libSDL2-2.0.so.0:SDL_CreateRGBSurfaceFrom
 libSDL2-2.0.so.0:SDL_CreateRGBSurfaceWithFormat
@@ -19,12 +21,13 @@ libSDL2-2.0.so.0:SDL_GetTicks
 libSDL2-2.0.so.0:SDL_GetWindowDisplayIndex
 libSDL2-2.0.so.0:SDL_Init
 libSDL2-2.0.so.0:SDL_JoystickOpen
+libSDL2-2.0.so.0:SDL_LockAudioDevice
 libSDL2-2.0.so.0:SDL_LockSurface
 libSDL2-2.0.so.0:SDL_MapRGB
-libSDL2-2.0.so.0:SDL_MixAudio
+libSDL2-2.0.so.0:SDL_MixAudioFormat
 libSDL2-2.0.so.0:SDL_NumJoysticks
-libSDL2-2.0.so.0:SDL_OpenAudio
-libSDL2-2.0.so.0:SDL_PauseAudio
+libSDL2-2.0.so.0:SDL_OpenAudioDevice
+libSDL2-2.0.so.0:SDL_PauseAudioDevice
 libSDL2-2.0.so.0:SDL_PollEvent
 libSDL2-2.0.so.0:SDL_Quit
 libSDL2-2.0.so.0:SDL_RenderClear
@@ -37,6 +40,7 @@ libSDL2-2.0.so.0:SDL_SetWindowFullscreen
 libSDL2-2.0.so.0:SDL_SetWindowSize
 libSDL2-2.0.so.0:SDL_SetWindowTitle
 libSDL2-2.0.so.0:SDL_ShowCursor
+libSDL2-2.0.so.0:SDL_UnlockAudioDevice
 libSDL2-2.0.so.0:SDL_UnlockSurface
 libSDL2-2.0.so.0:SDL_UpdateTexture
 libSDL2-2.0.so.0:SDL_UpperBlit
@@ -93,7 +97,6 @@ libc.so.6:send
 libc.so.6:socket
 libc.so.6:stderr
 libc.so.6:stdout
-libc.so.6:stpcpy
 libc.so.6:strcat
 libc.so.6:strcmp
 libc.so.6:strcpy
@@ -115,7 +118,8 @@ libstdc++.so.6:_ZTVN10__cxxabiv117__class_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv120__si_class_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv121__vmi_class_type_infoE
 libstdc++.so.6:_ZdaPv
-libstdc++.so.6:_ZdlPv
+libstdc++.so.6:_ZdaPvm
+libstdc++.so.6:_ZdlPvm
 libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
 libstdc++.so.6:__cxa_allocate_exception

--- a/packages/o/openjazz/package.yml
+++ b/packages/o/openjazz/package.yml
@@ -1,10 +1,10 @@
 name       : openjazz
-version    : '20231028'
-release    : 7
+version    : '20240919'
+release    : 8
 source     :
-    - https://github.com/AlisterT/openjazz/archive/20231028.tar.gz : c45ff414dc846563ad7ae4b6c848f938ab695eb4ae6f958856b3fa409da0b8ac
+    - https://github.com/AlisterT/openjazz/archive/20240919.tar.gz : c50193b630c375840026d729bb9dda6c7210b1523e62d7ae019ce2e37f806627
     - https://image.dosgamesarchive.com/games/jazz.zip : ed025415c0bc5ebc3a41e7a070551bdfdfb0b65b5314241152d8bd31f87c22da
-homepage   : http://alister.eu/jazz/oj/
+homepage   : https://alister.eu/jazz/oj/
 license    : GPL-2.0-or-later
 component  : games.platformer
 summary    : Jazz Jackrabbit reborn on Linux

--- a/packages/o/openjazz/pspec_x86_64.xml
+++ b/packages/o/openjazz/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>openjazz</Name>
-        <Homepage>http://alister.eu/jazz/oj/</Homepage>
+        <Homepage>https://alister.eu/jazz/oj/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>games.platformer</PartOf>
@@ -96,12 +96,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2024-02-17</Date>
-            <Version>20231028</Version>
+        <Update release="8">
+            <Date>2025-11-07</Date>
+            <Version>20240919</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://alister.eu/jazz/oj/). 
- Fix homepage link. Part of https://github.com/getsolus/packages/issues/5522

**Test Plan**

Installed openjazz

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
