### PR TITLE
uv: update to 0.9.28

### DIFF
--- a/packages/u/uv/abi_used_symbols
+++ b/packages/u/uv/abi_used_symbols
@@ -61,6 +61,7 @@ libc.so.6:getpgid
 libc.so.6:getpid
 libc.so.6:getppid
 libc.so.6:getpwuid_r
+libc.so.6:getrlimit
 libc.so.6:getsockname
 libc.so.6:getsockopt
 libc.so.6:gettimeofday
@@ -158,6 +159,7 @@ libc.so.6:setenv
 libc.so.6:setgid
 libc.so.6:setgroups
 libc.so.6:setpgid
+libc.so.6:setrlimit
 libc.so.6:setsid
 libc.so.6:setsockopt
 libc.so.6:setuid

--- a/packages/u/uv/package.yml
+++ b/packages/u/uv/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : uv
-version    : 0.9.21
-release    : 7
+version    : 0.9.28
+release    : 8
 source     :
-    - https://github.com/astral-sh/uv/archive/refs/tags/0.9.21.tar.gz : d574c8717b079ca6f006506d5338fd485dc626d6bd0fe29b4283282634e83227
+    - https://github.com/astral-sh/uv/archive/refs/tags/0.9.28.tar.gz : 99651696304efb4d2b24950763ef11b57f7ec55369b970b373a626333daf8ff5
 homepage   : https://docs.astral.sh/uv
 license    :
     - Apache-2.0

--- a/packages/u/uv/pspec_x86_64.xml
+++ b/packages/u/uv/pspec_x86_64.xml
@@ -32,9 +32,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2026-01-03</Date>
-            <Version>0.9.21</Version>
+        <Update release="8">
+            <Date>2026-01-31</Date>
+            <Version>0.9.28</Version>
             <Comment>Packaging update</Comment>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>


### PR DESCRIPTION
**Summary**

- Release notes:
  - [v0.9.28](https://github.com/astral-sh/uv/releases/tag/0.9.28)
  - [v0.9.27](https://github.com/astral-sh/uv/releases/tag/0.9.27)
  - [v0.9.26](https://github.com/astral-sh/uv/releases/tag/0.9.26)
  - [v0.9.25](https://github.com/astral-sh/uv/releases/tag/0.9.25)
  - [v0.9.24](https://github.com/astral-sh/uv/releases/tag/0.9.24)
  - [v0.9.23](https://github.com/astral-sh/uv/releases/tag/0.9.23)
  - [v0.9.22](https://github.com/astral-sh/uv/releases/tag/0.9.22)

**Test Plan**

- Run smoke tests defined in source
- Installed locally and run some commands.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
