### PR TITLE
deja-dup: Update to v49.3

### DIFF
--- a/packages/d/deja-dup/abi_symbols
+++ b/packages/d/deja-dup/abi_symbols
@@ -67,6 +67,7 @@ libdeja.so:deja_dup_backend_file_mount
 libdeja.so:deja_dup_backend_file_mount_finish
 libdeja.so:deja_dup_backend_file_replace_path_with_uri
 libdeja.so:deja_dup_backend_file_set_unmount_when_done
+libdeja.so:deja_dup_backend_file_test_space_free
 libdeja.so:deja_dup_backend_file_unmount
 libdeja.so:deja_dup_backend_file_unmount_finish
 libdeja.so:deja_dup_backend_get_default
@@ -107,6 +108,7 @@ libdeja.so:deja_dup_backend_microsoft_get_drive_id
 libdeja.so:deja_dup_backend_microsoft_get_folder
 libdeja.so:deja_dup_backend_microsoft_get_type
 libdeja.so:deja_dup_backend_microsoft_new
+libdeja.so:deja_dup_backend_needs_dependencies
 libdeja.so:deja_dup_backend_oauth_clear_refresh_token
 libdeja.so:deja_dup_backend_oauth_clear_refresh_token_finish
 libdeja.so:deja_dup_backend_oauth_construct
@@ -481,6 +483,7 @@ libdeja.so:deja_dup_tool_plugin_get_dependencies
 libdeja.so:deja_dup_tool_plugin_get_name
 libdeja.so:deja_dup_tool_plugin_get_type
 libdeja.so:deja_dup_tool_plugin_get_version
+libdeja.so:deja_dup_tool_plugin_needs_dependencies
 libdeja.so:deja_dup_tool_plugin_set_name
 libdeja.so:deja_dup_tool_plugin_supports_backend
 libdeja.so:deja_dup_tool_plugin_supports_mount

--- a/packages/d/deja-dup/abi_used_symbols
+++ b/packages/d/deja-dup/abi_used_symbols
@@ -495,6 +495,7 @@ libglib-2.0.so.0:g_unix_signal_add_full
 libglib-2.0.so.0:g_uri_error_quark
 libglib-2.0.so.0:g_uri_get_host
 libglib-2.0.so.0:g_uri_get_query
+libglib-2.0.so.0:g_uri_get_scheme
 libglib-2.0.so.0:g_uri_parse
 libglib-2.0.so.0:g_uri_parse_params
 libglib-2.0.so.0:g_uri_parse_scheme

--- a/packages/d/deja-dup/package.yml
+++ b/packages/d/deja-dup/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : deja-dup
-version    : '49.2'
-release    : 37
+version    : '49.3'
+release    : 38
 source     :
-    - https://gitlab.gnome.org/World/deja-dup/-/archive/49.2/deja-dup-49.2.tar.gz : bbd1a9ba01c2d4ef65e6eec6c100c8e41e0daf4cc4abd75da20df26e0cd8c872
+    - https://gitlab.gnome.org/World/deja-dup/-/archive/49.3/deja-dup-49.3.tar.gz : 99d1e574537b9b938c43220191a7f2f2736b73c8c842e63d3642459cfd8ce98c
 homepage   : https://apps.gnome.org/DejaDup/
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/d/deja-dup/pspec_x86_64.xml
+++ b/packages/d/deja-dup/pspec_x86_64.xml
@@ -405,9 +405,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="37">
-            <Date>2025-11-01</Date>
-            <Version>49.2</Version>
+        <Update release="38">
+            <Date>2026-02-16</Date>
+            <Version>49.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
             <Email>malfisya.dev@hotmail.com</Email>


### PR DESCRIPTION
**Summary**

- Fix occasional errors when mounting FUSE from a removable drive backup
- Allow selecting text in some error dialogs
- Don't try to use new Rclone encryption calls on old Rclones
- Don't bother with packagekit if a command is already in PATH
- Ignore trailing colons on URL hostnames, which can confuse gvfs
- Add a nice error message if the user uses `https://` instead of `davs://`
- Quiet some console warnings about hidden files when interacting with SMB filesystems

**Test Plan**

<!-- Short description of how the package was tested -->
Launch app, backup and restore files

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
