### PR TITLE
nextcloud-client: Add appstream metainfo

### DIFF
--- a/packages/n/nextcloud-client/files/com.nextcloud.desktopclient.nextcloud.metainfo.xml
+++ b/packages/n/nextcloud-client/files/com.nextcloud.desktopclient.nextcloud.metainfo.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.nextcloud.desktopclient.nextcloud</id>
+  <name>Nextcloud Desktop Client</name>
+  <project_license>GPL-2.0+</project_license>
+  <summary>Sync and collaborate on your desktop or laptop</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <developer id="com.nextcloud">
+    <name>Nextcloud GmbH</name>
+  </developer>
+  <description>
+    <p>The Nextcloud desktop client keeps photos and documents always up to date, enabling you to work like you always did.
+Any file you add, modify or delete in the synced folders on your desktop or laptop will show up, change or disappear on the server and all other connected devices.</p>
+  </description>
+  <launchable type="desktop-id">com.nextcloud.desktopclient.nextcloud.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <caption>The options dialog</caption>
+      <image>https://nextcloud.com/wp-content/uploads/2022/04/linux.png</image>
+    </screenshot>
+  </screenshots>
+  <branding>
+    <color type="primary" scheme_preference="light">#0082c9</color>
+    <color type="primary" scheme_preference="dark">#0082c9</color>
+  </branding>
+  <url type="homepage">https://nextcloud.com</url>
+  <url type="bugtracker">https://github.com/nextcloud/desktop/issues</url>
+  <url type="faq">https://docs.nextcloud.com/server/latest/user_manual/en/desktop/index.html</url>
+  <url type="vcs-browser">https://github.com/nextcloud/desktop</url>
+  <content_rating type="oars-1.1"/>
+</component>

--- a/packages/n/nextcloud-client/package.yml
+++ b/packages/n/nextcloud-client/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : nextcloud-client
 version    : 4.0.3
-release    : 78
+release    : 79
 source     :
     - https://github.com/nextcloud/desktop/archive/refs/tags/v4.0.3.tar.gz : 05ce3368956a2e5792a3eba242ee2d649e6073d494d81a22f9d8bbba71a92fc9
 homepage   : https://docs.nextcloud.com/desktop
@@ -61,3 +61,6 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+
+    # Install AppStream metainfo
+    install -Dm00644 $pkgfiles/com.nextcloud.desktopclient.nextcloud.metainfo.xml $installdir/usr/share/metainfo/com.nextcloud.desktopclient.nextcloud.metainfo.xml

--- a/packages/n/nextcloud-client/pspec_x86_64.xml
+++ b/packages/n/nextcloud-client/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nextcloud-client</Name>
         <Homepage>https://docs.nextcloud.com/desktop</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>network.download</PartOf>
@@ -77,6 +77,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/72x72/apps/Nextcloud_ok.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/72x72/apps/Nextcloud_sync.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/72x72/apps/Nextcloud_warn.png</Path>
+            <Path fileType="data">/usr/share/metainfo/com.nextcloud.desktopclient.nextcloud.metainfo.xml</Path>
             <Path fileType="data">/usr/share/mime/packages/nextcloud.xml</Path>
             <Path fileType="data">/usr/share/nautilus-python/extensions/syncstate-Nextcloud.py</Path>
             <Path fileType="data">/usr/share/nemo-python/extensions/syncstate-Nextcloud.py</Path>
@@ -151,7 +152,7 @@
         <Description xml:lang="en">Nextcloud client enables you to connect to your private Nextcloud Server. With it you can create directories in your home directory, and keep the contents of those directories synced with the server.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="78">nextcloud-client</Dependency>
+            <Dependency release="79">nextcloud-client</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/nextcloudsync/creds/abstractcredentials.h</Path>
@@ -171,7 +172,7 @@
         <Description xml:lang="en">Dolphin file manager integration for the Nextcloud client.</Description>
         <PartOf>network.download</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="78">nextcloud-client</Dependency>
+            <Dependency releaseFrom="79">nextcloud-client</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libnextclouddolphinpluginhelper.so</Path>
@@ -180,12 +181,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="78">
-            <Date>2025-12-03</Date>
+        <Update release="79">
+            <Date>2025-12-06</Date>
             <Version>4.0.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add appstream metainfo so it appears in discover.

Resolves getsolus/packages#7266

**Test Plan**

- Check with appstreamcli compose and appstreamcli validate

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
