### PR TITLE
pocillo-gtk-theme: Update to v0.12.1

### DIFF
--- a/packages/p/pocillo-gtk-theme/package.yml
+++ b/packages/p/pocillo-gtk-theme/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : pocillo-gtk-theme
-version    : '0.12'
-release    : 6
+version    : 0.12.1
+release    : 7
 source     :
-    - https://github.com/UbuntuBudgie/pocillo-gtk-theme/archive/refs/tags/v0.12.tar.gz : 990dc79afa4c70cafcb9c9c0aa7a218a90359f315009c9a847afac913a5dfcc6
+    - https://github.com/UbuntuBudgie/pocillo-gtk-theme/archive/refs/tags/v0.12.1.tar.gz : e12a1fc5cb0dd80f7f98ddcf59d163e1b8802faae98b9dd2108e5b5d85d0d4f0
 homepage   : https://github.com/UbuntuBudgie/pocillo-gtk-theme
 license    : GPL-2.0-or-later
 component  :

--- a/packages/p/pocillo-gtk-theme/pspec_x86_64.xml
+++ b/packages/p/pocillo-gtk-theme/pspec_x86_64.xml
@@ -694,7 +694,7 @@
 </Description>
         <PartOf>desktop.theme</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="6">pocillo-gtk-theme</Dependency>
+            <Dependency releaseFrom="7">pocillo-gtk-theme</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/themes/Pocillo-slim-dark/COPYING</Path>
@@ -1365,9 +1365,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2025-12-27</Date>
-            <Version>0.12</Version>
+        <Update release="7">
+            <Date>2026-01-14</Date>
+            <Version>0.12.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
A minor adjustment to fix Pocillo-dark, which wasn't using the correct colors.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install and start a new Budgie session using the theme.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
