### PR TITLE
fuzzel: Update to v1.14.0

### DIFF
--- a/packages/f/fuzzel/abi_used_symbols
+++ b/packages/f/fuzzel/abi_used_symbols
@@ -25,6 +25,7 @@ libc.so.6:abort
 libc.so.6:c32rtomb
 libc.so.6:calloc
 libc.so.6:chdir
+libc.so.6:clock_gettime
 libc.so.6:close
 libc.so.6:closedir
 libc.so.6:closelog
@@ -54,7 +55,6 @@ libc.so.6:fwrite
 libc.so.6:getenv
 libc.so.6:gethostname
 libc.so.6:getopt_long
-libc.so.6:gettimeofday
 libc.so.6:isatty
 libc.so.6:iswspace
 libc.so.6:malloc

--- a/packages/f/fuzzel/package.yml
+++ b/packages/f/fuzzel/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : fuzzel
-version    : 1.13.1
-release    : 2
+version    : 1.14.0
+release    : 3
 source     :
-    - https://codeberg.org/dnkl/fuzzel/releases/download/1.13.1/fuzzel-1.13.1.tar.gz : 5dd0ad62836d7f2f3d8de3bce453ce8d2d354984a116ad8751b941fa71e6b838
+    - https://codeberg.org/dnkl/fuzzel/releases/download/1.14.0/fuzzel-1.14.0.tar.gz : 8af4e28c235d63e3de83b1507f5f3017fdfbab2e70fb486ff0c8d98ced4c7ae5
 homepage   : https://codeberg.org/dnkl/fuzzel
 license    : MIT
 component  : desktop

--- a/packages/f/fuzzel/pspec_x86_64.xml
+++ b/packages/f/fuzzel/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>fuzzel</Name>
         <Homepage>https://codeberg.org/dnkl/fuzzel</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Gavin Zhao</Name>
+            <Email>me@gzgz.dev</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>desktop</PartOf>
@@ -32,12 +32,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2025-09-02</Date>
-            <Version>1.13.1</Version>
+        <Update release="3">
+            <Date>2026-02-01</Date>
+            <Version>1.14.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Gavin Zhao</Name>
+            <Email>me@gzgz.dev</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Update fuzzel to v1.14.0. Changelog available [here](https://codeberg.org/dnkl/fuzzel/releases/tag/1.14.0).

**Test Plan**

Ran the `fuzzel` for a day and haven't noticed any issues.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
