### PR TITLE
libnotify: Fix homepage link

### DIFF
--- a/packages/l/libnotify/package.yml
+++ b/packages/l/libnotify/package.yml
@@ -1,9 +1,9 @@
 name       : libnotify
 version    : 0.8.7
-release    : 10
+release    : 11
 source     :
     - https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.7.tar.xz : 4be15202ec4184fce1ac15997ece5530d2be32fe9573875aeb10e3b573858748
-homepage   : http://www.gnome.org
+homepage   : https://gitlab.gnome.org/GNOME/libnotify
 component  : desktop.gnome.core
 license    : GPL-2.0-or-later
 emul32     : true

--- a/packages/l/libnotify/pspec_x86_64.xml
+++ b/packages/l/libnotify/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>libnotify</Name>
-        <Homepage>http://www.gnome.org</Homepage>
+        <Homepage>https://gitlab.gnome.org/GNOME/libnotify</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.gnome.core</PartOf>
@@ -34,7 +34,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">libnotify</Dependency>
+            <Dependency release="11">libnotify</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnotify.so.4</Path>
@@ -48,8 +48,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">libnotify-32bit</Dependency>
-            <Dependency release="10">libnotify-devel</Dependency>
+            <Dependency release="11">libnotify-devel</Dependency>
+            <Dependency release="11">libnotify-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnotify.so</Path>
@@ -63,7 +63,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">libnotify</Dependency>
+            <Dependency release="11">libnotify</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libnotify/notification.h</Path>
@@ -76,12 +76,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2025-11-01</Date>
+        <Update release="11">
+            <Date>2025-11-09</Date>
             <Version>0.8.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Part of https://github.com/getsolus/packages/issues/5522

**Test Plan**

Install libnotify

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
