### PR TITLE
plasma-desktop: Change default sddm SolusPlasma theme wallpaper

### DIFF
--- a/packages/p/plasma-desktop/files/branding/0001-Change-default-sddm-background.patch
+++ b/packages/p/plasma-desktop/files/branding/0001-Change-default-sddm-background.patch
@@ -16,5 +16,5 @@ index a560da377..ded046aa5 100644
  color=#1d99f3
  fontSize=10
 -background=${KDE_INSTALL_FULL_WALLPAPERDIR}/Next/contents/images/5120x2880.png
-+background=${KDE_INSTALL_FULL_WALLPAPERDIR}/SolusPlasma/contents/images/5120x2880.jpg
++background=${KDE_INSTALL_FULL_WALLPAPERDIR}/SolusPlasma/contents/images/3840x2160.jxl
  needsFullUserModel=false

--- a/packages/p/plasma-desktop/package.yml
+++ b/packages/p/plasma-desktop/package.yml
@@ -1,6 +1,6 @@
 name       : plasma-desktop
 version    : 6.5.2
-release    : 166
+release    : 167
 source     :
     - https://download.kde.org/stable/plasma/6.5.2/plasma-desktop-6.5.2.tar.xz : b0b2b3351fc8e6f53f0673e7bb4e0772d9df620e9d3de65e651d3d70306c7a58
 homepage   : https://www.kde.org/workspaces/plasmadesktop/

--- a/packages/p/plasma-desktop/pspec_x86_64.xml
+++ b/packages/p/plasma-desktop/pspec_x86_64.xml
@@ -3501,8 +3501,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="166">
-            <Date>2025-11-05</Date>
+        <Update release="167">
+            <Date>2025-11-16</Date>
             <Version>6.5.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Troy Harvey</Name>


### PR DESCRIPTION
**Summary**

This changes the sddm wallpaper for SolusPlasma theme. 

Depends on #7063 

**Test Plan**
- Install new plasma-desktop-branding and plasma-desktop
- See that default image for sddm changed.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
