### PR TITLE
gnome-desktop-branding: Update to v20

### DIFF
--- a/packages/g/gnome-desktop-branding/package.yml
+++ b/packages/g/gnome-desktop-branding/package.yml
@@ -1,8 +1,8 @@
 name       : gnome-desktop-branding
-version    : '19'
-release    : 59
+version    : '20'
+release    : 60
 source     :
-    - git|https://github.com/getsolus/gnome-desktop-branding.git : 1e6a8b805ef2db4af456d15d9de19329071ea783
+    - git|https://github.com/getsolus/gnome-desktop-branding.git: c1f572d1f57e64911955a35c4d21a605cb12913a
 homepage   : https://github.com/getsolus/gnome-desktop-branding
 license    : GPL-2.0-only
 component  :
@@ -10,10 +10,10 @@ component  :
     - livecd : desktop.gnome
 summary    :
     - Defaults for the GNOME Desktop
-    - livecd : Solus 4.0 GNOME LiveCD configuration
+    - livecd : Solus GNOME LiveCD configuration
 description:
     - Defaults for the GNOME Desktop
-    - livecd : Solus 4.0 LiveCD configuration.
+    - livecd : Solus GNOME LiveCD configuration.
 patterns   :
     - livecd :
         - /usr/share/glib-2.0/schemas/*livecd.gschema.override
@@ -28,7 +28,6 @@ rundeps    :
     - font-hack-ttf
     - font-noto-emoji
     - gnome-browser-connector
-    - gnome-shell
     - gnome-shell-extension-appindicator
     - gnome-shell-extension-apps-menu # default ext.
     - gnome-shell-extension-auto-move-windows # default ext.
@@ -40,7 +39,7 @@ rundeps    :
     - gnome-shell-extensions
     - noto-sans-ttf
     - noto-serif-ttf
-    - papirus-icon-theme
+    - morewaita-icon-theme
     - qt5-wayland # qt5 applications need this to be able to launch in native wayland mode
     - qadwaitadecorations
     - solus-artwork

--- a/packages/g/gnome-desktop-branding/pspec_x86_64.xml
+++ b/packages/g/gnome-desktop-branding/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-desktop-branding</Name>
         <Homepage>https://github.com/getsolus/gnome-desktop-branding</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>desktop.gnome</PartOf>
@@ -32,23 +32,23 @@
     </Package>
     <Package>
         <Name>gnome-desktop-branding-livecd</Name>
-        <Summary xml:lang="en">Solus 4.0 GNOME LiveCD configuration</Summary>
-        <Description xml:lang="en">Solus 4.0 LiveCD configuration.</Description>
+        <Summary xml:lang="en">Solus GNOME LiveCD configuration</Summary>
+        <Description xml:lang="en">Solus GNOME LiveCD configuration.</Description>
         <PartOf>desktop.gnome</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="59">gnome-desktop-branding</Dependency>
+            <Dependency releaseFrom="60">gnome-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/glib-2.0/schemas/50_gnome_livecd.gschema.override</Path>
         </Files>
     </Package>
     <History>
-        <Update release="59">
-            <Date>2025-10-30</Date>
-            <Version>19</Version>
+        <Update release="60">
+            <Date>2025-11-14</Date>
+            <Version>20</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Depends on  https://github.com/getsolus/iso-tooling/pull/89 
Depends on https://github.com/getsolus/gnome-desktop-branding/pull/28

**Test Plan**

<!-- Short description of how the package was tested -->
Spin GNOME ISO

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
