### PR TITLE
python-click: Update to v8.3.1

### DIFF
--- a/packages/py/python-click/package.yml
+++ b/packages/py/python-click/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-click
-version    : 8.1.8
-release    : 15
+version    : 8.3.1
+release    : 16
 source     :
-    - https://github.com/pallets/click/archive/refs/tags/8.1.8.tar.gz : 33b16b4899d3deda7be154c0be415d898511abf928c988972cd97c4d90444a18
+    - https://github.com/pallets/click/archive/refs/tags/8.3.1.tar.gz : df2fb64b9c3f0b5fbf65f1b69dd164cd2d8e7d5d8f6ee3abdafcff7fe2d63719
 homepage   : https://click.palletsprojects.com
 license    : BSD-3-Clause
 component  : programming.python

--- a/packages/py/python-click/pspec_x86_64.xml
+++ b/packages/py/python-click/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-click</Name>
         <Homepage>https://click.palletsprojects.com</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/click-8.1.8.dist-info/LICENSE.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/click-8.1.8.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/click-8.1.8.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/click-8.1.8.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/click-8.3.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/click-8.3.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/click-8.3.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/click-8.3.1.dist-info/licenses/LICENSE.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/click/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/click/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/click/__pycache__/__init__.cpython-312.pyc</Path>
@@ -33,6 +33,8 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/click/__pycache__/_termui_impl.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/click/__pycache__/_textwrap.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/click/__pycache__/_textwrap.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/click/__pycache__/_utils.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/click/__pycache__/_utils.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/click/__pycache__/_winconsole.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/click/__pycache__/_winconsole.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/click/__pycache__/core.cpython-312.opt-1.pyc</Path>
@@ -60,6 +62,7 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/click/_compat.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/click/_termui_impl.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/click/_textwrap.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/click/_utils.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/click/_winconsole.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/click/core.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/click/decorators.py</Path>
@@ -76,12 +79,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2025-05-15</Date>
-            <Version>8.1.8</Version>
+        <Update release="16">
+            <Date>2025-12-16</Date>
+            <Version>8.3.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Release notes can be found [here](https://github.com/pallets/click/releases/8.3.1)

**Test Plan**
Prereq: Be on Solus Staff.
- Install `python-click` (and typer, and all the other requirements for open collective exports, including ones which are not yet in the repo).
- Attempt to run `oc-export.py`. 
- See that it fails with an awful error from Typer.
- Install `python-click` from this PR.
- Try `oc-export.py` again.
- See that it works now.
- Try `ypkg`.
- See that it still works with the new version of `click`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
