### PR TITLE
Adding the option to generate the Labwc theme with Papirus icons.

### DIFF
--- a/packages/p/pocillo-gtk-theme/package.yml
+++ b/packages/p/pocillo-gtk-theme/package.yml
@@ -25,7 +25,7 @@ rundeps    :
 patterns   :
     - slim : /usr/share/themes/*slim*
 setup      : |
-    %meson_configure -Dtheme_name=Pocillo
+    %meson_configure -Dtheme_name=Pocillo -Dlabwc_icons=papirus
 build      : |
     %ninja_build
 install    : |


### PR DESCRIPTION
**Summary**

<!-- Info on what this pull request updates/changes/etc -->

This is just a small modification so that when the Pocillo GTK theme is created, it uses the Papirus icons in the Labwc titlebar, instead of continuing to use the Qogir icons.

**Test Plan**

<!-- Short description of how the package was tested -->

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
