### PR TITLE
xfce4-desktop-branding: Update to v1.2.0

### DIFF
--- a/packages/x/xfce4-desktop-branding/package.yml
+++ b/packages/x/xfce4-desktop-branding/package.yml
@@ -1,8 +1,8 @@
 name       : xfce4-desktop-branding
-version    : 1.1.1
-release    : 18
+version    : 1.2.0
+release    : 19
 source     :
-    - https://github.com/getsolus/xfce4-desktop-branding/archive/refs/tags/v1.1.1.tar.gz : a2e5487d0364f77d3ca7211ca3f5d20cc427553f1c233d2e6df7054b5606dde6
+    - https://github.com/getsolus/xfce4-desktop-branding/releases/download/v1.2.0/xfce4-desktop-branding-v1.2.0.tar.xz : 092421614e56c670443c16b65024e7951d4540e566a1bc4d267742f0647313c8
 homepage   : https://github.com/getsolus/xfce4-desktop-branding
 license    : GPL-2.0-only
 component  :

--- a/packages/x/xfce4-desktop-branding/pspec_x86_64.xml
+++ b/packages/x/xfce4-desktop-branding/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xfce4-desktop-branding</Name>
         <Homepage>https://github.com/getsolus/xfce4-desktop-branding</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>desktop.xfce</PartOf>
@@ -33,19 +33,19 @@
         <Description xml:lang="en">Defaults for the XFCE4 Desktop.</Description>
         <PartOf>desktop.xfce</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="18">xfce4-desktop-branding</Dependency>
+            <Dependency releaseFrom="19">xfce4-desktop-branding</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/lightdm/lightdm.conf.d/xfce_config.conf</Path>
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2025-06-08</Date>
-            <Version>1.1.1</Version>
+        <Update release="19">
+            <Date>2025-11-13</Date>
+            <Version>1.2.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/getsolus/xfce4-desktop-branding/releases/tag/v1.2.0).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

TBD

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
