### PR TITLE
[NFC] wine: Remove extraneous comments

### DIFF
--- a/packages/w/wine/package.yml
+++ b/packages/w/wine/package.yml
@@ -80,8 +80,6 @@ setup      : |
 build      : |
     %make
 install    : |
-    # %make_install -C wine32
-    # %make_install -C wine64
     %make_install
     %install_license AUTHORS COPYING.LIB LICENSE LICENSE.OLD MAINTAINERS
 


### PR DESCRIPTION
**Summary**
These were commented out in converting the recipe for wine 11.0. Forgot to delete them.

**Test Plan**
Didn't.

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
