### PR TITLE
libwacom: Update to v2.17.0

### DIFF
--- a/packages/l/libwacom/files/surface/0001-Add-support-for-BUS_VIRTUAL.patch
+++ b/packages/l/libwacom/files/surface/0001-Add-support-for-BUS_VIRTUAL.patch
@@ -1,4 +1,4 @@
-From 483de1767646e8a0cba4eb9c4c6e90a6abe19b23 Mon Sep 17 00:00:00 2001
+From 147c5f2be436cc25bdd5891b11fdb9c46a0d9417 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sat, 27 Jun 2020 18:21:11 +0200
 Subject: [PATCH 01/16] Add support for BUS_VIRTUAL
@@ -13,18 +13,18 @@ as BUS_VIRTUAL.
 Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>
 ---
  libwacom/libwacom-database.c | 4 ++++
- libwacom/libwacom.c          | 5 +++++
+ libwacom/libwacom.c          | 7 +++++++
  libwacom/libwacom.h          | 1 +
  test/test-tablet-validity.c  | 1 +
  test/test_data_files.py      | 1 +
- tools/debug-device.c         | 1 +
- 6 files changed, 13 insertions(+)
+ tools/debug-device.c         | 3 +++
+ 6 files changed, 17 insertions(+)
 
 diff --git a/libwacom/libwacom-database.c b/libwacom/libwacom-database.c
-index 7a6493ac..a6cd54b4 100644
+index eb84df4f..3aa398e5 100644
 --- a/libwacom/libwacom-database.c
 +++ b/libwacom/libwacom-database.c
-@@ -174,6 +174,8 @@ bus_from_str (const char *str)
+@@ -175,6 +175,8 @@ bus_from_str(const char *str)
  		return WBUSTYPE_BLUETOOTH;
  	if (g_str_equal(str, "i2c"))
  		return WBUSTYPE_I2C;
@@ -33,20 +33,20 @@ index 7a6493ac..a6cd54b4 100644
  	return WBUSTYPE_UNKNOWN;
  }
  
-@@ -192,6 +194,8 @@ bus_to_str (WacomBusType bus)
+@@ -193,6 +195,8 @@ bus_to_str(WacomBusType bus)
  		return "bluetooth";
  	case WBUSTYPE_I2C:
  		return "i2c";
 +	case WBUSTYPE_VIRTUAL:
 +		return "virt";
  	}
- 	g_assert_not_reached ();
+ 	g_assert_not_reached();
  }
 diff --git a/libwacom/libwacom.c b/libwacom/libwacom.c
-index 646a1525..fac97e65 100644
+index ab8b4e47..e6bab4ea 100644
 --- a/libwacom/libwacom.c
 +++ b/libwacom/libwacom.c
