### PR TITLE
nano: Rebuild for nano-syntax-highlighting update

### DIFF
--- a/packages/n/nano/package.yml
+++ b/packages/n/nano/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : nano
 version    : '8.7'
-release    : 207
+release    : 208
 source     :
     - https://www.nano-editor.org/dist/v8/nano-8.7.tar.xz : afd287aa672c48b8e1a93fdb6c6588453d527510d966822b687f2835f0d986e9
 homepage   : https://www.nano-editor.org
@@ -24,6 +24,8 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING
+
     # Include syntax definitions
     for rcfile in $installdir/usr/share/nano/*.nanorc; do
         echo include /usr/share/nano/${rcfile##*nano/} >> $pkgfiles/nanorc

--- a/packages/n/nano/pspec_x86_64.xml
+++ b/packages/n/nano/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nano</Name>
         <Homepage>https://www.nano-editor.org</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.devel</PartOf>
@@ -28,6 +28,7 @@
             <Path fileType="doc">/usr/share/doc/nano/faq.html</Path>
             <Path fileType="doc">/usr/share/doc/nano/nano.html</Path>
             <Path fileType="info">/usr/share/info/nano.info.zst</Path>
+            <Path fileType="data">/usr/share/licenses/nano/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/bg/LC_MESSAGES/nano.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/nano.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/nano.mo</Path>
@@ -117,12 +118,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="207">
-            <Date>2025-11-29</Date>
+        <Update release="208">
+            <Date>2025-12-09</Date>
             <Version>8.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

`nano-syntax-highlighting` merged the `javascript.nanorc` file into `js.nanor`c (https://github.com/galenguyer/nano-syntax-highlighting/commit/be2a9e34406d25a2dee76be53c803c1d690fab93)

Rebuild `nano` to fix the following error:

```
Error in /usr/share/defaults/nano/nanorc on line 403: Error reading /usr/share/nanorc/javascript.nanorc: No such file or directory
```

Also include the license file

Part of https://github.com/getsolus/packages/issues/7294

**Test Plan**

Opened a document (and the commit message) in `nano` and saw no more error message

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
