### PR TITLE
broot: Update to v1.53.0

### DIFF
--- a/packages/b/broot/MAINTAINERS.md
+++ b/packages/b/broot/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Jared Cervantes
+  - Matrix: @jaredy89:matrix.org
+  - Email: jared@jaredcervantes.com

--- a/packages/b/broot/monitoring.yaml
+++ b/packages/b/broot/monitoring.yaml
@@ -1,6 +1,6 @@
 releases:
   id: 141357
-  rss: hhttps://github.com/Canop/broot/tags.atom
+  rss: https://github.com/Canop/broot/tags.atom
 # Last checked: 2024-10-24
 security:
   cpe: ~

--- a/packages/b/broot/package.yml
+++ b/packages/b/broot/package.yml
@@ -1,8 +1,8 @@
 name       : broot
-version    : 1.52.0
-release    : 27
+version    : 1.53.0
+release    : 28
 source     :
-    - https://github.com/Canop/broot/archive/refs/tags/v1.52.0.tar.gz : 2f0c9b52a97cf32f617e39084bfff8271d4a3d9b30f8ec2811b577cb433d7743
+    - https://github.com/Canop/broot/archive/refs/tags/v1.53.0.tar.gz : cd675a81222ac82a238778325a51e3f14b971df32ceedf9bb892f3a1d012e10e
 homepage   : https://dystroy.org/broot/
 license    : MIT
 component  : system.utils

--- a/packages/b/broot/pspec_x86_64.xml
+++ b/packages/b/broot/pspec_x86_64.xml
@@ -26,9 +26,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2025-11-01</Date>
-            <Version>1.52.0</Version>
+        <Update release="28">
+            <Date>2025-11-08</Date>
+            <Version>1.53.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/Canop/broot/releases/tag/v1.53.0).
- Fixed extra letter in url in monitoring.yaml

**Test Plan**

Installed and opened broot. Searched around. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
