### PR TITLE
solseek: Update to 0.5.1

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 0.4.0
-release    : 5
+version    : 0.5.1
+release    : 6
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v0.4.0.tar.gz : eeb596a617fd8ea51f7a606da8d32fe8351e70be93f9785df71e02ad687a3c75
+    - https://github.com/clintre/solseek/archive/refs/tags/v0.5.1.tar.gz : 2c45f12dd0c968e56d701f581c9d924a3ecd6fb411374a945d5aafe6f19e6c72
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : systtem.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -42,6 +42,7 @@
             <Path fileType="data">/usr/share/solseek/lang/fr/package_action.txt</Path>
             <Path fileType="data">/usr/share/solseek/lang/fr/update_system.txt</Path>
             <Path fileType="data">/usr/share/solseek/lang/fr/welcome.txt</Path>
+            <Path fileType="data">/usr/share/solseek/menus</Path>
             <Path fileType="data">/usr/share/solseek/solseek-uc.service</Path>
             <Path fileType="data">/usr/share/solseek/solseek-uc.timer</Path>
             <Path fileType="data">/usr/share/solseek/solseek_fastfetch.jsonc</Path>
@@ -49,9 +50,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2025-11-19</Date>
-            <Version>0.4.0</Version>
+        <Update release="6">
+            <Date>2025-11-24</Date>
+            <Version>0.5.1</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
Bugfixes:

- Fixed issue with Flatpak not finding certain packages that are runtimes.
- Minor language correction

Enhancements:

- Navigation does not just take you back to the main window now
- Simplified the text in the menu to make translation easier
- Removed the User Installed for Package List
- Made the menu more clear and added sections
- Added a new config flag SS_ASSUMEYES where if set to 1 will add the -y flag to package functions.

Full release notes:

- [0.5.1](https://github.com/clintre/solseek/releases/tag/v0.5.1)

**Summary**

Major code refactoring, bug fixes and enhancements

**Test Plan**

Tested in lab and on main dev system.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
