### PR TITLE
systemd: Ensure wheel sysgroup has 30 gid

### DIFF
--- a/packages/s/systemd/abi_used_symbols32
+++ b/packages/s/systemd/abi_used_symbols32
@@ -30,6 +30,7 @@ libc.so.6:__sched_cpualloc
 libc.so.6:__sched_cpucount
 libc.so.6:__sched_cpufree
 libc.so.6:__stack_chk_fail
+libc.so.6:__stpcpy_chk
 libc.so.6:__strcpy_chk
 libc.so.6:__strncpy_chk
 libc.so.6:__ttyname_r_chk

--- a/packages/s/systemd/package.yml
+++ b/packages/s/systemd/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : systemd
 version    : '257.10'
-release    : 182
+release    : 183
 source     :
     - https://github.com/systemd/systemd/archive/refs/tags/v257.10.tar.gz : 5a2f477e6268630f6e2829c7bb3e442017549798a4122635817934eaa0c6ac10
 license    :
@@ -218,6 +218,7 @@ setup      : |
         -Dusers-gid=100 \
         -Dutmp=${_IS_64BIT_BOOL} \
         -Dvconsole=${_IS_64BIT_BOOL} \
+        -Dwheel-gid=30 \
         -Dwheel-group=true \
         -Dxdg-autostart=${_IS_64BIT_BOOL} \
         -Dxkbcommon=${_IS_64BIT_FEAT} \

--- a/packages/s/systemd/pspec_x86_64.xml
+++ b/packages/s/systemd/pspec_x86_64.xml
@@ -1333,7 +1333,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="182">systemd</Dependency>
+            <Dependency release="183">systemd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnss_myhostname.so.2</Path>
@@ -1356,8 +1356,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="182">systemd-devel</Dependency>
-            <Dependency release="182">systemd-32bit</Dependency>
+            <Dependency release="183">systemd-32bit</Dependency>
+            <Dependency release="183">systemd-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/lib32/pkgconfig/libsystemd.pc</Path>
@@ -1371,7 +1371,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="182">systemd</Dependency>
+            <Dependency release="183">systemd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libudev.h</Path>
@@ -2191,8 +2191,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="182">
-            <Date>2026-01-06</Date>
+        <Update release="183">
+            <Date>2026-02-09</Date>
             <Version>257.10</Version>
             <Comment>Packaging update</Comment>
             <Name>Joey Riches</Name>


### PR DESCRIPTION
**Summary**

Ensure the wheel sysgroup has a 30 gid without relying on qol-assist to create it for new installs

**Test Plan**

Ensure `usr/lib/sysusers.d/basic.conf` has the wheel group populated with a gid of 30
Run smoketest isos

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
