### PR TITLE
keepass: Update to v2.60

### DIFF
--- a/packages/k/keepass/package.yml
+++ b/packages/k/keepass/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : keepass
-version    : '2.59'
-release    : 47
+version    : '2.60'
+release    : 48
 source     :
-    - https://sourceforge.net/projects/keepass/files/KeePass%202.x/2.59/KeePass-2.59-Source.zip : 7ac2711821836fc0198b6f19ecd787318c8bf06585a4a3aeb2e6bd5319604a7b
+    - https://sourceforge.net/projects/keepass/files/KeePass%202.x/2.60/KeePass-2.60-Source.zip : 02b68076778090b4d2d7067ba560b4326e759b9d2cda10b2eb037be27954b71a
 homepage   : https://keepass.info/
 license    : GPL-2.0-or-later
 component  : security

--- a/packages/k/keepass/pspec_x86_64.xml
+++ b/packages/k/keepass/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>keepass</Name>
         <Homepage>https://keepass.info/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>security</PartOf>
@@ -44,12 +44,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="47">
-            <Date>2025-08-11</Date>
-            <Version>2.59</Version>
+        <Update release="48">
+            <Date>2026-01-31</Date>
+            <Version>2.60</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://keepass.info/news/n251102_2.60.html).

**Test Plan**
- Saved passwords.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
