### PR TITLE
gstreamer-1.0: Update to v1.26.10

### DIFF
--- a/packages/g/gstreamer-1.0/abi_used_symbols
+++ b/packages/g/gstreamer-1.0/abi_used_symbols
@@ -3648,6 +3648,7 @@ libopus.so.0:opus_multistream_encode
 libopus.so.0:opus_multistream_encoder_create
 libopus.so.0:opus_multistream_encoder_ctl
 libopus.so.0:opus_multistream_encoder_destroy
+libopus.so.0:opus_multistream_surround_encoder_create
 libopus.so.0:opus_packet_parse
 libopus.so.0:opus_strerror
 liborc-0.4.so.0:orc_executor_get_accumulator

--- a/packages/g/gstreamer-1.0/abi_used_symbols32
+++ b/packages/g/gstreamer-1.0/abi_used_symbols32
@@ -1360,6 +1360,7 @@ libopus.so.0:opus_multistream_encode
 libopus.so.0:opus_multistream_encoder_create
 libopus.so.0:opus_multistream_encoder_ctl
 libopus.so.0:opus_multistream_encoder_destroy
+libopus.so.0:opus_multistream_surround_encoder_create
 libopus.so.0:opus_strerror
 liborc-0.4.so.0:orc_init
 liborc-0.4.so.0:orc_memset

--- a/packages/g/gstreamer-1.0/package.yml
+++ b/packages/g/gstreamer-1.0/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gstreamer-1.0
-version    : 1.26.7
-release    : 123
+version    : 1.26.10
+release    : 124
 source     :
-    - https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/1.26.7/gstreamer-1.26.7.tar.gz : e3cdfcf076d5be5384c06e6710adc7980912679ea57df29fbd0383dd43cb5c03
+    - https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/1.26.10/gstreamer-1.26.10.tar.gz : 2839c9fa70fd4775d16bf4aa77cf339ca2f59b8e34b0944a832ad56db851b37f
 license    : LGPL-2.1-or-later
 homepage   : https://gstreamer.freedesktop.org/
 component  :
@@ -278,6 +278,7 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license LICENSE
 check      : |
     unset LD_PRELOAD
     %ninja_check

--- a/packages/g/gstreamer-1.0/pspec_x86_64.xml
+++ b/packages/g/gstreamer-1.0/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gstreamer-1.0</Name>
         <Homepage>https://gstreamer.freedesktop.org/</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>multimedia.gstreamer</PartOf>
@@ -35,18 +35,19 @@
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstcoreelements.so</Path>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstcoretracers.so</Path>
             <Path fileType="library">/usr/lib64/libgstbase-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstbase-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstbase-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstcheck-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstcheck-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstcheck-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstcontroller-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstcontroller-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstcontroller-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstnet-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstnet-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstnet-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstreamer-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstreamer-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstreamer-1.0.so.0.2610.0</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/gst-inspect-1.0</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/gst-launch-1.0</Path>
             <Path fileType="data">/usr/share/bash-completion/helpers/gst</Path>
+            <Path fileType="data">/usr/share/licenses/gstreamer-1.0/LICENSE</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/gstreamer-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ast/LC_MESSAGES/gstreamer-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/az/LC_MESSAGES/gstreamer-1.0.mo</Path>
@@ -103,7 +104,7 @@
         <Description xml:lang="en">GStreamer is a streaming media framework that enables applications to share a common set of plugins for things like video encoding and decoding, audio encoding and decoding, audio and video filters, audio visualisation, web streaming and anything else that streams in real-time or otherwise. This package only provides base functionality and libraries. You may need at least gst-plugins-base and one of Good, Bad, Ugly or Libav plugins.</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-1.0</Dependency>
+            <Dependency release="124">gstreamer-1.0</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/gstreamer-1.0/gstreamer-1.0/gst-completion-helper</Path>
@@ -113,15 +114,15 @@
             <Path fileType="library">/usr/lib32/gstreamer-1.0/libgstcoreelements.so</Path>
             <Path fileType="library">/usr/lib32/gstreamer-1.0/libgstcoretracers.so</Path>
             <Path fileType="library">/usr/lib32/libgstbase-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstbase-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib32/libgstbase-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib32/libgstcheck-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstcheck-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib32/libgstcheck-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib32/libgstcontroller-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstcontroller-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib32/libgstcontroller-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib32/libgstnet-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstnet-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib32/libgstnet-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib32/libgstreamer-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstreamer-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib32/libgstreamer-1.0.so.0.2610.0</Path>
         </Files>
     </Package>
     <Package>
