### PR TITLE
breeze: Add upstream patches

### DIFF
--- a/packages/b/breeze/files/upstream-1.patch
+++ b/packages/b/breeze/files/upstream-1.patch
@@ -1,0 +1,29 @@
+From 4a8a46aba6b9e39bfb02c7f46933079b5a50eff5 Mon Sep 17 00:00:00 2001
+From: Akseli Lahtinen <akselmo@akselmo.dev>
+Date: Wed, 19 Nov 2025 11:49:40 +0200
+Subject: [PATCH] Menu: Set ItemSpacing to 2
+
+This had been forgotten to change in
+https://invent.kde.org/plasma/breeze/-/merge_requests/563
+
+This is the same spacing as QtQuick styles use
+---
+ kstyle/breezemetrics.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kstyle/breezemetrics.h b/kstyle/breezemetrics.h
+index efad51c3c..647929013 100644
+--- a/kstyle/breezemetrics.h
++++ b/kstyle/breezemetrics.h
+@@ -55,7 +55,7 @@ struct Metrics {
+     static constexpr int MenuItem_HighlightGap = 4;
+     static constexpr int MenuItem_ExtraLeftMargin = 4;
+     static constexpr int MenuItem_MarginHeight = 5;
+-    static constexpr int MenuItem_ItemSpacing = 4;
++    static constexpr int MenuItem_ItemSpacing = 2;
+     static constexpr int MenuItem_AcceleratorSpace = 16;
+     static constexpr int MenuItem_TextLeftMargin = 8;
+ 
+-- 
+GitLab
+

--- a/packages/b/breeze/files/upstream-2.patch
+++ b/packages/b/breeze/files/upstream-2.patch
@@ -1,0 +1,32 @@
+From 2cd5b37dad8f213aab4029b6d3b80ca7f159ea50 Mon Sep 17 00:00:00 2001
+From: Nate Graham <nate@kde.org>
+Date: Wed, 19 Nov 2025 15:05:59 -0700
+Subject: [PATCH] Menu: Reduce margins to better match QQC2 style
+
+The vertical padding was 1px too high, causing the highlights to
+be taller than the qqc2-desktop-style version with the default font
+settings.
+
+Amends 35967f0a3c3d742b825a2ad7d6507a2c282857a5
+
+Resolves #24
+---
+ kstyle/breezemetrics.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kstyle/breezemetrics.h b/kstyle/breezemetrics.h
+index 647929013..d9b031358 100644
+--- a/kstyle/breezemetrics.h
++++ b/kstyle/breezemetrics.h
+@@ -54,7 +54,7 @@ struct Metrics {
+     static constexpr int MenuItem_MarginWidth = 4;
+     static constexpr int MenuItem_HighlightGap = 4;
+     static constexpr int MenuItem_ExtraLeftMargin = 4;
+-    static constexpr int MenuItem_MarginHeight = 5;
++    static constexpr int MenuItem_MarginHeight = 4;
+     static constexpr int MenuItem_ItemSpacing = 2;
+     static constexpr int MenuItem_AcceleratorSpace = 16;
+     static constexpr int MenuItem_TextLeftMargin = 8;
+-- 
+GitLab
+

--- a/packages/b/breeze/package.yml
+++ b/packages/b/breeze/package.yml
@@ -1,6 +1,6 @@
 name       : breeze
 version    : 6.5.3
-release    : 151
+release    : 152
 source     :
     - https://download.kde.org/stable/plasma/6.5.3/breeze-6.5.3.tar.xz : d782875a4510c31435ccd5aad209eb519c0a4ddfdb7da392f54eae863c2e8699
 homepage   : https://www.kde.org/workspaces/plasmadesktop/
@@ -54,6 +54,9 @@ optimize   :
     - speed
     - thin-lto
 setup      : |
+    %patch -p1 -i $pkgfiles/upstream-1.patch
+    %patch -p1 -i $pkgfiles/upstream-2.patch
+
     %cmake_kf6 -B qt5-build -DBUILD_QT5=ON -DBUILD_QT6=OFF
 
     %cmake_kf6 -B qt6-build -DBUILD_QT5=OFF -DBUILD_QT6=ON

--- a/packages/b/breeze/pspec_x86_64.xml
+++ b/packages/b/breeze/pspec_x86_64.xml
@@ -828,9 +828,9 @@
         <Description xml:lang="en">Artwork, styles and assets for the Breeze visual style for the Plasma Desktop</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="151">breeze</Dependency>
-            <Dependency releaseFrom="151">breeze-cursor-theme</Dependency>
-            <Dependency releaseFrom="151">breeze-light-cursor-theme</Dependency>
+            <Dependency release="152">breeze</Dependency>
+            <Dependency releaseFrom="152">breeze-cursor-theme</Dependency>
+            <Dependency releaseFrom="152">breeze-light-cursor-theme</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/cmake/Breeze/BreezeConfig.cmake</Path>
@@ -838,8 +838,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="151">
-            <Date>2025-11-19</Date>
+        <Update release="152">
+            <Date>2025-11-22</Date>
             <Version>6.5.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Troy Harvey</Name>


### PR DESCRIPTION
**Summary**

A breeze fix for menu paddings was not correct and cherry-picked too early. This results in things still being thicker than before the menu padding fix but removes extra padding making the issue worse.

**Test Plan**

- Use theme.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
