### PR TITLE
liblouis: Update to v3.35.0

### DIFF
--- a/packages/l/liblouis/abi_symbols
+++ b/packages/l/liblouis/abi_symbols
@@ -9,6 +9,7 @@ liblouis.so.20:_lou_extParseChars
 liblouis.so.20:_lou_extParseDots
 liblouis.so.20:_lou_findOpcodeName
 liblouis.so.20:_lou_findOpcodeNumber
+liblouis.so.20:_lou_freeTableIndex
 liblouis.so.20:_lou_getALine
 liblouis.so.20:_lou_getCharForDots
 liblouis.so.20:_lou_getDisplayTable
@@ -49,6 +50,10 @@ liblouis.so.20:lou_dotsToChar
 liblouis.so.20:lou_findTable
 liblouis.so.20:lou_findTables
 liblouis.so.20:lou_free
+liblouis.so.20:lou_freeEmphClasses
+liblouis.so.20:lou_freeTableFile
+liblouis.so.20:lou_freeTableFiles
+liblouis.so.20:lou_freeTableInfo
 liblouis.so.20:lou_getDataPath
 liblouis.so.20:lou_getEmphClasses
 liblouis.so.20:lou_getTable

--- a/packages/l/liblouis/abi_used_symbols
+++ b/packages/l/liblouis/abi_used_symbols
@@ -1,3 +1,4 @@
+libc.so.6:__ctype_tolower_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
 libc.so.6:__isoc23_strtol
@@ -12,6 +13,7 @@ libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__stpcpy_chk
 libc.so.6:__strcpy_chk
+libc.so.6:__strncat_chk
 libc.so.6:__vfprintf_chk
 libc.so.6:__vsnprintf_chk
 libc.so.6:abort
@@ -34,6 +36,7 @@ libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset
 libc.so.6:opendir
+libc.so.6:optarg
 libc.so.6:optind
 libc.so.6:program_invocation_name
 libc.so.6:program_invocation_short_name
@@ -51,5 +54,6 @@ libc.so.6:strcmp
 libc.so.6:strcpy
 libc.so.6:strdup
 libc.so.6:strlen
+libc.so.6:strncasecmp
 libc.so.6:strncmp
 libc.so.6:strrchr

--- a/packages/l/liblouis/package.yml
+++ b/packages/l/liblouis/package.yml
@@ -1,9 +1,9 @@
 name       : liblouis
-version    : 3.28.0
-release    : 14
+version    : 3.35.0
+release    : 15
 source     :
-    - https://github.com/liblouis/liblouis/releases/download/v3.28.0/liblouis-3.28.0.tar.gz : 69eddef2cf2118748a1d548cab3671ba31140c37dd821a2d893d95bc2796e1b0
-homepage   : http://liblouis.io/
+    - https://github.com/liblouis/liblouis/releases/download/v3.35.0/liblouis-3.35.0.tar.gz : f56b21029fe7bea4ec97bdbcfa430e7e8759fccb30ea1f8e1be13c386f5b64c7
+homepage   : https://liblouis.io/
 license    :
     - GPL-3.0-or-later
     - LGPL-2.1-or-later

--- a/packages/l/liblouis/pspec_x86_64.xml
+++ b/packages/l/liblouis/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>liblouis</Name>
-        <Homepage>http://liblouis.io/</Homepage>
+        <Homepage>https://liblouis.io/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -40,17 +40,15 @@
             <Path fileType="executable">/usr/bin/lou_tableinfo</Path>
             <Path fileType="executable">/usr/bin/lou_trace</Path>
             <Path fileType="executable">/usr/bin/lou_translate</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/louis-3.28.0-py3.12.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/louis-3.28.0-py3.12.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/louis-3.28.0-py3.12.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/louis-3.28.0-py3.12.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/louis-3.35.0-py3.12.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/louis-3.35.0-py3.12.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/louis-3.35.0-py3.12.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/louis-3.35.0-py3.12.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/louis/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/louis/__pycache__/__init__.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib64/liblouis.so.20</Path>
-            <Path fileType="library">/usr/lib64/liblouis.so.20.0.16</Path>
-            <Path fileType="doc">/usr/share/doc/liblouis/liblouis.html</Path>
-            <Path fileType="doc">/usr/share/doc/liblouis/liblouis.txt</Path>
-            <Path fileType="info">/usr/share/info/liblouis.info</Path>
+            <Path fileType="library">/usr/lib64/liblouis.so.20.1.0</Path>
+            <Path fileType="info">/usr/share/info/liblouis.info.zst</Path>
             <Path fileType="data">/usr/share/liblouis/tables/Es-Es-G0.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/IPA-unicode-range.uti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/IPA.utb</Path>