@@ -130,8 +131,8 @@
         <Description xml:lang="en">GStreamer is a streaming media framework that enables applications to share a common set of plugins for things like video encoding and decoding, audio encoding and decoding, audio and video filters, audio visualisation, web streaming and anything else that streams in real-time or otherwise. This package only provides base functionality and libraries. You may need at least gst-plugins-base and one of Good, Bad, Ugly or Libav plugins.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-1.0-32bit</Dependency>
-            <Dependency release="123">gstreamer-1.0-devel</Dependency>
+            <Dependency release="124">gstreamer-1.0-devel</Dependency>
+            <Dependency release="124">gstreamer-1.0-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libgstbase-1.0.so</Path>
@@ -152,8 +153,8 @@
         <Description xml:lang="en">GStreamer FFmpeg/LibAV plugin</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-1.0-plugins-base</Dependency>
-            <Dependency release="123">gstreamer-1.0</Dependency>
+            <Dependency release="124">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="124">gstreamer-1.0</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstlibav.so</Path>
@@ -168,13 +169,13 @@
         <Description xml:lang="en">GStreamer &quot;bad&quot; plugins OpenCV plugin</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-1.0-plugins-base</Dependency>
-            <Dependency release="123">gstreamer-1.0</Dependency>
+            <Dependency release="124">gstreamer-1.0</Dependency>
+            <Dependency release="124">gstreamer-1.0-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstopencv.so</Path>
             <Path fileType="library">/usr/lib64/libgstopencv-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstopencv-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstopencv-1.0.so.0.2610.0</Path>
         </Files>
         <Replaces>
             <Package>gstreamer-1.0-plugins-opencv</Package>
@@ -186,7 +187,7 @@
         <Description xml:lang="en">Development files for gstreamer-1.0-plugins-opencv</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="123">gstreamer-1.0-plugin-opencv</Dependency>
+            <Dependency releaseFrom="124">gstreamer-1.0-plugin-opencv</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gstreamer-1.0/gst/opencv/gstopencvutils.h</Path>
@@ -204,9 +205,9 @@
         <Description xml:lang="en">GStreamer streaming media framework &quot;bad&quot; plugins</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-1.0-plugins-base</Dependency>
-            <Dependency release="123">gstreamer-1.0</Dependency>
-            <Dependency release="123">gstreamer-1.0-plugins-bad-libs</Dependency>
+            <Dependency release="124">gstreamer-1.0</Dependency>
+            <Dependency release="124">gstreamer-1.0-plugins-bad-libs</Dependency>
+            <Dependency release="124">gstreamer-1.0-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/gst-transcoder-1.0</Path>
@@ -408,11 +409,11 @@
         <Description xml:lang="en">Development files for gstreamer-1.0-plugins-bad</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-1.0-devel</Dependency>
-            <Dependency release="123">gstreamer-1.0-plugins-base-devel</Dependency>
-            <Dependency release="123">gstreamer-1.0-plugins-bad-libs</Dependency>
-            <Dependency releaseFrom="123">gstreamer-1.0-plugins-bad</Dependency>
-            <Dependency releaseFrom="123">gstreamer-1.0-plugins-bad-extras</Dependency>
+            <Dependency release="124">gstreamer-1.0-plugins-bad-libs</Dependency>
+            <Dependency release="124">gstreamer-1.0-devel</Dependency>
+            <Dependency release="124">gstreamer-1.0-plugins-base-devel</Dependency>
+            <Dependency releaseFrom="124">gstreamer-1.0-plugins-bad</Dependency>
+            <Dependency releaseFrom="124">gstreamer-1.0-plugins-bad-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gstreamer-1.0/gst/analytics/analytics-meta-prelude.h</Path>
@@ -661,9 +662,9 @@
         <Description xml:lang="en">GStreamer streaming media framework &quot;bad&quot; plugins</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-1.0-plugins-base</Dependency>
-            <Dependency release="123">gstreamer-1.0</Dependency>
-            <Dependency release="123">gstreamer-1.0-plugins-bad-libs</Dependency>
+            <Dependency release="124">gstreamer-1.0</Dependency>
+            <Dependency release="124">gstreamer-1.0-plugins-bad-libs</Dependency>
+            <Dependency release="124">gstreamer-1.0-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstaom.so</Path>
@@ -682,8 +683,8 @@
         <Description xml:lang="en">GStreamer streaming media framework &quot;bad&quot; plugins - libs</Description>
         <PartOf>programming.library</PartOf>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-1.0-plugins-base</Dependency>
