### PR TITLE
halloy: Update to v2025.12

### DIFF
--- a/packages/h/halloy/package.yml
+++ b/packages/h/halloy/package.yml
@@ -1,8 +1,8 @@
 name       : halloy
-version    : '2025.11'
-release    : 5
+version    : '2025.12'
+release    : 6
 source     :
-    - https://github.com/squidowl/halloy/archive/refs/tags/2025.11.tar.gz : 19546fb2c49ea342e39c38b6771536089b16892b8de6ae4e4a09e4f25db3cd1b
+    - https://github.com/squidowl/halloy/archive/refs/tags/2025.12.tar.gz : 106689f15aeca87e88c7249812b0c8383c6c8f2746df4f5bbd83b579e2ebb756
 homepage   : https://halloy.squidowl.org/
 license    : GPL-3.0-or-later
 component  : network.im

--- a/packages/h/halloy/pspec_x86_64.xml
+++ b/packages/h/halloy/pspec_x86_64.xml
@@ -35,9 +35,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2025-10-29</Date>
-            <Version>2025.11</Version>
+        <Update release="6">
+            <Date>2025-11-29</Date>
+            <Version>2025.12</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://github.com/squidowl/halloy/releases/tag/2025.12)

**Test Plan**

- Join the old Solus channels

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
