### PR TITLE
svtplay-dl: Update to v4.167

### DIFF
--- a/packages/s/svtplay-dl/package.yml
+++ b/packages/s/svtplay-dl/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : svtplay-dl
-version    : '4.163'
-release    : 36
+version    : '4.167'
+release    : 37
 source     :
-    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.163.tar.gz : 6f2aaa827d6e25c4e4480239e9738c6ba686406e438254d8e3afdd45b616f2e5
+    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.167.tar.gz : f8da6fef13775c43d29a16c972b918a3818f022b7d0e0e4a0a1ff1018b4f446a
 homepage   : https://svtplay-dl.se/
 license    : MIT
 component  : network.download

--- a/packages/s/svtplay-dl/pspec_x86_64.xml
+++ b/packages/s/svtplay-dl/pspec_x86_64.xml
@@ -21,12 +21,12 @@
         <PartOf>network.download</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/svtplay-dl</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.163.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.163.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.163.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.163.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.163.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.163.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.167.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.167.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.167.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.167.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.167.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.167.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -243,9 +243,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2025-11-03</Date>
-            <Version>4.163</Version>
+        <Update release="37">
+            <Date>2025-12-25</Date>
+            <Version>4.167</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**

- svtplay: fix naming of the files
- svtplay: fix getting all subtitles (“normal” one and “allt tal”)
- tv4play: get swedish subtitles by default
- tv4play: fix a crash when people use the wrong token
- urplay: fixed a crash from series page
- nrk: fix downloading clips
- show a better error message when trying to fetch video with a specific role and format.

**Test Plan**
- Downloaded a video.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
