### PR TITLE
hplip: Update to v3.25.8

### DIFF
--- a/packages/h/hplip/files/0001-device_type-edge-handling-for-NoneType.patch
+++ b/packages/h/hplip/files/0001-device_type-edge-handling-for-NoneType.patch
@@ -5,23 +5,24 @@ Subject: [PATCH] device_type edge handling for NoneType
 
 Signed-off-by: Shannon Huggins <x@ptr.me>
 ---
- ui5/devmgr5.py | 20 ++++++++++----------
- 1 file changed, 10 insertions(+), 10 deletions(-)
+
+ ui5/devmgr5.py | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
 
 diff --git a/ui5/devmgr5.py b/ui5/devmgr5.py
-index b50eecc..20748b1 100644
+index 8a19840..93fbf9c 100644
 --- a/ui5/devmgr5.py
 +++ b/ui5/devmgr5.py
-@@ -818,7 +818,7 @@ class DevMgr5(Ui_MainWindow_Derived, Ui_MainWindow, QMainWindow):
- 
- 
+@@ -820,7 +820,7 @@ class DevMgr5(Ui_MainWindow_Derived, Ui_MainWindow, QMainWindow):
      def updateWindowTitle(self):
+         if self.cur_device is None or self.cur_printer is None:
+             return
 -        if self.cur_device.device_type == DEVICE_TYPE_FAX:
 +        if hasattr(self.cur_device,'device_type') and self.cur_device.device_type == DEVICE_TYPE_FAX:
                  self.setWindowTitle(self.__tr("HP Device Manager - %s (Fax)"%self.cur_device.model_ui))
          else:
              if self.cur_device.fax_type:
-@@ -851,7 +851,7 @@ class DevMgr5(Ui_MainWindow_Derived, Ui_MainWindow, QMainWindow):
+@@ -853,7 +853,7 @@ class DevMgr5(Ui_MainWindow_Derived, Ui_MainWindow, QMainWindow):
              self.updatePrinterCombos()
              self.updateCurrentTab()
              self.statusBar().showMessage(self.cur_device_uri)
@@ -30,7 +31,7 @@ index b50eecc..20748b1 100644
                  self.Tabs.setTabText(self.Tabs.indexOf(self.Settings), QApplication.translate("MainWindow", "Print Settings", None))
                  self.Tabs.setTabText(self.Tabs.indexOf(self.Control), QApplication.translate("MainWindow", "Printer Control", None))
              else:
-@@ -1782,7 +1782,7 @@ class DevMgr5(Ui_MainWindow_Derived, Ui_MainWindow, QMainWindow):
+@@ -1784,7 +1784,7 @@ class DevMgr5(Ui_MainWindow_Derived, Ui_MainWindow, QMainWindow):
      def updatePrintSettingsTab(self):
          beginWaitCursor()
          try:
@@ -39,16 +40,16 @@ index b50eecc..20748b1 100644
                  self.PrintSettingsPrinterNameLabel.setText(self.__tr("Printer Name:"))
              else:
                  self.PrintSettingsPrinterNameLabel.setText(self.__tr("Fax Name:"))
-@@ -1878,7 +1878,7 @@ class DevMgr5(Ui_MainWindow_Derived, Ui_MainWindow, QMainWindow):
- 
- 
+@@ -1882,7 +1882,7 @@ class DevMgr5(Ui_MainWindow_Derived, Ui_MainWindow, QMainWindow):
      def updatePrintControlTab(self):
+         if self.cur_device is None or self.cur_printer is None:
+             return
 -        if self.cur_device.device_type == DEVICE_TYPE_PRINTER:
 +        if hasattr(self.cur_device,'device_type') and self.cur_device.device_type == DEVICE_TYPE_PRINTER:
              self.PrintControlPrinterNameLabel.setText(self.__tr("Printer Name:"))
              self.groupBox.setTitle(QApplication.translate("MainWindow", "Printer Queue Control", None))
          else:
