### PR TITLE
fcitx-hangul: Fix homepage link

### DIFF
--- a/packages/f/fcitx-hangul/package.yml
+++ b/packages/f/fcitx-hangul/package.yml
@@ -1,9 +1,9 @@
 name       : fcitx-hangul
 version    : 0.3.1
-release    : 3
+release    : 4
 source     :
     - https://download.fcitx-im.org/fcitx-hangul/fcitx-hangul-0.3.1.tar.xz : 6dd5fd5956924c85af92ebefaef1e113e38fa814355fbb0f07c26049c3014437
-homepage   : http://fcitx-im.org/
+homepage   : https://fcitx-im.org/wiki/Fcitx_5
 license    : GPL-2.0-or-later
 component  : desktop.core
 summary    : Hangul (Korean) support for fcitx

--- a/packages/f/fcitx-hangul/pspec_x86_64.xml
+++ b/packages/f/fcitx-hangul/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>fcitx-hangul</Name>
-        <Homepage>http://fcitx-im.org/</Homepage>
+        <Homepage>https://fcitx-im.org/wiki/Fcitx_5</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.core</PartOf>
@@ -41,12 +41,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-04-19</Date>
+        <Update release="4">
+            <Date>2025-11-08</Date>
             <Version>0.3.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Part of https://github.com/getsolus/packages/issues/5522

**Test Plan**

Installed fcitx-hangul

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
