### PR TITLE
ne: Update to v3.3.4

### DIFF
--- a/packages/n/ne/abi_symbols
+++ b/packages/n/ne/abi_symbols
@@ -1,3 +1,4 @@
+ne:cur_term
 ne:re_compile_fastmap
 ne:re_compile_pattern
 ne:re_match
@@ -11,3 +12,6 @@ ne:regcomp
 ne:regerror
 ne:regexec
 ne:regfree
+ne:stderr
+ne:stdin
+ne:stdout

--- a/packages/n/ne/abi_used_symbols
+++ b/packages/n/ne/abi_used_symbols
@@ -4,7 +4,9 @@ libc.so.6:__ctype_tolower_loc
 libc.so.6:__ctype_toupper_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoll
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__memmove_chk
@@ -30,6 +32,7 @@ libc.so.6:fgets
 libc.so.6:fileno
 libc.so.6:fnmatch
 libc.so.6:fopen
+libc.so.6:fputc
 libc.so.6:free
 libc.so.6:freopen
 libc.so.6:getc
@@ -70,9 +73,6 @@ libc.so.6:signal
 libc.so.6:sigprocmask
 libc.so.6:sleep
 libc.so.6:stat
-libc.so.6:stderr
-libc.so.6:stdin
-libc.so.6:stdout
 libc.so.6:strcasecmp
 libc.so.6:strcat
 libc.so.6:strchr
@@ -83,8 +83,7 @@ libc.so.6:strncasecmp
 libc.so.6:strncmp
 libc.so.6:strncpy
 libc.so.6:strrchr
-libc.so.6:strtol
-libc.so.6:strtoll
+libc.so.6:strstr
 libc.so.6:system
 libc.so.6:tcgetattr
 libc.so.6:tcsetattr
@@ -95,7 +94,6 @@ libc.so.6:towupper
 libc.so.6:unlink
 libc.so.6:wcwidth
 libc.so.6:write
-libncursesw.so.6:cur_term
 libncursesw.so.6:setupterm
 libncursesw.so.6:tgetent
 libncursesw.so.6:tgoto

--- a/packages/n/ne/files/0001-fix-parallel-build.patch
+++ b/packages/n/ne/files/0001-fix-parallel-build.patch
@@ -1,0 +1,23 @@
+From 8b6af4242b6977391d14441f8f88204e10421e6a Mon Sep 17 00:00:00 2001
+From: Sebastiano Vigna <sebastiano.vigna@gmail.com>
+Date: Thu, 20 Nov 2025 16:36:20 +0700
+Subject: [PATCH] Added explicit dependency from $(MAINH) for ansi.o
+
+---
+ src/makefile | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/makefile b/src/makefile
+index ed593e5..4f38c7c 100644
+--- a/src/makefile
++++ b/src/makefile
+@@ -156,6 +156,8 @@ enums.h names.c names.h hash.c hash.h help.c help.h ext.c: ne.texinfo version.te
+ 	perl info2src.pl
+ 	rm -f ne.info*
+ 
++ansi.o: $(MAINH)
++
+ actions.o: $(MAINH) support.h keycodes.h names.h names.c errors.h errors.c protos.h version.h
+ 
+ autocomp.o: $(MAINH) support.h protos.h
+

--- a/packages/n/ne/files/0002-fix-parallel-build.patch
+++ b/packages/n/ne/files/0002-fix-parallel-build.patch
@@ -1,0 +1,33 @@
+From 5a13948467e01c060296ce01528338f1c45d9005 Mon Sep 17 00:00:00 2001
+From: Ivan Trepakov <liontiger23@gmail.com>
+Date: Fri, 21 Nov 2025 09:57:26 +0700
+Subject: [PATCH] Separate enums.h and other files that depend on it for
+ parallel building
+
+---
+ src/makefile | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/src/makefile b/src/makefile
+index 4f38c7c..194ecbf 100644
+--- a/src/makefile
++++ b/src/makefile
+@@ -146,12 +146,15 @@ ne.texinfo:
+ version.texinfo: ../doc/version.texinfo
+ 	-ln -sf ../doc/version.texinfo
+ 
+-SYNH = syn_types.h syn_hash.h syn_regex.h syn_utf8.h syn_utils.h
++ENUMH = enums.h
++SYNH = syn_types.h syn_hash.h syn_regex.h syn_utf8.h syn_utils.h $(ENUMH)
+ MAINH = ne.h debug.h enums.h errors.h utf8.h syntax.h keycodes.h termchar.h info2cap.h $(SYNH)
+ 
+ ext.c: ext.c.in
+ 
+-enums.h names.c names.h hash.c hash.h help.c help.h ext.c: ne.texinfo version.texinfo info2src.pl
++names.c names.h hash.c hash.h help.c help.h ext.c: $(ENUMH)
++
++$(ENUMH): ne.texinfo version.texinfo info2src.pl
+ 	makeinfo -D autohelp ne.texinfo
+ 	perl info2src.pl
+ 	rm -f ne.info*
+

--- a/packages/n/ne/package.yml
+++ b/packages/n/ne/package.yml
@@ -1,8 +1,8 @@
 name       : ne
-version    : 3.3.1
-release    : 8
+version    : 3.3.4
+release    : 9
 source     :
