### PR TITLE
protonmail-bridge: fix build and install license file

### DIFF
--- a/packages/p/protonmail-bridge/abi_used_symbols
+++ b/packages/p/protonmail-bridge/abi_used_symbols
@@ -35,8 +35,8 @@ libQt6Core.so.6:_ZN10QJsonValueC1ERK7QString
 libQt6Core.so.6:_ZN10QJsonValueC1Ei
 libQt6Core.so.6:_ZN10QJsonValueD1Ev
 libQt6Core.so.6:_ZN11QBasicMutex12lockInternalEv
-libQt6Core.so.6:_ZN11QBasicMutex14unlockInternalEv
 libQt6Core.so.6:_ZN11QBasicMutex15destroyInternalEPv
+libQt6Core.so.6:_ZN11QBasicMutex19unlockInternalFutexEPv
 libQt6Core.so.6:_ZN11QDataStreamlsEi
 libQt6Core.so.6:_ZN11QDataStreamrsERi
 libQt6Core.so.6:_ZN11QFileDevice5closeEv
@@ -211,7 +211,7 @@ libQt6Core.so.6:_ZN9QFileInfoC1ERK7QString
 libQt6Core.so.6:_ZN9QFileInfoD1Ev
 libQt6Core.so.6:_ZN9QIODevice5writeERK10QByteArray
 libQt6Core.so.6:_ZN9QIODevice7readAllEv
-libQt6Core.so.6:_ZN9QLockFile16setStaleLockTimeEi
+libQt6Core.so.6:_ZN9QLockFile16setStaleLockTimeENSt6chrono8durationIlSt5ratioILl1ELl1000EEEE
 libQt6Core.so.6:_ZN9QLockFile19removeStaleLockFileEv
 libQt6Core.so.6:_ZN9QLockFile6unlockEv
 libQt6Core.so.6:_ZN9QLockFile7tryLockENSt6chrono8durationIlSt5ratioILl1ELl1000EEEE
@@ -245,7 +245,6 @@ libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperIiE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate25QMetaTypeInterfaceWrapperIxE8metaTypeE
 libQt6Core.so.6:_ZN9QtPrivate52hasRegisteredConverterFunctionToIterableMetaSequenceE9QMetaType
 libQt6Core.so.6:_ZN9QtPrivate54hasRegisteredMutableViewFunctionToIterableMetaSequenceE9QMetaType
-libQt6Core.so.6:_ZNK10QByteArray11toStdStringB5cxx11Ev
 libQt6Core.so.6:_ZNK10QByteArray5toHexEc
 libQt6Core.so.6:_ZNK10QByteArray8toBase64E6QFlagsINS_12Base64OptionEE
 libQt6Core.so.6:_ZNK10QJsonArray13toVariantListEv
@@ -293,7 +292,7 @@ libQt6Core.so.6:_ZNK23QRegularExpressionMatch8capturedEi
 libQt6Core.so.6:_ZNK23QRegularExpressionMatch8hasMatchEv
 libQt6Core.so.6:_ZNK4QDir13entryInfoListERK5QListI7QStringE6QFlagsINS_6FilterEES5_INS_8SortFlagEE
 libQt6Core.so.6:_ZNK4QDir16absoluteFilePathERK7QString
-libQt6Core.so.6:_ZNK4QDir6mkpathERK7QString
+libQt6Core.so.6:_ZNK4QDir6mkpathERK7QStringSt8optionalI6QFlagsIN11QFileDevice10PermissionEEE
 libQt6Core.so.6:_ZNK4QDir7isEmptyE6QFlagsINS_6FilterEE
 libQt6Core.so.6:_ZNK4QUrl11toLocalFileEv
 libQt6Core.so.6:_ZNK5QFile6existsEv
@@ -303,6 +302,7 @@ libQt6Core.so.6:_ZNK7QObject6senderEv
 libQt6Core.so.6:_ZNK7QObject6threadEv
 libQt6Core.so.6:_ZNK7QObject8propertyEPKc
 libQt6Core.so.6:_ZNK7QString10startsWithERKS_N2Qt15CaseSensitivityE
