### PR TITLE
libptytty: Fix homepage link

### DIFF
--- a/packages/l/libptytty/package.yml
+++ b/packages/l/libptytty/package.yml
@@ -1,9 +1,9 @@
 name       : libptytty
 version    : 2.0
-release    : 2
+release    : 3
 source     :
-    - http://dist.schmorp.de/libptytty/libptytty-2.0.tar.gz : 8033ed3aadf28759660d4f11f2d7b030acf2a6890cb0f7926fb0cfa6739d31f7
-homepage   : http://software.schmorp.de/pkg/libptytty.html
+    - https://dist.schmorp.de/libptytty/libptytty-2.0.tar.gz : 8033ed3aadf28759660d4f11f2d7b030acf2a6890cb0f7926fb0cfa6739d31f7
+homepage   : https://software.schmorp.de/pkg/libptytty.html
 license    : GPL-2.0-or-later
 component  : programming.library
 summary    : A library for OS-independent pseudo-TTY management.

--- a/packages/l/libptytty/pspec_x86_64.xml
+++ b/packages/l/libptytty/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>libptytty</Name>
-        <Homepage>http://software.schmorp.de/pkg/libptytty.html</Homepage>
+        <Homepage>https://software.schmorp.de/pkg/libptytty.html</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>programming.library</PartOf>
@@ -30,22 +30,22 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">libptytty</Dependency>
+            <Dependency release="3">libptytty</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libptytty.h</Path>
             <Path fileType="library">/usr/lib64/libptytty.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/libptytty.pc</Path>
-            <Path fileType="man">/usr/share/man/man3/libptytty.3</Path>
+            <Path fileType="man">/usr/share/man/man3/libptytty.3.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-09-12</Date>
+        <Update release="3">
+            <Date>2025-11-10</Date>
             <Version>2.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Part of https://github.com/getsolus/packages/issues/5522

**Test Plan**

Installed libptytty

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
