### PR TITLE
common/Scripts: Don't fail if path doesn't exist in quickfixup

### DIFF
--- a/common/Scripts/helpers.sh
+++ b/common/Scripts/helpers.sh
@@ -66,7 +66,10 @@ function quickfixup() {
 
     # Be explicit about adding files specific to packaging to avoid
     # adding aliens
-    git add abi_* package.yml pspec_x86_64.xml monitoring.yaml files/
+    local paths=(abi_* package.yml pspec_x86_64.xml monitoring.yaml files/)
+    for path in "${paths[@]}"; do
+        [[ -e $path ]] && git add "$path"
+    done
 
     # Fixup the last commit in the directory
     git commit --fixup "$(git log -1 --format="%h" -- .)"


### PR DESCRIPTION
**Summary**

Resolves #7799

**Test Plan**

quickfixup on a package which doesn't contain some of these files no longer fails

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