-            <Dependency release="123">gstreamer-1.0</Dependency>
+            <Dependency release="124">gstreamer-1.0</Dependency>
+            <Dependency release="124">gstreamer-1.0-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/girepository-1.0/CudaGst-1.0.typelib</Path>
@@ -704,50 +705,50 @@
             <Path fileType="library">/usr/lib64/girepository-1.0/GstVulkanXCB-1.0.typelib</Path>
             <Path fileType="library">/usr/lib64/girepository-1.0/GstWebRTC-1.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libgstadaptivedemux-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstadaptivedemux-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstadaptivedemux-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstanalytics-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstanalytics-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstanalytics-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstbadaudio-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstbadaudio-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstbadaudio-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstbasecamerabinsrc-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstbasecamerabinsrc-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstbasecamerabinsrc-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstcodecparsers-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstcodecparsers-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstcodecparsers-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstcodecs-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstcodecs-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstcodecs-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstcuda-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstcuda-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstcuda-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstdxva-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstdxva-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstdxva-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstinsertbin-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstinsertbin-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstinsertbin-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstisoff-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstisoff-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstisoff-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstmpegts-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstmpegts-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstmpegts-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstmse-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstmse-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstmse-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstphotography-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstphotography-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstphotography-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstplay-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstplay-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstplay-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstplayer-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstplayer-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstplayer-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstsctp-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstsctp-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstsctp-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgsttranscoder-1.0.so.0</Path>
             <Path fileType="library">/usr/lib64/libgsturidownloader-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgsturidownloader-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgsturidownloader-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstva-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstva-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstva-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstvulkan-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstvulkan-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstvulkan-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstwayland-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstwayland-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstwayland-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstwebrtc-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstwebrtc-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstwebrtc-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstwebrtcnice-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstwebrtcnice-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstwebrtcnice-1.0.so.0.2610.0</Path>
         </Files>
     </Package>
     <Package>
@@ -756,7 +757,7 @@
         <Description xml:lang="en">GStreamer streaming media framework base plugins</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-1.0</Dependency>
+            <Dependency release="124">gstreamer-1.0</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/gst-device-monitor-1.0</Path>
@@ -808,29 +809,29 @@
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstximagesink.so</Path>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstxvimagesink.so</Path>
             <Path fileType="library">/usr/lib64/libgstallocators-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstallocators-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstallocators-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstapp-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstapp-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstapp-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstaudio-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstaudio-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstaudio-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstfft-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstfft-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstfft-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstgl-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstgl-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstgl-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstpbutils-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstpbutils-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstpbutils-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstriff-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstriff-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstriff-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstrtp-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstrtp-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstrtp-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstrtsp-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstrtsp-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstrtsp-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstsdp-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstsdp-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstsdp-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgsttag-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgsttag-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgsttag-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib64/libgstvideo-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstvideo-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstvideo-1.0.so.0.2610.0</Path>
             <Path fileType="data">/usr/share/gst-plugins-base/1.0/license-translations.dict</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/gst-plugins-base-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/az/LC_MESSAGES/gst-plugins-base-1.0.mo</Path>
@@ -883,7 +884,7 @@
         <Description xml:lang="en">GStreamer is a streaming media framework that enables applications to share a common set of plugins for things like video encoding and decoding, audio encoding and decoding, audio and video filters, audio visualisation, web streaming and anything else that streams in real-time or otherwise. This package only provides base functionality and libraries. You may need at least gst-plugins-base and one of Good, Bad, Ugly or Libav plugins.</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-1.0-32bit</Dependency>
+            <Dependency release="124">gstreamer-1.0-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/gstreamer-1.0/libgstadder.so</Path>
@@ -919,29 +920,29 @@
             <Path fileType="library">/usr/lib32/gstreamer-1.0/libgstximagesink.so</Path>
             <Path fileType="library">/usr/lib32/gstreamer-1.0/libgstxvimagesink.so</Path>
             <Path fileType="library">/usr/lib32/libgstallocators-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstallocators-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib32/libgstallocators-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib32/libgstapp-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstapp-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib32/libgstapp-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib32/libgstaudio-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstaudio-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib32/libgstaudio-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib32/libgstfft-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstfft-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib32/libgstfft-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib32/libgstgl-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstgl-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib32/libgstgl-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib32/libgstpbutils-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstpbutils-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib32/libgstpbutils-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib32/libgstriff-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstriff-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib32/libgstriff-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib32/libgstrtp-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstrtp-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib32/libgstrtp-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib32/libgstrtsp-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstrtsp-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib32/libgstrtsp-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib32/libgstsdp-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstsdp-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib32/libgstsdp-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib32/libgsttag-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgsttag-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib32/libgsttag-1.0.so.0.2610.0</Path>
             <Path fileType="library">/usr/lib32/libgstvideo-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstvideo-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib32/libgstvideo-1.0.so.0.2610.0</Path>
         </Files>
     </Package>
     <Package>
