### PR TITLE
bisq: update to 1.9.22

### DIFF
--- a/packages/b/bisq/files/network.bisq.Bisq.appdata.xml
+++ b/packages/b/bisq/files/network.bisq.Bisq.appdata.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+    <id>network.bisq.Bisq</id>
+    <launchable type="desktop-id">network.bisq.Bisq.desktop</launchable>
+
+    <name>Bisq</name>
+    <developer_name>Bisq</developer_name>
+    <summary>A decentralized bitcoin exchange network</summary>
+
+    <metadata_license>CC0-1.0</metadata_license>
+    <project_license>AGPL-3.0-only</project_license>
+    <content_rating type="oars-1.1">
+        <content_attribute id="money-purchasing">intense</content_attribute>
+    </content_rating>
+
+    <description>
+        <p>**NOTE: This release is not verified by, affiliated with, or supported by Bisq Network.**</p>
+        <p>Buy and sell bitcoin for fiat (or other cryptocurrencies) privately and securely using Bisq's peer-to-peer network 
+            and open-source desktop software. No registration required.</p>
+    </description>
+
+    <launchable type="desktop-id">network.bisq.Bisq.desktop</launchable>
+    <screenshots>
+        <screenshot type="default">
+            <image>https://github.com/bisq-network/bisq-website/raw/master/images/screens/bisq_hero_light.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://github.com/bisq-network/bisq-website/raw/master/images/screens/step3_light.png</image>
+        </screenshot>
+    </screenshots>
+
+    <url type="homepage">https://bisq.network/</url>
+    <releases>
+        <release version="1.9.22" date="2025-12-23">
+            <description></description>
+        </release>
+        <release version="1.9.21" date="2025-06-27">
+            <description/>
+        </release>
+        <release version="1.9.20" date="2025-06-25">
+            <description/>
+        </release>
+        <release version="1.9.19" date="2025-02-04">
+            <description/>
+        </release>
+        <release version="1.9.18" date="2024-11-22">
+            <description/>
+        </release>
+        <release version="1.9.17" date="2024-06-27">
+            <description/>
+        </release>
+        <release version="1.9.16" date="2024-06-23">
+            <description/>
+        </release>
+        <release version="1.9.15" date="2024-04-25"/>
+        <release version="1.9.14" date="2023-10-11"/>
+        <release version="1.9.13" date="2023-09-19"/>
+        <release version="1.9.12" date="2023-07-02"/>
+        <release version="1.9.11" date="2023-06-30"/>
+        <release version="1.9.10" date="2023-04-12"/>
+        <release version="1.9.9" date="2023-01-07"/>
+        <release version="1.9.8" date="2022-12-22"/>
+        <release version="1.9.7" date="2022-12-21"/>
+        <release version="1.9.6" date="2022-10-31"/>
+        <release version="1.9.5" date="2022-08-24"/>
+        <release version="1.9.4" date="2022-07-06"/>
+        <release version="1.9.3" date="2022-07-02"/>
+        <release version="1.9.2" date="2022-06-22"/>
+        <release version="1.9.1" date="2022-05-06"/>
+        <release version="1.9.0" date="2022-04-30"/>
+        <release version="1.8.4" date="2022-03-08"/>
+        <release version="1.8.3" date="2022-03-05"/>
+        <release version="1.8.2" date="2022-01-24"/>
+        <release version="1.8.1" date="2022-01-22"/>
+        <release version="1.8.0" date="2022-01-07"/>
+        <release version="1.7.5" date="2021-10-27"/>
+    </releases>
+</component>

--- a/packages/b/bisq/package.yml
+++ b/packages/b/bisq/package.yml
@@ -1,10 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : bisq
-version    : 1.9.19
-release    : 7
+version    : 1.9.22
+release    : 8
 source     :
