### PR TITLE
hugin: Update to v2025.0.1

### DIFF
--- a/packages/h/hugin/package.yml
+++ b/packages/h/hugin/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : hugin
-version    : 2025.0.0
-release    : 43
+version    : 2025.0.1
+release    : 44
 source     :
-    - https://sourceforge.net/projects/hugin/files/hugin/hugin-2025.0/hugin-2025.0.0.tar.bz2 : 0de27a5d5432e36d4e5d38ac25d7bcafc7b7dd542aab031640a61ed66767076c
+    - https://sourceforge.net/projects/hugin/files/hugin/hugin-2025.0/hugin-2025.0.1.tar.bz2 : 7cf8eb33a6a8848cc7f816faf4bc88389228883d5513136dccb5cb243912ab79
 homepage   : https://hugin.sourceforge.io/
 license    : GPL-2.0-or-later
 component  : multimedia.graphics

--- a/packages/h/hugin/pspec_x86_64.xml
+++ b/packages/h/hugin/pspec_x86_64.xml
@@ -608,9 +608,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="43">
-            <Date>2025-12-12</Date>
-            <Version>2025.0.0</Version>
+        <Update release="44">
+            <Date>2025-12-13</Date>
+            <Version>2025.0.1</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**
Release notes can be found [here](https://hugin.sourceforge.io/releases/2025.0.0/en.shtml).

**Test Plan**

Open hugin

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
