### PR TITLE
libgnutls: Update to v3.8.12

### DIFF
--- a/packages/l/libgnutls/package.yml
+++ b/packages/l/libgnutls/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libgnutls
-version    : 3.8.11
-release    : 51
+version    : 3.8.12
+release    : 52
 source     :
-    - https://www.gnupg.org/ftp/gcrypt/gnutls/v3.8/gnutls-3.8.11.tar.xz : 91bd23c4a86ebc6152e81303d20cf6ceaeb97bc8f84266d0faec6e29f17baa20
+    - https://www.gnupg.org/ftp/gcrypt/gnutls/v3.8/gnutls-3.8.12.tar.xz : a7b341421bfd459acf7a374ca4af3b9e06608dcd7bd792b2bf470bea012b8e51
 license    : LGPL-2.1-or-later
 component  :
     - security
@@ -40,6 +40,7 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license AUTHORS COPYING COPYING.*
 patterns   :
     - docs :
         - /usr/share/gtk-doc

--- a/packages/l/libgnutls/pspec_x86_64.xml
+++ b/packages/l/libgnutls/pspec_x86_64.xml
@@ -21,9 +21,12 @@
         <PartOf>security</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libgnutls.so.30</Path>
-            <Path fileType="library">/usr/lib64/libgnutls.so.30.41.0</Path>
+            <Path fileType="library">/usr/lib64/libgnutls.so.30.41.1</Path>
             <Path fileType="library">/usr/lib64/libgnutlsxx.so.30</Path>
             <Path fileType="library">/usr/lib64/libgnutlsxx.so.30.0.0</Path>
+            <Path fileType="data">/usr/share/licenses/libgnutls/AUTHORS</Path>
+            <Path fileType="data">/usr/share/licenses/libgnutls/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/libgnutls/COPYING.LESSERv2</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/gnutls.mo</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/gnutls.mo</Path>
             <Path fileType="localedata">/usr/share/locale/eo/LC_MESSAGES/gnutls.mo</Path>
@@ -51,11 +54,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="51">libgnutls</Dependency>
+            <Dependency release="52">libgnutls</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libgnutls.so.30</Path>
-            <Path fileType="library">/usr/lib32/libgnutls.so.30.41.0</Path>
+            <Path fileType="library">/usr/lib32/libgnutls.so.30.41.1</Path>
             <Path fileType="library">/usr/lib32/libgnutlsxx.so.30</Path>
             <Path fileType="library">/usr/lib32/libgnutlsxx.so.30.0.0</Path>
         </Files>
@@ -67,8 +70,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="51">libgnutls-32bit</Dependency>
-            <Dependency release="51">libgnutls-devel</Dependency>
+            <Dependency release="52">libgnutls-32bit</Dependency>
+            <Dependency release="52">libgnutls-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libgnutls.so</Path>
@@ -83,7 +86,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="51">libgnutls</Dependency>
+            <Dependency release="52">libgnutls</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gnutls/abstract.h</Path>
@@ -1320,7 +1323,7 @@
 </Description>
         <PartOf>programming.docs</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="51">libgnutls-devel</Dependency>
+            <Dependency releaseFrom="52">libgnutls-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="doc">/usr/share/gtk-doc/html/gnutls-client-server-use-case.png</Path>
@@ -1382,7 +1385,7 @@
 </Description>
         <PartOf>security</PartOf>
         <RuntimeDependencies>
-            <Dependency release="51">libgnutls</Dependency>
+            <Dependency release="52">libgnutls</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/certtool</Path>
@@ -1406,9 +1409,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="51">
-            <Date>2025-11-20</Date>
-            <Version>3.8.11</Version>
+        <Update release="52">
+            <Date>2026-02-11</Date>
+            <Version>3.8.12</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://lists.gnutls.org/pipermail/gnutls-help/2026-February/004914.html).

**Security**
- CVE-2026-1584
- CVE-2025-14831

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Download a file with `wget`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
