### PR TITLE
php: Update to v8.2.29

### DIFF
--- a/packages/p/php/abi_used_symbols
+++ b/packages/p/php/abi_used_symbols
@@ -4,6 +4,7 @@ UNKNOWN:_ZTIN6icu_7617StringEnumerationE
 UNKNOWN:_ZTIN6icu_766FormatE
 UNKNOWN:_ZTVN6icu_7613FieldPositionE
 UNKNOWN:_ZTVN6icu_7613UnicodeStringE
+UNKNOWN:floor
 libargon2.so.1:argon2_encodedlen
 libargon2.so.1:argon2_error_message
 libargon2.so.1:argon2_hash
@@ -147,8 +148,10 @@ libc.so.6:__libc_start_main
 libc.so.6:__longjmp_chk
 libc.so.6:__memcpy_chk
 libc.so.6:__memmove_chk
+libc.so.6:__memset_chk
 libc.so.6:__open_2
 libc.so.6:__printf_chk
+libc.so.6:__read_chk
 libc.so.6:__res_nclose
 libc.so.6:__res_ninit
 libc.so.6:__snprintf_chk
@@ -1499,6 +1502,7 @@ libm.so.6:cosh
 libm.so.6:exp
 libm.so.6:expf
 libm.so.6:expm1
+libm.so.6:floor
 libm.so.6:fmod
 libm.so.6:hypot
 libm.so.6:log
@@ -1512,6 +1516,7 @@ libm.so.6:sinh
 libm.so.6:sqrt
 libm.so.6:tan
 libm.so.6:tanh
+libm.so.6:trunc
 libnetsnmp.so.35:generate_Ku
 libnetsnmp.so.35:init_snmp
 libnetsnmp.so.35:netsnmp_ds_get_boolean
@@ -1986,9 +1991,6 @@ libstdc++.so.6:_ZdaPv
 libstdc++.so.6:_ZdlPvm
 libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
-libstdc++.so.6:__cxa_begin_catch
-libstdc++.so.6:__cxa_end_catch
-libstdc++.so.6:__cxa_rethrow
 libstdc++.so.6:__cxa_throw_bad_array_new_length
 libstdc++.so.6:__dynamic_cast
 libstdc++.so.6:__gxx_personality_v0

--- a/packages/p/php/package.yml
+++ b/packages/p/php/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : php
-version    : 8.2.28
-release    : 107
+version    : 8.2.29
+release    : 108
 source     :
-    - https://www.php.net/distributions/php-8.2.28.tar.gz : 3318300888de5023720cc84efad5e005e53f30b5f0072fae65a750dabcaf6ec3
+    - https://www.php.net/distributions/php-8.2.29.tar.gz : 0b27d330769d4bc67b1d8864347c38744b289664a946919c3ddb2235d326b3cd
 license    : PHP-3.01
 component  : programming
 homepage   : https://www.php.net

--- a/packages/p/php/pspec_x86_64.xml
+++ b/packages/p/php/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>php</Name>
         <Homepage>https://www.php.net</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>PHP-3.01</License>
         <PartOf>programming</PartOf>
@@ -62,14 +62,14 @@
             <Path fileType="library">/usr/lib64/tmpfiles.d/php-fpm.conf</Path>
             <Path fileType="executable">/usr/sbin/php-fpm</Path>
             <Path fileType="data">/usr/share/fpm/status.html</Path>
-            <Path fileType="man">/usr/share/man/man1/phar.1</Path>
-            <Path fileType="man">/usr/share/man/man1/phar.phar.1</Path>
-            <Path fileType="man">/usr/share/man/man1/php-cgi.1</Path>
-            <Path fileType="man">/usr/share/man/man1/php-config.1</Path>
-            <Path fileType="man">/usr/share/man/man1/php.1</Path>
-            <Path fileType="man">/usr/share/man/man1/phpdbg.1</Path>
-            <Path fileType="man">/usr/share/man/man1/phpize.1</Path>
-            <Path fileType="man">/usr/share/man/man8/php-fpm.8</Path>
+            <Path fileType="man">/usr/share/man/man1/phar.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/phar.phar.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/php-cgi.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/php-config.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/php.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/phpdbg.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/phpize.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/php-fpm.8.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -79,7 +79,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="107">php</Dependency>
+            <Dependency release="108">php</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/phpize</Path>
@@ -412,12 +412,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="107">
-            <Date>2025-04-15</Date>
-            <Version>8.2.28</Version>
+        <Update release="108">
+            <Date>2025-12-04</Date>
+            <Version>8.2.29</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://www.php.net/ChangeLog-8.php#8.2.29) (all security items)

**Security**

- CVE-2025-1735
- CVE-2025-6491
- CVE-2025-1220

**Test Plan**

- Build `composer`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
