### PR TITLE
osinfo-db: Update to v20250606

### DIFF
--- a/packages/o/osinfo-db/files/solus-rolling.xml
+++ b/packages/o/osinfo-db/files/solus-rolling.xml
@@ -62,7 +62,7 @@
     </variant>
 
     <variant id="xfce">
-      <name>Solus XFCE</name>
+      <name>Solus Xfce</name>
     </variant>
 
     <media arch="x86_64" live="true">
@@ -97,9 +97,9 @@
 
     <media arch="x86_64" live="true">
       <variant id="xfce"/>
-      <url>https://downloads.getsol.us/isos/latest/Solus-Latest-XFCE.iso</url>
+      <url>https://downloads.getsol.us/isos/latest/Solus-Latest-Xfce.iso</url>
       <iso>
-        <volume-id>SolusLiveXFCE</volume-id>
+        <volume-id>SolusLiveXfce</volume-id>
       </iso>
         <initrd>boot/initrd.img</initrd>
         <kernel>boot/kernel</kernel>

--- a/packages/o/osinfo-db/package.yml
+++ b/packages/o/osinfo-db/package.yml
@@ -1,8 +1,8 @@
 name       : osinfo-db
-version    : '20231215'
-release    : 15
+version    : '20250606'
+release    : 16
 source     :
-    - https://releases.pagure.org/libosinfo/osinfo-db-20231215.tar.xz : dfb7c5975ce4efffd92aadd00094a0f7c593b41988fda539915f6459f7164554
+    - https://releases.pagure.org/libosinfo/osinfo-db-20250606.tar.xz : 9940aa47df298073c51dcf8a4dcc855f494ab864c24cdbda46bd897957357fe1
 homepage   : https://libosinfo.org
 license    : GPL-2.0-or-later
 component  : virt

--- a/packages/o/osinfo-db/pspec_x86_64.xml
+++ b/packages/o/osinfo-db/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>osinfo-db</Name>
         <Homepage>https://libosinfo.org</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>virt</PartOf>
@@ -54,6 +54,7 @@
             <Path fileType="data">/usr/share/osinfo/device/pcisig.com/pci-1af4-1049.d/class.xml</Path>
             <Path fileType="data">/usr/share/osinfo/device/pcisig.com/pci-1af4-1050.d/class.xml</Path>
             <Path fileType="data">/usr/share/osinfo/device/pcisig.com/pci-1af4-1052.d/class.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/device/pcisig.com/pci-1af4-1058.d/class.xml</Path>
             <Path fileType="data">/usr/share/osinfo/device/pcisig.com/pci-1af4-105a.d/class.xml</Path>
             <Path fileType="data">/usr/share/osinfo/device/pcisig.com/pci-1b36-0004.d/class.xml</Path>
             <Path fileType="data">/usr/share/osinfo/device/pcisig.com/pci-1b36-0100.d/class.xml</Path>
@@ -90,8 +91,10 @@
             <Path fileType="data">/usr/share/osinfo/install-script/redhat.com/rhel-kickstart-jeos.xml</Path>
             <Path fileType="data">/usr/share/osinfo/install-script/ubuntu.com/ubuntu-preseed-desktop.xml</Path>
             <Path fileType="data">/usr/share/osinfo/install-script/ubuntu.com/ubuntu-preseed-jeos.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/almalinux.org/almalinux-10.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/almalinux.org/almalinux-8.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/almalinux.org/almalinux-9.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/almalinux.org/almalinux-kitten-10.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/alpinelinux.org/alpinelinux-3.10.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/alpinelinux.org/alpinelinux-3.11.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/alpinelinux.org/alpinelinux-3.12.xml</Path>
@@ -102,6 +105,8 @@
             <Path fileType="data">/usr/share/osinfo/os/alpinelinux.org/alpinelinux-3.17.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/alpinelinux.org/alpinelinux-3.18.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/alpinelinux.org/alpinelinux-3.19.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/alpinelinux.org/alpinelinux-3.20.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/alpinelinux.org/alpinelinux-3.21.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/alpinelinux.org/alpinelinux-3.5.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/alpinelinux.org/alpinelinux-3.6.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/alpinelinux.org/alpinelinux-3.7.xml</Path>
@@ -109,6 +114,8 @@
             <Path fileType="data">/usr/share/osinfo/os/alpinelinux.org/alpinelinux-3.9.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/altlinux.org/alt-10.0.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/altlinux.org/alt-10.1.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/altlinux.org/alt-10.2.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/altlinux.org/alt-10.3.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/altlinux.org/alt-8.0.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/altlinux.org/alt-8.1.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/altlinux.org/alt-8.2.xml</Path>
