### PR TITLE
protontricks: Update to v1.13.1

### DIFF
--- a/packages/p/protontricks/package.yml
+++ b/packages/p/protontricks/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : protontricks
-version    : 1.13.0
-release    : 31
+version    : 1.13.1
+release    : 32
 source     :
-    - https://files.pythonhosted.org/packages/source/p/protontricks/protontricks-1.13.0.tar.gz : c1351e9ebeb7a640147eaf53051137491a8a0a5bd6d5fdd0b962f78d11e7420c
+    - https://files.pythonhosted.org/packages/source/p/protontricks/protontricks-1.13.1.tar.gz : e44aa58ea07a2213e6d6eb98580f58a6b875df955dfbb7e3512897c5873d8ffa
 homepage   : https://github.com/Matoking/protontricks
 license    : GPL-3.0-or-later
 component  : virt

--- a/packages/p/protontricks/pspec_x86_64.xml
+++ b/packages/p/protontricks/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>protontricks</Name>
         <Homepage>https://github.com/Matoking/protontricks</Homepage>
         <Packager>
-            <Name>Marcus L&#xf6;nnqvist</Name>
-            <Email>marlonn.dev@proton.me</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>virt</PartOf>
@@ -23,12 +23,12 @@
             <Path fileType="executable">/usr/bin/protontricks</Path>
             <Path fileType="executable">/usr/bin/protontricks-desktop-install</Path>
             <Path fileType="executable">/usr/bin/protontricks-launch</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.13.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.13.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.13.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.13.0.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.13.0.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.13.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.13.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.13.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.13.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.13.1.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.13.1.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks-1.13.1.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/protontricks/__pycache__/__init__.cpython-312.pyc</Path>
@@ -93,12 +93,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2025-08-18</Date>
-            <Version>1.13.0</Version>
+        <Update release="32">
+            <Date>2025-12-07</Date>
+            <Version>1.13.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Marcus L&#xf6;nnqvist</Name>
-            <Email>marlonn.dev@proton.me</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- Fix Steam library folder discovery by using case-insensitive path matching
- Fix default Proton version discovery. Protontricks will now use Proton Experimental as default per Steam client's hardcoded default setting, with stable Proton as fallback.

**Test Plan**

Installed a Windows component for a Steam Proton game

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
