### PR TITLE
nano-syntax-highlighting: Update to v2025.07.01

### DIFF
--- a/packages/n/nano-syntax-highlighting/package.yml
+++ b/packages/n/nano-syntax-highlighting/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : nano-syntax-highlighting
-version    : 2022.11.02
-release    : 2
+version    : 2025.07.01
+release    : 3
 source     :
-    - https://github.com/galenguyer/nano-syntax-highlighting/archive/refs/tags/2022.11.02.tar.gz : 296c5f56408fc609d4b774ba23b80136233f50af083f05ccbd67218025d46858
+    - https://github.com/galenguyer/nano-syntax-highlighting/archive/refs/tags/2025.07.01.tar.gz : ae1138a436fb0c505ea0d309c70a5f43f9764a5deb9cedce71f8ba00a0a09e5c
 homepage   : https://github.com/galenguyer/nano-syntax-highlighting
 license    : GPL-3.0-or-later
 component  : system.devel

--- a/packages/n/nano-syntax-highlighting/pspec_x86_64.xml
+++ b/packages/n/nano-syntax-highlighting/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nano-syntax-highlighting</Name>
         <Homepage>https://github.com/galenguyer/nano-syntax-highlighting</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.devel</PartOf>
@@ -20,6 +20,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <Files>
+            <Path fileType="data">/usr/share/nanorc/Brewfile.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/Dockerfile.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/Rnw.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/apacheconf.nanorc</Path>
@@ -29,6 +30,7 @@
             <Path fileType="data">/usr/share/nanorc/awk.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/batch.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/beancount.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/brainfuck.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/c.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/clojure.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/cmake.nanorc</Path>
@@ -42,12 +44,14 @@
             <Path fileType="data">/usr/share/nanorc/css.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/csv.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/cython.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/d.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/dot.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/dotenv.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/elixir.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/email.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/erb.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/etc-hosts.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/expect.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/fish.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/fortran.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/fsharp.nanorc</Path>
@@ -58,6 +62,7 @@
             <Path fileType="data">/usr/share/nanorc/gitcommit.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/glsl.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/go.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/godot.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/gophermap.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/gradle.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/groff.nanorc</Path>
@@ -72,10 +77,10 @@
             <Path fileType="data">/usr/share/nanorc/inputrc.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/jade.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/java.nanorc</Path>
-            <Path fileType="data">/usr/share/nanorc/javascript.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/jrnl.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/js.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/json.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/jsx.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/julia.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/keymap.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/kickstart.nanorc</Path>
@@ -133,8 +138,10 @@
             <Path fileType="data">/usr/share/nanorc/toml.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/ts.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/twig.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/v.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/vala.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/verilog.nanorc</Path>
+            <Path fileType="data">/usr/share/nanorc/vhdl.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/vi.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/x11basic.nanorc</Path>
             <Path fileType="data">/usr/share/nanorc/xml.nanorc</Path>
@@ -151,12 +158,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-09-01</Date>
-            <Version>2022.11.02</Version>
+        <Update release="3">
+            <Date>2025-12-08</Date>
+            <Version>2025.07.01</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/galenguyer/nano-syntax-highlighting/compare/2022.11.02...2025.07.01).

**Test Plan**
- Checked syntax.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
