### PR TITLE
glibc: Update to v2.42+git.cbf39c2, raise kernel baseline to 6.1

### DIFF
--- a/packages/g/glibc/package.yml
+++ b/packages/g/glibc/package.yml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : glibc
 version    : '2.42'
-release    : 136
+release    : 137
 source     :
     # release/2.42/master
     # Use the bminor mirror since the upstream is unreliable
-    - git|https://github.com/bminor/glibc : de1fe81f471496366580ad728b8986a3424b2fd7
+    - git|https://github.com/bminor/glibc : cbf39c26b25801e9bc88499b4fd361ac172d4125
 homepage   : https://www.gnu.org/software/libc/
 license    : GPL-3.0-or-later
 summary    :
@@ -121,7 +121,7 @@ setup      : |
            --disable-nscd \
            --disable-sframe \
            --enable-bind-now \
-           --enable-kernel=5.15 \
+           --enable-kernel=6.1 \
            --enable-stack-protector=strong \
            --enable-systemtap \
            --prefix=/usr \
@@ -160,17 +160,17 @@ build      : |
         %make bench-build
     fi
 install    : |
-    cd glibc-build
+    pushd glibc-build
 
     if [[ ! -z "${EMUL32BUILD}" ]]; then
         cd b32
-        %make_install install_root=$installdir
+        %make_install
     else
         cd b64
-        %make_install install_root=$installdir
+        %make_install
 
         if [[ -z "${AVX2BUILD}" ]]; then
-            %make_install install_root=$installdir localedata/install-locale-files
+            %make_install localedata/install-locale-files
 
             # Hardlink everything to save space
             pushd $installdir/usr/lib64/locale/
@@ -229,7 +229,7 @@ install    : |
         for f in benchtests/*; do [ -x $f -a ! -d $f ] && cp -a $f $installdir/usr/bin/; done
     fi
 
-    # Clear out uneeded haswell files
+    # Clear out unneeded haswell files
     if [[ ! -z "${AVX2BUILD}" ]]; then
         for nuke in `ls $installdir/%libdir% | grep -v -E "libm.so.6|libm-$version.so|libc.so.6|libc-$version.so|libmvec|libcrypt"`; do
             rm -rfv $installdir/%libdir%/${nuke}
@@ -244,3 +244,7 @@ install    : |
            $installdir/var/db/Makefile
     # Cleanup
     find $installdir -type d -empty -print -delete
+
+    popd
+
+    %install_license LICENSES CONTRIBUTED-BY MAINTAINERS COPYING*

--- a/packages/g/glibc/pspec_x86_64.xml
+++ b/packages/g/glibc/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>glibc</Name>
         <Homepage>https://www.gnu.org/software/libc/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -6951,6 +6951,11 @@
             <Path fileType="info">/usr/share/info/libc.info-8.zst</Path>
             <Path fileType="info">/usr/share/info/libc.info-9.zst</Path>
             <Path fileType="info">/usr/share/info/libc.info.zst</Path>
+            <Path fileType="data">/usr/share/licenses/glibc/CONTRIBUTED-BY</Path>
+            <Path fileType="data">/usr/share/licenses/glibc/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/glibc/COPYING.LIB</Path>
+            <Path fileType="data">/usr/share/licenses/glibc/LICENSES</Path>
+            <Path fileType="data">/usr/share/licenses/glibc/MAINTAINERS</Path>
             <Path fileType="localedata">/usr/share/locale/be/LC_MESSAGES/libc.mo</Path>
             <Path fileType="localedata">/usr/share/locale/bg/LC_MESSAGES/libc.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/libc.mo</Path>
@@ -7000,7 +7005,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="136">glibc</Dependency>
+            <Dependency release="137">glibc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib32/ld-linux.so.2</Path>
@@ -7301,8 +7306,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="136">glibc-32bit</Dependency>
-            <Dependency release="136">glibc-devel</Dependency>
+            <Dependency release="137">glibc-devel</Dependency>
+            <Dependency release="137">glibc-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/Mcrt1.o</Path>
@@ -7812,7 +7817,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="136">glibc</Dependency>
+            <Dependency release="137">glibc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/mtrace</Path>
@@ -8329,12 +8334,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="136">
-            <Date>2025-11-12</Date>
+        <Update release="137">
+            <Date>2026-01-20</Date>
             <Version>2.42</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
The minimum required kernel version is now 6.1, from 5.15.

**Security**
- CVE-2026-0861
- CVE-2026-0915
- CVE-2025-15281

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Successfully build `nano`.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
