### PR TITLE
authenticator: Add dependency on gstreamer-1.0-plugins-rs

### DIFF
--- a/packages/a/authenticator/abi_used_symbols
+++ b/packages/a/authenticator/abi_used_symbols
@@ -70,11 +70,13 @@ libc.so.6:bind
 libc.so.6:bindtextdomain
 libc.so.6:calloc
 libc.so.6:chdir
+libc.so.6:chroot
 libc.so.6:clock_gettime
 libc.so.6:close
 libc.so.6:connect
 libc.so.6:dl_iterate_phdr
 libc.so.6:dlsym
+libc.so.6:dup
 libc.so.6:dup2
 libc.so.6:environ
 libc.so.6:epoll_create1
@@ -158,6 +160,7 @@ libc.so.6:setgid
 libc.so.6:setgroups
 libc.so.6:setlocale
 libc.so.6:setpgid
+libc.so.6:setsid
 libc.so.6:setsockopt
 libc.so.6:setuid
 libc.so.6:shutdown
@@ -773,13 +776,8 @@ libgtk-4.so.1:gtk_window_set_icon_name
 liblzma.so.5:lzma_code
 liblzma.so.5:lzma_end
 liblzma.so.5:lzma_stream_decoder
-libm.so.6:ceil
-libm.so.6:ceilf
-libm.so.6:floor
 libm.so.6:log2
 libm.so.6:pow
-libm.so.6:round
-libm.so.6:roundf
 libsqlite3.so.0:sqlite3_bind_blob
 libsqlite3.so.0:sqlite3_bind_double
 libsqlite3.so.0:sqlite3_bind_int

--- a/packages/a/authenticator/package.yml
+++ b/packages/a/authenticator/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : authenticator
 version    : 4.6.2
-release    : 3
+release    : 4
 source     :
     - https://gitlab.gnome.org/World/Authenticator/-/archive/4.6.2/Authenticator-4.6.2.tar.bz2 : 42d2da3f83ba50a2429ed0baa424a318f049f9c96dfca13a1dc96145347d172c
 homepage   : https://apps.gnome.org/Authenticator/
@@ -18,6 +18,8 @@ builddeps  :
     - pkgconfig(zbar)
     - desktop-file-utils
     - rust
+rundeps    :
+    - gstreamer-1.0-plugins-rs
 setup      : |
     %meson_configure
 build      : |

--- a/packages/a/authenticator/pspec_x86_64.xml
+++ b/packages/a/authenticator/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>authenticator</Name>
         <Homepage>https://apps.gnome.org/Authenticator/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>security</PartOf>
@@ -79,12 +79,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2025-03-27</Date>
+        <Update release="4">
+            <Date>2025-12-21</Date>
             <Version>4.6.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Fixes crash when opening "Add a New Account" window

Part of https://github.com/getsolus/packages/issues/7440

**Test Plan**

Launch authenticator and click on the plus button to open the "Add a New Account" window

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