+libQt6Core.so.6:_ZNK7QString11toStdStringB5cxx11Ev
 libQt6Core.so.6:_ZNK7QString5splitERKS_6QFlagsIN2Qt18SplitBehaviorFlagsEENS3_15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString7compareERKS_N2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString8arg_implE14QAnyStringViewi5QChar

--- a/packages/p/protonmail-bridge/files/0002-Fix-Qt6-10-Build.patch
+++ b/packages/p/protonmail-bridge/files/0002-Fix-Qt6-10-Build.patch
@@ -1,0 +1,13 @@
+diff --git a/internal/frontend/bridge-gui/bridge-gui/CMakeLists.txt b/internal/frontend/bridge-gui/bridge-gui/CMakeLists.txt
+index 93a9f499..a0ad070a 100644
+--- a/internal/frontend/bridge-gui/bridge-gui/CMakeLists.txt
++++ b/internal/frontend/bridge-gui/bridge-gui/CMakeLists.txt
+@@ -175,7 +175,7 @@ install(TARGETS bridge-gui
+ 
+ qt_generate_deploy_app_script(
+         TARGET bridge-gui
+-        FILENAME_VARIABLE deploy_script
++        OUTPUT_SCRIPT deploy_script
+         NO_UNSUPPORTED_PLATFORM_ERROR)
+ 
+ if(UNIX AND NOT APPLE)

--- a/packages/p/protonmail-bridge/files/series
+++ b/packages/p/protonmail-bridge/files/series
@@ -1,3 +1,4 @@
 0001-Solus-build-changes.patch
 0001-Solus-Fix-Wayland-AppID.patch
 0001-Remove-vcpkg-dependency.patch
+0002-Fix-Qt6-10-Build.patch

--- a/packages/p/protonmail-bridge/package.yml
+++ b/packages/p/protonmail-bridge/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : protonmail-bridge
 version    : 3.21.2
-release    : 28
+release    : 29
 source     :
     - https://github.com/ProtonMail/proton-bridge/archive/refs/tags/v3.21.2.tar.gz : d6c373f219d7351b18277061faab24cd677c28ea4398de5c48f752e7a14f1c2a
 homepage   : https://proton.me/mail/bridge
@@ -75,3 +75,4 @@ install    : |
     install -Dm00644 dist/bridge.svg $installdir/usr/share/icons/hicolor/scalable/apps/protonmail-bridge.svg
     install -Dm00644 dist/proton-bridge.desktop $installdir/usr/share/applications/ch.protonmail.protonmail-bridge.desktop
     install -Dm00644 $pkgfiles/ch.protonmail.protonmail-bridge.metainfo.xml $installdir/usr/share/metainfo/ch.protonmail.protonmail-bridge.metainfo.xml
+    %install_license LICENSE

--- a/packages/p/protonmail-bridge/pspec_x86_64.xml
+++ b/packages/p/protonmail-bridge/pspec_x86_64.xml
@@ -24,12 +24,13 @@
             <Path fileType="executable">/usr/bin/protonmail-bridge</Path>
             <Path fileType="data">/usr/share/applications/ch.protonmail.protonmail-bridge.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/protonmail-bridge.svg</Path>
+            <Path fileType="data">/usr/share/licenses/protonmail-bridge/LICENSE</Path>
             <Path fileType="data">/usr/share/metainfo/ch.protonmail.protonmail-bridge.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2025-07-26</Date>
+        <Update release="29">
+            <Date>2025-12-14</Date>
             <Version>3.21.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Jasper Behrensdorf</Name>


### PR DESCRIPTION
**Summary**

The build is currently broken because it passes an invalid option to `qt_generate_deploy_app_script`. Qt 6.5 deprecated `FILENAME_VARIABLE` in favour of `OUTPUT_SCRIPT` and it looks like it was finally removed in Qt 6.10. I've patched the relevant `CMakeLists.txt` to fix the build.

I've also installed the `LICENSE` file.

**Test Plan**

Successfully sent and received mail through Thunderbird.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
