### PR TITLE
libpng: Update to v1.6.53

### DIFF
--- a/packages/l/libpng/package.yml
+++ b/packages/l/libpng/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libpng
-version    : 1.6.52
-release    : 31
+version    : 1.6.53
+release    : 32
 source     :
-    - https://sourceforge.net/projects/libpng/files/libpng16/1.6.52/libpng-1.6.52.tar.gz : 86d4a88be1c8bc903674199f1d067a9ac940af4e4399caba0314e7a1bcaa0724
+    - https://sourceforge.net/projects/libpng/files/libpng16/1.6.53/libpng-1.6.53.tar.gz : da0b045cbb1d06a8fc9696f9441359f70645f280ff24ae453ccb7c722353654f
 homepage   : https://www.libpng.org/pub/png/
 license    : Libpng
 component  : multimedia.library
@@ -24,6 +24,7 @@ build      : |
 install    : |
     %make_install
     rm -v $installdir/%libdir%/*.la
+    %install_license LICENSE
 check      : |
     %make check || ( cat ./test-suite.log && exit 1 )
 patterns   :

--- a/packages/l/libpng/pspec_x86_64.xml
+++ b/packages/l/libpng/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libpng</Name>
         <Homepage>https://www.libpng.org/pub/png/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Libpng</License>
         <PartOf>multimedia.library</PartOf>
@@ -23,9 +23,10 @@
             <Path fileType="executable">/usr/bin/png-fix-itxt</Path>
             <Path fileType="executable">/usr/bin/pngfix</Path>
             <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libpng16.so.16</Path>
-            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libpng16.so.16.52.0</Path>
+            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libpng16.so.16.53.0</Path>
             <Path fileType="library">/usr/lib64/libpng16.so.16</Path>
-            <Path fileType="library">/usr/lib64/libpng16.so.16.52.0</Path>
+            <Path fileType="library">/usr/lib64/libpng16.so.16.53.0</Path>
+            <Path fileType="data">/usr/share/licenses/libpng/LICENSE</Path>
             <Path fileType="man">/usr/share/man/man5/png.5.zst</Path>
         </Files>
     </Package>
@@ -36,11 +37,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="31">libpng</Dependency>
+            <Dependency release="32">libpng</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpng16.so.16</Path>
-            <Path fileType="library">/usr/lib32/libpng16.so.16.52.0</Path>
+            <Path fileType="library">/usr/lib32/libpng16.so.16.53.0</Path>
         </Files>
     </Package>
     <Package>
@@ -50,8 +51,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="31">libpng-32bit</Dependency>
-            <Dependency release="31">libpng-devel</Dependency>
+            <Dependency release="32">libpng-32bit</Dependency>
+            <Dependency release="32">libpng-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpng.so</Path>
@@ -67,7 +68,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="31">libpng</Dependency>
+            <Dependency release="32">libpng</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/libpng-config</Path>
@@ -87,12 +88,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2025-12-03</Date>
-            <Version>1.6.52</Version>
+        <Update release="32">
+            <Date>2025-12-14</Date>
+            <Version>1.6.53</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](http://www.libpng.org/pub/png/src/libpng-1.6.53-README.txt).
- Add License

**Test Plan**

Install and see license. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
