### PR TITLE
python-tornado: Update to v6.5.4

### DIFF
--- a/packages/py/python-tornado/package.yml
+++ b/packages/py/python-tornado/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-tornado
-version    : 6.5.2
-release    : 17
+version    : 6.5.4
+release    : 18
 source     :
-    - https://github.com/tornadoweb/tornado/archive/refs/tags/v6.5.2.tar.gz : 051973247a5807cbdcad8af7fe6e511077ca55e5f024bde5799b4a6418937a23
+    - https://github.com/tornadoweb/tornado/archive/refs/tags/v6.5.4.tar.gz : 983f151603e388932ec2b6f5e0f5231c95d1ac8d1ac28fca834c0962ff9369e1
 homepage   : https://www.tornadoweb.org/
 license    : Apache-2.0
 component  : programming.python
@@ -21,6 +21,7 @@ build      : |
     %python3_setup
 install    : |
     %python3_install
+    %install_license LICENSE
 #check      : |
 #    # https://github.com/tornadoweb/tornado/issues/2947
 #    %python3_test -m tornado.test.runtests --verbose

--- a/packages/py/python-tornado/pspec_x86_64.xml
+++ b/packages/py/python-tornado/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-tornado</Name>
         <Homepage>https://www.tornadoweb.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -20,11 +20,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/tornado-6.5.2.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/tornado-6.5.2.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/tornado-6.5.2.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/tornado-6.5.2.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/tornado-6.5.2.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/tornado-6.5.4.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/tornado-6.5.4.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/tornado-6.5.4.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/tornado-6.5.4.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/tornado-6.5.4.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/tornado/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/tornado/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/tornado/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -263,15 +263,16 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/tornado/web.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/tornado/websocket.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/tornado/wsgi.py</Path>
+            <Path fileType="data">/usr/share/licenses/python-tornado/LICENSE</Path>
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2025-10-23</Date>
-            <Version>6.5.2</Version>
+        <Update release="18">
+            <Date>2026-01-24</Date>
+            <Version>6.5.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- [6.5.4](https://www.tornadoweb.org/en/stable/releases/v6.5.4.html)
- [6.5.3](https://www.tornadoweb.org/en/stable/releases/v6.5.3.html)

**Security**

- CVE-2025-67726
- CVE-2025-67725
- CVE-2025-67724

**Test Plan**

- Run `bup`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
