### PR TITLE
python-pycurl: Update to v7.45.7

### DIFF
--- a/packages/py/python-pycurl/abi_symbols
+++ b/packages/py/python-pycurl/abi_symbols
@@ -104,6 +104,7 @@ pycurl.cpython-312-x86_64-linux-gnu.so:p_CurlMulti_Type
 pycurl.cpython-312-x86_64-linux-gnu.so:p_CurlShare_Type
 pycurl.cpython-312-x86_64-linux-gnu.so:p_CurlSlist_Type
 pycurl.cpython-312-x86_64-linux-gnu.so:p_Curl_Type
+pycurl.cpython-312-x86_64-linux-gnu.so:prereq_callback
 pycurl.cpython-312-x86_64-linux-gnu.so:progress_callback
 pycurl.cpython-312-x86_64-linux-gnu.so:pycurl_acquire_thread
 pycurl.cpython-312-x86_64-linux-gnu.so:pycurl_acquire_thread_multi

--- a/packages/py/python-pycurl/package.yml
+++ b/packages/py/python-pycurl/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-pycurl
-version    : 7.45.6
-release    : 26
+version    : 7.45.7
+release    : 27
 source     :
-    - https://files.pythonhosted.org/packages/source/p/pycurl/pycurl-7.45.6.tar.gz : 2b73e66b22719ea48ac08a93fc88e57ef36d46d03cb09d972063c9aa86bb74e6
-homepage   : http://pycurl.io/
+    - https://files.pythonhosted.org/packages/source/p/pycurl/pycurl-7.45.7.tar.gz : 9d43013002eab2fd6d0dcc671cd1e9149e2fc1c56d5e796fad94d076d6cb69ef
+homepage   : https://pypi.org/project/pycurl 
 license    :
     - LGPL-2.1-or-later
     - MIT
@@ -31,5 +31,5 @@ check      : |
     # remove test-cases that won't work in our sandbox
     rm -fv tests/{ftp_test.py,seek_cb_test.py,ssh_key_cb_test.py}
     rm examples/tests/{test_gtk.py,test_build_config.py}
-    # Deselect test_libcurl_ssl tests because they require bundled libcurl
-    %python3_test pytest3 -v -k "not test_libcurl_ssl"
+    # Deselect test_libcurl_ssl tests (require bundled libcurl) and Kerberos tests (libcurl not built with Kerberos support)
+    %python3_test pytest3 -v -k "not (test_libcurl_ssl or test_krb4level or test_krblevel)"

--- a/packages/py/python-pycurl/pspec_x86_64.xml
+++ b/packages/py/python-pycurl/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>python-pycurl</Name>
-        <Homepage>http://pycurl.io/</Homepage>
+        <Homepage>https://pypi.org/project/pycurl</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <License>MIT</License>
@@ -24,13 +24,13 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/curl/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/curl/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/curl/__pycache__/__init__.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pycurl-7.45.6.dist-info/AUTHORS</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pycurl-7.45.6.dist-info/COPYING-LGPL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pycurl-7.45.6.dist-info/COPYING-MIT</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pycurl-7.45.6.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pycurl-7.45.6.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pycurl-7.45.6.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pycurl-7.45.6.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pycurl-7.45.7.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pycurl-7.45.7.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pycurl-7.45.7.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pycurl-7.45.7.dist-info/licenses/AUTHORS</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pycurl-7.45.7.dist-info/licenses/COPYING-LGPL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pycurl-7.45.7.dist-info/licenses/COPYING-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pycurl-7.45.7.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pycurl.cpython-312-x86_64-linux-gnu.so</Path>
             <Path fileType="doc">/usr/share/doc/python-pycurl/AUTHORS</Path>
             <Path fileType="doc">/usr/share/doc/python-pycurl/COPYING-LGPL</Path>
@@ -68,12 +68,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2025-06-06</Date>
-            <Version>7.45.6</Version>
+        <Update release="27">
+            <Date>2025-12-08</Date>
+            <Version>7.45.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Support unsetting all callback functions (patch by Scott Talbert)
- Fix linking fake-curl on AIX (patch by Sumitra Dawn)
- Support PREREQFUNCTION callback (patch by Scott Talbert)
- Fix debug test with curl 8.16.0 (patch by Carlos Henrique Lima Melara)
- Support setting CURLOPT_ECH (patch by Tommi Rantal
- Officially support Python 3.14 (patch by Scott Talbert)
- Release notes can be found [here](https://pypi.org/project/pycurl/#files).
- Part of https://github.com/getsolus/packages/issues/5522

**Test Plan**

Installed python-pycurl 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
