### PR TITLE
solseek: Update to v0.3.1

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,16 +1,17 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 0.2.0
-release    : 1
+version    : 0.3.1
+release    : 2
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v0.2.0.tar.gz : 93b9f2a19b85c6d6483619fd829e495349887415743d1ef6fcb2c8e45e552ddc
+    - https://github.com/clintre/solseek/archive/refs/tags/v0.3.1.tar.gz : f7655df087e6666f7a538d5b53a0ca788198cd99259fddf730f9823f9c7ac578
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : systtem.utils
 summary    : A TUI Package Manager for Solus
 description: |
     Solseek is a simple terminal user interface that allows you to browse, search, and manage packages from the Solus packages.
-rundeps:
+rundeps    :
+    - appstream
     - fzf
 install    : |
     install -Dm00755 $workdir/package/bin/solseek $installdir/usr/bin/solseek
@@ -18,3 +19,4 @@ install    : |
     cp -r $workdir/package/share/solseek $installdir/usr/share/
     install -Dm00644 $workdir/package/share/applications/Solseek.desktop $installdir/usr/share/applications/Solseek.desktop
     install -Dm00644 $workdir/package/share/icons/hicolor/scalable/apps/solseek.svg $installdir/usr/share/icons/hicolor/scalable/apps/solseek.svg
+    install -Dm00644 $workdir/package/share/metainfo/solseek.metainfo.xml $installdir/usr/share/metainfo/solseek.metainfo.xml

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -23,6 +23,7 @@
             <Path fileType="executable">/usr/bin/solseek</Path>
             <Path fileType="data">/usr/share/applications/Solseek.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/solseek.svg</Path>
+            <Path fileType="data">/usr/share/metainfo/solseek.metainfo.xml</Path>
             <Path fileType="data">/usr/share/solseek/LICENSE-solseek.txt</Path>
             <Path fileType="data">/usr/share/solseek/lang/en/_dictionary.lang</Path>
             <Path fileType="data">/usr/share/solseek/lang/en/eopkg_check.txt</Path>
@@ -33,12 +34,13 @@
             <Path fileType="data">/usr/share/solseek/lang/en/package_action.txt</Path>
             <Path fileType="data">/usr/share/solseek/lang/en/update_system.txt</Path>
             <Path fileType="data">/usr/share/solseek/lang/en/welcome.txt</Path>
+            <Path fileType="data">/usr/share/solseek/solseek_fastfetch.jsonc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2025-10-28</Date>
-            <Version>0.2.0</Version>
+        <Update release="2">
+            <Date>2025-11-08</Date>
+            <Version>0.3.1</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**

Notes for list in Sync Notes:
Added ability to list, search, and manage flatpaks and will now notify upon launch if there are any updates for eopkg or flatpak. 

Bugfixes:

- Fix cache issue where list would not reflect changes after install/remove
- Fix empty list issue if no flatpaks are installed

Enhancements:
- Checks for updates and will display if available
- Optional if Fastfetch is installed, displays basic system info
- Full Flatpak managment with same level as it has for eopkg
- General Cleanup

Full Release Notes:
- [0.3.1](https://github.com/clintre/solseek/releases/tag/v0.3.1)

**Summary**

Updated features and general bug fixes

**Test Plan**

Tested both update and fresh install against Plasma, Budgie, XFCE, and Gnome editions Unstable branch

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
