### PR TITLE
mir: Update to v2.25.1

### DIFF
--- a/packages/m/mir/package.yml
+++ b/packages/m/mir/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : mir
-version    : 2.25.0
-release    : 9
+version    : 2.25.1
+release    : 10
 source     :
-    - https://github.com/canonical/mir/releases/download/v2.25.0/mir-2.25.0.tar.xz : 16cb4b7157174b92bd6d21a54b3d24a1d6f9a9f07ee5918836e42312217af75d
+    - https://github.com/canonical/mir/releases/download/v2.25.1/mir-2.25.1.tar.xz : 4f38c8ed86f017b1f51a1fe8d46bcff041766f4744acd2c1bc39896dff605be2
 homepage   : https://mir-server.io/
 license    :
     - GPL-2.0-only

--- a/packages/m/mir/pspec_x86_64.xml
+++ b/packages/m/mir/pspec_x86_64.xml
@@ -49,7 +49,7 @@
         <Description xml:lang="en">Demo applications for the Mir compositor</Description>
         <PartOf>desktop</PartOf>
         <RuntimeDependencies>
-            <Dependency release="9">mir</Dependency>
+            <Dependency release="10">mir</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/mir-x11-kiosk</Path>
@@ -73,7 +73,7 @@
         <Description xml:lang="en">Mir is set of libraries for building Wayland based shells. Mir simplifies the complexity that shell authors need to deal with. It provides a stable, well tested and performant platform with touch, mouse and tablet input, multi-display capability and secure client-server communications.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="9">mir</Dependency>
+            <Dependency release="10">mir</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/miral/miral/add_init_callback.h</Path>
@@ -489,9 +489,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2025-12-13</Date>
-            <Version>2.25.0</Version>
+        <Update release="10">
+            <Date>2025-12-16</Date>
+            <Version>2.25.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/canonical/mir/releases/tag/v2.25.1).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a Budgie Mir/Miriway session.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
