### PR TITLE
ddcutil: Update to v2.2.3

### DIFF
--- a/packages/d/ddcutil/abi_symbols
+++ b/packages/d/ddcutil/abi_symbols
@@ -26,6 +26,7 @@ ddcutil:active_callback_thread_ct
 ddcutil:active_callback_threads
 ddcutil:active_callback_threads_mutex
 ddcutil:adapter_supports_drm_using_drm_api
+ddcutil:add_backtraced_function
 ddcutil:add_one_func_to_summary
 ddcutil:add_open_display_for_current_thread
 ddcutil:add_open_failures_reported
@@ -236,6 +237,7 @@ ddcutil:cur_realtime_nanosec
 ddcutil:current_traced_function_stack_size
 ddcutil:current_traced_function_stack_to_syslog
 ddcutil:dbgrpt_all_sysfs_i2c_info
+ddcutil:dbgrpt_backtraced_function_table
 ddcutil:dbgrpt_buffer
 ddcutil:dbgrpt_bus_open_errors
 ddcutil:dbgrpt_capabilities_feature_record
@@ -245,6 +247,7 @@ ddcutil:dbgrpt_connector_bus_numbers
 ddcutil:dbgrpt_connector_state
 ddcutil:dbgrpt_connector_state_basic
 ddcutil:dbgrpt_connector_states
+ddcutil:dbgrpt_current_traced_function_stack
 ddcutil:dbgrpt_ddca_feature_metadata
 ddcutil:dbgrpt_display_feature_metadata
 ddcutil:dbgrpt_display_handle
@@ -253,6 +256,7 @@ ddcutil:dbgrpt_display_locks
 ddcutil:dbgrpt_display_ref
 ddcutil:dbgrpt_display_ref0
 ddcutil:dbgrpt_display_ref_summary
+ddcutil:dbgrpt_display_selector
 ddcutil:dbgrpt_dumpload_data
 ddcutil:dbgrpt_dyn_feature_metadata
 ddcutil:dbgrpt_dyn_feature_set
@@ -287,10 +291,15 @@ ddcutil:dbgrpt_sysfs_basic_connector_attributes
 ddcutil:dbgrpt_sysfs_connector_names
 ddcutil:dbgrpt_sysfs_i2c_info
 ddcutil:dbgrpt_traced_callstack_call_table
+ddcutil:dbgrpt_traced_function_stack
 ddcutil:dbgrpt_traced_function_table
-ddcutil:dbgrpt_traced_object_table
 ddcutil:dbgrpt_udev_device
+ddcutil:dbgrpt_udev_device_by_function_call
+ddcutil:dbgrpt_udev_device_lists
+ddcutil:dbgrpt_udev_device_properties
+ddcutil:dbgrpt_udev_device_sysattrs
 ddcutil:dbgrpt_udev_event_detail
+ddcutil:dbgrpt_udev_list_entries
 ddcutil:dbgrpt_usb_monitor_info
 ddcutil:dbgrpt_vcp_entry
 ddcutil:dbgrpt_vcp_feature_set
@@ -303,6 +312,7 @@ ddcutil:dbgtrc_show_process_id
 ddcutil:dbgtrc_show_thread_id
 ddcutil:dbgtrc_show_time
 ddcutil:dbgtrc_show_wall_time
+ddcutil:dbgtrc_trace_to_syslog
 ddcutil:dbgtrc_trace_to_syslog_only
 ddcutil:dci_cmp
 ddcutil:dci_eq
@@ -331,6 +341,7 @@ ddcutil:ddc_ensure_displays_detected
 ddcutil:ddc_erase_displays_cache
 ddcutil:ddc_error_name_to_number
 ddcutil:ddc_find_deserialized_display
+ddcutil:ddc_find_display_ref_by_selector
 ddcutil:ddc_get_all_display_refs
 ddcutil:ddc_get_bus_open_errors
 ddcutil:ddc_get_capabilities_string
@@ -374,11 +385,8 @@ ddcutil:ddcrc_desc_t
 ddcutil:ddcrc_find_status_code_info
 ddcutil:ddcrc_is_derived_status_code
 ddcutil:ddcrc_is_not_error
-ddcutil:debug_current_traced_function_stack
 ddcutil:debug_flock
 ddcutil:debug_locks
-ddcutil:debug_traced_function_stack
-ddcutil:debug_watch_state
 ddcutil:default_table_feature_detail_function
 ddcutil:default_user_multiplier_source
 ddcutil:default_user_sleep_multiplier
@@ -436,6 +444,7 @@ ddcutil:directory_exists
 ddcutil:discard_usb_monitor_list
 ddcutil:display_caching_enabled
 ddcutil:display_detection_callbacks
