### PR TITLE
bazel: Fix wrapper script

### DIFF
--- a/packages/b/bazel/files/bazel.sh
+++ b/packages/b/bazel/files/bazel.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-[ -z "$JAVA_HOME" ] && export JAVA_HOME=/usr/lib64/openjdk-17
+[ -z "$JAVA_HOME" ] && export JAVA_HOME=/usr/lib64/openjdk-21
 
 exec /usr/share/bazel/bazel "$@"

--- a/packages/b/bazel/package.yml
+++ b/packages/b/bazel/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : bazel
 version    : 8.5.0
-release    : 20
+release    : 21
 source     :
     - https://github.com/bazelbuild/bazel/releases/download/8.5.0/bazel-8.5.0-dist.zip : b476d96141f9bd803562aee0448376b61494112918bce441898585493db33ed1
 license    : Apache-2.0

--- a/packages/b/bazel/pspec_x86_64.xml
+++ b/packages/b/bazel/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>bazel</Name>
         <Homepage>https://bazel.build/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.tools</PartOf>
@@ -28,12 +28,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2026-01-03</Date>
+        <Update release="21">
+            <Date>2026-01-27</Date>
             <Version>8.5.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Make the wrapper use jdk 21, like the rest of the package

**Test Plan**

- Build python-protobuf

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