@@ -116,6 +123,7 @@
             <Path fileType="data">/usr/share/osinfo/os/altlinux.org/alt-9.1.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/altlinux.org/alt-9.2.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/altlinux.org/alt-p10.starterkits.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/altlinux.org/alt-p11.starterkits.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/altlinux.org/alt-p8.starterkits.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/altlinux.org/alt-p9.starterkits.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/altlinux.org/alt-sisyphus.xml</Path>
@@ -179,6 +187,7 @@
             <Path fileType="data">/usr/share/osinfo/os/centos.org/centos-6.9.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/centos.org/centos-7.0.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/centos.org/centos-8.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/centos.org/centos-stream-10.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/centos.org/centos-stream-8.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/centos.org/centos-stream-9.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/cirros-cloud.net/cirros-0.3.0.xml</Path>
@@ -198,6 +207,7 @@
             <Path fileType="data">/usr/share/osinfo/os/debian.org/debian-10.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/debian.org/debian-11.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/debian.org/debian-12.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/debian.org/debian-13.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/debian.org/debian-2.0.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/debian.org/debian-2.1.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/debian.org/debian-2.2.xml</Path>
@@ -210,6 +220,7 @@
             <Path fileType="data">/usr/share/osinfo/os/debian.org/debian-8.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/debian.org/debian-9.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/debian.org/debian-testing.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/debian.org/debian-unstable.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/dragonflybsd.org/dragonflybsd-1.0.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/dragonflybsd.org/dragonflybsd-1.0A.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/dragonflybsd.org/dragonflybsd-1.10.0.xml</Path>
@@ -290,6 +301,7 @@
             <Path fileType="data">/usr/share/osinfo/os/endlessos.com/eos-4.0.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/endlessos.com/eos-5.0.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/endlessos.com/eos-5.1.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/endlessos.com/eos-6.0.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/euro-linux.com/eurolinux-8.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/euro-linux.com/eurolinux-9.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/fedoraproject.org/coreos-next.xml</Path>
@@ -329,6 +341,9 @@
             <Path fileType="data">/usr/share/osinfo/os/fedoraproject.org/fedora-38.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/fedoraproject.org/fedora-39.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/fedoraproject.org/fedora-4.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/fedoraproject.org/fedora-40.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/fedoraproject.org/fedora-41.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/fedoraproject.org/fedora-42.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/fedoraproject.org/fedora-5.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/fedoraproject.org/fedora-6.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/fedoraproject.org/fedora-7.xml</Path>
@@ -349,6 +364,8 @@
             <Path fileType="data">/usr/share/osinfo/os/fedoraproject.org/silverblue-37.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/fedoraproject.org/silverblue-38.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/fedoraproject.org/silverblue-39.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/fedoraproject.org/silverblue-40.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/fedoraproject.org/silverblue-41.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/fedoraproject.org/silverblue-rawhide.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/fedoraproject.org/silverblue-unknown.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/freebsd.org/freebsd-1.0.xml</Path>
@@ -370,7 +387,11 @@
             <Path fileType="data">/usr/share/osinfo/os/freebsd.org/freebsd-13.0.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/freebsd.org/freebsd-13.1.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/freebsd.org/freebsd-13.2.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/freebsd.org/freebsd-13.3.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/freebsd.org/freebsd-13.4.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/freebsd.org/freebsd-14.0.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/freebsd.org/freebsd-14.1.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/freebsd.org/freebsd-14.2.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/freebsd.org/freebsd-2.0.5.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/freebsd.org/freebsd-2.0.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/freebsd.org/freebsd-2.2.8.xml</Path>
@@ -425,10 +446,11 @@
             <Path fileType="data">/usr/share/osinfo/os/gnome.org/gnome-continuous-3.10.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/gnome.org/gnome-continuous-3.12.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/gnome.org/gnome-continuous-3.14.xml</Path>