+ddcutil:display_id_to_dsel
 ddcutil:display_id_type_name
 ddcutil:display_index_of_highest_non_zero_counter
 ddcutil:display_open_errors
@@ -443,6 +452,7 @@ ddcutil:display_status_event_repr
 ddcutil:display_status_event_repr_t
 ddcutil:displayid_requirement_name
 ddcutil:dispno_max
+ddcutil:dispsel_transition
 ddcutil:do_one_card
 ddcutil:dpath_eq
 ddcutil:dpath_hash
@@ -483,6 +493,12 @@ ddcutil:drm_connector_type_table
 ddcutil:drm_connector_type_title
 ddcutil:drm_encoder_type_table
 ddcutil:drm_property_flag_table
+ddcutil:drpt_g_ptr_array
+ddcutil:drpt_label
+ddcutil:drpt_multiline
+ddcutil:drpt_structure_loc
+ddcutil:drpt_vstring
+ddcutil:drpt_vstring_collect
 ddcutil:dsa2_enable
 ddcutil:dsa2_erase_persistent_stats
 ddcutil:dsa2_get_adjusted_sleep_mult
@@ -505,7 +521,10 @@ ddcutil:dsa2_stats_cache_file_name
 ddcutil:dsa2_step_floor
 ddcutil:dsa2_step_to_multiplier
 ddcutil:dsel_free
+ddcutil:dsel_is_empty
 ddcutil:dsel_new
+ddcutil:dsel_only_busno
+ddcutil:dsel_repr_t
 ddcutil:dump_detailed_sys_bus_pci
 ddcutil:dump_sysfs_i2c
 ddcutil:dumpvcp_as_dumpload_data
@@ -522,6 +541,8 @@ ddcutil:dw_display_event_type_name
 ddcutil:dw_emit_deferred_events
 ddcutil:dw_emit_display_status_record
 ddcutil:dw_emit_or_queue_display_status_event
+ddcutil:dw_event_classes_repr
+ddcutil:dw_event_classes_repr_t
 ddcutil:dw_execute_callback_func
 ddcutil:dw_free_callback_displays_data
 ddcutil:dw_free_recheck_displays_data
@@ -530,10 +551,6 @@ ddcutil:dw_free_watch_displays_data
 ddcutil:dw_get_active_watch_classes
 ddcutil:dw_get_display_watch_settings
 ddcutil:dw_hotplug_change_handler
-ddcutil:dw_i2c_check_bus_changes
-ddcutil:dw_i2c_check_bus_changes_for_connector
-ddcutil:dw_i2c_stabilized_bus_by_connector_id
-ddcutil:dw_i2c_stabilized_single_bus_by_connector_name
 ddcutil:dw_init_xevent_screen_change_notification
 ddcutil:dw_is_ddc_event
 ddcutil:dw_is_watch_displays_executing
@@ -553,9 +570,11 @@ ddcutil:dw_stabilized_buses_bs
 ddcutil:dw_start_watch_displays
 ddcutil:dw_stop_watch_displays
 ddcutil:dw_terminate_if_invalid_thread_or_process
+ddcutil:dw_udev_setup
+ddcutil:dw_udev_teardown
+ddcutil:dw_udev_watch
 ddcutil:dw_unregister_display_status_callback
 ddcutil:dw_watch_display_connections
-ddcutil:dw_watch_displays_udev
 ddcutil:dyn_create_feature_set
 ddcutil:dyn_feature_set_repr_t
 ddcutil:dyn_format_feature_detail
@@ -656,6 +675,7 @@ ddcutil:find_class_dirs
 ddcutil:find_command
 ddcutil:find_devices_by_sysattr_name
 ddcutil:find_dref
+ddcutil:find_dref_by_dsel
 ddcutil:find_drm_connector_name_by_busno
 ddcutil:find_drm_connector_state
 ddcutil:find_eizo_model_sn_report
@@ -985,6 +1005,7 @@ ddcutil:i2c_set_io_strategy_by_id
 ddcutil:identify_i2c_devices
 ddcutil:ignore_mmk
 ddcutil:ignore_mmk_by_string
+ddcutil:in_ddci_open_display
 ddcutil:include_open_failures_reported
 ddcutil:indirect_strcmp
 ddcutil:ini_file_dump
@@ -1034,7 +1055,7 @@ ddcutil:init_dw_poll
 ddcutil:init_dw_recheck
 ddcutil:init_dw_services
 ddcutil:init_dw_status_events
