### PR TITLE
soundconverter: Update to v4.1.1

### DIFF
--- a/packages/s/soundconverter/package.yml
+++ b/packages/s/soundconverter/package.yml
@@ -1,8 +1,8 @@
 name       : soundconverter
-version    : 4.0.6
-release    : 17
+version    : 4.1.1
+release    : 18
 source     :
-    - https://github.com/kassoulet/soundconverter/archive/refs/tags/4.0.6.tar.gz : bc881e5b40512a388323a5a3d163859c1277224045e46b97628d658c6f57d6fc
+    - https://github.com/kassoulet/soundconverter/archive/refs/tags/4.1.1.tar.gz : 8ac117e8e7668179b5dd88eb761976221cee63995d87d68b89b0059d5597a02a
 homepage   : https://soundconverter.org/
 license    : GPL-3.0-or-later
 component  : multimedia.audio

--- a/packages/s/soundconverter/pspec_x86_64.xml
+++ b/packages/s/soundconverter/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>soundconverter</Name>
         <Homepage>https://soundconverter.org/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>multimedia.audio</PartOf>
@@ -21,10 +21,10 @@
         <PartOf>multimedia.audio</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/soundconverter</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter-4.0.6-py3.12.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter-4.0.6-py3.12.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter-4.0.6-py3.12.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter-4.0.6-py3.12.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter-4.1.1-py3.12.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter-4.1.1-py3.12.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter-4.1.1-py3.12.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter-4.1.1-py3.12.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter/__pycache__/__init__.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter/gstreamer/__init__.py</Path>
@@ -41,6 +41,7 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter/interface/__pycache__/mainloop.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter/interface/__pycache__/notify.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter/interface/__pycache__/preferences.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter/interface/__pycache__/theme.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter/interface/__pycache__/ui.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter/interface/batch.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter/interface/filelist.py</Path>
@@ -48,6 +49,7 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter/interface/mainloop.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter/interface/notify.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter/interface/preferences.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter/interface/theme.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter/interface/ui.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter/util/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/soundconverter/util/__pycache__/__init__.cpython-312.pyc</Path>
@@ -135,12 +137,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2025-09-10</Date>
-            <Version>4.0.6</Version>
+        <Update release="18">
+            <Date>2025-11-27</Date>
+            <Version>4.1.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/kassoulet/soundconverter/compare/4.1.0...4.1.1).
- Resolves: https://github.com/getsolus/packages/issues/7173

**Test Plan**

Opened Soundconverter. Verified version. Converted mp3 to ogg. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
