### PR TITLE
safeeyes: Install desktop and metainfo files, and icons

### DIFF
--- a/packages/s/safeeyes/package.yml
+++ b/packages/s/safeeyes/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : safeeyes
 version    : 3.3.1
-release    : 20
+release    : 21
 source     :
     - https://github.com/slgobinath/SafeEyes/archive/refs/tags/v3.3.1.tar.gz : 61d91b4ac5fc583275e534cb7a475e4af5f16be19300ec5f31c3eae868d76c1b
 homepage   : https://slgobinath.github.io/safeeyes/
@@ -29,6 +29,19 @@ build      : |
     %python3_setup
 install    : |
     %python3_install
+
+    install -Dm00644 safeeyes/platform/io.github.slgobinath.SafeEyes.desktop -t ${installdir}/usr/share/applications
+
+    install -Dm00644 safeeyes/platform/io.github.slgobinath.SafeEyes.metainfo.xml -t ${installdir}/usr/share/metainfo
+
+    # Install icons
+    for size in 16x16 24x24 32x32 48x48 64x64 128x128; do
+        if [ -d safeeyes/platform/icons/hicolor/${size}/status ]; then
+            install -Dm00644 safeeyes/platform/icons/hicolor/${size}/status/*.png -t ${installdir}/usr/share/icons/hicolor/${size}/status
+        fi
+
+        install -Dm00644 safeeyes/platform/icons/hicolor/${size}/apps/*.png -t ${installdir}/usr/share/icons/hicolor/${size}/apps
+    done
 
     # Remove duplicate icons and desktop file.
     rm -rv $installdir/usr/lib/python%python3_version%/site-packages/safeeyes/platform

--- a/packages/s/safeeyes/pspec_x86_64.xml
+++ b/packages/s/safeeyes/pspec_x86_64.xml
@@ -251,11 +251,29 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/safeeyes/ui/required_plugin_dialog.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/safeeyes/ui/settings_dialog.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/safeeyes/utility.py</Path>
+            <Path fileType="data">/usr/share/applications/io.github.slgobinath.SafeEyes.desktop</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/io.github.slgobinath.SafeEyes.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16/apps/io.github.slgobinath.SafeEyes.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16/status/io.github.slgobinath.SafeEyes-disabled.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16/status/io.github.slgobinath.SafeEyes-enabled.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/16x16/status/io.github.slgobinath.SafeEyes-timer.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24/apps/io.github.slgobinath.SafeEyes.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24/status/io.github.slgobinath.SafeEyes-disabled.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24/status/io.github.slgobinath.SafeEyes-enabled.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/24x24/status/io.github.slgobinath.SafeEyes-timer.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/io.github.slgobinath.SafeEyes.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32/status/io.github.slgobinath.SafeEyes-disabled.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/32x32/status/io.github.slgobinath.SafeEyes-enabled.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/io.github.slgobinath.SafeEyes.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48/status/io.github.slgobinath.SafeEyes-disabled.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48/status/io.github.slgobinath.SafeEyes-enabled.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/io.github.slgobinath.SafeEyes.png</Path>
+            <Path fileType="data">/usr/share/metainfo/io.github.slgobinath.SafeEyes.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2026-01-20</Date>
+        <Update release="21">
+            <Date>2026-02-04</Date>
             <Version>3.3.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
Install desktop and metainfo files, and icons

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install package, find Safe Eyes in the Plasma menu, launch it, see it appear in the system tray.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
