### PR TITLE
pinta: Build against .net 10

### DIFF
--- a/packages/p/pinta/package.yml
+++ b/packages/p/pinta/package.yml
@@ -2,7 +2,7 @@
 name       : pinta
 version    : 3.1.1
 homepage   : https://www.pinta-project.com/
-release    : 25
+release    : 26
 source     :
     - https://github.com/PintaProject/Pinta/releases/download/3.1.1/pinta-3.1.1.tar.gz : 9a1453b630e7ad03a377a1bcc702cb84a2339acac3dca5fe3a30245e8a68b56d
 license    : MIT
@@ -15,12 +15,14 @@ networking : true
 builddeps  :
     - pkgconfig(libadwaita-1)
     - autoconf-archive
-    - dotnet-8-sdk
+    - dotnet-sdk
     - gettext-devel
     - intltool
 rundeps    :
-    - dotnet-8
+    - dotnet
     - libadwaita
+environment: |
+    export DOTNET_TARGET_FRAMEWORK="net10"
 setup      : |
     %patch -p1 -i $pkgfiles/0002-force-x11-compat.patch
     %reconfigure

--- a/packages/p/pinta/pspec_x86_64.xml
+++ b/packages/p/pinta/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pinta</Name>
         <Homepage>https://www.pinta-project.com/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>nelson</Name>
+            <Email>nelson@truran.dev</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>multimedia.graphics</PartOf>
@@ -280,12 +280,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="25">
-            <Date>2026-01-10</Date>
+        <Update release="26">
+            <Date>2026-02-07</Date>
             <Version>3.1.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>nelson</Name>
+            <Email>nelson@truran.dev</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Migrating from .net 8 ahead of the deprecation date.

**Test Plan**

- [x] paint

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
