### PR TITLE
libpng: Update to v1.6.54

### DIFF
--- a/packages/l/libpng/package.yml
+++ b/packages/l/libpng/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libpng
-version    : 1.6.53
-release    : 32
+version    : 1.6.54
+release    : 33
 source     :
-    - https://sourceforge.net/projects/libpng/files/libpng16/1.6.53/libpng-1.6.53.tar.gz : da0b045cbb1d06a8fc9696f9441359f70645f280ff24ae453ccb7c722353654f
+    - https://sourceforge.net/projects/libpng/files/libpng16/1.6.54/libpng-1.6.54.tar.gz : 472db714567391842e410090df5a37e0f5b2ec67148a3007678b0482d2ba5219
 homepage   : https://www.libpng.org/pub/png/
 license    : Libpng
 component  : multimedia.library

--- a/packages/l/libpng/pspec_x86_64.xml
+++ b/packages/l/libpng/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libpng</Name>
         <Homepage>https://www.libpng.org/pub/png/</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Libpng</License>
         <PartOf>multimedia.library</PartOf>
@@ -23,9 +23,9 @@
             <Path fileType="executable">/usr/bin/png-fix-itxt</Path>
             <Path fileType="executable">/usr/bin/pngfix</Path>
             <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libpng16.so.16</Path>
-            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libpng16.so.16.53.0</Path>
+            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libpng16.so.16.54.0</Path>
             <Path fileType="library">/usr/lib64/libpng16.so.16</Path>
-            <Path fileType="library">/usr/lib64/libpng16.so.16.53.0</Path>
+            <Path fileType="library">/usr/lib64/libpng16.so.16.54.0</Path>
             <Path fileType="data">/usr/share/licenses/libpng/LICENSE</Path>
             <Path fileType="man">/usr/share/man/man5/png.5.zst</Path>
         </Files>
@@ -37,11 +37,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="32">libpng</Dependency>
+            <Dependency release="33">libpng</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpng16.so.16</Path>
-            <Path fileType="library">/usr/lib32/libpng16.so.16.53.0</Path>
+            <Path fileType="library">/usr/lib32/libpng16.so.16.54.0</Path>
         </Files>
     </Package>
     <Package>
@@ -51,8 +51,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="32">libpng-32bit</Dependency>
-            <Dependency release="32">libpng-devel</Dependency>
+            <Dependency release="33">libpng-32bit</Dependency>
+            <Dependency release="33">libpng-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpng.so</Path>
@@ -68,7 +68,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="32">libpng</Dependency>
+            <Dependency release="33">libpng</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/libpng-config</Path>
@@ -88,12 +88,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2025-12-14</Date>
-            <Version>1.6.53</Version>
+        <Update release="33">
+            <Date>2026-01-13</Date>
+            <Version>1.6.54</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/pnggroup/libpng/blob/v1.6.54/ANNOUNCE)

**Security**
- CVE-2026-22695
- CVE-2026-22801

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Opened a PNG in an image viewer.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
