### PR TITLE
openssl: Update to v3.3.6

### DIFF
--- a/packages/o/openssl/files/0001-Fix-soname-dynamic-loading.patch
+++ b/packages/o/openssl/files/0001-Fix-soname-dynamic-loading.patch
@@ -14,51 +14,51 @@ Fix this in a hacky way by changing the libraries to be looked up by their actua
  4 files changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/crypto/comp/c_brotli.c b/crypto/comp/c_brotli.c
-index 07e1e76471..3d0bc66b1f 100644
+index d262ec6a4e..68a2d63fbd 100644
 --- a/crypto/comp/c_brotli.c
 +++ b/crypto/comp/c_brotli.c
 @@ -288,8 +288,8 @@ DEFINE_RUN_ONCE_STATIC(ossl_comp_brotli_init)
- #   define LIBBROTLIENC "BROTLIENC"
- #   define LIBBROTLIDEC "BROTLIDEC"
- #  else
--#   define LIBBROTLIENC "brotlienc"
--#   define LIBBROTLIDEC "brotlidec"
-+#   define LIBBROTLIENC "libbrotlienc.so.1"
-+#   define LIBBROTLIDEC "libbrotlidec.so.1"
- #  endif
+ #define LIBBROTLIENC "BROTLIENC"
+ #define LIBBROTLIDEC "BROTLIDEC"
+ #else
+-#define LIBBROTLIENC "brotlienc"
+-#define LIBBROTLIDEC "brotlidec"
++#define LIBBROTLIENC "libbrotlienc.so.1"
++#define LIBBROTLIDEC "libbrotlidec.so.1"
+ #endif
  
      brotli_encode_dso = DSO_load(NULL, LIBBROTLIENC, NULL, 0);
 diff --git a/crypto/comp/c_zlib.c b/crypto/comp/c_zlib.c
-index 0fbab8f014..3636a71c7d 100644
+index c90c7b090d..c33509cdc9 100644
 --- a/crypto/comp/c_zlib.c
 +++ b/crypto/comp/c_zlib.c
-@@ -278,7 +278,7 @@ DEFINE_RUN_ONCE_STATIC(ossl_comp_zlib_init)
- #   elif defined(OPENSSL_SYS_VMS)
- #    define LIBZ "LIBZ"
- #   else
--#    define LIBZ "z"
-+#    define LIBZ "libz.so.1"
- #   endif
- #  endif
+@@ -277,7 +277,7 @@ DEFINE_RUN_ONCE_STATIC(ossl_comp_zlib_init)
+ #elif defined(OPENSSL_SYS_VMS)
+ #define LIBZ "LIBZ"
+ #else
+-#define LIBZ "z"
++#define LIBZ "libz.so.1"
+ #endif
+ #endif
  
 diff --git a/crypto/comp/c_zstd.c b/crypto/comp/c_zstd.c
-index b4667649f3..e67722da48 100644
+index 44712b26fe..baa8a68494 100644
 --- a/crypto/comp/c_zstd.c
 +++ b/crypto/comp/c_zstd.c
-@@ -364,7 +364,7 @@ DEFINE_RUN_ONCE_STATIC(ossl_comp_zstd_init)
- #  if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_WIN32)
- #   define LIBZSTD "LIBZSTD"
- #  else
--#   define LIBZSTD  "zstd"
-+#   define LIBZSTD  "libzstd.so.1"
- #  endif
+@@ -363,7 +363,7 @@ DEFINE_RUN_ONCE_STATIC(ossl_comp_zstd_init)
+ #if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_WIN32)
+ #define LIBZSTD "LIBZSTD"
+ #else
+-#define LIBZSTD "zstd"
++#define LIBZSTD "libzstd.so.1"
+ #endif
  
      zstd_dso = DSO_load(NULL, LIBZSTD, NULL, 0);
 diff --git a/crypto/dso/dso_dlfcn.c b/crypto/dso/dso_dlfcn.c
-index 76737fa7b8..4dfe5dd3c2 100644
+index 2649300974..002c5705b3 100644
 --- a/crypto/dso/dso_dlfcn.c
 +++ b/crypto/dso/dso_dlfcn.c
-@@ -251,7 +251,7 @@ static char *dlfcn_name_converter(DSO *dso, const char *filename)
+@@ -248,7 +248,7 @@ static char *dlfcn_name_converter(DSO *dso, const char *filename)
  
      len = strlen(filename);
      rsize = len + 1;
