### PR TITLE
a2ps: Update to v4.15.8

### DIFF
--- a/packages/a/a2ps/abi_symbols
+++ b/packages/a/a2ps/abi_symbols
@@ -1,10 +1,4 @@
 a2ps:_end
-a2ps:_obstack_allocated_p
-a2ps:_obstack_begin
-a2ps:_obstack_begin_1
-a2ps:_obstack_free
-a2ps:_obstack_memory_used
-a2ps:_obstack_newchunk
 a2ps:obstack_alloc_failed_handler
 a2ps:re_compile_fastmap
 a2ps:re_compile_pattern

--- a/packages/a/a2ps/abi_used_symbols
+++ b/packages/a/a2ps/abi_used_symbols
@@ -11,6 +11,7 @@ libc.so.6:__isoc23_strtol
 libc.so.6:__libc_current_sigrtmax
 libc.so.6:__libc_current_sigrtmin
 libc.so.6:__libc_start_main
+libc.so.6:__openat_2
 libc.so.6:__printf_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
@@ -32,7 +33,6 @@ libc.so.6:error
 libc.so.6:error_at_line
 libc.so.6:exit
 libc.so.6:fclose
-libc.so.6:fcntl
 libc.so.6:fdopendir
 libc.so.6:ferror
 libc.so.6:fflush
@@ -57,7 +57,7 @@ libc.so.6:ioctl
 libc.so.6:isatty
 libc.so.6:iswprint
 libc.so.6:localtime
-libc.so.6:mbrtowc
+libc.so.6:mbrtoc32
 libc.so.6:mbsinit
 libc.so.6:memcmp
 libc.so.6:memcpy
@@ -65,9 +65,7 @@ libc.so.6:memmove
 libc.so.6:mempcpy
 libc.so.6:memset
 libc.so.6:mkstemp
-libc.so.6:nl_langinfo
 libc.so.6:open
-libc.so.6:openat
 libc.so.6:opendir
 libc.so.6:optarg
 libc.so.6:optind

--- a/packages/a/a2ps/package.yml
+++ b/packages/a/a2ps/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : a2ps
-version    : 4.15.7
-release    : 15
+version    : 4.15.8
+release    : 16
 source     :
-    - https://ftpmirror.gnu.org/gnu/a2ps/a2ps-4.15.7.tar.gz : 715f38670afd950b4ca71c01f468feefad265ca52d3f112934c63c0a8bfbb8af
+    - https://ftpmirror.gnu.org/gnu/a2ps/a2ps-4.15.8.tar.gz : 8d13915a36ebbfa8e7b236b350cc81adc714acb217a18e8d8c60747c0ad353f9
 homepage   : https://www.gnu.org/software/a2ps/
 license    : GPL-3.0-or-later
 component  : programming
@@ -26,6 +26,7 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING
 
     # Lets discourage things from building against it
     rm -rf $installdir/%libdir%

--- a/packages/a/a2ps/pspec_x86_64.xml
+++ b/packages/a/a2ps/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>a2ps</Name>
         <Homepage>https://www.gnu.org/software/a2ps/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>programming</PartOf>
@@ -225,6 +225,7 @@
             <Path fileType="info">/usr/share/info/a2ps.info.zst</Path>
             <Path fileType="info">/usr/share/info/ogonkify.info.zst</Path>
             <Path fileType="info">/usr/share/info/regex.info.zst</Path>
+            <Path fileType="data">/usr/share/licenses/a2ps/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/a2ps-gnulib.mo</Path>
             <Path fileType="localedata">/usr/share/locale/be/LC_MESSAGES/a2ps-gnulib.mo</Path>
             <Path fileType="localedata">/usr/share/locale/be/LC_MESSAGES/a2ps.mo</Path>
@@ -365,12 +366,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2025-10-29</Date>
-            <Version>4.15.7</Version>
+        <Update release="16">
+            <Date>2025-12-14</Date>
+            <Version>4.15.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://savannah.gnu.org/news/?id=10837).
- Add license

**Test Plan**

Verify version and license. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
