### PR TITLE
brave: Fix appstream catalog generation

### DIFF
--- a/packages/b/brave/files/com.brave.Browser.metainfo.xml
+++ b/packages/b/brave/files/com.brave.Browser.metainfo.xml
@@ -2,7 +2,7 @@
 <!-- Copyright 2017 the Chromium authors, with modifications -->
 <component type="desktop-application">
   <id>com.brave.Browser</id>
-  <launchable type="desktop-id">brave-browser.desktop</launchable>
+  <launchable type="desktop-id">com.brave.Browser.desktop</launchable>
   <name>Brave</name>
   <developer_name>Brave Software</developer_name>
   <summary>Fast Internet, AI, Adblock</summary>
@@ -35,6 +35,52 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.86.139" date="2026-01-15"/>
+    <release version="1.85.120" date="2026-01-07"/>
+    <release version="1.85.118" date="2025-12-19"/>
+    <release version="1.85.117" date="2025-12-17"/>
+    <release version="1.85.116" date="2025-12-11"/>
+    <release version="1.85.111" date="2025-12-03"/>
+    <release version="1.84.141" date="2025-11-18"/>
+    <release version="1.84.139" date="2025-11-12"/>
+    <release version="1.84.135" date="2025-11-06"/>
+    <release version="1.84.132" date="2025-10-29"/>
+    <release version="1.83.120" date="2025-10-22"/>
+    <release version="1.83.118" date="2025-10-15"/>
+    <release version="1.83.112" date="2025-10-08"/>
+    <release version="1.83.109" date="2025-10-03"/>
+    <release version="1.82.172" date="2025-10-02"/>
+    <release version="1.82.172" date="2025-09-24"/>
+    <release version="1.82.170" date="2025-09-18"/>
+    <release version="1.82.166" date="2025-09-10"/>
+    <release version="1.81.137" date="2025-08-27"/>
+    <release version="1.81.136" date="2025-08-20"/>
+    <release version="1.81.135" date="2025-08-13"/>
+    <release version="1.81.131" date="2025-08-06"/>
+    <release version="1.80.125" date="2025-07-30"/>
+    <release version="1.80.124" date="2025-07-23"/>
+    <release version="1.80.122" date="2025-07-16"/>
+    <release version="1.80.120" date="2025-07-09"/>
+    <release version="1.80.115" date="2025-07-01"/>
+    <release version="1.80.113" date="2025-06-26"/>
+    <release version="1.79.126" date="2025-06-18"/>
+    <release version="1.79.123" date="2025-06-11"/>
+    <release version="1.79.119" date="2025-06-03"/>
+    <release version="1.79.118" date="2025-05-29"/>
+    <release version="1.78.102" date="2025-05-15"/>
+    <release version="1.78.97" date="2025-05-07"/>
+    <release version="1.78.94" date="2025-05-01"/>
+    <release version="1.77.101" date="2025-04-23"/>
+    <release version="1.77.100" date="2025-04-16"/>
+    <release version="1.77.97" date="2025-04-09"/>
+    <release version="1.77.95" date="2025-04-02"/>
+    <release version="1.76.82" date="2025-03-26"/>
+    <release version="1.76.81" date="2025-03-22"/>
+    <release version="1.76.80" date="2025-03-20"/>
+    <release version="1.76.74" date="2025-03-11"/>
+    <release version="1.76.73" date="2025-03-05"/>
+    <release version="1.75.181" date="2025-02-26"/>
+    <release version="1.75.180" date="2025-02-19"/>
     <release version="1.75.178" date="2025-02-13"/>
     <release version="1.75.175" date="2025-02-06"/>
     <release version="1.74.51" date="2025-01-29"/>
@@ -229,4 +275,9 @@
   </releases>
   <content_rating type="oars-1.1"/>
   <update_contact>https://support.brave.com/hc/en-us/requests/new</update_contact>
+  <keywords>
+    <keyword>fast internet</keyword>
+    <keyword>ad blocker</keyword>
+    <keyword>privacy browser</keyword>
+  </keywords>
 </component>

--- a/packages/b/brave/package.yml
+++ b/packages/b/brave/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : brave
 version    : 1.86.139
-release    : 248
+release    : 249
 source     :
     - https://github.com/brave/brave-browser/releases/download/v1.86.139/brave-browser_1.86.139_amd64.deb : 9742ad88c53e2fb93a8b9b2388f0b6e0200151d9fd6b1d6e2aa92a59efdf94f3
 homepage   : https://brave.com
