### PR TITLE
libgit2: Update to v1.9.2

### DIFF
--- a/packages/l/libgit2/package.yml
+++ b/packages/l/libgit2/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libgit2
-version    : 1.9.1
-release    : 38
+version    : 1.9.2
+release    : 39
 source     :
-    - https://github.com/libgit2/libgit2/archive/refs/tags/v1.9.1.tar.gz : 14cab3014b2b7ad75970ff4548e83615f74d719afe00aa479b4a889c1e13fc00
+    - https://github.com/libgit2/libgit2/archive/refs/tags/v1.9.2.tar.gz : 6f097c82fc06ece4f40539fb17e9d41baf1a5a2fc26b1b8562d21b89bc355fe6
 homepage   : https://libgit2.org/
 license    : GPL-2.0-or-later
 component  : programming.library
@@ -27,3 +27,4 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING

--- a/packages/l/libgit2/pspec_x86_64.xml
+++ b/packages/l/libgit2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libgit2</Name>
         <Homepage>https://libgit2.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>programming.library</PartOf>
@@ -22,7 +22,8 @@
         <Files>
             <Path fileType="executable">/usr/bin/git2</Path>
             <Path fileType="library">/usr/lib64/libgit2.so.1.9</Path>
-            <Path fileType="library">/usr/lib64/libgit2.so.1.9.1</Path>
+            <Path fileType="library">/usr/lib64/libgit2.so.1.9.2</Path>
+            <Path fileType="data">/usr/share/licenses/libgit2/COPYING</Path>
         </Files>
     </Package>
     <Package>
@@ -32,7 +33,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="38">libgit2</Dependency>
+            <Dependency release="39">libgit2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/git2.h</Path>
@@ -137,12 +138,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="38">
-            <Date>2025-07-16</Date>
-            <Version>1.9.1</Version>
+        <Update release="39">
+            <Date>2025-12-09</Date>
+            <Version>1.9.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/libgit2/libgit2/releases/tag/v1.9.2).
Part of https://github.com/getsolus/packages/issues/7294

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build `geany-plugins` against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
