### PR TITLE
tlp: Update to v1.9.1

### DIFF
--- a/packages/t/tlp/package.yml
+++ b/packages/t/tlp/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : tlp
-version    : 1.8.0
-release    : 22
+version    : 1.9.1
+release    : 23
 source     :
-    - https://github.com/linrunner/TLP/archive/refs/tags/1.8.0.tar.gz : 65515f7652064a1be2940c031e045b762924bb1dbd94f5e58e3b765113cf5210
+    - https://github.com/linrunner/TLP/archive/refs/tags/1.9.1.tar.gz : 6f7c69a8c56706f83bc3566377caf846c2ccbd8f2621fe8e56c6d1e684d15156
 homepage   : https://linrunner.de/tlp/
 license    : GPL-2.0-only
 component  : system.utils
@@ -32,6 +32,8 @@ install    : |
     export TLP_WITH_ELOGIND='0'
     %make_install install-man
     rm -rf $installdir/var
+
+    %install_license COPYING LICENSE
 
     # Enable by default, users can disable now with systemctl mask tlp
     install -Ddm 00755 $installdir/%libdir%/systemd/system/multi-user.target.wants

--- a/packages/t/tlp/pspec_x86_64.xml
+++ b/packages/t/tlp/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>tlp</Name>
         <Homepage>https://linrunner.de/tlp/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>system.utils</PartOf>
@@ -35,16 +35,19 @@
             <Path fileType="executable">/usr/bin/run-on-bat</Path>
             <Path fileType="executable">/usr/bin/tlp-rdw</Path>
             <Path fileType="executable">/usr/bin/tlp-stat</Path>
+            <Path fileType="executable">/usr/bin/tlpctl</Path>
             <Path fileType="executable">/usr/bin/wifi</Path>
             <Path fileType="executable">/usr/bin/wwan</Path>
             <Path fileType="library">/usr/lib64/systemd/system-sleep/tlp</Path>
             <Path fileType="library">/usr/lib64/systemd/system/multi-user.target.wants/tlp.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/system/tlp-pd.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/tlp.service</Path>
             <Path fileType="library">/usr/lib64/udev/rules.d/85-tlp-rdw.rules</Path>
             <Path fileType="library">/usr/lib64/udev/rules.d/85-tlp.rules</Path>
             <Path fileType="library">/usr/lib64/udev/tlp-rdw-udev</Path>
             <Path fileType="library">/usr/lib64/udev/tlp-usb-udev</Path>
             <Path fileType="executable">/usr/sbin/tlp</Path>
+            <Path fileType="executable">/usr/sbin/tlp-pd</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/bluetooth</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/nfc</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/run-on-ac</Path>
@@ -52,8 +55,13 @@
             <Path fileType="data">/usr/share/bash-completion/completions/tlp</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/tlp-rdw</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/tlp-stat</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/tlpctl</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/wifi</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/wwan</Path>
+            <Path fileType="data">/usr/share/dbus-1/system-services/net.hadess.PowerProfiles.service</Path>
+            <Path fileType="data">/usr/share/dbus-1/system-services/org.freedesktop.UPower.PowerProfiles.service</Path>
+            <Path fileType="data">/usr/share/dbus-1/system.d/net.hadess.PowerProfiles.conf</Path>
+            <Path fileType="data">/usr/share/dbus-1/system.d/org.freedesktop.UPower.PowerProfiles.conf</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/bluetooth.fish</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/nfc.fish</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/run-on-ac.fish</Path>
@@ -61,19 +69,26 @@
             <Path fileType="data">/usr/share/fish/vendor_completions.d/tlp-rdw.fish</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/tlp-stat.fish</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/tlp.fish</Path>
+            <Path fileType="data">/usr/share/fish/vendor_completions.d/tlpctl.fish</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/wifi.fish</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/wwan.fish</Path>
-            <Path fileType="man">/usr/share/man/man1/bluetooth.1</Path>
-            <Path fileType="man">/usr/share/man/man1/nfc.1</Path>
-            <Path fileType="man">/usr/share/man/man1/run-on-ac.1</Path>
-            <Path fileType="man">/usr/share/man/man1/run-on-bat.1</Path>
-            <Path fileType="man">/usr/share/man/man1/wifi.1</Path>
-            <Path fileType="man">/usr/share/man/man1/wwan.1</Path>
-            <Path fileType="man">/usr/share/man/man8/tlp-rdw.8</Path>
-            <Path fileType="man">/usr/share/man/man8/tlp-stat.8</Path>
-            <Path fileType="man">/usr/share/man/man8/tlp.8</Path>
-            <Path fileType="man">/usr/share/man/man8/tlp.service.8</Path>
+            <Path fileType="data">/usr/share/licenses/tlp/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/tlp/LICENSE</Path>
+            <Path fileType="man">/usr/share/man/man1/bluetooth.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/nfc.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/run-on-ac.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/run-on-bat.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/tlpctl.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/wifi.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/wwan.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/tlp-pd.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/tlp-pd.service.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/tlp-rdw.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/tlp-stat.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/tlp.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/tlp.service.8.zst</Path>
             <Path fileType="data">/usr/share/metainfo/de.linrunner.tlp.metainfo.xml</Path>
+            <Path fileType="data">/usr/share/polkit-1/actions/tlp-pd.policy</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/05-thinkpad</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/10-thinkpad-legacy</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/15-lenovo</Path>
@@ -89,6 +104,7 @@
             <Path fileType="data">/usr/share/tlp/bat.d/56-framework</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/60-macbook</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/65-dell</Path>
+            <Path fileType="data">/usr/share/tlp/bat.d/70-tuxedo</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/89-asus</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/90-generic</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/TEMPLATE</Path>
@@ -114,15 +130,16 @@
             <Path fileType="data">/usr/share/zsh/site-functions/_tlp-rdw</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_tlp-run-on</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_tlp-stat</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_tlpctl</Path>
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2025-02-22</Date>
-            <Version>1.8.0</Version>
+        <Update release="23">
+            <Date>2026-01-07</Date>
+            <Version>1.9.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/linrunner/TLP/releases/tag/1.9.0) and [here](https://github.com/linrunner/TLP/releases/tag/1.9.1).

Note that 1.9.1 has a security fix for 1.9.0. Version 1.8.0 is unaffected.

**Security**
- CVE-2025-67859

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

TBD. Someone who uses this (preferably) should test this before it goes in.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
