### PR TITLE
poppler: Re-add dependency on urw-core35-fonts

### DIFF
--- a/packages/p/poppler/package.yml
+++ b/packages/p/poppler/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : poppler
 version    : 25.10.0
-release    : 57
+release    : 58
 source     :
     - https://poppler.freedesktop.org/poppler-25.10.0.tar.xz : 6b5e9bb64dabb15787a14db1675291c7afaf9387438cc93a4fb7f6aec4ee6fe0
     - git|https://gitlab.freedesktop.org/poppler/test.git : 9d5011815a14c157ba25bb160187842fb81579a5
@@ -42,6 +42,7 @@ rundeps    :
         - poppler-qt5
     - qt6-devel :
         - poppler-qt6
+    - urw-core35-fonts
 setup      : |
     %cmake_ninja -DTESTDATADIR=$sources/test.git \
                  -DLIB_SUFFIX=%LIBSUFFIX% \
@@ -52,6 +53,7 @@ profile    : |
     %ninja_check
 install    : |
     %ninja_install
+    %install_license AUTHORS COPYING*
 check      : |
     %ninja_check
 patterns   :

--- a/packages/p/poppler/pspec_x86_64.xml
+++ b/packages/p/poppler/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>poppler</Name>
         <Homepage>https://poppler.freedesktop.org/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.library</PartOf>
@@ -27,6 +27,9 @@
             <Path fileType="library">/usr/lib64/libpoppler-glib.so.8.31.0</Path>
             <Path fileType="library">/usr/lib64/libpoppler.so.154</Path>
             <Path fileType="library">/usr/lib64/libpoppler.so.154.0.0</Path>
+            <Path fileType="data">/usr/share/licenses/poppler/AUTHORS</Path>
+            <Path fileType="data">/usr/share/licenses/poppler/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/poppler/COPYING3</Path>
             <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/pdfsig.mo</Path>
         </Files>
     </Package>
@@ -37,8 +40,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="57">poppler</Dependency>
-            <Dependency releaseFrom="57">poppler-utils</Dependency>
+            <Dependency release="58">poppler</Dependency>
+            <Dependency releaseFrom="58">poppler-utils</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/poppler/Annot.h</Path>
@@ -184,7 +187,7 @@
 </Description>
         <PartOf>desktop.library</PartOf>
         <RuntimeDependencies>
-            <Dependency release="57">poppler</Dependency>
+            <Dependency release="58">poppler</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libpoppler-qt5.so.1</Path>
@@ -197,8 +200,8 @@
         <Description xml:lang="en">This is Poppler, a library for rendering PDF files, and examining or modifying their structure.
 </Description>
         <RuntimeDependencies>
-            <Dependency release="57">poppler-devel</Dependency>
-            <Dependency releaseFrom="57">poppler-qt5</Dependency>
+            <Dependency release="58">poppler-devel</Dependency>
+            <Dependency releaseFrom="58">poppler-qt5</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/poppler/qt5/poppler-annotation.h</Path>
@@ -221,7 +224,7 @@
 </Description>
         <PartOf>desktop.library</PartOf>
         <RuntimeDependencies>
-            <Dependency release="57">poppler</Dependency>
+            <Dependency release="58">poppler</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libpoppler-qt6.so.3</Path>
@@ -234,8 +237,8 @@
         <Description xml:lang="en">This is Poppler, a library for rendering PDF files, and examining or modifying their structure.
 </Description>
         <RuntimeDependencies>
-            <Dependency release="57">poppler-devel</Dependency>
-            <Dependency releaseFrom="57">poppler-qt6</Dependency>
+            <Dependency release="58">poppler-devel</Dependency>
+            <Dependency releaseFrom="58">poppler-qt6</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/poppler/qt6/poppler-annotation.h</Path>
@@ -259,7 +262,7 @@
 </Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency release="57">poppler</Dependency>
+            <Dependency release="58">poppler</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/pdfattach</Path>
@@ -291,12 +294,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="57">
-            <Date>2025-12-28</Date>
+        <Update release="58">
+            <Date>2026-01-19</Date>
             <Version>25.10.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Re-add dependency on urw-core35-fonts.

Fixes https://github.com/getsolus/packages/issues/7452
Depends on https://github.com/getsolus/packages/pull/7636

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the font package is added as a rundep.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
