### PR TITLE
python-maturin: Update to v1.11.0

### DIFF
--- a/packages/py/python-maturin/package.yml
+++ b/packages/py/python-maturin/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-maturin
-version    : 1.10.2
-release    : 65
+version    : 1.11.0
+release    : 66
 source     :
-    - https://github.com/PyO3/maturin/archive/refs/tags/v1.10.2.tar.gz : 8acb4eb224896b3fa67036680e9e7908eeb8e5c2ea3a495e987a3f2edb666f36
+    - https://github.com/PyO3/maturin/archive/refs/tags/v1.11.0.tar.gz : 0e25b8931fd4b4d894c739fd61500cc79289ed10be907440013a7ffb6492ef78
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-maturin/pspec_x86_64.xml
+++ b/packages/py/python-maturin/pspec_x86_64.xml
@@ -22,12 +22,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/maturin</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.10.2.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.10.2.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.10.2.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.10.2.dist-info/licenses/license-apache</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.10.2.dist-info/licenses/license-mit</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.10.2.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.11.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.11.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.11.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.11.0.dist-info/licenses/license-apache</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.11.0.dist-info/licenses/license-mit</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.11.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -40,9 +40,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="65">
-            <Date>2025-12-12</Date>
-            <Version>1.10.2</Version>
+        <Update release="66">
+            <Date>2026-01-02</Date>
+            <Version>1.11.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Correct tagging for x86_64 iOS simulator wheels
- Bump MSRV to 1.85.0 and use Rust 2024 edition
- Set entry type when adding to the tar file
- Update environment variables for Android cross-compilation support
- Upgrade some Rust dependencies
- Calculate file options for WheelWriter once and cache the result
- Clean up internal fields of WheelWriter
- Deprecate 'upload' and 'publish' CLI commands
- Create a binding generator trait
- Migrate cffi bindings to new BindingGenerator trait
- Always emit deprecation warning for 'upload' and 'publish'
- Migrate uniffi bindings to new BindingGenerator trait
- Emit a warning if a file is excluded from the archive by matching the target
- Migrate bin bindings to new BindingGenerator trait
- Update ModuleWriter logic to use ArchiveSource enum
- Auto-enable required features for uniffi-bindgen
- Add VirtualWriter to track and order archive entries
- Update manylinux/musllinux policies to the latest main
- Stop hardcode platform tag when using zig
- Make PEP 517 profile tests more resilient to cargo profiles
- Implement Android platform tag support

Full release notes available [here](https://github.com/PyO3/maturin/releases/tag/v1.11.0)

**Test Plan**

Successfully built `python-orjson` (minus the check step due to current `tzdata` issue)

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
