### PR TITLE
network-manager-applet: Fix startup on Budgie

### DIFF
--- a/packages/n/network-manager-applet/files/0001-Don-t-autostart-in-Budgie.patch
+++ b/packages/n/network-manager-applet/files/0001-Don-t-autostart-in-Budgie.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Evan Maddock <maddock.evan@vivaldi.net>
+Date: Wed, 12 Nov 2025 16:30:43 -0500
+Subject: [PATCH] Don't autostart in Budgie
+
+Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
+---
+ nm-applet.desktop.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/nm-applet.desktop.in b/nm-applet.desktop.in
+index 067229f6..a6eb5367 100644
+--- a/nm-applet.desktop.in
++++ b/nm-applet.desktop.in
+@@ -6,5 +6,5 @@ Exec=nm-applet
+ Terminal=false
+ Type=Application
+ NoDisplay=true
+-NotShowIn=KDE;GNOME;
++NotShowIn=KDE;GNOME;Budgie;
+ X-GNOME-UsesNotifications=true

--- a/packages/n/network-manager-applet/package.yml
+++ b/packages/n/network-manager-applet/package.yml
@@ -1,6 +1,6 @@
 name       : network-manager-applet
 version    : 1.36.0
-release    : 53
+release    : 54
 source     :
     - https://download.gnome.org/sources/network-manager-applet/1.36/network-manager-applet-1.36.0.tar.xz : a84704487ea3afe1485c47fb2ab598b8f779f540ae0dcbf0a1c5f85e64a7e253
 homepage   : https://gitlab.gnome.org/GNOME/network-manager-applet
@@ -18,6 +18,8 @@ builddeps  :
     - pkgconfig(libsecret-unstable)
     - pkgconfig(mm-glib)
 setup      : |
+    %patch -p1 -i $pkgfiles/0001-Don-t-autostart-in-Budgie.patch
+
     %meson_configure --sysconfdir=/usr/share/ -Dselinux=false
 build      : |
     %ninja_build

--- a/packages/n/network-manager-applet/pspec_x86_64.xml
+++ b/packages/n/network-manager-applet/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>network-manager-applet</Name>
         <Homepage>https://gitlab.gnome.org/GNOME/network-manager-applet</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.gnome</PartOf>
@@ -222,19 +222,19 @@
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/nm-applet.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_HK/LC_MESSAGES/nm-applet.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/nm-applet.mo</Path>
-            <Path fileType="man">/usr/share/man/man1/nm-applet.1</Path>
-            <Path fileType="man">/usr/share/man/man1/nm-connection-editor.1</Path>
+            <Path fileType="man">/usr/share/man/man1/nm-applet.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/nm-connection-editor.1.zst</Path>
             <Path fileType="data">/usr/share/metainfo/nm-connection-editor.appdata.xml</Path>
             <Path fileType="data">/usr/share/xdg/autostart/nm-applet.desktop</Path>
         </Files>
     </Package>
     <History>
-        <Update release="53">
-            <Date>2024-07-10</Date>
+        <Update release="54">
+            <Date>2025-11-12</Date>
             <Version>1.36.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

We want this to be started by Budgie, not `nm-applet`.

**Test Plan**

Start a new Budgie session and see that the network indicator is back.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
