### PR TITLE
libmpeg2: Fix homepage link

### DIFF
--- a/packages/l/libmpeg2/abi_used_symbols
+++ b/packages/l/libmpeg2/abi_used_symbols
@@ -1,7 +1,9 @@
 libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__fread_chk
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__printf_chk
@@ -32,5 +34,4 @@ libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncpy
 libc.so.6:strtod
-libc.so.6:strtol
 libc.so.6:time

--- a/packages/l/libmpeg2/package.yml
+++ b/packages/l/libmpeg2/package.yml
@@ -1,9 +1,9 @@
 name       : libmpeg2
 version    : 0.5.1
-release    : 3
+release    : 4
 source     :
-    - https://libmpeg2.sourceforge.net/files/libmpeg2-0.5.1.tar.gz : dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4
-homepage   : http://libmpeg2.sourceforge.net/
+    - https://download.videolan.org/contrib/libmpeg2/libmpeg2-0.5.1.tar.gz : dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4
+homepage   : https://libmpeg2.sourceforge.io/
 license    : GPL-2.0-or-later
 component  :
     - multimedia.codecs

--- a/packages/l/libmpeg2/pspec_x86_64.xml
+++ b/packages/l/libmpeg2/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>libmpeg2</Name>
-        <Homepage>http://libmpeg2.sourceforge.net/</Homepage>
+        <Homepage>https://libmpeg2.sourceforge.io/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>multimedia.codecs</PartOf>
@@ -30,7 +30,7 @@
         <Description xml:lang="en">Development files for libmpeg2</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="3">libmpeg2</Dependency>
+            <Dependency release="4">libmpeg2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/mpeg2dec/mpeg2.h</Path>
@@ -47,23 +47,23 @@
         <Description xml:lang="en">Command line utilities for libmpeg2</Description>
         <PartOf>multimedia.codecs</PartOf>
         <RuntimeDependencies>
-            <Dependency release="3">libmpeg2</Dependency>
+            <Dependency release="4">libmpeg2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/corrupt_mpeg2</Path>
             <Path fileType="executable">/usr/bin/extract_mpeg2</Path>
             <Path fileType="executable">/usr/bin/mpeg2dec</Path>
-            <Path fileType="man">/usr/share/man/man1/extract_mpeg2.1</Path>
-            <Path fileType="man">/usr/share/man/man1/mpeg2dec.1</Path>
+            <Path fileType="man">/usr/share/man/man1/extract_mpeg2.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/mpeg2dec.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2024-08-12</Date>
+        <Update release="4">
+            <Date>2025-11-29</Date>
             <Version>0.5.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fix download link
- Part of https://github.com/getsolus/packages/issues/5522

**Test Plan**

Install libmpeg2

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
