### PR TITLE
libslirp: Update to v4.9.1

### DIFF
--- a/packages/l/libslirp/abi_symbols
+++ b/packages/l/libslirp/abi_symbols
@@ -3,6 +3,7 @@ libslirp.so.0:SLIRP_4.1
 libslirp.so.0:SLIRP_4.2
 libslirp.so.0:SLIRP_4.5
 libslirp.so.0:SLIRP_4.7
+libslirp.so.0:SLIRP_4.9
 libslirp.so.0:slirp_add_exec
 libslirp.so.0:slirp_add_guestfwd
 libslirp.so.0:slirp_add_hostfwd
@@ -16,10 +17,13 @@ libslirp.so.0:slirp_input
 libslirp.so.0:slirp_neighbor_info
 libslirp.so.0:slirp_new
 libslirp.so.0:slirp_pollfds_fill
+libslirp.so.0:slirp_pollfds_fill_socket
 libslirp.so.0:slirp_pollfds_poll
 libslirp.so.0:slirp_remove_guestfwd
 libslirp.so.0:slirp_remove_hostfwd
 libslirp.so.0:slirp_remove_hostxfwd
+libslirp.so.0:slirp_reset_debug
+libslirp.so.0:slirp_set_debug
 libslirp.so.0:slirp_socket_can_recv
 libslirp.so.0:slirp_socket_recv
 libslirp.so.0:slirp_state_load

--- a/packages/l/libslirp/abi_used_symbols
+++ b/packages/l/libslirp/abi_used_symbols
@@ -11,6 +11,9 @@ libc.so.6:fclose
 libc.so.6:fcntl64
 libc.so.6:fgets
 libc.so.6:fopen64
+libc.so.6:freeaddrinfo
+libc.so.6:gai_strerror
+libc.so.6:getaddrinfo
 libc.so.6:getenv
 libc.so.6:getnameinfo
 libc.so.6:getpeername
@@ -45,7 +48,6 @@ libc.so.6:sigprocmask
 libc.so.6:socket
 libc.so.6:stat64
 libc.so.6:strchr
-libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strstr

--- a/packages/l/libslirp/package.yml
+++ b/packages/l/libslirp/package.yml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libslirp
-version    : 4.8.0
-release    : 8
+version    : 4.9.1
+release    : 9
 source     :
-    - https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v4.8.0/libslirp-v4.8.0.tar.gz : 2a98852e65666db313481943e7a1997abff0183bd9bea80caec1b5da89fda28c
+    - https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v4.9.1/libslirp-v4.9.1.tar.gz : 3970542143b7c11e6a09a4d2b50f30a133473c41f15ed0bdcc3b7a1c450d9a5c
 homepage   : https://gitlab.freedesktop.org/slirp/libslirp
-license    : GPL-2.0-or-later
+license    : BSD-3-Clause
 component  : virt
 summary    : User-mode networking for unprivileged network namespaces
 description: |
@@ -16,3 +16,4 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYRIGHT # LICENSE (will be added in next release)

--- a/packages/l/libslirp/pspec_x86_64.xml
+++ b/packages/l/libslirp/pspec_x86_64.xml
@@ -6,7 +6,7 @@
             <Name>Mislav &#x10c;akari&#x107;</Name>
             <Email>mcakaric@gmail.com</Email>
         </Packager>
-        <License>GPL-2.0-or-later</License>
+        <License>BSD-3-Clause</License>
         <PartOf>virt</PartOf>
         <Summary xml:lang="en">User-mode networking for unprivileged network namespaces</Summary>
         <Description xml:lang="en">A general purpose TCP-IP emulator used by virtual machine hypervisors to provide virtual networking services.
@@ -22,6 +22,7 @@
         <Files>
             <Path fileType="library">/usr/lib64/libslirp.so.0</Path>
             <Path fileType="library">/usr/lib64/libslirp.so.0.4.0</Path>
+            <Path fileType="data">/usr/share/licenses/libslirp/COPYRIGHT</Path>
         </Files>
     </Package>
     <Package>
@@ -31,7 +32,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="8">libslirp</Dependency>
+            <Dependency release="9">libslirp</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/slirp/libslirp-version.h</Path>
@@ -41,9 +42,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2024-05-22</Date>
-            <Version>4.8.0</Version>
+        <Update release="9">
+            <Date>2025-12-18</Date>
+            <Version>4.9.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Mislav &#x10c;akari&#x107;</Name>
             <Email>mcakaric@gmail.com</Email>


### PR DESCRIPTION
**Summary**
Release notes can be found [here](https://gitlab.freedesktop.org/slirp/libslirp/-/blob/v4.9.1/CHANGELOG.md).

**Test Plan**

- tested through quemu

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