-    - https://github.com/vigna/ne/archive/refs/tags/3.3.1.tar.gz : 931f01380b48e539b06d65d80ddf313cce67aab6d7b62462a548253ab9b3e10a
+    - https://github.com/vigna/ne/archive/refs/tags/3.3.4.tar.gz : 6958b5cd051d85dcdebbf45aeed2af077346a58d1d18ad14e1db477ce5519d29
 homepage   : http://ne.di.unimi.it/
 license    : GPL-3.0-or-later
 component  : editor
@@ -14,6 +14,8 @@ builddeps  :
     - texinfo
 setup      : |
     sed -i 's:CC=c99:CC=gcc:g' src/makefile
+    %patch -p1 -i $pkgfiles/0001-fix-parallel-build.patch
+    %patch -p1 -i $pkgfiles/0002-fix-parallel-build.patch
 build      : |
     %make build PREFIX=/usr
     cd $workdir

--- a/packages/n/ne/pspec_x86_64.xml
+++ b/packages/n/ne/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>ne</Name>
         <Homepage>http://ne.di.unimi.it/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Ivan Trepakov</Name>
+            <Email>liontiger23@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>editor</PartOf>
         <Summary xml:lang="en">ne, the nice editor</Summary>
         <Description xml:lang="en">ne, the nice editor. ne is a free (GPL&apos;d) text editor based on the POSIX standard.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>ne</Name>
@@ -40,6 +40,7 @@
             <Path fileType="doc">/usr/share/doc/ne/html/Basics.html</Path>
             <Path fileType="doc">/usr/share/doc/ne/html/Beep.html</Path>
             <Path fileType="doc">/usr/share/doc/ne/html/Binary.html</Path>
+            <Path fileType="doc">/usr/share/doc/ne/html/BracketedPaste.html</Path>
             <Path fileType="doc">/usr/share/doc/ne/html/CRLF.html</Path>
             <Path fileType="doc">/usr/share/doc/ne/html/Capitalize.html</Path>
             <Path fileType="doc">/usr/share/doc/ne/html/CaseSearch.html</Path>
@@ -219,7 +220,7 @@
             <Path fileType="doc">/usr/share/doc/ne/html/index.html</Path>
             <Path fileType="doc">/usr/share/doc/ne/ne.txt</Path>
             <Path fileType="info">/usr/share/info/ne.info.gz</Path>
-            <Path fileType="man">/usr/share/man/man1/ne.1</Path>
+            <Path fileType="man">/usr/share/man/man1/ne.1.zst</Path>
             <Path fileType="data">/usr/share/ne/extensions</Path>
             <Path fileType="data">/usr/share/ne/macros/DeleteSOL</Path>
             <Path fileType="data">/usr/share/ne/macros/aspell</Path>
@@ -288,6 +289,7 @@
             <Path fileType="data">/usr/share/ne/syntax/tcl.jsf</Path>
             <Path fileType="data">/usr/share/ne/syntax/tex.jsf</Path>
             <Path fileType="data">/usr/share/ne/syntax/texinfo.jsf</Path>
+            <Path fileType="data">/usr/share/ne/syntax/toml.jsf</Path>
             <Path fileType="data">/usr/share/ne/syntax/troff.jsf</Path>
             <Path fileType="data">/usr/share/ne/syntax/txt2tags.jsf</Path>
             <Path fileType="data">/usr/share/ne/syntax/typescript.jsf</Path>
@@ -299,12 +301,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2022-03-25</Date>
-            <Version>3.3.1</Version>
+        <Update release="9">
+            <Date>2025-11-21</Date>
+            <Version>3.3.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Ivan Trepakov</Name>
+            <Email>liontiger23@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Resolves https://github.com/getsolus/packages/issues/7086

**News**

- 3.3.4 2025-02-06

  * Bracketed paste now consults the AutoIndent flag to determine whether to
    preserve the cursor's initial horizontal offset. It's like a block
    level AutoIndent rather than a line-by-line (and therefore
    cumulative) AutoIndent. Being created internally by the Shift command,
    the introduced leading space also honors the Tabs and ShiftTabs flags.
    Like leading space introduced by AutoIndent, a single Undo removes the
    bracketed paste's auto indented space; a second Undo removes the pasted
    text itself.
    Bracketed pastes now act like "normal" pastes, setting the '<' and
    '>' bookmarks, and leaving the cursor at the head of the paste.

- 3.3.3 2023-10-19

  * BracketedPaste support has been added; turns off AutoIndent when
    pasting text from the system clipboard.

- 3.3.2 2022-09-13

  * Paste and PasteVert now set two bookmarks designated '<' and '>' which
    are set to the start and end of the most recently pasted text. Accessed
    by the "GotoBookmark <" and "GotoBookmark >" commands. Two associated
    menu items have been added to the "Search" menu.

  * Added toml.jsf syntax.

  * Support '_' in numeric constants, binary and hex constants, imaginary
    numbers in go.jsf syntax.

  * Now there is an uninstall target that uninstalls ne.

  * Additionally load key bindings from ~/.ne/.keys-${TERM}

**Fixes**

- 3.3.4 2025-02-06

  * Improved YAML style file.

- 3.3.3 2023-10-19

  * Fixed document reordering in SelectDoc requester when first or last
    document wraps around to the other end of the document list.

  * After closing the current document, the most recently active adjacent
    document is chosen as the new current document.

- 3.3.2 2022-09-13

  * Fixed issue where autocomplete could fail/crash with UTF-8 characters.

  * Fixed issue where file requester could return incorrect path
    to the selected file.

  * Fixed makefile so that it correctly supports parallel builds. Thanks
    to Emily Lucy Ishikawa for contributing this fix.

**Test Plan**

Open editor, make some changes, close.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
