### PR TITLE
frei0r: Update to v2.5.1

### DIFF
--- a/packages/f/frei0r/abi_libs
+++ b/packages/f/frei0r/abi_libs
@@ -66,6 +66,7 @@ glow.so
 grain_extract.so
 grain_merge.so
 hardlight.so
+heatmap0r.so
 hue.so
 hueshift0r.so
 invert0r.so

--- a/packages/f/frei0r/abi_symbols
+++ b/packages/f/frei0r/abi_symbols
@@ -876,7 +876,6 @@ glitch0r.so:f0r_get_plugin_info
 glitch0r.so:f0r_init
 glitch0r.so:f0r_set_param_value
 glitch0r.so:f0r_update
-glitch0r.so:g0r_state
 glow.so:f0r_construct
 glow.so:f0r_deinit
 glow.so:f0r_destruct
@@ -922,6 +921,16 @@ hardlight.so:f0r_set_param_value
 hardlight.so:f0r_update
 hardlight.so:f0r_update2
 hardlight.so:plugin
+heatmap0r.so:MAX255
+heatmap0r.so:f0r_construct
+heatmap0r.so:f0r_deinit
+heatmap0r.so:f0r_destruct
+heatmap0r.so:f0r_get_param_info
+heatmap0r.so:f0r_get_param_value
+heatmap0r.so:f0r_get_plugin_info
+heatmap0r.so:f0r_init
+heatmap0r.so:f0r_set_param_value
+heatmap0r.so:f0r_update
 hue.so:_Z6MAX255j
 hue.so:f0r_construct
 hue.so:f0r_deinit

--- a/packages/f/frei0r/package.yml
+++ b/packages/f/frei0r/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : frei0r
-version    : 2.5.0
-release    : 10
+version    : 2.5.1
+release    : 11
 source     :
-    - https://github.com/dyne/frei0r/archive/refs/tags/v2.5.0.tar.gz : c511aeb51faeb0de2afe47327c30026d5b76ccc910a0b93d286029f07d29c656
+    - https://github.com/dyne/frei0r/archive/refs/tags/v2.5.1.tar.gz : 318ec4a3042c94a00a58fccdc1eb0d911f36a22beb3504d27aefcca4598f40b0
 homepage   : https://frei0r.dyne.org/
 license    : GPL-2.0-or-later
 component  : multimedia.video
@@ -21,3 +21,4 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING

--- a/packages/f/frei0r/pspec_x86_64.xml
+++ b/packages/f/frei0r/pspec_x86_64.xml
@@ -92,6 +92,7 @@ It is our hope that this way these simple effects can be shared between many app
             <Path fileType="library">/usr/lib64/frei0r-1/grain_extract.so</Path>
             <Path fileType="library">/usr/lib64/frei0r-1/grain_merge.so</Path>
             <Path fileType="library">/usr/lib64/frei0r-1/hardlight.so</Path>
+            <Path fileType="library">/usr/lib64/frei0r-1/heatmap0r.so</Path>
             <Path fileType="library">/usr/lib64/frei0r-1/hue.so</Path>
             <Path fileType="library">/usr/lib64/frei0r-1/hueshift0r.so</Path>
             <Path fileType="library">/usr/lib64/frei0r-1/invert0r.so</Path>
@@ -181,6 +182,7 @@ It is our hope that this way these simple effects can be shared between many app
             <Path fileType="library">/usr/lib64/frei0r-1/vertigo.so</Path>
             <Path fileType="library">/usr/lib64/frei0r-1/vignette.so</Path>
             <Path fileType="library">/usr/lib64/frei0r-1/xfade0r.so</Path>
+            <Path fileType="data">/usr/share/licenses/frei0r/COPYING</Path>
         </Files>
     </Package>
     <Package>
@@ -192,7 +194,7 @@ It is our hope that this way these simple effects can be shared between many app
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">frei0r</Dependency>
+            <Dependency release="11">frei0r</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/frei0r.h</Path>
@@ -206,9 +208,9 @@ It is our hope that this way these simple effects can be shared between many app
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2025-11-15</Date>
-            <Version>2.5.0</Version>
+        <Update release="11">
+            <Date>2025-12-09</Date>
+            <Version>2.5.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/dyne/frei0r/releases/tag/v2.5.1).
- Part of https://github.com/getsolus/packages/issues/7294

**Test Plan**

Installed frei0r 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
