### PR TITLE
gphoto2: Update to v2.5.32

### DIFF
--- a/packages/g/gphoto2/abi_used_symbols
+++ b/packages/g/gphoto2/abi_used_symbols
@@ -34,6 +34,7 @@ libc.so.6:fflush
 libc.so.6:fgetc
 libc.so.6:fgets
 libc.so.6:fileno
+libc.so.6:fnmatch
 libc.so.6:fopen
 libc.so.6:fork
 libc.so.6:fputc

--- a/packages/g/gphoto2/package.yml
+++ b/packages/g/gphoto2/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gphoto2
-version    : 2.5.28
-release    : 9
+version    : 2.5.32
+release    : 10
 source     :
-    - https://github.com/gphoto/gphoto2/releases/download/v2.5.28/gphoto2-2.5.28.tar.gz : 54097ee429f57a9f076a814590f777cebbc837879fe7b16e41b2615e347f6ae0
+    - https://github.com/gphoto/gphoto2/releases/download/v2.5.32/gphoto2-2.5.32.tar.gz : 4b87dc03a0eb0677ac9158f2d38c6857da65f14514820743e8eef40350d5a3f6
 homepage   : https://github.com/gphoto/gphoto2
 license    : GPL-2.0-or-later
 component  : multimedia.graphics
@@ -21,3 +21,4 @@ install    : |
     %make_install
 check      : |
     %make check
+    %install_license COPYING

--- a/packages/g/gphoto2/pspec_x86_64.xml
+++ b/packages/g/gphoto2/pspec_x86_64.xml
@@ -22,6 +22,7 @@
         <Files>
             <Path fileType="executable">/usr/bin/gphoto2</Path>
             <Path fileType="doc">/usr/share/doc/gphoto2/test-hook.sh</Path>
+            <Path fileType="data">/usr/share/licenses/gphoto2/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/az/LC_MESSAGES/gphoto2.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/gphoto2.mo</Path>
             <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/gphoto2.mo</Path>
@@ -54,9 +55,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2025-11-08</Date>
-            <Version>2.5.28</Version>
+        <Update release="10">
+            <Date>2025-12-13</Date>
+            <Version>2.5.32</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
Release notes can be found [here](http://www.gphoto.org/news/).

**Test Plan**

test gphoto2 --list-ports

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
