### PR TITLE
solseek: Update to 0.9.0

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 0.8.1
-release    : 12
+version    : 0.9.0
+release    : 13
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v0.8.1.tar.gz : 85db3196c88befd36f0328fbbf28d59cb6a38c4ec1e137e3aca2dbbd5afa739b
+    - https://github.com/clintre/solseek/archive/refs/tags/v0.9.0.tar.gz : 1f8fe8285c646b779c5d4293e4e7fff997a903bedc59ada2e3797bbda200c850
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -37,16 +37,20 @@
             <Path fileType="data">/usr/share/solseek/lang/pl.ini</Path>
             <Path fileType="data">/usr/share/solseek/solseek-uc.service</Path>
             <Path fileType="data">/usr/share/solseek/solseek-uc.timer</Path>
-            <Path fileType="data">/usr/share/solseek/solseek_fastfetch.jsonc</Path>
-            <Path fileType="data">/usr/share/solseek/solseek_fastfetch_str.jsonc</Path>
+            <Path fileType="data">/usr/share/solseek/solseek_fastfetch_1.jsonc</Path>
+            <Path fileType="data">/usr/share/solseek/solseek_fastfetch_2.jsonc</Path>
+            <Path fileType="data">/usr/share/solseek/solseek_fastfetch_3.jsonc</Path>
+            <Path fileType="data">/usr/share/solseek/solseek_fastfetch_4.jsonc</Path>
+            <Path fileType="data">/usr/share/solseek/solseek_fastfetch_5.jsonc</Path>
+            <Path fileType="data">/usr/share/solseek/solseek_fastfetch_6.jsonc</Path>
             <Path fileType="data">/usr/share/solseek/themes/base.theme</Path>
             <Path fileType="data">/usr/share/solseek/themes/solus.theme</Path>
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2025-12-17</Date>
-            <Version>0.8.1</Version>
+        <Update release="13">
+            <Date>2026-01-20</Date>
+            <Version>0.9.0</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**

Bugfixes:
- Corrected where Fastfetch would not render proper colors due to FZF tty

Enhancements:
- Added the ability to add a custom update script to Solseek. This will allow the user to create their own bash script to update other package types, like brew or appimages.
- Enhanced the way how solseek list the updates. Will now cache the list during update check versus calling on load. This should minimalize the update list no showing when their is network congestion pulling from Solus repositories.
- Added built-in fetch for users that do not have Fastfetch installed.
- Added new buit-in fastfetch configs (icons, text, both) and color or no color
- Added ability for user to use custom fastfetch config

Full release notes:

- [0.9.0](https://github.com/clintre/solseek/releases/tag/v0.9.0

**Test Plan**

Tested on VM 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
