### PR TITLE
qspeakers: Update to v1.8.5

### DIFF
--- a/packages/q/qspeakers/abi_used_symbols
+++ b/packages/q/qspeakers/abi_used_symbols
@@ -180,7 +180,7 @@ libQt6Core.so.6:_ZNK18QAbstractListModel6parentERK11QModelIndex
 libQt6Core.so.6:_ZNK18QAbstractListModel7siblingEiiRK11QModelIndex
 libQt6Core.so.6:_ZNK18QCommandLineParser19positionalArgumentsEv
 libQt6Core.so.6:_ZNK4QDir6existsEv
-libQt6Core.so.6:_ZNK4QDir6mkpathERK7QString
+libQt6Core.so.6:_ZNK4QDir6mkpathERK7QStringSt8optionalI6QFlagsIN11QFileDevice10PermissionEEE
 libQt6Core.so.6:_ZNK5QFile6existsEv
 libQt6Core.so.6:_ZNK7QLocale4nameENS_12TagSeparatorE
 libQt6Core.so.6:_ZNK7QLocale5toIntE11QStringViewPb
@@ -199,7 +199,6 @@ libQt6Core.so.6:_ZNK7QString8arg_implExii5QChar
 libQt6Core.so.6:_ZNK7QString8arg_implEyii5QChar
 libQt6Core.so.6:_ZNK7QString8endsWithERKS_N2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK8QVariant12toStringListEv
-libQt6Core.so.6:_ZNK8QVariant8metaTypeEv
 libQt6Core.so.6:_ZNK8QVariant8toStringEv
 libQt6Core.so.6:_ZNK9QFileInfo8fileNameEv
 libQt6Core.so.6:_ZNK9QFileInfo8fileTimeEN11QFileDevice8FileTimeE
@@ -235,8 +234,6 @@ libQt6Gui.so.6:_ZN5QFont9setWeightENS_6WeightE
 libQt6Gui.so.6:_ZN5QFontC1ERKS_
 libQt6Gui.so.6:_ZN5QFontC1Ev
 libQt6Gui.so.6:_ZN5QFontD1Ev
-libQt6Gui.so.6:_ZN5QIcon12hasThemeIconERK7QString
-libQt6Gui.so.6:_ZN5QIcon7addFileERK7QStringRK5QSizeNS_4ModeENS_5StateE
 libQt6Gui.so.6:_ZN5QIcon9fromThemeERK7QString
 libQt6Gui.so.6:_ZN5QIconC1ERK7QString
 libQt6Gui.so.6:_ZN5QIconC1Ev
@@ -387,6 +384,7 @@ libQt6Widgets.so.6:_ZN16QDialogButtonBox8rejectedEv
 libQt6Widgets.so.6:_ZN16QDialogButtonBoxC1E6QFlagsINS_14StandardButtonEEN2Qt11OrientationEP7QWidget
 libQt6Widgets.so.6:_ZN16QDialogButtonBoxC1EP7QWidget
 libQt6Widgets.so.6:_ZN19QAbstractScrollArea11eventFilterEP7QObjectP6QEvent
+libQt6Widgets.so.6:_ZN19QAbstractScrollArea26setVerticalScrollBarPolicyEN2Qt15ScrollBarPolicyE
 libQt6Widgets.so.6:_ZN5QMenu10insertMenuEP7QActionPS_
 libQt6Widgets.so.6:_ZN5QMenu12addSeparatorEv
 libQt6Widgets.so.6:_ZN5QMenu8setTitleERK7QString
@@ -527,6 +525,7 @@ libQt6Widgets.so.6:_ZNK7QWidget8sizeHintEv
 libQt6Widgets.so.6:_ZNK8QSpinBox5valueEv
 libQt6Widgets.so.6:_ZNK9QComboBox11currentTextEv
 libQt6Widgets.so.6:_ZNK9QComboBox12currentIndexEv
+libQt6Widgets.so.6:_ZNK9QComboBox4viewEv
 libQt6Widgets.so.6:_ZNK9QComboBox5countEv
 libQt6Widgets.so.6:_ZNK9QComboBox8findDataERK8QVarianti6QFlagsIN2Qt9MatchFlagEE
 libQt6Widgets.so.6:_ZNK9QLineEdit4textEv

--- a/packages/q/qspeakers/package.yml
+++ b/packages/q/qspeakers/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : qspeakers
-version    : '1.8'
-release    : 4
+version    : 1.8.5
+release    : 5
 source     :
-    - https://github.com/be1/qspeakers/archive/refs/tags/1.8.tar.gz : 43d149e82db3ccb2ed4e29438b50f846452f8425431c04fd63bc2c794f6a08b7
+    - https://github.com/be1/qspeakers/archive/refs/tags/1.8.5.tar.gz : c9c5dca9e380a7c1507a9e0c7a14212e170d82f697d6fba640bda867b54cd373
 homepage   : https://github.com/be1/qspeakers/
 license    : GPL-3.0-or-later
 component  : office.scientific
@@ -20,3 +20,4 @@ build      : |
     %make
 install    : |
     %make_install INSTALL_ROOT=$installdir
+    %install_license COPYING LICENSE

--- a/packages/q/qspeakers/pspec_x86_64.xml
+++ b/packages/q/qspeakers/pspec_x86_64.xml
@@ -23,6 +23,8 @@
             <Path fileType="executable">/usr/bin/qspeakers</Path>
             <Path fileType="data">/usr/share/applications/qspeakers.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/qspeakers.svg</Path>
+            <Path fileType="data">/usr/share/licenses/qspeakers/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/qspeakers/LICENSE</Path>
             <Path fileType="man">/usr/share/man/man1/qspeakers.1.gz</Path>
             <Path fileType="data">/usr/share/metainfo/rocks.noise.qspeakers.metainfo.xml</Path>
             <Path fileType="data">/usr/share/mime/packages/application-x-qspeakers.xml</Path>
@@ -38,9 +40,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2025-11-15</Date>
-            <Version>1.8</Version>
+        <Update release="5">
+            <Date>2026-01-22</Date>
+            <Version>1.8.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/be1/qspeakers/releases/tag/1.8.5).
- Add license

**Test Plan**

Clicked around and checked version in qspeakers

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
