### PR TITLE
jujutsu: Update to v0.38.0 and restore fish dynamic completion

### DIFF
--- a/packages/j/jujutsu/abi_used_symbols
+++ b/packages/j/jujutsu/abi_used_symbols
@@ -65,7 +65,6 @@ libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset
 libc.so.6:mkdir
-libc.so.6:mmap
 libc.so.6:mmap64
 libc.so.6:mprotect
 libc.so.6:munmap
@@ -163,7 +162,6 @@ libgcc_s.so.1:_Unwind_Resume
 libgcc_s.so.1:_Unwind_SetGR
 libgcc_s.so.1:_Unwind_SetIP
 libm.so.6:exp
-libm.so.6:expf
 libm.so.6:log
 libm.so.6:log10
 libm.so.6:logf

--- a/packages/j/jujutsu/package.yml
+++ b/packages/j/jujutsu/package.yml
@@ -1,8 +1,8 @@
 name       : jujutsu
-version    : 0.37.0
-release    : 1
+version    : 0.38.0
+release    : 2
 source     :
-    - https://github.com/jj-vcs/jj/archive/refs/tags/v0.37.0.tar.gz : af0513ed0f1d6aa1c6ee83cd5432f6e77db8f7c7ac1b7244612f1e26895688a0
+    - https://github.com/jj-vcs/jj/archive/refs/tags/v0.38.0.tar.gz : f28e280c01abb11aa9ff5ae7a35df3e9822fd37a013b6c1d79d1453a5f21f5ad
 homepage   : https://jj-vcs.dev
 license    : Apache-2.0
 component  : programming.tools
@@ -22,17 +22,18 @@ setup      : |
 build      : |
     %cargo_build --all-features --package jj-cli
 
+    # TODO(GZGavinZhao): make everything use dynamic completion by default for
+    # best OOTB experience. Right now only fish shell can pick up dynamic
+    # completion automatically so no setup is needed.
     mkdir completions
     $jj util completion bash > completions/jj
     $jj util completion zsh > completions/_jj
-    $jj util completion fish > completions/jj.fish
 install    : |
     install -Dm00755 target/release/jj -t $installdir/usr/bin
     %install_license LICENSE
 
     install -Dm00644 completions/jj -t $installdir/usr/share/bash-completion/completions
     install -Dm00644 completions/_jj -t $installdir/usr/share/zsh/site-functions
-    install -Dm00644 completions/jj.fish -t $installdir/usr/share/fish/vendor_completions.d
 
     mkdir -p $installdir/usr/share/man
     $jj util install-man-pages $installdir/usr/share/man

--- a/packages/j/jujutsu/pspec_x86_64.xml
+++ b/packages/j/jujutsu/pspec_x86_64.xml
@@ -22,7 +22,6 @@
         <Files>
             <Path fileType="executable">/usr/bin/jj</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/jj</Path>
-            <Path fileType="data">/usr/share/fish/vendor_completions.d/jj.fish</Path>
             <Path fileType="data">/usr/share/licenses/jujutsu/LICENSE</Path>
             <Path fileType="man">/usr/share/man/man1/jj-abandon.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/jj-absorb.1.zst</Path>
@@ -89,6 +88,7 @@
             <Path fileType="man">/usr/share/man/man1/jj-next.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/jj-operation-abandon.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/jj-operation-diff.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/jj-operation-integrate.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/jj-operation-log.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/jj-operation-restore.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/jj-operation-revert.1.zst</Path>
@@ -139,9 +139,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2026-01-21</Date>
-            <Version>0.37.0</Version>
+        <Update release="2">
+            <Date>2026-02-12</Date>
+            <Version>0.38.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Gavin Zhao</Name>
             <Email>me@gzgz.dev</Email>


### PR DESCRIPTION
**Summary**

Update jujutsu to v0.38.0, changelog available [here](https://github.com/jj-vcs/jj/releases/tag/v0.38.0).

Also removed (static) completion scripts for Fish shell since Fish shell incorporates dynamic completion by default, and when fish shell detects both static and dynamic completion it prefers static completion.

The user experience is orders of magnitude better with dynamic completion since it can perform auto-completion based on your repo, e.g. when you want to push a branch it can autocomplete the branch name for you, something static completion can't do as it can only autocomplete the tool's sub-commands and flags.

**Test Plan**

Been using it since it released a week ago.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
