### PR TITLE
gnome-shell-extension-appindicator: Update to v63

### DIFF
--- a/packages/g/gnome-shell-extension-appindicator/package.yml
+++ b/packages/g/gnome-shell-extension-appindicator/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gnome-shell-extension-appindicator
-version    : '61'
-release    : 10
+version    : '63'
+release    : 11
 source     :
-    - https://github.com/ubuntu/gnome-shell-extension-appindicator/archive/refs/tags/v61.tar.gz : 48555dd9c9437f835c9b01238f69a8643d2b17dffd7dbb8e23ccf2e97bb4d8de
+    - https://github.com/ubuntu/gnome-shell-extension-appindicator/archive/refs/tags/v63.tar.gz : 5c9d19a9a17f66b02378865dac89071e7e08421e634676326fbd6fb2746fe1c8
 homepage   : https://github.com/ubuntu/gnome-shell-extension-appindicator
 license    : GPL-2.0-or-later
 component  : desktop.gnome

--- a/packages/g/gnome-shell-extension-appindicator/pspec_x86_64.xml
+++ b/packages/g/gnome-shell-extension-appindicator/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-shell-extension-appindicator</Name>
         <Homepage>https://github.com/ubuntu/gnome-shell-extension-appindicator</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.gnome</PartOf>
@@ -44,6 +44,7 @@
             <Path fileType="data">/usr/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com/trayIconsManager.js</Path>
             <Path fileType="data">/usr/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com/util.js</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/AppIndicatorExtension.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/bg/LC_MESSAGES/AppIndicatorExtension.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/AppIndicatorExtension.mo</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/AppIndicatorExtension.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/AppIndicatorExtension.mo</Path>
@@ -71,12 +72,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2025-09-19</Date>
-            <Version>61</Version>
+        <Update release="11">
+            <Date>2026-02-17</Date>
+            <Version>63</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Read the release note [here](https://github.com/ubuntu/gnome-shell-extension-appindicator/releases/tag/v63)

**Test Plan**

<!-- Short description of how the package was tested -->
Install the package

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
