### PR TITLE
apache-ant: Update to v1.10.15

### DIFF
--- a/packages/a/apache-ant/files/java-shim.txt
+++ b/packages/a/apache-ant/files/java-shim.txt
@@ -1,4 +1,4 @@
 if [ -z "$JAVA_HOME" ]; then
-    export JAVA_HOME=/usr/lib64/openjdk-11
+    export JAVA_HOME=/usr/lib64/openjdk-21
 fi
 

--- a/packages/a/apache-ant/package.yml
+++ b/packages/a/apache-ant/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : apache-ant
-version    : 1.10.14
-release    : 12
+version    : 1.10.15
+release    : 13
 source     :
-    - https://github.com/apache/ant/archive/refs/tags/rel/1.10.14.tar.gz : 0ee4e21cc383accd5efa436f31b8478358e0d5e8a777ebfd00703a6d32cf09eb
+    - https://github.com/apache/ant/archive/refs/tags/rel/1.10.15.tar.gz : ec9db6ab5d812b803ec82421f7e95527657def3bbc52f9f2da6e0cf22345db85
 license    : Apache-2.0
 component  : programming.java
 homepage   : https://ant.apache.org/
@@ -11,15 +11,18 @@ summary    : A software tool for automating software build processes
 description: |
     Apache Ant is a Java library and command-line tool whose mission is to drive processes described in build files as targets and extension points dependent upon each other.
 builddeps  :
-    - openjdk-11
+    - openjdk-21
 rundeps    :
-    - openjdk-11
+    - openjdk-21
 build      : |
-    export JAVA_HOME=/usr/lib64/openjdk-11
+    export JAVA_HOME=/usr/lib64/openjdk-21
     ./build.sh -Dant.install=$installdir/usr install-lite
 install    : |
     find $installdir/usr/bin \( -name '*.cmd' -o -name '*.bat' \) -delete
     mv $installdir/usr/lib $installdir/usr/lib64
 
-    cd $installdir/usr/bin
+    pushd $installdir/usr/bin
     find . -type f \! -name "*.*" -exec sed --debug -i "2r $pkgfiles/java-shim.txt" {} \;
+    popd 
+
+    %install_license LICENSE

--- a/packages/a/apache-ant/pspec_x86_64.xml
+++ b/packages/a/apache-ant/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>apache-ant</Name>
         <Homepage>https://ant.apache.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.java</PartOf>
@@ -52,15 +52,16 @@
             <Path fileType="library">/usr/lib64/ant-testutil.jar</Path>
             <Path fileType="library">/usr/lib64/ant-xz.jar</Path>
             <Path fileType="library">/usr/lib64/ant.jar</Path>
+            <Path fileType="data">/usr/share/licenses/apache-ant/LICENSE</Path>
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2023-10-22</Date>
-            <Version>1.10.14</Version>
+        <Update release="13">
+            <Date>2026-01-08</Date>
+            <Version>1.10.15</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Ant 1.10.15 is a regular bug fix release and can be used with Java runtime version 8 and higher, including the current latest version Java 22.
- Part of https://github.com/getsolus/packages/issues/146

**Test Plan**
- Built josm.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
