### PR TITLE
solseek: Update to 0.7.1

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 0.7.0
-release    : 9
+version    : 0.7.1
+release    : 10
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v0.7.0.tar.gz : 914c8db9130769c8d88a5b1c7b22e64ebc54197b4d49c26c6a00c98ee6654f1c
+    - https://github.com/clintre/solseek/archive/refs/tags/v0.7.1.tar.gz : ed09befd4d07a93b2d3f519ef26152fc3e3d9f869f256bfd14b9cda3a635ac55
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils
@@ -20,3 +20,4 @@ install    : |
     install -Dm00644 $workdir/package/share/applications/Solseek.desktop $installdir/usr/share/applications/Solseek.desktop
     install -Dm00644 $workdir/package/share/icons/hicolor/scalable/apps/solseek.svg $installdir/usr/share/icons/hicolor/scalable/apps/solseek.svg
     install -Dm00644 $workdir/package/share/metainfo/solseek.metainfo.xml $installdir/usr/share/metainfo/solseek.metainfo.xml
+    %install_license LICENSE

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -7,7 +7,7 @@
             <Email>clint@eschberger.info</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
-        <PartOf>systtem.utils</PartOf>
+        <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">A TUI Package Manager for Solus</Summary>
         <Description xml:lang="en">Solseek is a simple terminal user interface that allows you to browse, search, and manage packages from the Solus packages.
 </Description>
@@ -18,7 +18,7 @@
         <Summary xml:lang="en">A TUI Package Manager for Solus</Summary>
         <Description xml:lang="en">Solseek is a simple terminal user interface that allows you to browse, search, and manage packages from the Solus packages.
 </Description>
-        <PartOf>systtem.utils</PartOf>
+        <PartOf>system.utils</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/solseek</Path>
             <Path fileType="data">/usr/share/applications/Solseek.desktop</Path>
@@ -42,9 +42,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2025-12-08</Date>
-            <Version>0.7.0</Version>
+        <Update release="10">
+            <Date>2025-12-09</Date>
+            <Version>0.7.1</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**

Minor bug fix for issue found. Previus message for weekly sync notes should be the same as the 0.7.0. 
Which I will list here as well...

Topic: Sync Notes
Major update with Desktop Application advanced search using appstream catalog. Basic thheme support including a hint of Solus coloring.
New flags for debug and forcing cache clearing on launch as well as enhanced eopkg upgrade wrapper that allows for upgrading everthing in addition to eopkg.

Bugfixes:

- Fixed bug with the desktop apps and rollback would not populate due to language parsing

Full release notes:

- [0.7.1](https://github.com/clintre/solseek/releases/tag/v0.7.1)


**Test Plan**

Tested on unstable VM with language set to French

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
