### PR TITLE
dua-cli: Update to v2.34.0

### DIFF
--- a/packages/d/dua-cli/abi_used_symbols
+++ b/packages/d/dua-cli/abi_used_symbols
@@ -39,6 +39,7 @@ libc.so.6:getenv
 libc.so.6:getmntent
 libc.so.6:getpeername
 libc.so.6:getpid
+libc.so.6:getpwuid_r
 libc.so.6:getsockname
 libc.so.6:getuid
 libc.so.6:gnu_get_libc_version
@@ -72,6 +73,7 @@ libc.so.6:posix_spawnattr_setflags
 libc.so.6:posix_spawnattr_setpgroup
 libc.so.6:posix_spawnattr_setsigdefault
 libc.so.6:posix_spawnp
+libc.so.6:pread64
 libc.so.6:pthread_attr_destroy
 libc.so.6:pthread_attr_getguardsize
 libc.so.6:pthread_attr_getstack

--- a/packages/d/dua-cli/package.yml
+++ b/packages/d/dua-cli/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : dua-cli
-version    : 2.33.0
-release    : 1
+version    : 2.34.0
+release    : 2
 source     :
-    - https://github.com/Byron/dua-cli/archive/refs/tags/v2.33.0.tar.gz : 32ecebfd555f09cbcfae415499d68de6023cc4f8eb4f249e54761e521d1ee553
+    - https://github.com/Byron/dua-cli/archive/refs/tags/v2.34.0.tar.gz : eaa924f50efb425302c124f170644e95a08f8dad1f627b86f50d033ca5feb0c1
 homepage   : https://github.com/Byron/dua-cli
 license    : MIT
 component  : system.utils

--- a/packages/d/dua-cli/pspec_x86_64.xml
+++ b/packages/d/dua-cli/pspec_x86_64.xml
@@ -28,9 +28,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2026-02-10</Date>
-            <Version>2.33.0</Version>
+        <Update release="2">
+            <Date>2026-02-20</Date>
+            <Version>2.34.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/Byron/dua-cli/releases/tag/v2.34.0).

**Test Plan**

Tested new ```dua config edit``` and opened default editor. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
