### PR TITLE
[NFC] .github: add funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: getsolus


### PR DESCRIPTION
**Summary**

This should add a funding link on the sidebar. We mention OC in the README, but it's not very prominent 

ref: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