@@ -950,9 +951,9 @@
         <Description xml:lang="en">GStreamer is a streaming media framework that enables applications to share a common set of plugins for things like video encoding and decoding, audio encoding and decoding, audio and video filters, audio visualisation, web streaming and anything else that streams in real-time or otherwise. This package only provides base functionality and libraries. You may need at least gst-plugins-base and one of Good, Bad, Ugly or Libav plugins.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-1.0-32bit-devel</Dependency>
-            <Dependency releaseFrom="123">gstreamer-1.0-plugins-base-32bit</Dependency>
-            <Dependency releaseFrom="123">gstreamer-1.0-plugins-base-devel</Dependency>
+            <Dependency release="124">gstreamer-1.0-32bit-devel</Dependency>
+            <Dependency releaseFrom="124">gstreamer-1.0-plugins-base-32bit</Dependency>
+            <Dependency releaseFrom="124">gstreamer-1.0-plugins-base-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/gstreamer-1.0/include/gst/gl/gstglconfig.h</Path>
@@ -993,8 +994,8 @@
         <Description xml:lang="en">Development files for gstreamer-1.0-plugins-base</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-1.0-devel</Dependency>
-            <Dependency releaseFrom="123">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="124">gstreamer-1.0-devel</Dependency>
+            <Dependency releaseFrom="124">gstreamer-1.0-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gstreamer-1.0/gst/allocators/allocators-prelude.h</Path>
@@ -1249,8 +1250,8 @@
         <Description xml:lang="en">GStreamer streaming media framework &quot;good&quot; plugins</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-1.0-plugins-base</Dependency>
-            <Dependency release="123">gstreamer-1.0</Dependency>
+            <Dependency release="124">gstreamer-1.0</Dependency>
+            <Dependency release="124">gstreamer-1.0-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgst1394.so</Path>
@@ -1383,8 +1384,8 @@
         <Summary xml:lang="en">Streaming media framework</Summary>
         <Description xml:lang="en">GStreamer is a streaming media framework that enables applications to share a common set of plugins for things like video encoding and decoding, audio encoding and decoding, audio and video filters, audio visualisation, web streaming and anything else that streams in real-time or otherwise. This package only provides base functionality and libraries. You may need at least gst-plugins-base and one of Good, Bad, Ugly or Libav plugins.</Description>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-1.0-plugins-base</Dependency>
-            <Dependency release="123">gstreamer-1.0</Dependency>
+            <Dependency release="124">gstreamer-1.0</Dependency>
+            <Dependency release="124">gstreamer-1.0-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgsta52dec.so</Path>
@@ -1450,9 +1451,9 @@
         <Description xml:lang="en">GStreamer editing services</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-1.0-plugins-base</Dependency>
-            <Dependency release="123">gstreamer-1.0</Dependency>
-            <Dependency releaseFrom="123">python-gstreamer</Dependency>
+            <Dependency release="124">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="124">gstreamer-1.0</Dependency>
+            <Dependency releaseFrom="124">python-gstreamer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/ges-launch-1.0</Path>
@@ -1462,7 +1463,7 @@
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstges.so</Path>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstnle.so</Path>
             <Path fileType="library">/usr/lib64/libges-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libges-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libges-1.0.so.0.2610.0</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/ges-launch-1.0</Path>
             <Path fileType="man">/usr/share/man/man1/ges-launch-1.0.1.zst</Path>
         </Files>
@@ -1473,9 +1474,9 @@
         <Description xml:lang="en">Development files for gstreamer-editing-services</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-1.0-devel</Dependency>
-            <Dependency release="123">gstreamer-1.0-plugins-base-devel</Dependency>
-            <Dependency releaseFrom="123">gstreamer-editing-services</Dependency>
+            <Dependency release="124">gstreamer-1.0-plugins-base-devel</Dependency>
+            <Dependency release="124">gstreamer-1.0-devel</Dependency>
+            <Dependency releaseFrom="124">gstreamer-editing-services</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gstreamer-1.0/ges/ges-asset.h</Path>
@@ -1555,13 +1556,13 @@
         <Description xml:lang="en">GStreamer&apos;s RTSP server (gst-rtsp-server) is a featureful and easy-to-use library that allows applications to implement a complete RTSP server with just a couple of lines of code.</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-1.0</Dependency>
