### PR TITLE
libpng: Update to v1.6.50

### DIFF
--- a/packages/l/libpng/abi_symbols
+++ b/packages/l/libpng/abi_symbols
@@ -31,6 +31,9 @@ libpng16.so.16:png_get_cHRM
 libpng16.so.16:png_get_cHRM_XYZ
 libpng16.so.16:png_get_cHRM_XYZ_fixed
 libpng16.so.16:png_get_cHRM_fixed
+libpng16.so.16:png_get_cICP
+libpng16.so.16:png_get_cLLI
+libpng16.so.16:png_get_cLLI_fixed
 libpng16.so.16:png_get_channels
 libpng16.so.16:png_get_chunk_cache_max
 libpng16.so.16:png_get_chunk_malloc_max
@@ -58,6 +61,8 @@ libpng16.so.16:png_get_io_chunk_type
 libpng16.so.16:png_get_io_ptr
 libpng16.so.16:png_get_io_state
 libpng16.so.16:png_get_libpng_ver
+libpng16.so.16:png_get_mDCV
+libpng16.so.16:png_get_mDCV_fixed
 libpng16.so.16:png_get_mem_ptr
 libpng16.so.16:png_get_oFFs
 libpng16.so.16:png_get_pCAL
@@ -148,6 +153,9 @@ libpng16.so.16:png_set_cHRM
 libpng16.so.16:png_set_cHRM_XYZ
 libpng16.so.16:png_set_cHRM_XYZ_fixed
 libpng16.so.16:png_set_cHRM_fixed
+libpng16.so.16:png_set_cICP
+libpng16.so.16:png_set_cLLI
+libpng16.so.16:png_set_cLLI_fixed
 libpng16.so.16:png_set_check_for_invalid_index
 libpng16.so.16:png_set_chunk_cache_max
 libpng16.so.16:png_set_chunk_malloc_max
@@ -182,6 +190,8 @@ libpng16.so.16:png_set_invert_alpha
 libpng16.so.16:png_set_invert_mono
 libpng16.so.16:png_set_keep_unknown_chunks
 libpng16.so.16:png_set_longjmp_fn
+libpng16.so.16:png_set_mDCV
+libpng16.so.16:png_set_mDCV_fixed
 libpng16.so.16:png_set_mem_fn
 libpng16.so.16:png_set_oFFs
 libpng16.so.16:png_set_option

--- a/packages/l/libpng/abi_symbols32
+++ b/packages/l/libpng/abi_symbols32
@@ -31,6 +31,9 @@ libpng16.so.16:png_get_cHRM
 libpng16.so.16:png_get_cHRM_XYZ
 libpng16.so.16:png_get_cHRM_XYZ_fixed
 libpng16.so.16:png_get_cHRM_fixed
+libpng16.so.16:png_get_cICP
+libpng16.so.16:png_get_cLLI
+libpng16.so.16:png_get_cLLI_fixed
 libpng16.so.16:png_get_channels
 libpng16.so.16:png_get_chunk_cache_max
 libpng16.so.16:png_get_chunk_malloc_max
@@ -58,6 +61,8 @@ libpng16.so.16:png_get_io_chunk_type
 libpng16.so.16:png_get_io_ptr
 libpng16.so.16:png_get_io_state
 libpng16.so.16:png_get_libpng_ver
+libpng16.so.16:png_get_mDCV
+libpng16.so.16:png_get_mDCV_fixed
 libpng16.so.16:png_get_mem_ptr
 libpng16.so.16:png_get_oFFs
 libpng16.so.16:png_get_pCAL
@@ -148,6 +153,9 @@ libpng16.so.16:png_set_cHRM
 libpng16.so.16:png_set_cHRM_XYZ
 libpng16.so.16:png_set_cHRM_XYZ_fixed
 libpng16.so.16:png_set_cHRM_fixed
+libpng16.so.16:png_set_cICP
+libpng16.so.16:png_set_cLLI
+libpng16.so.16:png_set_cLLI_fixed
 libpng16.so.16:png_set_check_for_invalid_index
 libpng16.so.16:png_set_chunk_cache_max
 libpng16.so.16:png_set_chunk_malloc_max
@@ -182,6 +190,8 @@ libpng16.so.16:png_set_invert_alpha
 libpng16.so.16:png_set_invert_mono
 libpng16.so.16:png_set_keep_unknown_chunks
 libpng16.so.16:png_set_longjmp_fn
+libpng16.so.16:png_set_mDCV
+libpng16.so.16:png_set_mDCV_fixed
 libpng16.so.16:png_set_mem_fn
 libpng16.so.16:png_set_oFFs
 libpng16.so.16:png_set_option

