### PR TITLE
nvidia-open: Use a different icon for appstream metainfo

### DIFF
--- a/packages/n/nvidia-open/files/nvidia-open-current.metainfo.xml
+++ b/packages/n/nvidia-open/files/nvidia-open-current.metainfo.xml
@@ -17,7 +17,7 @@
     </p>
   </description>
   <url type="homepage">https://www.nvidia.com/</url>
-  <icon type="local" width="128" height="128">/usr/share/pixmaps/nvidia-settings.png</icon>
+  <icon type="local" width="128" height="128">/usr/share/icons/hicolor/64x64/apps/nvidia-current.png</icon>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>LicenseRef-proprietary:NVIDIA</project_license>
   <developer id="com.nvidia">

--- a/packages/n/nvidia-open/files/nvidia-open-lts.metainfo.xml
+++ b/packages/n/nvidia-open/files/nvidia-open-lts.metainfo.xml
@@ -17,7 +17,7 @@
     </p>
   </description>
   <url type="homepage">https://www.nvidia.com/</url>
-  <icon type="local" width="128" height="128">/usr/share/pixmaps/nvidia-settings.png</icon>
+  <icon type="local" width="128" height="128">/usr/share/icons/hicolor/64x64/apps/nvidia-lts.png</icon>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>LicenseRef-proprietary:NVIDIA</project_license>
   <developer id="com.nvidia">

--- a/packages/n/nvidia-open/monitoring.yaml
+++ b/packages/n/nvidia-open/monitoring.yaml
@@ -1,0 +1,9 @@
+releases:
+  id: 319677
+  rss: https://github.com/NVIDIA/open-gpu-kernel-modules/tags.atom
+  ignore:
+    # Change when the main GLX stable driver updates
+    - 590\..*
+ # No known CPE, checked 2025-12-12
+security:
+  cpe: ~

--- a/packages/n/nvidia-open/package.yml
+++ b/packages/n/nvidia-open/package.yml
@@ -1,6 +1,6 @@
 name       : nvidia-open
 version    : 580.119.02 # This has to be kept at the same version as nvidia-glx-driver
-release    : 2
+release    : 3
 source     :
     - https://download.nvidia.com/XFree86/NVIDIA-kernel-module-source/NVIDIA-kernel-module-source-580.119.02.tar.xz : ea06941cf2b095c2a9a6f1d0640a447d1c33baefbff9d95fd9726955dd210692
 homepage   : https://github.com/NVIDIA/open-gpu-kernel-modules

--- a/packages/n/nvidia-open/pspec_x86_64.xml
+++ b/packages/n/nvidia-open/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nvidia-open</Name>
         <Homepage>https://github.com/NVIDIA/open-gpu-kernel-modules</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>kernel.drivers</PartOf>
@@ -64,12 +64,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2025-12-11</Date>
+        <Update release="3">
+            <Date>2025-12-12</Date>
             <Version>580.119.02</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
The AppStream generator doesn't support icons in `/usr/share/pixmaps`,
so we have to use something in `/usr/share/icons`.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Can't really test this until generation of AppStream data.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