-@@ -1943,7 +1943,7 @@ class DevMgr5(Ui_MainWindow_Derived, Ui_MainWindow, QMainWindow):
+@@ -1947,7 +1947,7 @@ class DevMgr5(Ui_MainWindow_Derived, Ui_MainWindow, QMainWindow):
          
          default_printer = cups.getDefaultPrinter()
              
@@ -57,16 +58,7 @@ index b50eecc..20748b1 100644
              device_string = "Printer"
          else:
              device_string = "Fax"
-@@ -1996,7 +1996,7 @@ class DevMgr5(Ui_MainWindow_Derived, Ui_MainWindow, QMainWindow):
-             if self.printer_state in (cups.IPP_PRINTER_STATE_IDLE, cups.IPP_PRINTER_STATE_PROCESSING):
-                 result, result_str = cups.cups_operation(cups.stop, GUI_MODE, 'qt4', self, self.cur_printer)
-                 if result == cups.IPP_OK:
--                    if self.cur_device.device_type == DEVICE_TYPE_PRINTER:
-+                    if hasattr(self.cur_device,'device_type') and self.cur_device.device_type == DEVICE_TYPE_PRINTER:
-                         e = EVENT_PRINTER_QUEUE_STOPPED
-                     else:
-                         e = EVENT_FAX_QUEUE_STOPPED
-@@ -2004,7 +2004,7 @@ class DevMgr5(Ui_MainWindow_Derived, Ui_MainWindow, QMainWindow):
+@@ -2008,7 +2008,7 @@ class DevMgr5(Ui_MainWindow_Derived, Ui_MainWindow, QMainWindow):
              else:
                  result, result_str = cups.cups_operation(cups.start, GUI_MODE, 'qt4', self, self.cur_printer)
                  if result == cups.IPP_OK:
@@ -75,7 +67,7 @@ index b50eecc..20748b1 100644
                          e = EVENT_PRINTER_QUEUE_STARTED
                      else:
                          e = EVENT_FAX_QUEUE_STARTED
-@@ -2027,7 +2027,7 @@ class DevMgr5(Ui_MainWindow_Derived, Ui_MainWindow, QMainWindow):
+@@ -2031,7 +2031,7 @@ class DevMgr5(Ui_MainWindow_Derived, Ui_MainWindow, QMainWindow):
              if self.printer_accepting:
                  result, result_str = cups.cups_operation(cups.reject, GUI_MODE, 'qt4', self, self.cur_printer)
                  if result == cups.IPP_OK:
@@ -84,7 +76,7 @@ index b50eecc..20748b1 100644
                          e = EVENT_PRINTER_QUEUE_REJECTING_JOBS
                      else:
                          e = EVENT_FAX_QUEUE_REJECTING_JOBS
-@@ -2035,7 +2035,7 @@ class DevMgr5(Ui_MainWindow_Derived, Ui_MainWindow, QMainWindow):
+@@ -2039,7 +2039,7 @@ class DevMgr5(Ui_MainWindow_Derived, Ui_MainWindow, QMainWindow):
              else:
                  result, result_str = cups.cups_operation(cups.accept, GUI_MODE, 'qt4', self, self.cur_printer)
                  if result == cups.IPP_OK:
@@ -93,7 +85,7 @@ index b50eecc..20748b1 100644
                          e = EVENT_PRINTER_QUEUE_ACCEPTING_JOBS
                      else:
                          e = EVENT_FAX_QUEUE_ACCEPTING_JOBS
-@@ -2061,7 +2061,7 @@ class DevMgr5(Ui_MainWindow_Derived, Ui_MainWindow, QMainWindow):
+@@ -2065,7 +2065,7 @@ class DevMgr5(Ui_MainWindow_Derived, Ui_MainWindow, QMainWindow):
                  cups.releaseCupsInstance()
              else:
                  self.updatePrintController()
@@ -103,5 +95,5 @@ index b50eecc..20748b1 100644
                  else:
                      e = EVENT_FAX_QUEUE_SET_AS_DEFAULT
 -- 
-2.49.0
+2.52.0
 