-ddcutil:init_dw_udev
+ddcutil:init_dw_udev2
 ddcutil:init_dw_xevent
 ddcutil:init_dyn_feature_codes
 ddcutil:init_dyn_feature_files
@@ -1102,6 +1123,8 @@ ddcutil:io_mode_name
 ddcutil:isNullPacket
 ddcutil:is_abbrev
 ddcutil:is_adapter_class_display_controller
+ddcutil:is_backtraced_function
+ddcutil:is_backtracing
 ddcutil:is_cardN_dir
 ddcutil:is_card_connector_dir
 ddcutil:is_card_connector_dir1
@@ -1229,6 +1252,7 @@ ddcutil:only_fglrx
 ddcutil:only_nvidia_or_fglrx
 ddcutil:open_displays_for_thread
 ddcutil:output_level_name
+ddcutil:output_traced_function_stack
 ddcutil:parse_capabilities
 ddcutil:parse_capabilities_feature
 ddcutil:parse_capabilities_string
@@ -1334,6 +1358,7 @@ ddcutil:ptd_profile_reset_thread_stats
 ddcutil:ptd_thread_summary
 ddcutil:ptd_unlock_count
 ddcutil:publish_all_display_refs
+ddcutil:published_dref_hash_to_syslog
 ddcutil:push_traced_function
 ddcutil:pxc8_display_controller_type_values
 ddcutil:query_card_and_driver_using_sysfs
@@ -1430,6 +1455,7 @@ ddcutil:reset_current_traced_function_stack
 ddcutil:reset_execution_stats
 ddcutil:reset_published_dref_hash
 ddcutil:reset_sleep_event_counts
+ddcutil:restore_current_traced_function_stack
 ddcutil:retcode_range_ct
 ddcutil:retcode_range_table
 ddcutil:retry_thread_sleep_factor_millisec
@@ -1481,7 +1507,6 @@ ddcutil:rpt_set_ornamentation_enabled
 ddcutil:rpt_str
 ddcutil:rpt_structure_loc
 ddcutil:rpt_title
-ddcutil:rpt_title_collect
 ddcutil:rpt_uint8_as_hex
 ddcutil:rpt_unsigned
 ddcutil:rpt_vstring
@@ -1515,7 +1540,6 @@ ddcutil:set_output_level
 ddcutil:set_persistent_capabilites
 ddcutil:set_rpt_sysfs_attr_silent
 ddcutil:set_simple_dbgmsg_min_funcname_size
-ddcutil:set_trace_groups
 ddcutil:set_usage_value_by_report_type_and_ucode
 ddcutil:set_vcp_version_xdf_by_dh
 ddcutil:setvcp_value_type_name
@@ -1546,6 +1570,7 @@ ddcutil:stabilization_poll_millisec
 ddcutil:stabilize_added_buses_w_edid
 ddcutil:start_capture
 ddcutil:starts_with_any
+ddcutil:stash_current_traced_function_stack
 ddcutil:stats_multiple_call_option_help
 ddcutil:status_name_to_modulated_number
 ddcutil:status_name_to_unmodulated_number
@@ -1701,13 +1726,14 @@ ddcutil:usb_set_usage_value_by_vcprec
 ddcutil:usb_set_vcp_value
 ddcutil:usb_show_active_display_by_dref
 ddcutil:use_drm_connector_states
-ddcutil:use_sysfs_connector_id
 ddcutil:use_x37_detection_table
 ddcutil:user_multiplier_source_name
 ddcutil:valid_syslog_levels_string
 ddcutil:valid_vcp_versions
 ddcutil:validate_cmdinfo
 ddcutil:validate_output_level
+ddcutil:validate_section_key
+ddcutil:validate_section_name
 ddcutil:validate_subset_table
 ddcutil:vcp_code_table
 ddcutil:vcp_create_dummy_feature_for_hexid
@@ -1734,6 +1760,7 @@ ddcutil:vcp_version_gt
 ddcutil:vcp_version_is_valid
 ddcutil:vcp_version_le
 ddcutil:vcp_version_lt
+ddcutil:vdrpt_vstring_collect
 ddcutil:verify_i2c_access_for_single_bus
 ddcutil:vf0printf
 ddcutil:vnt_debug_table
@@ -1745,6 +1772,7 @@ ddcutil:vnt_title
 ddcutil:vrpt_vstring_collect
 ddcutil:watch_displays_mode
 ddcutil:watch_mode_name
+ddcutil:x11_init_state
 ddcutil:x37_detection_state_name
 ddcutil:x37_detection_table_key
 ddcutil:x60_v2_input_source_values
