### PR TITLE
feishin: Update to v1.5.0

### DIFF
--- a/packages/f/feishin/package.yml
+++ b/packages/f/feishin/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : feishin
-version    : 1.4.2
-release    : 3
+version    : 1.5.0
+release    : 4
 source     :
-    - https://github.com/jeffvli/feishin/archive/refs/tags/v1.4.2.tar.gz : 1a358cd766026b77a38d4a203b895bd1f66cba892c58515b53ba0373a9d5966d
+    - https://github.com/jeffvli/feishin/archive/refs/tags/v1.5.0.tar.gz : 0d868fed3f68a437e40199ad56c672454955e7df0e72781957c02607aa5efde2
 homepage   : https://github.com/jeffvli/feishin
 license    : GPL-3.0-or-later
 component  : multimedia.audio

--- a/packages/f/feishin/pspec_x86_64.xml
+++ b/packages/f/feishin/pspec_x86_64.xml
@@ -132,9 +132,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2026-02-04</Date>
-            <Version>1.4.2</Version>
+        <Update release="4">
+            <Date>2026-02-11</Date>
+            <Version>1.5.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Hans K</Name>
             <Email>hans@communitycomputing.net</Email>


### PR DESCRIPTION
**Summary**
    - Release notes can be found [here](https://github.com/jeffvli/feishin/releases/tag/v1.5.0)

**Test Plan**
- Build and install `feishin` from this PR.
- See that it still works, connecting to a Navidrome server and playing music.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
