### PR TITLE
weechat: Update to v4.8.0

### DIFF
--- a/packages/w/weechat/abi_symbols
+++ b/packages/w/weechat/abi_symbols
@@ -1239,7 +1239,6 @@ irc.so:irc_config_look_smart_filter_mode
 irc.so:irc_config_look_smart_filter_nick
 irc.so:irc_config_look_smart_filter_quit
 irc.so:irc_config_look_smart_filter_setname
-irc.so:irc_config_look_temporary_servers
 irc.so:irc_config_look_topic_strip_colors
 irc.so:irc_config_look_typing_status_nicks
 irc.so:irc_config_look_typing_status_self
@@ -1283,7 +1282,6 @@ irc.so:irc_config_server_read_cb
 irc.so:irc_config_server_write_cb
 irc.so:irc_config_update_cb
 irc.so:irc_config_write
-irc.so:irc_config_write_temp_servers
 irc.so:irc_ctcp_convert_legacy_format
 irc.so:irc_ctcp_dcc_filename_without_quotes
 irc.so:irc_ctcp_default_reply
@@ -1437,7 +1435,7 @@ irc.so:irc_message_split_string
 irc.so:irc_message_start_batch
 irc.so:irc_mode_channel_set
 irc.so:irc_mode_channel_update
-irc.so:irc_mode_get_arguments
+irc.so:irc_mode_get_arguments_colors
 irc.so:irc_mode_get_chanmode_type
 irc.so:irc_mode_registered_mode_change
 irc.so:irc_mode_smart_filtered
@@ -1687,6 +1685,7 @@ irc.so:irc_redirect_search_available
 irc.so:irc_redirect_stop
 irc.so:irc_sasl_get_key_content
 irc.so:irc_sasl_mechanism_ecdsa_nist256p_challenge
+irc.so:irc_sasl_mechanism_external
 irc.so:irc_sasl_mechanism_plain
 irc.so:irc_sasl_mechanism_scram
 irc.so:irc_sasl_mechanism_string

--- a/packages/w/weechat/abi_used_symbols
+++ b/packages/w/weechat/abi_used_symbols
@@ -231,10 +231,15 @@ libcjson.so.1:cJSON_PrintUnformatted
 libcurl.so.4:curl_easy_cleanup
 libcurl.so.4:curl_easy_getinfo
 libcurl.so.4:curl_easy_init
-libcurl.so.4:curl_easy_perform
 libcurl.so.4:curl_easy_setopt
 libcurl.so.4:curl_global_cleanup
 libcurl.so.4:curl_global_init
+libcurl.so.4:curl_multi_add_handle
+libcurl.so.4:curl_multi_cleanup
+libcurl.so.4:curl_multi_init
+libcurl.so.4:curl_multi_perform
+libcurl.so.4:curl_multi_poll
+libcurl.so.4:curl_multi_remove_handle
 libcurl.so.4:curl_slist_append
 libenchant-2.so.2:enchant_broker_dict_exists
 libenchant-2.so.2:enchant_broker_free

--- a/packages/w/weechat/package.yml
+++ b/packages/w/weechat/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : weechat
-version    : 4.7.1
-release    : 98
+version    : 4.8.0
+release    : 99
 source     :
-    - https://github.com/weechat/weechat/archive/refs/tags/v4.7.1.tar.gz : a00c8c4abc83b22f888d8d615684b39a5fb155bde1d69784aa1dbb88e03d3086
+    - https://github.com/weechat/weechat/archive/refs/tags/v4.8.0.tar.gz : 95d2b8fd691deb7def8a735832c0b306621bf026f95c0b61ef73f0a3f7f04138
 homepage   : https://weechat.org
 license    : GPL-3.0-or-later
 summary    : WeeChat is a fast, light and extensible chat client.
@@ -23,12 +23,17 @@ builddeps  :
     - pkgconfig(python3)
     - pkgconfig(ruby-3.4)
     - pkgconfig(tcl)
+    - asciidoctor
     - perl
 rundeps    :
     - perl
 setup      : |
-    %cmake -DENABLE_ENCHANT=ON -DENABLE_JAVASCRIPT=OFF -DENABLE_PHP=OFF -DWITH-DEBUG=1
+    %cmake_ninja \
+        -DENABLE_ENCHANT=ON \
+        -DENABLE_JAVASCRIPT=OFF \
+        -DENABLE_PHP=OFF \
+        -DENABLE_MAN=ON
 build      : |
-    %make
+    %ninja_build
 install    : |
-    %make_install
+    %ninja_install

--- a/packages/w/weechat/pspec_x86_64.xml
+++ b/packages/w/weechat/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>weechat</Name>
         <Homepage>https://weechat.org</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.irc</PartOf>
@@ -63,6 +63,24 @@
             <Path fileType="localedata">/usr/share/locale/ru/LC_MESSAGES/weechat.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sr/LC_MESSAGES/weechat.mo</Path>
             <Path fileType="localedata">/usr/share/locale/tr/LC_MESSAGES/weechat.mo</Path>
+            <Path fileType="man">/usr/share/man/cs/man1/weechat-headless.1.zst</Path>
+            <Path fileType="man">/usr/share/man/cs/man1/weechat.1.zst</Path>
+            <Path fileType="man">/usr/share/man/de/man1/weechat-headless.1.zst</Path>
+            <Path fileType="man">/usr/share/man/de/man1/weechat.1.zst</Path>
+            <Path fileType="man">/usr/share/man/fr/man1/weechat-headless.1.zst</Path>
+            <Path fileType="man">/usr/share/man/fr/man1/weechat.1.zst</Path>
+            <Path fileType="man">/usr/share/man/it/man1/weechat-headless.1.zst</Path>
+            <Path fileType="man">/usr/share/man/it/man1/weechat.1.zst</Path>
+            <Path fileType="man">/usr/share/man/ja/man1/weechat-headless.1.zst</Path>
+            <Path fileType="man">/usr/share/man/ja/man1/weechat.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/weechat-headless.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/weechat.1.zst</Path>
+            <Path fileType="man">/usr/share/man/pl/man1/weechat-headless.1.zst</Path>
+            <Path fileType="man">/usr/share/man/pl/man1/weechat.1.zst</Path>
+            <Path fileType="man">/usr/share/man/ru/man1/weechat-headless.1.zst</Path>
+            <Path fileType="man">/usr/share/man/ru/man1/weechat.1.zst</Path>
+            <Path fileType="man">/usr/share/man/sr/man1/weechat-headless.1.zst</Path>
+            <Path fileType="man">/usr/share/man/sr/man1/weechat.1.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -72,7 +90,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="98">weechat</Dependency>
+            <Dependency release="99">weechat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/weechat/weechat-plugin.h</Path>
@@ -80,12 +98,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="98">
-            <Date>2025-09-28</Date>
-            <Version>4.7.1</Version>
+        <Update release="99">
+            <Date>2025-11-30</Date>
+            <Version>4.8.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changelog available [here](https://github.com/weechat/weechat/releases/tag/v4.8.0).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Connect to Libera chat.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
