### PR TITLE
solseek: Update to 0.10.0

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 0.9.0
-release    : 13
+version    : 0.10.0
+release    : 14
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v0.9.0.tar.gz : 1f8fe8285c646b779c5d4293e4e7fff997a903bedc59ada2e3797bbda200c850
+    - https://github.com/clintre/solseek/archive/refs/tags/v0.10.0.tar.gz : 10bb6735a8910f940dd43f66b1d85767f2e1aad56238acc16a932b37ae125673
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -33,6 +33,7 @@
             <Path fileType="data">/usr/share/solseek/core/menus</Path>
             <Path fileType="data">/usr/share/solseek/core/pkg_functions</Path>
             <Path fileType="data">/usr/share/solseek/lang/en.ini</Path>
+            <Path fileType="data">/usr/share/solseek/lang/es.ini</Path>
             <Path fileType="data">/usr/share/solseek/lang/fr.ini</Path>
             <Path fileType="data">/usr/share/solseek/lang/pl.ini</Path>
             <Path fileType="data">/usr/share/solseek/solseek-uc.service</Path>
@@ -48,9 +49,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2026-01-20</Date>
-            <Version>0.9.0</Version>
+        <Update release="14">
+            <Date>2026-01-26</Date>
+            <Version>0.10.0</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**

Bugfixes:
- Fixed issue where when running solseek up -e from the cli it would update eopkg and flatpak twice

Enhancements:
- Added Spanish translation by RexFactorem
- Added Flatpak History in tools to match capabilities with eopkg. Made possible by a change on Solus
- Added link to wiki on main page

Full release notes:

- [0.10.0](https://github.com/clintre/solseek/releases/tag/v0.10.0)

**Test Plan**

Tested on VM across DEs
Make sure new features work

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
