### PR TITLE
openjpeg: Update to v2.5.4

### DIFF
--- a/packages/o/openjpeg/abi_used_symbols
+++ b/packages/o/openjpeg/abi_used_symbols
@@ -1,7 +1,8 @@
 libc.so.6:__ctype_b_loc
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_fscanf
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_fscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__longjmp_chk
 libc.so.6:__memcpy_chk
@@ -50,6 +51,7 @@ libc.so.6:pthread_mutex_destroy
 libc.so.6:pthread_mutex_init
 libc.so.6:pthread_mutex_lock
 libc.so.6:pthread_mutex_unlock
+libc.so.6:qsort
 libc.so.6:readdir
 libc.so.6:realloc
 libc.so.6:remove
@@ -67,7 +69,6 @@ libc.so.6:strrchr
 libc.so.6:strstr
 libc.so.6:strtod
 libc.so.6:strtok
-libc.so.6:strtol
 libc.so.6:sysconf
 liblcms2.so.2:cmsCloseProfile
 liblcms2.so.2:cmsCreateLab4Profile
@@ -79,6 +80,9 @@ liblcms2.so.2:cmsGetColorSpace
 liblcms2.so.2:cmsGetHeaderRenderingIntent
 liblcms2.so.2:cmsGetPCS
 liblcms2.so.2:cmsOpenProfileFromMem
+libm.so.6:ceilf
+libm.so.6:floor
+libm.so.6:floorf
 libm.so.6:lrintf
 libm.so.6:pow
 libm.so.6:sqrt

--- a/packages/o/openjpeg/package.yml
+++ b/packages/o/openjpeg/package.yml
@@ -1,8 +1,8 @@
 name       : openjpeg
-version    : 2.5.2
-release    : 21
+version    : 2.5.4
+release    : 22
 source     :
-    - https://github.com/uclouvain/openjpeg/archive/refs/tags/v2.5.2.tar.gz : 90e3896fed910c376aaf79cdd98bdfdaf98c6472efd8e1debf0a854938cbda6a
+    - https://github.com/uclouvain/openjpeg/archive/refs/tags/v2.5.4.tar.gz : a695fbe19c0165f295a8531b1e4e855cd94d0875d2f88ec4b61080677e27188a
 homepage   : https://www.openjpeg.org/
 license    : BSD-2-Clause
 component  : multimedia.library

--- a/packages/o/openjpeg/pspec_x86_64.xml
+++ b/packages/o/openjpeg/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>openjpeg</Name>
         <Homepage>https://www.openjpeg.org/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>multimedia.library</PartOf>
@@ -23,7 +23,7 @@
             <Path fileType="executable">/usr/bin/opj_compress</Path>
             <Path fileType="executable">/usr/bin/opj_decompress</Path>
             <Path fileType="executable">/usr/bin/opj_dump</Path>
-            <Path fileType="library">/usr/lib64/libopenjp2.so.2.5.2</Path>
+            <Path fileType="library">/usr/lib64/libopenjp2.so.2.5.4</Path>
             <Path fileType="library">/usr/lib64/libopenjp2.so.7</Path>
         </Files>
     </Package>
@@ -34,7 +34,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="21">openjpeg</Dependency>
+            <Dependency release="22">openjpeg</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/openjpeg-2.5/openjpeg.h</Path>
@@ -48,12 +48,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2024-06-20</Date>
-            <Version>2.5.2</Version>
+        <Update release="22">
+            <Date>2025-11-30</Date>
+            <Version>2.5.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Changelog [here](https://github.com/uclouvain/openjpeg/blob/v2.5.4/NEWS.md)
- *No API/ABI break compared to v2.5.2*

**Security**

- CVE-2025-54874

**Test Plan**

- Open a jp2 image in krita

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
