### PR TITLE
sccache: Update to v0.13.0

### DIFF
--- a/packages/s/sccache/abi_used_symbols
+++ b/packages/s/sccache/abi_used_symbols
@@ -23,6 +23,7 @@ libc.so.6:connect
 libc.so.6:dirfd
 libc.so.6:dl_iterate_phdr
 libc.so.6:dlsym
+libc.so.6:dup
 libc.so.6:dup2
 libc.so.6:environ
 libc.so.6:epoll_create1
@@ -195,9 +196,9 @@ libcrypto.so.3:CRYPTO_get_ex_new_index
 libcrypto.so.3:ERR_get_error_all
 libcrypto.so.3:ERR_lib_error_string
 libcrypto.so.3:ERR_reason_error_string
-libcrypto.so.3:EVP_PKEY_assign
 libcrypto.so.3:EVP_PKEY_free
 libcrypto.so.3:EVP_PKEY_new
+libcrypto.so.3:EVP_PKEY_set1_RSA
 libcrypto.so.3:EVP_sha1
 libcrypto.so.3:EVP_sha256
 libcrypto.so.3:GENERAL_NAME_free

--- a/packages/s/sccache/package.yml
+++ b/packages/s/sccache/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : sccache
-version    : 0.10.0
-release    : 11
+version    : 0.13.0
+release    : 12
 source     :
-    - https://github.com/mozilla/sccache/archive/refs/tags/v0.10.0.tar.gz : 2c9f82c43ce6a1b1d9b34f029ce6862bedc2f01deff45cde5dffc079deeba801
+    - https://github.com/mozilla/sccache/archive/refs/tags/v0.13.0.tar.gz : cc93c603b938f7444c180c049ce9d983e6b08eb2a0d44973b4794508589f891c
 homepage   : https://github.com/mozilla/sccache
 license    : Apache-2.0
 component  : programming.tools
@@ -16,6 +16,14 @@ builddeps  :
     - pkgconfig(openssl)
     - rust
 setup      : |
+    # Note(GZGavinZhao): occasionally sccache fails on Cargo startup when
+    # calling `sccache rustc -vV`, failing with message "Failed to create
+    # ~/.rustup"!
+    #
+    # This behavior is flaky and I can't reliably reproduce it. If that happens,
+    # uncomment the line below to make `sccache` work again.
+    # sccache --stop-server
+
     %cargo_fetch
 build      : |
     # Build against system zstd
@@ -24,3 +32,4 @@ build      : |
     %cargo_build --features all,native-zlib,dist-server
 install    : |
     install -Dm00755 target/release/sccache{,-dist} -t $installdir/usr/bin
+    %install_license LICENSE

--- a/packages/s/sccache/pspec_x86_64.xml
+++ b/packages/s/sccache/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>sccache</Name>
         <Homepage>https://github.com/mozilla/sccache</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Gavin Zhao</Name>
+            <Email>me@gzgz.dev</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.tools</PartOf>
@@ -22,15 +22,16 @@
         <Files>
             <Path fileType="executable">/usr/bin/sccache</Path>
             <Path fileType="executable">/usr/bin/sccache-dist</Path>
+            <Path fileType="data">/usr/share/licenses/sccache/LICENSE</Path>
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2025-09-12</Date>
-            <Version>0.10.0</Version>
+        <Update release="12">
+            <Date>2026-01-19</Date>
+            <Version>0.13.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Gavin Zhao</Name>
+            <Email>me@gzgz.dev</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Update `sccache` to v0.13.0.

Changelogs:
- [v0.13.0](https://github.com/mozilla/sccache/releases/tag/v0.13.0)
- [v0.12.0](https://github.com/mozilla/sccache/releases/tag/v0.12.0)
- [v0.11.0](http://github.com/mozilla/sccache/releases/tag/v0.11.0)

**Test Plan**

Compiled `sccache` with `sccache` and checked caching stats.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
