### PR TITLE
libheif: Update to v1.21.1

### DIFF
--- a/packages/l/libheif/abi_symbols
+++ b/packages/l/libheif/abi_symbols
@@ -73,6 +73,7 @@ libheif.so.1:heif_context_get_region_item
 libheif.so.1:heif_context_get_security_limits
 libheif.so.1:heif_context_get_sequence_duration
 libheif.so.1:heif_context_get_sequence_timescale
+libheif.so.1:heif_context_get_text_item
 libheif.so.1:heif_context_get_track
 libheif.so.1:heif_context_get_track_ids
 libheif.so.1:heif_context_has_sequence
@@ -85,6 +86,7 @@ libheif.so.1:heif_context_read_from_reader
 libheif.so.1:heif_context_set_major_brand
 libheif.so.1:heif_context_set_max_decoding_threads
 libheif.so.1:heif_context_set_maximum_image_size_limit
+libheif.so.1:heif_context_set_number_of_sequence_repetitions
 libheif.so.1:heif_context_set_primary_image
 libheif.so.1:heif_context_set_security_limits
 libheif.so.1:heif_context_set_sequence_timescale
@@ -183,6 +185,7 @@ libheif.so.1:heif_image_get_raw_color_profile_size
 libheif.so.1:heif_image_get_tai_timestamp
 libheif.so.1:heif_image_get_width
 libheif.so.1:heif_image_handle_add_region_item
+libheif.so.1:heif_image_handle_add_text_item
 libheif.so.1:heif_image_handle_decode_image_tile
 libheif.so.1:heif_image_handle_free_auxiliary_types
 libheif.so.1:heif_image_handle_get_auxiliary_image_handle
@@ -195,6 +198,7 @@ libheif.so.1:heif_image_handle_get_content_light_level
 libheif.so.1:heif_image_handle_get_context
 libheif.so.1:heif_image_handle_get_depth_image_handle
 libheif.so.1:heif_image_handle_get_depth_image_representation_info
+libheif.so.1:heif_image_handle_get_gimi_content_id
 libheif.so.1:heif_image_handle_get_grid_image_tile_id
 libheif.so.1:heif_image_handle_get_height
 libheif.so.1:heif_image_handle_get_image_tiling
@@ -205,6 +209,7 @@ libheif.so.1:heif_image_handle_get_list_of_auxiliary_image_IDs
 libheif.so.1:heif_image_handle_get_list_of_depth_image_IDs
 libheif.so.1:heif_image_handle_get_list_of_metadata_block_IDs
 libheif.so.1:heif_image_handle_get_list_of_region_item_ids
+libheif.so.1:heif_image_handle_get_list_of_text_item_ids
 libheif.so.1:heif_image_handle_get_list_of_thumbnail_IDs
 libheif.so.1:heif_image_handle_get_luma_bits_per_pixel
 libheif.so.1:heif_image_handle_get_mastering_display_colour_volume
@@ -218,6 +223,7 @@ libheif.so.1:heif_image_handle_get_number_of_auxiliary_images
 libheif.so.1:heif_image_handle_get_number_of_depth_images
 libheif.so.1:heif_image_handle_get_number_of_metadata_blocks
 libheif.so.1:heif_image_handle_get_number_of_region_items
+libheif.so.1:heif_image_handle_get_number_of_text_items
 libheif.so.1:heif_image_handle_get_number_of_thumbnails
 libheif.so.1:heif_image_handle_get_pixel_aspect_ratio
 libheif.so.1:heif_image_handle_get_preferred_decoding_colorspace
@@ -233,6 +239,9 @@ libheif.so.1:heif_image_handle_is_premultiplied_alpha
 libheif.so.1:heif_image_handle_is_primary_image
 libheif.so.1:heif_image_handle_release
 libheif.so.1:heif_image_handle_release_auxiliary_type
+libheif.so.1:heif_image_handle_set_content_light_level
+libheif.so.1:heif_image_handle_set_mastering_display_colour_volume
+libheif.so.1:heif_image_handle_set_pixel_aspect_ratio
 libheif.so.1:heif_image_has_channel
 libheif.so.1:heif_image_has_content_light_level
 libheif.so.1:heif_image_has_mastering_display_colour_volume
