### PR TITLE
python-coherent-licensed: Add at v0.5.2

### DIFF
--- a/packages/py/python-coherent-licensed/monitoring.yaml
+++ b/packages/py/python-coherent-licensed/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 379162
+  rss: https://pypi.org/rss/project/coherent_licensed/releases.xml
+ # No known CPE, checked 2025-12-15
+security:
+  cpe: ~

--- a/packages/py/python-coherent-licensed/package.yml
+++ b/packages/py/python-coherent-licensed/package.yml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
+name       : python-coherent-licensed
+version    : 0.5.2
+release    : 1
+source     :
+    - https://files.pythonhosted.org/packages/source/c/coherent_licensed/coherent_licensed-0.5.2.tar.gz : d8071403ce742d3ac3592ddc4fb7057a46caffb415b928b4d52802e5f208416d
+homepage   : https://pypi.org/project/coherent.licensed
+license    : MIT
+component  : programming.python
+summary    : Injects a license file at build time to reflect the license declared in the License Expression.
+description: |
+    This library was built for coherent.build and skeleton projects to inject a license file at build time to reflect the license declared in the License Expression.
+builddeps  :
+    - python-build
+    - python-flit
+    - python-installer
+setup      : |
+    %python3_setup
+install    : |
+    %python3_install

--- a/packages/py/python-coherent-licensed/pspec_x86_64.xml
+++ b/packages/py/python-coherent-licensed/pspec_x86_64.xml
@@ -1,0 +1,48 @@
+<PISI>
+    <Source>
+        <Name>python-coherent-licensed</Name>
+        <Homepage>https://pypi.org/project/coherent.licensed</Homepage>
+        <Packager>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
+        </Packager>
+        <License>MIT</License>
+        <PartOf>programming.python</PartOf>
+        <Summary xml:lang="en">Injects a license file at build time to reflect the license declared in the License Expression.</Summary>
+        <Description xml:lang="en">This library was built for coherent.build and skeleton projects to inject a license file at build time to reflect the license declared in the License Expression.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>python-coherent-licensed</Name>
+        <Summary xml:lang="en">Injects a license file at build time to reflect the license declared in the License Expression.</Summary>
+        <Description xml:lang="en">This library was built for coherent.build and skeleton projects to inject a license file at build time to reflect the license declared in the License Expression.
+</Description>
+        <PartOf>programming.python</PartOf>
+        <Files>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/coherent/licensed/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/coherent/licensed/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/coherent/licensed/__pycache__/__init__.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/coherent/licensed/__pycache__/_functools.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/coherent/licensed/__pycache__/_functools.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/coherent/licensed/__pycache__/setuptools.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/coherent/licensed/__pycache__/setuptools.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/coherent/licensed/_functools.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/coherent/licensed/setuptools.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/coherent_licensed-0.5.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/coherent_licensed-0.5.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/coherent_licensed-0.5.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/coherent_licensed-0.5.2.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/coherent_licensed-0.5.2.dist-info/licenses/LICENSE</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2025-12-16</Date>
+            <Version>0.5.2</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**
New builddep of python-keyring

**Test Plan**
- Built. Installed. Built the new version of `python-keyring` which now requires this. Worked.

**Checklist**
- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
