### PR TITLE
freerdp: Update to v3.22.0

### DIFF
--- a/packages/f/freerdp/abi_symbols
+++ b/packages/f/freerdp/abi_symbols
@@ -576,6 +576,7 @@ libfreerdp3.so.3:freerdp_context_new
 libfreerdp3.so.3:freerdp_context_new_ex
 libfreerdp3.so.3:freerdp_context_reset
 libfreerdp3.so.3:freerdp_del_signal_cleanup_handler
+libfreerdp3.so.3:freerdp_desktop_rotation_flags_to_string
 libfreerdp3.so.3:freerdp_detect_keyboard_layout_from_locale
 libfreerdp3.so.3:freerdp_detect_keyboard_layout_from_system_locale
 libfreerdp3.so.3:freerdp_device_clone
@@ -650,6 +651,7 @@ libfreerdp3.so.3:freerdp_get_transport_sent
 libfreerdp3.so.3:freerdp_get_version
 libfreerdp3.so.3:freerdp_get_version_string
 libfreerdp3.so.3:freerdp_glyph_convert
+libfreerdp3.so.3:freerdp_glyph_convert_ex
 libfreerdp3.so.3:freerdp_handle_signals
 libfreerdp3.so.3:freerdp_heartbeat_send_heartbeat_pdu
 libfreerdp3.so.3:freerdp_http_request
@@ -675,6 +677,7 @@ libfreerdp3.so.3:freerdp_input_send_qoe_timestamp
 libfreerdp3.so.3:freerdp_input_send_rel_mouse_event
 libfreerdp3.so.3:freerdp_input_send_synchronize_event
 libfreerdp3.so.3:freerdp_input_send_unicode_keyboard_event
+libfreerdp3.so.3:freerdp_input_touch_state_string
 libfreerdp3.so.3:freerdp_interruptible_get_line
 libfreerdp3.so.3:freerdp_interruptible_getc
 libfreerdp3.so.3:freerdp_io_callback_set_event
@@ -713,11 +716,13 @@ libfreerdp3.so.3:freerdp_message_queue_process_message
 libfreerdp3.so.3:freerdp_message_queue_process_pending_messages
 libfreerdp3.so.3:freerdp_nego_get_routing_token
 libfreerdp3.so.3:freerdp_new
+libfreerdp3.so.3:freerdp_nla_FreeContextBuffer
 libfreerdp3.so.3:freerdp_nla_QueryContextAttributes
 libfreerdp3.so.3:freerdp_nla_decrypt
 libfreerdp3.so.3:freerdp_nla_encrypt
 libfreerdp3.so.3:freerdp_nla_impersonate
 libfreerdp3.so.3:freerdp_nla_revert_to_self
+libfreerdp3.so.3:freerdp_order_support_flags_string
 libfreerdp3.so.3:freerdp_passphrase_read
 libfreerdp3.so.3:freerdp_peer_context_free
 libfreerdp3.so.3:freerdp_peer_context_new
@@ -985,9 +990,12 @@ libfreerdp3.so.3:rdp_update_lock
 libfreerdp3.so.3:rdp_update_unlock
 libfreerdp3.so.3:rdpdr_cap_type_string
 libfreerdp3.so.3:rdpdr_component_string
+libfreerdp3.so.3:rdpdr_device_type_string
 libfreerdp3.so.3:rdpdr_dump_received_packet
 libfreerdp3.so.3:rdpdr_dump_send_packet
+libfreerdp3.so.3:rdpdr_irp_mask2str
 libfreerdp3.so.3:rdpdr_irp_string
+libfreerdp3.so.3:rdpdr_irp_val2str
 libfreerdp3.so.3:rdpdr_packetid_string
 libfreerdp3.so.3:rdpdr_read_capset_header
 libfreerdp3.so.3:rdpdr_write_capset_header

--- a/packages/f/freerdp/abi_used_symbols
+++ b/packages/f/freerdp/abi_used_symbols
@@ -908,6 +908,7 @@ libkrb5.so.3:krb5_cc_resolve
 libkrb5.so.3:krb5_cc_retrieve_cred
 libkrb5.so.3:krb5_cc_set_default_name
 libkrb5.so.3:krb5_free_ap_rep_enc_part
+libkrb5.so.3:krb5_free_authenticator
 libkrb5.so.3:krb5_free_context
 libkrb5.so.3:krb5_free_cred_contents
 libkrb5.so.3:krb5_free_creds