@@ -257,6 +266,7 @@ libheif.so.1:heif_item_get_item_type
 libheif.so.1:heif_item_get_mime_item_content_encoding
 libheif.so.1:heif_item_get_mime_item_content_type
 libheif.so.1:heif_item_get_properties_of_type
+libheif.so.1:heif_item_get_property_extended_language
 libheif.so.1:heif_item_get_property_raw_data
 libheif.so.1:heif_item_get_property_raw_size
 libheif.so.1:heif_item_get_property_tai_clock_info
@@ -271,6 +281,7 @@ libheif.so.1:heif_item_get_transformation_properties
 libheif.so.1:heif_item_get_uri_item_uri_type
 libheif.so.1:heif_item_is_item_hidden
 libheif.so.1:heif_item_set_item_name
+libheif.so.1:heif_item_set_property_extended_language
 libheif.so.1:heif_item_set_property_tai_clock_info
 libheif.so.1:heif_item_set_property_tai_timestamp
 libheif.so.1:heif_list_compatible_brands
@@ -278,6 +289,7 @@ libheif.so.1:heif_load_plugin
 libheif.so.1:heif_load_plugins
 libheif.so.1:heif_main_brand
 libheif.so.1:heif_mastering_display_colour_volume_decode
+libheif.so.1:heif_metadata_compression_method_supported
 libheif.so.1:heif_nclx_color_profile_alloc
 libheif.so.1:heif_nclx_color_profile_free
 libheif.so.1:heif_nclx_color_profile_set_color_primaries
@@ -344,11 +356,19 @@ libheif.so.1:heif_tai_clock_info_release
 libheif.so.1:heif_tai_timestamp_packet_alloc
 libheif.so.1:heif_tai_timestamp_packet_copy
 libheif.so.1:heif_tai_timestamp_packet_release
+libheif.so.1:heif_text_item_get_content
+libheif.so.1:heif_text_item_get_id
+libheif.so.1:heif_text_item_get_property_extended_language
+libheif.so.1:heif_text_item_release
+libheif.so.1:heif_text_item_set_extended_language
 libheif.so.1:heif_track_add_raw_sequence_sample
 libheif.so.1:heif_track_add_reference_to_track
 libheif.so.1:heif_track_decode_next_image
+libheif.so.1:heif_track_encode_end_of_sequence
 libheif.so.1:heif_track_encode_sequence_image
 libheif.so.1:heif_track_find_referring_tracks
+libheif.so.1:heif_track_get_auxiliary_info_type
+libheif.so.1:heif_track_get_auxiliary_info_type_urn
 libheif.so.1:heif_track_get_gimi_track_content_id
 libheif.so.1:heif_track_get_id
 libheif.so.1:heif_track_get_image_resolution
@@ -364,6 +384,7 @@ libheif.so.1:heif_track_get_timescale
 libheif.so.1:heif_track_get_track_handler_type
 libheif.so.1:heif_track_get_track_reference_types
 libheif.so.1:heif_track_get_urim_sample_entry_uri_of_first_cluster
+libheif.so.1:heif_track_has_alpha_channel
 libheif.so.1:heif_track_options_alloc
 libheif.so.1:heif_track_options_enable_sample_gimi_content_ids
 libheif.so.1:heif_track_options_enable_sample_tai_timestamps

--- a/packages/l/libheif/abi_used_libs
+++ b/packages/l/libheif/abi_used_libs
@@ -12,4 +12,5 @@ libpng16.so.16
 librav1e.so.0.8
 libsharpyuv.so.0
 libstdc++.so.6
+libx264.so.164
 libx265.so.209

--- a/packages/l/libheif/abi_used_symbols
+++ b/packages/l/libheif/abi_used_symbols
@@ -32,6 +32,7 @@ libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
 libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoll
 libc.so.6:__isoc23_strtoul
 libc.so.6:__libc_single_threaded
 libc.so.6:__libc_start_main
@@ -58,6 +59,7 @@ libc.so.6:getenv
 libc.so.6:getopt
 libc.so.6:getopt_long
 libc.so.6:gettimeofday
+libc.so.6:isspace
 libc.so.6:lseek
 libc.so.6:malloc
 libc.so.6:memchr
