### PR TITLE
tailscale: Update to v1.90.9

### DIFF
--- a/packages/t/tailscale/package.yml
+++ b/packages/t/tailscale/package.yml
@@ -1,8 +1,8 @@
 name       : tailscale
-version    : 1.90.8
-release    : 45
+version    : 1.90.9
+release    : 46
 source     :
-    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.90.8.tar.gz : bcd8c284bf4b65811f3dd98a969e246bdba00491339608b75d51177085bfc09d
+    - https://github.com/tailscale/tailscale/archive/refs/tags/v1.90.9.tar.gz : df3f8fc2635826b59677f34b17d81299ffb0c6a0fe484d52e47f2bbdea000193
 homepage   : https://tailscale.com
 license    : BSD-3-Clause
 component  : network.clients

--- a/packages/t/tailscale/pspec_x86_64.xml
+++ b/packages/t/tailscale/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="45">
-            <Date>2025-11-19</Date>
-            <Version>1.90.8</Version>
+        <Update release="46">
+            <Date>2025-11-25</Date>
+            <Version>1.90.9</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Fixed: tailscaled no longer deadlocks during event bursts.
- Fixed: The client no longer hangs after wake up when port mapping is in use and interfaces are slow to become available.
- Release notes can be found [here](https://tailscale.com/changelog).

**Test Plan**

Connect to tailnet. Ping other machine via magicdns. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
