### PR TITLE
readline6: Switch to stable mirror and fix build

### DIFF
--- a/packages/r/readline6/abi_symbols
+++ b/packages/r/readline6/abi_symbols
@@ -233,7 +233,6 @@ libreadline.so.6:_rl_set_mark_at_pos
 libreadline.so.6:_rl_set_normal_color
 libreadline.so.6:_rl_set_screen_size
 libreadline.so.6:_rl_set_the_line
-libreadline.so.6:_rl_settracefp
 libreadline.so.6:_rl_show_mode_in_prompt
 libreadline.so.6:_rl_sigcleanarg
 libreadline.so.6:_rl_sigcleanup
@@ -265,9 +264,6 @@ libreadline.so.6:_rl_terminal_can_insert
 libreadline.so.6:_rl_to_lower
 libreadline.so.6:_rl_to_upper
 libreadline.so.6:_rl_top_level
-libreadline.so.6:_rl_trace
-libreadline.so.6:_rl_trclose
-libreadline.so.6:_rl_tropen
 libreadline.so.6:_rl_ttymsg
 libreadline.so.6:_rl_undo_group_level
 libreadline.so.6:_rl_unget_char

--- a/packages/r/readline6/abi_symbols32
+++ b/packages/r/readline6/abi_symbols32
@@ -233,7 +233,6 @@ libreadline.so.6:_rl_set_mark_at_pos
 libreadline.so.6:_rl_set_normal_color
 libreadline.so.6:_rl_set_screen_size
 libreadline.so.6:_rl_set_the_line
-libreadline.so.6:_rl_settracefp
 libreadline.so.6:_rl_show_mode_in_prompt
 libreadline.so.6:_rl_sigcleanarg
 libreadline.so.6:_rl_sigcleanup
@@ -265,9 +264,6 @@ libreadline.so.6:_rl_terminal_can_insert
 libreadline.so.6:_rl_to_lower
 libreadline.so.6:_rl_to_upper
 libreadline.so.6:_rl_top_level
-libreadline.so.6:_rl_trace
-libreadline.so.6:_rl_trclose
-libreadline.so.6:_rl_tropen
 libreadline.so.6:_rl_ttymsg
 libreadline.so.6:_rl_undo_group_level
 libreadline.so.6:_rl_unget_char

--- a/packages/r/readline6/abi_used_symbols
+++ b/packages/r/readline6/abi_used_symbols
@@ -5,6 +5,7 @@ libc.so.6:__ctype_toupper_loc
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
 libc.so.6:__longjmp_chk
 libc.so.6:__mbrlen
 libc.so.6:__memcpy_chk
@@ -22,11 +23,9 @@ libc.so.6:close
 libc.so.6:closedir
 libc.so.6:endpwent
 libc.so.6:exit
-libc.so.6:fclose
 libc.so.6:fcntl
 libc.so.6:fflush
 libc.so.6:fileno
-libc.so.6:fopen
 libc.so.6:fputc
 libc.so.6:fputs
 libc.so.6:free
@@ -88,7 +87,6 @@ libc.so.6:strncpy
 libc.so.6:strpbrk
 libc.so.6:strrchr
 libc.so.6:strstr
-libc.so.6:strtol
 libc.so.6:tcflow
 libc.so.6:tcgetattr
 libc.so.6:tcsetattr

--- a/packages/r/readline6/abi_used_symbols32
+++ b/packages/r/readline6/abi_used_symbols32
@@ -5,6 +5,7 @@ libc.so.6:__ctype_toupper_loc
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
 libc.so.6:__longjmp_chk
 libc.so.6:__mbrlen
 libc.so.6:__memcpy_chk
@@ -22,11 +23,9 @@ libc.so.6:close
 libc.so.6:closedir
 libc.so.6:endpwent
 libc.so.6:exit
-libc.so.6:fclose
 libc.so.6:fcntl64
 libc.so.6:fflush
 libc.so.6:fileno
-libc.so.6:fopen64
 libc.so.6:fputc
 libc.so.6:fputs
 libc.so.6:free
@@ -88,7 +87,6 @@ libc.so.6:strncpy
 libc.so.6:strpbrk
 libc.so.6:strrchr
 libc.so.6:strstr
-libc.so.6:strtol
 libc.so.6:tcflow
 libc.so.6:tcgetattr
 libc.so.6:tcsetattr

