### PR TITLE
python-icoextract: Add at v0.2.0

### DIFF
--- a/packages/py/python-icoextract/monitoring.yaml
+++ b/packages/py/python-icoextract/monitoring.yaml
@@ -1,0 +1,3 @@
+releases:
+    id: 111867
+    type: pypi

--- a/packages/py/python-icoextract/package.yml
+++ b/packages/py/python-icoextract/package.yml
@@ -1,0 +1,22 @@
+name       : python-icoextract
+version    : 0.2.0
+release    : 1
+source     :
+    - https://files.pythonhosted.org/packages/source/i/icoextract/icoextract-0.2.0.tar.gz : e7b4770c9a927a48ecfccc4ecd35afe477c2565a71449f92a95bdc92a0d10043
+homepage   : https://github.com/jake-stewart/icoextract
+license    : MIT
+component  : programming.python
+summary    : Windows PE EXE icon extractor
+description: |
+    icoextract is an icon extractor for Windows PE files (.exe/.dll/.mun), written in Python. It also includes a thumbnailer script for Linux desktops.
+builddeps  :
+    - python-build
+    - python-installer
+    - python-setuptools
+rundeps    :
+    - python-pefile
+    - python-pillow
+setup      : |
+    %python3_setup
+install    : |
+    %python3_install

--- a/packages/py/python-icoextract/pspec_x86_64.xml
+++ b/packages/py/python-icoextract/pspec_x86_64.xml
@@ -1,0 +1,61 @@
+<PISI>
+    <Source>
+        <Name>python-icoextract</Name>
+        <Homepage>https://github.com/jake-stewart/icoextract</Homepage>
+        <Packager>
+            <Name>iferon44</Name>
+            <Email>iferon44@gmail.com</Email>
+        </Packager>
+        <License>MIT</License>
+        <PartOf>programming.python</PartOf>
+        <Summary xml:lang="en">Windows PE EXE icon extractor</Summary>
+        <Description xml:lang="en">icoextract is an icon extractor for Windows PE files (.exe/.dll/.mun), written in Python. It also includes a thumbnailer script for Linux desktops.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>python-icoextract</Name>
+        <Summary xml:lang="en">Windows PE EXE icon extractor</Summary>
+        <Description xml:lang="en">icoextract is an icon extractor for Windows PE files (.exe/.dll/.mun), written in Python. It also includes a thumbnailer script for Linux desktops.
+</Description>
+        <PartOf>programming.python</PartOf>
+        <Files>
+            <Path fileType="executable">/usr/bin/exe-thumbnailer</Path>
+            <Path fileType="executable">/usr/bin/icoextract</Path>
+            <Path fileType="executable">/usr/bin/icolist</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract-0.2.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract-0.2.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract-0.2.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract-0.2.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract-0.2.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract-0.2.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract/__pycache__/__init__.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract/__pycache__/version.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract/__pycache__/version.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract/scripts/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract/scripts/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract/scripts/__pycache__/__init__.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract/scripts/__pycache__/extract.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract/scripts/__pycache__/extract.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract/scripts/__pycache__/icolist.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract/scripts/__pycache__/icolist.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract/scripts/__pycache__/thumbnailer.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract/scripts/__pycache__/thumbnailer.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract/scripts/extract.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract/scripts/icolist.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract/scripts/thumbnailer.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/icoextract/version.py</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2026-02-21</Date>
+            <Version>0.2.0</Version>
+            <Comment>Packaging update</Comment>
+            <Name>iferon44</Name>
+            <Email>iferon44@gmail.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**
Add the python-icoextract package.
It is required as a runtime dependency for faugus-launcher.


**Test Plan**

Built with solbuild. Installed locally and verified that it provides required modules for faugus-launcher.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
