### PR TITLE
hyperfine: Update to v1.20.0

### DIFF
--- a/packages/h/hyperfine/abi_used_libs
+++ b/packages/h/hyperfine/abi_used_libs
@@ -1,3 +1,3 @@
+ld-linux-x86-64.so.2
 libc.so.6
 libgcc_s.so.1
-libm.so.6

--- a/packages/h/hyperfine/abi_used_symbols
+++ b/packages/h/hyperfine/abi_used_symbols
@@ -1,3 +1,4 @@
+ld-linux-x86-64.so.2:__tls_get_addr
 libc.so.6:__errno_location
 libc.so.6:__libc_start_main
 libc.so.6:__register_atfork
@@ -7,6 +8,7 @@ libc.so.6:abort
 libc.so.6:bcmp
 libc.so.6:calloc
 libc.so.6:chdir
+libc.so.6:chroot
 libc.so.6:clock_gettime
 libc.so.6:close
 libc.so.6:dl_iterate_phdr
@@ -107,7 +109,3 @@ libgcc_s.so.1:_Unwind_RaiseException
 libgcc_s.so.1:_Unwind_Resume
 libgcc_s.so.1:_Unwind_SetGR
 libgcc_s.so.1:_Unwind_SetIP
-libm.so.6:ceil
-libm.so.6:round
-libm.so.6:trunc
-libm.so.6:truncf

--- a/packages/h/hyperfine/package.yml
+++ b/packages/h/hyperfine/package.yml
@@ -1,8 +1,8 @@
 name       : hyperfine
-version    : 1.19.0
-release    : 12
+version    : 1.20.0
+release    : 13
 source     :
-    - https://github.com/sharkdp/hyperfine/archive/refs/tags/v1.19.0.tar.gz : d1c782a54b9ebcdc1dedf8356a25ee11e11099a664a7d9413fdd3742138fa140
+    - https://github.com/sharkdp/hyperfine/archive/refs/tags/v1.20.0.tar.gz : f90c3b096af568438be7da52336784635a962c9822f10f98e5ad11ae8c7f5c64
 homepage   : https://github.com/sharkdp/hyperfine
 license    :
     - Apache-2.0

--- a/packages/h/hyperfine/pspec_x86_64.xml
+++ b/packages/h/hyperfine/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>hyperfine</Name>
         <Homepage>https://github.com/sharkdp/hyperfine</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>MIT</License>
@@ -24,17 +24,17 @@
             <Path fileType="executable">/usr/bin/hyperfine</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/hyperfine</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/hyperfine.fish</Path>
-            <Path fileType="man">/usr/share/man/man1/hyperfine.1</Path>
+            <Path fileType="man">/usr/share/man/man1/hyperfine.1.zst</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_hyperfine</Path>
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2025-01-07</Date>
-            <Version>1.19.0</Version>
+        <Update release="13">
+            <Date>2025-11-23</Date>
+            <Version>1.20.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Release notes can be found [here](https://github.com/sharkdp/hyperfine/releases/tag/v1.20.0).

**Test Plan**

Ran hyperfine 'sleep 0.3' and read output. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
