### PR TITLE
screenfetch: Update to v3.9.9

### DIFF
--- a/packages/s/screenfetch/package.yml
+++ b/packages/s/screenfetch/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : screenfetch
-version    : 3.9.1
-release    : 10
+version    : 3.9.9
+release    : 11
 source     :
-    - https://github.com/KittyKatt/screenFetch/archive/v3.9.1.tar.gz : aa97dcd2a8576ae18de6c16c19744aae1573a3da7541af4b98a91930a30a3178
+    - https://github.com/KittyKatt/screenFetch/archive/v3.9.9.tar.gz : 65ba578442a5b65c963417e18a78023a30c2c13a524e6e548809256798b9fb84
 homepage   : https://github.com/KittyKatt/screenFetch
 license    : GPL-3.0-or-later
 component  : system.utils
@@ -15,3 +15,4 @@ setup      : |
 install    : |
     install -Dm00755 screenfetch-dev $installdir/usr/bin/screenfetch
     install -Dm00644 screenfetch.1 $installdir/usr/share/man/man1/screenfetch.1
+    %install_license COPYING

--- a/packages/s/screenfetch/pspec_x86_64.xml
+++ b/packages/s/screenfetch/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>screenfetch</Name>
         <Homepage>https://github.com/KittyKatt/screenFetch</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -21,16 +21,17 @@
         <PartOf>system.utils</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/screenfetch</Path>
-            <Path fileType="man">/usr/share/man/man1/screenfetch.1</Path>
+            <Path fileType="data">/usr/share/licenses/screenfetch/COPYING</Path>
+            <Path fileType="man">/usr/share/man/man1/screenfetch.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2024-06-01</Date>
-            <Version>3.9.1</Version>
+        <Update release="11">
+            <Date>2026-02-16</Date>
+            <Version>3.9.9</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/KittyKatt/screenFetch/blob/HEAD/CHANGELOG).

**Test Plan**

Looked at output from screenfetch. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
