### PR TITLE
github-cli: Update to 2.86.0

### DIFF
--- a/packages/g/github-cli/package.yml
+++ b/packages/g/github-cli/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : github-cli
-version    : 2.85.0
-release    : 88
+version    : 2.86.0
+release    : 89
 source     :
-    - https://github.com/cli/cli/archive/refs/tags/v2.85.0.tar.gz : 5fa457376a343b022dd8e881228c7b33290940f6289a7f3342dff0c914980461
+    - https://github.com/cli/cli/archive/refs/tags/v2.86.0.tar.gz : cd2998310e81727af5c2056e9936e6541a20f968d6e3a4891f7fedbc0b336008
 homepage   : https://cli.github.com
 license    : MIT
 component  : system.utils

--- a/packages/g/github-cli/pspec_x86_64.xml
+++ b/packages/g/github-cli/pspec_x86_64.xml
@@ -73,6 +73,7 @@
             <Path fileType="man">/usr/share/man/man1/gh-config-list.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/gh-config-set.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/gh-config.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/gh-copilot.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/gh-extension-browse.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/gh-extension-create.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/gh-extension-exec.1.zst</Path>
@@ -241,9 +242,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="88">
-            <Date>2026-01-14</Date>
-            <Version>2.85.0</Version>
+        <Update release="89">
+            <Date>2026-01-23</Date>
+            <Version>2.86.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/cli/cli/releases/tag/v2.86.0).

**Test Plan**

Run `gh status` and `gh pr list`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
