### PR TITLE
libva-intel-driver: Update to v2.4.5

### DIFF
--- a/packages/l/libva-intel-driver/abi_symbols
+++ b/packages/l/libva-intel-driver/abi_symbols
@@ -45,8 +45,8 @@ i965_drv_video.so:default_tx_probs
 i965_drv_video.so:dso_close
 i965_drv_video.so:dso_get_symbols
 i965_drv_video.so:dso_open
-i965_drv_video.so:ensure_driver_vtable
 i965_drv_video.so:g4x_dec_hw_context_init
+i965_drv_video.so:g4x_get_hw_formats
 i965_drv_video.so:g_intel_debug_option_flags
 i965_drv_video.so:gen10_encoder_vp8_context_init
 i965_drv_video.so:gen10_hcp_fqm_state
@@ -98,6 +98,7 @@ i965_drv_video.so:gen10_vebox_process_picture
 i965_drv_video.so:gen5_fill_avc_ref_idx_state
 i965_drv_video.so:gen6_dec_hw_context_init
 i965_drv_video.so:gen6_enc_hw_context_init
+i965_drv_video.so:gen6_get_hw_formats
 i965_drv_video.so:gen6_gpe_pipeline_setup
 i965_drv_video.so:gen6_mfc_avc_encode_picture
 i965_drv_video.so:gen6_mfc_bsp_buf_base_addr_state
@@ -129,6 +130,7 @@ i965_drv_video.so:gen75_vebox_process_picture
 i965_drv_video.so:gen75_vme_context_init
 i965_drv_video.so:gen7_dec_hw_context_init
 i965_drv_video.so:gen7_enc_hw_context_init
+i965_drv_video.so:gen7_get_hw_formats
 i965_drv_video.so:gen7_gpe_buffer_suface_setup
 i965_drv_video.so:gen7_gpe_media_rw_surface_setup
 i965_drv_video.so:gen7_gpe_surface2_setup
@@ -151,6 +153,7 @@ i965_drv_video.so:gen8_avc_set_image_state
 i965_drv_video.so:gen8_dec_hw_context_init
 i965_drv_video.so:gen8_enc_hw_context_init
 i965_drv_video.so:gen8_encoder_vp8_context_init
+i965_drv_video.so:gen8_get_hw_formats
 i965_drv_video.so:gen8_gpe_buffer_suface_setup
 i965_drv_video.so:gen8_gpe_context_add_surface
 i965_drv_video.so:gen8_gpe_context_destroy
@@ -295,6 +298,8 @@ i965_drv_video.so:gen9_vme_context_init
 i965_drv_video.so:gen9_vp9_avs_coeffs
 i965_drv_video.so:gen9_vp9_pak_context_init
 i965_drv_video.so:gen9_vp9_vme_context_init
+i965_drv_video.so:gen9_workaround_avc_search_x
+i965_drv_video.so:gen9_workaround_avc_search_y
 i965_drv_video.so:gen9_yuv420p8_scaling_post_processing
 i965_drv_video.so:gen_free_avc_surface
 i965_drv_video.so:gen_free_hevc_surface
@@ -302,6 +307,8 @@ i965_drv_video.so:gen_free_vp9_surface
 i965_drv_video.so:genx_render_init
 i965_drv_video.so:get_fourcc_info
 i965_drv_video.so:get_hevc_slice_nalu_type
+i965_drv_video.so:get_max_height_for_codec
+i965_drv_video.so:get_max_width_for_codec
 i965_drv_video.so:hevc_ensure_surface_bo
 i965_drv_video.so:hevc_gen_default_iq_matrix
 i965_drv_video.so:hevc_short_term_ref_pic_set
@@ -343,6 +350,7 @@ i965_drv_video.so:i965_GetConfigAttributes
 i965_drv_video.so:i965_GetDisplayAttributes
 i965_drv_video.so:i965_GetImage
 i965_drv_video.so:i965_MapBuffer
+i965_drv_video.so:i965_MapBuffer2
 i965_drv_video.so:i965_PutSurface
 i965_drv_video.so:i965_QueryConfigAttributes
 i965_drv_video.so:i965_QueryConfigEntrypoints
@@ -360,7 +368,9 @@ i965_drv_video.so:i965_SetImagePalette
 i965_drv_video.so:i965_SetSubpictureChromakey
 i965_drv_video.so:i965_SetSubpictureGlobalAlpha
 i965_drv_video.so:i965_SetSubpictureImage
+i965_drv_video.so:i965_SyncBuffer
 i965_drv_video.so:i965_SyncSurface
+i965_drv_video.so:i965_SyncSurface2
 i965_drv_video.so:i965_Terminate
 i965_drv_video.so:i965_UnmapBuffer
 i965_drv_video.so:i965_add_2d_gpe_surface
@@ -407,7 +417,9 @@ i965_drv_video.so:i965_gpe_table_init
 i965_drv_video.so:i965_gpe_table_terminate
 i965_drv_video.so:i965_image_processing
 i965_drv_video.so:i965_init_media_object_walker_parameter
+i965_drv_video.so:i965_log_debug
 i965_drv_video.so:i965_log_error
+i965_drv_video.so:i965_log_error_nocb
 i965_drv_video.so:i965_log_info
 i965_drv_video.so:i965_map_gpe_resource
 i965_drv_video.so:i965_media_h264_dec_context_init
