### PR TITLE
adw-gtk3-theme: Update to v6.4

### DIFF
--- a/packages/a/adw-gtk3-theme/package.yml
+++ b/packages/a/adw-gtk3-theme/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : adw-gtk3-theme
-version    : '6.3'
-release    : 20
+version    : '6.4'
+release    : 21
 source     :
-    - https://github.com/lassekongo83/adw-gtk3/archive/refs/tags/v6.3.tar.gz : f87d03e46933a37c67dd2be57bc05ed094a2d8f2e1fa1831e1a96c46dffb088c
+    - https://github.com/lassekongo83/adw-gtk3/archive/refs/tags/v6.4.tar.gz : e96fc857360485689159adb0d5c9d2418cbf4cd38e79599d39e28ec0c32c24c4
     - https://github.com/sass/dart-sass/releases/download/1.87.0/dart-sass-1.87.0-linux-x64.tar.gz#sass.tar.gz : 1e7cf8d190c24c28b09389121d7eee328b5ed23524a3f1feca416a8124927bde
 license    : LGPL-2.1-only
 homepage   : https://github.com/lassekongo83/adw-gtk3
@@ -28,3 +28,4 @@ install    : |
     # Symlink adwaita gtk2 theme so we have _some_ gtk2 theming
     ln -sv /usr/share/themes/Adwaita/gtk-2.0/ $installdir/usr/share/themes/adw-gtk3/
     ln -sv /usr/share/themes/Adwaita-dark/gtk-2.0/ $installdir/usr/share/themes/adw-gtk3-dark/
+    %install_license LICENSE

--- a/packages/a/adw-gtk3-theme/pspec_x86_64.xml
+++ b/packages/a/adw-gtk3-theme/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>adw-gtk3-theme</Name>
         <Homepage>https://github.com/lassekongo83/adw-gtk3</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>LGPL-2.1-only</License>
         <PartOf>desktop.theme</PartOf>
@@ -20,6 +20,7 @@
 </Description>
         <PartOf>desktop.theme</PartOf>
         <Files>
+            <Path fileType="data">/usr/share/licenses/adw-gtk3-theme/LICENSE</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-2.0</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/bullet-symbolic.svg</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/assets/bullet-symbolic.symbolic.png</Path>
@@ -75,14 +76,8 @@
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/gtk.css</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-3.0/thumbnail.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/assets/bullet-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/assets/bullet-symbolic.symbolic.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/assets/bullet@2-symbolic.symbolic.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/assets/check-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/assets/check-symbolic.symbolic.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/assets/check@2-symbolic.symbolic.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/assets/dash-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/assets/dash-symbolic.symbolic.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/assets/dash@2-symbolic.symbolic.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/assets/devel-symbolic.svg</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/gtk-dark.css</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3-dark/gtk-4.0/gtk.css</Path>
@@ -144,14 +139,8 @@
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/gtk.css</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-3.0/thumbnail.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/assets/bullet-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/assets/bullet-symbolic.symbolic.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/assets/bullet@2-symbolic.symbolic.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/assets/check-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/assets/check-symbolic.symbolic.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/assets/check@2-symbolic.symbolic.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/assets/dash-symbolic.svg</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/assets/dash-symbolic.symbolic.png</Path>
-            <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/assets/dash@2-symbolic.symbolic.png</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/assets/devel-symbolic.svg</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/gtk-dark.css</Path>
             <Path fileType="data">/usr/share/themes/adw-gtk3/gtk-4.0/gtk.css</Path>
@@ -161,12 +150,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2025-09-05</Date>
-            <Version>6.3</Version>
+        <Update release="21">
+            <Date>2026-01-31</Date>
+            <Version>6.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
The GTK4 theme now requires GTK 4.20 or later.

The GTK4 theme now makes use of CSS `@media` query to apply the dark theme, therefore the version requirement bump. Make sure whatever desktop environment/WM you're using is properly setting the dark xdg-desktop-portal variant. Most major desktop environments should handle this automatically when you select dark from the settings.

**Test Plan**
- Switched theme.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
