### PR TITLE
caja: Update to v1.29.1

### DIFF
--- a/packages/c/caja/abi_symbols
+++ b/packages/c/caja/abi_symbols
@@ -218,6 +218,7 @@ caja:caja_directory_schedule_position_set
 caja:caja_directory_set_up_request
 caja:caja_directory_stop_monitoring_file_list
 caja:caja_directory_unref
+caja:caja_display_git_branch_enable
 caja:caja_drag_autoscroll_calculate_delta
 caja:caja_drag_autoscroll_in_scroll_region
 caja:caja_drag_autoscroll_start
@@ -926,6 +927,7 @@ caja:caja_search_bar_return_entry
 caja:caja_search_directory_file_get_type
 caja:caja_search_directory_file_update_display_name
 caja:caja_search_directory_generate_new_uri
+caja:caja_search_directory_get_engine
 caja:caja_search_directory_get_query
 caja:caja_search_directory_get_type
 caja:caja_search_directory_is_indexed
@@ -945,6 +947,7 @@ caja:caja_search_engine_hits_subtracted
 caja:caja_search_engine_is_indexed
 caja:caja_search_engine_new
 caja:caja_search_engine_set_query
+caja:caja_search_engine_set_show_hidden_files
 caja:caja_search_engine_simple_get_type
 caja:caja_search_engine_simple_new
 caja:caja_search_engine_start
@@ -2308,6 +2311,7 @@ caja-connect-server:caja_saved_search_file_get_type
 caja-connect-server:caja_search_directory_file_get_type
 caja-connect-server:caja_search_directory_file_update_display_name
 caja-connect-server:caja_search_directory_generate_new_uri
+caja-connect-server:caja_search_directory_get_engine
 caja-connect-server:caja_search_directory_get_query
 caja-connect-server:caja_search_directory_get_type
 caja-connect-server:caja_search_directory_is_indexed
@@ -2327,6 +2331,7 @@ caja-connect-server:caja_search_engine_hits_subtracted
 caja-connect-server:caja_search_engine_is_indexed
 caja-connect-server:caja_search_engine_new
 caja-connect-server:caja_search_engine_set_query
+caja-connect-server:caja_search_engine_set_show_hidden_files
 caja-connect-server:caja_search_engine_simple_get_type
 caja-connect-server:caja_search_engine_simple_new
 caja-connect-server:caja_search_engine_start
@@ -3025,6 +3030,7 @@ caja-file-management-properties:caja_saved_search_file_get_type
 caja-file-management-properties:caja_search_directory_file_get_type
 caja-file-management-properties:caja_search_directory_file_update_display_name
 caja-file-management-properties:caja_search_directory_generate_new_uri
+caja-file-management-properties:caja_search_directory_get_engine
 caja-file-management-properties:caja_search_directory_get_query
 caja-file-management-properties:caja_search_directory_get_type
 caja-file-management-properties:caja_search_directory_is_indexed
@@ -3044,6 +3050,7 @@ caja-file-management-properties:caja_search_engine_hits_subtracted
 caja-file-management-properties:caja_search_engine_is_indexed
 caja-file-management-properties:caja_search_engine_new
 caja-file-management-properties:caja_search_engine_set_query
+caja-file-management-properties:caja_search_engine_set_show_hidden_files
 caja-file-management-properties:caja_search_engine_simple_get_type
 caja-file-management-properties:caja_search_engine_simple_new
 caja-file-management-properties:caja_search_engine_start

--- a/packages/c/caja/abi_used_symbols
+++ b/packages/c/caja/abi_used_symbols
@@ -73,6 +73,7 @@ libc.so.6:fcntl
 libc.so.6:feof
 libc.so.6:fflush
 libc.so.6:fgetc
+libc.so.6:fnmatch
 libc.so.6:fopen
 libc.so.6:fputc
 libc.so.6:fputs
@@ -89,6 +90,7 @@ libc.so.6:getuid
 libc.so.6:kill
 libc.so.6:mallopt
 libc.so.6:memchr
+libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset
@@ -1232,6 +1234,7 @@ libgtk-3.so.0:gtk_box_set_homogeneous
 libgtk-3.so.0:gtk_box_set_spacing
 libgtk-3.so.0:gtk_builder_get_object
 libgtk-3.so.0:gtk_builder_new_from_resource
+libgtk-3.so.0:gtk_button_accessible_get_type
 libgtk-3.so.0:gtk_button_box_new
 libgtk-3.so.0:gtk_button_box_set_child_secondary
 libgtk-3.so.0:gtk_button_box_set_layout
