### PR TITLE
solseek: Update to v0.3.2

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 0.3.1
-release    : 2
+version    : 0.3.2
+release    : 3
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v0.3.1.tar.gz : f7655df087e6666f7a538d5b53a0ca788198cd99259fddf730f9823f9c7ac578
+    - https://github.com/clintre/solseek/archive/refs/tags/v0.3.2.tar.gz : 623c7ada1e755cd1e0b8680423ce063953d1d6eb8ab255c124e99e3d99c6270c
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : systtem.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -38,9 +38,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2025-11-08</Date>
-            <Version>0.3.1</Version>
+        <Update release="3">
+            <Date>2025-11-12</Date>
+            <Version>0.3.2</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**

This is a bump to fix a minor issue with update caching. Previous changelong and info below.

Notes for list in Sync Notes:
Added ability to list, search, and manage flatpaks and will now notify upon launch if there are any updates for eopkg or flatpak.

Bugfixes:
- Fix cache issue where list would not reflect changes after install/remove
- Fix empty list issue if no flatpaks are installed
- Fix new issue with caching issue on update checks

Enhancements:
- Checks for updates and will display if available
- Optional if Fastfetch is installed, displays basic system info
- Full Flatpak managment with same level as it has for eopkg
- General Cleanup



**Test Plan**

Tested on unstable across desktop versions.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