@@ -66,4 +66,4 @@ index 76737fa7b8..4dfe5dd3c2 100644
 +    transform = (strchr(filename, '/') == NULL) && (strstr(filename, ".so.") == NULL);
      if (transform) {
          /* We will convert this to "%s.so" or "lib%s.so" etc */
-         rsize += strlen(DSO_EXTENSION);    /* The length of ".so" */
+         rsize += strlen(DSO_EXTENSION); /* The length of ".so" */

--- a/packages/o/openssl/package.yml
+++ b/packages/o/openssl/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : openssl
-version    : 3.3.5
-release    : 55
+version    : 3.3.6
+release    : 56
 source     :
-    - https://github.com/openssl/openssl/releases/download/openssl-3.3.5/openssl-3.3.5.tar.gz : 9d62c00a5a6903740c8703f0e006257f429d565d3b91ac1a9bd4a4c700002e01
+    - https://github.com/openssl/openssl/releases/download/openssl-3.3.6/openssl-3.3.6.tar.gz : 22db04f3c8f9a808c9795dcf7d2713ff40c12c410ea2d1f6435c6c9c8558958b
 homepage   : https://www.openssl.org/
 license    : OpenSSL
 summary    : Cryptographic tools required by many packages

--- a/packages/o/openssl/pspec_x86_64.xml
+++ b/packages/o/openssl/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>openssl</Name>
         <Homepage>https://www.openssl.org/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Packager>
         <License>OpenSSL</License>
         <PartOf>system.base</PartOf>
@@ -353,7 +353,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="55">openssl</Dependency>
+            <Dependency release="56">openssl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/engines-3/afalg.so</Path>
@@ -372,8 +372,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="55">openssl-32bit</Dependency>
-            <Dependency release="55">openssl-devel</Dependency>
+            <Dependency release="56">openssl-32bit</Dependency>
+            <Dependency release="56">openssl-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/cmake/OpenSSL/OpenSSLConfig.cmake</Path>
@@ -394,7 +394,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="55">openssl</Dependency>
+            <Dependency release="56">openssl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/openssl/aes.h</Path>
@@ -745,6 +745,8 @@
             <Path fileType="man">/usr/share/man/man3/BIO_callback_ctrl.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_callback_fn.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_callback_fn_ex.3ossl</Path>
+            <Path fileType="man">/usr/share/man/man3/BIO_clear_flags.3ossl</Path>
+            <Path fileType="man">/usr/share/man/man3/BIO_clear_retry_flags.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_closesocket.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_connect.3ossl.zst</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_ctrl.3ossl.zst</Path>
@@ -817,6 +819,7 @@
             <Path fileType="man">/usr/share/man/man3/BIO_get_ex_data.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_get_ex_new_index.3ossl.zst</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_get_fd.3ossl</Path>
+            <Path fileType="man">/usr/share/man/man3/BIO_get_flags.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_get_fp.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_get_indent.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_get_info_callback.3ossl</Path>
@@ -834,6 +837,7 @@
             <Path fileType="man">/usr/share/man/man3/BIO_get_peer_port.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_get_read_request.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_get_retry_BIO.3ossl</Path>
+            <Path fileType="man">/usr/share/man/man3/BIO_get_retry_flags.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_get_retry_reason.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_get_rpoll_descriptor.3ossl.zst</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_get_shutdown.3ossl</Path>
@@ -946,6 +950,7 @@
             <Path fileType="man">/usr/share/man/man3/BIO_set_data.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_set_ex_data.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_set_fd.3ossl</Path>
+            <Path fileType="man">/usr/share/man/man3/BIO_set_flags.3ossl.zst</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_set_fp.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_set_indent.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_set_info_callback.3ossl</Path>
@@ -958,7 +963,10 @@
             <Path fileType="man">/usr/share/man/man3/BIO_set_next.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_set_prefix.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_set_read_buffer_size.3ossl</Path>
+            <Path fileType="man">/usr/share/man/man3/BIO_set_retry_read.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_set_retry_reason.3ossl</Path>
+            <Path fileType="man">/usr/share/man/man3/BIO_set_retry_special.3ossl</Path>
+            <Path fileType="man">/usr/share/man/man3/BIO_set_retry_write.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_set_shutdown.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_set_sock_type.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_set_ssl.3ossl</Path>
@@ -980,6 +988,7 @@
             <Path fileType="man">/usr/share/man/man3/BIO_ssl_copy_session_id.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_ssl_shutdown.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_tell.3ossl</Path>
+            <Path fileType="man">/usr/share/man/man3/BIO_test_flags.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_up_ref.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_vfree.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_vprintf.3ossl</Path>
@@ -1158,6 +1167,7 @@
             <Path fileType="man">/usr/share/man/man3/CMS_EncryptedData_decrypt.3ossl.zst</Path>
             <Path fileType="man">/usr/share/man/man3/CMS_EncryptedData_encrypt.3ossl.zst</Path>
             <Path fileType="man">/usr/share/man/man3/CMS_EncryptedData_encrypt_ex.3ossl</Path>
+            <Path fileType="man">/usr/share/man/man3/CMS_EncryptedData_set1_key.3ossl.zst</Path>
             <Path fileType="man">/usr/share/man/man3/CMS_EnvelopedData_create.3ossl.zst</Path>
             <Path fileType="man">/usr/share/man/man3/CMS_EnvelopedData_create_ex.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/CMS_EnvelopedData_decrypt.3ossl</Path>
@@ -1880,7 +1890,7 @@
             <Path fileType="man">/usr/share/man/man3/EVP_CIPHER_CTX_get0_cipher.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/EVP_CIPHER_CTX_get0_name.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/EVP_CIPHER_CTX_get1_cipher.3ossl</Path>
-            <Path fileType="man">/usr/share/man/man3/EVP_CIPHER_CTX_get_app_data.3ossl</Path>
+            <Path fileType="man">/usr/share/man/man3/EVP_CIPHER_CTX_get_app_data.3ossl.zst</Path>
             <Path fileType="man">/usr/share/man/man3/EVP_CIPHER_CTX_get_block_size.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/EVP_CIPHER_CTX_get_cipher_data.3ossl.zst</Path>
             <Path fileType="man">/usr/share/man/man3/EVP_CIPHER_CTX_get_iv_length.3ossl</Path>
@@ -6209,12 +6219,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="55">
-            <Date>2025-09-30</Date>
-            <Version>3.3.5</Version>
+        <Update release="56">
+            <Date>2026-01-30</Date>
+            <Version>3.3.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harveydevel@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://github.com/openssl/openssl/releases/tag/openssl-3.3.6)

**Security**

- CVE-2025-15467
- CVE-2025-15468
- CVE-2025-66199
- CVE-2025-68160
- CVE-2025-69418
- CVE-2025-69419
- CVE-2025-69420
- CVE-2025-69421
- CVE-2026-22795
- CVE-2026-22796

**Test Plan**

- make an ssh connection

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
