### PR TITLE
chatty: Update to v0.28

### DIFF
--- a/packages/c/chatty/files/chatty.sh
+++ b/packages/c/chatty/files/chatty.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ -z "$JAVA_HOME" ]; then
-    export JAVA_HOME=/usr/lib64/openjdk-17
+    export JAVA_HOME=/usr/lib64/openjdk-21
 fi
 
 exec $JAVA_HOME/bin/java -jar /usr/share/chatty/Chatty.jar "$@"

--- a/packages/c/chatty/package.yml
+++ b/packages/c/chatty/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : chatty
-version    : '0.27'
-release    : 33
+version    : '0.28'
+release    : 34
 source     :
-    - https://github.com/chatty/chatty/archive/refs/tags/v0.27.tar.gz : ac45c594a4229b05765735f75fa4221952f35576cb7f339db58b31b2258de3d7
+    - https://github.com/chatty/chatty/archive/refs/tags/v0.28.tar.gz : 55d635475e877e261f30bcd6cd4c94c95aa51de9a572b69669ce7a91552ffa33
 homepage   : https://chatty.github.io/
 license    :
     - GPL-3.0-or-later
@@ -15,12 +15,12 @@ description: |
 networking : true
 builddeps  :
     - gradle
-    - openjdk-17
+    - openjdk-21
     - unzip
 rundeps    :
-    - openjdk-17
+    - openjdk-21
 environment: |
-    JAVA_HOME=/usr/lib64/openjdk-17
+    JAVA_HOME=/usr/lib64/openjdk-21
     PATH=$JAVA_HOME/bin:$PATH
 setup      : |
     %apply_patches
@@ -31,9 +31,6 @@ install    : |
     # Unzip to destination
     mkdir -p $installdir/usr/share/chatty
     unzip $workdir/build/releases/Chatty_$version.zip -d $installdir/usr/share/chatty/
-
-    # Remove unneeded files
-    rm $installdir/usr/share/chatty/{LICENSE,readme.txt}
 
     # Install to $PATH
     install -Dm00755 $pkgfiles/chatty.sh  $installdir/usr/bin/chatty

--- a/packages/c/chatty/pspec_x86_64.xml
+++ b/packages/c/chatty/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>chatty</Name>
         <Homepage>https://chatty.github.io/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <License>MIT</License>
@@ -24,11 +24,13 @@
             <Path fileType="executable">/usr/bin/chatty</Path>
             <Path fileType="data">/usr/share/applications/io.github.chatty.desktop</Path>
             <Path fileType="data">/usr/share/chatty/Chatty.jar</Path>
+            <Path fileType="data">/usr/share/chatty/LICENSE</Path>
             <Path fileType="data">/usr/share/chatty/img/chatty.png</Path>
             <Path fileType="data">/usr/share/chatty/img/chatty_new_1.png</Path>
             <Path fileType="data">/usr/share/chatty/img/chatty_new_2.png</Path>
             <Path fileType="data">/usr/share/chatty/img/chatty_new_4.png</Path>
             <Path fileType="data">/usr/share/chatty/img/star.png</Path>
+            <Path fileType="data">/usr/share/chatty/readme.txt</Path>
             <Path fileType="data">/usr/share/chatty/sounds/ding.wav</Path>
             <Path fileType="data">/usr/share/chatty/sounds/dingdong.wav</Path>
             <Path fileType="data">/usr/share/chatty/sounds/typing.wav</Path>
@@ -39,12 +41,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2025-05-11</Date>
-            <Version>0.27</Version>
+        <Update release="34">
+            <Date>2026-01-09</Date>
+            <Version>0.28</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/chatty/chatty/releases/tag/v0.28).

**Test Plan**
- Ran the first time setup.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
