### PR TITLE
poppler: Remove font due to issues

### DIFF
--- a/packages/p/poppler/package.yml
+++ b/packages/p/poppler/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : poppler
 version    : 25.10.0
-release    : 56
+release    : 57
 source     :
     - https://poppler.freedesktop.org/poppler-25.10.0.tar.xz : 6b5e9bb64dabb15787a14db1675291c7afaf9387438cc93a4fb7f6aec4ee6fe0
     - git|https://gitlab.freedesktop.org/poppler/test.git : 9d5011815a14c157ba25bb160187842fb81579a5
@@ -42,7 +42,6 @@ rundeps    :
         - poppler-qt5
     - qt6-devel :
         - poppler-qt6
-    - urw-core35-fonts
 setup      : |
     %cmake_ninja -DTESTDATADIR=$sources/test.git \
                  -DLIB_SUFFIX=%LIBSUFFIX% \

--- a/packages/p/poppler/pspec_x86_64.xml
+++ b/packages/p/poppler/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>poppler</Name>
         <Homepage>https://poppler.freedesktop.org/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.library</PartOf>
@@ -37,8 +37,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="55">poppler</Dependency>
-            <Dependency releaseFrom="55">poppler-utils</Dependency>
+            <Dependency release="57">poppler</Dependency>
+            <Dependency releaseFrom="57">poppler-utils</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/poppler/Annot.h</Path>
@@ -184,7 +184,7 @@
 </Description>
         <PartOf>desktop.library</PartOf>
         <RuntimeDependencies>
-            <Dependency release="55">poppler</Dependency>
+            <Dependency release="57">poppler</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libpoppler-qt5.so.1</Path>
@@ -197,8 +197,8 @@
         <Description xml:lang="en">This is Poppler, a library for rendering PDF files, and examining or modifying their structure.
 </Description>
         <RuntimeDependencies>
-            <Dependency release="55">poppler-devel</Dependency>
-            <Dependency releaseFrom="55">poppler-qt5</Dependency>
+            <Dependency release="57">poppler-devel</Dependency>
+            <Dependency releaseFrom="57">poppler-qt5</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/poppler/qt5/poppler-annotation.h</Path>
@@ -221,7 +221,7 @@
 </Description>
         <PartOf>desktop.library</PartOf>
         <RuntimeDependencies>
-            <Dependency release="55">poppler</Dependency>
+            <Dependency release="57">poppler</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libpoppler-qt6.so.3</Path>
@@ -234,8 +234,8 @@
         <Description xml:lang="en">This is Poppler, a library for rendering PDF files, and examining or modifying their structure.
 </Description>
         <RuntimeDependencies>
-            <Dependency release="55">poppler-devel</Dependency>
-            <Dependency releaseFrom="55">poppler-qt6</Dependency>
+            <Dependency release="57">poppler-devel</Dependency>
+            <Dependency releaseFrom="57">poppler-qt6</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/poppler/qt6/poppler-annotation.h</Path>
@@ -259,7 +259,7 @@
 </Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency release="55">poppler</Dependency>
+            <Dependency release="57">poppler</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/pdfattach</Path>
@@ -291,12 +291,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="56">
-            <Date>2025-12-23</Date>
+        <Update release="57">
+            <Date>2025-12-28</Date>
             <Version>25.10.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Although recommended upstream as reported here: https://github.com/getsolus/packages/issues/7452

It is causing issues on Plasma:

With:
<img width="1232" height="448" alt="with" src="https://github.com/user-attachments/assets/b46c7c0b-cfb9-409e-aa22-ad41fd86a75d" />

Without:
<img width="1243" height="414" alt="without" src="https://github.com/user-attachments/assets/97fe900c-0c0d-4eef-9c78-f481ef750779" />

Its not just in firefox but seemingly screwed up in multiple locations and if we cannot find out how to stop it, it needs to be removed.

**Test Plan**

- Fonts no longer look like shit.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
