### PR TITLE
glib2: Update to v2.86.3

### DIFF
--- a/packages/g/glib2/package.yml
+++ b/packages/g/glib2/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : glib2
-version    : 2.86.2
-release    : 124
+version    : 2.86.3
+release    : 125
 source     :
-    - https://download.gnome.org/sources/glib/2.86/glib-2.86.2.tar.xz : 8a724e970855357ea8101e27727202392a0ffd5410a98336aed54ec59113e611
+    - https://download.gnome.org/sources/glib/2.86/glib-2.86.3.tar.xz : b3211d8d34b9df5dca05787ef0ad5d7ca75dec998b970e1aab0001d229977c65
 homepage   : https://docs.gtk.org/glib/
 license    : LGPL-2.1-or-later
 summary    : Low level C library containing data structure handling and interfaces
@@ -47,6 +47,9 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING
+    %install_license LICENSES/*
+
     # Allow emul32 to work correctly.
     install -Dm00644 $pkgfiles/glibconfig.h $installdir/usr/include/glib-2.0/glibconfig.h
 patterns   :

--- a/packages/g/glib2/pspec_x86_64.xml
+++ b/packages/g/glib2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>glib2</Name>
         <Homepage>https://docs.gtk.org/glib/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>system.base</PartOf>
@@ -43,17 +43,17 @@
             <Path fileType="library">/usr/lib64/glib-2.0/include/glibconfig.h</Path>
             <Path fileType="library">/usr/lib64/glib2/gio-launch-desktop</Path>
             <Path fileType="library">/usr/lib64/libgio-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgio-2.0.so.0.8600.2</Path>
+            <Path fileType="library">/usr/lib64/libgio-2.0.so.0.8600.3</Path>
             <Path fileType="library">/usr/lib64/libgirepository-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgirepository-2.0.so.0.8600.2</Path>
+            <Path fileType="library">/usr/lib64/libgirepository-2.0.so.0.8600.3</Path>
             <Path fileType="library">/usr/lib64/libglib-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libglib-2.0.so.0.8600.2</Path>
+            <Path fileType="library">/usr/lib64/libglib-2.0.so.0.8600.3</Path>
             <Path fileType="library">/usr/lib64/libgmodule-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgmodule-2.0.so.0.8600.2</Path>
+            <Path fileType="library">/usr/lib64/libgmodule-2.0.so.0.8600.3</Path>
             <Path fileType="library">/usr/lib64/libgobject-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgobject-2.0.so.0.8600.2</Path>
+            <Path fileType="library">/usr/lib64/libgobject-2.0.so.0.8600.3</Path>
             <Path fileType="library">/usr/lib64/libgthread-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgthread-2.0.so.0.8600.2</Path>
+            <Path fileType="library">/usr/lib64/libgthread-2.0.so.0.8600.3</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/gapplication</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/gdbus</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/gio</Path>
@@ -64,6 +64,16 @@
             <Path fileType="data">/usr/share/glib-2.0/gettext/po/Makefile.in.in</Path>
             <Path fileType="data">/usr/share/glib-2.0/schemas/gschema.dtd</Path>
             <Path fileType="data">/usr/share/glib-2.0/valgrind/glib.supp</Path>
+            <Path fileType="data">/usr/share/licenses/glib2/Apache-2.0.txt</Path>
+            <Path fileType="data">/usr/share/licenses/glib2/CC0-1.0.txt</Path>
+            <Path fileType="data">/usr/share/licenses/glib2/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/glib2/GPL-2.0-or-later.txt</Path>
+            <Path fileType="data">/usr/share/licenses/glib2/LGPL-2.1-only.txt</Path>
+            <Path fileType="data">/usr/share/licenses/glib2/LGPL-2.1-or-later.txt</Path>
+            <Path fileType="data">/usr/share/licenses/glib2/LLVM-exception.txt</Path>
+            <Path fileType="data">/usr/share/licenses/glib2/LicenseRef-old-glib-tests.txt</Path>
+            <Path fileType="data">/usr/share/licenses/glib2/MIT.txt</Path>
+            <Path fileType="data">/usr/share/licenses/glib2/MPL-1.1.txt</Path>
             <Path fileType="localedata">/usr/share/locale/ab/LC_MESSAGES/glib20.mo</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/glib20.mo</Path>
             <Path fileType="localedata">/usr/share/locale/am/LC_MESSAGES/glib20.mo</Path>
@@ -174,24 +184,24 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="124">glib2</Dependency>
+            <Dependency release="125">glib2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/gio/modules</Path>
             <Path fileType="library">/usr/lib32/glib-2.0/include/glibconfig.h</Path>
             <Path fileType="library">/usr/lib32/glib2/gio-launch-desktop</Path>
             <Path fileType="library">/usr/lib32/libgio-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgio-2.0.so.0.8600.2</Path>
+            <Path fileType="library">/usr/lib32/libgio-2.0.so.0.8600.3</Path>
             <Path fileType="library">/usr/lib32/libgirepository-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgirepository-2.0.so.0.8600.2</Path>
+            <Path fileType="library">/usr/lib32/libgirepository-2.0.so.0.8600.3</Path>
             <Path fileType="library">/usr/lib32/libglib-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libglib-2.0.so.0.8600.2</Path>
+            <Path fileType="library">/usr/lib32/libglib-2.0.so.0.8600.3</Path>
             <Path fileType="library">/usr/lib32/libgmodule-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgmodule-2.0.so.0.8600.2</Path>
+            <Path fileType="library">/usr/lib32/libgmodule-2.0.so.0.8600.3</Path>
             <Path fileType="library">/usr/lib32/libgobject-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgobject-2.0.so.0.8600.2</Path>
+            <Path fileType="library">/usr/lib32/libgobject-2.0.so.0.8600.3</Path>
             <Path fileType="library">/usr/lib32/libgthread-2.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgthread-2.0.so.0.8600.2</Path>
+            <Path fileType="library">/usr/lib32/libgthread-2.0.so.0.8600.3</Path>
         </Files>
     </Package>
     <Package>
@@ -201,8 +211,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="124">glib2-32bit</Dependency>
-            <Dependency release="124">glib2-devel</Dependency>
+            <Dependency release="125">glib2-32bit</Dependency>
+            <Dependency release="125">glib2-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libgio-2.0.so</Path>
@@ -229,7 +239,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="124">glib2</Dependency>
+            <Dependency release="125">glib2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/gdbus-codegen</Path>
@@ -563,10 +573,10 @@
             <Path fileType="data">/usr/share/aclocal/glib-gettext.m4</Path>
             <Path fileType="data">/usr/share/aclocal/gsettings.m4</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/gresource</Path>
-            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib32/libglib-2.0.so.0.8600.2-gdb.py</Path>
-            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib32/libgobject-2.0.so.0.8600.2-gdb.py</Path>
-            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib64/libglib-2.0.so.0.8600.2-gdb.py</Path>
-            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib64/libgobject-2.0.so.0.8600.2-gdb.py</Path>
+            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib32/libglib-2.0.so.0.8600.3-gdb.py</Path>
+            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib32/libgobject-2.0.so.0.8600.3-gdb.py</Path>
+            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib64/libglib-2.0.so.0.8600.3-gdb.py</Path>
+            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib64/libgobject-2.0.so.0.8600.3-gdb.py</Path>
             <Path fileType="data">/usr/share/gir-1.0/GIRepository-3.0.gir</Path>
             <Path fileType="data">/usr/share/gir-1.0/GLib-2.0.gir</Path>
             <Path fileType="data">/usr/share/gir-1.0/GLibUnix-2.0.gir</Path>
@@ -589,12 +599,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="124">
-            <Date>2025-11-26</Date>
-            <Version>2.86.2</Version>
+        <Update release="125">
+            <Date>2025-12-09</Date>
+            <Version>2.86.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://download.gnome.org/sources/glib/2.86/glib-2.86.3.news).
Part of https://github.com/getsolus/packages/issues/7294

**Security**
- CVE-2025-13601

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build `budgie-user-indicator-redux-applet` against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
