### PR TITLE
upx: Update to v5.1.0

### DIFF
--- a/packages/u/upx/abi_used_symbols
+++ b/packages/u/upx/abi_used_symbols
@@ -63,7 +63,6 @@ libc.so.6:strchr
 libc.so.6:strcmp
 libc.so.6:strcpy
 libc.so.6:strcspn
-libc.so.6:strdup
 libc.so.6:strerror
 libc.so.6:strftime
 libc.so.6:strlen
@@ -136,7 +135,6 @@ libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T
 libstdc++.so.6:_ZSt16__throw_bad_castv
 libstdc++.so.6:_ZSt17__throw_bad_allocv
 libstdc++.so.6:_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
-libstdc++.so.6:_ZSt18_Rb_tree_incrementPKSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base
 libstdc++.so.6:_ZSt19__throw_logic_errorPKc
 libstdc++.so.6:_ZSt19uncaught_exceptionsv
@@ -179,7 +177,6 @@ libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
 libstdc++.so.6:__cxa_allocate_exception
 libstdc++.so.6:__cxa_begin_catch
-libstdc++.so.6:__cxa_call_terminate
 libstdc++.so.6:__cxa_end_catch
 libstdc++.so.6:__cxa_guard_acquire
 libstdc++.so.6:__cxa_guard_release

--- a/packages/u/upx/package.yml
+++ b/packages/u/upx/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : upx
-version    : 5.0.0
-release    : 9
+version    : 5.1.0
+release    : 10
 source     :
-    - https://github.com/upx/upx/releases/download/v5.0.0/upx-5.0.0-src.tar.xz : e0eb96f9c50aefdb02eca445f8ed76aca5cd70b6b132bf61bea3ba4b8ebb64cc
+    - https://github.com/upx/upx/releases/download/v5.1.0/upx-5.1.0-src.tar.xz : 9f7a810b8a810b1ca2c5cb01ffcf23066e3fb8a51ddc406ea05bdd5d37d0b8bd
 homepage   : https://upx.github.io/
 license    : GPL-2.0-or-later
 component  : system.utils
@@ -15,3 +15,4 @@ build      : |
 install    : |
     install -Dm0755 build/release/upx $installdir/usr/bin/upx
     install -Dm0644 doc/upx.1 $installdir/usr/share/man/man1/upx.1
+    %install_license LICENSE COPYING

--- a/packages/u/upx/pspec_x86_64.xml
+++ b/packages/u/upx/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>upx</Name>
         <Homepage>https://upx.github.io/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Mislav &#x10c;akari&#x107;</Name>
+            <Email>mcakaric@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -21,16 +21,18 @@
         <PartOf>system.utils</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/upx</Path>
-            <Path fileType="man">/usr/share/man/man1/upx.1</Path>
+            <Path fileType="data">/usr/share/licenses/upx/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/upx/LICENSE</Path>
+            <Path fileType="man">/usr/share/man/man1/upx.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2025-04-11</Date>
-            <Version>5.0.0</Version>
+        <Update release="10">
+            <Date>2026-01-08</Date>
+            <Version>5.1.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Mislav &#x10c;akari&#x107;</Name>
+            <Email>mcakaric@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Release notes can be found [here](https://github.com/upx/upx/blob/v5.1.0/NEWS).

**Test Plan**
* test compressing one of the system binaries, for example:
  ` upx --ultra-brute /usr/bin/bash -o bash -f `
* compare size difference
* test compressed version of binary

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
