### PR TITLE
libtasn1: Update to v4.21.0

### DIFF
--- a/packages/l/libtasn1/abi_used_symbols
+++ b/packages/l/libtasn1/abi_used_symbols
@@ -13,14 +13,11 @@ libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__stpcpy_chk
 libc.so.6:__strcpy_chk
-libc.so.6:abort
 libc.so.6:alarm
 libc.so.6:calloc
 libc.so.6:clock_gettime
-libc.so.6:close
 libc.so.6:exit
 libc.so.6:fclose
-libc.so.6:fdopen
 libc.so.6:ferror
 libc.so.6:fgetc
 libc.so.6:fileno
@@ -38,7 +35,6 @@ libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset
-libc.so.6:open
 libc.so.6:optarg
 libc.so.6:opterr
 libc.so.6:optind
@@ -61,7 +57,6 @@ libc.so.6:strcpy
 libc.so.6:strdup
 libc.so.6:strlen
 libc.so.6:strncat
-libc.so.6:strncmp
 libc.so.6:strrchr
 libc.so.6:strverscmp
 libc.so.6:ungetc

--- a/packages/l/libtasn1/package.yml
+++ b/packages/l/libtasn1/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libtasn1
-version    : 4.20.0
-release    : 20
+version    : 4.21.0
+release    : 21
 source     :
-    - https://ftpmirror.gnu.org/gnu/libtasn1/libtasn1-4.20.0.tar.gz : 92e0e3bd4c02d4aeee76036b2ddd83f0c732ba4cda5cb71d583272b23587a76c
+    - https://ftpmirror.gnu.org/gnu/libtasn1/libtasn1-4.21.0.tar.gz : 1d8a444a223cc5464240777346e125de51d8e6abf0b8bac742ac84609167dc87
 homepage   : https://www.gnu.org/software/libtasn1/
 license    :
     - GPL-3.0-or-later
@@ -25,6 +25,7 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING COPYING.*
     %make -C doc/reference install-data-local DESTDIR="$installdir"
 check      : |
     %make check

--- a/packages/l/libtasn1/pspec_x86_64.xml
+++ b/packages/l/libtasn1/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libtasn1</Name>
         <Homepage>https://www.gnu.org/software/libtasn1/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -22,8 +22,10 @@
         <PartOf>security.crypto</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libtasn1.so.6</Path>
-            <Path fileType="library">/usr/lib64/libtasn1.so.6.6.4</Path>
+            <Path fileType="library">/usr/lib64/libtasn1.so.6.6.5</Path>
             <Path fileType="info">/usr/share/info/libtasn1.info.zst</Path>
+            <Path fileType="data">/usr/share/licenses/libtasn1/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/libtasn1/COPYING.LESSERv2</Path>
         </Files>
     </Package>
     <Package>
@@ -33,11 +35,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="20">libtasn1</Dependency>
+            <Dependency release="21">libtasn1</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libtasn1.so.6</Path>
-            <Path fileType="library">/usr/lib32/libtasn1.so.6.6.4</Path>
+            <Path fileType="library">/usr/lib32/libtasn1.so.6.6.5</Path>
         </Files>
     </Package>
     <Package>
@@ -47,8 +49,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="20">libtasn1-32bit</Dependency>
-            <Dependency release="20">libtasn1-devel</Dependency>
+            <Dependency release="21">libtasn1-32bit</Dependency>
+            <Dependency release="21">libtasn1-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libtasn1.so</Path>
@@ -62,7 +64,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="20">libtasn1</Dependency>
+            <Dependency release="21">libtasn1</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libtasn1.h</Path>
@@ -141,7 +143,7 @@
 </Description>
         <PartOf>security.crypto</PartOf>
         <RuntimeDependencies>
-            <Dependency release="20">libtasn1</Dependency>
+            <Dependency release="21">libtasn1</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/asn1Coding</Path>
@@ -153,12 +155,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2025-10-30</Date>
-            <Version>4.20.0</Version>
+        <Update release="21">
+            <Date>2026-01-08</Date>
+            <Version>4.21.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://codeberg.org/libtasn1/libtasn1/src/tag/v4.21.0/NEWS.md).

**Security**
- CVE-2025-13151

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build swtmp against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
