### PR TITLE
a2ps: Update to v4.15.8

### DIFF
--- a/packages/a/a2ps/abi_symbols
+++ b/packages/a/a2ps/abi_symbols
@@ -1,10 +1,4 @@
 a2ps:_end
-a2ps:_obstack_allocated_p
-a2ps:_obstack_begin
-a2ps:_obstack_begin_1
-a2ps:_obstack_free
-a2ps:_obstack_memory_used
-a2ps:_obstack_newchunk
 a2ps:obstack_alloc_failed_handler
 a2ps:re_compile_fastmap
 a2ps:re_compile_pattern

--- a/packages/a/a2ps/abi_used_symbols
+++ b/packages/a/a2ps/abi_used_symbols
@@ -11,6 +11,7 @@ libc.so.6:__isoc23_strtol
 libc.so.6:__libc_current_sigrtmax
 libc.so.6:__libc_current_sigrtmin
 libc.so.6:__libc_start_main
+libc.so.6:__openat_2
 libc.so.6:__printf_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
@@ -32,7 +33,6 @@ libc.so.6:error
 libc.so.6:error_at_line
 libc.so.6:exit
 libc.so.6:fclose
-libc.so.6:fcntl
 libc.so.6:fdopendir
 libc.so.6:ferror
 libc.so.6:fflush
@@ -57,7 +57,7 @@ libc.so.6:ioctl
 libc.so.6:isatty
 libc.so.6:iswprint
 libc.so.6:localtime
-libc.so.6:mbrtowc
+libc.so.6:mbrtoc32
 libc.so.6:mbsinit
 libc.so.6:memcmp
 libc.so.6:memcpy
@@ -65,9 +65,7 @@ libc.so.6:memmove
 libc.so.6:mempcpy
 libc.so.6:memset
 libc.so.6:mkstemp
-libc.so.6:nl_langinfo
 libc.so.6:open
-libc.so.6:openat
 libc.so.6:opendir
 libc.so.6:optarg
 libc.so.6:optind

--- a/packages/a/a2ps/package.yml
+++ b/packages/a/a2ps/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : a2ps
-version    : 4.15.7
-release    : 15
+version    : 4.15.8
+release    : 16
 source     :
-    - https://ftpmirror.gnu.org/gnu/a2ps/a2ps-4.15.7.tar.gz : 715f38670afd950b4ca71c01f468feefad265ca52d3f112934c63c0a8bfbb8af
+    - https://ftpmirror.gnu.org/gnu/a2ps/a2ps-4.15.8.tar.gz : 8d13915a36ebbfa8e7b236b350cc81adc714acb217a18e8d8c60747c0ad353f9
 homepage   : https://www.gnu.org/software/a2ps/
 license    : GPL-3.0-or-later
 component  : programming
@@ -30,3 +30,4 @@ install    : |
     # Lets discourage things from building against it
     rm -rf $installdir/%libdir%
     rm -rf $installdir/usr/include
+    %install_license COPYING

--- a/packages/a/a2ps/pspec_x86_64.xml
+++ b/packages/a/a2ps/pspec_x86_64.xml
@@ -225,6 +225,7 @@
             <Path fileType="info">/usr/share/info/a2ps.info.zst</Path>
             <Path fileType="info">/usr/share/info/ogonkify.info.zst</Path>
             <Path fileType="info">/usr/share/info/regex.info.zst</Path>
+            <Path fileType="data">/usr/share/licenses/a2ps/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/a2ps-gnulib.mo</Path>
             <Path fileType="localedata">/usr/share/locale/be/LC_MESSAGES/a2ps-gnulib.mo</Path>
             <Path fileType="localedata">/usr/share/locale/be/LC_MESSAGES/a2ps.mo</Path>
@@ -365,9 +366,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2025-10-29</Date>
-            <Version>4.15.7</Version>
+        <Update release="16">
+            <Date>2026-01-03</Date>
+            <Version>4.15.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
 * Bug fixes:
   - Fix a buffer overflow when a long value supplied to -E.
   - Include some header files with system paths, not user paths.
 * Build system:
   - Fix building on systems that need gnulib's malloc wrapper.
   - Remove a generated file from git.
   - Update the version of gettext used.
 * Documentation:
   - Update copyright notices to point to GPL online.

**Test Plan**
- Checked config.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