--- a/packages/h/hplip/files/hplip-keyserver.patch
+++ b/packages/h/hplip/files/hplip-keyserver.patch
@@ -22,12 +22,12 @@ diff -up hplip-3.20.3/base/validation.py.keyserver hplip-3.20.3/base/validation.
  
  
  class GPG_Verification(DigiSign_Verification):
--    def __init__(self, pgp_site = 'pgp.mit.edu', key = 0x4ABA2F66DBD5A95894910E0673D770CDA59047B9):
+-    def __init__(self, pgp_site = 'hkp://keyserver.ubuntu.com:80', key = 0x82FFA7C6AA7411D934BDE173AC69536A2CF3A243):
 -        self.__pgp_site = pgp_site
-+    def __init__(self, keyservers = ['pool.sks-keyservers.net',
-+                                     'keyserver.ubuntu.com',
-+                                     'sks-keyservers.net', 'pgp.mit.edu'],
-+                 key = 0x4ABA2F66DBD5A95894910E0673D770CDA59047B9):
++    def __init__(self, keyservers = ['keyserver.ubuntu.com',
++                'sks-keyservers.net',
++                'pgp.mit.edu'],
++                 key = 0x82FFA7C6AA7411D934BDE173AC69536A2CF3A243):
 +        self.__keyservers = keyservers
          self.__key = key
          self.__gpg = utils.which('gpg',True)

--- a/packages/h/hplip/package.yml
+++ b/packages/h/hplip/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : hplip
-version    : 3.25.2
-release    : 70
+version    : 3.25.8
+release    : 71
 source     :
-    - https://sourceforge.net/projects/hplip/files/hplip/3.25.2/hplip-3.25.2.tar.gz : e872ff28eb2517705a95f6e1839efa1e50a77a33aae8905278df2bd820919653
+    - https://downloads.sourceforge.net/project/hplip/hplip/3.25.8/hplip-3.25.8.tar.gz : 1cf6d6c28735435c8eb6646e83bcfb721e51c4b1f0e8cf9105a6faf96dc9ad25
 homepage   : https://developers.hp.com/hp-linux-imaging-and-printing/gethplip
 license    :
     - GPL-2.0-or-later

--- a/packages/h/hplip/pspec_x86_64.xml
+++ b/packages/h/hplip/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>hplip</Name>
         <Homepage>https://developers.hp.com/hp-linux-imaging-and-printing/gethplip</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>MIT</License>
@@ -22,7 +22,7 @@
 </Description>
         <PartOf>desktop.core</PartOf>
         <RuntimeDependencies>
-            <Dependency release="70">hplip-drivers</Dependency>
+            <Dependency release="71">hplip-drivers</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="config">/etc/hp/hplip.conf</Path>
@@ -71,40 +71,40 @@
             <Path fileType="library">/usr/lib/systemd/system/hplip-printer@.service</Path>
             <Path fileType="data">/usr/share/applications/hp-uiscan.desktop</Path>
             <Path fileType="data">/usr/share/applications/hplip.desktop</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/COPYING</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/README_LIBJPG</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/commandline.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/copying.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/copyright</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/devicemanager.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/faxtrouble.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/gettinghelp.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/hpscan.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/images/favicon.ico</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/images/print.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/images/toolbox_actions.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/images/toolbox_fax.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/images/toolbox_print_control.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/images/toolbox_print_settings.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/images/toolbox_status.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/images/toolbox_supplies.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/images/xsane.png</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/index.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/mainttask.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/plugins.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/print.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/printing.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/printoptions.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/printtroubleshooting.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/scanning.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/scantrouble.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/sendfax.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/setup.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/styles/css.css</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/systray.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/troubleshooting.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/uninstalling.html</Path>
