### PR TITLE
seatd: Update to v0.9.2

### DIFF
--- a/packages/s/seatd/package.yml
+++ b/packages/s/seatd/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : seatd
-version    : 0.9.1
-release    : 4
+version    : 0.9.2
+release    : 5
 source     :
-    - https://git.sr.ht/~kennylevinsen/seatd/archive/0.9.1.tar.gz : 819979c922a0be258aed133d93920bce6a3d3565a60588d6d372ce9db2712cd3
+    - https://git.sr.ht/~kennylevinsen/seatd/archive/0.9.2.tar.gz : 2811654fc87b3b1877f62e69cbf1e761c7072146f127860d9b8fe1ca27607d0e
 homepage   : https://sr.ht/~kennylevinsen/seatd/
 license    : MIT
 component  : desktop.library
@@ -16,3 +16,4 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license LICENSE

--- a/packages/s/seatd/pspec_x86_64.xml
+++ b/packages/s/seatd/pspec_x86_64.xml
@@ -23,6 +23,7 @@
             <Path fileType="executable">/usr/bin/seatd</Path>
             <Path fileType="executable">/usr/bin/seatd-launch</Path>
             <Path fileType="library">/usr/lib64/libseat.so.1</Path>
+            <Path fileType="data">/usr/share/licenses/seatd/LICENSE</Path>
         </Files>
     </Package>
     <Package>
@@ -32,7 +33,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="4">seatd</Dependency>
+            <Dependency release="5">seatd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libseat.h</Path>
@@ -41,9 +42,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2025-01-09</Date>
-            <Version>0.9.1</Version>
+        <Update release="5">
+            <Date>2026-01-25</Date>
+            <Version>0.9.2</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://git.sr.ht/~kennylevinsen/seatd/refs/0.9.2)

**Test Plan**

- Run a Sway session

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
