### PR TITLE
python-keyring: Update to v25.7.0

### DIFF
--- a/packages/py/python-keyring/package.yml
+++ b/packages/py/python-keyring/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-keyring
-version    : 25.6.0
-release    : 25
+version    : 25.7.0
+release    : 26
 source     :
-    - https://files.pythonhosted.org/packages/source/k/keyring/keyring-25.6.0.tar.gz : 0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66
+    - https://files.pythonhosted.org/packages/source/k/keyring/keyring-25.7.0.tar.gz : fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b
 homepage   : https://github.com/jaraco/keyring
 license    :
     - MIT
@@ -14,6 +14,7 @@ description: |
     The python keyring lib provides and easy way to access the system keyring service from python.  It can be used in any application that needs safe password storage.
 builddeps  :
     - python-build
+    - python-coherent-licensed
     - python-installer
     - python-setuptools-scm
     - python-wheel

--- a/packages/py/python-keyring/pspec_x86_64.xml
+++ b/packages/py/python-keyring/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-keyring</Name>
         <Homepage>https://github.com/jaraco/keyring</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>MIT</License>
         <License>Python-2.0</License>
@@ -22,12 +22,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/keyring</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/keyring-25.6.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/keyring-25.6.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/keyring-25.6.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/keyring-25.6.0.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/keyring-25.6.0.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/keyring-25.6.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/keyring-25.7.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/keyring-25.7.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/keyring-25.7.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/keyring-25.7.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/keyring-25.7.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/keyring-25.7.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/keyring/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/keyring/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/keyring/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -91,11 +91,8 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/keyring/compat/__pycache__/properties.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/keyring/compat/__pycache__/py312.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/keyring/compat/__pycache__/py312.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/keyring/compat/__pycache__/py38.cpython-312.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/keyring/compat/__pycache__/py38.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/keyring/compat/properties.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/keyring/compat/py312.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/keyring/compat/py38.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/keyring/completion.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/keyring/core.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/keyring/credentials.py</Path>
@@ -121,12 +118,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="25">
-            <Date>2025-07-04</Date>
-            <Version>25.6.0</Version>
+        <Update release="26">
+            <Date>2025-12-16</Date>
+            <Version>25.7.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Release notes can be found [here](https://github.com/jaraco/keyring/blob/HEAD/NEWS.rst)

Requires #7404 to be merged first.

**Test Plan**
On Solus Plasma:
- Install `python-keyring` from the repo.
- Run `python -m keyring -b keyring.backends.kwallet.DBusKeyringKWallet4 set test test`, then enter a password.
- See that it fails with a BIG UGLY EXCEPTION.
- Build and install `python-keyring` from this PR.
- Try `python -m keyring -b keyring.backends.kwallet.DBusKeyringKWallet4 set test test` again.
- See that it still fails, but with a nice error message this time. This means that applications using the library internally and auto-selecting a backend will not fail badly if they try `DBusKeyringKWallet4`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
