### PR TITLE
python-cffi: [NFC] update package with https homepage

### DIFF
--- a/packages/py/python-cffi/package.yml
+++ b/packages/py/python-cffi/package.yml
@@ -1,9 +1,9 @@
 name       : python-cffi
 version    : 1.17.1
-release    : 20
+release    : 21
 source     :
     - https://pypi.io/packages/source/c/cffi/cffi-1.17.1.tar.gz : 1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824
-homepage   : http://cffi.readthedocs.org
+homepage   : https://cffi.readthedocs.io
 license    : MIT
 component  : programming.python
 summary    : Foreign Function Interface for Python calling C code

--- a/packages/py/python-cffi/pspec_x86_64.xml
+++ b/packages/py/python-cffi/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>python-cffi</Name>
-        <Homepage>http://cffi.readthedocs.org</Homepage>
+        <Homepage>https://cffi.readthedocs.io</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Marcus Dallum</Name>
+            <Email>marcus@dallum.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -21,11 +21,11 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_cffi_backend.cpython-312-x86_64-linux-gnu.so</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/cffi-1.17.1.dist-info/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/cffi-1.17.1.dist-info/METADATA</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/cffi-1.17.1.dist-info/RECORD</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/cffi-1.17.1.dist-info/WHEEL</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/cffi-1.17.1.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/cffi-1.17.1.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/cffi-1.17.1.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/cffi/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/cffi/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -88,12 +88,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2025-05-15</Date>
+        <Update release="21">
+            <Date>2025-11-14</Date>
             <Version>1.17.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Marcus Dallum</Name>
+            <Email>marcus@dallum.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Update HTTPS homepage for python-ccfi
- Part of https://github.com/getsolus/packages/issues/5522

**Test Plan**

installed python-cffi

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged 
