### PR TITLE
pastebinit: Update to v1.8.0

### DIFF
--- a/packages/p/pastebinit/package.yml
+++ b/packages/p/pastebinit/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : pastebinit
-version    : 1.7.1
-release    : 4
+version    : 1.8.0
+release    : 5
 source     :
-    - https://github.com/pastebinit/pastebinit/archive/refs/tags/1.7.1.tar.gz : 8e91c2c0d02a41faaa40d9f585fe858893c3f0ef94836ee4ce14094cfc10b938
+    - https://github.com/pastebinit/pastebinit/archive/refs/tags/1.8.0.tar.gz : fc8ed4323ddfb130c17380af8f4970ac9c1648563fb1ab4efd307e87eb2c41e7
 homepage   : https://github.com/pastebinit/pastebinit
 license    : GPL-2.0-or-later
 component  : system.utils

--- a/packages/p/pastebinit/pspec_x86_64.xml
+++ b/packages/p/pastebinit/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pastebinit</Name>
         <Homepage>https://github.com/pastebinit/pastebinit</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -76,7 +76,7 @@
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/pastebinit.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/pastebinit.mo</Path>
             <Path fileType="man">/usr/share/man/man1/pbget.1</Path>
-            <Path fileType="man">/usr/share/man/man1/pbput.1</Path>
+            <Path fileType="man">/usr/share/man/man1/pbput.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/pbputs.1</Path>
             <Path fileType="data">/usr/share/pastebin.d/bpa.st.conf</Path>
             <Path fileType="data">/usr/share/pastebin.d/dpaste.com.conf</Path>
@@ -85,6 +85,7 @@
             <Path fileType="data">/usr/share/pastebin.d/paste.centos.org.conf</Path>
             <Path fileType="data">/usr/share/pastebin.d/paste.debian.net.conf</Path>
             <Path fileType="data">/usr/share/pastebin.d/paste.opendev.org.conf</Path>
+            <Path fileType="data">/usr/share/pastebin.d/paste.opensuse.org.conf</Path>
             <Path fileType="data">/usr/share/pastebin.d/paste.ubuntu.com.conf</Path>
             <Path fileType="data">/usr/share/pastebin.d/paste.ubuntu.org.cn.conf</Path>
             <Path fileType="data">/usr/share/pastebin.d/paste2.org.conf</Path>
@@ -93,12 +94,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2025-02-03</Date>
-            <Version>1.7.1</Version>
+        <Update release="5">
+            <Date>2025-12-05</Date>
+            <Version>1.8.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Add paste.opensuse.org as service

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Ran `pbput package.yml` and saw that a paste was created.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
