### PR TITLE
xkbcomp: Update to v1.5.0

### DIFF
--- a/packages/x/xkbcomp/abi_used_symbols
+++ b/packages/x/xkbcomp/abi_used_symbols
@@ -42,7 +42,6 @@ libc.so.6:__fprintf_chk
 libc.so.6:__isoc23_sscanf
 libc.so.6:__isoc23_strtol
 libc.so.6:__isoc23_strtoul
-libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk

--- a/packages/x/xkbcomp/package.yml
+++ b/packages/x/xkbcomp/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : xkbcomp
-version    : 1.4.7
-release    : 13
+version    : 1.5.0
+release    : 14
 source     :
-    - https://www.x.org/releases/individual/app/xkbcomp-1.4.7.tar.gz : 00cecc490fcbe2f789cf13c408c459673c2c33ab758d802677321cffcda35373
+    - https://www.x.org/releases/individual/app/xkbcomp-1.5.0.tar.gz : d070694dd8d94714aa1da3e3590b75084a4b183da3980866aedd68835954b97c
 license    : GPL-3.0-only
 component  : xorg.apps
 homepage   : https://www.x.org/

--- a/packages/x/xkbcomp/pspec_x86_64.xml
+++ b/packages/x/xkbcomp/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xkbcomp</Name>
         <Homepage>https://www.x.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <PartOf>xorg.apps</PartOf>
@@ -21,7 +21,7 @@
         <PartOf>xorg.apps</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/xkbcomp</Path>
-            <Path fileType="man">/usr/share/man/man1/xkbcomp.1</Path>
+            <Path fileType="man">/usr/share/man/man1/xkbcomp.1.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -31,19 +31,19 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="13">xkbcomp</Dependency>
+            <Dependency release="14">xkbcomp</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/lib64/pkgconfig/xkbcomp.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2024-02-04</Date>
-            <Version>1.4.7</Version>
+        <Update release="14">
+            <Date>2025-12-03</Date>
+            <Version>1.5.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://lists.freedesktop.org/archives/xorg-announce/2025-December/003645.html).

**Security**
- CVE-2018-15863
- CVE-2018-15861
- CVE-2018-15859
- CVE-2018-15853

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebooted after installing.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