@@ -58,6 +56,10 @@
             <Path fileType="data">/usr/share/liblouis/tables/Pl-Pl-g1.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/afr-za-g1.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/afr-za-g2.ctb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/akk-borger.utb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/akk.utb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/ancient-languages-borger.utb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/ancient-languages-us.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/ar-ar-comp8.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/ar-ar-g1-core.uti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/ar-ar-g1.utb</Path>
@@ -71,6 +73,7 @@
             <Path fileType="data">/usr/share/liblouis/tables/ba.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/be-in-g1.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/bel-comp.utb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/bel-detailed.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/bel.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/bengali.cti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/bg.ctb</Path>
@@ -97,13 +100,17 @@
             <Path fileType="data">/usr/share/liblouis/tables/compress.cti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/controlchars.cti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/cop-eg-comp8.utb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/cop.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/corrections.cti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/countries.cti</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/critical-apparatus.uti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/cs-chardefs.cti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/cs-comp8.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/cs-g1.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/cs-translation.cti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/cs.tbl</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/cuneiform-transliterated-compact.utb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/cuneiform-transliterated.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/cy-cy-g1.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/cy-cy-g2.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/cy.tbl</Path>
@@ -127,7 +134,6 @@
             <Path fileType="data">/usr/share/liblouis/tables/da-dk-g28.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/da-dk-g28_1993.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/da-dk-g28l_1993.ctb</Path>
-            <Path fileType="data">/usr/share/liblouis/tables/da-dk-g2_1993.dic</Path>
             <Path fileType="data">/usr/share/liblouis/tables/da-dk-octobraille.dis</Path>
             <Path fileType="data">/usr/share/liblouis/tables/da-dk-octobraille_1993.dis</Path>
             <Path fileType="data">/usr/share/liblouis/tables/de-accents-detailed.cti</Path>
@@ -218,14 +224,25 @@
             <Path fileType="data">/usr/share/liblouis/tables/grc-international-common.uti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/grc-international-composed.uti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/grc-international-decomposed.uti</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/grc-international-en-composed.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/grc-international-en.utb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/grc-international-es.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/gu-in-g1.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/gu.tbl</Path>
             <Path fileType="data">/usr/share/liblouis/tables/gujarati.cti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/gurumuki.cti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/haw-us-g1.ctb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/hbo-cantillated-rules.uti</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/hbo-cantillated.utb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/hbo-common-rules.uti</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/hbo-ihbc-rules.uti</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/hbo-slim-rules.uti</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/hbo-slim.utb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/hbo.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/he-IL-comp8.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/he-IL.utb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/he-common-consonants.uti</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/he-common-vowels-ihbc.uti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/hi-in-g1.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/hi.tbl</Path>
             <Path fileType="data">/usr/share/liblouis/tables/hr-chardefs.cti</Path>
@@ -271,7 +288,9 @@
             <Path fileType="data">/usr/share/liblouis/tables/it-it-comp8.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/it.tbl</Path>
             <Path fileType="data">/usr/share/liblouis/tables/iu-ca-g1.ctb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/ja-kantenji-ucs2.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/ja-kantenji.utb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/ja-rokutenkanji.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/ka-in-g1.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/ka.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/kannada.cti</Path>
@@ -302,12 +321,12 @@
             <Path fileType="data">/usr/share/liblouis/tables/lg-ug-g1.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/litdigits6Dots.uti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/litdigits6DotsPlusDot6.uti</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/lo-g1.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/loweredDigits6Dots.uti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/loweredDigits8Dots.uti</Path>
-            <Path fileType="data">/usr/share/liblouis/tables/lt-6dot.tbl</Path>
             <Path fileType="data">/usr/share/liblouis/tables/lt-6dot.utb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/lt-8dot.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/lt.ctb</Path>
-            <Path fileType="data">/usr/share/liblouis/tables/lt.tbl</Path>
             <Path fileType="data">/usr/share/liblouis/tables/lv.tbl</Path>
             <Path fileType="data">/usr/share/liblouis/tables/malayalam.cti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/mao-nz-g1.ctb</Path>
@@ -340,12 +359,12 @@
             <Path fileType="data">/usr/share/liblouis/tables/nl-comp8.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/nl-print.dis</Path>
             <Path fileType="data">/usr/share/liblouis/tables/nl-unicode.dis</Path>
-            <Path fileType="data">/usr/share/liblouis/tables/nl.tbl</Path>
             <Path fileType="data">/usr/share/liblouis/tables/no-no-8dot-fallback-6dot-g0.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/no-no-8dot.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/no-no-braillo-047-01.dis</Path>
             <Path fileType="data">/usr/share/liblouis/tables/no-no-chardefs6.uti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/no-no-comp8.ctb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/no-no-cyrillic6dot.uti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/no-no-g0.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/no-no-g1.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/no-no-g2.ctb</Path>
