### PR TITLE
mir: Update to v2.25.2

### DIFF
--- a/packages/m/mir/package.yml
+++ b/packages/m/mir/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : mir
-version    : 2.25.1
-release    : 10
+version    : 2.25.2
+release    : 11
 source     :
-    - https://github.com/canonical/mir/releases/download/v2.25.1/mir-2.25.1.tar.xz : 4f38c8ed86f017b1f51a1fe8d46bcff041766f4744acd2c1bc39896dff605be2
+    - https://github.com/canonical/mir/releases/download/v2.25.2/mir-2.25.2.tar.xz : fad807079146cff925aaf97b9efffa17a71b862d1082b992c0885c9072acdbbd
 homepage   : https://mir-server.io/
 license    :
     - GPL-2.0-only

--- a/packages/m/mir/pspec_x86_64.xml
+++ b/packages/m/mir/pspec_x86_64.xml
@@ -49,7 +49,7 @@
         <Description xml:lang="en">Demo applications for the Mir compositor</Description>
         <PartOf>desktop</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">mir</Dependency>
+            <Dependency release="11">mir</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/mir-x11-kiosk</Path>
@@ -73,7 +73,7 @@
         <Description xml:lang="en">Mir is set of libraries for building Wayland based shells. Mir simplifies the complexity that shell authors need to deal with. It provides a stable, well tested and performant platform with touch, mouse and tablet input, multi-display capability and secure client-server communications.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">mir</Dependency>
+            <Dependency release="11">mir</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/miral/miral/add_init_callback.h</Path>
@@ -489,9 +489,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2025-12-16</Date>
-            <Version>2.25.1</Version>
+        <Update release="11">
+            <Date>2025-12-22</Date>
+            <Version>2.25.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/canonical/mir/releases/tag/v2.25.2).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a Budgie Mir session.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
