### PR TITLE
python-aiohttp: Update to v3.13.3

### DIFF
--- a/packages/py/python-aiohttp/package.yml
+++ b/packages/py/python-aiohttp/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-aiohttp
-version    : 3.13.2
-release    : 22
+version    : 3.13.3
+release    : 23
 source     :
-    - https://files.pythonhosted.org/packages/source/a/aiohttp/aiohttp-3.13.2.tar.gz : 40176a52c186aefef6eb3cad2cdd30cd06e3afbe88fe8ab2af9c0b90f228daca
+    - https://files.pythonhosted.org/packages/source/a/aiohttp/aiohttp-3.13.3.tar.gz : a949eee43d3782f2daae4f4a2819b2cb9b0c5d3b7f7a927067cc84dafdbb9f88
 homepage   : https://docs.aiohttp.org/
 license    : Apache-2.0
 component  : programming.python

--- a/packages/py/python-aiohttp/pspec_x86_64.xml
+++ b/packages/py/python-aiohttp/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-aiohttp</Name>
         <Homepage>https://docs.aiohttp.org/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -20,12 +20,12 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.2.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.2.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.2.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.2.dist-info/licenses/LICENSE.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.2.dist-info/licenses/vendor/llhttp/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.2.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.3.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.3.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.3.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.3.dist-info/licenses/LICENSE.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.3.dist-info/licenses/vendor/llhttp/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.3.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp/.hash/_cparser.pxd.hash</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp/.hash/_find_header.pxd.hash</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp/.hash/_http_parser.pyx.hash</Path>
@@ -215,12 +215,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2025-11-06</Date>
-            <Version>3.13.2</Version>
+        <Update release="23">
+            <Date>2026-01-05</Date>
+            <Version>3.13.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/aio-libs/aiohttp/releases/tag/v3.13.3).

**Security**
- CVE-2025-69223
- CVE-2025-69228
- CVE-2025-69227
- CVE-2025-69229
- CVE-2025-69230
- CVE-2025-69226
- CVE-2025-69224
- CVE-2025-69225

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `spyder3`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
