### PR TITLE
libstartup-notification: Fix homepage link

### DIFF
--- a/packages/l/libstartup-notification/abi_used_symbols
+++ b/packages/l/libstartup-notification/abi_used_symbols
@@ -2,6 +2,8 @@ libX11-xcb.so.1:XGetXCBConnection
 libc.so.6:__assert_fail
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoul
 libc.so.6:__snprintf_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
@@ -21,8 +23,6 @@ libc.so.6:strcmp
 libc.so.6:strcpy
 libc.so.6:strlen
 libc.so.6:strncpy
-libc.so.6:strtol
-libc.so.6:strtoul
 libxcb-util.so.1:xcb_aux_get_screen
 libxcb.so.1:xcb_change_property
 libxcb.so.1:xcb_create_window

--- a/packages/l/libstartup-notification/abi_used_symbols32
+++ b/packages/l/libstartup-notification/abi_used_symbols32
@@ -2,6 +2,8 @@ libX11-xcb.so.1:XGetXCBConnection
 libc.so.6:__assert_fail
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoul
 libc.so.6:__snprintf_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
@@ -21,8 +23,6 @@ libc.so.6:strcmp
 libc.so.6:strcpy
 libc.so.6:strlen
 libc.so.6:strncpy
-libc.so.6:strtol
-libc.so.6:strtoul
 libxcb-util.so.1:xcb_aux_get_screen
 libxcb.so.1:xcb_change_property
 libxcb.so.1:xcb_create_window

--- a/packages/l/libstartup-notification/package.yml
+++ b/packages/l/libstartup-notification/package.yml
@@ -1,9 +1,9 @@
 name       : libstartup-notification
-version    : 0.12
-release    : 7
+version    : '0.12'
+release    : 8
 source     :
-    - http://www.freedesktop.org/software/startup-notification/releases/startup-notification-0.12.tar.gz : 3c391f7e930c583095045cd2d10eb73a64f085c7fde9d260f2652c7cb3cfbe4a
-homepage   : http://freedesktop.org/wiki/Software/startup-notification
+    - https://www.freedesktop.org/software/startup-notification/releases/startup-notification-0.12.tar.gz : 3c391f7e930c583095045cd2d10eb73a64f085c7fde9d260f2652c7cb3cfbe4a
+homepage   : https://freedesktop.org/wiki/Software/startup-notification/
 license    : LGPL-2.0
 summary    : Startup Notification libraries
 component  : desktop.library
@@ -17,7 +17,7 @@ builddeps  :
     - pkgconfig32(xcb-aux)
 emul32     : true
 setup      : |
-    %configure --prefix=/usr \
+    %configure_no_runstatedir --prefix=/usr \
                --disable-static
 build      : |
     %make

--- a/packages/l/libstartup-notification/pspec_x86_64.xml
+++ b/packages/l/libstartup-notification/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>libstartup-notification</Name>
-        <Homepage>http://freedesktop.org/wiki/Software/startup-notification</Homepage>
+        <Homepage>https://freedesktop.org/wiki/Software/startup-notification/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>LGPL-2.0</License>
         <PartOf>desktop.library</PartOf>
@@ -12,7 +12,7 @@
         <Description xml:lang="en">The startup-notification package contains startup-notification libraries.
 These are useful for building a consistent manner to notify the user through the cursor that the application is loading.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>libstartup-notification</Name>
@@ -34,7 +34,7 @@ These are useful for building a consistent manner to notify the user through the
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="7">libstartup-notification</Dependency>
+            <Dependency release="8">libstartup-notification</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libstartup-notification-1.so.0</Path>
@@ -49,8 +49,8 @@ These are useful for building a consistent manner to notify the user through the
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="7">libstartup-notification-devel</Dependency>
-            <Dependency release="7">libstartup-notification-32bit</Dependency>
+            <Dependency release="8">libstartup-notification-32bit</Dependency>
+            <Dependency release="8">libstartup-notification-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libstartup-notification-1.so</Path>
@@ -65,7 +65,7 @@ These are useful for building a consistent manner to notify the user through the
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="7">libstartup-notification</Dependency>
+            <Dependency release="8">libstartup-notification</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/startup-notification-1.0/libsn/sn-common.h</Path>
@@ -79,12 +79,12 @@ These are useful for building a consistent manner to notify the user through the
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2022-12-04</Date>
+        <Update release="8">
+            <Date>2025-11-17</Date>
             <Version>0.12</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Part of https://github.com/getsolus/packages/issues/5522
- 
**Test Plan**

Installed libstartup-notification

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
