### PR TITLE
x11vnc: Update to v0.9.17

### DIFF
--- a/packages/x/x11vnc/abi_used_symbols
+++ b/packages/x/x11vnc/abi_used_symbols
@@ -146,7 +146,8 @@ libc.so.6:__ctype_toupper_loc
 libc.so.6:__errno_location
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__memmove_chk
@@ -291,7 +292,6 @@ libc.so.6:strrchr
 libc.so.6:strstr
 libc.so.6:strtod
 libc.so.6:strtok
-libc.so.6:strtol
 libc.so.6:system
 libc.so.6:time
 libc.so.6:tmpfile
@@ -395,6 +395,7 @@ libssl.so.3:SSL_CTX_load_verify_locations
 libssl.so.3:SSL_CTX_new
 libssl.so.3:SSL_CTX_set_cipher_list
 libssl.so.3:SSL_CTX_set_default_passwd_cb
+libssl.so.3:SSL_CTX_set_security_level
 libssl.so.3:SSL_CTX_set_timeout
 libssl.so.3:SSL_CTX_set_verify
 libssl.so.3:SSL_CTX_use_RSAPrivateKey_file

--- a/packages/x/x11vnc/package.yml
+++ b/packages/x/x11vnc/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : x11vnc
-version    : 0.9.16
-release    : 8
+version    : 0.9.17
+release    : 9
 source     :
-    - https://github.com/LibVNC/x11vnc/archive/0.9.16.tar.gz : 885e5b5f5f25eec6f9e4a1e8be3d0ac71a686331ee1cfb442dba391111bd32bd
+    - https://github.com/LibVNC/x11vnc/archive/0.9.17.tar.gz : 3ab47c042bc1c33f00c7e9273ab674665b85ab10592a8e0425589fe7f3eb1a69
 homepage   : https://libvnc.github.io
 license    : GPL-2.0-or-later
 component  : network.util
@@ -23,3 +23,4 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING

--- a/packages/x/x11vnc/pspec_x86_64.xml
+++ b/packages/x/x11vnc/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>x11vnc</Name>
         <Homepage>https://libvnc.github.io</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>network.util</PartOf>
@@ -23,16 +23,17 @@
             <Path fileType="executable">/usr/bin/Xdummy</Path>
             <Path fileType="executable">/usr/bin/x11vnc</Path>
             <Path fileType="data">/usr/share/applications/x11vnc.desktop</Path>
-            <Path fileType="man">/usr/share/man/man1/x11vnc.1</Path>
+            <Path fileType="data">/usr/share/licenses/x11vnc/COPYING</Path>
+            <Path fileType="man">/usr/share/man/man1/x11vnc.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2024-02-24</Date>
-            <Version>0.9.16</Version>
+        <Update release="9">
+            <Date>2026-02-16</Date>
+            <Version>0.9.17</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/LibVNC/x11vnc/releases/tag/0.9.17).

**Security**
Includes fixes for:
- CVE-2020-29074

**Test Plan**

vnc into desktop. moved around desktop via guacamole. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
