### PR TITLE
python-maturin: Update to v1.10.2

### DIFF
--- a/packages/py/python-maturin/abi_used_libs
+++ b/packages/py/python-maturin/abi_used_libs
@@ -1,5 +1,4 @@
 ld-linux-x86-64.so.2
-libbz2.so.1.0
 libc.so.6
 libcrypto.so.3
 libgcc_s.so.1

--- a/packages/py/python-maturin/abi_used_symbols
+++ b/packages/py/python-maturin/abi_used_symbols
@@ -1,10 +1,4 @@
 ld-linux-x86-64.so.2:__tls_get_addr
-libbz2.so.1.0:BZ2_bzCompress
-libbz2.so.1.0:BZ2_bzCompressEnd
-libbz2.so.1.0:BZ2_bzCompressInit
-libbz2.so.1.0:BZ2_bzDecompress
-libbz2.so.1.0:BZ2_bzDecompressEnd
-libbz2.so.1.0:BZ2_bzDecompressInit
 libc.so.6:__errno_location
 libc.so.6:__libc_start_main
 libc.so.6:__register_atfork
@@ -26,6 +20,7 @@ libc.so.6:connect
 libc.so.6:dirfd
 libc.so.6:dl_iterate_phdr
 libc.so.6:dlsym
+libc.so.6:dup
 libc.so.6:dup2
 libc.so.6:environ
 libc.so.6:execvp
@@ -123,6 +118,7 @@ libc.so.6:setenv
 libc.so.6:setgid
 libc.so.6:setgroups
 libc.so.6:setpgid
+libc.so.6:setsid
 libc.so.6:setsockopt
 libc.so.6:setuid
 libc.so.6:sigaction
@@ -198,12 +194,14 @@ liblzma.so.5:lzma_code
 liblzma.so.5:lzma_end
 liblzma.so.5:lzma_stream_decoder
 libm.so.6:log
+libm.so.6:log2
 libm.so.6:log2f
 libm.so.6:pow
 libssl.so.3:OPENSSL_init_ssl
 libssl.so.3:SSL_CTX_ctrl
 libssl.so.3:SSL_CTX_free
 libssl.so.3:SSL_CTX_get_cert_store
+libssl.so.3:SSL_CTX_load_verify_locations
 libssl.so.3:SSL_CTX_new
 libssl.so.3:SSL_CTX_set_cert_store
 libssl.so.3:SSL_CTX_set_cipher_list

--- a/packages/py/python-maturin/package.yml
+++ b/packages/py/python-maturin/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-maturin
-version    : 1.9.6
-release    : 64
+version    : 1.10.2
+release    : 65
 source     :
-    - https://github.com/PyO3/maturin/archive/refs/tags/v1.9.6.tar.gz : c8aef8af6cd3d5b3331191b21191ec92d7b4ee0633e0799351a01af1c5ea2a6c
+    - https://github.com/PyO3/maturin/archive/refs/tags/v1.10.2.tar.gz : 8acb4eb224896b3fa67036680e9e7908eeb8e5c2ea3a495e987a3f2edb666f36
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-maturin/pspec_x86_64.xml
+++ b/packages/py/python-maturin/pspec_x86_64.xml
@@ -22,12 +22,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/maturin</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.6.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.6.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.6.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.6.dist-info/licenses/license-apache</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.6.dist-info/licenses/license-mit</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.9.6.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.10.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.10.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.10.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.10.2.dist-info/licenses/license-apache</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.10.2.dist-info/licenses/license-mit</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.10.2.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -40,9 +40,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="64">
-            <Date>2025-10-17</Date>
-            <Version>1.9.6</Version>
+        <Update release="65">
+            <Date>2025-12-12</Date>
+            <Version>1.10.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Release notes:
- [1.10.0](https://github.com/PyO3/maturin/releases/tag/v1.10.0)
- [1.10.1](https://github.com/PyO3/maturin/releases/tag/v1.10.1)
- [1.10.2](https://github.com/PyO3/maturin/releases/tag/v1.10.2)

**Test Plan**

Successfully built `python-orjson` (excluding tests due to ongoing pytz issues)

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
