### PR TITLE
sox_ng: Update to v14.7.0.1

### DIFF
--- a/packages/s/sox_ng/package.yml
+++ b/packages/s/sox_ng/package.yml
@@ -1,8 +1,8 @@
 name       : sox_ng
-version    : 14.7.0
-release    : 26
+version    : 14.7.0.1
+release    : 27
 source     :
-    - https://codeberg.org/sox_ng/sox_ng/releases/download/sox_ng-14.7.0/sox_ng-14.7.0.tar.gz : 3c7258bc20dc2af628f1633d5db053698d433d4fc3b5219cf9bb4946a9d34d50
+    - https://codeberg.org/sox_ng/sox_ng/releases/download/sox_ng-14.7.0.1/sox_ng-14.7.0.1.tar.gz : 8f2af178a11a3f664121c916af6428e42a5000bc018056b2f4a2c8dad0f339c9
 homepage   : https://codeberg.org/sox_ng/sox_ng
 license    :
     - GPL-2.0-only

--- a/packages/s/sox_ng/pspec_x86_64.xml
+++ b/packages/s/sox_ng/pspec_x86_64.xml
@@ -44,7 +44,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="26">sox_ng</Dependency>
+            <Dependency release="27">sox_ng</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/sox_ng.h</Path>
@@ -54,9 +54,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2025-11-22</Date>
-            <Version>14.7.0</Version>
+        <Update release="27">
+            <Date>2025-11-30</Date>
+            <Version>14.7.0.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
o Make multi-format plugins register the formats they handle 
o phaser: Put limit on gain-out back up to 1e9

**Test Plan**
- Installed checked version.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
