### PR TITLE
yazi: Add ya shell completions and other cleanups

### DIFF
--- a/packages/y/yazi/package.yml
+++ b/packages/y/yazi/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : yazi
 version    : 26.1.4
-release    : 5
+release    : 6
 source     :
     - https://github.com/sxyazi/yazi/archive/refs/tags/v26.1.4.tar.gz : 17839410a2865dc6ddb40da4b034dbf2729602fc325d07ad4df7dbc354c94c9e
 homepage   : https://yazi-rs.github.io
@@ -13,36 +13,36 @@ description: |
     and extensibility through plugins and themes.
 networking : true
 builddeps  :
-    - imagemagick
     - rust
 rundeps    :
     - file
 
 setup      : |
-    # Fix desktop file categories to appear in FileManager category
+    # Fix desktop to avoid duplicate entries
     sed -i 's/Categories=.*/Categories=System;FileManager;/' "assets/yazi.desktop"
-
     %cargo_fetch
 
 build      : |
-    YAZI_GEN_COMPLETIONS=true %cargo_build
+    export YAZI_GEN_COMPLETIONS=true
+    %cargo_build
 
 install    : |
     %cargo_install yazi ya
-    %install_license LICENSE LICENSE-ICONS
-    install -Dm644 "assets/yazi.desktop" "$installdir/usr/share/applications/yazi.desktop"
+    %install_license LICENSE*
+    install -Dm00644 "assets/yazi.desktop" "$installdir/usr/share/applications/yazi.desktop"
 
     # Install appstream metainfo
-    install -Dm644 "$pkgfiles/org.yazi.Yazi.metainfo.xml" "$installdir/usr/share/metainfo/org.yazi.Yazi.metainfo.xml"
+    install -Dm00644 "$pkgfiles/org.yazi.Yazi.metainfo.xml" "$installdir/usr/share/metainfo/org.yazi.Yazi.metainfo.xml"
 
-    # Install icons
-    for r in 16 24 32 48 64 128 256; do
-      install -dm755 "$installdir/usr/share/icons/hicolor/${r}x${r}/apps"
-      magick assets/logo.png -resize "${r}x${r}" "$installdir/usr/share/icons/hicolor/${r}x${r}/apps/yazi.png"
-    done
+    # Install icon
+    install -Dm00644 "assets/logo.png" "$installdir/usr/share/icons/hicolor/512x512/apps/yazi.png"
 
-    # Install shell completions
-    cd yazi-boot/completions
-    install -Dm644 "yazi.bash" "$installdir/usr/share/bash-completion/completions/yazi"
-    install -Dm644 "yazi.fish" "$installdir/usr/share/fish/vendor_completions.d/yazi.fish"
-    install -Dm644 "_yazi" "$installdir/usr/share/zsh/site-functions/_yazi"
+    # Install shell completions for yazi
+    install -Dm00644 "yazi-boot/completions/yazi.bash" "$installdir/usr/share/bash-completion/completions/yazi"
+    install -Dm00644 "yazi-boot/completions/yazi.fish" "$installdir/usr/share/fish/vendor_completions.d/yazi.fish"
+    install -Dm00644 "yazi-boot/completions/_yazi" "$installdir/usr/share/zsh/site-functions/_yazi"
+
+    # Install shell completions for ya
+    install -Dm00644 "yazi-cli/completions/ya.bash" "$installdir/usr/share/bash-completion/completions/ya"
+    install -Dm00644 "yazi-cli/completions/ya.fish" "$installdir/usr/share/fish/vendor_completions.d/ya.fish"
+    install -Dm00644 "yazi-cli/completions/_ya" "$installdir/usr/share/zsh/site-functions/_ya"

--- a/packages/y/yazi/pspec_x86_64.xml
+++ b/packages/y/yazi/pspec_x86_64.xml
@@ -25,24 +25,21 @@ and extensibility through plugins and themes.
             <Path fileType="executable">/usr/bin/ya</Path>
             <Path fileType="executable">/usr/bin/yazi</Path>
             <Path fileType="data">/usr/share/applications/yazi.desktop</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/ya</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/yazi</Path>
+            <Path fileType="data">/usr/share/fish/vendor_completions.d/ya.fish</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/yazi.fish</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/yazi.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/16x16/apps/yazi.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/24x24/apps/yazi.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/yazi.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/yazi.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/yazi.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/yazi.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512/apps/yazi.png</Path>
             <Path fileType="data">/usr/share/licenses/yazi/LICENSE</Path>
             <Path fileType="data">/usr/share/licenses/yazi/LICENSE-ICONS</Path>
             <Path fileType="data">/usr/share/metainfo/org.yazi.Yazi.metainfo.xml</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_ya</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_yazi</Path>
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2026-01-04</Date>
+        <Update release="6">
+            <Date>2026-01-07</Date>
             <Version>26.1.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>


### PR DESCRIPTION
**Summary**
- Add ya shell completions
- Simplify png install (Similar to AerynOS)

**Test Plan**

Tested on KDE and Budgie. Opened yazi and moved around file system. Tested ya shell completions. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