@@ -918,6 +919,7 @@ libkrb5.so.3:krb5_free_error
 libkrb5.so.3:krb5_free_error_message
 libkrb5.so.3:krb5_free_keytab_entry_contents
 libkrb5.so.3:krb5_free_principal
+libkrb5.so.3:krb5_free_unparsed_name
 libkrb5.so.3:krb5_fwd_tgt_creds
 libkrb5.so.3:krb5_get_credentials
 libkrb5.so.3:krb5_get_default_realm
@@ -958,6 +960,7 @@ libkrb5.so.3:krb5_rd_req
 libkrb5.so.3:krb5_set_default_realm
 libkrb5.so.3:krb5_sname_to_principal
 libkrb5.so.3:krb5_timeofday
+libkrb5.so.3:krb5_unparse_name_flags
 libkrb5.so.3:profile_abandon
 libkrb5.so.3:profile_add_relation
 libkrb5.so.3:profile_clear_relation

--- a/packages/f/freerdp/package.yml
+++ b/packages/f/freerdp/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : freerdp
-version    : 3.20.2
-release    : 45
+version    : 3.22.0
+release    : 46
 source     :
-    - https://pub.freerdp.com/releases/freerdp-3.20.2.tar.gz : 9fd28a5fc4167575d0fa91edbdab58cf7dd96a445a57d77fdb2df965b40eeb6d
+    - https://pub.freerdp.com/releases/freerdp-3.22.0.tar.gz : 656670f3aac2c995cb4b1ba181549cc122cc9c95ec31be68a582c1182f474376
 homepage   : https://www.freerdp.com/
 license    : Apache-2.0
 component  : network.util

--- a/packages/f/freerdp/pspec_x86_64.xml
+++ b/packages/f/freerdp/pspec_x86_64.xml
@@ -33,23 +33,23 @@
             <Path fileType="library">/usr/lib64/freerdp3/proxy/libproxy-demo-plugin.so</Path>
             <Path fileType="library">/usr/lib64/freerdp3/proxy/libproxy-dyn-channel-dump-plugin.so</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-client3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-client3.so.3.20.2</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-client3.so.3.22.0</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-server-proxy3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-server-proxy3.so.3.20.2</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-server-proxy3.so.3.22.0</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-server3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-server3.so.3.20.2</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-server3.so.3.22.0</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-shadow-subsystem3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-shadow-subsystem3.so.3.20.2</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-shadow-subsystem3.so.3.22.0</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-shadow3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-shadow3.so.3.20.2</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-shadow3.so.3.22.0</Path>
             <Path fileType="library">/usr/lib64/libfreerdp3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp3.so.3.20.2</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp3.so.3.22.0</Path>
             <Path fileType="library">/usr/lib64/librdtk0.so.0</Path>
             <Path fileType="library">/usr/lib64/librdtk0.so.0.2.0</Path>
             <Path fileType="library">/usr/lib64/libwinpr-tools3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libwinpr-tools3.so.3.20.2</Path>
+            <Path fileType="library">/usr/lib64/libwinpr-tools3.so.3.22.0</Path>
             <Path fileType="library">/usr/lib64/libwinpr3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libwinpr3.so.3.20.2</Path>
+            <Path fileType="library">/usr/lib64/libwinpr3.so.3.22.0</Path>
             <Path fileType="data">/usr/share/FreeRDP/images/test_icon.bmp</Path>
             <Path fileType="data">/usr/share/FreeRDP/images/test_icon.jpg</Path>
             <Path fileType="data">/usr/share/FreeRDP/images/test_icon.png</Path>
@@ -72,7 +72,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="45">freerdp</Dependency>
+            <Dependency release="46">freerdp</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/freerdp3/freerdp/addin.h</Path>
@@ -389,9 +389,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="45">
-            <Date>2026-01-14</Date>
-            <Version>3.20.2</Version>
+        <Update release="46">
+            <Date>2026-02-11</Date>
+            <Version>3.22.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://www.freerdp.com/2026/01/28/3_22_0-release).

**Security**
- CVE-2026-23948
- CVE-2026-24682
- CVE-2026-24683
- CVE-2026-24676
- CVE-2026-24677
- CVE-2026-24678
- CVE-2026-24684
- CVE-2026-24679
- CVE-2026-24681
- CVE-2026-24675
- CVE-2026-24491
- CVE-2026-24680

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build `gnome-remote-desktop` against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
