### PR TITLE
minizip-ng: Backport zlib-ng detection fix

### DIFF
--- a/packages/m/minizip-ng/abi_used_symbols
+++ b/packages/m/minizip-ng/abi_used_symbols
@@ -7,8 +7,8 @@ libbz2.so.1.0:BZ2_bzDecompressInit
 libc.so.6:__ctype_tolower_loc
 libc.so.6:__errno_location
 libc.so.6:__memmove_chk
-libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
+libc.so.6:__vsnprintf_chk
 libc.so.6:calloc
 libc.so.6:chmod
 libc.so.6:clock_gettime

--- a/packages/m/minizip-ng/files/find-zlib-ng-properly.patch
+++ b/packages/m/minizip-ng/files/find-zlib-ng-properly.patch
@@ -1,0 +1,210 @@
+From 1176a22cade246914422cdf0be994016a2fc62ab Mon Sep 17 00:00:00 2001
+From: Sebastian Goth <mail@sgoth.de>
+Date: Mon, 26 May 2025 10:43:34 +0200
+Subject: [PATCH 1/3] Fix transitive finding of zlib-ng
+
+---
+ CMakeLists.txt          | 18 +++++++++---------
+ cmake/FindZLIB-NG.cmake | 32 ++++++++++++++++++++++++++++++++
+ cmake/FindZLIBNG.cmake  | 32 --------------------------------
+ 3 files changed, 41 insertions(+), 41 deletions(-)
+ create mode 100644 cmake/FindZLIB-NG.cmake
+ delete mode 100644 cmake/FindZLIBNG.cmake
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 213d03a3..18c5c752 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -173,17 +173,17 @@ endif()
+ if(MZ_ZLIB)
+     # Check if zlib is present
+     if(NOT MZ_FORCE_FETCH_LIBS)
+-        find_package(ZLIBNG QUIET)
++        find_package(ZLIB-NG QUIET)
+         find_package(ZLIB QUIET)
+         set(ZLIB_VERSION ${ZLIB_VERSION_STRING})
+     endif()
+ 
+-    if(ZLIBNG_FOUND AND NOT MZ_FORCE_FETCH_LIBS)
+-        message(STATUS "Using ZLIBNG")
++    if(ZLIB-NG_FOUND AND NOT MZ_FORCE_FETCH_LIBS)
++        message(STATUS "Using ZLIB-NG")
+ 
+-        list(APPEND MINIZIP_INC ${ZLIBNG_INCLUDE_DIRS})
+-        list(APPEND MINIZIP_LIB ${ZLIBNG_LIBRARIES})
+-        list(APPEND MINIZIP_LBD ${ZLIBNG_LIBRARY_DIRS})
++        list(APPEND MINIZIP_INC ${ZLIB-NG_INCLUDE_DIRS})
++        list(APPEND MINIZIP_LIB ${ZLIB-NG_LIBRARIES})
++        list(APPEND MINIZIP_LBD ${ZLIB-NG_LIBRARY_DIRS})
+ 
+         set(PC_PRIVATE_DEPS "zlib-ng")
+         set(ZLIB_COMPAT OFF)
+@@ -215,7 +215,7 @@ if(MZ_ZLIB)
+         endif()
+ 
+         if(EXISTS "${ZLIB_BINARY_DIR}/zlib-ng.h")
+-            message(STATUS "ZLIB repository detected as ZLIBNG")
++            message(STATUS "ZLIB repository detected as ZLIB-NG")
+             set(ZLIB_COMPAT OFF)
+         else()
+             set(ZLIB_COMPAT ON)
+@@ -231,8 +231,8 @@ if(MZ_ZLIB)
+         if(ZLIB_COMPAT)
+             list(APPEND MINIZIP_DEF -DZLIB_COMPAT)
+         endif()
+-        if(ZLIBNG_FOUND OR NOT ZLIB_COMPAT)
+-            list(APPEND MINIZIP_DEP_PKG ZLIBNG)
++        if(ZLIB-NG_FOUND OR NOT ZLIB_COMPAT)
++            list(APPEND MINIZIP_DEP_PKG ZLIB-NG)
+         elseif(ZLIB_FOUND)
+             list(APPEND MINIZIP_DEP_PKG ZLIB)
+         endif()
+diff --git a/cmake/FindZLIB-NG.cmake b/cmake/FindZLIB-NG.cmake
+new file mode 100644
+index 00000000..fd5d924e
+--- /dev/null
++++ b/cmake/FindZLIB-NG.cmake
+@@ -0,0 +1,32 @@
++find_path(ZLIB-NG_INCLUDE_DIRS NAMES zlib-ng.h)
++
++if(ZLIB_INCLUDE_DIRS)
++    set(ZLIB-NG_LIBRARY_DIRS ${ZLIB-NG_INCLUDE_DIRS})
++
++    if("${ZLIB-NG_LIBRARY_DIRS}" MATCHES "/include$")
++        # Strip off the trailing "/include" in the path.
++        get_filename_component(ZLIB-NG_LIBRARY_DIRS ${ZLIB-NG_LIBRARY_DIRS} PATH)
++    endif()
++
++    if(EXISTS "${ZLIB-NG_LIBRARY_DIRS}/lib")
++        set(ZLIB-NG_LIBRARY_DIRS ${ZLIB-NG_LIBRARY_DIRS}/lib)
++    endif()
++endif()
++
++find_library(ZLIB-NG_LIBRARY NAMES z-ng libz-ng libz-ng.a)
++
++set(ZLIB-NG_LIBRARIES ${ZLIB-NG_LIBRARY})
++set(ZLIB-NG_INCLUDE_DIRS ${ZLIB-NG_INCLUDE_DIRS})
++
++include(FindPackageHandleStandardArgs)
++find_package_handle_standard_args(ZLIB-NG DEFAULT_MSG ZLIB-NG_LIBRARY ZLIB-NG_INCLUDE_DIRS)
++
++if(ZLIB-NG_INCLUDE_DIRS AND ZLIB-NG_LIBRARIES)
++    set(ZLIB-NG_FOUND ON)
++else(ZLIB-NG_INCLUDE_DIRS AND ZLIB-NG_LIBRARIES)
++    set(ZLIB-NG_FOUND OFF)
++endif()
++
++if(ZLIB-NG_FOUND)
++    message(STATUS "Found zlib-ng: ${ZLIB-NG_LIBRARIES}, ${ZLIB-NG_INCLUDE_DIRS}")
++endif()
+diff --git a/cmake/FindZLIBNG.cmake b/cmake/FindZLIBNG.cmake
+deleted file mode 100644
+index 5da91ec0..00000000
+--- a/cmake/FindZLIBNG.cmake
++++ /dev/null
+@@ -1,32 +0,0 @@
+-find_path(ZLIBNG_INCLUDE_DIRS NAMES zlib-ng.h)
+-
+-if(ZLIB_INCLUDE_DIRS)
+-    set(ZLIBNG_LIBRARY_DIRS ${ZLIBNG_INCLUDE_DIRS})
+-
+-    if("${ZLIBNG_LIBRARY_DIRS}" MATCHES "/include$")
+-        # Strip off the trailing "/include" in the path.
+-        get_filename_component(ZLIBNG_LIBRARY_DIRS ${ZLIBNG_LIBRARY_DIRS} PATH)
+-    endif()
+-
+-    if(EXISTS "${ZLIBNG_LIBRARY_DIRS}/lib")
+-        set(ZLIBNG_LIBRARY_DIRS ${ZLIBNG_LIBRARY_DIRS}/lib)
+-    endif()
+-endif()
+-
+-find_library(ZLIBNG_LIBRARY NAMES z-ng libz-ng libz-ng.a)
+-
+-set(ZLIBNG_LIBRARIES ${ZLIBNG_LIBRARY})
+-set(ZLIBNG_INCLUDE_DIRS ${ZLIBNG_INCLUDE_DIRS})
+-
+-include(FindPackageHandleStandardArgs)
+-find_package_handle_standard_args(ZLIBNG DEFAULT_MSG ZLIBNG_LIBRARY ZLIBNG_INCLUDE_DIRS)
+-
+-if(ZLIBNG_INCLUDE_DIRS AND ZLIBNG_LIBRARIES)
+-    set(ZLIBNG_FOUND ON)
+-else(ZLIBNG_INCLUDE_DIRS AND ZLIBNG_LIBRARIES)
+-    set(ZLIBNG_FOUND OFF)
+-endif()
+-
+-if(ZLIBNG_FOUND)
+-    message(STATUS "Found zlib-ng: ${ZLIBNG_LIBRARIES}, ${ZLIBNG_INCLUDE_DIRS}")
+-endif()
+
+From 57d1e28d1c950490622fd300418a3569e5c1d2e8 Mon Sep 17 00:00:00 2001
+From: Sebastian Goth <mail@sgoth.de>
+Date: Mon, 26 May 2025 13:52:11 +0200
+Subject: [PATCH 2/3] Add cmake control to select zlib flavor
+
+Instead of assuming zlib-ng preference over zlib as a dependency, let
+the user decide.
+
+New cmake variable MZ_ZLIB_FLAVOR can be set to auto | zlib-ng | zlib
+defaults to auto.
+---
+ CMakeLists.txt | 18 ++++++++++++++++--
+ 1 file changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 18c5c752..e18ffc66 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -39,6 +39,16 @@ message(STATUS "Using CMake version ${CMAKE_VERSION}")
+ option(MZ_COMPAT "Enables compatibility layer" ON)
+ # Compression library options
+ option(MZ_ZLIB "Enables ZLIB compression" ON)
++
++# Controls to select either zlib-ng or zlib
++set(MZ_ZLIB_FLAVOR "auto" CACHE STRING "Select the preferred zlib flavor - auto searches for zlib-ng then zlib")
++set(MZ_ZLIB_FLAVORS "auto" "zlib-ng" "zlib")
++set_property(CACHE MZ_ZLIB_FLAVOR PROPERTY STRINGS ${MZ_ZLIB_FLAVORS})
++
++if(NOT MZ_ZLIB_FLAVOR IN_LIST MZ_ZLIB_FLAVORS)
++    message(FATAL_ERROR "MZ_ZLIB_FLAVOR must be one of ${MZ_ZLIB_FLAVORS}")
++endif()
++
+ option(MZ_BZIP2 "Enables BZIP2 compression" ON)
+ option(MZ_LZMA "Enables LZMA & XZ compression" ON)
+ option(MZ_ZSTD "Enables ZSTD compression" ON)
+@@ -173,8 +183,12 @@ endif()
+ if(MZ_ZLIB)
+     # Check if zlib is present
+     if(NOT MZ_FORCE_FETCH_LIBS)
+-        find_package(ZLIB-NG QUIET)
+-        find_package(ZLIB QUIET)
++        if (MZ_ZLIB_FLAVOR STREQUAL "zlib-ng" OR MZ_ZLIB_FLAVOR STREQUAL "auto")
++            find_package(ZLIB-NG QUIET)
++        endif()
++        if (MZ_ZLIB_FLAVOR STREQUAL "zlib" OR MZ_ZLIB_FLAVOR STREQUAL "auto")
++            find_package(ZLIB QUIET)
++        endif()
+         set(ZLIB_VERSION ${ZLIB_VERSION_STRING})
+     endif()
+ 
+
+From 6154e4934b6293eda35447972d6b35631124a94b Mon Sep 17 00:00:00 2001
+From: Sebastian Goth <mail@sgoth.de>
+Date: Thu, 19 Jun 2025 11:11:28 +0200
+Subject: [PATCH 3/3] Document MZ_ZLIB_FLAVOR
+
+---
+ README.md | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/README.md b/README.md
+index b0f6b16b..fbc895c3 100644
+--- a/README.md
++++ b/README.md
+@@ -69,6 +69,7 @@ cmake --build build
+ |:--------------------|:---------------------------------------------------------------|:-------------:|
+ | MZ_COMPAT           | Enables compatibility layer                                    |      ON       |
+ | MZ_ZLIB             | Enables ZLIB compression                                       |      ON       |
++| MZ_ZLIB_FLAVOR      | Select ZLIB implementation (auto, zlib-ng, zlib)               |      auto     |
+ | MZ_BZIP2            | Enables BZIP2 compression                                      |      ON       |
+ | MZ_LZMA             | Enables LZMA & XZ compression                                  |      ON       |
+ | MZ_ZSTD             | Enables ZSTD compression                                       |      ON       |