--- a/packages/r/readline6/files/compat-readline6-configure-c99.patch
+++ b/packages/r/readline6/files/compat-readline6-configure-c99.patch
@@ -1,0 +1,194 @@
+diff --git a/aclocal.m4 b/aclocal.m4
+index 26b0ed27e80cbbaa..568abec17ec2a0c7 100644
+--- a/aclocal.m4
++++ b/aclocal.m4
+@@ -787,10 +787,11 @@ AC_CACHE_VAL(bash_cv_func_sigsetjmp,
+ #include <signal.h>
+ #include <setjmp.h>
+ 
++int
+ main()
+ {
+ #if !defined (_POSIX_VERSION) || !defined (HAVE_POSIX_SIGNALS)
+-exit (1);
++return 1;
+ #else
+ 
+ int code;
+@@ -806,7 +807,7 @@ sigprocmask(SIG_BLOCK, (sigset_t *)NULL, &oset);
+ /* save it */
+ code = sigsetjmp(xx, 1);
+ if (code)
+-  exit(0);	/* could get sigmask and compare to oset here. */
++  return 0;	/* could get sigmask and compare to oset here. */
+ 
+ /* change it */
+ sigaddset(&set, SIGINT);
+@@ -814,7 +815,7 @@ sigprocmask(SIG_BLOCK, &set, (sigset_t *)NULL);
+ 
+ /* and siglongjmp */
+ siglongjmp(xx, 10);
+-exit(1);
++return 1;
+ #endif
+ }], bash_cv_func_sigsetjmp=present, bash_cv_func_sigsetjmp=missing,
+     [AC_MSG_WARN(cannot check for sigsetjmp/siglongjmp if cross-compiling -- defaulting to missing)
+@@ -835,7 +836,11 @@ AC_CACHE_VAL(bash_cv_func_strcoll_broken,
+ #if defined (HAVE_LOCALE_H)
+ #include <locale.h>
+ #endif
++#if defined (HAVE_STRING_H)
++#include <string.h>
++#endif
+ 
++int
+ main(c, v)
+ int     c;
+ char    *v[];
+@@ -863,7 +868,7 @@ char    *v[];
+         /* Exit with 1 (failure) if these two values are both > 0, since
+ 	   this tests whether strcoll(3) is broken with respect to strcmp(3)
+ 	   in the default locale. */
+-	exit (r1 > 0 && r2 > 0);
++	return (r1 > 0 && r2 > 0);
+ }
+ ], bash_cv_func_strcoll_broken=yes, bash_cv_func_strcoll_broken=no,
+    [AC_MSG_WARN(cannot check strcoll if cross compiling -- defaulting to no)
+@@ -1334,13 +1339,14 @@ int s;
+   nsigint++;
+ }
+ 
++int
+ main()
+ {
+ 	nsigint = 0;
+ 	set_signal_handler(SIGINT, sigint);
+ 	kill((int)getpid(), SIGINT);
+ 	kill((int)getpid(), SIGINT);
+-	exit(nsigint != 2);
++	return nsigint != 2;
+ }
+ ], bash_cv_must_reinstall_sighandlers=no, bash_cv_must_reinstall_sighandlers=yes,
+    [AC_MSG_WARN(cannot check signal handling if cross compiling -- defaulting to no)
+@@ -1773,6 +1779,7 @@ bash_cv_wcwidth_broken,
+ #include <locale.h>
+ #include <wchar.h>
+ 
++int
+ main(c, v)
+ int     c;
+ char    **v;
+@@ -1928,6 +1935,7 @@ AC_CACHE_VAL(bash_cv_func_ctype_nonascii,
+ #include <stdio.h>
+ #include <ctype.h>
+ 
++int
+ main(c, v)
+ int	c;
+ char	*v[];
+@@ -1949,7 +1957,7 @@ char	*v[];
+ 	r1 = isprint(x);
+ 	x -= 128;
+ 	r2 = isprint(x);
+-	exit (r1 == 0 || r2 == 0);
++	return r1 == 0 || r2 == 0;
+ }
+ ], bash_cv_func_ctype_nonascii=yes, bash_cv_func_ctype_nonascii=no,
+    [AC_MSG_WARN(cannot check ctype macros if cross compiling -- defaulting to no)
+diff --git a/configure b/configure
+index 002bcf07a6503b6f..3b180725df6c67c0 100755
+--- a/configure
++++ b/configure
+@@ -5056,13 +5056,14 @@ int s;
+   nsigint++;
+ }
+ 
++int
+ main()
+ {
+ 	nsigint = 0;
+ 	set_signal_handler(SIGINT, sigint);
+ 	kill((int)getpid(), SIGINT);
+ 	kill((int)getpid(), SIGINT);
+-	exit(nsigint != 2);
++	return nsigint != 2;
+ }
+ 
+ _ACEOF
+@@ -5107,10 +5108,11 @@ else
+ #include <signal.h>
+ #include <setjmp.h>
+ 
++int
+ main()
+ {
+ #if !defined (_POSIX_VERSION) || !defined (HAVE_POSIX_SIGNALS)
+-exit (1);
++return 1;
+ #else
+ 
+ int code;
+@@ -5126,7 +5128,7 @@ sigprocmask(SIG_BLOCK, (sigset_t *)NULL, &oset);
+ /* save it */
+ code = sigsetjmp(xx, 1);
+ if (code)
+-  exit(0);	/* could get sigmask and compare to oset here. */
++  return 0;	/* could get sigmask and compare to oset here. */
+ 
+ /* change it */
+ sigaddset(&set, SIGINT);
+@@ -5134,7 +5136,7 @@ sigprocmask(SIG_BLOCK, &set, (sigset_t *)NULL);
+ 
+ /* and siglongjmp */
+ siglongjmp(xx, 10);
+-exit(1);
++return 1;
+ #endif
+ }
+ _ACEOF
+@@ -5209,7 +5211,11 @@ else
+ #if defined (HAVE_LOCALE_H)
+ #include <locale.h>
+ #endif
++#if defined (HAVE_STRING_H)
++#include <string.h>
++#endif
+ 
++int
+ main(c, v)
+ int     c;
+ char    *v[];
+@@ -5237,7 +5243,7 @@ char    *v[];
+         /* Exit with 1 (failure) if these two values are both > 0, since
+ 	   this tests whether strcoll(3) is broken with respect to strcmp(3)
+ 	   in the default locale. */
+-	exit (r1 > 0 && r2 > 0);
++	return (r1 > 0 && r2 > 0);
+ }
+ 
+ _ACEOF
+@@ -5280,6 +5286,7 @@ else
+ #include <stdio.h>
+ #include <ctype.h>
+ 
++int
+ main(c, v)
+ int	c;
+ char	*v[];
+@@ -5301,7 +5308,7 @@ char	*v[];
+ 	r1 = isprint(x);
+ 	x -= 128;
+ 	r2 = isprint(x);
+-	exit (r1 == 0 || r2 == 0);
++	return r1 == 0 || r2 == 0;
+ }
+ 
+ _ACEOF
+@@ -6337,6 +6344,7 @@ else
+ #include <locale.h>
+ #include <wchar.h>
+ 
++int
+ main(c, v)
+ int     c;
+ char    **v;

