### PR TITLE
[NFC] gnuradio: remove inactive maintainer

### DIFF
--- a/packages/g/gnuradio/MAINTAINERS.md
+++ b/packages/g/gnuradio/MAINTAINERS.md
@@ -1,4 +1,0 @@
-This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
-
-- Valentin Assfalg
-  - Email: valentin.assfalg@gmx.de


### PR DESCRIPTION
**Summary**
- Resolves https://github.com/getsolus/packages/issues/1438

**Test Plan**
- Checked file was deleted.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->


**Packaging notes**
- This has been updated but the old maintainer file was still there.