### PR TITLE
acsccid: Update to v1.1.13

### DIFF
--- a/packages/a/acsccid/abi_used_symbols
+++ b/packages/a/acsccid/abi_used_symbols
@@ -2,7 +2,8 @@ UNKNOWN:log_msg
 UNKNOWN:log_xxd
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtoul
 libc.so.6:__memmove_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__sprintf_chk
@@ -53,7 +54,6 @@ libc.so.6:strlcpy
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strstr
-libc.so.6:strtoul
 libc.so.6:usleep
 libusb-1.0.so.0:libusb_alloc_transfer
 libusb-1.0.so.0:libusb_bulk_transfer

--- a/packages/a/acsccid/package.yml
+++ b/packages/a/acsccid/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : acsccid
-version    : 1.1.10
-release    : 9
+version    : 1.1.13
+release    : 10
 source     :
-    - https://sourceforge.net/projects/acsccid/files/acsccid-1.1.10.tar.bz2 : 5ee112febdcac6656629025f3a85923f155f6ca150b2d24fd716f9043265528e
+    - https://sourceforge.net/projects/acsccid/files/acsccid-1.1.13.tar.bz2 : 8b19aba103ec03c448b9d1b562c8322f8d2ff37cf21d4cb8b0cf522c5f385c9f
 homepage   : https://acsccid.sourceforge.io/
 license    : LGPL-2.1-or-later
 component  : security.library
@@ -19,4 +19,5 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING
     install -Dm00644 src/92_pcscd_acsccid.rules $installdir%libdir%/udev/rules.d/92_pcscd_acsccid.rules

--- a/packages/a/acsccid/pspec_x86_64.xml
+++ b/packages/a/acsccid/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>acsccid</Name>
         <Homepage>https://acsccid.sourceforge.io/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>security.library</PartOf>
@@ -23,15 +23,16 @@
             <Path fileType="library">/usr/lib64/pcsc/drivers/ifd-acsccid.bundle/Contents/Info.plist</Path>
             <Path fileType="library">/usr/lib64/pcsc/drivers/ifd-acsccid.bundle/Contents/Linux/libacsccid.so</Path>
             <Path fileType="library">/usr/lib64/udev/rules.d/92_pcscd_acsccid.rules</Path>
+            <Path fileType="data">/usr/share/licenses/acsccid/COPYING</Path>
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2023-12-25</Date>
-            <Version>1.1.10</Version>
+        <Update release="10">
+            <Date>2025-12-14</Date>
+            <Version>1.1.13</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://sourceforge.net/p/acsccid/news/2025/11/acsccid-1113-released/).
- Add license

**Test Plan**

I don't really have a way to test it other than starting the pcscd service. It started. 


**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
