### PR TITLE
darkly: Update to v0.5.24

### DIFF
--- a/packages/d/darkly/abi_used_symbols
+++ b/packages/d/darkly/abi_used_symbols
@@ -327,7 +327,6 @@ libQt5Gui.so.5:_ZN14QSurfaceFormatD1Ev
 libQt5Gui.so.5:_ZN15QGuiApplication14paletteChangedERK8QPalette
 libQt5Gui.so.5:_ZN15QGuiApplication15layoutDirectionEv
 libQt5Gui.so.5:_ZN15QGuiApplication16staticMetaObjectE
-libQt5Gui.so.5:_ZN15QGuiApplication17setOverrideCursorERK7QCursor
 libQt5Gui.so.5:_ZN15QGuiApplication21restoreOverrideCursorEv
 libQt5Gui.so.5:_ZN15QGuiApplication7paletteEv
 libQt5Gui.so.5:_ZN15QLinearGradientC1ERK7QPointFS2_
@@ -387,6 +386,7 @@ libQt5Gui.so.5:_ZN7QRegionD1Ev
 libQt5Gui.so.5:_ZN7QRegionmIERKS_
 libQt5Gui.so.5:_ZN7QRegionpLERK5QRect
 libQt5Gui.so.5:_ZN7QRegionpLERKS_
+libQt5Gui.so.5:_ZN7QWindow15startSystemMoveEv
 libQt5Gui.so.5:_ZN7QWindow9setFormatERK14QSurfaceFormat
 libQt5Gui.so.5:_ZN8QPainter10drawPixmapERK6QRectFRK7QPixmapS2_
 libQt5Gui.so.5:_ZN8QPainter10drawPixmapERK7QPointFRK7QPixmap
@@ -483,8 +483,11 @@ libQt5Gui.so.5:_ZNK8QPainter4fontEv
 libQt5Gui.so.5:_ZNK8QPainter6deviceEv
 libQt5Gui.so.5:_ZNK8QPalette5brushENS_10ColorGroupENS_9ColorRoleE
 libQt5Gui.so.5:_ZNK8QPaletteeqERKS_
+libQt5Quick.so.5:_ZN10QQuickItem11ungrabMouseEv
 libQt5Quick.so.5:_ZN10QQuickItem16staticMetaObjectE
 libQt5Quick.so.5:_ZN10QQuickItem23setAcceptedMouseButtonsE6QFlagsIN2Qt11MouseButtonEE
+libQt5Quick.so.5:_ZN12QQuickWindow16staticMetaObjectE
+libQt5Quick.so.5:_ZN19QQuickRenderControl15renderWindowForEP12QQuickWindowP6QPoint
 libQt5Quick.so.5:_ZNK10QQuickItem6windowEv
 libQt5Quick.so.5:_ZNK12QQuickWindow11contentItemEv
 libQt5Widgets.so.5:_Z24qt_qscrollbarStyleOptionP10QScrollBar
@@ -1077,6 +1080,7 @@ libQt6Gui.so.6:_ZN7QRegionD1Ev
 libQt6Gui.so.6:_ZN7QRegionmIERKS_
 libQt6Gui.so.6:_ZN7QRegionpLERK5QRect
 libQt6Gui.so.6:_ZN7QRegionpLERKS_
+libQt6Gui.so.6:_ZN7QWindow15startSystemMoveEv
 libQt6Gui.so.6:_ZN7QWindow9setFormatERK14QSurfaceFormat
 libQt6Gui.so.6:_ZN8QPainter10drawPixmapERK6QRectFRK7QPixmapS2_
 libQt6Gui.so.6:_ZN8QPainter10drawPixmapERK7QPointFRK7QPixmap
@@ -1197,7 +1201,10 @@ libQt6Gui.so.6:_ZlsR11QDataStreamRK5QIcon
 libQt6Gui.so.6:_ZlsR11QDataStreamRK6QColor
 libQt6Gui.so.6:_ZrsR11QDataStreamR5QIcon
 libQt6Gui.so.6:_ZrsR11QDataStreamR6QColor
