### PR TITLE
solseek: Update to 0.7.0

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,12 +1,12 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 0.6.0
-release    : 8
+version    : 0.7.0
+release    : 9
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v0.6.0.tar.gz : d9f2565e845a34d779437a67d466c6c108a25a0d158db4481cbeeaae8cce9a2e
+    - https://github.com/clintre/solseek/archive/refs/tags/v0.7.0.tar.gz : 914c8db9130769c8d88a5b1c7b22e64ebc54197b4d49c26c6a00c98ee6654f1c
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
-component  : systtem.utils
+component  : system.utils
 summary    : A TUI Package Manager for Solus
 description: |
     Solseek is a simple terminal user interface that allows you to browse, search, and manage packages from the Solus packages.

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -26,34 +26,25 @@
             <Path fileType="data">/usr/share/metainfo/solseek.metainfo.xml</Path>
             <Path fileType="data">/usr/share/solseek/LICENSE-solseek.txt</Path>
             <Path fileType="data">/usr/share/solseek/config</Path>
-            <Path fileType="data">/usr/share/solseek/functions</Path>
-            <Path fileType="data">/usr/share/solseek/lang/en/_dictionary.lang</Path>
-            <Path fileType="data">/usr/share/solseek/lang/en/help.txt</Path>
-            <Path fileType="data">/usr/share/solseek/lang/en/history.txt</Path>
-            <Path fileType="data">/usr/share/solseek/lang/en/information.txt</Path>
-            <Path fileType="data">/usr/share/solseek/lang/en/list.txt</Path>
-            <Path fileType="data">/usr/share/solseek/lang/en/package_action.txt</Path>
-            <Path fileType="data">/usr/share/solseek/lang/en/update_system.txt</Path>
-            <Path fileType="data">/usr/share/solseek/lang/en/welcome.txt</Path>
-            <Path fileType="data">/usr/share/solseek/lang/fr/_dictionary.lang</Path>
-            <Path fileType="data">/usr/share/solseek/lang/fr/help.txt</Path>
-            <Path fileType="data">/usr/share/solseek/lang/fr/history.txt</Path>
-            <Path fileType="data">/usr/share/solseek/lang/fr/information.txt</Path>
-            <Path fileType="data">/usr/share/solseek/lang/fr/list.txt</Path>
-            <Path fileType="data">/usr/share/solseek/lang/fr/package_action.txt</Path>
-            <Path fileType="data">/usr/share/solseek/lang/fr/update_system.txt</Path>
-            <Path fileType="data">/usr/share/solseek/lang/fr/welcome.txt</Path>
-            <Path fileType="data">/usr/share/solseek/menus</Path>
+            <Path fileType="data">/usr/share/solseek/core/boot</Path>
+            <Path fileType="data">/usr/share/solseek/core/core_functions</Path>
+            <Path fileType="data">/usr/share/solseek/core/defaults</Path>
+            <Path fileType="data">/usr/share/solseek/core/menus</Path>
+            <Path fileType="data">/usr/share/solseek/core/pkg_functions</Path>
+            <Path fileType="data">/usr/share/solseek/lang/en.lang</Path>
+            <Path fileType="data">/usr/share/solseek/lang/fr.lang</Path>
             <Path fileType="data">/usr/share/solseek/solseek-uc.service</Path>
             <Path fileType="data">/usr/share/solseek/solseek-uc.timer</Path>
             <Path fileType="data">/usr/share/solseek/solseek_fastfetch.jsonc</Path>
             <Path fileType="data">/usr/share/solseek/solseek_fastfetch_str.jsonc</Path>
+            <Path fileType="data">/usr/share/solseek/themes/base.theme</Path>
+            <Path fileType="data">/usr/share/solseek/themes/solus.theme</Path>
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2025-12-02</Date>
-            <Version>0.6.0</Version>
+        <Update release="9">
+            <Date>2025-12-08</Date>
+            <Version>0.7.0</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**

Bugfixes:

- Better handling when there are multiple active repos
- Better handling when there is a local repo in use
- Proper detection if there is a local eopkg-index.xml if if set to using local cache
- Fallback to eopkg-index.xml.xz if for some reason the uncompressed version is missing if set to using local cache=1

Enhancement:

- Added experimental Desktop Applications using the Appstream catalog to bring advanced search capabilities.
- Added the ability to rollback Solus packages. Browse, select, and execute rollbacks within the tool.
- Enhanced the eopkg update wrapper for Solseek. solseek up will check and install upgrades for eopkg and flatpak. Add the solseek up -e will check and install upgrades for everything.
- Added wrap capabilities in the menu since I made the menu longer. Meaning if you are at the top and go up, it will wrap to the bottom.
- Added basic theme support. Currently only 2 exist.
- Added Solus color theme and set as default. It can be changed through the configuration
- Added an About section to show access to support and changelog
- Added Changelog  list for the current version in the About section. It requires curl to be installed to work.
- Added the --debug flag to help debug issues with Solseek
- Added -cc flag to force starting Solseek with clean cache
- Added 2 new config options. THEME for the new theme option. EDITOR for the cmd line editor. 
- Moved to a single language file per language. This will make it much easier for translators.
- Continued to cleanup and refactor the code for better support.

Topic: Sync Notes
Major update with Desktop Application  advanced search using appstream catalog. Basic thheme support including a hint of Solus coloring. 
New flags for debug and forcing cache clearing on launch as well as enhanced eopkg upgrade wrapper that allows for upgrading everthing in addition to eopkg.


**Test Plan**

Tested in VM lab across desktops and wms. Tested on unstable.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
