### PR TITLE
fcitx-configtool: Fix homepage link

### DIFF
--- a/packages/f/fcitx-configtool/abi_used_symbols
+++ b/packages/f/fcitx-configtool/abi_used_symbols
@@ -133,8 +133,8 @@ libglib-2.0.so.0:g_match_info_fetch_named
 libglib-2.0.so.0:g_match_info_free
 libglib-2.0.so.0:g_match_info_is_partial_match
 libglib-2.0.so.0:g_match_info_matches
-libglib-2.0.so.0:g_once_init_enter
-libglib-2.0.so.0:g_once_init_leave
+libglib-2.0.so.0:g_once_init_enter_pointer
+libglib-2.0.so.0:g_once_init_leave_pointer
 libglib-2.0.so.0:g_pattern_match_string
 libglib-2.0.so.0:g_pattern_spec_free
 libglib-2.0.so.0:g_pattern_spec_new

--- a/packages/f/fcitx-configtool/package.yml
+++ b/packages/f/fcitx-configtool/package.yml
@@ -1,9 +1,9 @@
 name       : fcitx-configtool
 version    : 0.4.10
-release    : 3
+release    : 4
 source     :
     - https://download.fcitx-im.org/fcitx-configtool/fcitx-configtool-0.4.10.tar.xz : bcc4976976bfbddbfec3f689f38927fbabc7f7fa611ea252a789583ea14cd1fb
-homepage   : http://fcitx-im.org/
+homepage   : https://fcitx-im.org/wiki/Fcitx_5
 license    : GPL-2.0-or-later
 component  : desktop.core
 summary    : GTK based config tool for Fcitx

--- a/packages/f/fcitx-configtool/pspec_x86_64.xml
+++ b/packages/f/fcitx-configtool/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>fcitx-configtool</Name>
-        <Homepage>http://fcitx-im.org/</Homepage>
+        <Homepage>https://fcitx-im.org/wiki/Fcitx_5</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.core</PartOf>
@@ -34,12 +34,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-04-19</Date>
+        <Update release="4">
+            <Date>2025-11-08</Date>
             <Version>0.4.10</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Part of https://github.com/getsolus/packages/issues/5522

**Test Plan**

Installed fcitx-configtool

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
