### PR TITLE
pychromecast: Update to v14.0.9

### DIFF
--- a/packages/py/pychromecast/monitoring.yaml
+++ b/packages/py/pychromecast/monitoring.yaml
@@ -1,6 +1,6 @@
 releases:
   id: 67295
-  rss: https://github.com/balloob/pychromecast/tags.atom
- # No known CPE, checked 2025-10-12
+  rss: https://github.com/home-assistant-libs/pychromecast/tags.atom
+ # No known CPE, checked 2026-01-07
 security:
   cpe: ~

--- a/packages/py/pychromecast/package.yml
+++ b/packages/py/pychromecast/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : pychromecast
-version    : 4.1.0
-release    : 13
+version    : 14.0.9
+release    : 14
 source     :
-    - https://github.com/balloob/pychromecast/archive/4.1.0.tar.gz : 648921783ee29ae50719aac83a6cbb7f6c6651c6d4ef2b32554575ee08d87c62
+    - https://github.com/home-assistant-libs/pychromecast/archive/refs/tags/14.0.9.tar.gz : d5494eff226119d9a0c2fd4d9fbc7f1025cedb2e699047cc9a0ba76236bed64d
 homepage   : https://github.com/home-assistant-libs/pychromecast
 license    : MIT
 component  : programming.python
@@ -14,6 +14,7 @@ builddeps  :
     - python-build
     - python-installer
     - python-setuptools
+    - python-wheel
 rundeps    :
     - python-casttube
     - python-protobuf

--- a/packages/py/pychromecast/pspec_x86_64.xml
+++ b/packages/py/pychromecast/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pychromecast</Name>
         <Homepage>https://github.com/home-assistant-libs/pychromecast</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,71 +20,118 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast-4.1.0.dist-info/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast-4.1.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast-4.1.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast-4.1.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast-4.1.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast-14.0.9.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast-14.0.9.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast-14.0.9.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast-14.0.9.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast-14.0.9.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/__init__.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/authority_keys_pb2.cpython-312.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/authority_keys_pb2.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/cast_channel_pb2.cpython-312.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/cast_channel_pb2.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/config.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/config.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/const.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/const.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/dial.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/dial.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/discovery.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/discovery.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/error.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/error.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/logging_pb2.cpython-312.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/logging_pb2.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/models.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/models.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/quick_play.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/quick_play.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/response_handler.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/response_handler.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/socket_client.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/__pycache__/socket_client.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/authority_keys_pb2.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/cast_channel_pb2.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/config.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/const.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/__init__.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/bbciplayer.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/bbciplayer.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/bbcsounds.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/bbcsounds.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/bubbleupnp.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/bubbleupnp.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/dashcast.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/dashcast.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/heartbeat.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/heartbeat.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/homeassistant.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/homeassistant.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/homeassistant_media.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/homeassistant_media.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/media.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/media.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/multizone.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/multizone.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/nrkradio.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/nrkradio.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/nrktv.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/nrktv.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/plex.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/plex.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/spotify.cpython-312.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/spotify.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/receiver.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/receiver.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/shaka.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/shaka.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/supla.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/supla.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/yleareena.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/yleareena.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/youtube.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/__pycache__/youtube.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/bbciplayer.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/bbcsounds.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/bubbleupnp.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/dashcast.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/heartbeat.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/homeassistant.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/homeassistant_media.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/media.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/multizone.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/nrkradio.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/nrktv.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/plex.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/spotify.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/receiver.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/shaka.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/supla.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/yleareena.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/controllers/youtube.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/dial.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/discovery.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/error.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/logging_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/generated/__pycache__/authority_keys_pb2.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/generated/__pycache__/authority_keys_pb2.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/generated/__pycache__/cast_channel_pb2.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/generated/__pycache__/cast_channel_pb2.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/generated/__pycache__/logging_pb2.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/generated/__pycache__/logging_pb2.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/generated/authority_keys_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/generated/authority_keys_pb2.pyi</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/generated/cast_channel_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/generated/cast_channel_pb2.pyi</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/generated/logging_pb2.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/generated/logging_pb2.pyi</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/generated/readme.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/models.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/py.typed</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/quick_play.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/response_handler.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pychromecast/socket_client.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2025-05-20</Date>
-            <Version>4.1.0</Version>
+        <Update release="14">
+            <Date>2026-01-05</Date>
+            <Version>14.0.9</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
I think this was last updated in 2019, so there are probably many
changes. The latest changelog is [here](https://github.com/home-assistant-libs/pychromecast/releases/tag/14.0.9).

Ref https://github.com/getsolus/packages/issues/7510

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start DisplayCAL. I don't know where in the program `pychromecast` is used, but it at least starts.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
