### PR TITLE
hunspell-he: Update to v1.4

### DIFF
--- a/packages/h/hunspell-he/package.yml
+++ b/packages/h/hunspell-he/package.yml
@@ -1,9 +1,9 @@
 name       : hunspell-he
-version    : 1.3
-release    : 3
+version    : '1.4'
+release    : 4
 source     :
-    - http://hspell.ivrix.org.il/hspell-1.3.tar.gz : 603c25dcbaa65d171d9065da7369cfe0dc21bda8378bade13b42eda69c8b2fe7
-homepage   : http://www.ivrix.org.il/projects/spell-checker/
+    - http://hspell.ivrix.org.il/hspell-1.4.tar.gz : 7310f5d58740d21d6d215c1179658602ef7da97a816bc1497c8764be97aabea3
+homepage   : http://www.ivrix.org.il/
 license    : GPL-2.0-or-later
 component  : office.spelling
 summary    : Hebrew hunspell dictionaries

--- a/packages/h/hunspell-he/pspec_x86_64.xml
+++ b/packages/h/hunspell-he/pspec_x86_64.xml
@@ -1,17 +1,17 @@
 <PISI>
     <Source>
         <Name>hunspell-he</Name>
-        <Homepage>http://www.ivrix.org.il/projects/spell-checker/</Homepage>
+        <Homepage>http://www.ivrix.org.il/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>office.spelling</PartOf>
         <Summary xml:lang="en">Hebrew hunspell dictionaries</Summary>
         <Description xml:lang="en">Hebrew hunspell dictionaries
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>hunspell-he</Name>
@@ -25,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2023-08-24</Date>
-            <Version>1.3</Version>
+        <Update release="4">
+            <Date>2025-11-15</Date>
+            <Version>1.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
• This month, the Academy of the Hebrew Language published a new version of their niqqud-less spelling standard, with some important changes from the old rules—mostly adding yod and waw in additional places; this version of Hspell will be the last one following the previous spelling standard, and the next release will be named "2.0" and will follow the new spelling standard.

• The niqqudless.odt document, which describes (in Hebrew) Hspell's spelling standard, is finally complete at 110 pages; there is still room for improvement and more content expected in the next releases, but the current document no longer has major holes and discusses the majority of spelling issues encountered during Hspell's development.

• Vocabulary: 469,509 words (when built with "--enable-fatverb") based on 24,534 base words: 12,929 nouns, 3,897 adjectives, 5,269 verb stems, and 2,439 other words.

**Test Plan**
- Spell checked.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
