### PR TITLE
rustup: Add rust-analyzer symlink

### DIFF
--- a/packages/r/rustup/abi_used_libs
+++ b/packages/r/rustup/abi_used_libs
@@ -1,3 +1,4 @@
+ld-linux-x86-64.so.2
 libc.so.6
 libcrypto.so.3
 libcurl.so.4

--- a/packages/r/rustup/abi_used_symbols
+++ b/packages/r/rustup/abi_used_symbols
@@ -1,3 +1,4 @@
+ld-linux-x86-64.so.2:__tls_get_addr
 libc.so.6:__assert_fail
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
@@ -16,6 +17,7 @@ libc.so.6:bind
 libc.so.6:calloc
 libc.so.6:chdir
 libc.so.6:chmod
+libc.so.6:chroot
 libc.so.6:clock_gettime
 libc.so.6:close
 libc.so.6:closedir
@@ -23,6 +25,7 @@ libc.so.6:connect
 libc.so.6:dirfd
 libc.so.6:dl_iterate_phdr
 libc.so.6:dlsym
+libc.so.6:dup
 libc.so.6:dup2
 libc.so.6:environ
 libc.so.6:epoll_create1
@@ -134,6 +137,7 @@ libc.so.6:sendmsg
 libc.so.6:setgid
 libc.so.6:setgroups
 libc.so.6:setpgid
+libc.so.6:setsid
 libc.so.6:setsockopt
 libc.so.6:setuid
 libc.so.6:shutdown

--- a/packages/r/rustup/package.yml
+++ b/packages/r/rustup/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : rustup
 version    : 1.28.2
-release    : 29
+release    : 30
 source     :
     - https://github.com/rust-lang/rustup/archive/1.28.2.tar.gz : 5987dcb828068a4a5e29ba99ab26f2983ac0c6e2e4dc3e5b3a3c0fafb69abbc0
 homepage   : https://rust-lang.github.io/rustup/
@@ -30,7 +30,7 @@ build      : |
 install    : |
     install -Dm00755 target/release/rustup-init $installdir/usr/bin/rustup
 
-    binlinks=('cargo' 'cargo-clippy' 'cargo-fmt' 'cargo-miri' 'clippy-driver' 'rustc' 'rustfmt' 'rustdoc' 'rust-gdb' 'rust-lldb')
+    binlinks=('cargo' 'cargo-clippy' 'cargo-fmt' 'cargo-miri' 'clippy-driver' 'rust-analyzer' 'rustc' 'rustfmt' 'rustdoc' 'rust-gdb' 'rust-lldb')
 
     for link in "${binlinks[@]}"; do
         ln -srv $installdir/usr/bin/rustup $installdir/usr/bin/$link

--- a/packages/r/rustup/pspec_x86_64.xml
+++ b/packages/r/rustup/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>rustup</Name>
         <Homepage>https://rust-lang.github.io/rustup/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Gavin Zhao</Name>
+            <Email>me@gzgz.dev</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>MIT</License>
@@ -26,6 +26,7 @@
             <Path fileType="executable">/usr/bin/cargo-fmt</Path>
             <Path fileType="executable">/usr/bin/cargo-miri</Path>
             <Path fileType="executable">/usr/bin/clippy-driver</Path>
+            <Path fileType="executable">/usr/bin/rust-analyzer</Path>
             <Path fileType="executable">/usr/bin/rust-gdb</Path>
             <Path fileType="executable">/usr/bin/rust-lldb</Path>
             <Path fileType="executable">/usr/bin/rustc</Path>
@@ -44,12 +45,12 @@
         </Conflicts>
     </Package>
     <History>
-        <Update release="29">
-            <Date>2025-07-26</Date>
+        <Update release="30">
+            <Date>2025-12-24</Date>
             <Version>1.28.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Gavin Zhao</Name>
+            <Email>me@gzgz.dev</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add `/usr/bin/rust-analyzer` symlink to `rustup` so that `rust-analyzer` just works after `rustup install`, no need for user to manually add symlinks on their own.

**Test Plan**

Currently using this `rust-analyzer` symlink to provide Rust LSP to my editor.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