-            <Path fileType="data">/usr/share/osinfo/os/guix.gnu.org/guix-1.1.xml</Path>
-            <Path fileType="data">/usr/share/osinfo/os/guix.gnu.org/guix-1.3.xml</Path>
-            <Path fileType="data">/usr/share/osinfo/os/guix.gnu.org/guix-hurd-latest.xml</Path>
-            <Path fileType="data">/usr/share/osinfo/os/guix.gnu.org/guix-latest.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/guix.gnu.org/guix-system-1.1.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/guix.gnu.org/guix-system-1.3.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/guix.gnu.org/guix-system-1.4.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/guix.gnu.org/guix-system-hurd-latest.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/guix.gnu.org/guix-system-latest.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/haiku-os.org/haiku-nightly.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/haiku-os.org/haiku-r1alpha1.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/haiku-os.org/haiku-r1alpha2.xml</Path>
@@ -443,6 +465,7 @@
             <Path fileType="data">/usr/share/osinfo/os/libosinfo.org/linux-2018.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/libosinfo.org/linux-2020.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/libosinfo.org/linux-2022.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/libosinfo.org/linux-2024.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/libosinfo.org/unknown.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/mageia.org/mageia-1.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/mageia.org/mageia-2.xml</Path>
@@ -499,6 +522,7 @@
             <Path fileType="data">/usr/share/osinfo/os/microsoft.com/win-2k16.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/microsoft.com/win-2k19.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/microsoft.com/win-2k22.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/microsoft.com/win-2k25.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/microsoft.com/win-2k3.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/microsoft.com/win-2k3r2.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/microsoft.com/win-2k8.xml</Path>
@@ -524,6 +548,7 @@
             <Path fileType="data">/usr/share/osinfo/os/microsoft.com/winnt-3.5.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/microsoft.com/winnt-3.51.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/microsoft.com/winnt-4.0.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/miraclelinux.com/miraclelinux-8-unknown.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/miraclelinux.com/miraclelinux-8.4.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/miraclelinux.com/miraclelinux-9-unknown.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/miraclelinux.com/miraclelinux-9.0.xml</Path>
@@ -536,6 +561,7 @@
             <Path fileType="data">/usr/share/osinfo/os/netbsd.org/netbsd-1.4.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/netbsd.org/netbsd-1.5.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/netbsd.org/netbsd-1.6.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/netbsd.org/netbsd-10.0.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/netbsd.org/netbsd-2.0.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/netbsd.org/netbsd-3.0.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/netbsd.org/netbsd-4.0.xml</Path>
@@ -552,6 +578,10 @@
             <Path fileType="data">/usr/share/osinfo/os/netbsd.org/netbsd-8.1.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/netbsd.org/netbsd-8.2.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/netbsd.org/netbsd-9.0.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/netbsd.org/netbsd-9.1.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/netbsd.org/netbsd-9.2.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/netbsd.org/netbsd-9.3.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/netbsd.org/netbsd-9.4.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/nixos.org/nixos-20.03.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/nixos.org/nixos-20.09.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/nixos.org/nixos-21.05.xml</Path>
@@ -560,12 +590,26 @@
             <Path fileType="data">/usr/share/osinfo/os/nixos.org/nixos-22.11.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/nixos.org/nixos-23.05.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/nixos.org/nixos-23.11.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/nixos.org/nixos-24.05.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/nixos.org/nixos-24.11.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/nixos.org/nixos-25.05.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/nixos.org/nixos-unknown.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/nixos.org/nixos-unstable.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/novell.com/netware-4.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/novell.com/netware-5.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/novell.com/netware-6.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/omnios.org/bloody-rolling.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/openanolis.cn/anolis-23.0.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/openanolis.cn/anolis-23.1.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/openanolis.cn/anolis-7.7.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/openanolis.cn/anolis-7.9.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/openanolis.cn/anolis-8-unknown.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/openanolis.cn/anolis-8.2.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/openanolis.cn/anolis-8.4.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/openanolis.cn/anolis-8.6.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/openanolis.cn/anolis-8.8.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/openanolis.cn/anolis-8.9.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/openanolis.cn/anolis-unknown.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/openbsd.org/openbsd-4.2.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/openbsd.org/openbsd-4.3.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/openbsd.org/openbsd-4.4.xml</Path>
@@ -597,6 +641,8 @@
             <Path fileType="data">/usr/share/osinfo/os/openbsd.org/openbsd-7.2.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/openbsd.org/openbsd-7.3.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/openbsd.org/openbsd-7.4.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/openbsd.org/openbsd-7.5.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/openbsd.org/openbsd-7.6.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/openindiana.org/hipster-rolling.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/opensuse.org/opensuse-10.2.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/opensuse.org/opensuse-10.3.xml</Path>
@@ -616,6 +662,7 @@
             <Path fileType="data">/usr/share/osinfo/os/opensuse.org/opensuse-15.3.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/opensuse.org/opensuse-15.4.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/opensuse.org/opensuse-15.5.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/opensuse.org/opensuse-15.6.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/opensuse.org/opensuse-42.1.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/opensuse.org/opensuse-42.2.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/opensuse.org/opensuse-42.3.xml</Path>
