### PR TITLE
libdiscid: Update to v0.6.5

### DIFF
--- a/packages/l/libdiscid/abi_used_symbols
+++ b/packages/l/libdiscid/abi_used_symbols
@@ -1,6 +1,7 @@
 ld-linux-x86-64.so.2:__tls_get_addr
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__sprintf_chk
@@ -26,4 +27,3 @@ libc.so.6:strlen
 libc.so.6:strncpy
 libc.so.6:strstr
 libc.so.6:strtok_r
-libc.so.6:strtol

--- a/packages/l/libdiscid/package.yml
+++ b/packages/l/libdiscid/package.yml
@@ -1,9 +1,9 @@
 name       : libdiscid
-version    : 0.6.4
-release    : 4
+version    : 0.6.5
+release    : 5
 source     :
-    - https://github.com/metabrainz/libdiscid/archive/v0.6.4.tar.gz : c581baeabaf6e410398005645d66acaaa41ff2cab272c267a2d6839e41486ebb
-homepage   : http://musicbrainz.org/doc/libdiscid
+    - https://github.com/metabrainz/libdiscid/archive/v0.6.5.tar.gz : 1ecc4280b88d6a65c7fcde695f991ac28e3b54ce41d83ab3fffddfb3d5764a11
+homepage   : https://github.com/metabrainz/libdiscid
 license    : LGPL-2.1-or-later
 component  : multimedia.library
 summary    : C library for creating MusicBrainz DiscIDs from audio CDs.

--- a/packages/l/libdiscid/pspec_x86_64.xml
+++ b/packages/l/libdiscid/pspec_x86_64.xml
@@ -1,17 +1,17 @@
 <PISI>
     <Source>
         <Name>libdiscid</Name>
-        <Homepage>http://musicbrainz.org/doc/libdiscid</Homepage>
+        <Homepage>https://github.com/metabrainz/libdiscid</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>multimedia.library</PartOf>
         <Summary xml:lang="en">C library for creating MusicBrainz DiscIDs from audio CDs.</Summary>
         <Description xml:lang="en">libdiscid is a C library for creating MusicBrainz DiscIDs from audio CDs. It reads a CD&apos;s table of contents (TOC) and generates an identifier which can be used to lookup the CD at MusicBrainz (http://musicbrainz.org). Additionally, it provides a submission URL for adding the DiscID to the database.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>libdiscid</Name>
@@ -21,7 +21,7 @@
         <PartOf>multimedia.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libdiscid.so.0</Path>
-            <Path fileType="library">/usr/lib64/libdiscid.so.0.6.4</Path>
+            <Path fileType="library">/usr/lib64/libdiscid.so.0.6.5</Path>
         </Files>
     </Package>
     <Package>
@@ -31,7 +31,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="4">libdiscid</Dependency>
+            <Dependency release="5">libdiscid</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/discid/discid.h</Path>
@@ -40,12 +40,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2023-09-08</Date>
-            <Version>0.6.4</Version>
+        <Update release="5">
+            <Date>2025-11-10</Date>
+            <Version>0.6.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/metabrainz/libdiscid/releases/tag/v0.6.5).
- Part of https://github.com/getsolus/packages/issues/5522

**Test Plan**

Installed libdiscid

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
