### PR TITLE
qutebrowser: Update to v3.6.3

### DIFF
--- a/packages/q/qutebrowser/package.yml
+++ b/packages/q/qutebrowser/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : qutebrowser
-version    : 3.6.0
-release    : 52
+version    : 3.6.3
+release    : 53
 source     :
-    - https://github.com/qutebrowser/qutebrowser/releases/download/v3.6.0/qutebrowser-3.6.0.tar.gz : 5c1b518c0881bd2311170756d5164ad99427c708737637cae4ee9266b1d467bc
+    - https://github.com/qutebrowser/qutebrowser/releases/download/v3.6.3/qutebrowser-3.6.3.tar.gz : 6dbe2889e61ebd63003ae40b319e1e81f306e924e8316c6795ae4884021c2faf
 homepage   : https://qutebrowser.org
 license    : GPL-3.0-or-later
 component  : network.web.browser
@@ -23,3 +23,4 @@ build      : |
     %make -f misc/Makefile
 install    : |
     %make_install -f misc/Makefile PREFIX=/usr
+    %install_license LICENSE

--- a/packages/q/qutebrowser/pspec_x86_64.xml
+++ b/packages/q/qutebrowser/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>qutebrowser</Name>
         <Homepage>https://qutebrowser.org</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.web.browser</PartOf>
@@ -21,13 +21,13 @@
         <PartOf>network.web.browser</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/qutebrowser</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.0-py3.12.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.0-py3.12.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.0-py3.12.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.0-py3.12.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.0-py3.12.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.0-py3.12.egg-info/top_level.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.0-py3.12.egg-info/zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.3-py3.12.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.3-py3.12.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.3-py3.12.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.3-py3.12.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.3-py3.12.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.3-py3.12.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser-3.6.3-py3.12.egg-info/zip-safe</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/qutebrowser/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -734,6 +734,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/512x512/apps/qutebrowser.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/qutebrowser.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/qutebrowser.svg</Path>
+            <Path fileType="data">/usr/share/licenses/qutebrowser/LICENSE</Path>
             <Path fileType="man">/usr/share/man/man1/qutebrowser.1.zst</Path>
             <Path fileType="data">/usr/share/metainfo/org.qutebrowser.qutebrowser.appdata.xml</Path>
             <Path fileType="data">/usr/share/qutebrowser/scripts/cycle-inputs.js</Path>
@@ -775,12 +776,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="52">
-            <Date>2025-10-24</Date>
-            <Version>3.6.0</Version>
+        <Update release="53">
+            <Date>2026-01-22</Date>
+            <Version>3.6.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/qutebrowser/qutebrowser/blob/main/doc/changelog.asciidoc).
- Add license

**Test Plan**

Used vim bindings to browse web. Checked version. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
