### PR TITLE
eza: Update to v0.23.4

### DIFF
--- a/packages/e/eza/abi_used_symbols
+++ b/packages/e/eza/abi_used_symbols
@@ -21,6 +21,7 @@ libc.so.6:closedir
 libc.so.6:dirfd
 libc.so.6:dl_iterate_phdr
 libc.so.6:dlsym
+libc.so.6:dup
 libc.so.6:exit
 libc.so.6:fcntl
 libc.so.6:free

--- a/packages/e/eza/package.yml
+++ b/packages/e/eza/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : eza
-version    : 0.23.3
-release    : 58
+version    : 0.23.4
+release    : 59
 source     :
-    - https://github.com/eza-community/eza/archive/refs/tags/v0.23.3.tar.gz : ebd13c47763cb0cd9337a1d6e89e1a3be4e76e0dd9225ac8058d6d338c617a29
+    - https://github.com/eza-community/eza/archive/refs/tags/v0.23.4.tar.gz : 9fbcad518b8a2095206ac385329ca62d216bf9fdc652dde2d082fcb37c309635
 homepage   : https://github.com/eza-community/eza
 license    : EUPL-1.2
 component  : system.utils
@@ -29,6 +29,7 @@ build      : |
     done
 install    : |
     %cargo_install
+    %install_license LICENSES/*
 
     install -Dm00644 completions/bash/eza -t $installdir/usr/share/bash-completion/completions
     install -Dm00644 completions/zsh/_eza -t $installdir/usr/share/zsh/site-functions

--- a/packages/e/eza/pspec_x86_64.xml
+++ b/packages/e/eza/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>eza</Name>
         <Homepage>https://github.com/eza-community/eza</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>EUPL-1.2</License>
         <PartOf>system.utils</PartOf>
@@ -23,6 +23,9 @@
             <Path fileType="executable">/usr/bin/eza</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/eza</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/eza.fish</Path>
+            <Path fileType="data">/usr/share/licenses/eza/CC-BY-4.0.txt</Path>
+            <Path fileType="data">/usr/share/licenses/eza/EUPL-1.2.txt</Path>
+            <Path fileType="data">/usr/share/licenses/eza/MIT.txt</Path>
             <Path fileType="man">/usr/share/man/man1/eza.1.zst</Path>
             <Path fileType="man">/usr/share/man/man5/eza_colors-explanation.5.zst</Path>
             <Path fileType="man">/usr/share/man/man5/eza_colors.5.zst</Path>
@@ -33,12 +36,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="58">
-            <Date>2025-09-14</Date>
-            <Version>0.23.3</Version>
+        <Update release="59">
+            <Date>2025-12-18</Date>
+            <Version>0.23.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/eza-community/eza/releases/tag/v0.23.4).
- Add license

**Test Plan**

eza --color-scale. everything is good. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