@@ -32,23 +32,20 @@ builddeps  :
 rundeps    :
     - libgnome-keyring
 setup      : |
-    ar x $sources/brave-browser_${version}_amd64.deb
+    ar x ${sources}/brave-browser_${version}_amd64.deb
     tar xf data.tar.*
-    mv usr/share/man/man1/brave-browser-stable.1.gz usr/share/man/man1/brave-browser.1.gz
 install    : |
-    mkdir -p $installdir
-    cp -r usr $installdir/
-    cp -r opt/brave.com/brave $installdir/usr/share/
-    ln -sfn /usr/share/brave/brave $installdir/usr/bin/brave-browser
-    install -Dm00644 opt/brave.com/brave/product_logo_128.png $installdir/usr/share/pixmaps/brave-browser.png
+    install -Ddm00755 ${installdir}
+    cp -r usr ${installdir}/
+    cp -r opt/brave.com/brave ${installdir}/usr/share/
+    install -Dm00644 opt/brave.com/brave/product_logo_128.png ${installdir}/usr/share/icons/hicolor/128x128/apps/brave-browser.png
 
-    # Remove stuff that aren't necessary on Solus
-    sed -i 's/brave-browser-stable/brave-browser/g' $installdir/usr/share/applications/brave-browser.desktop
-    rm -f $installdir/usr/bin/brave-browser-stable
-    rm -f $installdir/usr/share/brave/LICENSE
+    # Fix symlink
+    rm ${installdir}/usr/bin/brave-browser-stable
+    ln -s /usr/share/brave/brave ${installdir}/usr/bin/brave-browser-stable
 
     # Fix appdata
-    rm -f $installdir/usr/share/appdata/brave-browser.appdata.xml
-    rmdir $installdir/usr/share/appdata
-    install -dm00755 $installdir/usr/share/metainfo
-    install -Dm00644 $pkgfiles/com.brave.Browser.metainfo.xml $installdir/usr/share/metainfo/brave-browser.metainfo.xml
+    rm -f ${installdir}/usr/share/appdata/brave-browser.appdata.xml
+    rmdir ${installdir}/usr/share/appdata
+    install -dm00755 ${installdir}/usr/share/metainfo
+    install -Dm00644 ${pkgfiles}/com.brave.Browser.metainfo.xml -t ${installdir}/usr/share/metainfo

--- a/packages/b/brave/pspec_x86_64.xml
+++ b/packages/b/brave/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>brave</Name>
         <Homepage>https://brave.com</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>GPL-3.0-or-later</License>
@@ -22,9 +22,10 @@
 </Description>
         <PartOf>network.web.browser</PartOf>
         <Files>
-            <Path fileType="executable">/usr/bin/brave-browser</Path>
+            <Path fileType="executable">/usr/bin/brave-browser-stable</Path>
             <Path fileType="data">/usr/share/applications/brave-browser.desktop</Path>
             <Path fileType="data">/usr/share/applications/com.brave.Browser.desktop</Path>
+            <Path fileType="data">/usr/share/brave/LICENSE</Path>
             <Path fileType="data">/usr/share/brave/MEIPreload/manifest.json</Path>
             <Path fileType="data">/usr/share/brave/MEIPreload/preloaded_data.pb</Path>
             <Path fileType="data">/usr/share/brave/PrivacySandboxAttestationsPreloaded/manifest.json</Path>
@@ -131,18 +132,19 @@
             <Path fileType="doc">/usr/share/doc/brave-browser-stable</Path>
             <Path fileType="doc">/usr/share/doc/brave-browser/changelog.gz</Path>
             <Path fileType="data">/usr/share/gnome-control-center/default-apps/brave-browser.xml</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/brave-browser.png</Path>
+            <Path fileType="man">/usr/share/man/man1/brave-browser-stable.1.gz</Path>
             <Path fileType="man">/usr/share/man/man1/brave-browser.1.gz</Path>
-            <Path fileType="data">/usr/share/metainfo/brave-browser.metainfo.xml</Path>
-            <Path fileType="data">/usr/share/pixmaps/brave-browser.png</Path>
+            <Path fileType="data">/usr/share/metainfo/com.brave.Browser.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="248">
-            <Date>2026-01-15</Date>
+        <Update release="249">
+            <Date>2026-01-16</Date>
             <Version>1.86.139</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Install icon to `/usr/share/icons` instead of `/usr/share/pixmaps`.
- Update AppStream metainfo file.
- Use upstream name for symlink.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Successfully generate an appstream catalog with the built package.
Launch Brave and see the welcome page.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
