### PR TITLE
iperf: Update to v3.20

### DIFF
--- a/packages/i/iperf/abi_symbols
+++ b/packages/i/iperf/abi_symbols
@@ -20,7 +20,6 @@ libiperf.so.0:auth_text_format
 libiperf.so.0:bind_address
 libiperf.so.0:bind_dev
 libiperf.so.0:bind_port
-libiperf.so.0:build_tcpinfo_message
 libiperf.so.0:cJSON_AddArrayToObject
 libiperf.so.0:cJSON_AddBoolToObject
 libiperf.so.0:cJSON_AddFalseToObject
@@ -103,6 +102,7 @@ libiperf.so.0:calcDecodeLength
 libiperf.so.0:check_authentication
 libiperf.so.0:client_datagram_size
 libiperf.so.0:client_port
+libiperf.so.0:clock_gettime_helper
 libiperf.so.0:connect_msg
 libiperf.so.0:conversion_bits
 libiperf.so.0:conversion_bytes
@@ -112,11 +112,13 @@ libiperf.so.0:decode_auth_setting
 libiperf.so.0:decrypt_rsa_message
 libiperf.so.0:encode_auth_setting
 libiperf.so.0:encrypt_rsa_message
+libiperf.so.0:errarg
 libiperf.so.0:fill_with_repeating_pattern
 libiperf.so.0:gerror
 libiperf.so.0:get_optional_features
 libiperf.so.0:get_pmtu
 libiperf.so.0:get_protocol
+libiperf.so.0:get_reorder
 libiperf.so.0:get_rtt
 libiperf.so.0:get_rttvar
 libiperf.so.0:get_snd_cwnd
@@ -265,6 +267,7 @@ libiperf.so.0:iperf_set_test_burst
 libiperf.so.0:iperf_set_test_bytes
 libiperf.so.0:iperf_set_test_client_password
 libiperf.so.0:iperf_set_test_client_rsa_pubkey
+libiperf.so.0:iperf_set_test_client_rsa_pubkey_from_file
 libiperf.so.0:iperf_set_test_client_username
 libiperf.so.0:iperf_set_test_congestion_control
 libiperf.so.0:iperf_set_test_connect_timeout
@@ -276,6 +279,7 @@ libiperf.so.0:iperf_set_test_idle_timeout
 libiperf.so.0:iperf_set_test_json_callback
 libiperf.so.0:iperf_set_test_json_output
 libiperf.so.0:iperf_set_test_json_stream
+libiperf.so.0:iperf_set_test_json_stream_full_output
 libiperf.so.0:iperf_set_test_logfile
 libiperf.so.0:iperf_set_test_mss
 libiperf.so.0:iperf_set_test_no_delay
@@ -293,6 +297,7 @@ libiperf.so.0:iperf_set_test_server_authorized_users
 libiperf.so.0:iperf_set_test_server_hostname
 libiperf.so.0:iperf_set_test_server_port
 libiperf.so.0:iperf_set_test_server_rsa_privkey
+libiperf.so.0:iperf_set_test_server_rsa_privkey_from_file
 libiperf.so.0:iperf_set_test_server_skew_threshold
 libiperf.so.0:iperf_set_test_socket_bufsize
 libiperf.so.0:iperf_set_test_state
@@ -320,6 +325,7 @@ libiperf.so.0:iperf_time_diff
 libiperf.so.0:iperf_time_in_secs
 libiperf.so.0:iperf_time_in_usecs
 libiperf.so.0:iperf_time_now
+libiperf.so.0:iperf_time_now_wallclock
 libiperf.so.0:iperf_timestrerr
 libiperf.so.0:iperf_udp_accept
 libiperf.so.0:iperf_udp_buffercheck

--- a/packages/i/iperf/package.yml
+++ b/packages/i/iperf/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : iperf
-version    : '3.19'
-release    : 7
+version    : '3.20'
+release    : 8
 source     :
-    - https://github.com/esnet/iperf/archive/refs/tags/3.19.tar.gz : da5cff29e4945b2ee05dcf9a0c67768cc000dc1b122935bce3492c4e36f6b5e9
+    - https://github.com/esnet/iperf/archive/refs/tags/3.20.tar.gz : 84640ea0f43831850434e50134d0554b7a94f97fb02e2488ffbe252c9fb05a56
 homepage   : https://iperf.fr
 license    :
     - BSD-3-Clause
@@ -18,3 +18,4 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license LICENSE

--- a/packages/i/iperf/pspec_x86_64.xml
+++ b/packages/i/iperf/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>iperf</Name>
         <Homepage>https://iperf.fr</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>MIT</License>
@@ -24,7 +24,8 @@
             <Path fileType="executable">/usr/bin/iperf3</Path>
             <Path fileType="library">/usr/lib64/libiperf.so.0</Path>
             <Path fileType="library">/usr/lib64/libiperf.so.0.0.0</Path>
-            <Path fileType="man">/usr/share/man/man1/iperf3.1</Path>
+            <Path fileType="data">/usr/share/licenses/iperf/LICENSE</Path>
+            <Path fileType="man">/usr/share/man/man1/iperf3.1.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -34,21 +35,21 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="7">iperf</Dependency>
+            <Dependency release="8">iperf</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/iperf_api.h</Path>
             <Path fileType="library">/usr/lib64/libiperf.so</Path>
-            <Path fileType="man">/usr/share/man/man3/libiperf.3</Path>
+            <Path fileType="man">/usr/share/man/man3/libiperf.3.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2025-06-17</Date>
-            <Version>3.19</Version>
+        <Update release="8">
+            <Date>2025-12-20</Date>
+            <Version>3.20</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/esnet/iperf/releases/tag/3.20).
- Add license

**Test Plan**

iperf3 -c (my server)

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
