### PR TITLE
flatpak: Update to v1.16.3

### DIFF
--- a/packages/f/flatpak/abi_used_symbols
+++ b/packages/f/flatpak/abi_used_symbols
@@ -364,6 +364,7 @@ libgio-2.0.so.0:g_file_new_build_filename
 libgio-2.0.so.0:g_file_new_for_commandline_arg
 libgio-2.0.so.0:g_file_new_for_path
 libgio-2.0.so.0:g_file_new_for_uri
+libgio-2.0.so.0:g_file_peek_path
 libgio-2.0.so.0:g_file_query_exists
 libgio-2.0.so.0:g_file_query_file_type
 libgio-2.0.so.0:g_file_query_info
@@ -823,6 +824,7 @@ libglib-2.0.so.0:g_uri_parse
 libglib-2.0.so.0:g_uri_parse_relative
 libglib-2.0.so.0:g_uri_to_string_partial
 libglib-2.0.so.0:g_uri_unref
+libglib-2.0.so.0:g_usleep
 libglib-2.0.so.0:g_utf8_find_next_char
 libglib-2.0.so.0:g_utf8_get_char
 libglib-2.0.so.0:g_utf8_get_char_validated

--- a/packages/f/flatpak/package.yml
+++ b/packages/f/flatpak/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : flatpak
-version    : 1.16.0
-release    : 83
+version    : 1.16.3
+release    : 84
 source     :
-    - https://github.com/flatpak/flatpak/releases/download/1.16.0/flatpak-1.16.0.tar.xz : cb0ac565adcb62127c6d11ed50ee7044d6a836fa69c354b2f4b640a22bfa4b2a
+    - https://github.com/flatpak/flatpak/archive/refs/tags/1.16.3.tar.gz : b1f778a392cefc1a936fb7158da046f02348d1866245ad383ba482446d1a3c4a
 homepage   : https://flatpak.org/
 license    : LGPL-2.1-or-later
 component  : desktop
@@ -48,6 +48,7 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING
 
     # Make sure that flatpak profile script is loaded after 10-xdg.sh
     mv $installdir/usr/share/defaults/etc/profile.d/flatpak.sh $installdir/usr/share/defaults/etc/profile.d/70-flatpak.sh

--- a/packages/f/flatpak/pspec_x86_64.xml
+++ b/packages/f/flatpak/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>flatpak</Name>
         <Homepage>https://flatpak.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>desktop</PartOf>
@@ -39,7 +39,7 @@
             <Path fileType="library">/usr/lib64/flatpak/revokefs-fuse</Path>
             <Path fileType="library">/usr/lib64/girepository-1.0/Flatpak-1.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libflatpak.so.0</Path>
-            <Path fileType="library">/usr/lib64/libflatpak.so.0.11600.0</Path>
+            <Path fileType="library">/usr/lib64/libflatpak.so.0.11603.0</Path>
             <Path fileType="library">/usr/lib64/systemd/system/flatpak-update.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/flatpak-update.timer</Path>
             <Path fileType="library">/usr/lib64/systemd/user/flatpak-update.service</Path>
@@ -56,12 +56,15 @@
             <Path fileType="data">/usr/share/defaults/etc/profile.d/70-flatpak.sh</Path>
             <Path fileType="doc">/usr/share/doc/flatpak/docbook.css</Path>
             <Path fileType="doc">/usr/share/doc/flatpak/flatpak-docs.html</Path>
+            <Path fileType="doc">/usr/share/doc/flatpak/libflatpak-docs.html</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/flatpak.fish</Path>
             <Path fileType="data">/usr/share/fish/vendor_conf.d/flatpak.fish</Path>
             <Path fileType="data">/usr/share/flatpak/remotes.d/flathub.flatpakrepo</Path>
             <Path fileType="data">/usr/share/flatpak/triggers/desktop-database.trigger</Path>
             <Path fileType="data">/usr/share/flatpak/triggers/gtk-icon-cache.trigger</Path>
             <Path fileType="data">/usr/share/flatpak/triggers/mime-database.trigger</Path>
+            <Path fileType="data">/usr/share/licenses/flatpak/COPYING</Path>
+            <Path fileType="localedata">/usr/share/locale/bg/LC_MESSAGES/flatpak.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/flatpak.mo</Path>
             <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/flatpak.mo</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/flatpak.mo</Path>
@@ -82,6 +85,7 @@
             <Path fileType="localedata">/usr/share/locale/ro/LC_MESSAGES/flatpak.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ru/LC_MESSAGES/flatpak.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sk/LC_MESSAGES/flatpak.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sl/LC_MESSAGES/flatpak.mo</Path>
             <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/flatpak.mo</Path>
             <Path fileType="localedata">/usr/share/locale/tr/LC_MESSAGES/flatpak.mo</Path>
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/flatpak.mo</Path>
@@ -151,7 +155,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="83">flatpak</Dependency>
+            <Dependency release="84">flatpak</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/flatpak/flatpak-bundle-ref.h</Path>
@@ -220,12 +224,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="83">
-            <Date>2026-01-17</Date>
-            <Version>1.16.0</Version>
+        <Update release="84">
+            <Date>2026-01-24</Date>
+            <Version>1.16.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- [1.16.3](https://github.com/flatpak/flatpak/releases/tag/1.16.3)
- [1.16.2](https://github.com/flatpak/flatpak/releases/tag/1.16.2)
- [1.16.1](https://github.com/flatpak/flatpak/releases/tag/1.16.1)

Resolves https://github.com/getsolus/packages/issues/7687

**Test Plan**

- Uninstall a crusty flatpak, update others

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
