### PR TITLE
openvpn: Update to v2.6.16

### DIFF
--- a/packages/o/openvpn/abi_used_symbols
+++ b/packages/o/openvpn/abi_used_symbols
@@ -1,4 +1,3 @@
-libc.so.6:__assert_fail
 libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_toupper_loc
 libc.so.6:__errno_location

--- a/packages/o/openvpn/package.yml
+++ b/packages/o/openvpn/package.yml
@@ -1,8 +1,8 @@
 name       : openvpn
-version    : 2.6.14
-release    : 37
+version    : 2.6.16
+release    : 38
 source     :
-    - https://github.com/OpenVPN/openvpn/archive/v2.6.14.tar.gz : a48131afa86ad7c90d16748ecea76ae519a81f2dc37521941a373c54d41f4c77
+    - https://github.com/OpenVPN/openvpn/archive/v2.6.16.tar.gz : 80256bf2f9f4c912dbc72e8b00180f6c30fb40a1bb2122fb5e686e71af6a06e7
 license    :
     - GPL-2.0-only
     - BSD-4-Clause

--- a/packages/o/openvpn/pspec_x86_64.xml
+++ b/packages/o/openvpn/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>openvpn</Name>
         <Homepage>https://openvpn.net/community/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <License>BSD-4-Clause</License>
@@ -29,8 +29,8 @@
             <Path fileType="library">/usr/lib64/systemd/system/openvpn-server@.service</Path>
             <Path fileType="library">/usr/lib64/tmpfiles.d/openvpn.conf</Path>
             <Path fileType="executable">/usr/sbin/openvpn</Path>
-            <Path fileType="man">/usr/share/man/man5/openvpn-examples.5</Path>
-            <Path fileType="man">/usr/share/man/man8/openvpn.8</Path>
+            <Path fileType="man">/usr/share/man/man5/openvpn-examples.5.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/openvpn.8.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -40,7 +40,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="37">openvpn</Dependency>
+            <Dependency release="38">openvpn</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/openvpn-msg.h</Path>
@@ -48,12 +48,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="37">
-            <Date>2025-04-15</Date>
-            <Version>2.6.14</Version>
+        <Update release="38">
+            <Date>2025-11-19</Date>
+            <Version>2.6.16</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/OpenVPN/openvpn/releases/tag/v2.6.16).

**Security**
- CVE-2025-13086

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

I don't have a way to test this.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
