### PR TITLE
weechat: Update to v4.8.1

### DIFF
--- a/packages/w/weechat/package.yml
+++ b/packages/w/weechat/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : weechat
-version    : 4.8.0
-release    : 99
+version    : 4.8.1
+release    : 100
 source     :
-    - https://github.com/weechat/weechat/archive/refs/tags/v4.8.0.tar.gz : 95d2b8fd691deb7def8a735832c0b306621bf026f95c0b61ef73f0a3f7f04138
+    - https://github.com/weechat/weechat/archive/refs/tags/v4.8.1.tar.gz : ff5677d3fa37ded130288cc9d4a254311c9e7c41ce48fc9101e0df1caa28f9fd
 homepage   : https://weechat.org
 license    : GPL-3.0-or-later
 summary    : WeeChat is a fast, light and extensible chat client.

--- a/packages/w/weechat/pspec_x86_64.xml
+++ b/packages/w/weechat/pspec_x86_64.xml
@@ -90,7 +90,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="99">weechat</Dependency>
+            <Dependency release="100">weechat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/weechat/weechat-plugin.h</Path>
@@ -98,9 +98,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="99">
-            <Date>2025-11-30</Date>
-            <Version>4.8.0</Version>
+        <Update release="100">
+            <Date>2025-12-04</Date>
+            <Version>4.8.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/weechat/weechat/releases/tag/v4.8.1).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Connect to Libera chat.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
