### PR TITLE
atril: Update to v1.28.3

### DIFF
--- a/packages/a/atril/abi_used_symbols
+++ b/packages/a/atril/abi_used_symbols
@@ -63,7 +63,8 @@ libatk-1.0.so.0:atk_text_get_text
 libatk-1.0.so.0:atk_text_get_type
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
@@ -109,7 +110,6 @@ libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strrchr
 libc.so.6:strstr
-libc.so.6:strtol
 libc.so.6:textdomain
 libc.so.6:time
 libc.so.6:unlink
@@ -287,6 +287,7 @@ libgdk-3.so.0:gdk_x11_display_get_type
 libgdk-3.so.0:gdk_x11_display_get_user_time
 libgdk-3.so.0:gdk_x11_get_server_time
 libgdk-3.so.0:gdk_x11_screen_get_screen_number
+libgdk-3.so.0:gdk_x11_screen_get_type
 libgdk-3.so.0:gdk_x11_set_sm_client_id
 libgdk-3.so.0:gdk_x11_window_get_type
 libgdk-3.so.0:gdk_x11_window_set_user_time
@@ -749,6 +750,7 @@ libglib-2.0.so.0:g_variant_builder_add
 libglib-2.0.so.0:g_variant_builder_close
 libglib-2.0.so.0:g_variant_builder_end
 libglib-2.0.so.0:g_variant_builder_init
+libglib-2.0.so.0:g_variant_builder_init_static
 libglib-2.0.so.0:g_variant_builder_open
 libglib-2.0.so.0:g_variant_classify
 libglib-2.0.so.0:g_variant_get
@@ -1144,7 +1146,7 @@ libgtk-3.so.0:gtk_menu_shell_deactivate
 libgtk-3.so.0:gtk_menu_shell_prepend
 libgtk-3.so.0:gtk_menu_shell_select_first
 libgtk-3.so.0:gtk_menu_tool_button_get_type
-libgtk-3.so.0:gtk_menu_tool_button_new_from_stock
+libgtk-3.so.0:gtk_menu_tool_button_new
 libgtk-3.so.0:gtk_menu_tool_button_set_arrow_tooltip_text
 libgtk-3.so.0:gtk_menu_tool_button_set_menu
 libgtk-3.so.0:gtk_message_dialog_format_secondary_text
@@ -1833,11 +1835,8 @@ libwebkit2gtk-4.1.so.0:webkit_web_view_can_execute_editing_command
 libwebkit2gtk-4.1.so.0:webkit_web_view_can_execute_editing_command_finish
 libwebkit2gtk-4.1.so.0:webkit_web_view_execute_editing_command
 libwebkit2gtk-4.1.so.0:webkit_web_view_get_find_controller
-libwebkit2gtk-4.1.so.0:webkit_web_view_get_snapshot
-libwebkit2gtk-4.1.so.0:webkit_web_view_get_snapshot_finish
 libwebkit2gtk-4.1.so.0:webkit_web_view_get_type
 libwebkit2gtk-4.1.so.0:webkit_web_view_load_uri
-libwebkit2gtk-4.1.so.0:webkit_web_view_new
 libwebkit2gtk-4.1.so.0:webkit_web_view_reload
 libwebkit2gtk-4.1.so.0:webkit_web_view_set_zoom_level
 libxml2.so.2:__xmlIndentTreeOutput

--- a/packages/a/atril/package.yml
+++ b/packages/a/atril/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : atril
-version    : 1.28.1
-release    : 46
+version    : 1.28.3
+release    : 47
 source     :
-    - https://github.com/mate-desktop/atril/releases/download/v1.28.1/atril-1.28.1.tar.xz : 74c4f42979f3ead52def23767448d06ad7f715421e03c9b509404b096de8193e
+    - https://github.com/mate-desktop/atril/releases/download/v1.28.3/atril-1.28.3.tar.xz : 1a89724cdfb8af83fa44f08d89d66049f9aac053b28be9cef13eb27148a970da
 homepage   : https://mate-desktop.org/
 license    : GPL-2.0-or-later
 component  : desktop.mate

--- a/packages/a/atril/pspec_x86_64.xml
+++ b/packages/a/atril/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>atril</Name>
         <Homepage>https://mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.mate</PartOf>
@@ -5890,9 +5890,9 @@
             <Path fileType="localedata">/usr/share/locale/zh_HK/LC_MESSAGES/atril.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/atril.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zu/LC_MESSAGES/atril.mo</Path>
-            <Path fileType="man">/usr/share/man/man1/atril-previewer.1</Path>
-            <Path fileType="man">/usr/share/man/man1/atril-thumbnailer.1</Path>
-            <Path fileType="man">/usr/share/man/man1/atril.1</Path>
+            <Path fileType="man">/usr/share/man/man1/atril-previewer.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/atril-thumbnailer.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/atril.1.zst</Path>
             <Path fileType="data">/usr/share/metainfo/atril.appdata.xml</Path>
             <Path fileType="data">/usr/share/thumbnailers/atril.thumbnailer</Path>
         </Files>
@@ -5904,7 +5904,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="46">atril</Dependency>
+            <Dependency release="47">atril</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/atril/1.5.0/atril-document.h</Path>
@@ -6091,12 +6091,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="46">
-            <Date>2024-12-11</Date>
-            <Version>1.28.1</Version>
+        <Update release="47">
+            <Date>2026-02-15</Date>
+            <Version>1.28.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/mate-desktop/atril/releases/tag/v1.28.3).

**Test Plan**
- Opened a file.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
