### PR TITLE
python-urllib3: Update to v2.6.3

### DIFF
--- a/packages/py/python-urllib3/package.yml
+++ b/packages/py/python-urllib3/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-urllib3
-version    : 2.6.0
-release    : 21
+version    : 2.6.3
+release    : 22
 source     :
-    - https://pypi.debian.net/urllib3/urllib3-2.6.0.tar.gz : cb9bcef5a4b345d5da5d145dc3e30834f58e8018828cbc724d30b4cb7d4d49f1
+    - https://pypi.debian.net/urllib3/urllib3-2.6.3.tar.gz : 1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed
 homepage   : https://urllib3.readthedocs.io/
 license    : MIT
 component  : programming.python
@@ -35,6 +35,7 @@ build      : |
     %python3_setup
 install    : |
     %python3_install
+    %install_license LICENSE.txt
 # todo 3.12, shite takes forever or hangs idk
 #check      : |
 #    %python3_test pytest -v \

--- a/packages/py/python-urllib3/pspec_x86_64.xml
+++ b/packages/py/python-urllib3/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-urllib3</Name>
         <Homepage>https://urllib3.readthedocs.io/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.6.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.6.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.6.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.6.0.dist-info/licenses/LICENSE.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.6.3.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.6.3.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.6.3.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.6.3.dist-info/licenses/LICENSE.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3/__pycache__/__init__.cpython-312.pyc</Path>
@@ -134,15 +134,16 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3/util/url.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3/util/util.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3/util/wait.py</Path>
+            <Path fileType="data">/usr/share/licenses/python-urllib3/LICENSE.txt</Path>
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2025-12-05</Date>
-            <Version>2.6.0</Version>
+        <Update release="22">
+            <Date>2026-01-24</Date>
+            <Version>2.6.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://urllib3.readthedocs.io/en/stable/changelog.html#id1)

**Security**

- https://github.com/urllib3/urllib3/security/advisories/GHSA-38jv-5279-wg99

**Test Plan**

- Use `pastebinit` to post something

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
