### PR TITLE
yazi: Update to v26.1.22

### DIFF
--- a/packages/y/yazi/files/io.github.sxyazi.yazi.metainfo.xml
+++ b/packages/y/yazi/files/io.github.sxyazi.yazi.metainfo.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2024 Yazi Developers -->
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Copyright 2024 sxyazi -->
 <component type="desktop-application">
-  <id>org.yazi.Yazi</id>
+  <id>io.github.sxyazi.yazi</id>
   <launchable type="desktop-id">yazi.desktop</launchable>
   <name>Yazi</name>
-  <developer_name>Yazi Developers</developer_name>
+  <developer_name>sxyazi</developer_name>
   <summary>Blazingly fast terminal file manager</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MIT</project_license>
@@ -21,12 +21,9 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image xml:space="preserve">https://raw.githubusercontent.com/yazi-rs/yazi-rs.github.io/main/static/images/no-status-bar.jpg</image>
+      <image type="source" xml:space="preserve">https://raw.githubusercontent.com/yazi-rs/yazi-rs.github.io/main/static/images/no-status-bar.jpg</image>
       <caption>Yazi file manager interface</caption>
     </screenshot>
   </screenshots>
-  <releases>
-    <release version="25.5.31" date="2025-05-31"/>
-  </releases>
   <update_contact>https://github.com/sxyazi/yazi/issues</update_contact>
 </component>

--- a/packages/y/yazi/package.yml
+++ b/packages/y/yazi/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : yazi
-version    : 26.1.4
-release    : 6
+version    : 26.1.22
+release    : 7
 source     :
-    - https://github.com/sxyazi/yazi/archive/refs/tags/v26.1.4.tar.gz : 17839410a2865dc6ddb40da4b034dbf2729602fc325d07ad4df7dbc354c94c9e
+    - https://github.com/sxyazi/yazi/archive/refs/tags/v26.1.22.tar.gz : 83b8a1bf166bfcb54b44b966fa3f34afa7c55584bf81d29275a1cdd99d1c9c4c
 homepage   : https://yazi-rs.github.io
 license    : MIT
 component  : system.utils
@@ -16,23 +16,20 @@ builddeps  :
     - rust
 rundeps    :
     - file
-
 setup      : |
     # Fix desktop to avoid duplicate entries
     sed -i 's/Categories=.*/Categories=System;FileManager;/' "assets/yazi.desktop"
     %cargo_fetch
-
 build      : |
     export YAZI_GEN_COMPLETIONS=true
     %cargo_build
-
 install    : |
     %cargo_install yazi ya
     %install_license LICENSE*
     install -Dm00644 "assets/yazi.desktop" "$installdir/usr/share/applications/yazi.desktop"
 
     # Install appstream metainfo
-    install -Dm00644 "$pkgfiles/org.yazi.Yazi.metainfo.xml" "$installdir/usr/share/metainfo/org.yazi.Yazi.metainfo.xml"
+    install -Dm00644 "$pkgfiles/io.github.sxyazi.yazi.metainfo.xml" "$installdir/usr/share/metainfo/io.github.sxyazi.yazi.metainfo.xml"
 
     # Install icon
     install -Dm00644 "assets/logo.png" "$installdir/usr/share/icons/hicolor/512x512/apps/yazi.png"

--- a/packages/y/yazi/pspec_x86_64.xml
+++ b/packages/y/yazi/pspec_x86_64.xml
@@ -32,15 +32,15 @@ and extensibility through plugins and themes.
             <Path fileType="data">/usr/share/icons/hicolor/512x512/apps/yazi.png</Path>
             <Path fileType="data">/usr/share/licenses/yazi/LICENSE</Path>
             <Path fileType="data">/usr/share/licenses/yazi/LICENSE-ICONS</Path>
-            <Path fileType="data">/usr/share/metainfo/org.yazi.Yazi.metainfo.xml</Path>
+            <Path fileType="data">/usr/share/metainfo/io.github.sxyazi.yazi.metainfo.xml</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_ya</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_yazi</Path>
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2026-01-07</Date>
-            <Version>26.1.4</Version>
+        <Update release="7">
+            <Date>2026-01-24</Date>
+            <Version>26.1.22</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/sxyazi/yazi/blob/main/CHANGELOG.md).
- Changed appstream info to match the flatpak

**Test Plan**

Moved around file system. Deleted the a file with yazi. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
