### PR TITLE
fcitx-libpinyin: Fix homepage link

### DIFF
--- a/packages/f/fcitx-libpinyin/package.yml
+++ b/packages/f/fcitx-libpinyin/package.yml
@@ -1,10 +1,10 @@
 name       : fcitx-libpinyin
 version    : 0.5.4
-release    : 4
+release    : 5
 source     :
     - https://github.com/fcitx/fcitx-libpinyin/archive/refs/tags/0.5.4.tar.gz : af230d530da552fee46d4d8ebe6e0d7c5085dd1c04e72b3e98691f6219fa2a7c
     - https://download.fcitx-im.org/data/model.text.20161206.tar.gz : 5c7024e5735389c471f54b867eda0d98c5a40a5e5e75333a9febac107508f704
-homepage   : http://fcitx-im.org/
+homepage   : https://fcitx-im.org/wiki/Fcitx_5
 license    : GPL-2.0-or-later
 component  : desktop.core
 summary    : Chinese input method based on libpinyin for fcitx

--- a/packages/f/fcitx-libpinyin/pspec_x86_64.xml
+++ b/packages/f/fcitx-libpinyin/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>fcitx-libpinyin</Name>
-        <Homepage>http://fcitx-im.org/</Homepage>
+        <Homepage>https://fcitx-im.org/wiki/Fcitx_5</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.core</PartOf>
@@ -63,12 +63,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-04-19</Date>
+        <Update release="5">
+            <Date>2025-11-08</Date>
             <Version>0.5.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Part of https://github.com/getsolus/packages/issues/5522

**Test Plan**

Installed fcitx-libpinyin

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
