### PR TITLE
yad: Update to v14.2 and install license file

### DIFF
--- a/packages/y/yad/abi_used_symbols
+++ b/packages/y/yad/abi_used_symbols
@@ -1,8 +1,8 @@
 libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_sscanf
 libc.so.6:__isoc23_strtol
-libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
 libc.so.6:__stack_chk_fail
 libc.so.6:bind_textdomain_codeset
@@ -41,7 +41,6 @@ libc.so.6:strlen
 libc.so.6:strncasecmp
 libc.so.6:strncmp
 libc.so.6:strncpy
-libc.so.6:strtol
 libc.so.6:textdomain
 libc.so.6:usleep
 libcairo.so.2:cairo_line_to
@@ -65,6 +64,7 @@ libgdk-3.so.0:gdk_display_get_default
 libgdk-3.so.0:gdk_display_get_default_seat
 libgdk-3.so.0:gdk_event_get_device
 libgdk-3.so.0:gdk_event_get_screen
+libgdk-3.so.0:gdk_event_get_scroll_deltas
 libgdk-3.so.0:gdk_events_pending
 libgdk-3.so.0:gdk_get_default_root_window
 libgdk-3.so.0:gdk_pixbuf_get_from_surface

--- a/packages/y/yad/package.yml
+++ b/packages/y/yad/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : yad
-version    : '14.1'
-release    : 20
+version    : '14.2'
+release    : 21
 source     :
-    - https://github.com/v1cont/yad/archive/v14.1.tar.gz : 84ea6abe80106a6cebe14425d591517542d93f7c8b19729e2cf93f4db83e5cc3
+    - https://github.com/v1cont/yad/archive/v14.2.tar.gz : 6748c0ecb917043326cc70646f143890151dea2fc50db5fe54439de6dc04b1e3
 license    : GPL-3.0-or-later
 homepage   : https://github.com/v1cont/yad
 component  : system.utils
@@ -17,7 +17,6 @@ builddeps  :
     - gettext-devel
 setup      : |
     autoreconf -ivf
-    intltoolize
     %configure --enable-html \
                --enable-sourceview \
                --enable-spell \
@@ -26,3 +25,4 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING

--- a/packages/y/yad/pspec_x86_64.xml
+++ b/packages/y/yad/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>yad</Name>
         <Homepage>https://github.com/v1cont/yad</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -33,6 +33,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/yad.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/yad.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/96x96/apps/yad.png</Path>
+            <Path fileType="data">/usr/share/licenses/yad/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/yad.mo</Path>
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/yad.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/yad.mo</Path>
@@ -42,8 +43,8 @@
             <Path fileType="localedata">/usr/share/locale/sk/LC_MESSAGES/yad.mo</Path>
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/yad.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/yad.mo</Path>
-            <Path fileType="man">/usr/share/man/man1/yad-tools.1</Path>
-            <Path fileType="man">/usr/share/man/man1/yad.1</Path>
+            <Path fileType="man">/usr/share/man/man1/yad-tools.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/yad.1.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -53,19 +54,19 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="20">yad</Dependency>
+            <Dependency release="21">yad</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/aclocal/yad.m4</Path>
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2024-09-21</Date>
-            <Version>14.1</Version>
+        <Update release="21">
+            <Date>2025-12-12</Date>
+            <Version>14.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- remove intltool dependency (use pure gettext)
- fix zooming in html dialog
- fix extra arguments handling in html dialog
- fix yad settings script
- fix typo in man page
- update translations
- code cleanup

**Test Plan**

Used `protontricks --gui` to install a Windows component for a game

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
