### PR TITLE
libarchive: Update to v3.8.3

### DIFF
--- a/packages/l/libarchive/package.yml
+++ b/packages/l/libarchive/package.yml
@@ -1,8 +1,8 @@
 name       : libarchive
-version    : 3.8.2
-release    : 59
+version    : 3.8.3
+release    : 60
 source     :
-    - https://github.com/libarchive/libarchive/releases/download/v3.8.2/libarchive-3.8.2.tar.xz : db0dee91561cbd957689036a3a71281efefd131d35d1d98ebbc32720e4da58e2
+    - https://github.com/libarchive/libarchive/releases/download/v3.8.3/libarchive-3.8.3.tar.xz : 90e21f2b89f19391ce7b90f6e48ed9fde5394d23ad30ae256fb8236b38b99788
 homepage   : https://www.libarchive.org/
 license    : BSD-2-Clause
 component  :

--- a/packages/l/libarchive/pspec_x86_64.xml
+++ b/packages/l/libarchive/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libarchive</Name>
         <Homepage>https://www.libarchive.org/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>programming.library</PartOf>
@@ -21,7 +21,7 @@
         <PartOf>programming.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libarchive.so.13</Path>
-            <Path fileType="library">/usr/lib64/libarchive.so.13.8.2</Path>
+            <Path fileType="library">/usr/lib64/libarchive.so.13.8.3</Path>
         </Files>
     </Package>
     <Package>
@@ -31,11 +31,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="59">libarchive</Dependency>
+            <Dependency release="60">libarchive</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libarchive.so.13</Path>
-            <Path fileType="library">/usr/lib32/libarchive.so.13.8.2</Path>
+            <Path fileType="library">/usr/lib32/libarchive.so.13.8.3</Path>
         </Files>
     </Package>
     <Package>
@@ -45,8 +45,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="59">libarchive-devel</Dependency>
-            <Dependency release="59">libarchive-32bit</Dependency>
+            <Dependency release="60">libarchive-32bit</Dependency>
+            <Dependency release="60">libarchive-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libarchive.so</Path>
@@ -60,7 +60,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="59">libarchive</Dependency>
+            <Dependency release="60">libarchive</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/bsdcat</Path>
@@ -84,7 +84,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="59">libarchive</Dependency>
+            <Dependency release="60">libarchive</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/archive.h</Path>
@@ -131,12 +131,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="59">
-            <Date>2025-11-15</Date>
-            <Version>3.8.2</Version>
+        <Update release="60">
+            <Date>2025-11-19</Date>
+            <Version>3.8.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/libarchive/libarchive/releases/tag/v3.8.3).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Open zip files and compressed tar files with File Roller.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