-            <Path fileType="doc">/usr/share/doc/hplip-3.25.2/upgrading.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/COPYING</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/README_LIBJPG</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/commandline.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/copying.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/copyright</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/devicemanager.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/faxtrouble.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/gettinghelp.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/hpscan.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/images/favicon.ico</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/images/print.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/images/toolbox_actions.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/images/toolbox_fax.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/images/toolbox_print_control.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/images/toolbox_print_settings.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/images/toolbox_status.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/images/toolbox_supplies.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/images/xsane.png</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/index.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/mainttask.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/plugins.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/print.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/printing.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/printoptions.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/printtroubleshooting.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/scanning.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/scantrouble.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/sendfax.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/setup.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/styles/css.css</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/systray.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/troubleshooting.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/uninstalling.html</Path>
+            <Path fileType="doc">/usr/share/doc/hplip-3.25.8/upgrading.html</Path>
             <Path fileType="data">/usr/share/hplip/__init__.py</Path>
             <Path fileType="data">/usr/share/hplip/align.py</Path>
             <Path fileType="data">/usr/share/hplip/base/CdmWifi.py</Path>
@@ -996,6 +996,7 @@
             <Path fileType="data">/usr/share/ppd/HP/hp-designjet_t795ps_44in-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-designjet_t920-postscript.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-designjet_t930-postscript.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-designjet_xl_3800_mfp-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-designjet_z2600_postscript-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-designjet_z5200_postscript-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-designjet_z5400-postscript.ppd.gz</Path>
@@ -1231,7 +1232,9 @@
             <Path fileType="data">/usr/share/ppd/HP/hp-envy_inspire_7900_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-envy_photo_6200_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-envy_photo_7100_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-envy_photo_7200_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-envy_photo_7800_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-envy_photo_7900_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-envy_pro_6400_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-ink_tank_110_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-ink_tank_310_series.ppd.gz</Path>
@@ -1371,6 +1374,8 @@
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_5200l-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_5200lx-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_5200lx.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_5501-ps.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_5502-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_5l.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_5mp-pcl3.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_5mp-ps.ppd.gz</Path>
@@ -1381,6 +1386,8 @@
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_5si_mopier-pcl3.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_5si_mopier-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_600_m601_m602_m603-ps.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_6500-ps.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_6501-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_6l.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_6mp-pcl3.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_6mp-ps.ppd.gz</Path>
@@ -1429,6 +1436,7 @@
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_cp1025nw.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_cp1520_series-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_cp_1025nw.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_d50452-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_e40040-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_e50145-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_e60055-e60075-ps.ppd.gz</Path>
@@ -1443,6 +1451,8 @@
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_flow_e82650-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_flow_e82660-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_flow_e82670-ps.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_flow_mfp_5602-ps.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_flow_mfp_6600-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_flow_mfp_e52645-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_flow_mfp_e731-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_flow_mfp_e826-ps.ppd.gz</Path>
@@ -1450,6 +1460,8 @@
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_flow_mfp_m528-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_flow_mfp_m630-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_flow_mfp_m830-ps.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_flow_mfp_x530-ps.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_flow_mfp_x627-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_m1005.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_m101-m106.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_m109-m112.ppd.gz</Path>
@@ -1495,7 +1507,11 @@
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_m9050_mfp-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_m9059_mfp-pcl3.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_m9059_mfp-ps.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_mfp_5601-ps.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_mfp_5602-ps.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_mfp_6600-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_mfp_8601-ps.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_mfp_d53052-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_mfp_e42540-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_mfp_e72425-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_mfp_e72430-ps.ppd.gz</Path>
@@ -1527,6 +1543,9 @@
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_mfp_m631_m632_m633-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_mfp_m634_m635_m636-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_mfp_m725-ps.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_mfp_x529-ps.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_mfp_x530-ps.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_mfp_x627-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_p1005.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_p1006.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_p1007.ppd.gz</Path>
@@ -1600,6 +1619,7 @@
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_pro_mfp_m125r.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_pro_mfp_m125rnw.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_pro_mfp_m125s.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_pro_mfp_m126_plus_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_pro_mfp_m126a.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_pro_mfp_m126nw.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_pro_mfp_m127fn.ppd.gz</Path>
@@ -1660,6 +1680,10 @@
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_tank_mfp_1005.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_tank_mfp_160x.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_tank_mfp_260x.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_x503-ps.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_x504-ps.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_x602-ps.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-laserjet_x603-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-lj_300_400_color_m351_m451-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-lj_300_400_color_mfp_m375_m475-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-mopier_240-pcl3.ppd.gz</Path>
@@ -1731,6 +1755,8 @@
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_8700.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_9010_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_9100_series-pcl3.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_9120_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_9120e_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_color_mfp_x585.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_color_x555-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_d_series.ppd.gz</Path>
@@ -1797,9 +1823,15 @@
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_8740-ps.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9010_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9020_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9110_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9110b_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9110e_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9120_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9120b_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9120e_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9130_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9130b_series.ppd.gz</Path>
+            <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9130e_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9720_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9720e_series.ppd.gz</Path>
             <Path fileType="data">/usr/share/ppd/HP/hp-officejet_pro_9730_series.ppd.gz</Path>