--- a/packages/r/readline6/files/compat-readline6-wcwidth.patch
+++ b/packages/r/readline6/files/compat-readline6-wcwidth.patch
@@ -1,0 +1,47 @@
+Include <wchar.h> for wcwidth prototype.
+
+diff --git a/complete.c b/complete.c
+index 35d86e915a7e74c5..df267e2754098ba2 100644
+--- a/complete.c
++++ b/complete.c
+@@ -82,6 +82,10 @@ typedef int QSFUNC ();
+ #  define LSTAT stat
+ #endif
+ 
++/* Ideally, we would build with -D_XOPEN_SOURCE.  */
++#include <wchar.h>
++int wcwidth (wchar_t);
++
+ /* Unix version of a hidden file.  Could be different on other systems. */
+ #define HIDDEN_FILE(fname)	((fname)[0] == '.')
+ 
+diff --git a/display.c b/display.c
+index 10a7b81cff278df9..dbf6db53300ee2ff 100644
+--- a/display.c
++++ b/display.c
+@@ -63,6 +63,10 @@
+ extern char *strchr (), *strrchr ();
+ #endif /* !strchr && !__STDC__ */
+ 
++/* Ideally, we would build with -D_XOPEN_SOURCE.  */
++#include <wchar.h>
++int wcwidth (wchar_t);
++
+ static void update_line PARAMS((char *, char *, int, int, int, int));
+ static void space_to_eol PARAMS((int));
+ static void delete_chars PARAMS((int));
+diff --git a/mbutil.c b/mbutil.c
+index b036e0c3264fc71b..792c5ed59e5790c4 100644
+--- a/mbutil.c
++++ b/mbutil.c
+@@ -42,6 +42,10 @@
+ #include <stdio.h>
+ #include <ctype.h>
+ 
++/* Ideally, we would build with -D_XOPEN_SOURCE.  */
++#include <wchar.h>
++int wcwidth (wchar_t);
++
+ /* System-specific feature definitions and include files. */
+ #include "rldefs.h"
+ #include "rlmbutil.h"

--- a/packages/r/readline6/files/readline-6.2-gdb.patch
+++ b/packages/r/readline6/files/readline-6.2-gdb.patch
@@ -1,0 +1,24 @@
+diff -up ./complete.c.old ./complete.c
+--- ./complete.c.old	2012-01-11 14:26:23.610354454 +0100
++++ ./complete.c	2012-01-11 14:31:44.073348115 +0100
+@@ -485,7 +485,7 @@ get_y_or_n (for_pager)
+      driven functions.  Have to wait until next major version to add new
+      state definition, since it will change value of RL_STATE_DONE. */
+ #if defined (READLINE_CALLBACKS)
+-  if (RL_ISSTATE (RL_STATE_CALLBACK))
++  if (RL_ISSTATE (RL_STATE_CALLBACK) && (! RL_ISSTATE (RL_STATE_FEDORA_GDB)))
+     return 1;
+ #endif
+ 
+diff -up ./readline.h.old ./readline.h
+--- ./readline.h.old	2012-01-11 14:25:55.049711510 +0100
++++ ./readline.h	2012-01-11 14:28:22.854863691 +0100
+@@ -840,6 +840,8 @@ extern int rl_inhibit_completion;
+ 
+ #define RL_STATE_DONE		0x1000000	/* done; accepted line */
+ 
++#define RL_STATE_FEDORA_GDB		0x2000000	/* exception for fedora gdb */
++
+ #define RL_SETSTATE(x)		(rl_readline_state |= (x))
+ #define RL_UNSETSTATE(x)	(rl_readline_state &= ~(x))
+ #define RL_ISSTATE(x)		(rl_readline_state & (x))

