### PR TITLE
torbrowser-launcher: Update to v0.3.9

### DIFF
--- a/packages/t/torbrowser-launcher/package.yml
+++ b/packages/t/torbrowser-launcher/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : torbrowser-launcher
-version    : 0.3.7
-release    : 18
+version    : 0.3.9
+release    : 19
 source     :
-    - https://gitlab.torproject.org/tpo/applications/torbrowser-launcher/-/archive/v0.3.7/torbrowser-launcher-v0.3.7.tar.gz : bd348fd5d923f078c75870a9139678a467b2ab5ba21117fd42ccf0cfa3e4be21
+    - https://gitlab.torproject.org/tpo/applications/torbrowser-launcher/-/archive/v0.3.9/torbrowser-launcher-v0.3.9.tar.gz : 267483c88760dacf4af2d480d2d0b094f3ffd10f8fd0f3e5f52c61df91e9ccdb
 homepage   : https://gitlab.torproject.org/tpo/applications/torbrowser-launcher
 license    : BSD-1-Clause
 component  : network.web.browser
@@ -17,9 +17,9 @@ rundeps    :
     - gnupg
     - python-gpg
     - python-packaging
+    - python-pyside6
     - python-pysocks
     - python-requests
-    - python3-qt5
     - tor
 setup      : |
     %python3_setup

--- a/packages/t/torbrowser-launcher/pspec_x86_64.xml
+++ b/packages/t/torbrowser-launcher/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>torbrowser-launcher</Name>
         <Homepage>https://gitlab.torproject.org/tpo/applications/torbrowser-launcher</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>BSD-1-Clause</License>
         <PartOf>network.web.browser</PartOf>
@@ -26,11 +26,11 @@
             <Path fileType="config">/etc/apparmor.d/torbrowser.Tor.tor</Path>
             <Path fileType="config">/etc/apparmor.d/tunables/torbrowser</Path>
             <Path fileType="executable">/usr/bin/torbrowser-launcher</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/torbrowser_launcher-0.3.7-py3.12.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/torbrowser_launcher-0.3.7-py3.12.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/torbrowser_launcher-0.3.7-py3.12.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/torbrowser_launcher-0.3.7-py3.12.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/torbrowser_launcher-0.3.7-py3.12.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/torbrowser_launcher-0.3.9-py3.12.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/torbrowser_launcher-0.3.9-py3.12.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/torbrowser_launcher-0.3.9-py3.12.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/torbrowser_launcher-0.3.9-py3.12.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/torbrowser_launcher-0.3.9-py3.12.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/torbrowser_launcher/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/torbrowser_launcher/__pycache__/__init__.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/torbrowser_launcher/__pycache__/common.cpython-312.pyc</Path>
@@ -39,9 +39,9 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/torbrowser_launcher/common.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/torbrowser_launcher/launcher.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/torbrowser_launcher/settings.py</Path>
-            <Path fileType="data">/usr/share/applications/torbrowser-settings.desktop</Path>
-            <Path fileType="data">/usr/share/applications/torbrowser.desktop</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/torbrowser.png</Path>
+            <Path fileType="data">/usr/share/applications/org.torproject.torbrowser-launcher.desktop</Path>
+            <Path fileType="data">/usr/share/applications/org.torproject.torbrowser-launcher.settings.desktop</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/org.torproject.torbrowser-launcher.png</Path>
             <Path fileType="localedata">/usr/share/locale/be/LC_MESSAGES/torbrowser-launcher.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/torbrowser-launcher.mo</Path>
             <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/torbrowser-launcher.mo</Path>
@@ -63,12 +63,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2025-05-06</Date>
-            <Version>0.3.7</Version>
+        <Update release="19">
+            <Date>2025-12-07</Date>
+            <Version>0.3.9</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://gitlab.torproject.org/tpo/applications/torbrowser-launcher/-/blob/main/CHANGELOG.md?ref_type=heads).

**Test Plan**

Opened browser, connected to tor, searched ip to ensure it was rerouted. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
