### PR TITLE
libconfuse: Fix homepage link

### DIFF
--- a/packages/l/libconfuse/abi_used_symbols
+++ b/packages/l/libconfuse/abi_used_symbols
@@ -2,7 +2,8 @@ libc.so.6:__assert_fail
 libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__vfprintf_chk
@@ -49,4 +50,3 @@ libc.so.6:strncpy
 libc.so.6:strndup
 libc.so.6:strspn
 libc.so.6:strtod
-libc.so.6:strtol

--- a/packages/l/libconfuse/package.yml
+++ b/packages/l/libconfuse/package.yml
@@ -1,9 +1,9 @@
 name       : libconfuse
 version    : '3.3'
-release    : 7
+release    : 8
 source     :
     - https://github.com/libconfuse/libconfuse/releases/download/v3.3/confuse-3.3.tar.xz : 1dd50a0320e135a55025b23fcdbb3f0a81913b6d0b0a9df8cc2fdf3b3dc67010
-homepage   : http://www.nongnu.org/confuse
+homepage   : https://github.com/libconfuse/libconfuse
 license    : ISC
 component  : desktop.library
 summary    : C-library for parsing configuration files

--- a/packages/l/libconfuse/pspec_x86_64.xml
+++ b/packages/l/libconfuse/pspec_x86_64.xml
@@ -1,17 +1,17 @@
 <PISI>
     <Source>
         <Name>libconfuse</Name>
-        <Homepage>http://www.nongnu.org/confuse</Homepage>
+        <Homepage>https://github.com/libconfuse/libconfuse</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>ISC</License>
         <PartOf>desktop.library</PartOf>
         <Summary xml:lang="en">C-library for parsing configuration files</Summary>
         <Description xml:lang="en">C-library for parsing configuration files
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>libconfuse</Name>
@@ -38,7 +38,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="7">libconfuse</Dependency>
+            <Dependency release="8">libconfuse</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/confuse.h</Path>
@@ -47,12 +47,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2021-06-20</Date>
+        <Update release="8">
+            <Date>2025-11-08</Date>
             <Version>3.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Part of https://github.com/getsolus/packages/issues/5522

**Test Plan**

Installed libconfuse

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
