### PR TITLE
calamares: Fix a couple of sudo group references

### DIFF
--- a/packages/c/calamares/files/10-livecd.rules
+++ b/packages/c/calamares/files/10-livecd.rules
@@ -1,5 +1,5 @@
 polkit.addRule(function(action, subject) {
-    if (subject.isInGroup("sudo") &&
+    if (subject.isInGroup("wheel") &&
         subject.user == "live") {
             return polkit.Result.YES;
     }

--- a/packages/c/calamares/files/install/modules/users.conf
+++ b/packages/c/calamares/files/install/modules/users.conf
@@ -15,7 +15,7 @@ defaultGroups:
     - lpadmin
     - plugdev
     - scanner
-    - name: sudo
+    - name: wheel
       must_exist: true
       system: true
 

--- a/packages/c/calamares/package.yml
+++ b/packages/c/calamares/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : calamares
 version    : 3.3.14
-release    : 44
+release    : 45
 source     :
     - https://codeberg.org/Calamares/calamares/releases/download/v3.3.14/calamares-3.3.14.tar.gz : 5547f80db067dea923ae693ba6bb88eb2b2eeac1da3ebec42fce453e31c290c0
 homepage   : https://calamares.io

--- a/packages/c/calamares/pspec_x86_64.xml
+++ b/packages/c/calamares/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>calamares</Name>
         <Homepage>https://calamares.io</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <License>CC-BY-4.0</License>
@@ -301,7 +301,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="44">calamares</Dependency>
+            <Dependency release="45">calamares</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libcalamares/Branding.h</Path>
@@ -420,12 +420,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="44">
-            <Date>2026-02-07</Date>
+        <Update release="45">
+            <Date>2026-02-09</Date>
             <Version>3.3.14</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- wheel is now the default, ref #7227

**Test Plan**

Ensure groups are still working as expected for new users in smoke test isos
Ensure live user still has root perms in the ISO

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
