### PR TITLE
openxr: Update to v1.1.54

### DIFF
--- a/packages/o/openxr/abi_used_symbols
+++ b/packages/o/openxr/abi_used_symbols
@@ -155,7 +155,6 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_dispose
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructEmc
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6appendEPKc
-libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6appendEPKcm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7reserveEm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_appendEPKcm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_assignERKS4_
@@ -166,7 +165,6 @@ libstdc++.so.6:_ZNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE7_M_syncE
 libstdc++.so.6:_ZNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEC1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEED1Ev
-libstdc++.so.6:_ZNSt8__detail15_List_node_base7_M_hookEPS0_
 libstdc++.so.6:_ZNSt8ios_baseC2Ev
 libstdc++.so.6:_ZNSt8ios_baseD2Ev
 libstdc++.so.6:_ZNSt8time_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE2idE
@@ -238,12 +236,16 @@ libvulkan.so.1:vkCmdBeginRenderPass
 libvulkan.so.1:vkCmdBindIndexBuffer
 libvulkan.so.1:vkCmdBindPipeline
 libvulkan.so.1:vkCmdBindVertexBuffers
+libvulkan.so.1:vkCmdClearAttachments
 libvulkan.so.1:vkCmdDrawIndexed
 libvulkan.so.1:vkCmdEndRenderPass
 libvulkan.so.1:vkCmdPipelineBarrier
 libvulkan.so.1:vkCmdPushConstants
+libvulkan.so.1:vkCmdSetScissor
+libvulkan.so.1:vkCmdSetViewport
 libvulkan.so.1:vkCreateBuffer
 libvulkan.so.1:vkCreateCommandPool
+libvulkan.so.1:vkCreateComputePipelines
 libvulkan.so.1:vkCreateFence
 libvulkan.so.1:vkCreateFramebuffer
 libvulkan.so.1:vkCreateGraphicsPipelines
@@ -255,6 +257,7 @@ libvulkan.so.1:vkCreateSemaphore
 libvulkan.so.1:vkCreateShaderModule
 libvulkan.so.1:vkDestroyBuffer
 libvulkan.so.1:vkDestroyCommandPool
+libvulkan.so.1:vkDestroyDescriptorSetLayout
 libvulkan.so.1:vkDestroyFence
 libvulkan.so.1:vkDestroyFramebuffer
 libvulkan.so.1:vkDestroyImage

--- a/packages/o/openxr/package.yml
+++ b/packages/o/openxr/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : openxr
-version    : 1.1.53
-release    : 3
+version    : 1.1.54
+release    : 4
 source     :
-    - https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-1.1.53/OpenXR-SDK-Source-release-1.1.53.tar.gz : 1bf766990ff47dfb9b32df201777f666a6399aaab4a249e43b7ad676ad240a3c
+    - https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-1.1.54/OpenXR-SDK-Source-release-1.1.54.tar.gz : 959be5d4ee500c2426555f335bf7fd5d7fb86754192a1d18fa2a7b3ef7f03005
 homepage   : https://www.khronos.org/openxr/
 license    : Apache-2.0
 component  : multimedia.library
@@ -23,3 +23,4 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license LICENSES/*

--- a/packages/o/openxr/pspec_x86_64.xml
+++ b/packages/o/openxr/pspec_x86_64.xml
@@ -24,8 +24,22 @@
             <Path fileType="executable">/usr/bin/openxr_runtime_list</Path>
             <Path fileType="executable">/usr/bin/openxr_runtime_list_json</Path>
             <Path fileType="library">/usr/lib64/libopenxr_loader.so.1</Path>
-            <Path fileType="library">/usr/lib64/libopenxr_loader.so.1.1.53</Path>
+            <Path fileType="library">/usr/lib64/libopenxr_loader.so.1.1.54</Path>
             <Path fileType="doc">/usr/share/doc/openxr/LICENSE</Path>
+            <Path fileType="data">/usr/share/licenses/openxr/Apache-2.0.txt</Path>
+            <Path fileType="data">/usr/share/licenses/openxr/BSD-3-Clause.txt</Path>
+            <Path fileType="data">/usr/share/licenses/openxr/BSL-1.0.txt</Path>
+            <Path fileType="data">/usr/share/licenses/openxr/CC-BY-4.0.txt</Path>
+            <Path fileType="data">/usr/share/licenses/openxr/CC0-1.0.txt</Path>
+            <Path fileType="data">/usr/share/licenses/openxr/ISC.txt</Path>
+            <Path fileType="data">/usr/share/licenses/openxr/LicenseRef-Khronos-Free-Use-License-for-Software-and-Documentation.txt</Path>
+            <Path fileType="data">/usr/share/licenses/openxr/LicenseRef-KhronosSpecCopyright-WithNormativeWording-v10.txt</Path>
+            <Path fileType="data">/usr/share/licenses/openxr/LicenseRef-jsoncpp-public-domain.txt</Path>
+            <Path fileType="data">/usr/share/licenses/openxr/MIT.txt</Path>
+            <Path fileType="data">/usr/share/licenses/openxr/OFL-1.1-RFN.txt</Path>
+            <Path fileType="data">/usr/share/licenses/openxr/Unlicense.txt</Path>
+            <Path fileType="data">/usr/share/licenses/openxr/WTFPL.txt</Path>
+            <Path fileType="data">/usr/share/licenses/openxr/Zlib.txt</Path>
             <Path fileType="man">/usr/share/man/man1/hello_xr.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/openxr_runtime_list.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/openxr_runtime_list_json.1.zst</Path>
@@ -41,7 +55,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="3">openxr</Dependency>
+            <Dependency release="4">openxr</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/openxr/openxr.h</Path>
@@ -63,9 +77,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2025-11-29</Date>
-            <Version>1.1.53</Version>
+        <Update release="4">
+            <Date>2025-12-13</Date>
+            <Version>1.1.54</Version>
             <Comment>Packaging update</Comment>
             <Name>Hurican Dev</Name>
             <Email>hurican@keemail.me</Email>


### PR DESCRIPTION
**Summary**
   - Update to v1.1.54
   - Install licence file

Release notes can be found [here](https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/tag/release-1.1.54).

**Test Plan**

Installed the regular and -devel package then built a profile using Envision. Also checked to see if the licence file was installed and in the correct directory. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
