### PR TITLE
newsboat: Update to v2.42

### DIFF
--- a/packages/n/newsboat/abi_used_symbols
+++ b/packages/n/newsboat/abi_used_symbols
@@ -31,6 +31,7 @@ libc.so.6:chmod
 libc.so.6:chown
 libc.so.6:chroot
 libc.so.6:clock_gettime
+libc.so.6:clock_nanosleep
 libc.so.6:close
 libc.so.6:closedir
 libc.so.6:connect
@@ -38,6 +39,7 @@ libc.so.6:dirfd
 libc.so.6:dirname
 libc.so.6:dl_iterate_phdr
 libc.so.6:dlsym
+libc.so.6:dup
 libc.so.6:dup2
 libc.so.6:environ
 libc.so.6:execvp
@@ -68,6 +70,7 @@ libc.so.6:getauxval
 libc.so.6:getcwd
 libc.so.6:getenv
 libc.so.6:getgrgid
+libc.so.6:gethostname
 libc.so.6:getopt_long
 libc.so.6:getpass
 libc.so.6:getpeername
@@ -184,6 +187,7 @@ libc.so.6:setgid
 libc.so.6:setgroups
 libc.so.6:setlocale
 libc.so.6:setpgid
+libc.so.6:setsid
 libc.so.6:setsockopt
 libc.so.6:setuid
 libc.so.6:shutdown
@@ -207,6 +211,7 @@ libc.so.6:strerror
 libc.so.6:strftime
 libc.so.6:strlen
 libc.so.6:strncmp
+libc.so.6:strnlen
 libc.so.6:strptime
 libc.so.6:strtod
 libc.so.6:symlink
@@ -220,6 +225,7 @@ libc.so.6:uname
 libc.so.6:unlink
 libc.so.6:unlinkat
 libc.so.6:unsetenv
+libc.so.6:utimensat
 libc.so.6:waitid
 libc.so.6:waitpid
 libc.so.6:wcrtomb

--- a/packages/n/newsboat/package.yml
+++ b/packages/n/newsboat/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : newsboat
-version    : '2.41'
-release    : 8
+version    : '2.42'
+release    : 9
 source     :
-    - https://newsboat.org/releases/2.41/newsboat-2.41.tar.xz : 2a98bcdab999f9f453b937cb19127fa978e440b98688d126bf3333e57b2189a4
+    - https://github.com/newsboat/newsboat/archive/refs/tags/r2.42.tar.gz : f06e39279a7c884e60f9dbcb58fd1f23ff888dd6fca6dbab5879fb039c83f03a
 homepage   : https://newsboat.org/
 license    : MIT
 component  : network.news
@@ -27,3 +27,4 @@ build      : |
     %make prefix=/usr
 install    : |
     %make_install prefix=/usr
+    %install_license LICENSE

--- a/packages/n/newsboat/pspec_x86_64.xml
+++ b/packages/n/newsboat/pspec_x86_64.xml
@@ -84,6 +84,7 @@
             <Path fileType="doc">/usr/share/doc/newsboat/newsboat.html</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/newsboat.fish</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/newsboat.svg</Path>
+            <Path fileType="data">/usr/share/licenses/newsboat/LICENSE</Path>
             <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/newsboat.mo</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/newsboat.mo</Path>
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/newsboat.mo</Path>
@@ -108,9 +109,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2025-09-24</Date>
-            <Version>2.41</Version>
+        <Update release="9">
+            <Date>2026-02-16</Date>
+            <Version>2.42</Version>
             <Comment>Packaging update</Comment>
             <Name>Muhammad Alfi Syahrin</Name>
             <Email>malfisya.dev@hotmail.com</Email>


### PR DESCRIPTION
**Summary**

Release note can be read [here](https://github.com/newsboat/newsboat/blob/r2.42/CHANGELOG.md)

**Test Plan**

<!-- Short description of how the package was tested -->
Launch the app and read news

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