@@ -418,17 +430,15 @@ i965_drv_video.so:i965_media_mpeg2_surfaces_setup
 i965_drv_video.so:i965_media_mpeg2_vld_state
 i965_drv_video.so:i965_object_surface_to_2d_gpe_resource
 i965_drv_video.so:i965_object_surface_to_2d_gpe_resource_with_align
-i965_drv_video.so:i965_output_dri_init
-i965_drv_video.so:i965_output_dri_terminate
-i965_drv_video.so:i965_output_wayland_init
-i965_drv_video.so:i965_output_wayland_terminate
+i965_drv_video.so:i965_output_x11_init
+i965_drv_video.so:i965_output_x11_terminate
 i965_drv_video.so:i965_post_processing
 i965_drv_video.so:i965_post_processing_context_init
 i965_drv_video.so:i965_post_processing_init
 i965_drv_video.so:i965_post_processing_terminate
 i965_drv_video.so:i965_proc_context_init
 i965_drv_video.so:i965_proc_picture
-i965_drv_video.so:i965_put_surface_dri
+i965_drv_video.so:i965_put_surface_x11
 i965_drv_video.so:i965_reference_buffer_store
 i965_drv_video.so:i965_release_buffer_store
 i965_drv_video.so:i965_render_init
@@ -517,6 +527,7 @@ i965_drv_video.so:intel_write_uncompressed_header
 i965_drv_video.so:intra_kernel_header_gen4
 i965_drv_video.so:intra_kernel_header_gen5
 i965_drv_video.so:ironlake_dec_hw_context_init
+i965_drv_video.so:ironlake_get_hw_formats
 i965_drv_video.so:kbl_avc_encoder_kernels
 i965_drv_video.so:map_huffval_to_index
 i965_drv_video.so:media_vp9_kernels
@@ -544,6 +555,7 @@ i965_drv_video.so:set_std_table_3
 i965_drv_video.so:set_std_table_6
 i965_drv_video.so:set_std_table_9
 i965_drv_video.so:set_std_table_default
+i965_drv_video.so:should_enable_int
 i965_drv_video.so:skl_avc_encoder_kernels
 i965_drv_video.so:skl_avc_fei_encoder_kernels
 i965_drv_video.so:skl_veb_dndi_table

--- a/packages/l/libva-intel-driver/abi_used_symbols
+++ b/packages/l/libva-intel-driver/abi_used_symbols
@@ -63,8 +63,12 @@ libdrm_intel.so.1:drm_intel_bufmgr_gem_set_aub_dump
 libdrm_intel.so.1:drm_intel_bufmgr_gem_set_aub_filename
 libdrm_intel.so.1:drm_intel_gem_bo_map_gtt
 libdrm_intel.so.1:drm_intel_gem_bo_unmap_gtt
+libdrm_intel.so.1:drm_intel_gem_bo_wait
+libm.so.6:ceilf
 libm.so.6:cos
 libm.so.6:exp
+libm.so.6:floor
+libm.so.6:floorf
 libm.so.6:log
 libm.so.6:log10
 libm.so.6:log2
@@ -75,3 +79,4 @@ libm.so.6:powf
 libm.so.6:roundf
 libm.so.6:sin
 libm.so.6:sincos
+libm.so.6:truncf

--- a/packages/l/libva-intel-driver/package.yml
+++ b/packages/l/libva-intel-driver/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libva-intel-driver
-version    : 2.4.1
-release    : 19
+version    : 2.4.5
+release    : 20
 source     :
-    - https://github.com/intel/intel-vaapi-driver/releases/download/2.4.1/intel-vaapi-driver-2.4.1.tar.bz2 : 0081fce08eb3a83f7d99c3b853c8fdfa0af437b8f5b0fb7c66faeb83bcbe0c19
+    - https://github.com/irql-notlessorequal/intel-vaapi-driver/archive/refs/tags/2.4.5.tar.gz : f89f77bc46ec6f46392c1b90b9bf34d09f908bf33c9d16d385897b1fe282bacc
 homepage   : https://github.com/intel/intel-vaapi-driver
 license    : MIT
 component  : xorg.display

--- a/packages/l/libva-intel-driver/pspec_x86_64.xml
+++ b/packages/l/libva-intel-driver/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libva-intel-driver</Name>
         <Homepage>https://github.com/intel/intel-vaapi-driver</Homepage>
         <Packager>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>xorg.display</PartOf>
@@ -24,12 +24,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2024-07-17</Date>
-            <Version>2.4.1</Version>
+        <Update release="20">
+            <Date>2025-12-28</Date>
+            <Version>2.4.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Expose ARGB as a supported post-processing format on Ironlake
- Improvements to ARGB handling in the VPP backend
- Don't advertise VAProfileHEVCMain10 format support on Haswell and Ivy Bridge.
- Disable this driver's Wayland backend by default.
- Switch to per-generation format helpers to cleanup i965_QuerySurfaceAttributes.
- Add a debug help menu, available behind the VA_INTEL_DEBUG=help environment variable
- Downgrade the Not using hybrid_drv_video.so message to a debug message.
- Silence multiple compile-time warnings
- Resolves https://github.com/getsolus/packages/issues/7439

**Test Plan**
- TBD

**Checklist**

- [X] Package was built and tested against unstable
- [X] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
