### PR TITLE
uv: update to 0.10.2

### DIFF
--- a/packages/u/uv/package.yml
+++ b/packages/u/uv/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : uv
-version    : 0.9.28
-release    : 8
+version    : 0.10.2
+release    : 9
 source     :
-    - https://github.com/astral-sh/uv/archive/refs/tags/0.9.28.tar.gz : 99651696304efb4d2b24950763ef11b57f7ec55369b970b373a626333daf8ff5
+    - https://github.com/astral-sh/uv/archive/refs/tags/0.10.2.tar.gz : e2568df6596c743f583f65e764e60709d974494c2a12a2b3f1e67ec28a6448d3
 homepage   : https://docs.astral.sh/uv
 license    :
     - Apache-2.0

--- a/packages/u/uv/pspec_x86_64.xml
+++ b/packages/u/uv/pspec_x86_64.xml
@@ -32,9 +32,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2026-01-31</Date>
-            <Version>0.9.28</Version>
+        <Update release="9">
+            <Date>2026-02-12</Date>
+            <Version>0.10.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>


### PR DESCRIPTION
**Summary**

UV version 0.10.0 includes the stabilization of several preview features and important usability fixes. Key updates include stabilized Python management commands, workspace tools, and configuration options, alongside breaking changes for improved correctness and various improvements like better error diagnostics and network stability.

- Release notes:
  - [v0.10.2](https://github.com/astral-sh/uv/releases/tag/0.10.2)
  - [v0.10.1](https://github.com/astral-sh/uv/releases/tag/0.10.1)
  - [v0.10.0](https://github.com/astral-sh/uv/releases/tag/0.10.0)

**Test Plan**

- Run smoke tests defined in source
- Installed locally and run some commands.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
