### PR TITLE
elfutils: Setup default DEBUGINFOD_URLS for solus

### DIFF
--- a/packages/e/elfutils/files/0001-config-Hardcode-profile-to-look-in-usr-share-default.patch
+++ b/packages/e/elfutils/files/0001-config-Hardcode-profile-to-look-in-usr-share-default.patch
@@ -1,0 +1,78 @@
+From bbf08fc5aba7a859d4e0ddb96cc00e63edb6e361 Mon Sep 17 00:00:00 2001
+From: Joey Riches <josephriches@gmail.com>
+Date: Mon, 12 Jan 2026 12:20:38 +0000
+Subject: [PATCH 1/1] config: Hardcode profile to look in
+ /usr/share/defaults/etc/ instead
+
+We don't need to add statelessness support here as there are other
+user mechanisms to override the DEBUGINFOD_URLS.
+---
+ config/profile.csh.in  | 4 ++--
+ config/profile.fish.in | 4 ++--
+ config/profile.sh.in   | 4 ++--
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/config/profile.csh.in b/config/profile.csh.in
+index 1da9626c..cbc78634 100644
+--- a/config/profile.csh.in
++++ b/config/profile.csh.in
+@@ -6,13 +6,13 @@
+ 
+ set prefix="@prefix@"
+ if (! $?DEBUGINFOD_URLS) then
+-    set DEBUGINFOD_URLS=`sh -c 'cat /dev/null "$0"/*.urls 2>/dev/null; :' "@sysconfdir@/debuginfod" | tr '\n' ' '`
++    set DEBUGINFOD_URLS=`sh -c 'cat /dev/null "$0"/*.urls 2>/dev/null; :' "/usr/share/defaults/etc/debuginfod" | tr '\n' ' '`
+     if ( "$DEBUGINFOD_URLS" != "" ) then
+         setenv DEBUGINFOD_URLS "$DEBUGINFOD_URLS"
+     else
+         unset DEBUGINFOD_URLS
+     endif
+-    set DEBUGINFOD_IMA_CERT_PATH=`sh -c 'cat /dev/null "$0"/*.certpath 2>/dev/null; :' "@sysconfdir@/debuginfod" | tr '\n' ':'`
++    set DEBUGINFOD_IMA_CERT_PATH=`sh -c 'cat /dev/null "$0"/*.certpath 2>/dev/null; :' "/usr/share/defaults/etc/debuginfod" | tr '\n' ':'`
+     if ( "$DEBUGINFOD_IMA_CERT_PATH" != "" ) then
+         setenv DEBUGINFOD_IMA_CERT_PATH "$DEBUGINFOD_IMA_CERT_PATH"
+     else
+diff --git a/config/profile.fish.in b/config/profile.fish.in
+index 12b5e6f1..f7b536f7 100644
+--- a/config/profile.fish.in
++++ b/config/profile.fish.in
+@@ -8,7 +8,7 @@
+ set --local prefix "@prefix@"
+ 
+ if not set --query DEBUGINFOD_URLS
+-    set --local files "@sysconfdir@/debuginfod/"*.urls
++    set --local files "/usr/share/defaults/etc/debuginfod/"*.urls
+     set --local DEBUGINFOD_URLS (cat /dev/null $files 2>/dev/null | string replace '\n' ' ')
+     if test -n "$DEBUGINFOD_URLS"
+         set --global --export DEBUGINFOD_URLS "$DEBUGINFOD_URLS"
+@@ -16,7 +16,7 @@ if not set --query DEBUGINFOD_URLS
+ end
+ 
+ if not set --query DEBUGINFOD_IMA_CERT_PATH
+-    set --local files "@sysconfdir@/debuginfod/"*.certpath
++    set --local files "/usr/share/defaults/etc/debuginfod/"*.certpath
+     set --local DEBUGINFOD_IMA_CERT_PATH (cat /dev/null $files 2>/dev/null | string replace '\n' ':')
+     if test -n "$DEBUGINFOD_IMA_CERT_PATH"
+         set --global --export DEBUGINFOD_IMA_CERT_PATH "$DEBUGINFOD_IMA_CERT_PATH"
+diff --git a/config/profile.sh.in b/config/profile.sh.in
+index 9f3e415a..6e477cde 100644
+--- a/config/profile.sh.in
++++ b/config/profile.sh.in
+@@ -6,12 +6,12 @@
+ 
+ prefix="@prefix@"
+ if [ -z "$DEBUGINFOD_URLS" ]; then
+-    DEBUGINFOD_URLS=$(find "@sysconfdir@/debuginfod" -name "*.urls" -print0 2>/dev/null | xargs -0 cat 2>/dev/null | tr '\n' ' ' || :)
++    DEBUGINFOD_URLS=$(find "/usr/share/defaults/etc/debuginfod" -name "*.urls" -print0 2>/dev/null | xargs -0 cat 2>/dev/null | tr '\n' ' ' || :)
+     [ -n "$DEBUGINFOD_URLS" ] && export DEBUGINFOD_URLS || unset DEBUGINFOD_URLS
+ fi
+ 
+ if [ -z "$DEBUGINFOD_IMA_CERT_PATH" ]; then
+-    DEBUGINFOD_IMA_CERT_PATH=$(find "@sysconfdir@/debuginfod" -name "*.certpath" -print0 2>/dev/null | xargs -0 cat 2>/dev/null | tr '\n' ':' || :)
++    DEBUGINFOD_IMA_CERT_PATH=$(find "/usr/share/defaults/etc/debuginfod" -name "*.certpath" -print0 2>/dev/null | xargs -0 cat 2>/dev/null | tr '\n' ':' || :)
+     [ -n "$DEBUGINFOD_IMA_CERT_PATH" ] && export DEBUGINFOD_IMA_CERT_PATH || unset DEBUGINFOD_IMA_CERT_PATH
+ fi
+ unset prefix
+-- 
+2.52.0
+