@@ -2057,12 +2089,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="70">
-            <Date>2026-01-24</Date>
-            <Version>3.25.2</Version>
+        <Update release="71">
+            <Date>2026-02-15</Date>
+            <Version>3.25.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Tracey Clark</Name>
+            <Email>traceyc.dev@tlcnet.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

After installing or updating this pkg, run `hp-plugin` on command line before attempting to add a printer, print or scan.

Added support for new printers in 3.25.8:
HP LaserJet Enterprise Flow MFP 8601z
HP LaserJet Enterprise 5501
HP LaserJet Enterprise MFP 5601dn
HP LaserJet Enterprise 6500dn
HP LaserJet Enterprise 5501n
HP LaserJet Enterprise MFP 5601
HP LaserJet Enterprise 6500
HP LaserJet Enterprise 5502dn
HP LaserJet Enterprise MFP 5602dn
HP LaserJet Enterprise 6500n
HP LaserJet Enterprise 5502
HP LaserJet Enterprise MFP 5602f
HP LaserJet Enterprise 6501dn
HP LaserJet Enterprise X50452dn
HP LaserJet Enterprise Flow MFP 5602zfw
HP LaserJet Enterprise 6501
HP LaserJet Enterprise X50452
HP LaserJet Enterprise MFP 5602
HP LaserJet Enterprise X60257dn
HP LaserJet Enterprise MFP X53052dn
HP LaserJet Enterprise Flow MFP X530
HP LaserJet Enterprise X60257
HP LaserJet Enterprise MFP X53052
HP LaserJet Enterprise X60357dn
HP LaserJet Enterprise X60357
HP LaserJet Enterprise MFP 6600dn
HP LaserJet Enterprise Flow MFP 6600zfw
HP LaserJet Enterprise MFP 6600
HP LaserJet Enterprise Flow MFP 6600zfsw
HP LaserJet Enterprise MFP X62757dn
HP LaserJet Enterprise Flow MFP X62757zs
HP LaserJet Enterprise MFP X62757
DEX D50452dn
DEX MFP D53052dn

Added support for new printers in 3.25.6:

HP LaserJet Enterprise Flow MFP 8601z
HP LaserJet Pro MFP M126a plus
HP LaserJet Pro MFP M126nw plus
HP LaserJet Pro MFP M126snw plus
HP Envy Photo 7200 series
HP Envy Photo 7900 series
HP OfficeJet Pro 9110 Series
HP OfficeJet 9120 Series
HP OfficeJet Pro 9120 Series
HP OfficeJet Pro 9130 Series

**Known Issue**
The HP Device Manager UI may display an error on the status tab of the printer 'Device is busy, powered down or unplugged (5002)'. You may also see "Device communication error" with code 5012.

Workaround: Manage the printer via System Settings rather than HP Device Manager. Printing and scanning are still successful.

**Test Plan**

Verified
- plugin was installed successfully by `hp-plugin`
- previously installed HP Printer is still configurable in Print Settings
- `hp-toolbox` launches HP Device Manager successfully
- ability to remove and re-add printer / fax in hp-toolbox (Note: must first run hp-plugin)
- scanning works with Simple Scan
- printing works

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
