### PR TITLE
solseek: Update to 0.4.0

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 0.3.3
-release    : 4
+version    : 0.4.0
+release    : 5
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v0.3.3.tar.gz : 4ec8e3372c495b00182b1d83cce50c00ba937e43e262208756cecd03357220a2
+    - https://github.com/clintre/solseek/archive/refs/tags/v0.4.0.tar.gz : eeb596a617fd8ea51f7a606da8d32fe8351e70be93f9785df71e02ad687a3c75
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : systtem.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -27,7 +27,6 @@
             <Path fileType="data">/usr/share/solseek/LICENSE-solseek.txt</Path>
             <Path fileType="data">/usr/share/solseek/config</Path>
             <Path fileType="data">/usr/share/solseek/lang/en/_dictionary.lang</Path>
-            <Path fileType="data">/usr/share/solseek/lang/en/eopkg_check.txt</Path>
             <Path fileType="data">/usr/share/solseek/lang/en/help.txt</Path>
             <Path fileType="data">/usr/share/solseek/lang/en/history.txt</Path>
             <Path fileType="data">/usr/share/solseek/lang/en/information.txt</Path>
@@ -36,7 +35,6 @@
             <Path fileType="data">/usr/share/solseek/lang/en/update_system.txt</Path>
             <Path fileType="data">/usr/share/solseek/lang/en/welcome.txt</Path>
             <Path fileType="data">/usr/share/solseek/lang/fr/_dictionary.lang</Path>
-            <Path fileType="data">/usr/share/solseek/lang/fr/eopkg_check.txt</Path>
             <Path fileType="data">/usr/share/solseek/lang/fr/help.txt</Path>
             <Path fileType="data">/usr/share/solseek/lang/fr/history.txt</Path>
             <Path fileType="data">/usr/share/solseek/lang/fr/information.txt</Path>
@@ -44,14 +42,16 @@
             <Path fileType="data">/usr/share/solseek/lang/fr/package_action.txt</Path>
             <Path fileType="data">/usr/share/solseek/lang/fr/update_system.txt</Path>
             <Path fileType="data">/usr/share/solseek/lang/fr/welcome.txt</Path>
+            <Path fileType="data">/usr/share/solseek/solseek-uc.service</Path>
+            <Path fileType="data">/usr/share/solseek/solseek-uc.timer</Path>
             <Path fileType="data">/usr/share/solseek/solseek_fastfetch.jsonc</Path>
             <Path fileType="data">/usr/share/solseek/solseek_fastfetch_str.jsonc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2025-11-15</Date>
-            <Version>0.3.3</Version>
+        <Update release="5">
+            <Date>2025-11-19</Date>
+            <Version>0.4.0</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**

Bugfixes:

- Fixed minor bugs with the check updates
- Fixed minor translation and spelling issues

Enhancements:

- Added methods to clean unused packages from eopkg
- Added methods to clean unused packages from flatpak
- Added templates for systemd timers and service to check for updates
- Added listing up available updates if there are any available for both eopkg and flatpak

Full release notes:

- [0.4.0](https://github.com/clintre/solseek/releases/tag/v0.4.0)


**Test Plan**
Tested against unstable 


**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
