### PR TITLE
yazi: Update to v26.1.4

### DIFF
--- a/packages/y/yazi/package.yml
+++ b/packages/y/yazi/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : yazi
-version    : 25.12.29
-release    : 4
+version    : 26.1.4
+release    : 5
 source     :
-    - https://github.com/sxyazi/yazi/archive/refs/tags/v25.12.29.tar.gz : 95d426eb933837bc499d3cddadaf845b919586d0105ffb831dcd5e085f73fd6c
+    - https://github.com/sxyazi/yazi/archive/refs/tags/v26.1.4.tar.gz : 17839410a2865dc6ddb40da4b034dbf2729602fc325d07ad4df7dbc354c94c9e
 homepage   : https://yazi-rs.github.io
 license    : MIT
 component  : system.utils

--- a/packages/y/yazi/pspec_x86_64.xml
+++ b/packages/y/yazi/pspec_x86_64.xml
@@ -41,9 +41,9 @@ and extensibility through plugins and themes.
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2025-12-29</Date>
-            <Version>25.12.29</Version>
+        <Update release="5">
+            <Date>2026-01-04</Date>
+            <Version>26.1.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/sxyazi/yazi/blob/main/CHANGELOG.md#v2614).

**Test Plan**

Click around in yazi.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
