### PR TITLE
solseek: Update to 0.6.0

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 0.5.5
-release    : 7
+version    : 0.6.0
+release    : 8
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v0.5.5.tar.gz : 028ff4ad065c7c055016b06d05afe517e0401e56b67d203e56d792c827f4d459
+    - https://github.com/clintre/solseek/archive/refs/tags/v0.6.0.tar.gz : d9f2565e845a34d779437a67d466c6c108a25a0d158db4481cbeeaae8cce9a2e
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : systtem.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -26,6 +26,7 @@
             <Path fileType="data">/usr/share/metainfo/solseek.metainfo.xml</Path>
             <Path fileType="data">/usr/share/solseek/LICENSE-solseek.txt</Path>
             <Path fileType="data">/usr/share/solseek/config</Path>
+            <Path fileType="data">/usr/share/solseek/functions</Path>
             <Path fileType="data">/usr/share/solseek/lang/en/_dictionary.lang</Path>
             <Path fileType="data">/usr/share/solseek/lang/en/help.txt</Path>
             <Path fileType="data">/usr/share/solseek/lang/en/history.txt</Path>
@@ -50,9 +51,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2025-11-26</Date>
-            <Version>0.5.5</Version>
+        <Update release="8">
+            <Date>2025-12-02</Date>
+            <Version>0.6.0</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**

Enhancements:
- Performance improvements on launch
- Modularizing the distinct cache areas so that they do not impact each other as much, even in parallel.
- Improved the on-launch update checks so that when launching it will not be required to finish before launching. It will finish when it finishes and update the display when needed.
- Created a new method to use the local eopkg index file, if it exists to create the cache file for Solseek. This is MUCH faster. If the index file cannot be found it will automatically fall back to the eopkg la call. It will be disabled by default, but you will be able to enable it in the config file. This will be considered experimental at this time until better tested.
- Added eopkg delete-cache and update-repo functions in tool

**Summary**

Updated core caching system 

**Test Plan**

Tested in VM lab

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
