### PR TITLE
libpng: Update to v1.6.52

### DIFF
--- a/packages/l/libpng/package.yml
+++ b/packages/l/libpng/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libpng
-version    : 1.6.51
-release    : 30
+version    : 1.6.52
+release    : 31
 source     :
-    - https://sourceforge.net/projects/libpng/files/libpng16/1.6.51/libpng-1.6.51.tar.gz : ac25cafc2054cda3f6f0fe22ee9fc587024b99e01d03bd72b765824e48f39021
+    - https://sourceforge.net/projects/libpng/files/libpng16/1.6.52/libpng-1.6.52.tar.gz : 86d4a88be1c8bc903674199f1d067a9ac940af4e4399caba0314e7a1bcaa0724
 homepage   : https://www.libpng.org/pub/png/
 license    : Libpng
 component  : multimedia.library

--- a/packages/l/libpng/pspec_x86_64.xml
+++ b/packages/l/libpng/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libpng</Name>
         <Homepage>https://www.libpng.org/pub/png/</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Libpng</License>
         <PartOf>multimedia.library</PartOf>
@@ -23,9 +23,9 @@
             <Path fileType="executable">/usr/bin/png-fix-itxt</Path>
             <Path fileType="executable">/usr/bin/pngfix</Path>
             <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libpng16.so.16</Path>
-            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libpng16.so.16.51.0</Path>
+            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libpng16.so.16.52.0</Path>
             <Path fileType="library">/usr/lib64/libpng16.so.16</Path>
-            <Path fileType="library">/usr/lib64/libpng16.so.16.51.0</Path>
+            <Path fileType="library">/usr/lib64/libpng16.so.16.52.0</Path>
             <Path fileType="man">/usr/share/man/man5/png.5.zst</Path>
         </Files>
     </Package>
@@ -36,11 +36,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="30">libpng</Dependency>
+            <Dependency release="31">libpng</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpng16.so.16</Path>
-            <Path fileType="library">/usr/lib32/libpng16.so.16.51.0</Path>
+            <Path fileType="library">/usr/lib32/libpng16.so.16.52.0</Path>
         </Files>
     </Package>
     <Package>
@@ -50,8 +50,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="30">libpng-devel</Dependency>
-            <Dependency release="30">libpng-32bit</Dependency>
+            <Dependency release="31">libpng-32bit</Dependency>
+            <Dependency release="31">libpng-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpng.so</Path>
@@ -67,7 +67,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="30">libpng</Dependency>
+            <Dependency release="31">libpng</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/libpng-config</Path>
@@ -87,12 +87,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="30">
-            <Date>2025-11-22</Date>
-            <Version>1.6.51</Version>
+        <Update release="31">
+            <Date>2025-12-03</Date>
+            <Version>1.6.52</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/pnggroup/libpng/blob/v1.6.52/ANNOUNCE).

**Security**
- CVE-2025-66293

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Open a PNG file in an image viewer.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
