### PR TITLE
libmtp: Fix homepage link

### DIFF
--- a/packages/l/libmtp/package.yml
+++ b/packages/l/libmtp/package.yml
@@ -1,9 +1,9 @@
 name       : libmtp
 version    : 1.1.22
-release    : 12
+release    : 13
 source     :
     - https://sourceforge.net/projects/libmtp/files/libmtp/1.1.22/libmtp-1.1.22.tar.gz : c3fcf411aea9cb9643590cbc9df99fa5fe30adcac695024442973d76fa5f87bc
-homepage   : http://libmtp.sourceforge.net/
+homepage   : https://libmtp.sourceforge.net/
 license    : LGPL-2.1-or-later
 component  : desktop.library
 summary    : Library implementation of the Media Transfer Protocol

--- a/packages/l/libmtp/pspec_x86_64.xml
+++ b/packages/l/libmtp/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>libmtp</Name>
-        <Homepage>http://libmtp.sourceforge.net/</Homepage>
+        <Homepage>https://libmtp.sourceforge.net/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>desktop.library</PartOf>
@@ -62,7 +62,7 @@ players, smartphones, etc.
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="12">libmtp</Dependency>
+            <Dependency release="13">libmtp</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libmtp.h</Path>
@@ -71,12 +71,12 @@ players, smartphones, etc.
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2025-10-24</Date>
+        <Update release="13">
+            <Date>2025-11-08</Date>
             <Version>1.1.22</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Part of https://github.com/getsolus/packages/issues/5522

**Test Plan**

Installed libmtp

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