@@ -663,6 +710,7 @@
             <Path fileType="data">/usr/share/osinfo/os/oracle.com/ol-7.9.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/oracle.com/ol-8.0.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/oracle.com/ol-8.1.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/oracle.com/ol-8.10.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/oracle.com/ol-8.2.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/oracle.com/ol-8.3.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/oracle.com/ol-8.4.xml</Path>
@@ -676,10 +724,14 @@
             <Path fileType="data">/usr/share/osinfo/os/oracle.com/ol-9.1.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/oracle.com/ol-9.2.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/oracle.com/ol-9.3.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/oracle.com/ol-9.4.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/oracle.com/solaris-11.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/pureos.net/pureos-10.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/pureos.net/pureos-8.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/pureos.net/pureos-9.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/redhat.com/rhel-10-unknown.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/redhat.com/rhel-10.0.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/redhat.com/rhel-10.1.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/redhat.com/rhel-2.1.1.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/redhat.com/rhel-2.1.2.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/redhat.com/rhel-2.1.3.xml</Path>
@@ -761,6 +813,9 @@
             <Path fileType="data">/usr/share/osinfo/os/redhat.com/rhel-9.2.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/redhat.com/rhel-9.3.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/redhat.com/rhel-9.4.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/redhat.com/rhel-9.5.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/redhat.com/rhel-9.6.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/redhat.com/rhel-9.7.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/redhat.com/rhel-atomic-7.0.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/redhat.com/rhel-atomic-7.1.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/redhat.com/rhel-atomic-7.2.xml</Path>
@@ -827,8 +882,40 @@
             <Path fileType="data">/usr/share/osinfo/os/scientificlinux.org/scientificlinux-7.4.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/scientificlinux.org/scientificlinux-7.5.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/scientificlinux.org/scientificlinux-7.6.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-10.0.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-10.1.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-10.2.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-11.0.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-12.0.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-12.1.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-12.2.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-13.0.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-13.1.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-13.37.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-14.0.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-14.1.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-14.2.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-15.0.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-3.0.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-3.1.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-3.3.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-3.4.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-3.5.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-3.6.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-3.9.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-4.0.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-7.0.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-7.1.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-8.0.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-8.1.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-9.0.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-9.1.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackware-current.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackwarearm-14.0.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackwarearm-14.1.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackwarearm-14.2.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackwarearm-15.0.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/slackware.com/slackwarearm-current.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/smartos.org/smartos-rolling.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/sun.com/opensolaris-2009.06.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/sun.com/solaris-10.xml</Path>
@@ -843,6 +930,7 @@
             <Path fileType="data">/usr/share/osinfo/os/suse.com/sle-15.3.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/suse.com/sle-15.4.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/suse.com/sle-15.5.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/suse.com/sle-15.6.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/suse.com/sle-15.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/suse.com/sle-unknown.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/suse.com/sled-10.1.xml</Path>
@@ -868,6 +956,7 @@
             <Path fileType="data">/usr/share/osinfo/os/suse.com/slem-5.2.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/suse.com/slem-5.3.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/suse.com/slem-5.4.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/suse.com/slem-5.5.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/suse.com/sles-10.1.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/suse.com/sles-10.2.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/suse.com/sles-10.3.xml</Path>
@@ -925,6 +1014,9 @@
             <Path fileType="data">/usr/share/osinfo/os/ubuntu.com/ubuntu-23.04.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/ubuntu.com/ubuntu-23.10.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/ubuntu.com/ubuntu-24.04.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/ubuntu.com/ubuntu-24.10.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/ubuntu.com/ubuntu-25.04.xml</Path>
+            <Path fileType="data">/usr/share/osinfo/os/ubuntu.com/ubuntu-25.10.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/ubuntu.com/ubuntu-4.10.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/ubuntu.com/ubuntu-5.04.xml</Path>
             <Path fileType="data">/usr/share/osinfo/os/ubuntu.com/ubuntu-5.10.xml</Path>
@@ -1015,12 +1107,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2024-01-07</Date>
-            <Version>20231215</Version>
+        <Update release="16">
+            <Date>2025-11-22</Date>
+            <Version>20250606</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Update osdb-info to v202250606
- Fix solus-rolling.xml

**Test Plan**

<!-- Short description of how the package was tested -->
Install the package and make sure Solus Xfce is now auto detected in virt-manager

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
