### PR TITLE
ed: Update to v1.22.3

### DIFF
--- a/packages/e/ed/package.yml
+++ b/packages/e/ed/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : ed
-version    : 1.22.2
-release    : 12
+version    : 1.22.3
+release    : 13
 source     :
-    - https://ftpmirror.gnu.org/gnu/ed/ed-1.22.2.tar.lz : f58d15242056e15af76f13f34c60d890fa2a2d5cb0abef91c115e4d83794ffe3
+    - https://ftpmirror.gnu.org/gnu/ed/ed-1.22.3.tar.lz : 47a55ddfc52d4a1ff6f7559fbd00cf948a16b6cf151ec520392761aeae4e97be
 homepage   : https://www.gnu.org/software/ed/
 license    : GPL-2.0-or-later
 component  : editor
@@ -19,3 +19,4 @@ install    : |
     %make_install install-man
 check      : |
     %make check
+    %install_license COPYING

--- a/packages/e/ed/pspec_x86_64.xml
+++ b/packages/e/ed/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ed</Name>
         <Homepage>https://www.gnu.org/software/ed/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>editor</PartOf>
@@ -23,17 +23,18 @@
             <Path fileType="executable">/usr/bin/ed</Path>
             <Path fileType="executable">/usr/bin/red</Path>
             <Path fileType="info">/usr/share/info/ed.info.zst</Path>
+            <Path fileType="data">/usr/share/licenses/ed/COPYING</Path>
             <Path fileType="man">/usr/share/man/man1/ed.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/red.1</Path>
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2025-10-29</Date>
-            <Version>1.22.2</Version>
+        <Update release="13">
+            <Date>2025-12-17</Date>
+            <Version>1.22.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/happy5214/gnu-ed/blob/main/ChangeLog).
- Add license

**Test Plan**

Edited line with ed. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
