### PR TITLE
noto-sans-ttf: Update to v2025.12.01

### DIFF
--- a/packages/n/noto-sans-ttf/files/noto-sans-ttf.metainfo.xml
+++ b/packages/n/noto-sans-ttf/files/noto-sans-ttf.metainfo.xml
@@ -1059,5 +1059,6 @@
     <font>Noto Sans Bengali SemiCondensed Medium</font>
     <font>Noto Sans Bengali SemiCondensed SemiBold</font>
     <font>Noto Sans Bengali SemiCondensed Thin</font>
+    <font>Noto Sans Sinhala Condensed Thin</font>
   </provides>
 </component>

--- a/packages/n/noto-sans-ttf/files/noto-serif-ttf.metainfo.xml
+++ b/packages/n/noto-sans-ttf/files/noto-serif-ttf.metainfo.xml
@@ -496,5 +496,11 @@
     <font>Noto Serif Display Condensed Italic</font>
     <font>Noto Serif Display SemiCondensed Regular</font>
     <font>Noto Serif Sinhala SemiCondensed SemiBold</font>
+    <font>Noto Serif Hentaigana Bold</font>
+    <font>Noto Serif Hentaigana Light</font>
+    <font>Noto Serif Hentaigana Medium</font>
+    <font>Noto Serif Hentaigana Regular</font>
+    <font>Noto Serif Hentaigana SemiBold</font>
+    <font>Noto Serif Todhri Regular</font>
   </provides>
 </component>

--- a/packages/n/noto-sans-ttf/package.yml
+++ b/packages/n/noto-sans-ttf/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : noto-sans-ttf
-version    : 2025.08.01
-release    : 44
+version    : 2025.12.01
+release    : 45
 source     :
-    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-2025.08.01.tar.gz : b1e2ce44aacc1773a18c2fb7345c3c710cb269684747a68d2a97c0a8b180b652
+    - https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-2025.12.01.tar.gz : a06f15babc162a10768964965e95a062022622a078af4bc9d988c9ba65b4c8f7
 homepage   : https://fonts.google.com/noto
 license    : OFL-1.1
 component  :
@@ -27,6 +27,10 @@ install    : |
 
     install -Dm00644 $pkgfiles/noto-sans-ttf.metainfo.xml $installdir/usr/share/metainfo/noto-sans-ttf.metainfo.xml
     install -Dm00644 $pkgfiles/noto-serif-ttf.metainfo.xml $installdir/usr/share/metainfo/noto-serif-ttf.metainfo.xml
+
+    install -dm00755 $installdir/usr/share/licenses/noto-{sans,serif}-ttf/
+    install -Dm00644 fonts/LICENSE $installdir/usr/share/licenses/noto-sans-ttf/
+    install -Dm00644 fonts/LICENSE $installdir/usr/share/licenses/noto-serif-ttf/
 patterns   :
     - ^noto-serif-ttf :
         - /usr/share/fonts/truetype/noto-sans-ttf/NotoSerif*

--- a/packages/n/noto-sans-ttf/pspec_x86_64.xml
+++ b/packages/n/noto-sans-ttf/pspec_x86_64.xml
@@ -820,6 +820,7 @@
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansSinhala-SemiCondensedSemiBold.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansSinhala-SemiCondensedThin.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansSinhala-Thin.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansSinhala-ThinCondensed.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansSinhalaUI-Bold.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansSinhalaUI-Condensed.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSansSinhalaUI-CondensedBlack.ttf</Path>
@@ -1061,6 +1062,8 @@
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoTraditionalNushu-Light.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoTraditionalNushu-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoZnamennyMusicalNotation-Regular.ttf</Path>
+            <Path fileType="data">/usr/share/licenses/noto-sans-ttf/LICENSE</Path>
+            <Path fileType="data">/usr/share/licenses/noto-serif-ttf/LICENSE</Path>
             <Path fileType="data">/usr/share/metainfo/noto-sans-ttf.metainfo.xml</Path>
         </Files>
     </Package>
@@ -1328,6 +1331,11 @@
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifHebrew-SemiCondensedSemiBold.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifHebrew-SemiCondensedThin.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifHebrew-Thin.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifHentaigana-Bold.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifHentaigana-Light.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifHentaigana-Medium.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifHentaigana-Regular.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifHentaigana-SemiBold.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifKannada-Bold.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifKannada-Light.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifKannada-Medium.ttf</Path>
@@ -1537,6 +1545,7 @@
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifTibetan-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifTibetan-SemiBold.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifTibetan-Thin.ttf</Path>
+            <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifTodhri-Regular.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifToto-Bold.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifToto-Medium.ttf</Path>
             <Path fileType="data">/usr/share/fonts/truetype/noto-sans-ttf/NotoSerifToto-Regular.ttf</Path>
@@ -1553,9 +1562,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="44">
-            <Date>2025-08-01</Date>
-            <Version>2025.08.01</Version>
+        <Update release="45">
+            <Date>2025-12-09</Date>
+            <Version>2025.12.01</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Added fonts / font variants:
- Noto Sans Sinhala Condensed Thin
- Noto Serif Hentaigana Bold
- Noto Serif Hentaigana Light
- Noto Serif Hentaigana Medium
- Noto Serif Hentaigana Regular
- Noto Serif Hentaigana SemiBold
- Noto Serif Todhri Regular

Full commit log available [here](https://github.com/notofonts/notofonts.github.io/compare/noto-monthly-release-2025.08.01...noto-monthly-release-2025.12.01)

Also include license file

Part of https://github.com/getsolus/packages/issues/7294

**Test Plan**
- Confirmed system UI with Noto Sans font looks alright
- Wrote some text in LibreOffice with Noto Sans / Serif

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
