### PR TITLE
yakuake: Update to v25.12.0

### DIFF
--- a/packages/y/yakuake/package.yml
+++ b/packages/y/yakuake/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : yakuake
-version    : 25.08.3
-release    : 84
+version    : 25.12.0
+release    : 85
 source     :
-    - https://download.kde.org/stable/release-service/25.08.3/src/yakuake-25.08.3.tar.xz : d8d3f0ffecfd98f00c8618a7dcf5cf85ef745f704717df8198f6321d83451eec
+    - https://download.kde.org/stable/release-service/25.12.0/src/yakuake-25.12.0.tar.xz : 5a3f8854e74094b161cd1d628745b17545b5a9c41cb2dfe11c744e524bfb3c9e
 homepage   : https://kde.org/applications/system/org.kde.yakuake
 license    : GPL-2.0
 component  : desktop.kde
@@ -37,3 +37,4 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license LICENSES/*

--- a/packages/y/yakuake/pspec_x86_64.xml
+++ b/packages/y/yakuake/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>yakuake</Name>
         <Homepage>https://kde.org/applications/system/org.kde.yakuake</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-2.0</License>
         <PartOf>desktop.kde</PartOf>
@@ -32,6 +32,10 @@
             <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/yakuake.png</Path>
             <Path fileType="data">/usr/share/knotifications6/yakuake.notifyrc</Path>
             <Path fileType="data">/usr/share/knsrcfiles/yakuake.knsrc</Path>
+            <Path fileType="data">/usr/share/licenses/yakuake/CC0-1.0.txt</Path>
+            <Path fileType="data">/usr/share/licenses/yakuake/GPL-2.0-only.txt</Path>
+            <Path fileType="data">/usr/share/licenses/yakuake/GPL-3.0-only.txt</Path>
+            <Path fileType="data">/usr/share/licenses/yakuake/LicenseRef-KDE-Accepted-GPL.txt</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/yakuake.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ast/LC_MESSAGES/yakuake.mo</Path>
             <Path fileType="localedata">/usr/share/locale/az/LC_MESSAGES/yakuake.mo</Path>
@@ -221,12 +225,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="84">
-            <Date>2025-12-02</Date>
-            <Version>25.08.3</Version>
+        <Update release="85">
+            <Date>2025-12-22</Date>
+            <Version>25.12.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://invent.kde.org/utilities/yakuake/-/tags).
- Add license

**Test Plan**

Opened yakuake, did some commands. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
