### PR TITLE
tv-lite: Update to v0.8.1

### DIFF
--- a/packages/t/tv-lite/abi_used_libs
+++ b/packages/t/tv-lite/abi_used_libs
@@ -11,3 +11,4 @@ libuuid.so.1
 libvlc.so.5
 libwx_baseu-3.2.so.0
 libwx_gtk3u_core-3.2.so.0
+libwx_gtk3u_xrc-3.2.so.0

--- a/packages/t/tv-lite/abi_used_symbols
+++ b/packages/t/tv-lite/abi_used_symbols
@@ -14,6 +14,7 @@ libc.so.6:memset
 libc.so.6:puts
 libc.so.6:rand
 libc.so.6:realloc
+libc.so.6:sleep
 libc.so.6:strcmp
 libc.so.6:strlen
 libc.so.6:strncmp
@@ -75,6 +76,7 @@ libvlc.so.5:libvlc_event_attach
 libvlc.so.5:libvlc_get_version
 libvlc.so.5:libvlc_media_add_option
 libvlc.so.5:libvlc_media_get_meta
+libvlc.so.5:libvlc_media_new_callbacks
 libvlc.so.5:libvlc_media_new_fd
 libvlc.so.5:libvlc_media_new_location
 libvlc.so.5:libvlc_media_parse_with_options
@@ -113,6 +115,7 @@ libwx_baseu-3.2.so.0:_Z14wxNewEventTypev
 libwx_baseu-3.2.so.0:_Z15wxMutexGuiEnterv
 libwx_baseu-3.2.so.0:_Z15wxMutexGuiLeavev
 libwx_baseu-3.2.so.0:_Z18wxGetOsDescriptionv
+libwx_baseu-3.2.so.0:_Z18wxGetUTCTimeMillisv
 libwx_baseu-3.2.so.0:_Z19wxGet_wxConvLibcPtrv
 libwx_baseu-3.2.so.0:_Z19wxGet_wxConvUTF8Ptrv
 libwx_baseu-3.2.so.0:_Z24wxGetCpuArchitectureNamev
@@ -145,6 +148,9 @@ libwx_baseu-3.2.so.0:_ZN12wxEvtHandler9TryBeforeER7wxEvent
 libwx_baseu-3.2.so.0:_ZN12wxEvtHandlerC2Ev
 libwx_baseu-3.2.so.0:_ZN12wxEvtHandlerD2Ev
 libwx_baseu-3.2.so.0:_ZN12wxFileConfigC1ERK8wxStringS2_S2_S2_lRK8wxMBConv
+libwx_baseu-3.2.so.0:_ZN12wxFileSystem10AddHandlerEP19wxFileSystemHandler
+libwx_baseu-3.2.so.0:_ZN12wxFileSystem8OpenFileERK8wxStringi
+libwx_baseu-3.2.so.0:_ZN12wxFileSystemD1Ev
 libwx_baseu-3.2.so.0:_ZN12wxStringHash10stringHashEPKw
 libwx_baseu-3.2.so.0:_ZN13wxArrayString3AddERK8wxStringm
 libwx_baseu-3.2.so.0:_ZN13wxArrayString4InitEb
@@ -194,9 +200,22 @@ libwx_baseu-3.2.so.0:_ZN19wxStandardPathsBase3GetEv
 libwx_baseu-3.2.so.0:_ZN19wxStandardPathsBaseD2Ev
 libwx_baseu-3.2.so.0:_ZN21wxClientDataContainerC2Ev
 libwx_baseu-3.2.so.0:_ZN21wxClientDataContainerD2Ev
