### PR TITLE
nvidia-vaapi-driver: Update to v0.0.15

### DIFF
--- a/packages/n/nvidia-vaapi-driver/package.yml
+++ b/packages/n/nvidia-vaapi-driver/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : nvidia-vaapi-driver
-version    : 0.0.14
-release    : 18
+version    : 0.0.15
+release    : 19
 homepage   : https://github.com/elFarto/nvidia-vaapi-driver
 source     :
-    - https://github.com/elFarto/nvidia-vaapi-driver/archive/refs/tags/v0.0.14.tar.gz : 4ded132ec4164f3e05656061675dffce677327e4af0d8da33da5f8527609ad2a
+    - https://github.com/elFarto/nvidia-vaapi-driver/archive/refs/tags/v0.0.15.tar.gz : 2118a0f37c415adfadad53ef3aab3f53c54164f8a4b0c2d4de9e0b61e5ece536
 license    : MIT
 component  : xorg.display
 summary    : A VA-API implemention using NVIDIA's NVDEC as the backend (UNSUPPORTED)

--- a/packages/n/nvidia-vaapi-driver/pspec_x86_64.xml
+++ b/packages/n/nvidia-vaapi-driver/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Conflicts>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2025-06-09</Date>
-            <Version>0.0.14</Version>
+        <Update release="19">
+            <Date>2026-01-30</Date>
+            <Version>0.0.15</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- VP8: null slice headers

**Test Plan**

Played a bunch of videos in `firefox` and confirmed acceleration worked with `nvidia-smi`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