@@ -1549,6 +1552,7 @@ libgtk-3.so.0:gtk_radio_action_get_current_value
 libgtk-3.so.0:gtk_radio_action_get_group
 libgtk-3.so.0:gtk_radio_action_new
 libgtk-3.so.0:gtk_radio_action_set_group
+libgtk-3.so.0:gtk_radio_button_accessible_get_type
 libgtk-3.so.0:gtk_radio_button_get_group
 libgtk-3.so.0:gtk_radio_button_get_type
 libgtk-3.so.0:gtk_radio_button_set_group
@@ -1651,6 +1655,7 @@ libgtk-3.so.0:gtk_text_view_set_editable
 libgtk-3.so.0:gtk_text_view_set_wrap_mode
 libgtk-3.so.0:gtk_toggle_action_get_active
 libgtk-3.so.0:gtk_toggle_action_set_active
+libgtk-3.so.0:gtk_toggle_button_accessible_get_type
 libgtk-3.so.0:gtk_toggle_button_get_active
 libgtk-3.so.0:gtk_toggle_button_get_inconsistent
 libgtk-3.so.0:gtk_toggle_button_get_type
@@ -1664,6 +1669,7 @@ libgtk-3.so.0:gtk_tool_item_get_type
 libgtk-3.so.0:gtk_tool_item_new
 libgtk-3.so.0:gtk_tool_item_set_expand
 libgtk-3.so.0:gtk_toolbar_insert
+libgtk-3.so.0:gtk_tooltip_set_text
 libgtk-3.so.0:gtk_tree_drag_source_get_type
 libgtk-3.so.0:gtk_tree_iter_get_type
 libgtk-3.so.0:gtk_tree_model_filter_convert_child_iter_to_iter
@@ -1861,6 +1867,7 @@ libgtk-3.so.0:gtk_widget_set_child_visible
 libgtk-3.so.0:gtk_widget_set_events
 libgtk-3.so.0:gtk_widget_set_focus_on_click
 libgtk-3.so.0:gtk_widget_set_halign
+libgtk-3.so.0:gtk_widget_set_has_tooltip
 libgtk-3.so.0:gtk_widget_set_has_window
 libgtk-3.so.0:gtk_widget_set_hexpand
 libgtk-3.so.0:gtk_widget_set_mapped

--- a/packages/c/caja/package.yml
+++ b/packages/c/caja/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : caja
-version    : 1.28.0
-release    : 44
+version    : 1.29.1
+release    : 45
 source     :
-    - https://github.com/mate-desktop/caja/releases/download/v1.28.0/caja-1.28.0.tar.xz : 1e3014ce1455817ec2ef74d09efdfb6835d8a372ed9a16efb5919ef7b821957a
+    - https://github.com/mate-desktop/caja/releases/download/v1.29.1/caja-1.29.1.tar.xz : ff2e1cbc7cf0d3e2762b9c156f4e7039e8c0f3cdcb2a1794375b590597b6fb8b
 homepage   : https://www.mate-desktop.org/
 license    :
     - GPL-2.0-or-later

--- a/packages/c/caja/pspec_x86_64.xml
+++ b/packages/c/caja/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>caja</Name>
         <Homepage>https://www.mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.0-or-later</License>
@@ -216,10 +216,10 @@
             <Path fileType="localedata">/usr/share/locale/zh_HK/LC_MESSAGES/caja.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/caja.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zu/LC_MESSAGES/caja.mo</Path>
-            <Path fileType="man">/usr/share/man/man1/caja-autorun-software.1</Path>
-            <Path fileType="man">/usr/share/man/man1/caja-connect-server.1</Path>
-            <Path fileType="man">/usr/share/man/man1/caja-file-management-properties.1</Path>
-            <Path fileType="man">/usr/share/man/man1/caja.1</Path>
+            <Path fileType="man">/usr/share/man/man1/caja-autorun-software.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/caja-connect-server.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/caja-file-management-properties.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/caja.1.zst</Path>
             <Path fileType="data">/usr/share/metainfo/caja.metainfo.xml</Path>
             <Path fileType="data">/usr/share/mime/packages/caja.xml</Path>
             <Path fileType="data">/usr/share/pixmaps/caja/audio.svg</Path>
@@ -239,7 +239,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="44">caja</Dependency>
+            <Dependency release="45">caja</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/caja/libcaja-extension/caja-column-provider.h</Path>
@@ -295,12 +295,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="44">
-            <Date>2025-06-02</Date>
-            <Version>1.28.0</Version>
+        <Update release="45">
+            <Date>2026-02-14</Date>
+            <Version>1.29.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/mate-desktop/caja/releases/tag/v1.29.1).

**Test Plan**
- Browsed files.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