@@ -104,6 +106,7 @@ libde265.so.0:de265_get_image_height
 libde265.so.0:de265_get_image_matrix_coefficients
 libde265.so.0:de265_get_image_plane
 libde265.so.0:de265_get_image_transfer_characteristics
+libde265.so.0:de265_get_image_user_data
 libde265.so.0:de265_get_image_width
 libde265.so.0:de265_get_next_picture
 libde265.so.0:de265_get_version
@@ -176,6 +179,7 @@ librav1e.so.0.8:rav1e_config_parse
 librav1e.so.0.8:rav1e_config_parse_int
 librav1e.so.0.8:rav1e_config_set_color_description
 librav1e.so.0.8:rav1e_config_set_pixel_format
+librav1e.so.0.8:rav1e_config_set_time_base
 librav1e.so.0.8:rav1e_config_unref
 librav1e.so.0.8:rav1e_context_new
 librav1e.so.0.8:rav1e_context_unref
@@ -195,8 +199,8 @@ libstdc++.so.6:_ZNKSt10filesystem7__cxx114path5_List13_Impl_deleterclEPNS2_5_Imp
 libstdc++.so.6:_ZNKSt10filesystem7__cxx114path5_List3endEv
 libstdc++.so.6:_ZNKSt5ctypeIcE13_M_widen_initEv
 libstdc++.so.6:_ZNKSt6locale2id5_M_idEv
+libstdc++.so.6:_ZNKSt8__detail20_Prime_rehash_policy11_M_next_bktEm
 libstdc++.so.6:_ZNKSt8__detail20_Prime_rehash_policy14_M_need_rehashEmmm
-libstdc++.so.6:_ZNSdC2Ev
 libstdc++.so.6:_ZNSdD2Ev
 libstdc++.so.6:_ZNSi10_M_extractIlEERSiRT_
 libstdc++.so.6:_ZNSi4readEPcl
@@ -210,6 +214,7 @@ libstdc++.so.6:_ZNSo9_M_insertIdEERSoT_
 libstdc++.so.6:_ZNSo9_M_insertIlEERSoT_
 libstdc++.so.6:_ZNSo9_M_insertImEERSoT_
 libstdc++.so.6:_ZNSolsEi
+libstdc++.so.6:_ZNSolsEs
 libstdc++.so.6:_ZNSt10filesystem6statusERKNS_7__cxx114pathE
 libstdc++.so.6:_ZNSt10filesystem7__cxx1118directory_iteratorC1ERKNS0_4pathENS_17directory_optionsEPSt10error_code
 libstdc++.so.6:_ZNSt10filesystem7__cxx1118directory_iteratorppEv
@@ -233,6 +238,7 @@ libstdc++.so.6:_ZNSt13basic_filebufIcSt11char_traitsIcEED1Ev
 libstdc++.so.6:_ZNSt13runtime_errorC2EPKc
 libstdc++.so.6:_ZNSt14basic_ifstreamIcSt11char_traitsIcEEC1EPKcSt13_Ios_Openmode
 libstdc++.so.6:_ZNSt14basic_ifstreamIcSt11char_traitsIcEED1Ev
+libstdc++.so.6:_ZNSt14basic_ofstreamIcSt11char_traitsIcEEC1EPKcSt13_Ios_Openmode
 libstdc++.so.6:_ZNSt14basic_ofstreamIcSt11char_traitsIcEED1Ev
 libstdc++.so.6:_ZNSt15__exception_ptr13exception_ptr10_M_releaseEv
 libstdc++.so.6:_ZNSt15__exception_ptr13exception_ptr9_M_addrefEv
@@ -259,6 +265,7 @@ libstdc++.so.6:_ZNSt8ios_baseC2Ev
 libstdc++.so.6:_ZNSt8ios_baseD2Ev
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE4initEPSt15basic_streambufIcS1_E
 libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE5clearESt12_Ios_Iostate
+libstdc++.so.6:_ZNSt9exceptionD2Ev
 libstdc++.so.6:_ZSt11__once_call
 libstdc++.so.6:_ZSt15__once_callable
 libstdc++.so.6:_ZSt15future_categoryv
@@ -333,5 +340,15 @@ libstdc++.so.6:__cxa_throw_bad_array_new_length
 libstdc++.so.6:__dynamic_cast
 libstdc++.so.6:__gxx_personality_v0
 libstdc++.so.6:__once_proxy
