### PR TITLE
curl: Update to v8.18.0

### DIFF
--- a/packages/c/curl/abi_used_symbols
+++ b/packages/c/curl/abi_used_symbols
@@ -5,12 +5,10 @@ libbrotlidec.so.1:BrotliDecoderGetErrorCode
 libbrotlidec.so.1:BrotliDecoderVersion
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
-libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
-libc.so.6:__strcpy_chk
 libc.so.6:__xpg_basename
 libc.so.6:accept4
 libc.so.6:bind
@@ -56,7 +54,6 @@ libc.so.6:getpwuid_r
 libc.so.6:getsockname
 libc.so.6:getsockopt
 libc.so.6:gettimeofday
-libc.so.6:gmtime
 libc.so.6:gmtime_r
 libc.so.6:if_nametoindex
 libc.so.6:inet_ntop
@@ -64,7 +61,7 @@ libc.so.6:inet_pton
 libc.so.6:ioctl
 libc.so.6:isatty
 libc.so.6:listen
-libc.so.6:localtime
+libc.so.6:localtime_r
 libc.so.6:lseek
 libc.so.6:malloc
 libc.so.6:memchr
@@ -109,11 +106,9 @@ libc.so.6:stat
 libc.so.6:stderr
 libc.so.6:stdin
 libc.so.6:stdout
-libc.so.6:stpcpy
 libc.so.6:strcasecmp
 libc.so.6:strchr
 libc.so.6:strcmp
-libc.so.6:strcpy
 libc.so.6:strcspn
 libc.so.6:strdup
 libc.so.6:strerror_r
@@ -330,6 +325,7 @@ libgnutls.so.30:gnutls_certificate_set_x509_simple_pkcs12_file
 libgnutls.so.30:gnutls_certificate_set_x509_system_trust
 libgnutls.so.30:gnutls_certificate_set_x509_trust_dir
 libgnutls.so.30:gnutls_certificate_set_x509_trust_file
+libgnutls.so.30:gnutls_certificate_set_x509_trust_mem
 libgnutls.so.30:gnutls_certificate_verify_peers2
 libgnutls.so.30:gnutls_check_version
 libgnutls.so.30:gnutls_cipher_get

--- a/packages/c/curl/abi_used_symbols32
+++ b/packages/c/curl/abi_used_symbols32
@@ -5,11 +5,9 @@ libbrotlidec.so.1:BrotliDecoderGetErrorCode
 libbrotlidec.so.1:BrotliDecoderVersion
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
-libc.so.6:__isoc23_strtol
 libc.so.6:__memcpy_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
-libc.so.6:__strcpy_chk
 libc.so.6:__xpg_basename
 libc.so.6:accept4
 libc.so.6:bind
@@ -91,10 +89,8 @@ libc.so.6:stat64
 libc.so.6:stderr
 libc.so.6:stdin
 libc.so.6:stdout
-libc.so.6:stpcpy
 libc.so.6:strchr
 libc.so.6:strcmp
-libc.so.6:strcpy
 libc.so.6:strcspn
 libc.so.6:strdup
 libc.so.6:strerror_r
@@ -304,6 +300,7 @@ libgnutls.so.30:gnutls_certificate_set_x509_simple_pkcs12_file
 libgnutls.so.30:gnutls_certificate_set_x509_system_trust
 libgnutls.so.30:gnutls_certificate_set_x509_trust_dir
 libgnutls.so.30:gnutls_certificate_set_x509_trust_file
+libgnutls.so.30:gnutls_certificate_set_x509_trust_mem
 libgnutls.so.30:gnutls_certificate_verify_peers2
 libgnutls.so.30:gnutls_check_version
 libgnutls.so.30:gnutls_cipher_get

--- a/packages/c/curl/package.yml
+++ b/packages/c/curl/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : curl
-version    : 8.17.0
-release    : 111
+version    : 8.18.0
+release    : 112
 source     :
-    - https://github.com/curl/curl/releases/download/curl-8_17_0/curl-8.17.0.tar.bz2 : 230032528ce5f85594d4f3eace63364c4244ccc3c801b7f8db1982722f2761f4
+    - https://github.com/curl/curl/releases/download/curl-8_18_0/curl-8.18.0.tar.bz2 : ffd671a3dad424fb68e113a5b9894c5d1b5e13a88c6bdf0d4af6645123b31faf
 extract    : false
 homepage   : https://curl.se
 license    : MIT

--- a/packages/c/curl/pspec_x86_64.xml
+++ b/packages/c/curl/pspec_x86_64.xml
@@ -36,7 +36,7 @@
         <Description xml:lang="en">curl is a client to get files from servers using any of the supported protocols. The command is designed to work without user interaction or any kind of interactivity. curl offers a busload of useful tricks like proxy support, user authentication, ftp upload, HTTP post, file transfer resume and more.</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="111">curl</Dependency>
+            <Dependency release="112">curl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libcurl.so.4</Path>
@@ -49,8 +49,8 @@
         <Description xml:lang="en">curl is a client to get files from servers using any of the supported protocols. The command is designed to work without user interaction or any kind of interactivity. curl offers a busload of useful tricks like proxy support, user authentication, ftp upload, HTTP post, file transfer resume and more.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="111">curl-32bit</Dependency>
-            <Dependency release="111">curl-devel</Dependency>
+            <Dependency release="112">curl-32bit</Dependency>
+            <Dependency release="112">curl-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libcurl.so</Path>
@@ -63,7 +63,7 @@
         <Description xml:lang="en">curl is a client to get files from servers using any of the supported protocols. The command is designed to work without user interaction or any kind of interactivity. curl offers a busload of useful tricks like proxy support, user authentication, ftp upload, HTTP post, file transfer resume and more.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="111">curl</Dependency>
+            <Dependency release="112">curl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/curl/curl.h</Path>
@@ -623,9 +623,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="111">
-            <Date>2025-11-05</Date>
-            <Version>8.17.0</Version>
+        <Update release="112">
+            <Date>2026-01-07</Date>
+            <Version>8.18.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://curl.se/ch/8.18.0.html).

**Security**
- CVE-2025-13034
- CVE-2025-14017
- CVE-2025-14524
- CVE-2025-14819
- CVE-2025-15079
- CVE-2025-15224

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Download the `curl` source tarball using `curl`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
