### PR TITLE
azahar: Update to v2124.3

### DIFF
--- a/packages/a/azahar/abi_used_symbols
+++ b/packages/a/azahar/abi_used_symbols
@@ -945,7 +945,6 @@ libQt6Multimedia.so.6:_ZNK11QVideoFrame7toImageEv
 libQt6Multimedia.so.6:_ZNK13QCameraDevice11descriptionEv
 libQt6Multimedia.so.6:_ZNK7QCamera11isAvailableEv
 libQt6Multimedia.so.6:_ZNK7QCamera8isActiveEv
-libQt6Widgets.so.6:_ZN10QBoxLayout10addStretchEi
 libQt6Widgets.so.6:_ZN10QBoxLayout10setStretchEii
 libQt6Widgets.so.6:_ZN10QBoxLayout9addLayoutEP7QLayouti
 libQt6Widgets.so.6:_ZN10QBoxLayout9addWidgetEP7QWidgeti6QFlagsIN2Qt13AlignmentFlagEE
@@ -1029,7 +1028,6 @@ libQt6Widgets.so.6:_ZN11QMessageBoxC1EP7QWidget
 libQt6Widgets.so.6:_ZN11QMessageBoxD1Ev
 libQt6Widgets.so.6:_ZN11QPushButton10setDefaultEb
 libQt6Widgets.so.6:_ZN11QPushButton14setAutoDefaultEb
-libQt6Widgets.so.6:_ZN11QPushButton7setFlatEb
 libQt6Widgets.so.6:_ZN11QPushButtonC1EP7QWidget
 libQt6Widgets.so.6:_ZN11QPushButtonC1ERK5QIconRK7QStringP7QWidget
 libQt6Widgets.so.6:_ZN11QPushButtonC1ERK7QStringP7QWidget

--- a/packages/a/azahar/package.yml
+++ b/packages/a/azahar/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : azahar
-version    : '2124.2'
-release    : 6
+version    : '2124.3'
+release    : 7
 source     :
-    - https://github.com/azahar-emu/azahar/releases/download/2124.2/azahar-unified-source-2124.2.tar.xz : f2af9cdf51c504ad9231ea3d4bb4d5d99cf0ad672c96b9409cb105d702dd67b4
+    - https://github.com/azahar-emu/azahar/releases/download/2124.3/azahar-unified-source-2124.3.tar.xz : b43191b613ed67072af037f9c8d89c1460d5532cc8381757a875f656bb6a10b1
 homepage   : https://azahar-emu.org/
 license    : GPL-2.0-or-later
 component  : games.emulator

--- a/packages/a/azahar/pspec_x86_64.xml
+++ b/packages/a/azahar/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>azahar</Name>
         <Homepage>https://azahar-emu.org/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>games.emulator</PartOf>
@@ -36,12 +36,12 @@
         </Conflicts>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2026-01-30</Date>
-            <Version>2124.2</Version>
+        <Update release="7">
+            <Date>2026-01-31</Date>
+            <Version>2124.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- This update re-enables support for the .3ds extension, which was previously removed in Azahar's initial release. For more information on this change, please see the [release notes](https://github.com/azahar-emu/azahar/releases/tag/2124.3).

**Test Plan**
- Played a game.

**Checklist**

- [X] Package was built and tested against unstable
- [X] This change could gainfully be listed in the weekly sync notes once merged