### PR TITLE
speech-dispatcher: Update to v0.12.1

### DIFF
--- a/packages/s/speech-dispatcher/abi_symbols
+++ b/packages/s/speech-dispatcher/abi_symbols
@@ -556,6 +556,7 @@ sd_generic:EPunctMode2str
 sd_generic:ESpellMode2str
 sd_generic:EVoice2str
 sd_generic:GenericCmdDependency_cb
+sd_generic:GenericDefaultCharset_cb
 sd_generic:GenericDelimiters_cb
 sd_generic:GenericExecuteSynth_cb
 sd_generic:GenericLanguage
@@ -938,7 +939,6 @@ speech-dispatcher:output_module_debug
 speech-dispatcher:output_module_nodebug
 speech-dispatcher:output_modules
 speech-dispatcher:output_pause
-speech-dispatcher:output_read_event
 speech-dispatcher:output_read_message
 speech-dispatcher:output_read_reply
 speech-dispatcher:output_send_audio_settings

--- a/packages/s/speech-dispatcher/package.yml
+++ b/packages/s/speech-dispatcher/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : speech-dispatcher
-version    : 0.12.0
-release    : 25
+version    : 0.12.1
+release    : 26
 source     :
-    - https://github.com/brailcom/speechd/releases/download/0.12.0/speech-dispatcher-0.12.0.tar.gz : e1dd0bfa24b8338545e165451330adf51c4c0dca862b1b67e76fba5142dbbb74
+    - https://github.com/brailcom/speechd/releases/download/0.12.1/speech-dispatcher-0.12.1.tar.gz : b14a5238d287d2dcce4dd42bbd66ca65fa228e7e683708267f7b34036f7ba4b4
 homepage   : https://freebsoft.org/speechd
 license    :
     - GPL-2.0-or-later

--- a/packages/s/speech-dispatcher/pspec_x86_64.xml
+++ b/packages/s/speech-dispatcher/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>speech-dispatcher</Name>
         <Homepage>https://freebsoft.org/speechd</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -88,10 +88,10 @@
             <Path fileType="data">/usr/share/defaults/speech-dispatcher/modules/openjtalk.conf</Path>
             <Path fileType="data">/usr/share/defaults/speech-dispatcher/modules/swift-generic.conf</Path>
             <Path fileType="data">/usr/share/defaults/speech-dispatcher/speechd.conf</Path>
-            <Path fileType="info">/usr/share/info/spd-say.info</Path>
-            <Path fileType="info">/usr/share/info/speech-dispatcher-cs.info</Path>
-            <Path fileType="info">/usr/share/info/speech-dispatcher.info</Path>
-            <Path fileType="info">/usr/share/info/ssip.info</Path>
+            <Path fileType="info">/usr/share/info/spd-say.info.zst</Path>
+            <Path fileType="info">/usr/share/info/speech-dispatcher-cs.info.zst</Path>
+            <Path fileType="info">/usr/share/info/speech-dispatcher.info.zst</Path>
+            <Path fileType="info">/usr/share/info/ssip.info.zst</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/speech-dispatcher.mo</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/speech-dispatcher.mo</Path>
             <Path fileType="localedata">/usr/share/locale/eo/LC_MESSAGES/speech-dispatcher.mo</Path>
@@ -132,7 +132,7 @@
             <Path fileType="data">/usr/share/speech-dispatcher/locale/base/font-variants.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/base/orca-chars.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/base/orca.dic</Path>
-            <Path fileType="data">/usr/share/speech-dispatcher/locale/base/symbols-fallback.dic</Path>
+            <Path fileType="data">/usr/share/speech-dispatcher/locale/base/symbols.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/be/emojis.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/be/orca-chars.dic</Path>
             <Path fileType="data">/usr/share/speech-dispatcher/locale/be/orca.dic</Path>
@@ -469,7 +469,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="25">speech-dispatcher</Dependency>
+            <Dependency release="26">speech-dispatcher</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/speech-dispatcher/libspeechd.h</Path>
@@ -484,12 +484,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="25">
-            <Date>2025-05-21</Date>
-            <Version>0.12.0</Version>
+        <Update release="26">
+            <Date>2025-12-05</Date>
+            <Version>0.12.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/brailcom/speechd/blob/0.12.1/NEWS).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Ran `spd-say hi`. It said "hi".

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