--- a/packages/e/elfutils/package.yml
+++ b/packages/e/elfutils/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : elfutils
 version    : '0.194'
-release    : 28
+release    : 29
 source     :
     - https://sourceware.org/elfutils/ftp/0.194/elfutils-0.194.tar.bz2 : 09e2ff033d39baa8b388a2d7fbc5390bfde99ae3b7c67c7daaf7433fbcf0f01e
 homepage   : https://fedorahosted.org/elfutils/
@@ -54,6 +54,9 @@ setup      : |
     if [[ ! -z "${EMUL32BUILD}" ]]; then
         debuginfod="--disable-debuginfod"
     fi
+
+    %patch -p1 -i $pkgfiles/0001-config-Hardcode-profile-to-look-in-usr-share-default.patch
+
     %configure --disable-static \
             --program-prefix=eu- \
             --enable-deterministic-archives \
@@ -62,6 +65,13 @@ build      : |
     %make
 install    : |
     %make_install
+
+    install -dm00755 $installdir/usr/share/defaults/etc/profile.d
+    mv $installdir/etc/profile.d/* $installdir/usr/share/defaults/etc/profile.d/
+
+    install -dm00755 $installdir/usr/share/defaults/etc/debuginfod
+    echo "https://debuginfod.getsol.us" > $installdir/usr/share/defaults/etc/debuginfod/solus.urls
+
     rm -rvf $installdir/etc
 
     # No static libs!

--- a/packages/e/elfutils/pspec_x86_64.xml
+++ b/packages/e/elfutils/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>elfutils</Name>
         <Homepage>https://fedorahosted.org/elfutils/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-3.0-or-later</License>
@@ -21,8 +21,8 @@
 </Description>
         <PartOf>programming.tools</PartOf>
         <RuntimeDependencies>
-            <Dependency release="28">libdw</Dependency>
-            <Dependency release="28">libelf</Dependency>
+            <Dependency release="29">libelf</Dependency>
+            <Dependency release="29">libdw</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/debuginfod</Path>
@@ -49,6 +49,9 @@
             <Path fileType="library">/usr/lib64/libasm.so.1</Path>
             <Path fileType="library">/usr/lib64/libdebuginfod-0.194.so</Path>
             <Path fileType="library">/usr/lib64/libdebuginfod.so.1</Path>
+            <Path fileType="data">/usr/share/defaults/etc/debuginfod/solus.urls</Path>
+            <Path fileType="data">/usr/share/defaults/etc/profile.d/debuginfod.csh</Path>
+            <Path fileType="data">/usr/share/defaults/etc/profile.d/debuginfod.sh</Path>
             <Path fileType="data">/usr/share/fish/vendor_conf.d/debuginfod.fish</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/elfutils.mo</Path>
             <Path fileType="localedata">/usr/share/locale/en@boldquot/LC_MESSAGES/elfutils.mo</Path>
@@ -73,7 +76,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="28">elfutils</Dependency>
+            <Dependency release="29">elfutils</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libasm.so.1</Path>
@@ -87,10 +90,10 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="28">libdw-32bit</Dependency>
-            <Dependency release="28">libelf-32bit</Dependency>
-            <Dependency release="28">elfutils-32bit</Dependency>
-            <Dependency release="28">elfutils-devel</Dependency>
+            <Dependency release="29">elfutils-devel</Dependency>
+            <Dependency release="29">elfutils-32bit</Dependency>
+            <Dependency release="29">libelf-32bit</Dependency>
+            <Dependency release="29">libdw-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libasm-0.194.so</Path>
@@ -107,7 +110,7 @@
 </Description>
         <PartOf>system.base</PartOf>
         <RuntimeDependencies>
-            <Dependency release="28">libelf</Dependency>
+            <Dependency release="29">libelf</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libdw-0.194.so</Path>
@@ -121,8 +124,8 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="28">libelf-32bit</Dependency>
-            <Dependency releaseFrom="28">libdw</Dependency>
+            <Dependency release="29">libelf-32bit</Dependency>
+            <Dependency releaseFrom="29">libdw</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libdw-0.194.so</Path>
@@ -136,9 +139,9 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="28">libelf-32bit-devel</Dependency>
-            <Dependency releaseFrom="28">libdw-32bit</Dependency>
-            <Dependency releaseFrom="28">libdw-devel</Dependency>
+            <Dependency release="29">libelf-32bit-devel</Dependency>
+            <Dependency releaseFrom="29">libdw-32bit</Dependency>
+            <Dependency releaseFrom="29">libdw-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libdw.so</Path>
@@ -152,8 +155,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="28">libelf-devel</Dependency>
-            <Dependency releaseFrom="28">libdw</Dependency>
+            <Dependency release="29">libelf-devel</Dependency>
+            <Dependency releaseFrom="29">libdw</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/dwarf.h</Path>
@@ -184,7 +187,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="28">libelf</Dependency>
+            <Dependency releaseFrom="29">libelf</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libelf-0.194.so</Path>
@@ -198,8 +201,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="28">libelf-32bit</Dependency>
-            <Dependency releaseFrom="28">libelf-devel</Dependency>
+            <Dependency releaseFrom="29">libelf-32bit</Dependency>
+            <Dependency releaseFrom="29">libelf-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libelf.so</Path>
@@ -213,7 +216,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="28">libelf</Dependency>
+            <Dependency releaseFrom="29">libelf</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/elfutils/elf-knowledge.h</Path>
@@ -232,9 +235,9 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="28">elfutils</Dependency>
-            <Dependency releaseFrom="28">libdw-devel</Dependency>
-            <Dependency releaseFrom="28">libelf-devel</Dependency>
+            <Dependency release="29">elfutils</Dependency>
+            <Dependency releaseFrom="29">libdw-devel</Dependency>
+            <Dependency releaseFrom="29">libelf-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/elfutils/debuginfod.h</Path>
@@ -324,12 +327,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2025-11-12</Date>
+        <Update release="29">
+            <Date>2026-01-12</Date>
             <Version>0.194</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Setup the default DEBUGINFOD_URLS for solus so debuginfod works OOTB

**Test Plan**

Install, reboot, 
- `echo $DEBUGINFOD_URLS` <- debuginfod.getsol.us
- `debuginfod-find executable /bin/ls` <- works

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