-@@ -153,6 +153,10 @@ get_bus_vid_pid (GUdevDevice  *device,
+@@ -156,6 +156,10 @@ get_bus_vid_pid(GUdevDevice *device,
  		*bus = WBUSTYPE_I2C;
  		retval = TRUE;
  		break;
@@ -57,38 +57,40 @@ index 646a1525..fac97e65 100644
  	}
  
  out:
-@@ -1032,6 +1036,7 @@ static void print_match(int fd, const WacomMatch *match)
- 		case WBUSTYPE_USB:		bus_name = "usb";	break;
- 		case WBUSTYPE_SERIAL:		bus_name = "serial";	break;
- 		case WBUSTYPE_I2C:		bus_name = "i2c";	break;
-+		case WBUSTYPE_VIRTUAL:		bus_name = "virt";	break;
- 		case WBUSTYPE_UNKNOWN:		bus_name = "unknown";	break;
- 		default:			g_assert_not_reached(); break;
- 	}
+@@ -1100,6 +1104,9 @@ print_match(int fd,
+ 	case WBUSTYPE_I2C:
+ 		bus_name = "i2c";
+ 		break;
++	case WBUSTYPE_VIRTUAL:
++		bus_name = "virt";
++		break;
+ 	case WBUSTYPE_UNKNOWN:
+ 		bus_name = "unknown";
+ 		break;
 diff --git a/libwacom/libwacom.h b/libwacom/libwacom.h
-index 3c820f4a..17dd7600 100644
+index 9d9fe650..6b07c23d 100644
 --- a/libwacom/libwacom.h
 +++ b/libwacom/libwacom.h
-@@ -154,6 +154,7 @@ typedef enum {
- 	WBUSTYPE_SERIAL,	/**< Serial tablet */
- 	WBUSTYPE_BLUETOOTH,	/**< Bluetooth tablet */
- 	WBUSTYPE_I2C,		/**< I2C tablet */
-+	WBUSTYPE_VIRTUAL,	/**< Virtual (uinput) tablet */
+@@ -153,6 +153,7 @@ typedef enum {
+ 	WBUSTYPE_SERIAL,    /**< Serial tablet */
+ 	WBUSTYPE_BLUETOOTH, /**< Bluetooth tablet */
+ 	WBUSTYPE_I2C,       /**< I2C tablet */
++	WBUSTYPE_VIRTUAL,   /**< Virtual (uinput) tablet */
  } WacomBusType;
  
  /**
 diff --git a/test/test-tablet-validity.c b/test/test-tablet-validity.c
-index c20e582e..77ff1327 100644
+index bf4609b7..24078f64 100644
 --- a/test/test-tablet-validity.c
 +++ b/test/test-tablet-validity.c
-@@ -177,6 +177,7 @@ assert_vidpid(WacomBusType bus, int vid, int pid)
- 			break;
- 		case WBUSTYPE_BLUETOOTH:
- 		case WBUSTYPE_I2C:
-+		case WBUSTYPE_VIRTUAL:
- 			g_assert_cmpint(vid, >, 0);
- 			g_assert_cmpint(pid, >, 0);
- 			break;
+@@ -180,6 +180,7 @@ assert_vidpid(WacomBusType bus,
+ 		break;
+ 	case WBUSTYPE_BLUETOOTH:
+ 	case WBUSTYPE_I2C:
++	case WBUSTYPE_VIRTUAL:
+ 		g_assert_cmpint(vid, >, 0);
+ 		g_assert_cmpint(pid, >, 0);
+ 		break;
 diff --git a/test/test_data_files.py b/test/test_data_files.py
 index 4cff174f..ee6ffcd3 100755
 --- a/test/test_data_files.py
@@ -102,17 +104,19 @@ index 4cff174f..ee6ffcd3 100755
          assert re.match("[0-9a-f]{4}", vid), (
              f"{tabletfile}: {vid} must be lowercase hex"
 diff --git a/tools/debug-device.c b/tools/debug-device.c
-index c15bf41b..286e9148 100644
+index 4f9762e9..43a6072d 100644
 --- a/tools/debug-device.c
 +++ b/tools/debug-device.c
-@@ -177,6 +177,7 @@ handle_device(WacomDeviceDatabase *db, const char *path)
- 			case WBUSTYPE_SERIAL: busstr = "SERIAL"; break;
- 			case WBUSTYPE_BLUETOOTH: busstr = "BLUETOOTH"; break;
- 			case WBUSTYPE_I2C: busstr = "I2C"; break;
-+			case WBUSTYPE_VIRTUAL: busstr = "VIRTUAL"; break;
+@@ -191,6 +191,9 @@ handle_device(WacomDeviceDatabase *db,
+ 		case WBUSTYPE_I2C:
+ 			busstr = "I2C";
+ 			break;
++		case WBUSTYPE_VIRTUAL:
++			busstr = "VIRTUAL";
++			break;
  		}
  		func(libwacom_get_bustype, "%s", busstr);
  	}
 -- 
-2.49.0
+2.52.0
 

--- a/packages/l/libwacom/files/surface/0002-Add-support-for-Intel-Management-Engine-bus.patch
+++ b/packages/l/libwacom/files/surface/0002-Add-support-for-Intel-Management-Engine-bus.patch
@@ -1,4 +1,4 @@
-From 2f55d3df2ef4908bc09ee3349793192acbb2042e Mon Sep 17 00:00:00 2001
+From e0a76b8bf65076825880652c0f4ed52cada8e26d Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 1 Jun 2019 21:17:15 +0200
 Subject: [PATCH 02/16] Add support for Intel Management Engine bus
@@ -8,18 +8,18 @@ This is required to support IPTS based devices, such as (among others)
 the Microsoft Surface Books, Surface Pro 5 and 6, and Surface Laptops.
 ---
  libwacom/libwacom-database.c | 4 ++++
- libwacom/libwacom.c          | 5 +++++
+ libwacom/libwacom.c          | 7 +++++++
  libwacom/libwacom.h          | 1 +
  test/test-tablet-validity.c  | 1 +
  test/test_data_files.py      | 1 +
- tools/debug-device.c         | 1 +
- 6 files changed, 13 insertions(+)
+ tools/debug-device.c         | 3 +++
+ 6 files changed, 17 insertions(+)
 
 diff --git a/libwacom/libwacom-database.c b/libwacom/libwacom-database.c
-index a6cd54b4..2883bccb 100644
+index 3aa398e5..44f08742 100644
 --- a/libwacom/libwacom-database.c
 +++ b/libwacom/libwacom-database.c
-@@ -176,6 +176,8 @@ bus_from_str (const char *str)
+@@ -177,6 +177,8 @@ bus_from_str(const char *str)
  		return WBUSTYPE_I2C;
  	if (g_str_equal(str, "virt"))
  		return WBUSTYPE_VIRTUAL;
@@ -28,20 +28,20 @@ index a6cd54b4..2883bccb 100644
  	return WBUSTYPE_UNKNOWN;
  }
  
-@@ -196,6 +198,8 @@ bus_to_str (WacomBusType bus)
+@@ -197,6 +199,8 @@ bus_to_str(WacomBusType bus)
  		return "i2c";
  	case WBUSTYPE_VIRTUAL:
  		return "virt";
 +	case WBUSTYPE_MEI:
 +		return "mei";
  	}
- 	g_assert_not_reached ();
+ 	g_assert_not_reached();
  }
 diff --git a/libwacom/libwacom.c b/libwacom/libwacom.c
-index fac97e65..17f8607d 100644
+index e6bab4ea..497b0608 100644
 --- a/libwacom/libwacom.c
 +++ b/libwacom/libwacom.c
-@@ -157,6 +157,10 @@ get_bus_vid_pid (GUdevDevice  *device,
+@@ -160,6 +160,10 @@ get_bus_vid_pid(GUdevDevice *device,
  		*bus = WBUSTYPE_VIRTUAL;
  		retval = TRUE;
  		break;
@@ -52,38 +52,40 @@ index fac97e65..17f8607d 100644
  	}
  
  out:
-@@ -1037,6 +1041,7 @@ static void print_match(int fd, const WacomMatch *match)
- 		case WBUSTYPE_SERIAL:		bus_name = "serial";	break;
- 		case WBUSTYPE_I2C:		bus_name = "i2c";	break;
- 		case WBUSTYPE_VIRTUAL:		bus_name = "virt";	break;
-+		case WBUSTYPE_MEI:		bus_name = "mei";	break;
- 		case WBUSTYPE_UNKNOWN:		bus_name = "unknown";	break;
- 		default:			g_assert_not_reached(); break;
- 	}
+@@ -1107,6 +1111,9 @@ print_match(int fd,
+ 	case WBUSTYPE_VIRTUAL:
+ 		bus_name = "virt";
+ 		break;
++	case WBUSTYPE_MEI:
++		bus_name = "mei";
++		break;
+ 	case WBUSTYPE_UNKNOWN:
+ 		bus_name = "unknown";
+ 		break;
 diff --git a/libwacom/libwacom.h b/libwacom/libwacom.h
-index 17dd7600..798a31dd 100644
+index 6b07c23d..34cfbff0 100644
 --- a/libwacom/libwacom.h
 +++ b/libwacom/libwacom.h
-@@ -155,6 +155,7 @@ typedef enum {
- 	WBUSTYPE_BLUETOOTH,	/**< Bluetooth tablet */
- 	WBUSTYPE_I2C,		/**< I2C tablet */
- 	WBUSTYPE_VIRTUAL,	/**< Virtual (uinput) tablet */
-+	WBUSTYPE_MEI,		/**< MEI */
+@@ -154,6 +154,7 @@ typedef enum {
+ 	WBUSTYPE_BLUETOOTH, /**< Bluetooth tablet */
+ 	WBUSTYPE_I2C,       /**< I2C tablet */
+ 	WBUSTYPE_VIRTUAL,   /**< Virtual (uinput) tablet */
++	WBUSTYPE_MEI,       /**< MEI */
  } WacomBusType;
  
  /**
 diff --git a/test/test-tablet-validity.c b/test/test-tablet-validity.c
-index 77ff1327..ad350912 100644
+index 24078f64..50b931c2 100644
 --- a/test/test-tablet-validity.c
 +++ b/test/test-tablet-validity.c
-@@ -178,6 +178,7 @@ assert_vidpid(WacomBusType bus, int vid, int pid)
- 		case WBUSTYPE_BLUETOOTH:
- 		case WBUSTYPE_I2C:
- 		case WBUSTYPE_VIRTUAL:
-+		case WBUSTYPE_MEI:
- 			g_assert_cmpint(vid, >, 0);
- 			g_assert_cmpint(pid, >, 0);
- 			break;
+@@ -181,6 +181,7 @@ assert_vidpid(WacomBusType bus,
+ 	case WBUSTYPE_BLUETOOTH:
+ 	case WBUSTYPE_I2C:
+ 	case WBUSTYPE_VIRTUAL:
++	case WBUSTYPE_MEI:
+ 		g_assert_cmpint(vid, >, 0);
+ 		g_assert_cmpint(pid, >, 0);
+ 		break;
 diff --git a/test/test_data_files.py b/test/test_data_files.py
 index ee6ffcd3..bd7d798f 100755
 --- a/test/test_data_files.py
@@ -97,17 +99,19 @@ index ee6ffcd3..bd7d798f 100755
          assert re.match("[0-9a-f]{4}", vid), (
              f"{tabletfile}: {vid} must be lowercase hex"
 diff --git a/tools/debug-device.c b/tools/debug-device.c
-index 286e9148..f5b17b56 100644
+index 43a6072d..91553316 100644
 --- a/tools/debug-device.c
 +++ b/tools/debug-device.c
-@@ -178,6 +178,7 @@ handle_device(WacomDeviceDatabase *db, const char *path)
- 			case WBUSTYPE_BLUETOOTH: busstr = "BLUETOOTH"; break;
- 			case WBUSTYPE_I2C: busstr = "I2C"; break;
- 			case WBUSTYPE_VIRTUAL: busstr = "VIRTUAL"; break;
-+			case WBUSTYPE_MEI: busstr = "MEI"; break;
+@@ -194,6 +194,9 @@ handle_device(WacomDeviceDatabase *db,
+ 		case WBUSTYPE_VIRTUAL:
+ 			busstr = "VIRTUAL";
+ 			break;
++		case WBUSTYPE_MEI:
++			busstr = "MEI";
++			break;
  		}
  		func(libwacom_get_bustype, "%s", busstr);
  	}
 -- 
-2.49.0
+2.52.0
 

--- a/packages/l/libwacom/files/surface/0003-data-Add-Microsoft-Surface-Pro-3.patch
+++ b/packages/l/libwacom/files/surface/0003-data-Add-Microsoft-Surface-Pro-3.patch
@@ -1,4 +1,4 @@
-From 761db70bf8c45f2e4d9d3a6c3f729ba02a3f896e Mon Sep 17 00:00:00 2001
+From f24a2cafee7a356b82377d7c8fffdb0931df959c Mon Sep 17 00:00:00 2001
 From: "Antony Jordan (Tablet)" <wiccan.two@gmail.com>
 Date: Wed, 8 Jun 2022 22:03:33 +0200
 Subject: [PATCH 03/16] data: Add Microsoft Surface Pro 3
@@ -29,5 +29,5 @@ index 00000000..2f535410
 +Touch=true
 +Buttons=0
 -- 
-2.49.0
+2.52.0
 

--- a/packages/l/libwacom/files/surface/0004-data-Add-Microsoft-Surface-Pro-4.patch
+++ b/packages/l/libwacom/files/surface/0004-data-Add-Microsoft-Surface-Pro-4.patch
@@ -1,4 +1,4 @@
-From 1c6924a7d9e239086d3a4241a841c9c2261c40cd Mon Sep 17 00:00:00 2001
+From 7cdbe797e2c38cb97f2e89700e6965e33c040b8b Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Tue, 18 Aug 2020 20:18:55 +0200
 Subject: [PATCH 04/16] data: Add Microsoft Surface Pro 4
@@ -29,5 +29,5 @@ index 00000000..f77f3a2b
 +Touch=true
 +Buttons=0
 -- 
-2.49.0
+2.52.0
 

--- a/packages/l/libwacom/files/surface/0005-data-Add-Microsoft-Surface-Pro-5.patch
+++ b/packages/l/libwacom/files/surface/0005-data-Add-Microsoft-Surface-Pro-5.patch
@@ -1,4 +1,4 @@
-From 0ea86d1e42bb69c20ac4526a21f581dc9c5bb7ee Mon Sep 17 00:00:00 2001
+From eff6b609d266db23e61316538016dd8f59f887ea Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Tue, 18 Aug 2020 20:19:02 +0200
 Subject: [PATCH 05/16] data: Add Microsoft Surface Pro 5
@@ -29,5 +29,5 @@ index 00000000..410a0d3f
 +Touch=true
 +Buttons=0
 -- 
-2.49.0
+2.52.0
 

--- a/packages/l/libwacom/files/surface/0006-data-Add-Microsoft-Surface-Pro-6.patch
+++ b/packages/l/libwacom/files/surface/0006-data-Add-Microsoft-Surface-Pro-6.patch
@@ -1,4 +1,4 @@
-From 6071bde57d05b256b40b1ba462458c61ef27fd60 Mon Sep 17 00:00:00 2001
+From d3bf424a70e01a4ad670d7329e2ea42c3bf1ae77 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Tue, 18 Aug 2020 20:19:07 +0200
 Subject: [PATCH 06/16] data: Add Microsoft Surface Pro 6
@@ -29,5 +29,5 @@ index 00000000..eb89df02
 +Touch=true
 +Buttons=0
 -- 
-2.49.0
+2.52.0
 

--- a/packages/l/libwacom/files/surface/0007-data-Add-Microsoft-Surface-Pro-7.patch
+++ b/packages/l/libwacom/files/surface/0007-data-Add-Microsoft-Surface-Pro-7.patch
@@ -1,4 +1,4 @@
-From 5af4100c1d91fc8b4d7addd622086e9e99b1d3fc Mon Sep 17 00:00:00 2001
+From 9a49d50070a67622a1715f210db0b5128ed6a4b0 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Tue, 18 Aug 2020 20:19:13 +0200
 Subject: [PATCH 07/16] data: Add Microsoft Surface Pro 7
@@ -29,5 +29,5 @@ index 00000000..f9601079
 +Touch=true
 +Buttons=0
 -- 
-2.49.0
+2.52.0
 

--- a/packages/l/libwacom/files/surface/0008-data-Add-Microsoft-Surface-Pro-7.patch
+++ b/packages/l/libwacom/files/surface/0008-data-Add-Microsoft-Surface-Pro-7.patch
@@ -1,4 +1,4 @@
-From 70653ee99139d138dc62922dacddb36ad141f5ed Mon Sep 17 00:00:00 2001
+From f437a692428e19f12e6acecbebb2f3b9b032f9d2 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Fri, 26 May 2023 12:32:21 +0200
 Subject: [PATCH 08/16] data: Add Microsoft Surface Pro 7+
@@ -30,5 +30,5 @@ index 00000000..5c4e540f
 +Touch=true
 +Buttons=0
 -- 
-2.49.0
+2.52.0
 

--- a/packages/l/libwacom/files/surface/0009-data-Add-Microsoft-Surface-Pro-8.patch
+++ b/packages/l/libwacom/files/surface/0009-data-Add-Microsoft-Surface-Pro-8.patch
@@ -1,4 +1,4 @@
-From cc85faa92c8f56bc133200825d45510d355703db Mon Sep 17 00:00:00 2001
+From 945a192ce9e5324528f5a0a6209ec3010ef758a6 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 11 Jun 2023 21:29:52 +0200
 Subject: [PATCH 09/16] data: Add Microsoft Surface Pro 8
@@ -30,5 +30,5 @@ index 00000000..dcfef119
 +Touch=true
 +Buttons=0
 -- 
-2.49.0
+2.52.0
 

--- a/packages/l/libwacom/files/surface/0010-data-Add-Microsoft-Surface-Pro-9.patch
+++ b/packages/l/libwacom/files/surface/0010-data-Add-Microsoft-Surface-Pro-9.patch
@@ -1,4 +1,4 @@
-From 8b29c5fd2a5a5dcc4cbaa4d6faddb4b14cf344cb Mon Sep 17 00:00:00 2001
+From 95d76814f237270815bc4d8ddbb626befb0ab9a8 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Wed, 14 Jun 2023 21:11:36 +0200
 Subject: [PATCH 10/16] data: Add Microsoft Surface Pro 9
@@ -30,5 +30,5 @@ index 00000000..ee2b3eea
 +Touch=true
 +Buttons=0
 -- 
-2.49.0
+2.52.0
 

--- a/packages/l/libwacom/files/surface/0011-data-Add-Microsoft-Surface-Book.patch
+++ b/packages/l/libwacom/files/surface/0011-data-Add-Microsoft-Surface-Book.patch
@@ -1,4 +1,4 @@
-From aaa20b65269c22181b5cbc838f3a33d4b7209516 Mon Sep 17 00:00:00 2001
+From f806de9a1225ae46863821493afef8fbc684d8e9 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Tue, 18 Aug 2020 20:19:38 +0200
 Subject: [PATCH 11/16] data: Add Microsoft Surface Book
@@ -29,5 +29,5 @@ index 00000000..6daf5b6f
 +Touch=true
 +Buttons=0
 -- 
-2.49.0
+2.52.0
 

--- a/packages/l/libwacom/files/surface/0012-data-Add-Microsoft-Surface-Book-2-13.5.patch
+++ b/packages/l/libwacom/files/surface/0012-data-Add-Microsoft-Surface-Book-2-13.5.patch
@@ -1,4 +1,4 @@
-From 76d222d2b953a3b0f8b925e7636e4ec0aa6d2e7d Mon Sep 17 00:00:00 2001
+From 23728d43bc2f7f965dc5fb9c6b9761678d35d43e Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Tue, 18 Aug 2020 20:20:04 +0200
 Subject: [PATCH 12/16] data: Add Microsoft Surface Book 2 (13.5")
@@ -29,5 +29,5 @@ index 00000000..7cf7ba35
 +Touch=true
 +Buttons=0
 -- 
-2.49.0
+2.52.0
 

--- a/packages/l/libwacom/files/surface/0013-data-Add-Microsoft-Surface-Book-2-15.patch
+++ b/packages/l/libwacom/files/surface/0013-data-Add-Microsoft-Surface-Book-2-15.patch
@@ -1,4 +1,4 @@
-From 2ab4dca4dbb95969962c4d09f471c2f6126a07b3 Mon Sep 17 00:00:00 2001
+From 6489af6e7ae2579005359f1225b25f5e54f7c8dc Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Tue, 18 Aug 2020 20:20:13 +0200
 Subject: [PATCH 13/16] data: Add Microsoft Surface Book 2 (15")
@@ -29,5 +29,5 @@ index 00000000..3266fca7
 +Touch=true
 +Buttons=0
 -- 
-2.49.0
+2.52.0
 

--- a/packages/l/libwacom/files/surface/0014-data-Add-Microsoft-Surface-Book-3-13.5.patch
+++ b/packages/l/libwacom/files/surface/0014-data-Add-Microsoft-Surface-Book-3-13.5.patch
@@ -1,4 +1,4 @@
-From 418eba79553eb7c59454197bfaffb17be0c3c18b Mon Sep 17 00:00:00 2001
+From 366587c5be1c5a1349c02a50e4b3f7cafc3c702f Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Tue, 18 Aug 2020 20:20:29 +0200
 Subject: [PATCH 14/16] data: Add Microsoft Surface Book 3 (13.5")
@@ -29,5 +29,5 @@ index 00000000..e363f330
 +Touch=true
 +Buttons=0
 -- 
-2.49.0
+2.52.0
 

--- a/packages/l/libwacom/files/surface/0015-data-Add-Microsoft-Surface-Book-3-15.patch
+++ b/packages/l/libwacom/files/surface/0015-data-Add-Microsoft-Surface-Book-3-15.patch
@@ -1,4 +1,4 @@
-From 63d35b369bac6ba2a071cb5647d24bf371416de5 Mon Sep 17 00:00:00 2001
+From d34867628f2073fbf88f68f4f4c9575f4f4cafb0 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Tue, 18 Aug 2020 20:20:42 +0200
 Subject: [PATCH 15/16] data: Add Microsoft Surface Book 3 (15")
@@ -29,5 +29,5 @@ index 00000000..4954b615
 +Touch=true
 +Buttons=0
 -- 
-2.49.0
+2.52.0
 

--- a/packages/l/libwacom/files/surface/0016-data-Add-Microsoft-Surface-Laptop-Studio.patch
+++ b/packages/l/libwacom/files/surface/0016-data-Add-Microsoft-Surface-Laptop-Studio.patch
@@ -1,4 +1,4 @@
-From a35d865d82ff2faa8ddb7964a3095a2c85dd424f Mon Sep 17 00:00:00 2001
+From 44a71fd732668fed1a13962b3058b6f80fb34d3c Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Wed, 14 Jun 2023 21:12:41 +0200
 Subject: [PATCH 16/16] data: Add Microsoft Surface Laptop Studio
@@ -30,5 +30,5 @@ index 00000000..60774030
 +Touch=true
 +Buttons=0
 -- 
-2.49.0
+2.52.0
 

--- a/packages/l/libwacom/package.yml
+++ b/packages/l/libwacom/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 # Updating this package? Check https://github.com/linux-surface/libwacom-surface to see if there are any new/updated patches
 name       : libwacom
-version    : 2.16.1
-release    : 44
+version    : 2.17.0
+release    : 45
 source     :
-    - https://github.com/linuxwacom/libwacom/releases/download/libwacom-2.16.1/libwacom-2.16.1.tar.xz : 0f9bc90babad92b2c4c6571b53af3aee065f437cce01c06c860599e1a10680aa
+    - https://github.com/linuxwacom/libwacom/releases/download/libwacom-2.17.0/libwacom-2.17.0.tar.xz : 41a0f239841567b101904df8ced81e1e0115334ccfd82a024412aa0903dae5a7
 license    : MIT
 component  : desktop.core
 homepage   : https://github.com/linuxwacom/libwacom/
@@ -29,6 +29,7 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING
 # test_new_from_path_unknown_device failing
 check      : |
     %ninja_check || :

--- a/packages/l/libwacom/pspec_x86_64.xml
+++ b/packages/l/libwacom/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libwacom</Name>
         <Homepage>https://github.com/linuxwacom/libwacom/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>desktop.core</PartOf>
@@ -59,6 +59,7 @@
             <Path fileType="data">/usr/share/libwacom/elan-4259.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/elan-425a.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/elan-425b.tablet</Path>
+            <Path fileType="data">/usr/share/libwacom/elan-42ab.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/elan-42ec.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/elan-5515.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/framework-laptop12.tablet</Path>
@@ -168,8 +169,10 @@
             <Path fileType="data">/usr/share/libwacom/huion-inspiroy-q620m.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/huion-inspiroy-wh1409-v2.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/huion-kamvas-12-gs1161.tablet</Path>
+            <Path fileType="data">/usr/share/libwacom/huion-kamvas-13-gs1333.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/huion-kamvas-13.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/huion-kamvas-16-gs1562.tablet</Path>
+            <Path fileType="data">/usr/share/libwacom/huion-kamvas-16-gs1563.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/huion-kamvas-162019.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/huion-kamvas-19.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/huion-kamvas-20-gs1901.tablet</Path>
@@ -182,7 +185,6 @@
             <Path fileType="data">/usr/share/libwacom/huion-kamvas-gt-191-v2.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/huion-kamvas-gt-191.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/huion-kamvas-gt-220-v2.tablet</Path>
-            <Path fileType="data">/usr/share/libwacom/huion-kamvas-gt-221-pro.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/huion-kamvas-pro-12-gt-116.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/huion-kamvas-pro-13-gt1302.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/huion-kamvas-pro-13.tablet</Path>
@@ -195,7 +197,6 @@
             <Path fileType="data">/usr/share/libwacom/huion-kamvas-pro-22-gt-221.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/huion-kamvas-pro-24-gt2401.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/huion-kamvas-pro-24.tablet</Path>
-            <Path fileType="data">/usr/share/libwacom/huion-kamvas-pro-studio-22.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/huion-kamvas-rds-220.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/huion-keydial-k20.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/huion-kizuna-hs952.tablet</Path>
@@ -292,12 +293,13 @@
             <Path fileType="data">/usr/share/libwacom/layouts/huion-inspiroy-q620m.svg</Path>
             <Path fileType="data">/usr/share/libwacom/layouts/huion-inspiroy-wh1409-v2.svg</Path>
             <Path fileType="data">/usr/share/libwacom/layouts/huion-kamvas-12-gs1161.svg</Path>
+            <Path fileType="data">/usr/share/libwacom/layouts/huion-kamvas-13-gs1333.svg</Path>
             <Path fileType="data">/usr/share/libwacom/layouts/huion-kamvas-13.svg</Path>
             <Path fileType="data">/usr/share/libwacom/layouts/huion-kamvas-16-gs1562.svg</Path>
+            <Path fileType="data">/usr/share/libwacom/layouts/huion-kamvas-16-gs1563.svg</Path>
             <Path fileType="data">/usr/share/libwacom/layouts/huion-kamvas-162019.svg</Path>
             <Path fileType="data">/usr/share/libwacom/layouts/huion-kamvas-gt-156-2021.svg</Path>
             <Path fileType="data">/usr/share/libwacom/layouts/huion-kamvas-gt-156hd-v2.svg</Path>
-            <Path fileType="data">/usr/share/libwacom/layouts/huion-kamvas-gt-221-pro.svg</Path>
             <Path fileType="data">/usr/share/libwacom/layouts/huion-kamvas-pro-12-gt-116.svg</Path>
             <Path fileType="data">/usr/share/libwacom/layouts/huion-kamvas-pro-13-gt1302.svg</Path>
             <Path fileType="data">/usr/share/libwacom/layouts/huion-kamvas-pro-13.svg</Path>
@@ -307,7 +309,6 @@
             <Path fileType="data">/usr/share/libwacom/layouts/huion-kamvas-pro-20-gt1901.svg</Path>
             <Path fileType="data">/usr/share/libwacom/layouts/huion-kamvas-pro-22-gt-221.svg</Path>
             <Path fileType="data">/usr/share/libwacom/layouts/huion-kamvas-pro-24.svg</Path>
-            <Path fileType="data">/usr/share/libwacom/layouts/huion-kamvas-pro-studio-22.svg</Path>
             <Path fileType="data">/usr/share/libwacom/layouts/huion-keydial-k20.svg</Path>
             <Path fileType="data">/usr/share/libwacom/layouts/huion-mini-keydial-kd100.svg</Path>
             <Path fileType="data">/usr/share/libwacom/layouts/huion-new-1060-plus.svg</Path>
@@ -825,6 +826,7 @@
             <Path fileType="data">/usr/share/libwacom/wacom-movink-13.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/wacom-one-12.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/wacom-one-13.tablet</Path>
+            <Path fileType="data">/usr/share/libwacom/wacom-one-14.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/wacom-one-by-wacom-m-p.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/wacom-one-by-wacom-m-p2.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/wacom-one-by-wacom-s-p.tablet</Path>
@@ -834,6 +836,7 @@
             <Path fileType="data">/usr/share/libwacom/wacom-one.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/wacom-volito-4x5.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/wacom.stylus</Path>
+            <Path fileType="data">/usr/share/libwacom/waltop-batteryless-tablet.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/waltop-slim-tablet-12-1.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/xp-pen-ack05-remote.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/xp-pen-artist-22r-pro.tablet</Path>
@@ -846,8 +849,8 @@
             <Path fileType="data">/usr/share/libwacom/xp-pen-deco-mini4.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/xp-pen-deco-mini7.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/xp-pen-deco-mw.tablet</Path>
+            <Path fileType="data">/usr/share/libwacom/xp-pen-deco-pro-lw-gen2.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/xp-pen-deco-pro-mw.tablet</Path>
-            <Path fileType="data">/usr/share/libwacom/xp-pen-deco-pro-s.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/xp-pen-deco-pro-sw.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/xp-pen-deco01-v2.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/xp-pen-deco01-v3.tablet</Path>
@@ -856,6 +859,7 @@
             <Path fileType="data">/usr/share/libwacom/xp-pen-g640.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/xp-pen-innovator-16.tablet</Path>
             <Path fileType="data">/usr/share/libwacom/xp-pen-star03.tablet</Path>
+            <Path fileType="data">/usr/share/licenses/libwacom/COPYING</Path>
             <Path fileType="man">/usr/share/man/man1/libwacom-list-devices.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/libwacom-list-local-devices.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/libwacom-show-stylus.1.zst</Path>
@@ -868,7 +872,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="44">libwacom</Dependency>
+            <Dependency release="45">libwacom</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libwacom-1.0/libwacom/libwacom.h</Path>
@@ -877,12 +881,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="44">
-            <Date>2025-10-24</Date>
-            <Version>2.16.1</Version>
+        <Update release="45">
+            <Date>2026-01-07</Date>
+            <Version>2.17.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/linuxwacom/libwacom/releases/tag/libwacom-2.17.0).
- Updated surface patches

**Test Plan**

Not sure how to test. Verified license install. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
