### PR TITLE
zoxide: Update to v0.9.9

### DIFF
--- a/packages/z/zoxide/package.yml
+++ b/packages/z/zoxide/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : zoxide
-version    : 0.9.8
-release    : 6
+version    : 0.9.9
+release    : 7
 source     :
-    - https://github.com/ajeetdsouza/zoxide/archive/refs/tags/v0.9.8.tar.gz : 1b276edbf328aafc86afe1ebce41f45ccba3a3125412e89c8c5d8e825b0c7407
+    - https://github.com/ajeetdsouza/zoxide/archive/refs/tags/v0.9.9.tar.gz : eddc76e94db58567503a3893ecac77c572f427f3a4eabdfc762f6773abf12c63
 homepage   : https://github.com/ajeetdsouza/zoxide
 license    : MIT
 component  : programming.tools

--- a/packages/z/zoxide/pspec_x86_64.xml
+++ b/packages/z/zoxide/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>zoxide</Name>
         <Homepage>https://github.com/ajeetdsouza/zoxide</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.tools</PartOf>
@@ -35,12 +35,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2025-12-18</Date>
-            <Version>0.9.8</Version>
+        <Update release="7">
+            <Date>2026-01-31</Date>
+            <Version>0.9.9</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/ajeetdsouza/zoxide/releases/tag/v0.9.9).

**Test Plan**

z around the file system. z back into zoxide in packages. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
