### PR TITLE
rio: Patch default editor

### DIFF
--- a/packages/r/rio/files/0001-Default-config-editor-to-nano.patch
+++ b/packages/r/rio/files/0001-Default-config-editor-to-nano.patch
@@ -1,0 +1,24 @@
+Rio crashes when opening the config editor (Ctrl+Shift+,) if the
+configured editor is not available (e.g. vi on systems that don't
+ship it). Default to nano which is more commonly available.
+
+See: https://github.com/raphamorim/rio/issues/998
+
+---
+ rio-backend/src/config/defaults.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rio-backend/src/config/defaults.rs b/rio-backend/src/config/defaults.rs
+index 1234567..89abcde 100644
+--- a/rio-backend/src/config/defaults.rs
++++ b/rio-backend/src/config/defaults.rs
+@@ -97,7 +97,7 @@ pub fn default_theme() -> String {
+ pub fn default_editor() -> Shell {
+     #[cfg(not(target_os = "windows"))]
+     {
+         Shell {
+-            program: String::from("vi"),
++            program: String::from("nano"),
+             args: vec![],
+         }
+     }

--- a/packages/r/rio/package.yml
+++ b/packages/r/rio/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : rio
 version    : 0.2.37
-release    : 1
+release    : 2
 source     :
     - https://github.com/raphamorim/rio/archive/refs/tags/v0.2.37.tar.gz : f52bcd0fb3c669cae016c614a77a95547c2769e6a98a17d7bbc703b6e72af169
 homepage   : https://rioterm.com
@@ -20,6 +20,8 @@ builddeps  :
     - pkgconfig(xkbcommon)
     - rust
 setup      : |
+    %patch -p1 -i $pkgfiles/0001-Default-config-editor-to-nano.patch
+
     # Generate man pages
     for fname in rio.1 rio.5 rio-bindings.5; do
         scdoc < extra/man/$fname.scd > extra/man/$fname

--- a/packages/r/rio/pspec_x86_64.xml
+++ b/packages/r/rio/pspec_x86_64.xml
@@ -31,7 +31,7 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
+        <Update release="2">
             <Date>2026-02-06</Date>
             <Version>0.2.37</Version>
             <Comment>Packaging update</Comment>


### PR DESCRIPTION
**Summary**
- Patch default editor from vim to nano to avoid rio crashing.

**Test Plan**

Use Ctrl+Shift+, and see that nano opens and rio doesn't crash. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
