### PR TITLE
openrct2: Update to v0.4.31

### DIFF
--- a/packages/o/openrct2/abi_used_symbols
+++ b/packages/o/openrct2/abi_used_symbols
@@ -520,7 +520,7 @@ libstdc++.so.6:_ZNSt6thread4joinEv
 libstdc++.so.6:_ZNSt6thread6_StateD2Ev
 libstdc++.so.6:_ZNSt6thread6detachEv
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE15_M_replace_coldEPcmPKcmm
-libstdc++.so.6:_ZNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE7_M_syncEPcmm
+libstdc++.so.6:_ZNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE3strEONS_12basic_stringIcS2_S3_EE
 libstdc++.so.6:_ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEEC1Ev
 libstdc++.so.6:_ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEC1Ev

--- a/packages/o/openrct2/package.yml
+++ b/packages/o/openrct2/package.yml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : openrct2
-version    : 0.4.30
-release    : 63
+version    : 0.4.31
+release    : 64
 source     :
-    - git|https://github.com/OpenRCT2/OpenRCT2.git : v0.4.30
+    - git|https://github.com/OpenRCT2/OpenRCT2.git : v0.4.31
     - https://github.com/OpenRCT2/title-sequences/releases/download/v0.4.26/title-sequences.zip : dabb9787b1576342fca4dd9f64b3f8cfa04a7e6ce9c2bb9610f47b762905c858
-    - https://github.com/OpenRCT2/objects/releases/download/v1.7.5/objects.zip : c8b9d3039a920f67caf15b09e8312cc4f80d59ed7fe0288625b9ccedef606797
+    - https://github.com/OpenRCT2/objects/releases/download/v1.7.6/objects.zip : 6aca2eb441fbe8c022ff84d59fb51ed7ea577756640970dc989eab685ff45696
     - https://github.com/OpenRCT2/OpenSoundEffects/releases/download/v1.0.6/opensound.zip : 06b90f3e19c216752df441d551b26a9e3e1ba7755bdd2102504b73bf993608be
     - https://github.com/OpenRCT2/OpenMusic/releases/download/v1.6.1/openmusic.zip : 994b350d3b180ee1cb9619fe27f7ebae3a1a5232840c4bd47a89f33fa89de1a1
 license    :

--- a/packages/o/openrct2/pspec_x86_64.xml
+++ b/packages/o/openrct2/pspec_x86_64.xml
@@ -1387,7 +1387,7 @@
             <Path fileType="data">/usr/share/openrct2/object/rct2tt/scenery_large/rct2tt.scenery_large.jailxx17.json</Path>
             <Path fileType="data">/usr/share/openrct2/object/rct2tt/scenery_large/rct2tt.scenery_large.jailxx18.json</Path>
             <Path fileType="data">/usr/share/openrct2/object/rct2tt/scenery_large/rct2tt.scenery_large.jetplan1.json</Path>
-            <Path fileType="data">/usr/share/openrct2/object/rct2tt/scenery_large/rct2tt.scenery_large.jetplan2.json</Path>
+            <Path fileType="data">/usr/share/openrct2/object/rct2tt/scenery_large/rct2tt.scenery_large.jetplan2.parkobj</Path>
             <Path fileType="data">/usr/share/openrct2/object/rct2tt/scenery_large/rct2tt.scenery_large.jetplan3.json</Path>
             <Path fileType="data">/usr/share/openrct2/object/rct2tt/scenery_large/rct2tt.scenery_large.majoroak.json</Path>
             <Path fileType="data">/usr/share/openrct2/object/rct2tt/scenery_large/rct2tt.scenery_large.mcastl01.json</Path>
@@ -2593,6 +2593,7 @@
             <Path fileType="data">/usr/share/openrct2/object/rct2ww/scenery_wall/rct2ww.scenery_wall.wwind04.json</Path>
             <Path fileType="data">/usr/share/openrct2/object/rct2ww/scenery_wall/rct2ww.scenery_wall.wwind05.json</Path>
             <Path fileType="data">/usr/share/openrct2/object/rct2ww/scenery_wall/rct2ww.scenery_wall.wwind06.json</Path>
+            <Path fileType="data">/usr/share/openrct2/palettes.dat</Path>
             <Path fileType="data">/usr/share/openrct2/scenario_patches/0153987.parkpatch</Path>
             <Path fileType="data">/usr/share/openrct2/scenario_patches/020ed74.parkpatch</Path>
             <Path fileType="data">/usr/share/openrct2/scenario_patches/081feb1.parkpatch</Path>
@@ -2727,9 +2728,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="63">
-            <Date>2026-01-07</Date>
-            <Version>0.4.30</Version>
+        <Update release="64">
+            <Date>2026-02-01</Date>
+            <Version>0.4.31</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- *Live from the Grill-O-Mat*
- Release notes [here](https://github.com/OpenRCT2/OpenRCT2/releases/tag/v0.4.31)

**Test Plan**

- Play a scenario

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
