### PR TITLE
solseek: Update to 0.8.0

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 0.7.1
-release    : 10
+version    : 0.8.0
+release    : 11
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v0.7.1.tar.gz : ed09befd4d07a93b2d3f519ef26152fc3e3d9f869f256bfd14b9cda3a635ac55
+    - https://github.com/clintre/solseek/archive/refs/tags/v0.8.0.tar.gz : 4c1bb4170b479a85c97e4013b8b54884679c5501854632fbc300df4dd989723a
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils
@@ -13,7 +13,7 @@ description: |
 rundeps    :
     - appstream
     - fzf
-install    : |
+install    : |-
     install -Dm00755 $workdir/package/bin/solseek $installdir/usr/bin/solseek
     install -dm00755 $installdir/usr/share
     cp -r $workdir/package/share/solseek $installdir/usr/share/

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -23,6 +23,7 @@
             <Path fileType="executable">/usr/bin/solseek</Path>
             <Path fileType="data">/usr/share/applications/Solseek.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/solseek.svg</Path>
+            <Path fileType="data">/usr/share/licenses/solseek/LICENSE</Path>
             <Path fileType="data">/usr/share/metainfo/solseek.metainfo.xml</Path>
             <Path fileType="data">/usr/share/solseek/LICENSE-solseek.txt</Path>
             <Path fileType="data">/usr/share/solseek/config</Path>
@@ -31,8 +32,9 @@
             <Path fileType="data">/usr/share/solseek/core/defaults</Path>
             <Path fileType="data">/usr/share/solseek/core/menus</Path>
             <Path fileType="data">/usr/share/solseek/core/pkg_functions</Path>
-            <Path fileType="data">/usr/share/solseek/lang/en.lang</Path>
-            <Path fileType="data">/usr/share/solseek/lang/fr.lang</Path>
+            <Path fileType="data">/usr/share/solseek/lang/en.ini</Path>
+            <Path fileType="data">/usr/share/solseek/lang/fr.ini</Path>
+            <Path fileType="data">/usr/share/solseek/lang/pl.ini</Path>
             <Path fileType="data">/usr/share/solseek/solseek-uc.service</Path>
             <Path fileType="data">/usr/share/solseek/solseek-uc.timer</Path>
             <Path fileType="data">/usr/share/solseek/solseek_fastfetch.jsonc</Path>
@@ -42,9 +44,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2025-12-09</Date>
-            <Version>0.7.1</Version>
+        <Update release="11">
+            <Date>2025-12-14</Date>
+            <Version>0.8.0</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**

Bugfixes:

- Fixed issue when displaying updates for flatpaks it would wrap after 7 columns instead of 70 due to typo
- Fixed issue if user has changed to a user repo for flatpak instead of system. The fix is a new setting to override the repo setting

Enhancements:

- New main menu based on feedback from survey. Simple main menu layout with proper sections.
- Added config setting to allow for users that want the 0.7.x menu to continue to use the expanded main menu.
- Added ability to filter Flatpak or Packages in the Desktop apps list using Alt+F/P
- Cleaned up Desktop Apps list to clearly show if an entry is Flatpak or Package
- Added Polish language.
- Added ability to disable update checks for Solseek
- Added settings for notifications: disable, default, service only
- Added repo type for flatpak, if the user is using the user repo instead of system
- Added ability to enable disable update check service from within Solseek
- Added System Lifetime to show age of the Solus install on the Welcome page
- Cleaned up the Welcome page
- Added more non fzf areas to accept theme coloring
- New config for rollback history limit. Default is 100
- If user sets alternate editor in the config and it is not found, nano will be used as a backup
- Change .lang file to .ini to better conform to how they are set and make using weblate easier in the future.
- Set the default language to fill-in, if the detect language file is missing a variable. As I should have done since the start.
- Enabled auto detect of language. Will only use local language if the language file exists
- Many other small updates and code cleanup

Full release notes:

- [0.8.0](https://github.com/clintre/solseek/releases/tag/v0.8.0)


**Test Plan**

Tested in VM lab on multiple desktops

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