@@ -1774,6 +1802,13 @@ ddcutil:xdg_data_path
 ddcutil:xdg_state_home_dir
 ddcutil:xdg_state_home_file
 ddcutil:xevent_watch_loop_millisec
+ddcutil:xrpt_g_ptr_array
+ddcutil:xrpt_label_collect
+ddcutil:xrpt_nl
+ddcutil:xrpt_trc_to_syslog
+ddcutil:xrpt_trc_to_syslog_only
+ddcutil:xrpt_vstring
+ddcutil:xvrpt_vstring
 libddcutil.so.5:DDCA_EMPTY_FEATURE_LIST
 libddcutil.so.5:DDCA_VSPEC_ANY
 libddcutil.so.5:DDCA_VSPEC_UNKNOWN

--- a/packages/d/ddcutil/abi_used_symbols
+++ b/packages/d/ddcutil/abi_used_symbols
@@ -230,6 +230,7 @@ libglib-2.0.so.0:g_ptr_array_set_free_func
 libglib-2.0.so.0:g_ptr_array_set_size
 libglib-2.0.so.0:g_ptr_array_sized_new
 libglib-2.0.so.0:g_ptr_array_sort
+libglib-2.0.so.0:g_queue_free
 libglib-2.0.so.0:g_queue_free_full
 libglib-2.0.so.0:g_queue_get_length
 libglib-2.0.so.0:g_queue_new
@@ -306,6 +307,7 @@ libudev.so.1:udev_list_entry_get_next
 libudev.so.1:udev_list_entry_get_value
 libudev.so.1:udev_monitor_enable_receiving
 libudev.so.1:udev_monitor_filter_add_match_subsystem_devtype
+libudev.so.1:udev_monitor_get_fd
 libudev.so.1:udev_monitor_new_from_netlink
 libudev.so.1:udev_monitor_receive_device
 libudev.so.1:udev_monitor_unref

--- a/packages/d/ddcutil/package.yml
+++ b/packages/d/ddcutil/package.yml
@@ -1,8 +1,8 @@
 name       : ddcutil
-version    : 2.2.1
-release    : 13
+version    : 2.2.3
+release    : 14
 source     :
-    - https://github.com/rockowitz/ddcutil/archive/v2.2.1.tar.gz : ff8eb39b4559fcbc83de7b16834a010262dfa825938625272212fcaeefaef692
+    - https://github.com/rockowitz/ddcutil/archive/v2.2.3.tar.gz : fc95b7362932e79938b1c21ee83d9e54f1737bd403368fc2b926c9eb510e10e5
 license    : GPL-2.0-or-later
 component  : system.utils
 homepage   : https://ddcutil.com/

--- a/packages/d/ddcutil/pspec_x86_64.xml
+++ b/packages/d/ddcutil/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ddcutil</Name>
         <Homepage>https://ddcutil.com/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -32,12 +32,12 @@ A particular use case for ddcutil is as part of color profile management. Monito
             <Path fileType="library">/usr/lib/modules-load.d/ddcutil.conf</Path>
             <Path fileType="library">/usr/lib/udev/rules.d/60-ddcutil-i2c.rules</Path>
             <Path fileType="library">/usr/lib64/libddcutil.so.5</Path>
-            <Path fileType="library">/usr/lib64/libddcutil.so.5.3.0</Path>
+            <Path fileType="library">/usr/lib64/libddcutil.so.5.4.0</Path>
             <Path fileType="data">/usr/share/ddcutil/data/60-ddcutil-i2c.rules</Path>
             <Path fileType="data">/usr/share/ddcutil/data/60-ddcutil-usb.rules</Path>
             <Path fileType="data">/usr/share/ddcutil/data/90-nvidia-i2c.conf</Path>
             <Path fileType="data">/usr/share/ddcutil/data/nvidia-i2c.conf</Path>
-            <Path fileType="man">/usr/share/man/man1/ddcutil.1</Path>
+            <Path fileType="man">/usr/share/man/man1/ddcutil.1.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -51,7 +51,7 @@ A particular use case for ddcutil is as part of color profile management. Monito
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="13">ddcutil</Dependency>
+            <Dependency release="14">ddcutil</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/ddcutil_c_api.h</Path>
@@ -64,12 +64,12 @@ A particular use case for ddcutil is as part of color profile management. Monito
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2025-07-11</Date>
-            <Version>2.2.1</Version>
+        <Update release="14">
+            <Date>2025-11-22</Date>
+            <Version>2.2.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Release notes available [here](https://github.com/rockowitz/ddcutil/releases/tag/v2.2.3)

**Test Plan**

- Use system and disconnection/reconnect monitors.
- Change monitor brightness through Plasma widget.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