+libx264.so.164:x264_encoder_close
+libx264.so.164:x264_encoder_delayed_frames
+libx264.so.164:x264_encoder_encode
+libx264.so.164:x264_encoder_headers
+libx264.so.164:x264_encoder_open_164
+libx264.so.164:x264_param_apply_profile
+libx264.so.164:x264_param_cleanup
+libx264.so.164:x264_param_default_preset
+libx264.so.164:x264_param_parse
+libx264.so.164:x264_picture_init
 libx265.so.209:x265_api_get_209
 libx265.so.209:x265_cleanup

--- a/packages/l/libheif/package.yml
+++ b/packages/l/libheif/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libheif
-version    : 1.20.2
-release    : 54
+version    : 1.21.1
+release    : 55
 source     :
-    - https://github.com/strukturag/libheif/releases/download/v1.20.2/libheif-1.20.2.tar.gz : 68ac9084243004e0ef3633f184eeae85d615fe7e4444373a0a21cebccae9d12a
+    - https://github.com/strukturag/libheif/releases/download/v1.21.1/libheif-1.21.1.tar.gz : 9799b4b1c19006f052bcf399c761cc147e279762683cefaf16871dbb9b4ea2a1
 license    :
     - LGPL-3.0-or-later
     - MIT # /usr/include/libheif/heif_cxx.h
@@ -23,6 +23,7 @@ builddeps  :
     - pkgconfig(libturbojpeg)
     - pkgconfig(openh264)
     - pkgconfig(rav1e)
+    - pkgconfig(x264)
     - pkgconfig(x265)
 setup      : |
     %cmake_ninja -DWITH_DAV1D=ON \
@@ -35,3 +36,4 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING

--- a/packages/l/libheif/pspec_x86_64.xml
+++ b/packages/l/libheif/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libheif</Name>
         <Homepage>https://github.com/strukturag/libheif</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>LGPL-3.0-or-later</License>
         <License>MIT</License>
@@ -30,7 +30,8 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
             <Path fileType="executable">/usr/bin/heif-thumbnailer</Path>
             <Path fileType="library">/usr/lib64/libheif</Path>
             <Path fileType="library">/usr/lib64/libheif.so.1</Path>
-            <Path fileType="library">/usr/lib64/libheif.so.1.20.2</Path>
+            <Path fileType="library">/usr/lib64/libheif.so.1.21.1</Path>
+            <Path fileType="data">/usr/share/licenses/libheif/COPYING</Path>
             <Path fileType="man">/usr/share/man/man1/heif-dec.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/heif-enc.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/heif-info.1.zst</Path>
@@ -46,7 +47,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="54">libheif</Dependency>
+            <Dependency release="55">libheif</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libheif/heif.h</Path>
@@ -70,6 +71,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
             <Path fileType="header">/usr/include/libheif/heif_security.h</Path>
             <Path fileType="header">/usr/include/libheif/heif_sequences.h</Path>
             <Path fileType="header">/usr/include/libheif/heif_tai_timestamps.h</Path>
+            <Path fileType="header">/usr/include/libheif/heif_text.h</Path>
             <Path fileType="header">/usr/include/libheif/heif_tiling.h</Path>
             <Path fileType="header">/usr/include/libheif/heif_uncompressed.h</Path>
             <Path fileType="header">/usr/include/libheif/heif_version.h</Path>
@@ -81,12 +83,12 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
         </Files>
     </Package>
     <History>
-        <Update release="54">
-            <Date>2025-10-29</Date>
-            <Version>1.20.2</Version>
+        <Update release="55">
+            <Date>2026-01-02</Date>
+            <Version>1.21.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Changes:
- This release adds full support for reading and writing HEIF image sequences
- Support for image sequences with alpha channels
- Support for sequence track edit lists to define the number of sequence repetitions
- New encoder plugin using x264 to write H.264-compressed video streams and images
- The FFmpeg decoder plugin will now decode both H.265 and H.264
- Support for HEIF text items and language properties

Full release notes available [here](https://github.com/strukturag/libheif/releases/tag/v1.21.0)

**Security**
Includes fixes for:
- CVE-2025-68431

**Test Plan**

Encoded and decoded a bunch of images

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
