### PR TITLE
hipblaslt: Don't use rocm-openmp-devel

### DIFF
--- a/packages/h/hipblaslt/package.yml
+++ b/packages/h/hipblaslt/package.yml
@@ -21,8 +21,8 @@ builddeps  :
     - amd-blis-devel
     - hipblas-common-devel
     - libboost-devel
-    - rocm-openmp-devel
     - roctracer-devel
+    - rocm-openmp
     - msgpack-cxx
     - python-joblib
     - python-msgpack


### PR DESCRIPTION
**Summary**

`rocm-openmp-devel` doesn't exist. It existed in a previous local build attempt that got copied to my local repository (`go-task localcp`) hence the build succeeded locally :face_with_diagonal_mouth: 

**Test Plan**

Should build...

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
