### PR TITLE
budgie-desktop-branding: Update to v23.3.1

### DIFF
--- a/packages/b/budgie-desktop-branding/package.yml
+++ b/packages/b/budgie-desktop-branding/package.yml
@@ -1,8 +1,8 @@
 name       : budgie-desktop-branding
-version    : '23.2'
-release    : 82
+version    : 23.3.1
+release    : 83
 source     :
-    - https://github.com/getsolus/budgie-desktop-branding/archive/refs/tags/v23.2.tar.gz : 22eee9f620eeb401f165ce4586c8281be62553cdc1d16003f6d7ac987062bdc2
+    - https://github.com/getsolus/budgie-desktop-branding/releases/download/v23.3.1/budgie-desktop-branding-v23.3.1.tar.xz : c029f0c25b6967a391bc7b7543c8d23848536f1950fae8d8605fe1d52ce5d1ba
 homepage   : https://github.com/getsolus/budgie-desktop-branding
 license    : GPL-2.0-only
 summary    :

--- a/packages/b/budgie-desktop-branding/pspec_x86_64.xml
+++ b/packages/b/budgie-desktop-branding/pspec_x86_64.xml
@@ -36,7 +36,7 @@
         <Description xml:lang="en">Budgie LiveCD-specific Configuration</Description>
         <PartOf>desktop.budgie</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="82">budgie-desktop-branding</Dependency>
+            <Dependency releaseFrom="83">budgie-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/glib-2.0/schemas/50_budgie_settings.gschema.override</Path>
@@ -44,9 +44,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="82">
-            <Date>2025-10-24</Date>
-            <Version>23.2</Version>
+        <Update release="83">
+            <Date>2025-11-13</Date>
+            <Version>23.3.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/getsolus/budgie-desktop-branding/releases/tag/v23.3.1).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

TBD

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
