### PR TITLE
libcupsfilters:

### DIFF
--- a/packages/l/libcupsfilters/files/CVE-2025-57812.patch
+++ b/packages/l/libcupsfilters/files/CVE-2025-57812.patch
@@ -1,0 +1,124 @@
+From b69dfacec7f176281782e2f7ac44f04bf9633cfa Mon Sep 17 00:00:00 2001
+From: zdohnal <zdohnal@redhat.com>
+Date: Mon, 10 Nov 2025 18:58:31 +0100
+Subject: [PATCH] Merge commit from fork
+
+* Fix heap-buffer overflow write in cfImageLut
+
+1. fix for CVE-2025-57812
+
+* Reject color images with 1 bit per sample
+
+2. fix for CVE-2025-57812
+
+* Reject images where the number of samples does not correspond with the color space
+
+3. fix for CVE-2025-57812
+
+* Reject images with planar color configuration
+
+4. fix for CVE-2025-57812
+
+* Reject images with vertical scanlines
+
+5.  fix for CVE-2025-57812
+
+---------
+
+Co-authored-by: Till Kamppeter <till.kamppeter@gmail.com>
+---
+ cupsfilters/image-tiff.c | 46 +++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 45 insertions(+), 1 deletion(-)
+
+diff --git a/cupsfilters/image-tiff.c b/cupsfilters/image-tiff.c
+index 20dfbaee6..748e2db63 100644
+--- a/cupsfilters/image-tiff.c
++++ b/cupsfilters/image-tiff.c
+@@ -41,6 +41,7 @@ _cfImageReadTIFF(
+   TIFF		*tif;			// TIFF file
+   uint32_t	width, height;		// Size of image
+   uint16_t	photometric,		// Colorspace
++    planar,         // Color components in separate planes
+ 		compression,		// Type of compression
+ 		orientation,		// Orientation
+ 		resunit,		// Units for resolution
+@@ -113,6 +114,15 @@ _cfImageReadTIFF(
+     return (-1);
+   }
+ 
++  if (TIFFGetField(tif, TIFFTAG_PLANARCONFIG, &planar) &&
++      planar == PLANARCONFIG_SEPARATE)
++  {
++    fputs("DEBUG: Images with planar color configuration are not supported!\n", stderr);
++    TIFFClose(tif);
++    fclose(fp);
++    return (1);
++  }
++
+   if (!TIFFGetField(tif, TIFFTAG_COMPRESSION, &compression))
+   {
+     DEBUG_puts("DEBUG: No compression tag in the file!\n");
+@@ -127,6 +137,15 @@ _cfImageReadTIFF(
+   if (!TIFFGetField(tif, TIFFTAG_BITSPERSAMPLE, &bits))
+     bits = 1;
+ 
++  if (bits == 1 && samples > 1)
++  {
++    fprintf(stderr, "ERROR: Color images with 1 bit per sample not supported! "
++                    "Samples per pixel: %d; Bits per sample: %d\n", samples, bits);
++    TIFFClose(tif);
++    fclose(fp);
++    return (1);
++  }
++
+   //
+   // Get the image orientation...
+   //
+@@ -193,6 +212,23 @@ _cfImageReadTIFF(
+   else
+     alpha = 0;
+ 
++  //
++  // Check whether number of samples per pixel corresponds with color space
++  //
++
++  if ((photometric == PHOTOMETRIC_RGB && (samples < 3 || samples > 4)) ||
++      (photometric == PHOTOMETRIC_SEPARATED && samples != 4))
++  {
++    fprintf(stderr, "DEBUG: Number of samples per pixel does not correspond to color space! "
++                    "Color space: %s; Samples per pixel: %d\n",
++                    (photometric == PHOTOMETRIC_RGB ? "RGB" :
++                     (photometric == PHOTOMETRIC_SEPARATED ? "CMYK" : "Unknown")),
++                    samples);
++    TIFFClose(tif);
++    fclose(fp);
++    return (1);
++  }
++
+   //
+   // Check the size of the image...
+   //
+@@ -265,6 +301,14 @@ _cfImageReadTIFF(
+         break;
+   }
+ 
++  if (orientation >= ORIENTATION_LEFTTOP)
++  {
++    fputs("ERROR: TIFF files with vertical scanlines are not supported!\n", stderr);
++    TIFFClose(tif);
++    fclose(fp);
++    return (-1);
++  }
++
+   switch (orientation)
+   {
+     case ORIENTATION_TOPRIGHT :
+@@ -1493,7 +1537,7 @@ _cfImageReadTIFF(
+ 	      }
+ 
+ 	      if (lut)
+-	        cfImageLut(out, img->xsize * 3, lut);
++	        cfImageLut(out, img->xsize * bpp, lut);
+ 
+               _cfImagePutRow(img, 0, y, img->xsize, out);
+             }

--- a/packages/l/libcupsfilters/package.yml
+++ b/packages/l/libcupsfilters/package.yml
@@ -1,6 +1,6 @@
 name       : libcupsfilters
 version    : 2.1.0
-release    : 6
+release    : 7
 source     :
     - https://github.com/OpenPrinting/libcupsfilters/releases/download/2.1.0/libcupsfilters-2.1.0.tar.gz : 33b35a3761f2adaaf1c4210e956255b4d9ba2d79008008537356bc34057b3471
 homepage   : https://github.com/OpenPrinting/libcupsfilters
@@ -24,6 +24,7 @@ rundeps    :
         - cups-devel
 clang      : true
 setup      : |
+    %patch -p1 -i $pkgfiles/CVE-2025-57812.patch
     %configure \
                --disable-mutool \
                --disable-static \

--- a/packages/l/libcupsfilters/pspec_x86_64.xml
+++ b/packages/l/libcupsfilters/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libcupsfilters</Name>
         <Homepage>https://github.com/OpenPrinting/libcupsfilters</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>Apache-2.0 WITH LLVM-exception</License>
         <PartOf>desktop.core</PartOf>
@@ -54,7 +54,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="6">libcupsfilters</Dependency>
+            <Dependency release="7">libcupsfilters</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/cupsfilters/bitmap.h</Path>
@@ -74,12 +74,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2025-09-28</Date>
+        <Update release="7">
+            <Date>2025-11-13</Date>
             <Version>2.1.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Security**

- CVE-2025-57812

**Test Plan**

- WIP

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
