### PR TITLE
valkey: Update to v9.0.1

### DIFF
--- a/packages/v/valkey/abi_used_symbols
+++ b/packages/v/valkey/abi_used_symbols
@@ -1,4 +1,4 @@
-UNKNOWN:llrint
+UNKNOWN:lround
 libc.so.6:__asprintf_chk
 libc.so.6:__assert_fail
 libc.so.6:__ctype_b_loc
@@ -283,7 +283,6 @@ libm.so.6:llrint
 libm.so.6:llroundl
 libm.so.6:log
 libm.so.6:log10
-libm.so.6:lround
 libm.so.6:modf
 libm.so.6:pow
 libm.so.6:round

--- a/packages/v/valkey/package.yml
+++ b/packages/v/valkey/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : valkey
-version    : 9.0.0
-release    : 8
+version    : 9.0.1
+release    : 9
 source     :
-    - https://github.com/valkey-io/valkey/archive/refs/tags/9.0.0.tar.gz : 088f47e167eb640ea31af48c81c5d62ee56321f25a4b05d4e54a0ef34232724b
+    - https://github.com/valkey-io/valkey/archive/refs/tags/9.0.1.tar.gz : 9cfbc5f32a2a6058ee0f8c532b9c4d24167cc49d719f091dd75f1bb8353a1fc5
 homepage   : https://valkey.io/
 license    : BSD-3-Clause
 component  : database
@@ -28,6 +28,7 @@ install    : |
     # Valkey is for local development, not server use so there's no point in having valkey-sentinel
     rm -v $installdir/usr/bin/valkey-sentinel \
           $installdir/usr/bin/redis-sentinel
+    %install_license COPYING
 replaces   :
     - redis
     - dbginfo : redis-dbginfo

--- a/packages/v/valkey/pspec_x86_64.xml
+++ b/packages/v/valkey/pspec_x86_64.xml
@@ -33,15 +33,16 @@
             <Path fileType="library">/usr/lib/systemd/system/valkey.service</Path>
             <Path fileType="library">/usr/lib/sysusers.d/valkey.conf</Path>
             <Path fileType="library">/usr/lib/tmpfiles.d/valkey.conf</Path>
+            <Path fileType="data">/usr/share/licenses/valkey/COPYING</Path>
         </Files>
         <Replaces>
             <Package>redis</Package>
         </Replaces>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2025-10-23</Date>
-            <Version>9.0.0</Version>
+        <Update release="9">
+            <Date>2025-12-10</Date>
+            <Version>9.0.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**

- Authenticate slot migration client on source node to internal user
- Bug fix: reset io_last_written on c->buf resize to prevent stale pointers
- Sentinel: fix regression requiring "+failover" ACL in failover path
- Cluster: Avoid usage of light weight messages to nodes with not ready bidirectional links
- Send duplicate multi meet packet only for node which supports it in mixed clusters
- Fix: LTRIM should not call signalModifiedKey when no elements are removed
- Fix build on some 32-bit ARM by only using NEON on AArch64
- Fix deadlock in IO-thread shutdown during panic
- Fix COMMANDLOG large-reply when using reply copy avoidance
- Fix CLUSTER SLOTS crash when called from module timer callback

**Test Plan**
- Connected.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