--- a/packages/l/libpng/abi_used_symbols
+++ b/packages/l/libpng/abi_used_symbols
@@ -2,6 +2,7 @@ libc.so.6:__assert_fail
 libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__longjmp_chk
 libc.so.6:__memcpy_chk
@@ -40,11 +41,10 @@ libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strtod
-libc.so.6:strtol
+libm.so.6:floor
 libm.so.6:frexp
 libm.so.6:modf
 libm.so.6:pow
-libz.so.1:adler32
 libz.so.1:crc32
 libz.so.1:deflate
 libz.so.1:deflateEnd

--- a/packages/l/libpng/abi_used_symbols32
+++ b/packages/l/libpng/abi_used_symbols32
@@ -23,10 +23,10 @@ libc.so.6:stderr
 libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strtod
+libm.so.6:floor
 libm.so.6:frexp
 libm.so.6:modf
 libm.so.6:pow
-libz.so.1:adler32
 libz.so.1:crc32
 libz.so.1:deflate
 libz.so.1:deflateEnd

--- a/packages/l/libpng/package.yml
+++ b/packages/l/libpng/package.yml
@@ -1,9 +1,9 @@
 name       : libpng
-version    : 1.6.44
-release    : 28
+version    : 1.6.50
+release    : 29
 source     :
-    - https://sourceforge.net/projects/libpng/files/libpng16/1.6.44/libpng-1.6.44.tar.gz : 8c25a7792099a0089fa1cc76c94260d0bb3f1ec52b93671b572f8bb61577b732
-homepage   : http://www.libpng.org/pub/png/
+    - https://sourceforge.net/projects/libpng/files/libpng16/1.6.50/libpng-1.6.50.tar.gz : 708f4398f996325819936d447f982e0db90b6b8212b7507e7672ea232210949a
+homepage   : https://www.libpng.org/pub/png/
 license    : Libpng
 component  : multimedia.library
 summary    : libpng (Official PNG reference library)

--- a/packages/l/libpng/pspec_x86_64.xml
+++ b/packages/l/libpng/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>libpng</Name>
-        <Homepage>http://www.libpng.org/pub/png/</Homepage>
+        <Homepage>https://www.libpng.org/pub/png/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Libpng</License>
         <PartOf>multimedia.library</PartOf>
@@ -23,10 +23,10 @@
             <Path fileType="executable">/usr/bin/png-fix-itxt</Path>
             <Path fileType="executable">/usr/bin/pngfix</Path>
             <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libpng16.so.16</Path>
-            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libpng16.so.16.44.0</Path>
+            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libpng16.so.16.50.0</Path>
             <Path fileType="library">/usr/lib64/libpng16.so.16</Path>
-            <Path fileType="library">/usr/lib64/libpng16.so.16.44.0</Path>
-            <Path fileType="man">/usr/share/man/man5/png.5</Path>
+            <Path fileType="library">/usr/lib64/libpng16.so.16.50.0</Path>
+            <Path fileType="man">/usr/share/man/man5/png.5.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -36,11 +36,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="28">libpng</Dependency>
+            <Dependency release="29">libpng</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpng16.so.16</Path>
-            <Path fileType="library">/usr/lib32/libpng16.so.16.44.0</Path>
+            <Path fileType="library">/usr/lib32/libpng16.so.16.50.0</Path>
         </Files>
     </Package>
     <Package>
@@ -50,8 +50,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="28">libpng-32bit</Dependency>
-            <Dependency release="28">libpng-devel</Dependency>
+            <Dependency release="29">libpng-devel</Dependency>
+            <Dependency release="29">libpng-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpng.so</Path>
@@ -67,7 +67,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="28">libpng</Dependency>
+            <Dependency release="29">libpng</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/libpng-config</Path>
@@ -82,17 +82,17 @@
             <Path fileType="library">/usr/lib64/libpng16.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/libpng.pc</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/libpng16.pc</Path>
-            <Path fileType="man">/usr/share/man/man3/libpng.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libpngpf.3</Path>
+            <Path fileType="man">/usr/share/man/man3/libpng.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libpngpf.3.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2024-10-27</Date>
-            <Version>1.6.44</Version>
+        <Update release="29">
+            <Date>2025-11-17</Date>
+            <Version>1.6.50</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://www.libpng.org/pub/png/libpng.html).
- Part of https://github.com/getsolus/packages/issues/5522

**Test Plan**

Installed libpng

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