--- a/packages/r/readline6/files/readline-6.2-shlib.patch
+++ b/packages/r/readline6/files/readline-6.2-shlib.patch
@@ -1,0 +1,58 @@
+From 5f7f73a57b16ef58769004fe2f4111baf1c81690 Mon Sep 17 00:00:00 2001
+From: Jan Chaloupka <jchaloup@redhat.com>
+Date: Mon, 21 Jul 2014 13:50:01 +0200
+Subject: [PATCH] shlib
+
+---
+ shlib/Makefile.in     | 2 +-
+ support/shlib-install | 2 +-
+ support/shobj-conf    | 5 +++--
+ 3 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/shlib/Makefile.in b/shlib/Makefile.in
+index eb16211..3a34840 100644
+--- a/shlib/Makefile.in
++++ b/shlib/Makefile.in
+@@ -178,7 +178,7 @@ $(SHARED_READLINE):	$(SHARED_OBJ)
+ 
+ $(SHARED_HISTORY):	$(SHARED_HISTOBJ) xmalloc.so xfree.so
+ 	$(RM) $@
+-	$(SHOBJ_LD) ${SHOBJ_LDFLAGS} ${SHLIB_XLDFLAGS} -o $@ $(SHARED_HISTOBJ) xmalloc.so xfree.so $(SHLIB_LIBS)
++	$(SHOBJ_LD) ${SHOBJ_LDFLAGS} ${SHLIB_XLDFLAGS} -o $@ $(SHARED_HISTOBJ) xmalloc.so xfree.so
+ 
+ # Since tilde.c is shared between readline and bash, make sure we compile 
+ # it with the right flags when it's built as part of readline
+diff --git a/support/shlib-install b/support/shlib-install
+index cfec3bd..f4eea27 100755
+--- a/support/shlib-install
++++ b/support/shlib-install
+@@ -73,7 +73,7 @@ fi
+ case "$host_os" in
+ hpux*|darwin*|macosx*|linux*|solaris2*)
+ 	if [ -z "$uninstall" ]; then
+-		chmod 555 ${INSTALLDIR}/${LIBNAME}
++		chmod 755 ${INSTALLDIR}/${LIBNAME}
+ 	fi ;;
+ cygwin*|mingw*)
+ 	IMPLIBNAME=`echo ${LIBNAME} \
+diff --git a/support/shobj-conf b/support/shobj-conf
+index 1f64433..40827a4 100644
+--- a/support/shobj-conf
++++ b/support/shobj-conf
+@@ -126,10 +126,11 @@ sunos5*|solaris2*)
+ linux*-*|gnu*-*|k*bsd*-gnu-*|freebsd*-gentoo)
+ 	SHOBJ_CFLAGS=-fPIC
+ 	SHOBJ_LD='${CC}'
+-	SHOBJ_LDFLAGS='-shared -Wl,-soname,$@'
++	SHOBJ_LDFLAGS='$(CFLAGS) -shared -Wl,-soname,$@'
+ 
+-	SHLIB_XLDFLAGS='-Wl,-rpath,$(libdir) -Wl,-soname,`basename $@ $(SHLIB_MINOR)`'
++	SHLIB_XLDFLAGS='-Wl,-soname,`basename $@ $(SHLIB_MINOR)`'
+ 	SHLIB_LIBVERSION='$(SHLIB_LIBSUFF).$(SHLIB_MAJOR)$(SHLIB_MINOR)'
++	SHLIB_LIBS='-ltinfo'
+ 	;;
+ 
+ freebsd2*)
+-- 
+1.9.3
+

--- a/packages/r/readline6/files/readline-6.3-config.patch
+++ b/packages/r/readline6/files/readline-6.3-config.patch
@@ -1,0 +1,24 @@
+diff -Nrup a/aclocal.m4 b/aclocal.m4
+--- a/aclocal.m4	2013-10-20 16:37:50.000000000 -0600
++++ b/aclocal.m4	2020-01-14 10:41:28.792393160 -0700
+@@ -1307,7 +1307,7 @@ AC_CACHE_VAL(bash_cv_must_reinstall_sigh
+ 
+ typedef RETSIGTYPE sigfunc();
+ 
+-int nsigint;
++volatile int nsigint;
+ 
+ #ifdef HAVE_POSIX_SIGNALS
+ sigfunc *
+diff -Nrup a/configure b/configure
+--- a/configure	2013-03-13 08:14:53.000000000 -0600
++++ b/configure	2020-01-14 11:34:47.043290210 -0700
+@@ -5029,7 +5029,7 @@ else
+ 
+ typedef RETSIGTYPE sigfunc();
+ 
+-int nsigint;
++volatile int nsigint;
+ 
+ #ifdef HAVE_POSIX_SIGNALS
+ sigfunc *

--- a/packages/r/readline6/files/readline-6.3-pre-c23.patch
+++ b/packages/r/readline6/files/readline-6.3-pre-c23.patch
@@ -1,0 +1,427 @@
+commit 3c7a6b61220f18c9a23e6be1e94027f0a732f5d4
+Author: Ivan Trepakov <liontiger23@gmail.com>
+Date:   Thu Nov 13 00:08:09 2025 +0700
+
+    Fix compatibility with C23
+
+diff --git a/bind.c b/bind.c
+index 8acf4ac..19e9299 100644
+--- a/bind.c
++++ b/bind.c
+@@ -65,10 +65,6 @@ extern int errno;
+ #include "rlshell.h"
+ #include "xmalloc.h"
+ 
+-#if !defined (strchr) && !defined (__STDC__)
+-extern char *strchr (), *strrchr ();
+-#endif /* !strchr && !__STDC__ */
+-
+ /* Variables exported by this file. */
+ Keymap rl_binding_keymap;
+ 
+diff --git a/display.c b/display.c
+index dbf6db5..9cb7f1a 100644
+--- a/display.c
++++ b/display.c
+@@ -59,9 +59,6 @@
+ #include "rlprivate.h"
+ #include "xmalloc.h"
+ 
+-#if !defined (strchr) && !defined (__STDC__)
+-extern char *strchr (), *strrchr ();
+-#endif /* !strchr && !__STDC__ */
+ 
+ /* Ideally, we would build with -D_XOPEN_SOURCE.  */
+ #include <wchar.h>
+@@ -2222,29 +2219,15 @@ rl_character_len (c, pos)
+    mini-modeline. */
+ static int msg_saved_prompt = 0;
+ 
+-#if defined (USE_VARARGS)
+ int
+-#if defined (PREFER_STDARG)
+ rl_message (const char *format, ...)
+-#else
+-rl_message (va_alist)
+-     va_dcl
+-#endif
+ {
+   va_list args;
+-#if defined (PREFER_VARARGS)
+-  char *format;
+-#endif
+ #if defined (HAVE_VSNPRINTF)
+   int bneed;
+ #endif
+ 
+-#if defined (PREFER_STDARG)
+   va_start (args, format);
+-#else
+-  va_start (args);
+-  format = va_arg (args, char *);
+-#endif
+ 
+   if (msg_buf == 0)
+     msg_buf = xmalloc (msg_bufsiz = 128);
+@@ -2257,12 +2240,7 @@ rl_message (va_alist)
+       msg_buf = xrealloc (msg_buf, msg_bufsiz);
+       va_end (args);
+ 
+-#if defined (PREFER_STDARG)
+       va_start (args, format);
+-#else
+-      va_start (args);
+-      format = va_arg (args, char *);
+-#endif
+       vsnprintf (msg_buf, msg_bufsiz - 1, format, args);
+     }
+ #else
+@@ -2293,40 +2271,6 @@ rl_message (va_alist)
+ 
+   return 0;
+ }
+-#else /* !USE_VARARGS */
+-int
+-rl_message (format, arg1, arg2)
+-     char *format;
+-{
+-  if (msg_buf == 0)
+-    msg_buf = xmalloc (msg_bufsiz = 128);
+-
+-  sprintf (msg_buf, format, arg1, arg2);
+-  msg_buf[msg_bufsiz - 1] = '\0';	/* overflow? */
+-
+-  rl_display_prompt = msg_buf;
+-  if (saved_local_prompt == 0)
+-    {
+-      rl_save_prompt ();
+-      msg_saved_prompt = 1;
+-    }
+-  else if (local_prompt != saved_local_prompt)
+-    {
+-      FREE (local_prompt);
+-      FREE (local_prompt_prefix);
+-      local_prompt = (char *)NULL;
+-    }
+-  local_prompt = expand_prompt (msg_buf, &prompt_visible_length,
+-					 &prompt_last_invisible,
+-					 &prompt_invis_chars_first_line,
+-					 &prompt_physical_chars);
+-  local_prompt_prefix = (char *)NULL;
+-  local_prompt_len = local_prompt ? strlen (local_prompt) : 0;
+-  (*rl_redisplay_function) ();
+-      
+-  return 0;
+-}
+-#endif /* !USE_VARARGS */
+ 
+ /* How to clear things from the "echo-area". */
+ int
+diff --git a/histlib.h b/histlib.h
+index c938a10..018097e 100644
+--- a/histlib.h
++++ b/histlib.h
+@@ -51,9 +51,6 @@
+ #endif
+ 
+ #ifndef member
+-#  ifndef strchr
+-extern char *strchr ();
+-#  endif
+ #define member(c, s) ((c) ? ((char *)strchr ((s), (c)) != (char *)NULL) : 0)
+ #endif
+ 
+diff --git a/parens.c b/parens.c
+index 9c98488..5640973 100644
+--- a/parens.c
++++ b/parens.c
+@@ -46,10 +46,6 @@
+ #  include <strings.h>
+ #endif /* !HAVE_STRING_H */
+ 
+-#if !defined (strchr) && !defined (__STDC__)
+-extern char *strchr (), *strrchr ();
+-#endif /* !strchr && !__STDC__ */
+-
+ #include "readline.h"
+ #include "rlprivate.h"
+ 
+diff --git a/readline.h b/readline.h
+index 08dcd2b..202baaa 100644
+--- a/readline.h
++++ b/readline.h
+@@ -379,11 +379,7 @@ extern int rl_clear_message PARAMS((void));
+ extern int rl_reset_line_state PARAMS((void));
+ extern int rl_crlf PARAMS((void));
+ 
+-#if defined (USE_VARARGS) && defined (PREFER_STDARG)
+ extern int rl_message (const char *, ...)  __attribute__((__format__ (printf, 1, 2)));
+-#else
+-extern int rl_message ();
+-#endif
+ 
+ extern int rl_show_char PARAMS((int));
+ 
+diff --git a/rldefs.h b/rldefs.h
+index dab1beb..7b0f656 100644
+--- a/rldefs.h
++++ b/rldefs.h
+@@ -63,17 +63,7 @@
+ #  include <strings.h>
+ #endif /* !HAVE_STRING_H */
+ 
+-#if !defined (strchr) && !defined (__STDC__)
+-extern char *strchr (), *strrchr ();
+-#endif /* !strchr && !__STDC__ */
+-
+-#if defined (PREFER_STDARG)
+-#  include <stdarg.h>
+-#else
+-#  if defined (PREFER_VARARGS)
+-#    include <varargs.h>
+-#  endif
+-#endif
++#include <stdarg.h>
+ 
+ #if defined (HAVE_STRCASECMP)
+ #define _rl_stricmp strcasecmp
+diff --git a/rlprivate.h b/rlprivate.h
+index 14a370d..886548b 100644
+--- a/rlprivate.h
++++ b/rlprivate.h
+@@ -380,15 +380,9 @@ extern UNDO_LIST *_rl_copy_undo_list PARAMS((UNDO_LIST *));
+ extern void _rl_free_undo_list PARAMS((UNDO_LIST *));
+ 
+ /* util.c */
+-#if defined (USE_VARARGS) && defined (PREFER_STDARG)
+ extern void _rl_ttymsg (const char *, ...)  __attribute__((__format__ (printf, 1, 2)));
+ extern void _rl_errmsg (const char *, ...)  __attribute__((__format__ (printf, 1, 2)));
+ extern void _rl_trace (const char *, ...)  __attribute__((__format__ (printf, 1, 2)));
+-#else
+-extern void _rl_ttymsg ();
+-extern void _rl_errmsg ();
+-extern void _rl_trace ();
+-#endif
+ extern void _rl_audit_tty PARAMS((char *));
+ 
+ extern int _rl_tropen PARAMS((void));
+diff --git a/rlstdc.h b/rlstdc.h
+index 2aaa30b..a6d2394 100644
+--- a/rlstdc.h
++++ b/rlstdc.h
+@@ -42,16 +42,4 @@
+ #  endif
+ #endif
+ 
+-/* Moved from config.h.in because readline.h:rl_message depends on these
+-   defines. */
+-#if defined (__STDC__) && defined (HAVE_STDARG_H)
+-#  define PREFER_STDARG
+-#  define USE_VARARGS
+-#else
+-#  if defined (HAVE_VARARGS_H)
+-#    define PREFER_VARARGS
+-#    define USE_VARARGS
+-#  endif
+-#endif
+-
+ #endif /* !_RL_STDC_H_ */
+diff --git a/signals.c b/signals.c
+index 61f02f9..efed49d 100644
+--- a/signals.c
++++ b/signals.c
+@@ -48,23 +48,11 @@
+ 
+ #if defined (HANDLE_SIGNALS)
+ 
+-#if !defined (RETSIGTYPE)
+-#  if defined (VOID_SIGHANDLER)
+-#    define RETSIGTYPE void
+-#  else
+-#    define RETSIGTYPE int
+-#  endif /* !VOID_SIGHANDLER */
+-#endif /* !RETSIGTYPE */
+-
+-#if defined (VOID_SIGHANDLER)
+-#  define SIGHANDLER_RETURN return
+-#else
+-#  define SIGHANDLER_RETURN return (0)
+-#endif
++#define SIGHANDLER_RETURN return
+ 
+ /* This typedef is equivalent to the one for Function; it allows us
+    to say SigHandler *foo = signal (SIGKILL, SIG_IGN); */
+-typedef RETSIGTYPE SigHandler ();
++typedef void SigHandler (int);
+ 
+ #if defined (HAVE_POSIX_SIGNALS)
+ typedef struct sigaction sighandler_cxt;
+@@ -82,8 +70,8 @@ static SigHandler *rl_set_sighandler PARAMS((int, SigHandler *, sighandler_cxt *
+ static void rl_maybe_set_sighandler PARAMS((int, SigHandler *, sighandler_cxt *));
+ static void rl_maybe_restore_sighandler PARAMS((int, sighandler_cxt *));
+ 
+-static RETSIGTYPE rl_signal_handler PARAMS((int));
+-static RETSIGTYPE _rl_handle_signal PARAMS((int));
++static void rl_signal_handler PARAMS((int));
++static void _rl_handle_signal PARAMS((int));
+      
+ /* Exported variables for use by applications. */
+ 
+@@ -133,7 +121,7 @@ void *_rl_sigcleanarg;
+ /* Readline signal handler functions. */
+ 
+ /* Called from RL_CHECK_SIGNALS() macro */
+-RETSIGTYPE
++void
+ _rl_signal_handler (sig)
+      int sig;
+ {
+@@ -157,7 +145,7 @@ _rl_signal_handler (sig)
+   SIGHANDLER_RETURN;
+ }
+ 
+-static RETSIGTYPE
++static void
+ rl_signal_handler (sig)
+      int sig;
+ {
+@@ -172,7 +160,7 @@ rl_signal_handler (sig)
+   SIGHANDLER_RETURN;
+ }
+ 
+-static RETSIGTYPE
++static void
+ _rl_handle_signal (sig)
+      int sig;
+ {
+@@ -268,7 +256,7 @@ _rl_handle_signal (sig)
+ }
+ 
+ #if defined (SIGWINCH)
+-static RETSIGTYPE
++static void
+ rl_sigwinch_handler (sig)
+      int sig;
+ {
+diff --git a/util.c b/util.c
+index a8ab81a..a567656 100644
+--- a/util.c
++++ b/util.c
+@@ -232,26 +232,12 @@ rl_tilde_expand (ignore, key)
+   return (0);
+ }
+ 
+-#if defined (USE_VARARGS)
+ void
+-#if defined (PREFER_STDARG)
+ _rl_ttymsg (const char *format, ...)
+-#else
+-_rl_ttymsg (va_alist)
+-     va_dcl
+-#endif
+ {
+   va_list args;
+-#if defined (PREFER_VARARGS)
+-  char *format;
+-#endif
+ 
+-#if defined (PREFER_STDARG)
+   va_start (args, format);
+-#else
+-  va_start (args);
+-  format = va_arg (args, char *);
+-#endif
+ 
+   fprintf (stderr, "readline: ");
+   vfprintf (stderr, format, args);
+@@ -264,24 +250,11 @@ _rl_ttymsg (va_alist)
+ }
+ 
+ void
+-#if defined (PREFER_STDARG)
+ _rl_errmsg (const char *format, ...)
+-#else
+-_rl_errmsg (va_alist)
+-     va_dcl
+-#endif
+ {
+   va_list args;
+-#if defined (PREFER_VARARGS)
+-  char *format;
+-#endif
+ 
+-#if defined (PREFER_STDARG)
+   va_start (args, format);
+-#else
+-  va_start (args);
+-  format = va_arg (args, char *);
+-#endif
+ 
+   fprintf (stderr, "readline: ");
+   vfprintf (stderr, format, args);
+@@ -291,28 +264,6 @@ _rl_errmsg (va_alist)
+   va_end (args);
+ }
+ 
+-#else /* !USE_VARARGS */
+-void
+-_rl_ttymsg (format, arg1, arg2)
+-     char *format;
+-{
+-  fprintf (stderr, "readline: ");
+-  fprintf (stderr, format, arg1, arg2);
+-  fprintf (stderr, "\n");
+-
+-  rl_forced_update_display ();
+-}
+-
+-void
+-_rl_errmsg (format, arg1, arg2)
+-     char *format;
+-{
+-  fprintf (stderr, "readline: ");
+-  fprintf (stderr, format, arg1, arg2);
+-  fprintf (stderr, "\n");
+-}
+-#endif /* !USE_VARARGS */
+-
+ /* **************************************************************** */
+ /*								    */
+ /*			String Utility Functions		    */
+@@ -477,28 +428,14 @@ _rl_savestring (s)
+ }
+ 
+ #if defined (DEBUG)
+-#if defined (USE_VARARGS)
+ static FILE *_rl_tracefp;
+ 
+ void
+-#if defined (PREFER_STDARG)
+ _rl_trace (const char *format, ...)
+-#else
+-_rl_trace (va_alist)
+-     va_dcl
+-#endif
+ {
+   va_list args;
+-#if defined (PREFER_VARARGS)
+-  char *format;
+-#endif
+ 
+-#if defined (PREFER_STDARG)
+   va_start (args, format);
+-#else
+-  va_start (args);
+-  format = va_arg (args, char *);
+-#endif
+ 
+   if (_rl_tracefp == 0)
+     _rl_tropen ();
+@@ -538,7 +475,6 @@ _rl_settracefp (fp)
+ {
+   _rl_tracefp = fp;
+ }
+-#endif
+ #endif /* DEBUG */
+ 
+ #if HAVE_DECL_AUDIT_USER_TTY && defined (ENABLE_TTY_AUDIT_SUPPORT)

--- a/packages/r/readline6/files/readline6.3-upstream-patches1-6.patch
+++ b/packages/r/readline6/files/readline6.3-upstream-patches1-6.patch
@@ -1,0 +1,126 @@
+From 549b257cc32325658360b2e349dfc9cadc33ff80 Mon Sep 17 00:00:00 2001
+From: Jan Chaloupka <jchaloup@redhat.com>
+Date: Mon, 21 Jul 2014 14:40:03 +0200
+Subject: [PATCH] upstream
+
+---
+ display.c    | 10 ++++++++--
+ readline.c   |  6 ++++--
+ rltypedefs.h | 19 +++++++++++++++++++
+ util.c       |  3 ++-
+ 4 files changed, 33 insertions(+), 5 deletions(-)
+
+diff --git a/display.c b/display.c
+index 913e0da..10a7b81 100644
+--- a/display.c
++++ b/display.c
+@@ -1637,7 +1637,7 @@ update_line (old, new, current_line, omax, nmax, inv_botlin)
+   /* If we are changing the number of invisible characters in a line, and
+      the spot of first difference is before the end of the invisible chars,
+      lendiff needs to be adjusted. */
+-  if (current_line == 0 && !_rl_horizontal_scroll_mode &&
++  if (current_line == 0 && /* !_rl_horizontal_scroll_mode && */
+       current_invis_chars != visible_wrap_offset)
+     {
+       if (MB_CUR_MAX > 1 && rl_byte_oriented == 0)
+@@ -1825,8 +1825,13 @@ update_line (old, new, current_line, omax, nmax, inv_botlin)
+ 	      else
+ 		_rl_last_c_pos += bytes_to_insert;
+ 
++	      /* XXX - we only want to do this if we are at the end of the line
+++                so we move there with _rl_move_cursor_relative */
+ 	      if (_rl_horizontal_scroll_mode && ((oe-old) > (ne-new)))
+-		goto clear_rest_of_line;
++		{
++                  _rl_move_cursor_relative (ne-new, new);
++                  goto clear_rest_of_line;
++                }
+ 	    }
+ 	}
+       /* Otherwise, print over the existing material. */
+@@ -2677,6 +2682,7 @@ _rl_clean_up_for_exit ()
+ {
+   if (_rl_echoing_p)
+     {
++      if (_rl_vis_botlin > 0) /* minor optimization plus bug fix */
+       _rl_move_vert (_rl_vis_botlin);
+       _rl_vis_botlin = 0;
+       fflush (rl_outstream);
+diff --git a/readline.c b/readline.c
+index 03eefa6..684a589 100644
+--- a/readline.c
++++ b/readline.c
+@@ -744,7 +744,9 @@ _rl_dispatch_callback (cxt)
+     r = _rl_subseq_result (r, cxt->oldmap, cxt->okey, (cxt->flags & KSEQ_SUBSEQ));
+ 
+   RL_CHECK_SIGNALS ();
+-  if (r == 0)			/* success! */
++  /* We only treat values < 0 specially to simulate recursion. */
++  if (r >= 0 || (r == -1 && (cxt->flags & KSEQ_SUBSEQ) == 0)) /* success! or 
++failure! */
+     {
+       _rl_keyseq_chain_dispose ();
+       RL_UNSETSTATE (RL_STATE_MULTIKEY);
+@@ -964,7 +966,7 @@ _rl_dispatch_subseq (key, map, got_subseq)
+ #if defined (VI_MODE)
+   if (rl_editing_mode == vi_mode && _rl_keymap == vi_movement_keymap &&
+       key != ANYOTHERKEY &&
+-      rl_key_sequence_length == 1 &&	/* XXX */
++      _rl_dispatching_keymap == vi_movement_keymap &&
+       _rl_vi_textmod_command (key))
+     _rl_vi_set_last (key, rl_numeric_arg, rl_arg_sign);
+ #endif
+diff --git a/rltypedefs.h b/rltypedefs.h
+index b113ee6..f9f5cd3 100644
+--- a/rltypedefs.h
++++ b/rltypedefs.h
+@@ -26,6 +26,25 @@
+ extern "C" {
+ #endif
+ 
++/* Old-style, attempt to mark as deprecated in some way people will notice. */
++
++#if !defined (_FUNCTION_DEF)
++#  define _FUNCTION_DEF
++
++#if defined(__GNUC__) || defined(__clang__)
++typedef int Function () __attribute__ ((deprecated));
++typedef void VFunction () __attribute__ ((deprecated));
++typedef char *CPFunction () __attribute__ ((deprecated));
++typedef char **CPPFunction () __attribute__ ((deprecated));
++#else
++typedef int Function ();
++typedef void VFunction ();
++typedef char *CPFunction ();
++typedef char **CPPFunction ();
++#endif
++
++#endif /* _FUNCTION_DEF */
++
+ /* New style. */
+ 
+ #if !defined (_RL_FUNCTION_TYPEDEF)
+diff --git a/util.c b/util.c
+index fa3a667..a8ab81a 100644
+--- a/util.c
++++ b/util.c
+@@ -476,6 +476,7 @@ _rl_savestring (s)
+   return (strcpy ((char *)xmalloc (1 + (int)strlen (s)), (s)));
+ }
+ 
++#if defined (DEBUG)
+ #if defined (USE_VARARGS)
+ static FILE *_rl_tracefp;
+ 
+@@ -538,7 +539,7 @@ _rl_settracefp (fp)
+   _rl_tracefp = fp;
+ }
+ #endif
+-
++#endif /* DEBUG */
+ 
+ #if HAVE_DECL_AUDIT_USER_TTY && defined (ENABLE_TTY_AUDIT_SUPPORT)
+ #include <sys/socket.h>
+-- 
+1.9.3
+

--- a/packages/r/readline6/package.yml
+++ b/packages/r/readline6/package.yml
@@ -1,8 +1,8 @@
 name       : readline6
 version    : 6.3.008
-release    : 2
+release    : 3
 source     :
-    - https://ftp.gnu.org/gnu/readline/readline-6.3.tar.gz : 56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43
+    - https://ftpmirror.gnu.org/gnu/readline/readline-6.3.tar.gz : 56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43
 homepage   : https://tiswww.case.edu/php/chet/readline/rltop.html
 license    : GPL-3.0-or-later
 component  : binary.compat
@@ -13,10 +13,27 @@ builddeps  :
     - pkgconfig32(ncursesw)
 emul32     : true
 setup      : |
-    %configure --disable-static \
+    %patch -p1 -i $pkgfiles/readline6.3-upstream-patches1-6.patch
+
+    # add workaround for problem in gdb
+    # in new version of readline needs to be deleted
+    %patch -p1 -i $pkgfiles/readline-6.2-gdb.patch
+
+    # fix file permissions, remove RPATH, use CFLAGS
+    %patch -p1 -i $pkgfiles/readline-6.2-shlib.patch
+    %patch -p1 -i $pkgfiles/readline-6.3-config.patch
+    %patch -p1 -i $pkgfiles/compat-readline6-wcwidth.patch
+    %patch -p1 -i $pkgfiles/compat-readline6-configure-c99.patch
+
+    %patch -p1 -i $pkgfiles/readline-6.3-pre-c23.patch
+
+    %configure_no_runstatedir \
+        --disable-static \
         --with-curses
 build      : |
-    %make SHLIB_LIBS=-lncurses
+    export CPPFLAGS="-I/usr/include"
+    # make SHLIB_LIBS=-lncurses
+    %make
 install    : |
     %make_install
 

--- a/packages/r/readline6/pspec_x86_64.xml
+++ b/packages/r/readline6/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>readline6</Name>
         <Homepage>https://tiswww.case.edu/php/chet/readline/rltop.html</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Ivan Trepakov</Name>
+            <Email>liontiger23@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>binary.compat</PartOf>
         <Summary xml:lang="en">readline6 (Binary Compatibility Library)</Summary>
         <Description xml:lang="en">This package provides binary compatibility only. It is forbidden to build against it.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>readline6</Name>
@@ -33,7 +33,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">readline6</Dependency>
+            <Dependency release="3">readline6</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libhistory.so.6</Path>
@@ -43,12 +43,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2022-03-30</Date>
+        <Update release="3">
+            <Date>2025-11-12</Date>
             <Version>6.3.008</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Ivan Trepakov</Name>
+            <Email>liontiger23@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Switch to stable mirror
- Pull in all the patches that Fedora carries
- Backport patch for C23 compilation from upstream
- Resolves https://github.com/getsolus/packages/issues/6760

**Test Plan**

<!-- Short description of how the package was tested -->

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
