### PR TITLE
harfbuzz: Update to v12.3.0

### DIFF
--- a/packages/h/harfbuzz/package.yml
+++ b/packages/h/harfbuzz/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : harfbuzz
-version    : 12.1.0
-release    : 81
+version    : 12.3.0
+release    : 82
 source     :
-    - https://github.com/harfbuzz/harfbuzz/releases/download/12.1.0/harfbuzz-12.1.0.tar.xz : e5c81b7f6e0b102dfb000cfa424538b8e896ab78a2f4b8a5ec8cae62ab43369e
+    - https://github.com/harfbuzz/harfbuzz/releases/download/12.3.0/harfbuzz-12.3.0.tar.xz : 8660ebd3c27d9407fc8433b5d172bafba5f0317cb0bb4339f28e5370c93d42b7
 license    :
     - MIT
     - HPND
@@ -57,5 +57,6 @@ profile    : |
     %ninja_check
 install    : |
     %ninja_install
+    %install_license COPYING
 check      : |
     %ninja_check

--- a/packages/h/harfbuzz/pspec_x86_64.xml
+++ b/packages/h/harfbuzz/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>harfbuzz</Name>
         <Homepage>https://harfbuzz.github.io/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <License>HPND</License>
@@ -26,21 +26,22 @@
             <Path fileType="executable">/usr/bin/hb-subset</Path>
             <Path fileType="library">/usr/lib64/girepository-1.0/HarfBuzz-0.0.typelib</Path>
             <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libharfbuzz-gobject.so.0</Path>
-            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libharfbuzz-gobject.so.0.61210.0</Path>
+            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libharfbuzz-gobject.so.0.61230.0</Path>
             <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libharfbuzz-icu.so.0</Path>
-            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libharfbuzz-icu.so.0.61210.0</Path>
+            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libharfbuzz-icu.so.0.61230.0</Path>
             <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libharfbuzz-subset.so.0</Path>
-            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libharfbuzz-subset.so.0.61210.0</Path>
+            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libharfbuzz-subset.so.0.61230.0</Path>
             <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libharfbuzz.so.0</Path>
-            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libharfbuzz.so.0.61210.0</Path>
+            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libharfbuzz.so.0.61230.0</Path>
             <Path fileType="library">/usr/lib64/libharfbuzz-gobject.so.0</Path>
-            <Path fileType="library">/usr/lib64/libharfbuzz-gobject.so.0.61210.0</Path>
+            <Path fileType="library">/usr/lib64/libharfbuzz-gobject.so.0.61230.0</Path>
             <Path fileType="library">/usr/lib64/libharfbuzz-icu.so.0</Path>
-            <Path fileType="library">/usr/lib64/libharfbuzz-icu.so.0.61210.0</Path>
+            <Path fileType="library">/usr/lib64/libharfbuzz-icu.so.0.61230.0</Path>
             <Path fileType="library">/usr/lib64/libharfbuzz-subset.so.0</Path>
-            <Path fileType="library">/usr/lib64/libharfbuzz-subset.so.0.61210.0</Path>
+            <Path fileType="library">/usr/lib64/libharfbuzz-subset.so.0.61230.0</Path>
             <Path fileType="library">/usr/lib64/libharfbuzz.so.0</Path>
-            <Path fileType="library">/usr/lib64/libharfbuzz.so.0.61210.0</Path>
+            <Path fileType="library">/usr/lib64/libharfbuzz.so.0.61230.0</Path>
+            <Path fileType="data">/usr/share/licenses/harfbuzz/COPYING</Path>
         </Files>
     </Package>
     <Package>
@@ -50,17 +51,17 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="81">harfbuzz</Dependency>
+            <Dependency release="82">harfbuzz</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libharfbuzz-gobject.so.0</Path>
-            <Path fileType="library">/usr/lib32/libharfbuzz-gobject.so.0.61210.0</Path>
+            <Path fileType="library">/usr/lib32/libharfbuzz-gobject.so.0.61230.0</Path>
             <Path fileType="library">/usr/lib32/libharfbuzz-icu.so.0</Path>
-            <Path fileType="library">/usr/lib32/libharfbuzz-icu.so.0.61210.0</Path>
+            <Path fileType="library">/usr/lib32/libharfbuzz-icu.so.0.61230.0</Path>
             <Path fileType="library">/usr/lib32/libharfbuzz-subset.so.0</Path>
-            <Path fileType="library">/usr/lib32/libharfbuzz-subset.so.0.61210.0</Path>
+            <Path fileType="library">/usr/lib32/libharfbuzz-subset.so.0.61230.0</Path>
             <Path fileType="library">/usr/lib32/libharfbuzz.so.0</Path>
-            <Path fileType="library">/usr/lib32/libharfbuzz.so.0.61210.0</Path>
+            <Path fileType="library">/usr/lib32/libharfbuzz.so.0.61230.0</Path>
         </Files>
     </Package>
     <Package>
@@ -70,8 +71,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="81">harfbuzz-32bit</Dependency>
-            <Dependency release="81">harfbuzz-devel</Dependency>
+            <Dependency release="82">harfbuzz-devel</Dependency>
+            <Dependency release="82">harfbuzz-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/cmake/harfbuzz/harfbuzz-config.cmake</Path>
@@ -92,7 +93,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="81">harfbuzz</Dependency>
+            <Dependency release="82">harfbuzz</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/harfbuzz/hb-aat-layout.h</Path>
@@ -149,12 +150,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="81">
-            <Date>2025-10-02</Date>
-            <Version>12.1.0</Version>
+        <Update release="82">
+            <Date>2026-01-11</Date>
+            <Version>12.3.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/harfbuzz/harfbuzz/blob/12.3.0/NEWS).

**Security**
- CVE-2026-22693

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Reboot my computer, open programs, see that nothing blew up.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
