### PR TITLE
openxr: Update to v1.1.53

### DIFF
--- a/packages/o/openxr/MAINTAINERS.md
+++ b/packages/o/openxr/MAINTAINERS.md
@@ -1,5 +1,5 @@
 This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
 
-- Hurican Solas
+- Hurican Dev
   - Matrix: @hurican:matrix.org
   - Email: hurican@keemail.me

--- a/packages/o/openxr/package.yml
+++ b/packages/o/openxr/package.yml
@@ -1,8 +1,8 @@
 name       : openxr
-version    : 1.1.51
-release    : 2
+version    : 1.1.53
+release    : 3
 source     :
-    - https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-1.1.51/OpenXR-SDK-Source-release-1.1.51.tar.gz : 0efacfbaada35f877d6be1d283d381717536b2743c24697c1145409377a6da2c
+    - https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-1.1.53/OpenXR-SDK-Source-release-1.1.53.tar.gz : 1bf766990ff47dfb9b32df201777f666a6399aaab4a249e43b7ad676ad240a3c
 homepage   : https://www.khronos.org/openxr/
 license    : Apache-2.0
 component  : multimedia.library

--- a/packages/o/openxr/pspec_x86_64.xml
+++ b/packages/o/openxr/pspec_x86_64.xml
@@ -3,7 +3,7 @@
         <Name>openxr</Name>
         <Homepage>https://www.khronos.org/openxr/</Homepage>
         <Packager>
-            <Name>Hurican Solas</Name>
+            <Name>Hurican Dev</Name>
             <Email>hurican@keemail.me</Email>
         </Packager>
         <License>Apache-2.0</License>
@@ -24,11 +24,11 @@
             <Path fileType="executable">/usr/bin/openxr_runtime_list</Path>
             <Path fileType="executable">/usr/bin/openxr_runtime_list_json</Path>
             <Path fileType="library">/usr/lib64/libopenxr_loader.so.1</Path>
-            <Path fileType="library">/usr/lib64/libopenxr_loader.so.1.1.51</Path>
+            <Path fileType="library">/usr/lib64/libopenxr_loader.so.1.1.53</Path>
             <Path fileType="doc">/usr/share/doc/openxr/LICENSE</Path>
-            <Path fileType="man">/usr/share/man/man1/hello_xr.1</Path>
-            <Path fileType="man">/usr/share/man/man1/openxr_runtime_list.1</Path>
-            <Path fileType="man">/usr/share/man/man1/openxr_runtime_list_json.1</Path>
+            <Path fileType="man">/usr/share/man/man1/hello_xr.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/openxr_runtime_list.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/openxr_runtime_list_json.1.zst</Path>
             <Path fileType="data">/usr/share/openxr/1/api_layers/explicit.d/XrApiLayer_api_dump.json</Path>
             <Path fileType="data">/usr/share/openxr/1/api_layers/explicit.d/XrApiLayer_best_practices_validation.json</Path>
             <Path fileType="data">/usr/share/openxr/1/api_layers/explicit.d/XrApiLayer_core_validation.json</Path>
@@ -41,7 +41,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">openxr</Dependency>
+            <Dependency release="3">openxr</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/openxr/openxr.h</Path>
@@ -63,11 +63,11 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2025-08-29</Date>
-            <Version>1.1.51</Version>
+        <Update release="3">
+            <Date>2025-11-29</Date>
+            <Version>1.1.53</Version>
             <Comment>Packaging update</Comment>
-            <Name>Hurican Solas</Name>
+            <Name>Hurican Dev</Name>
             <Email>hurican@keemail.me</Email>
         </Update>
     </History>


### PR DESCRIPTION
**Summary**

Updated to the latest version. 
[1.1.53](https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/tag/release-1.1.53)

**Test Plan**

Installed both the regular and the devel package and successfully built an envision profile.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