@@ -367,22 +386,24 @@
             <Path fileType="data">/usr/share/liblouis/tables/pl-pl-comp8.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/pl.tbl</Path>
             <Path fileType="data">/usr/share/liblouis/tables/printables.cti</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/pt-comp6.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/pt-pt-comp8.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/pt-pt-g1.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/pt-pt-g2.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/pt.tbl</Path>
             <Path fileType="data">/usr/share/liblouis/tables/pu-in-g1.utb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/quotation-marks.uti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/ro-g0.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/ro.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/ro.tbl</Path>
             <Path fileType="data">/usr/share/liblouis/tables/ru-brf.dis</Path>
-            <Path fileType="data">/usr/share/liblouis/tables/ru-compbrl.ctb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/ru-comp6.utb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/ru-comp8.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/ru-letters.dis</Path>
             <Path fileType="data">/usr/share/liblouis/tables/ru-litbrl-detailed.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/ru-litbrl.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/ru-ru-g1.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/ru-unicode.dis</Path>
-            <Path fileType="data">/usr/share/liblouis/tables/ru.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/rw-rw-g1.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/sa-in-g1.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/sa.tbl</Path>
@@ -402,9 +423,11 @@
             <Path fileType="data">/usr/share/liblouis/tables/sot-za-g1.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/sot-za-g2.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/spaces.uti</Path>
-            <Path fileType="data">/usr/share/liblouis/tables/sr-chardefs.cti</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/sr-Cyrl.ctb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/sr-common.cti</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/sr-cyrletters.cti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/sr-g1.ctb</Path>
-            <Path fileType="data">/usr/share/liblouis/tables/sr.tbl</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/sr-latletters.cti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/sv-1989.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/sv-1996.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/sv-g0.utb</Path>
@@ -416,6 +439,7 @@
             <Path fileType="data">/usr/share/liblouis/tables/sw-ke-g1-5.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/sw-ke-g1.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/sw-ke-g2.ctb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/syc.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/ta-ta-g1.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/ta.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/ta.tbl</Path>
@@ -426,6 +450,9 @@
             <Path fileType="data">/usr/share/liblouis/tables/text_nabcc.dis</Path>
             <Path fileType="data">/usr/share/liblouis/tables/th-comp8-backward.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/th-g0.utb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/th-g1.utb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/th-g1.uti</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/th-g2.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/tr-g1.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/tr-g2.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/tr-g2.tbl</Path>
@@ -434,7 +461,9 @@
             <Path fileType="data">/usr/share/liblouis/tables/tsn-za-g1.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/tsn-za-g2.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/tt.utb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/uga.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/uk-comp.utb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/uk-detailed.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/uk.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/ukchardefs.cti</Path>
             <Path fileType="data">/usr/share/liblouis/tables/ukmaths_single_cell_defs.cti</Path>
@@ -461,24 +490,24 @@
             <Path fileType="data">/usr/share/liblouis/tables/wordcx.dis</Path>
             <Path fileType="data">/usr/share/liblouis/tables/xh-za-g1.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/xh-za-g2.ctb</Path>
+            <Path fileType="data">/usr/share/liblouis/tables/yi.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/zh-chn.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/zh-hk.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/zh-tw.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/zh_CHN.tbl</Path>
-            <Path fileType="data">/usr/share/liblouis/tables/zh_HK.tbl</Path>
             <Path fileType="data">/usr/share/liblouis/tables/zhcn-cbs.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/zhcn-g1.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/zhcn-g2.ctb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/zu-za-g1.utb</Path>
             <Path fileType="data">/usr/share/liblouis/tables/zu-za-g2.ctb</Path>
-            <Path fileType="man">/usr/share/man/man1/lou_allround.1</Path>
-            <Path fileType="man">/usr/share/man/man1/lou_checkhyphens.1</Path>
-            <Path fileType="man">/usr/share/man/man1/lou_checktable.1</Path>
-            <Path fileType="man">/usr/share/man/man1/lou_checkyaml.1</Path>
-            <Path fileType="man">/usr/share/man/man1/lou_debug.1</Path>
-            <Path fileType="man">/usr/share/man/man1/lou_tableinfo.1</Path>
-            <Path fileType="man">/usr/share/man/man1/lou_trace.1</Path>
-            <Path fileType="man">/usr/share/man/man1/lou_translate.1</Path>
+            <Path fileType="man">/usr/share/man/man1/lou_allround.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/lou_checkhyphens.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/lou_checktable.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/lou_checkyaml.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/lou_debug.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/lou_tableinfo.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/lou_trace.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/lou_translate.1.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -488,7 +517,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="14">liblouis</Dependency>
+            <Dependency release="15">liblouis</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/liblouis/liblouis.h</Path>
@@ -497,12 +526,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2025-05-22</Date>
-            <Version>3.28.0</Version>
+        <Update release="15">
+            <Date>2025-11-08</Date>
+            <Version>3.35.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://liblouis.io/liblouis/2025/09/01/liblouis-release-3.35.0.html).
- Fix homepage link. Part of https://github.com/getsolus/packages/issues/5522

**Test Plan**

Installed liblouis

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
