### PR TITLE
xwayland_satellite: update to 0.8

### DIFF
--- a/packages/x/xwayland-satellite/abi_used_libs
+++ b/packages/x/xwayland-satellite/abi_used_libs
@@ -1,5 +1,6 @@
 ld-linux-x86-64.so.2
 libc.so.6
 libgcc_s.so.1
+libm.so.6
 libxcb-cursor.so.0
 libxcb.so.1

--- a/packages/x/xwayland-satellite/abi_used_symbols
+++ b/packages/x/xwayland-satellite/abi_used_symbols
@@ -15,6 +15,7 @@ libc.so.6:close
 libc.so.6:connect
 libc.so.6:dl_iterate_phdr
 libc.so.6:dlsym
+libc.so.6:dup
 libc.so.6:dup2
 libc.so.6:environ
 libc.so.6:execvp
@@ -23,6 +24,7 @@ libc.so.6:fcntl
 libc.so.6:fork
 libc.so.6:free
 libc.so.6:fstat64
+libc.so.6:ftruncate64
 libc.so.6:getauxval
 libc.so.6:getcwd
 libc.so.6:getenv
@@ -74,10 +76,12 @@ libc.so.6:realpath
 libc.so.6:recv
 libc.so.6:recvmsg
 libc.so.6:sched_yield
+libc.so.6:send
 libc.so.6:sendmsg
 libc.so.6:setgid
 libc.so.6:setgroups
 libc.so.6:setpgid
+libc.so.6:setsid
 libc.so.6:setuid
 libc.so.6:sigaction
 libc.so.6:sigaddset
@@ -108,6 +112,11 @@ libgcc_s.so.1:_Unwind_RaiseException
 libgcc_s.so.1:_Unwind_Resume
 libgcc_s.so.1:_Unwind_SetGR
 libgcc_s.so.1:_Unwind_SetIP
+libm.so.6:acos
+libm.so.6:acosf
+libm.so.6:cos
+libm.so.6:cosf
+libm.so.6:powf
 libxcb-cursor.so.0:xcb_cursor_context_free
 libxcb-cursor.so.0:xcb_cursor_context_new
 libxcb-cursor.so.0:xcb_cursor_load_cursor
@@ -116,6 +125,7 @@ libxcb.so.1:xcb_connection_has_error
 libxcb.so.1:xcb_disconnect
 libxcb.so.1:xcb_generate_id
 libxcb.so.1:xcb_get_extension_data
+libxcb.so.1:xcb_get_maximum_request_length
 libxcb.so.1:xcb_get_setup
 libxcb.so.1:xcb_poll_for_event
 libxcb.so.1:xcb_prefetch_extension_data

--- a/packages/x/xwayland-satellite/package.yml
+++ b/packages/x/xwayland-satellite/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : xwayland-satellite
-version    : '0.7'
-release    : 2
+version    : '0.8'
+release    : 3
 source     :
-    - https://github.com/Supreeeme/xwayland-satellite/archive/refs/tags/v0.7.tar.gz : 466fc8d44b45f446a581549ab4e55ce65aa32e090e98638dde79f9da9faf89a0
+    - https://github.com/Supreeeme/xwayland-satellite/archive/refs/tags/v0.8.tar.gz : c93bae2f9e3df5cb5511a65684cd6ecf8559c1663163e8a19b4894e4424e73c3
 homepage   : https://github.com/Supreeeme/xwayland-satellite
 license    : MPL-2.0
 component  : desktop

--- a/packages/x/xwayland-satellite/pspec_x86_64.xml
+++ b/packages/x/xwayland-satellite/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xwayland-satellite</Name>
         <Homepage>https://github.com/Supreeeme/xwayland-satellite</Homepage>
         <Packager>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>pago.relam</Name>
+            <Email>pago.relam@googlemail.com</Email>
         </Packager>
         <License>MPL-2.0</License>
         <PartOf>desktop</PartOf>
@@ -25,12 +25,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2025-09-29</Date>
-            <Version>0.7</Version>
+        <Update release="3">
+            <Date>2026-02-04</Date>
+            <Version>0.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>pago.relam</Name>
+            <Email>pago.relam@googlemail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

https://github.com/Supreeeme/xwayland-satellite/releases/tag/v0.8
- Clipboard improvements (**fixes crash when opening steam**)
- Client side decorations

**Test Plan**

1. Updated xwayland-satellite from 0.7 to 0.8. 
2. Logged into niri-session
3. Confirm that steam is not longer crashing when clipboard contains entries.

**Checklist**

- [x] Package was built and tested against **stable**
- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
