### PR TITLE
iotop: Update to v1.31

### DIFF
--- a/packages/i/iotop/package.yml
+++ b/packages/i/iotop/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : iotop
-version    : '1.30'
-release    : 13
+version    : '1.31'
+release    : 14
 source     :
-    - https://github.com/Tomas-M/iotop/releases/download/v1.30/iotop-1.30.tar.xz : b6d8001cd06b583b42bc366d337c3c6e94ae8eadd29f501dbb333b11a2f0bce0
+    - https://github.com/Tomas-M/iotop/releases/download/v1.31/iotop-1.31.tar.xz : 7740ada353262808c12f19b5efc37b3c7bfb6be3be4abc0404557806d0204b26
 homepage   : https://github.com/Tomas-M/iotop
 license    : GPL-2.0-or-later
 component  : system.utils

--- a/packages/i/iotop/pspec_x86_64.xml
+++ b/packages/i/iotop/pspec_x86_64.xml
@@ -25,9 +25,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2025-12-10</Date>
-            <Version>1.30</Version>
+        <Update release="14">
+            <Date>2026-02-07</Date>
+            <Version>1.31</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/Tomas-M/iotop/releases).

**Test Plan**

sudo iotop, saw processes. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
