### PR TITLE
ed: Update to v1.22.4

### DIFF
--- a/packages/e/ed/package.yml
+++ b/packages/e/ed/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : ed
-version    : 1.22.3
-release    : 13
+version    : 1.22.4
+release    : 14
 source     :
-    - https://ftpmirror.gnu.org/gnu/ed/ed-1.22.3.tar.lz : 47a55ddfc52d4a1ff6f7559fbd00cf948a16b6cf151ec520392761aeae4e97be
+    - https://ftpmirror.gnu.org/gnu/ed/ed-1.22.4.tar.lz : 987a1ebbbad3fcf63a1ffa9e29b3fa7de065150d16319d0a49dd8b57f81d3e9c
 homepage   : https://www.gnu.org/software/ed/
 license    : GPL-2.0-or-later
 component  : editor

--- a/packages/e/ed/pspec_x86_64.xml
+++ b/packages/e/ed/pspec_x86_64.xml
@@ -29,9 +29,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2025-12-17</Date>
-            <Version>1.22.3</Version>
+        <Update release="14">
+            <Date>2026-01-09</Date>
+            <Version>1.22.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://lists.gnu.org/archive/html/bug-ed/2026-01/msg00000.html).

**Test Plan**

edit line with ed. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
