### PR TITLE
ypkg: Update to v35.1.0

### DIFF
--- a/packages/y/ypkg/package.yml
+++ b/packages/y/ypkg/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : ypkg
-version    : 35.0.2
-release    : 212
+version    : 35.1.0
+release    : 213
 source     :
-    - https://github.com/getsolus/ypkg/archive/refs/tags/v35.0.2.tar.gz : c944b5129aeb33d245cbdaabeaa55fb65dcdc7dcab80e32ef10dc59f96d31bc0
+    - https://github.com/getsolus/ypkg/archive/refs/tags/v35.1.0.tar.gz : 0c2f864f87226a6e6943d02f12e9d6e8bb9c8dbb6334ae8dc4a8b2a949a4e892
 homepage   : https://github.com/getsolus/ypkg
 license    : GPL-3.0-or-later
 component  : system.devel

--- a/packages/y/ypkg/pspec_x86_64.xml
+++ b/packages/y/ypkg/pspec_x86_64.xml
@@ -29,11 +29,11 @@ Simply put, it is a tool to convert a build process into a packaging operation.
             <Path fileType="executable">/usr/bin/ypkg.bin</Path>
             <Path fileType="executable">/usr/bin/ypkg.py</Path>
             <Path fileType="executable">/usr/bin/yupdate</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2-35.0.2.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2-35.0.2.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2-35.0.2.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2-35.0.2.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2-35.0.2.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2-35.1.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2-35.1.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2-35.1.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2-35.1.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2-35.1.0.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ypkg2/__pycache__/__init__.cpython-312.pyc</Path>
@@ -114,9 +114,9 @@ Simply put, it is a tool to convert a build process into a packaging operation.
         </Files>
     </Package>
     <History>
-        <Update release="212">
-            <Date>2025-11-10</Date>
-            <Version>35.0.2</Version>
+        <Update release="213">
+            <Date>2025-12-08</Date>
+            <Version>35.1.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/getsolus/ypkg/releases/tag/v35.1.0).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build Bluejay after adding the new `%install_license` calls to the `install` section, see that all the licenses were included in the package.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
