### PR TITLE
darkly: Update to v0.5.27

### DIFF
--- a/packages/d/darkly/abi_used_symbols
+++ b/packages/d/darkly/abi_used_symbols
@@ -115,6 +115,7 @@ libKF5WindowSystem.so.5:_ZNK11KWindowInfo16windowClassClassEv
 libKF5WindowSystem.so.5:_ZNK11KWindowInfo4nameEv
 libKF5WindowSystem.so.5:_ZNK11KWindowInfo5validEb
 libKF5WindowSystem.so.5:_ZNK13KWindowShadow9isCreatedEv
+libKF6ColorScheme.so.6:_ZN12KColorScheme13frameContrastERK28QExplicitlySharedDataPointerI13KSharedConfigE
 libKF6ConfigCore.so.6:_ZN19KCoreConfigSkeleton14ItemStringListC1ERK7QStringS3_R5QListIS1_ERKS5_
 libKF6CoreAddons.so.6:_ZN14KPluginFactory11qt_metacallEN11QMetaObject4CallEiPPv
 libKF6CoreAddons.so.6:_ZN14KPluginFactory11qt_metacastEPKc
@@ -882,7 +883,7 @@ libQt6Core.so.6:_ZN7QObject11eventFilterEPS_P6QEvent
 libQt6Core.so.6:_ZN7QObject11qt_metacallEN11QMetaObject4CallEiPPv
 libQt6Core.so.6:_ZN7QObject11qt_metacastEPKc
 libQt6Core.so.6:_ZN7QObject13connectNotifyERK11QMetaMethod
-libQt6Core.so.6:_ZN7QObject13doSetPropertyEPKcPK8QVariantPS2_
+libQt6Core.so.6:_ZN7QObject13doSetPropertyEPKcRK8QVariantPS2_
 libQt6Core.so.6:_ZN7QObject13setObjectNameE14QAnyStringView
 libQt6Core.so.6:_ZN7QObject16disconnectNotifyERK11QMetaMethod
 libQt6Core.so.6:_ZN7QObject16staticMetaObjectE
@@ -962,6 +963,7 @@ libQt6Core.so.6:_ZNK23QRegularExpressionMatch8hasMatchEv
 libQt6Core.so.6:_ZNK5QRect10intersectsERKS_
 libQt6Core.so.6:_ZNK5QRect8containsERK6QPointb
 libQt6Core.so.6:_ZNK5QRectanERKS_
+libQt6Core.so.6:_ZNK6QRectF10intersectsERKS_
 libQt6Core.so.6:_ZNK7QObject10metaObjectEv
 libQt6Core.so.6:_ZNK7QObject10objectNameEv
 libQt6Core.so.6:_ZNK7QObject8propertyEPKc
@@ -975,7 +977,6 @@ libQt6Core.so.6:_ZNK8QVariant5toIntEPb
 libQt6Core.so.6:_ZNK8QVariant6equalsERKS_
 libQt6Core.so.6:_ZNK8QVariant6toBoolEv
 libQt6Core.so.6:_ZNK8QVariant6toRealEPb
-libQt6Core.so.6:_ZNK8QVariant8metaTypeEv
 libQt6Core.so.6:_ZNK8QVariant8toStringEv
 libQt6Core.so.6:_ZNKR7QString3midExx
 libQt6Core.so.6:_ZTI18QAbstractItemModel
@@ -1049,6 +1050,7 @@ libQt6Gui.so.6:_ZN6QBrushC1ERK6QColorN2Qt10BrushStyleE
 libQt6Gui.so.6:_ZN6QBrushC1ERK7QPixmap
 libQt6Gui.so.6:_ZN6QBrushC1ERK9QGradient
 libQt6Gui.so.6:_ZN6QBrushC1ERKS_
+libQt6Gui.so.6:_ZN6QBrushC1Ev
 libQt6Gui.so.6:_ZN6QBrushD1Ev
 libQt6Gui.so.6:_ZN6QColor6setHsvEiiii
 libQt6Gui.so.6:_ZN6QColor8setAlphaEi
@@ -1645,6 +1647,8 @@ libkdecorations3.so.6:_ZN12KDecoration310Decoration14mouseMoveEventEP11QMouseEve
 libkdecorations3.so.6:_ZN12KDecoration310Decoration15hoverEnterEventEP11QHoverEvent
 libkdecorations3.so.6:_ZN12KDecoration310Decoration15hoverLeaveEventEP11QHoverEvent
 libkdecorations3.so.6:_ZN12KDecoration310Decoration15mousePressEventEP11QMouseEvent
