### PR TITLE
socat: Update to v1.8.1.0

### DIFF
--- a/packages/s/socat/package.yml
+++ b/packages/s/socat/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : socat
-version    : 1.8.0.3
-release    : 9
+version    : 1.8.1.0
+release    : 10
 source     :
-    - https://www.dest-unreach.org/socat/download/socat-1.8.0.3.tar.gz : a9f9eb6cfb9aa6b1b4b8fe260edbac3f2c743f294db1e362b932eb3feca37ba4
-homepage   : https://repo.or.cz/socat.git
+    - http://www.dest-unreach.org/socat/download/socat-1.8.1.0.tar.gz : 9a884880b1b00dfb2ffc6959197b1554b200af731018174cd048115dc28ef239
+homepage   : http://www.dest-unreach.org/socat/
 license    : GPL-2.0-or-later
 component  : network.util
 summary    : Bidirectional data transfer relay
@@ -18,3 +18,4 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING*

--- a/packages/s/socat/pspec_x86_64.xml
+++ b/packages/s/socat/pspec_x86_64.xml
@@ -1,7 +1,7 @@
 <PISI>
     <Source>
         <Name>socat</Name>
-        <Homepage>https://repo.or.cz/socat.git</Homepage>
+        <Homepage>http://www.dest-unreach.org/socat/</Homepage>
         <Packager>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>
@@ -27,14 +27,16 @@
             <Path fileType="executable">/usr/bin/socat-chain.sh</Path>
             <Path fileType="executable">/usr/bin/socat-mux.sh</Path>
             <Path fileType="executable">/usr/bin/socat1</Path>
+            <Path fileType="data">/usr/share/licenses/socat/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/socat/COPYING.OpenSSL</Path>
             <Path fileType="man">/usr/share/man/man1/socat.1</Path>
             <Path fileType="man">/usr/share/man/man1/socat1.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2025-11-29</Date>
-            <Version>1.8.0.3</Version>
+        <Update release="10">
+            <Date>2025-12-09</Date>
+            <Version>1.8.1.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](http://www.dest-unreach.org/socat/CHANGES).
- Part of https://github.com/getsolus/packages/issues/7294

**Test Plan**

- Verified socat version.
- socat -d -d TCP-LISTEN:12345,reuseaddr,fork -

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
