### PR TITLE
acpica-unix: Update to v20251212

### DIFF
--- a/packages/a/acpica-unix/package.yml
+++ b/packages/a/acpica-unix/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : acpica-unix
-version    : '20250807'
-release    : 13
+version    : '20251212'
+release    : 14
 source     :
-    - https://github.com/acpica/acpica/archive/refs/tags/20250807.tar.gz : 971df1f78944e5f3bb314209acbf8a127c0db34b4a3c26e011b4076eba1c2bbc
-license    : GPL-2.0-or-later
+    - https://github.com/acpica/acpica/archive/refs/tags/20251212.tar.gz : 6f77bd550655183c63f0a307fb0f29ef6140b1f522d61783a16b2af8d9149a0d
+license    : GPL-2.0-only
 homepage   : https://www.intel.com/content/www/us/en/developer/topic-technology/open/acpica/overview.html
 component  : programming.tools
 summary    : ACPI Source Code Compiler & Disassembler
@@ -16,3 +16,4 @@ build      : |
     NOWERROR=TRUE %make
 install    : |
     %make_install
+    %install_license LICENSE

--- a/packages/a/acpica-unix/pspec_x86_64.xml
+++ b/packages/a/acpica-unix/pspec_x86_64.xml
@@ -3,10 +3,10 @@
         <Name>acpica-unix</Name>
         <Homepage>https://www.intel.com/content/www/us/en/developer/topic-technology/open/acpica/overview.html</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
-        <License>GPL-2.0-or-later</License>
+        <License>GPL-2.0-only</License>
         <PartOf>programming.tools</PartOf>
         <Summary xml:lang="en">ACPI Source Code Compiler &amp; Disassembler</Summary>
         <Description xml:lang="en">ACPICA defines and implements a group of software components that together create an implementation of the ACPI specification for both 32-bit and 64-bit platforms.
@@ -28,15 +28,16 @@
             <Path fileType="executable">/usr/bin/acpisrc</Path>
             <Path fileType="executable">/usr/bin/acpixtract</Path>
             <Path fileType="executable">/usr/bin/iasl</Path>
+            <Path fileType="data">/usr/share/licenses/acpica-unix/LICENSE</Path>
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2025-08-23</Date>
-            <Version>20250807</Version>
+        <Update release="14">
+            <Date>2026-01-17</Date>
+            <Version>20251212</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/acpica/acpica/releases/tag/20251212).

**Test Plan**
* Ran these commands:
```
iasl -v
acpidump -h
acpixtract -h
```

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
