### PR TITLE
shapelib: Update to v1.6.2

### DIFF
--- a/packages/s/shapelib/package.yml
+++ b/packages/s/shapelib/package.yml
@@ -1,15 +1,17 @@
 name       : shapelib
-version    : 1.6.1
-release    : 2
+version    : 1.6.2
+release    : 3
 source     :
-    - https://download.osgeo.org/shapelib/shapelib-1.6.1.tar.gz : 5da90a60e25440f108f4e8e95732bfa83ede13c8e0c2bcf80ae41006cc8ebc20
+    - https://download.osgeo.org/shapelib/shapelib-1.6.2.tar.gz : 4b74a36ced94e9a7bea401157e664addcc5be251e7df7f88d4674361da012c21
 homepage   : http://shapelib.maptools.org/
-license    : LGPL-2.0-or-later
+license    : MIT OR LGPL-2.0-or-later
 component  : programming.library
 summary    : Simple C API for reading and writing ESRI Shapefiles
 description: |
     Simple C API for reading and writing ESRI Shapefiles
 libsplit   : false
+environment: |
+    export CFLAGS="${CFLAGS} -std=gnu17"
 setup      : |
     %configure
 build      : |

--- a/packages/s/shapelib/pspec_x86_64.xml
+++ b/packages/s/shapelib/pspec_x86_64.xml
@@ -3,10 +3,10 @@
         <Name>shapelib</Name>
         <Homepage>http://shapelib.maptools.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
-        <License>LGPL-2.0-or-later</License>
+        <License>MIT OR LGPL-2.0-or-later</License>
         <PartOf>programming.library</PartOf>
         <Summary xml:lang="en">Simple C API for reading and writing ESRI Shapefiles</Summary>
         <Description xml:lang="en">Simple C API for reading and writing ESRI Shapefiles
@@ -44,17 +44,17 @@
             <Path fileType="header">/usr/include/shapefil.h</Path>
             <Path fileType="library">/usr/lib64/libshp.so</Path>
             <Path fileType="library">/usr/lib64/libshp.so.4</Path>
-            <Path fileType="library">/usr/lib64/libshp.so.4.1.0</Path>
+            <Path fileType="library">/usr/lib64/libshp.so.4.2.0</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/shapelib.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-11-06</Date>
-            <Version>1.6.1</Version>
+        <Update release="3">
+            <Date>2025-11-15</Date>
+            <Version>1.6.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Nullify userdata also in SASetupUtf8Hooks
- Test suite enhancements
- CMake: no longer use CTest and add manual BUILD_TESTING option instead (default to ON)
- Prefer tagged version of Google Benchmark
- dbfcreate: allow creation of Date and Logical fields
- Fix cppcheck nullPointerOutOfMemory warnings
- DBFWriteAttribute(): return true when no precision loss occured when writing a double
- SHPCreateLL()/DBFCreate(): make error message contains full filename (in case it is very long)

**Test Plan**
- Checked version.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
