### PR TITLE
eopkg: Update to v4.4.1

### DIFF
--- a/packages/e/eopkg/package.yml
+++ b/packages/e/eopkg/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : eopkg
-version    : 4.4.0
-release    : 33
+version    : 4.4.1
+release    : 34
 source     :
-    - https://github.com/getsolus/eopkg/archive/refs/tags/v4.4.0.tar.gz : d96c9b34f1a4d0ba263e3607496f441c3644bc345e8c988c2d552a80a8b112ca
+    - https://github.com/getsolus/eopkg/archive/refs/tags/v4.4.1.tar.gz : 945b2a12971dcec45a049b004e30187b1d362aee4f37b7559f0f57831e6483a8
     - git|https://github.com/getsolus/PackageKit.git : 9b0f17c1ba6addc1c85bff34b64efad6a905ca50
 homepage   : https://github.com/getsolus/eopkg
 license    : GPL-2.0-or-later

--- a/packages/e/eopkg/pspec_x86_64.xml
+++ b/packages/e/eopkg/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>eopkg</Name>
         <Homepage>https://github.com/getsolus/eopkg</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Hans Kelson</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -463,12 +463,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2025-12-30</Date>
-            <Version>4.4.0</Version>
+        <Update release="34">
+            <Date>2026-01-09</Date>
+            <Version>4.4.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Hans Kelson</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Release notes can be found [here](https://github.com/getsolus/eopkg/releases/tag/v4.4.1)

**Test Plan**
- Build and install `eopkg` from this PR.
- Ensure that `uneopkg` actually works

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
