### PR TITLE
python-setuptools-git-versioning: Update to v3.0.1

### DIFF
--- a/packages/py/python-setuptools-git-versioning/package.yml
+++ b/packages/py/python-setuptools-git-versioning/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-setuptools-git-versioning
-version    : 2.1.0
-release    : 1
+version    : 3.0.1
+release    : 2
 source     :
-    - https://files.pythonhosted.org/packages/source/s/setuptools-git-versioning/setuptools_git_versioning-2.1.0.tar.gz : 6aef5b8bb1cfb953b6b343d27cbfc561d96cf2a2ee23c2e0dd3591042a059921
+    - https://files.pythonhosted.org/packages/source/s/setuptools-git-versioning/setuptools_git_versioning-3.0.1.tar.gz : c8a599bacf163b5d215552b5701faf5480ffc4d65426a5711a010b802e1590eb
 homepage   : https://pypi.org/project/setuptools-git-versioning/
 license    : MIT
 component  : programming.python
@@ -14,6 +14,7 @@ builddeps  :
     - python-build
     - python-installer
     - python-setuptools
+    - python-wheel
 build      : |
     %python3_setup
 install    : |

--- a/packages/py/python-setuptools-git-versioning/pspec_x86_64.xml
+++ b/packages/py/python-setuptools-git-versioning/pspec_x86_64.xml
@@ -21,21 +21,48 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/setuptools-git-versioning</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/__pycache__/setuptools_git_versioning.cpython-312.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/__pycache__/setuptools_git_versioning.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-2.1.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-2.1.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-2.1.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-2.1.0.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-2.1.0.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-2.1.0.dist-info/top_level.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-3.0.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-3.0.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-3.0.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-3.0.1.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-3.0.1.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-3.0.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__main__.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/__init__.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/__main__.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/__main__.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/cli.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/cli.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/defaults.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/defaults.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/factories.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/factories.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/git.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/git.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/log.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/log.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/setup.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/setup.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/subst.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/subst.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/version.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/version.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/cli.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/defaults.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/factories.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/git.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/log.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/setup.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/subst.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/version.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2025-12-18</Date>
-            <Version>2.1.0</Version>
+        <Update release="2">
+            <Date>2026-01-16</Date>
+            <Version>3.0.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Make most of args in `version_from_git` keyword-only
- Change return type of `version_from_git` and `infer_version` from `str` to `packaging.version.Version`
- Timestamps in version templates are now timezone-aware
- Refactoring
- Fix calling `get_version(root=...)` in combination with version-file strategy
- Fix epoch versions like `0!2025.12.3` were wrongly converted to `0.2025.12.3`
- Using version_file-based schema with shallow git clone lead to version numbers like `1.2.3.postNone`
- Fix `OSError` exception raised if using `setuptools-git-versioning` in system without `git` installed

Full release notes available [here](https://github.com/dolfinus/setuptools-git-versioning/releases/tag/v3.0.0)

**Test Plan**

Successfully built `python-toolz`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