+libQt6Quick.so.6:_ZN10QQuickItem11ungrabMouseEv
 libQt6Quick.so.6:_ZN10QQuickItem23setAcceptedMouseButtonsE6QFlagsIN2Qt11MouseButtonEE
+libQt6Quick.so.6:_ZN12QQuickWindow16staticMetaObjectE
+libQt6Quick.so.6:_ZN19QQuickRenderControl15renderWindowForEP12QQuickWindowP6QPoint
 libQt6Quick.so.6:_ZNK10QQuickItem6windowEv
 libQt6Quick.so.6:_ZNK12QQuickWindow11contentItemEv
 libQt6Widgets.so.6:_Z24qt_qscrollbarStyleOptionP10QScrollBar

--- a/packages/d/darkly/files/io.github.bali10050.darkly.metainfo.xml
+++ b/packages/d/darkly/files/io.github.bali10050.darkly.metainfo.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>io.github.bali10050.darkly</id>
+
+  <name>Darkly</name>
+  <summary>A modern style for Qt applications</summary>
+
+  <developer id="bali10050">
+    <name>Bali10050</name>
+    <url>https://github.com/Bali10050</url>
+  </developer>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-or-later</project_license>
+
+  <extends>
+    <id>org.kde.plasmashell</id>
+  </extends>
+
+  <description>
+    <p>
+      Fork of Lightly (A modern style for Qt applications)
+    </p>
+  </description>
+
+  <url type="homepage">https://github.com/Bali10050/Darkly</url>
+  <url type="bugtracker">https://github.com/Bali10050/Darkly/issues</url>
+
+</component>

--- a/packages/d/darkly/package.yml
+++ b/packages/d/darkly/package.yml
@@ -1,8 +1,8 @@
 name       : darkly
-version    : 0.5.23
-release    : 10
+version    : 0.5.24
+release    : 11
 source     :
-    - https://github.com/Bali10050/Darkly/archive/refs/tags/v0.5.23.tar.gz : a897784e4e43fe7947afe65fd91e796f98f8eec6beec7f94a04f3c102c5d5577
+    - https://github.com/Bali10050/Darkly/archive/refs/tags/v0.5.24.tar.gz : 83f299e92978b98b6e43de14fa6402dc9c2fb3110e554506d1d00d0ba8b0b92b
 homepage   : https://github.com/Bali10050/Darkly
 license    : GPL-2.0-or-later
 component  : desktop.theme
@@ -55,3 +55,6 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+
+    # Install appstream metadata
+    install -Dm00644 $pkgfiles/io.github.bali10050.darkly.metainfo.xml -t $installdir/usr/share/metainfo

--- a/packages/d/darkly/pspec_x86_64.xml
+++ b/packages/d/darkly/pspec_x86_64.xml
@@ -32,6 +32,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/darkly-settings.svgz</Path>
             <Path fileType="data">/usr/share/kservices6/darklydecorationconfig.desktop</Path>
             <Path fileType="data">/usr/share/kstyle/themes/darkly.themerc</Path>
+            <Path fileType="data">/usr/share/metainfo/io.github.bali10050.darkly.metainfo.xml</Path>
         </Files>
     </Package>
     <Package>
@@ -41,7 +42,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">darkly</Dependency>
+            <Dependency release="11">darkly</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/cmake/Darkly/DarklyConfig.cmake</Path>
@@ -49,9 +50,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2025-10-05</Date>
-            <Version>0.5.23</Version>
+        <Update release="11">
+            <Date>2025-11-09</Date>
+            <Version>0.5.24</Version>
             <Comment>Packaging update</Comment>
             <Name>Hurican Dev</Name>
             <Email>hurican@keemail.me</Email>


### PR DESCRIPTION
```
**Summary**
   - Update to v0.5.24
   - Add Appstream Metainfo

Release notes can be found [here](https://github.com/Bali10050/Darkly/releases/tag/v0.5.24).
```
With the recent switch over to Discover/Gnome Software, there's no longer a way to install this theme through a GUI. This is my attempt at rectifying that and my first try at adding appstream metainfo so please let me know if there's anything wrong/missing or if anything can be improved. 

**Test Plan**

Installed the package and made sure it still worked.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
