### PR TITLE
python-urllib3: Update to v2.6.0

### DIFF
--- a/packages/py/python-urllib3/package.yml
+++ b/packages/py/python-urllib3/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-urllib3
-version    : 2.5.0
-release    : 20
+version    : 2.6.0
+release    : 21
 source     :
-    - https://pypi.debian.net/urllib3/urllib3-2.5.0.tar.gz : 3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760
+    - https://pypi.debian.net/urllib3/urllib3-2.6.0.tar.gz : cb9bcef5a4b345d5da5d145dc3e30834f58e8018828cbc724d30b4cb7d4d49f1
 homepage   : https://urllib3.readthedocs.io/
 license    : MIT
 component  : programming.python

--- a/packages/py/python-urllib3/pspec_x86_64.xml
+++ b/packages/py/python-urllib3/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-urllib3</Name>
         <Homepage>https://urllib3.readthedocs.io/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.5.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.5.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.5.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.5.0.dist-info/licenses/LICENSE.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.6.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.6.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.6.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.6.0.dist-info/licenses/LICENSE.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3/__pycache__/__init__.cpython-312.pyc</Path>
@@ -137,12 +137,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2025-06-25</Date>
-            <Version>2.5.0</Version>
+        <Update release="21">
+            <Date>2025-12-05</Date>
+            <Version>2.6.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://urllib3.readthedocs.io/en/stable/changelog.html#id1).

**Security**
- CVE-2025-66418
- CVE-2025-66471

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `pbput` from `pastebinit`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
