### PR TITLE
parole: Add missing dependencies

### DIFF
--- a/packages/p/parole/abi_used_libs
+++ b/packages/p/parole/abi_used_libs
@@ -16,6 +16,7 @@ libgsttag-1.0.so.0
 libgstvideo-1.0.so.0
 libgtk-3.so.0
 libnotify.so.4
+libtag_c.so.2
 libxfce4ui-2.so.0
 libxfce4util.so.7
 libxfconf-0.so.3

--- a/packages/p/parole/abi_used_symbols
+++ b/packages/p/parole/abi_used_symbols
@@ -232,6 +232,8 @@ libglib-2.0.so.0:g_str_equal
 libglib-2.0.so.0:g_str_has_prefix
 libglib-2.0.so.0:g_str_has_suffix
 libglib-2.0.so.0:g_str_hash
+libglib-2.0.so.0:g_strchomp
+libglib-2.0.so.0:g_strchug
 libglib-2.0.so.0:g_strcmp0
 libglib-2.0.so.0:g_strconcat
 libglib-2.0.so.0:g_strdup
@@ -729,6 +731,13 @@ libnotify.so.4:notify_notification_set_icon_from_pixbuf
 libnotify.so.4:notify_notification_set_timeout
 libnotify.so.4:notify_notification_set_urgency
 libnotify.so.4:notify_notification_show
+libtag_c.so.2:taglib_audioproperties_length
+libtag_c.so.2:taglib_file_audioproperties
+libtag_c.so.2:taglib_file_free
+libtag_c.so.2:taglib_file_new
+libtag_c.so.2:taglib_file_tag
+libtag_c.so.2:taglib_tag_free_strings
+libtag_c.so.2:taglib_tag_title
 libxfce4ui-2.so.0:xfce_dialog_show_help_with_version
 libxfce4ui-2.so.0:xfce_sm_client_connect
 libxfce4ui-2.so.0:xfce_sm_client_get_full

--- a/packages/p/parole/package.yml
+++ b/packages/p/parole/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : parole
 version    : 4.20.0
-release    : 4
+release    : 5
 source     :
     - https://archive.xfce.org/src/apps/parole/4.20/parole-4.20.0.tar.xz : 5cf753e670d6518701133eb860d8bceb3a08a496af6a2b7cc67b93320230c983
 homepage   : https://docs.xfce.org/apps/parole/start
@@ -15,9 +15,15 @@ builddeps  :
     - pkgconfig(gstreamer-video-1.0)
     - pkgconfig(libnotify)
     - pkgconfig(libxfce4ui-2)
+    - pkgconfig(taglib_c)
+rundeps    :
+    - gstreamer-1.0-plugin-libav
+    - gstreamer-1.0-plugins-bad
+    - gstreamer-1.0-plugins-good
 setup      : |
     %meson_configure
 build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license AUTHORS COPYING THANKS

--- a/packages/p/parole/pspec_x86_64.xml
+++ b/packages/p/parole/pspec_x86_64.xml
@@ -36,6 +36,9 @@
             <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/org.xfce.parole.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/96x96/apps/org.xfce.parole.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/org.xfce.parole.svg</Path>
+            <Path fileType="data">/usr/share/licenses/parole/AUTHORS</Path>
+            <Path fileType="data">/usr/share/licenses/parole/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/parole/THANKS</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/parole.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ast/LC_MESSAGES/parole.mo</Path>
             <Path fileType="localedata">/usr/share/locale/be/LC_MESSAGES/parole.mo</Path>
@@ -105,7 +108,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="4">parole</Dependency>
+            <Dependency release="5">parole</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/parole/parole-debug.h</Path>
@@ -119,8 +122,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2025-05-21</Date>
+        <Update release="5">
+            <Date>2026-02-03</Date>
             <Version>4.20.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
- Add dependency on `taglib`
- Add dependency on gstreamer codec packages

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Play an audio file in Parole.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
