### PR TITLE
asio: Fix build and update website URL

### DIFF
--- a/packages/a/asio/package.yml
+++ b/packages/a/asio/package.yml
@@ -1,20 +1,24 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : asio
 version    : 1.30.2
-release    : 4
+release    : 5
 source     :
     - https://sourceforge.net/projects/asio/files/asio/1.30.2%20%28Stable%29/asio-1.30.2.tar.gz : 12e7bb4dada8bc1191de9d550a59ee658ce4e645ffc97c911c099ab4e8699d55
 license    : BSL-1.0
-homepage   : http://think-async.com/Asio/
+homepage   : https://think-async.com/Asio/
 component  : programming.library
 summary    : Cross-platform C++ library for network and low-level I/O programming
 description: |
     Asio is a cross-platform C++ library for network and low-level I/O programming that provides developers with a consistent asynchronous model using a modern C++ approach
+extract    : false
 setup      : |
+    # manually extract to work around https://github.com/getsolus/solbuild/issues/126
+    tar --strip-components=1 -xf $sources/asio-%version%.tar.gz
     %configure
 build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING LICENSE_1_0.txt
 patterns   :
     - /*

--- a/packages/a/asio/pspec_x86_64.xml
+++ b/packages/a/asio/pspec_x86_64.xml
@@ -1,7 +1,7 @@
 <PISI>
     <Source>
         <Name>asio</Name>
-        <Homepage>http://think-async.com/Asio/</Homepage>
+        <Homepage>https://think-async.com/Asio/</Homepage>
         <Packager>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>
@@ -642,11 +642,13 @@
             <Path fileType="header">/usr/include/asio/write_at.hpp</Path>
             <Path fileType="header">/usr/include/asio/yield.hpp</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/asio.pc</Path>
+            <Path fileType="data">/usr/share/licenses/asio/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/asio/LICENSE_1_0.txt</Path>
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-04-27</Date>
+        <Update release="5">
+            <Date>2026-01-17</Date>
             <Version>1.30.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>


### PR DESCRIPTION
**Summary**

Manually extract the tarball to work around https://github.com/getsolus/solbuild/issues/126

Resolves https://github.com/getsolus/packages/issues/6784

Part of https://github.com/getsolus/packages/issues/5522

Note: Not updating to a later release yet because it leads to build failures for at least the `openvpn3` and `obs-studio` versions currently in the repository

**Test Plan**

Successfully built `openvpn3`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
