### PR TITLE
leiningen: switch to openjdk-21

### DIFF
--- a/packages/l/leiningen/package.yml
+++ b/packages/l/leiningen/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : leiningen
 version    : 2.9.8
-release    : 4
+release    : 5
 source     :
     - https://github.com/technomancy/leiningen/archive/refs/tags/2.9.8.tar.gz : be299cbd70693213c6887f931327fb9df3bd54930a521d0fc88bea04d55c5cd4
 homepage   : https://leiningen.org/
@@ -12,11 +12,11 @@ summary    : Leiningen is for automating Clojure projects without setting your h
 description: |
     Leiningen is the easiest way to use Clojure. With a focus on project automation and declarative configuration, it gets out of your way and lets you focus on your code.
 environment: |
-    export JAVA_CMD=/usr/lib64/openjdk-17/bin/java
+    export JAVA_CMD=/usr/lib64/openjdk-21/bin/java
 builddeps  :
-    - openjdk-17
+    - openjdk-21
 rundeps    :
-    - openjdk-17
+    - openjdk-21
 build      : |
     curl https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein > lein
     chmod a+x ./lein

--- a/packages/l/leiningen/pspec_x86_64.xml
+++ b/packages/l/leiningen/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>leiningen</Name>
         <Homepage>https://leiningen.org/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>EPL-1.0</License>
         <PartOf>programming.tools</PartOf>
@@ -25,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-05-25</Date>
+        <Update release="5">
+            <Date>2026-01-25</Date>
             <Version>2.9.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Switch to openjdk-21
- Part of https://github.com/getsolus/packages/issues/7692

**Test Plan**
- Created a simple test project.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