--- a/packages/m/minizip-ng/package.yml
+++ b/packages/m/minizip-ng/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : minizip-ng
 version    : 4.0.7
-release    : 9
+release    : 10
 source     :
     - https://github.com/zlib-ng/minizip-ng/archive/refs/tags/4.0.7.tar.gz : a87f1f734f97095fe1ef0018217c149d53d0f78438bcb77af38adc21dff2dfbc
 license    : Zlib
@@ -23,6 +23,9 @@ replaces   :
     - zlib-minizip
     - devel : zlib-minizip-devel
 setup      : |
+    # https://github.com/zlib-ng/minizip-ng/issues/722
+    %patch -p1 -i $pkgfiles/find-zlib-ng-properly.patch
+
     %cmake_ninja -B compat \
                  -DBUILD_SHARED_LIBS=ON \
                  -DMZ_LIBBSD=OFF \

--- a/packages/m/minizip-ng/pspec_x86_64.xml
+++ b/packages/m/minizip-ng/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>minizip-ng</Name>
         <Homepage>https://github.com/zlib-ng/minizip-ng</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Gavin Zhao</Name>
+            <Email>me@gzgz.dev</Email>
         </Packager>
         <License>Zlib</License>
         <PartOf>system.utils</PartOf>
@@ -36,7 +36,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="9">minizip-ng</Dependency>
+            <Dependency release="10">minizip-ng</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/minizip-ng/mz.h</Path>
@@ -93,12 +93,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2024-07-07</Date>
+        <Update release="10">
+            <Date>2026-01-24</Date>
             <Version>4.0.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Gavin Zhao</Name>
+            <Email>me@gzgz.dev</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Fix `minizip-ng` unable to find `zlib-ng` through `find_package(minizip-ng)` when building OpenColorIO.

**Test Plan**

Built OpenColorIO. This is a CMake-only change and has no effect on the binaries.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
