### PR TITLE
gnupg: Update to v2.5.17

### DIFF
--- a/packages/g/gnupg/package.yml
+++ b/packages/g/gnupg/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gnupg
-version    : 2.5.16
-release    : 47
+version    : 2.5.17
+release    : 48
 source     :
-    - https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.5.16.tar.bz2 : 05144040fedb828ced2a6bafa2c4a0479ee4cceacf3b6d68ccc75b175ac13b7e
+    - https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.5.17.tar.bz2 : 2c1fbe20e2958fd8fb53cf37d7c38e84a900edc0d561a1c4af4bc3a10888685d
 license    : GPL-3.0-or-later
 homepage   : https://www.gnupg.org
 summary    : Complete and free implementation of OpenPGP

--- a/packages/g/gnupg/pspec_x86_64.xml
+++ b/packages/g/gnupg/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnupg</Name>
         <Homepage>https://www.gnupg.org</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>security</PartOf>
@@ -157,12 +157,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="47">
-            <Date>2025-12-30</Date>
-            <Version>2.5.16</Version>
+        <Update release="48">
+            <Date>2026-01-28</Date>
+            <Version>2.5.17</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- agent: Fix stack buffer overflow when using gpgsm and KEM.  This was introduced with 2.5.13; see the advisory
- tpm: Fix possible buffer overflow in PKDECRYPT
- gpg: Fix possible NULL-deref with overlong signature packets
- gpg: New export-option "keep-expired-subkeys"
- gpgsm: Make multiple search patterns work with keyboxd
- agent: Add accelerator keys for "Wrong" and "Correct"
- dirmngr: Help detection of bad keyserver configurations
- Full details [here](https://dev.gnupg.org/T7996)

**Security**

- CVE-2026-24881
- CVE-2026-24882
- CVE-2026-24883

**Test Plan**

- Generate a new key, sign something

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
