### PR TITLE
broot: Update to v1.54.0

### DIFF
--- a/packages/b/broot/abi_used_symbols
+++ b/packages/b/broot/abi_used_symbols
@@ -28,6 +28,7 @@ libc.so.6:connect
 libc.so.6:dirfd
 libc.so.6:dl_iterate_phdr
 libc.so.6:dlsym
+libc.so.6:dup
 libc.so.6:dup2
 libc.so.6:environ
 libc.so.6:epoll_create1
@@ -149,6 +150,7 @@ libc.so.6:sendmsg
 libc.so.6:setgid
 libc.so.6:setgroups
 libc.so.6:setpgid
+libc.so.6:setsid
 libc.so.6:setuid
 libc.so.6:sigaction
 libc.so.6:sigaddset

--- a/packages/b/broot/package.yml
+++ b/packages/b/broot/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : broot
-version    : 1.53.0
-release    : 28
+version    : 1.54.0
+release    : 29
 source     :
-    - https://github.com/Canop/broot/archive/refs/tags/v1.53.0.tar.gz : cd675a81222ac82a238778325a51e3f14b971df32ceedf9bb892f3a1d012e10e
+    - https://github.com/Canop/broot/archive/refs/tags/v1.54.0.tar.gz : 92f88c6051c8ed7276d43a4ab45aacfe7b0dd1d65b3503d45ba1f9dad5e95cf1
 homepage   : https://dystroy.org/broot/
 license    : MIT
 component  : system.utils

--- a/packages/b/broot/pspec_x86_64.xml
+++ b/packages/b/broot/pspec_x86_64.xml
@@ -26,9 +26,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2025-11-08</Date>
-            <Version>1.53.0</Version>
+        <Update release="29">
+            <Date>2025-12-03</Date>
+            <Version>1.54.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
Release notes can be found [here](https://github.com/Canop/broot/releases/tag/v1.54.0).

**Test Plan**

Open broot. move around file structure. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