-    - https://github.com/bisq-network/bisq/archive/refs/tags/v1.9.19.tar.gz : 73c960c25bb40f7e42256544279f44b7b526895f493c13c7fdd6b593048912d1
-    - https://raw.githubusercontent.com/flathub/network.bisq.Bisq/be42d8b5292f38fc9daf6f2c8a6cb59da63d2d9a/network.bisq.Bisq.appdata.xml : 0f0d67109c19e885f464566cbadd5aea9ed81c047484146dac9bac6672aa6301
+    - https://github.com/bisq-network/bisq/archive/refs/tags/v1.9.22.tar.gz : 0a7dbf8e01f7ce293a6b9d580f507c03b093bf7c062e8bd3a1b93334bf76b002
 homepage   : https://bisq.network/
 license    : AGPL-3.0-or-later
 component  : network.web
@@ -29,7 +28,7 @@ build      : |
     ./gradlew --no-daemon build -x test
 install    : |
     # Install all build folder
-    install -dm00644 $installdir/usr/share/bisq/{desktop,cli,daemon,apitest,seednode,statsnode}/
+    install -dm00755 $installdir/usr/share/bisq/{desktop,cli,daemon,apitest,seednode,statsnode}/
     cp -R desktop/build/app/* $installdir/usr/share/bisq/desktop/
     cp -R cli/build/app/* $installdir/usr/share/bisq/cli/
     cp -R daemon/build/app/* $installdir/usr/share/bisq/daemon/
@@ -37,26 +36,20 @@ install    : |
     cp -R seednode/build/app/* $installdir/usr/share/bisq/seednode/
     cp -R statsnode/build/app/* $installdir/usr/share/bisq/statsnode/
 
-    # Make symlink to binary
-    ln -sv /usr/share/bisq/desktop/bin/desktop $installdir/usr/share/bisq/bisq-desktop
-    ln -sv /usr/share/bisq/cli/bin/cli $installdir/usr/share/bisq/bisq-cli
-    ln -sv /usr/share/bisq/daemon/bin/daemon $installdir/usr/share/bisq/bisq-daemon
-    ln -sv /usr/share/bisq/apitest/bin/apitest $installdir/usr/share/bisq/bisq-apitest
-    ln -sv /usr/share/bisq/seednode/bin/seednode $installdir/usr/share/bisq/bisq-seednode
-    ln -sv /usr/share/bisq/statsnode/bin/statsnode $installdir/usr/share/bisq/bisq-statsnode
-
-    # Install all symlink to /usr/bin/
+    # Install wrapper scripts to /usr/bin/
     install -dm00755 $installdir/usr/bin/
-    pushd $installdir/usr/share/bisq/
-    for FILE in bisq-*; do
-        cp $pkgfiles/java-shim.sh $installdir/usr/bin/$FILE
-        echo "/usr/share/bisq/$FILE \"\$@\"" >> $installdir/usr/bin/$FILE
-        chmod +x $installdir/usr/bin/$FILE
+
+    # Create wrapper scripts that call the actual binaries directly
+    for app in desktop cli daemon apitest seednode statsnode; do
+        cp $pkgfiles/java-shim.sh $installdir/usr/bin/bisq-$app
+        echo "/usr/share/bisq/$app/bin/bisq-$app \"\$@\"" >> $installdir/usr/bin/bisq-$app
+        chmod +x $installdir/usr/bin/bisq-$app
     done
-    popd
 
     # Install icon, desktop file and appdata
     install -Dm00644 desktop/package/linux/icon.png $installdir/usr/share/pixmaps/network.bisq.Bisq.png
     install -Dm00644 Bisq1_icon.svg $installdir/usr/share/icons/hicolor/scalable/apps/network.bisq.Bisq.svg
     install -Dm00644 $pkgfiles/network.bisq.Bisq.desktop -t $installdir/usr/share/applications
-    install -Dm00644 $sources/network.bisq.Bisq.appdata.xml -t $installdir/usr/share/metainfo
+    install -Dm00644 $pkgfiles/network.bisq.Bisq.appdata.xml -t $installdir/usr/share/metainfo
+
+    %install_license LICENSE

--- a/packages/b/bisq/pspec_x86_64.xml
+++ b/packages/b/bisq/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>bisq</Name>
         <Homepage>https://bisq.network/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>AGPL-3.0-or-later</License>
         <PartOf>network.web</PartOf>
@@ -38,7 +38,7 @@
             <Path fileType="data">/usr/share/bisq/apitest/lib/bcpg-jdk15on-1.63.jar</Path>
             <Path fileType="data">/usr/share/bisq/apitest/lib/bcprov-jdk15on-1.63.jar</Path>
             <Path fileType="data">/usr/share/bisq/apitest/lib/bcprov-jdk15to18-1.63.jar</Path>
-            <Path fileType="data">/usr/share/bisq/apitest/lib/bitcoinj-b005953e5eec339a82daf4866f85518091f6b9f6.jar</Path>
+            <Path fileType="data">/usr/share/bisq/apitest/lib/bitcoinj-7dc0851a807857ba19f76824e48d75ab0390eca7.jar</Path>
             <Path fileType="data">/usr/share/bisq/apitest/lib/checker-qual-3.8.0.jar</Path>
             <Path fileType="data">/usr/share/bisq/apitest/lib/cli.jar</Path>
             <Path fileType="data">/usr/share/bisq/apitest/lib/common.jar</Path>
@@ -163,12 +163,6 @@
             <Path fileType="data">/usr/share/bisq/apitest/lib/tor.native-2b459dc.jar</Path>
             <Path fileType="data">/usr/share/bisq/apitest/lib/videoinput-0.200-1.5.9.jar</Path>
             <Path fileType="data">/usr/share/bisq/apitest/lib/xz-1.6.jar</Path>
-            <Path fileType="data">/usr/share/bisq/bisq-apitest</Path>
-            <Path fileType="data">/usr/share/bisq/bisq-cli</Path>
-            <Path fileType="data">/usr/share/bisq/bisq-daemon</Path>
-            <Path fileType="data">/usr/share/bisq/bisq-desktop</Path>
-            <Path fileType="data">/usr/share/bisq/bisq-seednode</Path>
-            <Path fileType="data">/usr/share/bisq/bisq-statsnode</Path>
             <Path fileType="data">/usr/share/bisq/cli/bin/bisq-cli</Path>
             <Path fileType="data">/usr/share/bisq/cli/bin/bisq-cli.bat</Path>
             <Path fileType="data">/usr/share/bisq/cli/lib/annotations-4.1.1.4.jar</Path>
@@ -205,7 +199,7 @@
             <Path fileType="data">/usr/share/bisq/daemon/lib/bcpg-jdk15on-1.63.jar</Path>
             <Path fileType="data">/usr/share/bisq/daemon/lib/bcprov-jdk15on-1.63.jar</Path>
             <Path fileType="data">/usr/share/bisq/daemon/lib/bcprov-jdk15to18-1.63.jar</Path>
-            <Path fileType="data">/usr/share/bisq/daemon/lib/bitcoinj-b005953e5eec339a82daf4866f85518091f6b9f6.jar</Path>
+            <Path fileType="data">/usr/share/bisq/daemon/lib/bitcoinj-7dc0851a807857ba19f76824e48d75ab0390eca7.jar</Path>
             <Path fileType="data">/usr/share/bisq/daemon/lib/checker-qual-3.8.0.jar</Path>
             <Path fileType="data">/usr/share/bisq/daemon/lib/common.jar</Path>
             <Path fileType="data">/usr/share/bisq/daemon/lib/commons-codec-1.13.jar</Path>
@@ -277,7 +271,7 @@
             <Path fileType="data">/usr/share/bisq/desktop/lib/bcpg-jdk15on-1.63.jar</Path>
             <Path fileType="data">/usr/share/bisq/desktop/lib/bcprov-jdk15on-1.63.jar</Path>
             <Path fileType="data">/usr/share/bisq/desktop/lib/bcprov-jdk15to18-1.63.jar</Path>
-            <Path fileType="data">/usr/share/bisq/desktop/lib/bitcoinj-b005953e5eec339a82daf4866f85518091f6b9f6.jar</Path>
+            <Path fileType="data">/usr/share/bisq/desktop/lib/bitcoinj-7dc0851a807857ba19f76824e48d75ab0390eca7.jar</Path>
             <Path fileType="data">/usr/share/bisq/desktop/lib/checker-qual-3.8.0.jar</Path>
             <Path fileType="data">/usr/share/bisq/desktop/lib/common.jar</Path>
             <Path fileType="data">/usr/share/bisq/desktop/lib/commons-codec-1.13.jar</Path>
@@ -381,7 +375,7 @@
             <Path fileType="data">/usr/share/bisq/seednode/lib/bcpg-jdk15on-1.63.jar</Path>
             <Path fileType="data">/usr/share/bisq/seednode/lib/bcprov-jdk15on-1.63.jar</Path>
             <Path fileType="data">/usr/share/bisq/seednode/lib/bcprov-jdk15to18-1.63.jar</Path>
-            <Path fileType="data">/usr/share/bisq/seednode/lib/bitcoinj-b005953e5eec339a82daf4866f85518091f6b9f6.jar</Path>
+            <Path fileType="data">/usr/share/bisq/seednode/lib/bitcoinj-7dc0851a807857ba19f76824e48d75ab0390eca7.jar</Path>
             <Path fileType="data">/usr/share/bisq/seednode/lib/checker-qual-3.8.0.jar</Path>
             <Path fileType="data">/usr/share/bisq/seednode/lib/common.jar</Path>
             <Path fileType="data">/usr/share/bisq/seednode/lib/commons-codec-1.13.jar</Path>
@@ -452,7 +446,7 @@
             <Path fileType="data">/usr/share/bisq/statsnode/lib/bcpg-jdk15on-1.63.jar</Path>
             <Path fileType="data">/usr/share/bisq/statsnode/lib/bcprov-jdk15on-1.63.jar</Path>
             <Path fileType="data">/usr/share/bisq/statsnode/lib/bcprov-jdk15to18-1.63.jar</Path>
-            <Path fileType="data">/usr/share/bisq/statsnode/lib/bitcoinj-b005953e5eec339a82daf4866f85518091f6b9f6.jar</Path>
+            <Path fileType="data">/usr/share/bisq/statsnode/lib/bitcoinj-7dc0851a807857ba19f76824e48d75ab0390eca7.jar</Path>
             <Path fileType="data">/usr/share/bisq/statsnode/lib/checker-qual-3.8.0.jar</Path>
             <Path fileType="data">/usr/share/bisq/statsnode/lib/common.jar</Path>
             <Path fileType="data">/usr/share/bisq/statsnode/lib/commons-codec-1.13.jar</Path>
@@ -515,17 +509,18 @@
             <Path fileType="data">/usr/share/bisq/statsnode/lib/tor.native-2b459dc.jar</Path>
             <Path fileType="data">/usr/share/bisq/statsnode/lib/xz-1.6.jar</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/network.bisq.Bisq.svg</Path>
+            <Path fileType="data">/usr/share/licenses/bisq/LICENSE</Path>
             <Path fileType="data">/usr/share/metainfo/network.bisq.Bisq.appdata.xml</Path>
             <Path fileType="data">/usr/share/pixmaps/network.bisq.Bisq.png</Path>
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2025-05-24</Date>
-            <Version>1.9.19</Version>
+        <Update release="8">
+            <Date>2026-01-12</Date>
+            <Version>1.9.22</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Resolves https://github.com/getsolus/packages/issues/7542
- This is a hotfix release that applies the upstream BitcoinJ fix for the chainwork . The bug caused Bisq to stall at block height 928,895 because the field used to store the accumulated proof of work was too small.  If you experience any wallet-related issues, you may perform an SPV resync, although this should not be necessary.

**Test Plan**
- Started it, checked value of bitcoin.

**Checklist**

- [X] Package was built and tested against unstable
- [X] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
