### PR TITLE
solseek: Update to 0.8.1

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 0.8.0
-release    : 11
+version    : 0.8.1
+release    : 12
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v0.8.0.tar.gz : 4c1bb4170b479a85c97e4013b8b54884679c5501854632fbc300df4dd989723a
+    - https://github.com/clintre/solseek/archive/refs/tags/v0.8.1.tar.gz : 85db3196c88befd36f0328fbbf28d59cb6a38c4ec1e137e3aca2dbbd5afa739b
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils
@@ -12,6 +12,7 @@ description: |
     Solseek is a simple terminal user interface that allows you to browse, search, and manage packages from the Solus packages.
 rundeps    :
     - appstream
+    - font-firacode-nerd
     - fzf
 install    : |-
     install -Dm00755 $workdir/package/bin/solseek $installdir/usr/bin/solseek

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -44,9 +44,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2025-12-14</Date>
-            <Version>0.8.0</Version>
+        <Update release="12">
+            <Date>2025-12-17</Date>
+            <Version>0.8.1</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**

Bugfixes:

- Notification ID issue when using mixed levels
- Information panel blank for Desktop App categories

Full release notes:

- [0.8.1](https://github.com/clintre/solseek/releases/tag/v0.8.1)


**Test Plan**

Tested in VM Lab

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
