### PR TITLE
libheif: Update to v1.21.2

### DIFF
--- a/packages/l/libheif/package.yml
+++ b/packages/l/libheif/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libheif
-version    : 1.21.1
-release    : 55
+version    : 1.21.2
+release    : 56
 source     :
-    - https://github.com/strukturag/libheif/releases/download/v1.21.1/libheif-1.21.1.tar.gz : 9799b4b1c19006f052bcf399c761cc147e279762683cefaf16871dbb9b4ea2a1
+    - https://github.com/strukturag/libheif/releases/download/v1.21.2/libheif-1.21.2.tar.gz : 75f530b7154bc93e7ecf846edfc0416bf5f490612de8c45983c36385aa742b42
 license    :
     - LGPL-3.0-or-later
     - MIT # /usr/include/libheif/heif_cxx.h

--- a/packages/l/libheif/pspec_x86_64.xml
+++ b/packages/l/libheif/pspec_x86_64.xml
@@ -30,7 +30,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
             <Path fileType="executable">/usr/bin/heif-thumbnailer</Path>
             <Path fileType="library">/usr/lib64/libheif</Path>
             <Path fileType="library">/usr/lib64/libheif.so.1</Path>
-            <Path fileType="library">/usr/lib64/libheif.so.1.21.1</Path>
+            <Path fileType="library">/usr/lib64/libheif.so.1.21.2</Path>
             <Path fileType="data">/usr/share/licenses/libheif/COPYING</Path>
             <Path fileType="man">/usr/share/man/man1/heif-dec.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/heif-enc.1.zst</Path>
@@ -47,7 +47,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="55">libheif</Dependency>
+            <Dependency release="56">libheif</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libheif/heif.h</Path>
@@ -83,9 +83,9 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
         </Files>
     </Package>
     <History>
-        <Update release="55">
-            <Date>2026-01-02</Date>
-            <Version>1.21.1</Version>
+        <Update release="56">
+            <Date>2026-01-16</Date>
+            <Version>1.21.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- build script for JS/WASM now supports building with JPEG2000 and "ISO23001-17 Uncompressed" support
- image sequence SAI data now works when using the OpenH264 decoder plugin

**Test Plan**

Encoded and decoded a bunch of images

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
