### PR TITLE
imagemagick: Update to v7.1.2.8

### DIFF
--- a/packages/i/imagemagick/package.yml
+++ b/packages/i/imagemagick/package.yml
@@ -1,8 +1,8 @@
 name       : imagemagick
-version    : 7.1.2.7
-release    : 203
+version    : 7.1.2.8
+release    : 204
 source     :
-    - https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-7.tar.gz : d532c7be0b4fbd17d03ef311f55ad8a4845c63cb74f8725320b7d3d3c6a7a4f7
+    - https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-8.tar.gz : acf76a9dafbd18f4dd7b24c45ca10c77e31289fc28e4da0ce5cc3929fd0aef16
 homepage   : https://imagemagick.org/
 license    : Apache-2.0
 component  : multimedia.graphics

--- a/packages/i/imagemagick/pspec_x86_64.xml
+++ b/packages/i/imagemagick/pspec_x86_64.xml
@@ -93,7 +93,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="203">imagemagick</Dependency>
+            <Dependency release="204">imagemagick</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/ImageMagick-7/Magick++.h</Path>
@@ -592,9 +592,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="203">
-            <Date>2025-10-25</Date>
-            <Version>7.1.2.7</Version>
+        <Update release="204">
+            <Date>2025-11-28</Date>
+            <Version>7.1.2.8</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://github.com/ImageMagick/Website/blob/main/ChangeLog.md#712-8---2025-10-26)

**Security**

- https://github.com/ImageMagick/ImageMagick/security/advisories/GHSA-g5vw-p55v-8742 (dead?)
- https://github.com/ImageMagick/ImageMagick/security/advisories/GHSA-wpp4-vqfq-v4hp

**Test Plan**

- Rotate an image

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