+libwx_baseu-3.2.so.0:_ZN21wxMemoryFSHandlerBase10RemoveFileERK8wxString
+libwx_baseu-3.2.so.0:_ZN21wxMemoryFSHandlerBase19AddFileWithMimeTypeERK8wxStringPKvmS2_
+libwx_baseu-3.2.so.0:_ZN21wxMemoryFSHandlerBase7AddFileERK8wxStringS2_
+libwx_baseu-3.2.so.0:_ZN21wxMemoryFSHandlerBase7CanOpenERK8wxString
+libwx_baseu-3.2.so.0:_ZN21wxMemoryFSHandlerBase8FindNextEv
+libwx_baseu-3.2.so.0:_ZN21wxMemoryFSHandlerBase8OpenFileER12wxFileSystemRK8wxString
+libwx_baseu-3.2.so.0:_ZN21wxMemoryFSHandlerBase9FindFirstERK8wxStringi
+libwx_baseu-3.2.so.0:_ZN21wxMemoryFSHandlerBaseC2Ev
+libwx_baseu-3.2.so.0:_ZN21wxMemoryFSHandlerBaseD2Ev
 libwx_baseu-3.2.so.0:_ZN23wxSingleInstanceChecker6CreateERK8wxStringS2_
 libwx_baseu-3.2.so.0:_ZN23wxSingleInstanceCheckerD1Ev
 libwx_baseu-3.2.so.0:_ZN5wxDir11GetAllFilesERK8wxStringP13wxArrayStringS2_i
+libwx_baseu-3.2.so.0:_ZN5wxLog17GetComponentLevelERK8wxString
+libwx_baseu-3.2.so.0:_ZN5wxLog22IsThreadLoggingEnabledEv
+libwx_baseu-3.2.so.0:_ZN5wxLog5OnLogEmRK8wxStringRK15wxLogRecordInfo
+libwx_baseu-3.2.so.0:_ZN5wxLog8ms_doLogE
 libwx_baseu-3.2.so.0:_ZN5wxURI6CreateERK8wxString
 libwx_baseu-3.2.so.0:_ZN5wxURI8UnescapeERK8wxString
 libwx_baseu-3.2.so.0:_ZN5wxURIC1ERK8wxString
@@ -230,11 +249,14 @@ libwx_baseu-3.2.so.0:_ZN8wxString13DoFormatWcharEPKwz
 libwx_baseu-3.2.so.0:_ZN8wxString13DoPrintfWcharEPKwz
 libwx_baseu-3.2.so.0:_ZN8wxString4TrimEb
 libwx_baseu-3.2.so.0:_ZN8wxString4nposE
+libwx_baseu-3.2.so.0:_ZN8wxString7FormatVERKS_P13__va_list_tag
 libwx_baseu-3.2.so.0:_ZN8wxString7ReplaceERKS_S1_b
 libwx_baseu-3.2.so.0:_ZN8wxString9FromAsciiEPKc
 libwx_baseu-3.2.so.0:_ZN8wxString9MakeLowerEv
 libwx_baseu-3.2.so.0:_ZN8wxString9MakeUpperEv
 libwx_baseu-3.2.so.0:_ZN8wxThread11TestDestroyEv
+libwx_baseu-3.2.so.0:_ZN8wxThread12GetCurrentIdEv
+libwx_baseu-3.2.so.0:_ZN8wxThread15ms_idMainThreadE
 libwx_baseu-3.2.so.0:_ZN8wxThread3RunEv
 libwx_baseu-3.2.so.0:_ZN8wxThread4WaitE12wxThreadWait
 libwx_baseu-3.2.so.0:_ZN8wxThread5YieldEv
@@ -274,6 +296,7 @@ libwx_baseu-3.2.so.0:_ZNK16wxAppConsoleBase10GetAppNameEv
 libwx_baseu-3.2.so.0:_ZNK16wxAppConsoleBase11HandleEventEP12wxEvtHandlerMS0_FvR7wxEventES3_
 libwx_baseu-3.2.so.0:_ZNK16wxAppConsoleBase16CallEventHandlerEP12wxEvtHandlerR14wxEventFunctorR7wxEvent
 libwx_baseu-3.2.so.0:_ZNK17wxFileInputStream4IsOkEv