+libkdecorations3.so.6:_ZN12KDecoration310Decoration15setBorderRadiusERKNS_12BorderRadiusE
+libkdecorations3.so.6:_ZN12KDecoration310Decoration16setBorderOutlineERKNS_13BorderOutlineE
 libkdecorations3.so.6:_ZN12KDecoration310Decoration16staticMetaObjectE
 libkdecorations3.so.6:_ZN12KDecoration310Decoration17mouseReleaseEventEP11QMouseEvent
 libkdecorations3.so.6:_ZN12KDecoration310Decoration20setResizeOnlyBordersERK9QMarginsF
@@ -1655,6 +1659,9 @@ libkdecorations3.so.6:_ZN12KDecoration310Decoration9setOpaqueEb
 libkdecorations3.so.6:_ZN12KDecoration310Decoration9setShadowERKSt10shared_ptrINS_16DecorationShadowEE
 libkdecorations3.so.6:_ZN12KDecoration310DecorationC2EP7QObjectRK5QListI8QVariantE
 libkdecorations3.so.6:_ZN12KDecoration310DecorationD2Ev
+libkdecorations3.so.6:_ZN12KDecoration312BorderRadiusC1Edddd
+libkdecorations3.so.6:_ZN12KDecoration313BorderOutlineC1EdRK6QColorRKNS_12BorderRadiusE
+libkdecorations3.so.6:_ZN12KDecoration313BorderOutlineC1Ev
 libkdecorations3.so.6:_ZN12KDecoration315DecoratedWindow11iconChangedE5QIcon
 libkdecorations3.so.6:_ZN12KDecoration315DecoratedWindow11sizeChangedERK6QSizeF
 libkdecorations3.so.6:_ZN12KDecoration315DecoratedWindow12widthChangedEd

--- a/packages/d/darkly/package.yml
+++ b/packages/d/darkly/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : darkly
-version    : 0.5.24
-release    : 11
+version    : 0.5.27
+release    : 12
 source     :
-    - https://github.com/Bali10050/Darkly/archive/refs/tags/v0.5.24.tar.gz : 83f299e92978b98b6e43de14fa6402dc9c2fb3110e554506d1d00d0ba8b0b92b
+    - https://github.com/Bali10050/Darkly/archive/refs/tags/v0.5.27.tar.gz : 73408b871eb31f7fa933447ce32ea103d65a080a522cc64585ee99896aef20aa
 homepage   : https://github.com/Bali10050/Darkly
 license    : GPL-2.0-or-later
 component  : desktop.theme
@@ -59,3 +59,6 @@ install    : |
 
     # Install appstream metadata
     install -Dm00644 $pkgfiles/io.github.bali10050.darkly.metainfo.xml -t $installdir/usr/share/metainfo
+
+    # Install Licence
+    %install_license COPYING

--- a/packages/d/darkly/pspec_x86_64.xml
+++ b/packages/d/darkly/pspec_x86_64.xml
@@ -32,6 +32,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/darkly-settings.svgz</Path>
             <Path fileType="data">/usr/share/kservices6/darklydecorationconfig.desktop</Path>
             <Path fileType="data">/usr/share/kstyle/themes/darkly.themerc</Path>
+            <Path fileType="data">/usr/share/licenses/darkly/COPYING</Path>
             <Path fileType="data">/usr/share/metainfo/io.github.bali10050.darkly.metainfo.xml</Path>
         </Files>
     </Package>
@@ -42,7 +43,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="11">darkly</Dependency>
+            <Dependency release="12">darkly</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/cmake/Darkly/DarklyConfig.cmake</Path>
@@ -50,9 +51,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2025-11-09</Date>
-            <Version>0.5.24</Version>
+        <Update release="12">
+            <Date>2025-12-12</Date>
+            <Version>0.5.27</Version>
             <Comment>Packaging update</Comment>
             <Name>Hurican Dev</Name>
             <Email>hurican@keemail.me</Email>


### PR DESCRIPTION
**Summary**
   - Update from v0.5.24 to v0.5.27
   - Install licence file

Release notes can be found [here](https://github.com/Bali10050/Darkly/releases/tag/v0.5.27).

**Test Plan**

Install the package to check if everything was working and checked the licence directory to check if the licence was installed there.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