-            <Dependency release="123">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="124">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="124">gstreamer-1.0</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/girepository-1.0/GstRtspServer-1.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libgstrtspserver-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstrtspserver-1.0.so.0.2607.0</Path>
+            <Path fileType="library">/usr/lib64/libgstrtspserver-1.0.so.0.2610.0</Path>
         </Files>
         <Replaces>
             <Package>gst-rtsp-server</Package>
@@ -1573,11 +1574,11 @@
         <Description xml:lang="en">Development files for gstreamer-1.0-plugins-ugly</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-rtsp-server</Dependency>
-            <Dependency release="123">gstreamer-1.0-plugins-base</Dependency>
-            <Dependency release="123">gstreamer-1.0-plugins-base-devel</Dependency>
-            <Dependency release="123">gstreamer-1.0</Dependency>
-            <Dependency release="123">gstreamer-1.0-devel</Dependency>
+            <Dependency release="124">gstreamer-rtsp-server</Dependency>
+            <Dependency release="124">gstreamer-1.0-devel</Dependency>
+            <Dependency release="124">gstreamer-1.0</Dependency>
+            <Dependency release="124">gstreamer-1.0-plugins-base-devel</Dependency>
+            <Dependency release="124">gstreamer-1.0-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gstreamer-1.0/gst/rtsp-server/rtsp-address-pool.h</Path>
@@ -1620,9 +1621,9 @@
         <Description xml:lang="en">GStreamer VA API library</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-1.0-plugins-base</Dependency>
-            <Dependency release="123">gstreamer-1.0</Dependency>
-            <Dependency release="123">gstreamer-1.0-plugins-bad-libs</Dependency>
+            <Dependency release="124">gstreamer-1.0</Dependency>
+            <Dependency release="124">gstreamer-1.0-plugins-bad-libs</Dependency>
+            <Dependency release="124">gstreamer-1.0-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstvaapi.so</Path>
@@ -1634,9 +1635,9 @@
         <Description xml:lang="en">GStreamer python overrides for the gobject-introspection-based pygst bindings.</Description>
         <PartOf>programming.python</PartOf>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-1.0-plugins-bad-libs</Dependency>
-            <Dependency release="123">gstreamer-1.0</Dependency>
-            <Dependency releaseFrom="123">gstreamer-1.0-plugins-base</Dependency>
+            <Dependency release="124">gstreamer-1.0</Dependency>
+            <Dependency release="124">gstreamer-1.0-plugins-bad-libs</Dependency>
+            <Dependency releaseFrom="124">gstreamer-1.0-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib/python3.12/site-packages/gi/overrides/Gst.py</Path>
@@ -1665,7 +1666,7 @@
         <Description xml:lang="en">GStreamer is a streaming media framework that enables applications to share a common set of plugins for things like video encoding and decoding, audio encoding and decoding, audio and video filters, audio visualisation, web streaming and anything else that streams in real-time or otherwise. This package only provides base functionality and libraries. You may need at least gst-plugins-base and one of Good, Bad, Ugly or Libav plugins.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="123">gstreamer-1.0</Dependency>
+            <Dependency release="124">gstreamer-1.0</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gstreamer-1.0/gst/base/base-prelude.h</Path>
@@ -1805,8 +1806,8 @@
             <Path fileType="data">/usr/lib64/pkgconfig/gstreamer-net-1.0.pc</Path>
             <Path fileType="data">/usr/share/aclocal/gst-element-check-1.0.m4</Path>
             <Path fileType="data">/usr/share/cmake/FindGStreamer.cmake</Path>
-            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib32/libgstreamer-1.0.so.0.2607.0-gdb.py</Path>
-            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib64/libgstreamer-1.0.so.0.2607.0-gdb.py</Path>
+            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib32/libgstreamer-1.0.so.0.2610.0-gdb.py</Path>
+            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib64/libgstreamer-1.0.so.0.2610.0-gdb.py</Path>
             <Path fileType="data">/usr/share/gir-1.0/Gst-1.0.gir</Path>
             <Path fileType="data">/usr/share/gir-1.0/GstBase-1.0.gir</Path>
             <Path fileType="data">/usr/share/gir-1.0/GstCheck-1.0.gir</Path>
@@ -1817,12 +1818,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="123">
-            <Date>2026-01-11</Date>
-            <Version>1.26.7</Version>
+        <Update release="124">
+            <Date>2026-01-29</Date>
+            <Version>1.26.10</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://gstreamer.freedesktop.org/releases/1.26/#1.26.10).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install the updated packages and listen to an audio file.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