+libwx_baseu-3.2.so.0:_ZNK19wxFileSystemHandler12GetClassInfoEv
 libwx_baseu-3.2.so.0:_ZNK23wxSingleInstanceChecker18DoIsAnotherRunningEv
 libwx_baseu-3.2.so.0:_ZNK5wxURI10DoBuildURIEPF8wxStringRKS0_E
 libwx_baseu-3.2.so.0:_ZNK6wxFile4TellEv
@@ -281,6 +304,7 @@ libwx_baseu-3.2.so.0:_ZNK6wxFile6LengthEv
 libwx_baseu-3.2.so.0:_ZNK7wxEvent12GetClassInfoEv
 libwx_baseu-3.2.so.0:_ZNK7wxTimer5GetIdEv
 libwx_baseu-3.2.so.0:_ZNK7wxTimer9IsRunningEv
+libwx_baseu-3.2.so.0:_ZNK8wxMBConv14DoConvertMB2WCEPKcm
 libwx_baseu-3.2.so.0:_ZNK8wxObject12CloneRefDataEPK12wxRefCounter
 libwx_baseu-3.2.so.0:_ZNK8wxObject12GetClassInfoEv
 libwx_baseu-3.2.so.0:_ZNK8wxObject13CreateRefDataEv
@@ -303,17 +327,20 @@ libwx_baseu-3.2.so.0:_ZNK9wxVariant9GetStringEv
 libwx_baseu-3.2.so.0:_ZTI10wxListBase
 libwx_baseu-3.2.so.0:_ZTI12wxEvtHandler
 libwx_baseu-3.2.so.0:_ZTI14wxEventFunctor
+libwx_baseu-3.2.so.0:_ZTI21wxMemoryFSHandlerBase
 libwx_baseu-3.2.so.0:_ZTI7wxEvent
 libwx_baseu-3.2.so.0:_ZTI8wxObject
 libwx_baseu-3.2.so.0:_ZTI8wxThread
 libwx_baseu-3.2.so.0:_ZTI9wxProcess
 libwx_baseu-3.2.so.0:_ZTV10wxConvAuto
 libwx_baseu-3.2.so.0:_ZTV10wxListBase
+libwx_baseu-3.2.so.0:_ZTV12wxFileSystem
 libwx_baseu-3.2.so.0:_ZTV12wxMBConvUTF8
 libwx_baseu-3.2.so.0:_ZTV13wxThreadEvent
 libwx_baseu-3.2.so.0:_ZTV14wxProcessEvent
 libwx_baseu-3.2.so.0:_ZTV15wxStandardPaths
 libwx_baseu-3.2.so.0:_ZTV7wxTimer
+libwx_baseu-3.2.so.0:_ZTV8wxFSFile
 libwx_baseu-3.2.so.0:_ZTV8wxLocale
 libwx_baseu-3.2.so.0:_ZTV8wxObject
 libwx_baseu-3.2.so.0:_ZTV9wxProcess
@@ -332,6 +359,7 @@ libwx_baseu-3.2.so.0:wxEVT_IDLE
 libwx_baseu-3.2.so.0:wxEVT_NULL
 libwx_baseu-3.2.so.0:wxEVT_TIMER
 libwx_baseu-3.2.so.0:wxEmptyString
+libwx_baseu-3.2.so.0:wxLOG_COMPONENT
 libwx_baseu-3.2.so.0:wxPendingDelete
 libwx_baseu-3.2.so.0:wxTheAssertHandler
 libwx_baseu-3.2.so.0:wxTrapInAssert
@@ -467,6 +495,8 @@ libwx_gtk3u_core-3.2.so.0:_ZN13wxControlBase16DoUpdateWindowUIER15wxUpdateUIEven
 libwx_gtk3u_core-3.2.so.0:_ZN13wxControlBase7CommandER14wxCommandEvent
 libwx_gtk3u_core-3.2.so.0:_ZN13wxControlBaseD2Ev
 libwx_gtk3u_core-3.2.so.0:_ZN13wxTextWrapper4WrapEP8wxWindowRK8wxStringi
