### PR TITLE
svtplay-dl: Update to v4.173

### DIFF
--- a/packages/s/svtplay-dl/package.yml
+++ b/packages/s/svtplay-dl/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : svtplay-dl
-version    : '4.167'
-release    : 37
+version    : '4.173'
+release    : 38
 source     :
-    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.167.tar.gz : f8da6fef13775c43d29a16c972b918a3818f022b7d0e0e4a0a1ff1018b4f446a
+    - https://github.com/spaam/svtplay-dl/archive/refs/tags/4.173.tar.gz : f685fbdb48eedf858cbd69ea3f4532dc0c1d64f99df5ec63dc834b7c9efad149
 homepage   : https://svtplay-dl.se/
 license    : MIT
 component  : network.download

--- a/packages/s/svtplay-dl/pspec_x86_64.xml
+++ b/packages/s/svtplay-dl/pspec_x86_64.xml
@@ -21,12 +21,12 @@
         <PartOf>network.download</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/svtplay-dl</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.167.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.167.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.167.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.167.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.167.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.167.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.173.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.173.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.173.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.173.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.173.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl-4.173.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/svtplay_dl/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -243,9 +243,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="37">
-            <Date>2025-12-25</Date>
-            <Version>4.167</Version>
+        <Update release="38">
+            <Date>2026-01-14</Date>
+            <Version>4.173</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
- nrk: add support for —all-episodes
- pluto: fix an issue not downloading the whole video
- svt: fix getting clips for news articles
- urplay: dont crash on old python 3.11 version
- urplay: fix getting —all-episodes
- add a warning when trying to use —nfo on unsupported sites.

**Test Plan**
- Downloaded a video.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
