### PR TITLE
calamares: Increase recommended EFI partition size

### DIFF
--- a/packages/c/calamares/files/install/modules/partition.conf
+++ b/packages/c/calamares/files/install/modules/partition.conf
@@ -3,7 +3,7 @@
 ---
 efi:
   mountPoint: "/boot"
-  recommendedSize: 1GiB
+  recommendedSize: 2GiB
   minimumSize: 500MiB
   label: "EFI"
 

--- a/packages/c/calamares/monitoring.yaml
+++ b/packages/c/calamares/monitoring.yaml
@@ -1,6 +1,6 @@
 releases:
   id: 7666
-  rss: https://github.com/calamares/calamares/tags.atom
+  rss: https://codeberg.org/Calamares/calamares/releases.rss
 security:
   cpe:
     - vendor: calamares

--- a/packages/c/calamares/package.yml
+++ b/packages/c/calamares/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : calamares
 version    : 3.3.14
-release    : 43
+release    : 44
 source     :
-    - https://github.com/calamares/calamares/releases/download/v3.3.14/calamares-3.3.14.tar.gz : 5547f80db067dea923ae693ba6bb88eb2b2eeac1da3ebec42fce453e31c290c0
+    - https://codeberg.org/Calamares/calamares/releases/download/v3.3.14/calamares-3.3.14.tar.gz : 5547f80db067dea923ae693ba6bb88eb2b2eeac1da3ebec42fce453e31c290c0
 homepage   : https://calamares.io
 license    :
     - BSD-2-Clause
@@ -47,6 +47,7 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license AUTHORS LICENSES/*
 
     install -Dm00755 $pkgfiles/calamares-gui $installdir/usr/bin/calamares-gui
 

--- a/packages/c/calamares/pspec_x86_64.xml
+++ b/packages/c/calamares/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>calamares</Name>
         <Homepage>https://calamares.io</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <License>CC-BY-4.0</License>
@@ -220,6 +220,14 @@
             <Path fileType="data">/usr/share/calamares/qml/calamares/slideshow/qmldir.license</Path>
             <Path fileType="data">/usr/share/calamares/settings.conf</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/calamares.svg</Path>
+            <Path fileType="data">/usr/share/licenses/calamares/AUTHORS</Path>
+            <Path fileType="data">/usr/share/licenses/calamares/BSD-2-Clause.txt</Path>
+            <Path fileType="data">/usr/share/licenses/calamares/CC-BY-4.0.txt</Path>
+            <Path fileType="data">/usr/share/licenses/calamares/CC0-1.0.txt</Path>
+            <Path fileType="data">/usr/share/licenses/calamares/GPL-3.0-or-later.txt</Path>
+            <Path fileType="data">/usr/share/licenses/calamares/LGPL-2.1-only.txt</Path>
+            <Path fileType="data">/usr/share/licenses/calamares/LGPL-3.0-or-later.txt</Path>
+            <Path fileType="data">/usr/share/licenses/calamares/MIT.txt</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/calamares-python.mo</Path>
             <Path fileType="localedata">/usr/share/locale/as/LC_MESSAGES/calamares-python.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ast/LC_MESSAGES/calamares-python.mo</Path>
@@ -293,7 +301,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="43">calamares</Dependency>
+            <Dependency release="44">calamares</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libcalamares/Branding.h</Path>
@@ -412,12 +420,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="43">
-            <Date>2026-02-06</Date>
+        <Update release="44">
+            <Date>2026-02-07</Date>
             <Version>3.3.14</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

The size of initram stuff keeps increasing, and at least one distro is already bumping the size of the EFI partition to 2GiB. We should keep ahead of this.

**Test Plan**

To be tested ahead of next release.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
