### PR TITLE
sox_ng: Update to v14.7.0.4

### DIFF
--- a/packages/s/sox_ng/MAINTAINERS.md
+++ b/packages/s/sox_ng/MAINTAINERS.md
@@ -1,4 +1,0 @@
-This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
-
-- Jakob Gezelius 
-  - Email: jakob@knugen.nu 

--- a/packages/s/sox_ng/package.yml
+++ b/packages/s/sox_ng/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : sox_ng
-version    : 14.7.0.3
-release    : 30
+version    : 14.7.0.4
+release    : 31
 source     :
-    - https://codeberg.org/sox_ng/sox_ng/releases/download/sox_ng-14.7.0.3/sox_ng-14.7.0.3.tar.gz : 969446ace6452a91d7bb5e3d908cadfd57fac05dfd99baa812001474bf68fa63
+    - https://codeberg.org/sox_ng/sox_ng/releases/download/sox_ng-14.7.0.4/sox_ng-14.7.0.4.tar.gz : 399740e1a16b9eea1285c80c3dbd0c5e2abcf3953327447cc90baa1abea8bbe2
 homepage   : https://codeberg.org/sox_ng/sox_ng
 license    :
     - GPL-2.0-only

--- a/packages/s/sox_ng/pspec_x86_64.xml
+++ b/packages/s/sox_ng/pspec_x86_64.xml
@@ -56,7 +56,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="30">sox_ng</Dependency>
+            <Dependency release="31">sox_ng</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/sox.h</Path>
@@ -70,9 +70,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="30">
-            <Date>2025-12-10</Date>
-            <Version>14.7.0.3</Version>
+        <Update release="31">
+            <Date>2026-01-15</Date>
+            <Version>14.7.0.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
o Make spectrogram -S with a time after EOF fail instead of looping forever 
o Put extra_usage after priv_size in effects' options

**Test Plan**
- Checked version.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