+libwx_gtk3u_core-3.2.so.0:_ZN13wxToolBarBaseC2Ev
+libwx_gtk3u_core-3.2.so.0:_ZN13wxToolBarBaseD2Ev
 libwx_gtk3u_core-3.2.so.0:_ZN14wxBitmapBundleC1EPKPKc
 libwx_gtk3u_core-3.2.so.0:_ZN14wxBitmapBundleC1ERK8wxBitmap
 libwx_gtk3u_core-3.2.so.0:_ZN14wxBitmapBundleC1Ev
@@ -604,6 +634,7 @@ libwx_gtk3u_core-3.2.so.0:_ZN22wxControlContainerBase22UpdateCanFocusChildrenEv
 libwx_gtk3u_core-3.2.so.0:_ZN22wxStdDialogButtonSizer7RealizeEv
 libwx_gtk3u_core-3.2.so.0:_ZN22wxStdDialogButtonSizer9AddButtonEP8wxButton
 libwx_gtk3u_core-3.2.so.0:_ZN22wxStdDialogButtonSizerC1Ev
+libwx_gtk3u_core-3.2.so.0:_ZN22wxSystemSettingsNative13GetAppearanceEv
 libwx_gtk3u_core-3.2.so.0:_ZN22wxSystemSettingsNative9GetColourE14wxSystemColour
 libwx_gtk3u_core-3.2.so.0:_ZN24wxDataViewIndexListModel15RowValueChangedEjj
 libwx_gtk3u_core-3.2.so.0:_ZN24wxItemContainerImmutableD2Ev
@@ -727,6 +758,8 @@ libwx_gtk3u_core-3.2.so.0:_ZN9wxDisplay13GetFromWindowEPK8wxWindow
 libwx_gtk3u_core-3.2.so.0:_ZN9wxDisplayC1Ej
 libwx_gtk3u_core-3.2.so.0:_ZN9wxMenuBarC1El
 libwx_gtk3u_core-3.2.so.0:_ZN9wxPaintDCC1EP8wxWindow
+libwx_gtk3u_core-3.2.so.0:_ZN9wxToolBar4InitEv
+libwx_gtk3u_core-3.2.so.0:_ZN9wxToolBar6CreateEP8wxWindowiRK7wxPointRK6wxSizelRK8wxString
 libwx_gtk3u_core-3.2.so.0:_ZNK10wxListCtrl12GetClassInfoEv
 libwx_gtk3u_core-3.2.so.0:_ZNK11wxAnyButton11DoGetBitmapEN15wxAnyButtonBase5StateE
 libwx_gtk3u_core-3.2.so.0:_ZNK11wxAnyButton12GTKGetWindowER17wxArrayGdkWindows
@@ -820,6 +853,7 @@ libwx_gtk3u_core-3.2.so.0:_ZNK18wxDataViewCtrlBase8GetModelEv
 libwx_gtk3u_core-3.2.so.0:_ZNK18wxScrollHelperBase14DoGetViewStartEPiS0_
 libwx_gtk3u_core-3.2.so.0:_ZNK18wxScrollHelperBase20SendAutoScrollEventsER16wxScrollWinEvent
 libwx_gtk3u_core-3.2.so.0:_ZNK18wxScrollHelperBase24ScrollGetBestVirtualSizeEv
+libwx_gtk3u_core-3.2.so.0:_ZNK18wxSystemAppearance6IsDarkEv
 libwx_gtk3u_core-3.2.so.0:_ZNK19wxDataViewListStore12GetItemCountEv
 libwx_gtk3u_core-3.2.so.0:_ZNK19wxTopLevelWindowGTK10IsIconizedEv
 libwx_gtk3u_core-3.2.so.0:_ZNK19wxTopLevelWindowGTK11IsMaximizedEv
