### PR TITLE
unbound: Update to v1.24.2

### DIFF
--- a/packages/u/unbound/package.yml
+++ b/packages/u/unbound/package.yml
@@ -1,8 +1,8 @@
 name       : unbound
-version    : 1.24.1
-release    : 20
+version    : 1.24.2
+release    : 21
 source     :
-    - https://nlnetlabs.nl/downloads/unbound/unbound-1.24.1.tar.gz : 7f2b1633e239409619ae0527f67878b0f33ae0ec0ee5a3a51c042c359ba1eeab
+    - https://nlnetlabs.nl/downloads/unbound/unbound-1.24.2.tar.gz : 44e7b53e008a6dcaec03032769a212b46ab5c23c105284aa05a4f3af78e59cdb
 homepage   : https://nlnetlabs.nl/projects/unbound/about/
 license    : BSD-3-Clause
 component  : network.util

--- a/packages/u/unbound/pspec_x86_64.xml
+++ b/packages/u/unbound/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>unbound</Name>
         <Homepage>https://nlnetlabs.nl/projects/unbound/about/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>network.util</PartOf>
@@ -49,7 +49,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="20">unbound</Dependency>
+            <Dependency release="21">unbound</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/unbound-event.h</Path>
@@ -90,12 +90,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2025-10-23</Date>
-            <Version>1.24.1</Version>
+        <Update release="21">
+            <Date>2025-11-27</Date>
+            <Version>1.24.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://nlnetlabs.nl/news/2025/Nov/26/unbound-1.24.2-released/).

**Security**
- CVE-2025-11411

**Test Plan**

TBD

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
