### PR TITLE
solseek: Update to 0.10.1

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 0.10.0
-release    : 14
+version    : 0.10.1
+release    : 15
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v0.10.0.tar.gz : 10bb6735a8910f940dd43f66b1d85767f2e1aad56238acc16a932b37ae125673
+    - https://github.com/clintre/solseek/archive/refs/tags/v0.10.1.tar.gz : fccec0d4f1b673b90099b8c698a7e5eaad69abe0b75c103d85d77e8fc9fc7c6b
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -36,6 +36,7 @@
             <Path fileType="data">/usr/share/solseek/lang/es.ini</Path>
             <Path fileType="data">/usr/share/solseek/lang/fr.ini</Path>
             <Path fileType="data">/usr/share/solseek/lang/pl.ini</Path>
+            <Path fileType="data">/usr/share/solseek/lang/sl.ini</Path>
             <Path fileType="data">/usr/share/solseek/solseek-uc.service</Path>
             <Path fileType="data">/usr/share/solseek/solseek-uc.timer</Path>
             <Path fileType="data">/usr/share/solseek/solseek_fastfetch_1.jsonc</Path>
@@ -49,9 +50,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2026-01-26</Date>
-            <Version>0.10.0</Version>
+        <Update release="15">
+            <Date>2026-02-04</Date>
+            <Version>0.10.1</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**

Bugfixes:

- Fixed minor issue where if a user has a custom update script and updates everything, it is possible for firmware updates to reboot and not allow the custom update script to run.

Enhancements:

- Added sl.ini with a Slovenian translation by @trinajstica in https://github.com/clintre/solseek/pull/35

Other:

- @trinajstica made their first contribution in https://github.com/clintre/solseek/pull/35

Full release notes:

- [0.10.1](https://github.com/clintre/solseek/compare/v0.10.0...v0.10.1


**Test Plan**

- Tested on VM
- Launched solseek
- Set to use new language
- Test functionality

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
