### PR TITLE
scala: Update to v2.13.18

### DIFF
--- a/packages/s/scala/files/java-shim.sh
+++ b/packages/s/scala/files/java-shim.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 if [ -z "$JAVA_HOME" ]; then
-    export JAVA_HOME=/usr/lib64/openjdk-11
+    export JAVA_HOME=/usr/lib64/openjdk-21
 fi
 

--- a/packages/s/scala/package.yml
+++ b/packages/s/scala/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : scala
-version    : 2.13.6
-release    : 9
+version    : 2.13.18
+release    : 10
 source     :
-    - https://github.com/scala/scala/archive/refs/tags/v2.13.6.tar.gz : 728c51ef68e47f76f955c51e5aae25d5546966193fa722d27c5259c9558d80bb
+    - https://github.com/scala/scala/archive/refs/tags/v2.13.18.tar.gz : 7eb4e84b20967e49540c288214816f826314bae6c44ec81800b0426a885cd438
 license    : BSD-3-Clause
 component  : programming
 homepage   : https://www.scala-lang.org/
@@ -12,10 +12,10 @@ description: |
     Scala combines object-oriented and functional programming in one concise, high-level language. Scala's static types help avoid bugs in complex applications, and its JVM and JavaScript runtimes let you build high-performance systems with easy access to huge ecosystems of libraries.
 builddeps  :
     - git
-    - openjdk-11-devel
+    - openjdk-21-devel
     - sbt
 rundeps    :
-    - openjdk-11
+    - openjdk-21
 networking : true
 build      : |
     export SBT_OPTS="-Xmx4G"
@@ -26,6 +26,7 @@ build      : |
         -Duser.home=$workdir/.java \
         enableOptimizer package dist/mkPack
 install    : |
+    %install_license LICENSE
     cd build
 
     install -dm00755 $installdir/usr/share/scala

--- a/packages/s/scala/pspec_x86_64.xml
+++ b/packages/s/scala/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>scala</Name>
         <Homepage>https://www.scala-lang.org/</Homepage>
         <Packager>
-            <Name>Campbell Jones</Name>
-            <Email>dev@serebit.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Scala Language Toolchain</Summary>
         <Description xml:lang="en">Scala combines object-oriented and functional programming in one concise, high-level language. Scala&apos;s static types help avoid bugs in complex applications, and its JVM and JavaScript runtimes let you build high-performance systems with easy access to huge ecosystems of libraries.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>scala</Name>
@@ -25,18 +25,18 @@
             <Path fileType="executable">/usr/bin/scalac</Path>
             <Path fileType="executable">/usr/bin/scaladoc</Path>
             <Path fileType="executable">/usr/bin/scalap</Path>
-            <Path fileType="man">/usr/share/man/man1/fsc.1</Path>
-            <Path fileType="man">/usr/share/man/man1/scala.1</Path>
-            <Path fileType="man">/usr/share/man/man1/scalac.1</Path>
-            <Path fileType="man">/usr/share/man/man1/scaladoc.1</Path>
-            <Path fileType="man">/usr/share/man/man1/scalap.1</Path>
+            <Path fileType="data">/usr/share/licenses/scala/LICENSE</Path>
+            <Path fileType="man">/usr/share/man/man1/fsc.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/scala.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/scalac.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/scaladoc.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/scalap.1.zst</Path>
             <Path fileType="data">/usr/share/scala/bin/fsc</Path>
             <Path fileType="data">/usr/share/scala/bin/scala</Path>
             <Path fileType="data">/usr/share/scala/bin/scalac</Path>
             <Path fileType="data">/usr/share/scala/bin/scaladoc</Path>
             <Path fileType="data">/usr/share/scala/bin/scalap</Path>
             <Path fileType="data">/usr/share/scala/lib/jline.jar</Path>
-            <Path fileType="data">/usr/share/scala/lib/jna.jar</Path>
             <Path fileType="data">/usr/share/scala/lib/repl.jar</Path>
             <Path fileType="data">/usr/share/scala/lib/scala-compiler-doc.jar</Path>
             <Path fileType="data">/usr/share/scala/lib/scala-compiler-interactive.jar</Path>
@@ -45,17 +45,19 @@
             <Path fileType="data">/usr/share/scala/lib/scala-partest.jar</Path>
             <Path fileType="data">/usr/share/scala/lib/scala-reflect.jar</Path>
             <Path fileType="data">/usr/share/scala/lib/scala-repl-frontend.jar</Path>
+            <Path fileType="data">/usr/share/scala/lib/scala-tastytest.jar</Path>
             <Path fileType="data">/usr/share/scala/lib/scala-testkit.jar</Path>
+            <Path fileType="data">/usr/share/scala/lib/scala2-sbt-bridge.jar</Path>
             <Path fileType="data">/usr/share/scala/lib/scalap.jar</Path>
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2021-06-13</Date>
-            <Version>2.13.6</Version>
+        <Update release="10">
+            <Date>2026-01-08</Date>
+            <Version>2.13.18</Version>
             <Comment>Packaging update</Comment>
-            <Name>Campbell Jones</Name>
-            <Email>dev@serebit.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/scala/scala/releases/tag/v2.13.18).
- Part of https://github.com/getsolus/packages/issues/146

**Test Plan**
- Ran scala prompt. 
- Compiled code
- Checked it used the correct Java version.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