@@ -931,6 +965,7 @@ libwx_gtk3u_core-3.2.so.0:_ZTV8wxColour
 libwx_gtk3u_core-3.2.so.0:_ZTV8wxCursor
 libwx_gtk3u_core-3.2.so.0:_ZTV8wxSlider
 libwx_gtk3u_core-3.2.so.0:_ZTV9wxControl
+libwx_gtk3u_core-3.2.so.0:_ZTV9wxToolBar
 libwx_gtk3u_core-3.2.so.0:_ZThn944_N17wxGenericListCtrl31GetSizeAvailableForScrollTargetERK6wxSize
 libwx_gtk3u_core-3.2.so.0:wxButtonNameStr
 libwx_gtk3u_core-3.2.so.0:wxCheckBoxNameStr
@@ -970,6 +1005,7 @@ libwx_gtk3u_core-3.2.so.0:wxEVT_SEARCH
 libwx_gtk3u_core-3.2.so.0:wxEVT_SHOW
 libwx_gtk3u_core-3.2.so.0:wxEVT_SIZE
 libwx_gtk3u_core-3.2.so.0:wxEVT_SLIDER
+libwx_gtk3u_core-3.2.so.0:wxEVT_SYS_COLOUR_CHANGED
 libwx_gtk3u_core-3.2.so.0:wxEVT_TEXT
 libwx_gtk3u_core-3.2.so.0:wxEVT_TEXT_ENTER
 libwx_gtk3u_core-3.2.so.0:wxEVT_TOGGLEBUTTON
@@ -989,3 +1025,8 @@ libwx_gtk3u_core-3.2.so.0:wxStaticBitmapNameStr
 libwx_gtk3u_core-3.2.so.0:wxStaticTextNameStr
 libwx_gtk3u_core-3.2.so.0:wxStatusLineNameStr
 libwx_gtk3u_core-3.2.so.0:wxTextCtrlNameStr
+libwx_gtk3u_core-3.2.so.0:wxToolBarNameStr
+libwx_gtk3u_xrc-3.2.so.0:_ZN13wxXmlResource10LoadBitmapERK8wxString
+libwx_gtk3u_xrc-3.2.so.0:_ZN13wxXmlResource15InitAllHandlersEv
+libwx_gtk3u_xrc-3.2.so.0:_ZN13wxXmlResource3GetEv
+libwx_gtk3u_xrc-3.2.so.0:_ZN13wxXmlResource4LoadERK8wxString

--- a/packages/t/tv-lite/package.yml
+++ b/packages/t/tv-lite/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : TV-Lite
-version    : 0.8.0
-release    : 8
+version    : 0.8.1
+release    : 9
 source     :
-    - https://gitlab.com/cburneci/tv-lite/-/archive/0.8.0/tv-lite-0.8.0.tar.gz : 5c2c8cb2e74091009dddcdc36e39b940da335f296fd50e921b9365fda98e84fd
+    - https://gitlab.com/cburneci/tv-lite/-/archive/0.8.1/tv-lite-0.8.1.tar.gz : 4303be9c37a8c721ddc5a34d6c6793936e97f18f5856bf782a56be5b61297781
 homepage   : https://tv-lite.com
 license    : GPL-2.0-or-later
 component  : multimedia.video

--- a/packages/t/tv-lite/pspec_x86_64.xml
+++ b/packages/t/tv-lite/pspec_x86_64.xml
@@ -38,9 +38,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2026-01-02</Date>
-            <Version>0.8.0</Version>
+        <Update release="9">
+            <Date>2026-01-31</Date>
+            <Version>0.8.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
- Lists and subscriptions now feature TV and Radio sections
- The Windows version uses yt-dlp as well as the Linux version.
- Improvements in the handling of the external processes (acestream, yt-dlp)

**Test Plan**
- Watched TV.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
