### PR TITLE
miriway: Update to v25.13

### DIFF
--- a/packages/m/miriway/package.yml
+++ b/packages/m/miriway/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : miriway
-version    : '25.12'
-release    : 5
+version    : '25.13'
+release    : 6
 source     :
-    - https://github.com/Miriway/Miriway/archive/refs/tags/v25.12.tar.gz : a4077e23a10744d32a533da5ca508c8f499f69e9b86166a862e205e0348136db
+    - https://github.com/Miriway/Miriway/archive/refs/tags/v25.13.tar.gz : e36b02e0c3785e0b61d31ddb5f5a74b74385a01cab68b39a02165556afd6478e
 homepage   : https://github.com/Miriway/Miriway
 license    : GPL-3.0-only
 component  :

--- a/packages/m/miriway/pspec_x86_64.xml
+++ b/packages/m/miriway/pspec_x86_64.xml
@@ -43,7 +43,7 @@ Miriway has been tested with shell components from several desktop environments 
 </Description>
         <PartOf>desktop</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="5">miriway</Dependency>
+            <Dependency releaseFrom="6">miriway</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/sddm/sddm.conf.d/miriway.conf</Path>
@@ -58,7 +58,7 @@ Miriway has been tested with shell components from several desktop environments 
 </Description>
         <PartOf>desktop</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="5">miriway</Dependency>
+            <Dependency releaseFrom="6">miriway</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/miriway-session</Path>
@@ -69,9 +69,9 @@ Miriway has been tested with shell components from several desktop environments 
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2025-11-03</Date>
-            <Version>25.12</Version>
+        <Update release="6">
+            <Date>2025-11-30</Date>
+            <Version>25.13</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/Miriway/Miriway/releases/tag/v25.13).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Launched a Budgie Miriway session.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
