### PR TITLE
fastfetch: Update to v2.56.1

### DIFF
--- a/packages/f/fastfetch/package.yml
+++ b/packages/f/fastfetch/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : fastfetch
-version    : 2.56.0
-release    : 64
+version    : 2.56.1
+release    : 65
 source     :
-    - https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/2.56.0.tar.gz : 8df6f21b168069dc35eb361eed47815650a5253f5e0f6948c5490faf375aad74
+    - https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/2.56.1.tar.gz : 6ffd75c32b2a885fd8497867645ac837ed37d588c94e0df05408cdaa0c8fd2c7
 homepage   : https://github.com/fastfetch-cli/fastfetch
 license    : MIT
 component  : system.utils
@@ -36,4 +36,3 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
-    rm -rfv $installdir/usr/share/licenses

--- a/packages/f/fastfetch/pspec_x86_64.xml
+++ b/packages/f/fastfetch/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>fastfetch</Name>
         <Homepage>https://github.com/fastfetch-cli/fastfetch</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -59,17 +59,18 @@
             <Path fileType="data">/usr/share/fastfetch/presets/paleofetch.jsonc</Path>
             <Path fileType="data">/usr/share/fastfetch/presets/screenfetch.jsonc</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/fastfetch.fish</Path>
+            <Path fileType="data">/usr/share/licenses/fastfetch/LICENSE</Path>
             <Path fileType="man">/usr/share/man/man1/fastfetch.1.zst</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_fastfetch</Path>
         </Files>
     </Package>
     <History>
-        <Update release="64">
-            <Date>2025-12-06</Date>
-            <Version>2.56.0</Version>
+        <Update release="65">
+            <Date>2025-12-18</Date>
+            <Version>2.56.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/fastfetch-cli/fastfetch/releases/tag/2.56.1).
- Add license

**Test Plan**

fastfetch -c all. Everything showed up. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
