### PR TITLE
faugus-launcher: Add at v1.15.1

### DIFF
--- a/packages/f/faugus-launcher/monitoring.yaml
+++ b/packages/f/faugus-launcher/monitoring.yaml
@@ -1,0 +1,5 @@
+releases:
+    id: Faugus/faugus-launcher
+    type: github
+
+

--- a/packages/f/faugus-launcher/package.yml
+++ b/packages/f/faugus-launcher/package.yml
@@ -1,0 +1,45 @@
+name       : faugus-launcher
+version    : 1.15.1
+release    : 1
+source     :
+    - https://github.com/Faugus/faugus-launcher/archive/refs/tags/1.15.1.tar.gz : 4b6a8d1c2a33f2f66facc115d4e32c899186e278a9921c199593d15205841264
+homepage   : https://github.com/Faugus/faugus-launcher
+license    : MIT
+component  : games.tools
+summary    : A simple and lightweight app for running Windows games using UMU-Launcher
+description: |
+    Faugus Launcher is a simple and lightweight app for running Windows games using UMU-Launcher.
+    It supports playing Windows games using Proton, Linux native games, prefix management, and Steam shortcut management.
+builddeps  :
+    - pkgconfig(gtk+-3.0)
+    - meson
+rundeps    :
+    - imagemagick
+    - libayatana-appindicator
+    - python-filelock
+    - python-gobject
+    - python-icoextract
+    - python-pillow
+    - python-psutil
+    - python-requests
+    - python-vdf
+    - python3
+setup      : |
+    %meson_configure
+build      : |
+    %ninja_build
+install    : |
+    %ninja_install
+    
+    install -d -m 0755 $installdir/usr/share/applications/
+    cat > $installdir/usr/share/applications/faugus-launcher.desktop << EOF
+    [Desktop Entry]
+    Name=Faugus Launcher
+    GenericName=Game Launcher
+    Comment=Run Windows games using UMU-Launcher
+    Exec=faugus-launcher
+    Icon=faugus-launcher
+    Terminal=false
+    Type=Application
+    Categories=Game;Utility;
+    EOF

--- a/packages/f/faugus-launcher/pspec_x86_64.xml
+++ b/packages/f/faugus-launcher/pspec_x86_64.xml
@@ -1,0 +1,123 @@
+<PISI>
+    <Source>
+        <Name>faugus-launcher</Name>
+        <Homepage>https://github.com/Faugus/faugus-launcher</Homepage>
+        <Packager>
+            <Name>iferon44</Name>
+            <Email>iferon44@gmail.com</Email>
+        </Packager>
+        <License>MIT</License>
+        <PartOf>games.tools</PartOf>
+        <Summary xml:lang="en">A simple and lightweight app for running Windows games using UMU-Launcher</Summary>
+        <Description xml:lang="en">Faugus Launcher is a simple and lightweight app for running Windows games using UMU-Launcher.
+It supports playing Windows games using Proton, Linux native games, prefix management, and Steam shortcut management.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>faugus-launcher</Name>
+        <Summary xml:lang="en">A simple and lightweight app for running Windows games using UMU-Launcher</Summary>
+        <Description xml:lang="en">Faugus Launcher is a simple and lightweight app for running Windows games using UMU-Launcher.
+It supports playing Windows games using Proton, Linux native games, prefix management, and Steam shortcut management.
+</Description>
+        <PartOf>games.tools</PartOf>
+        <Files>
+            <Path fileType="executable">/usr/bin/faugus-launcher</Path>
+            <Path fileType="executable">/usr/bin/faugus-proton-manager</Path>
+            <Path fileType="executable">/usr/bin/faugus-run</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/faugus/__pycache__/components.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/faugus/__pycache__/config_manager.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/faugus/__pycache__/dark_theme.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/faugus/__pycache__/language_config.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/faugus/__pycache__/path_manager.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/faugus/__pycache__/proton_downloader.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/faugus/__pycache__/shortcut.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/faugus/components.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/faugus/config_manager.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/faugus/dark_theme.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/faugus/language_config.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/faugus/path_manager.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/faugus/proton_downloader.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/faugus/shortcut.py</Path>
+            <Path fileType="data">/usr/share/applications/faugus-launcher.desktop</Path>
+            <Path fileType="data">/usr/share/applications/faugus-proton-manager.desktop</Path>
+            <Path fileType="data">/usr/share/applications/faugus-run.desktop</Path>
+            <Path fileType="data">/usr/share/applications/faugus-shortcut.desktop</Path>
+            <Path fileType="data">/usr/share/faugus-launcher/faugus-banner.png</Path>
+            <Path fileType="data">/usr/share/faugus-launcher/faugus-notification.ogg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/faugus-battlenet.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/faugus-ea.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/faugus-epic-games.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/faugus-launcher.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/faugus-mono.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/faugus-rockstar.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/faugus-ubisoft-connect.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/io.github.Faugus.faugus-launcher.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/faugus-add-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/faugus-exit-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/faugus-kill-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/faugus-play-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/faugus-settings-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/actions/faugus-stop-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/licenses/faugus-launcher/LICENSE</Path>
+            <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/faugus-launcher.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/faugus-proton-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/faugus-run.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/faugus-launcher.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/faugus-proton-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/faugus-run.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/faugus-launcher.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/faugus-proton-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/faugus-run.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/el/LC_MESSAGES/faugus-launcher.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/el/LC_MESSAGES/faugus-proton-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/el/LC_MESSAGES/faugus-run.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/faugus-launcher.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/faugus-proton-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/faugus-run.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/fa/LC_MESSAGES/faugus-launcher.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/fa/LC_MESSAGES/faugus-proton-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/fa/LC_MESSAGES/faugus-run.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/faugus-launcher.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/faugus-proton-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/faugus-run.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/hu/LC_MESSAGES/faugus-launcher.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/hu/LC_MESSAGES/faugus-proton-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/hu/LC_MESSAGES/faugus-run.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/faugus-launcher.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/faugus-proton-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/faugus-run.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/nl/LC_MESSAGES/faugus-launcher.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/nl/LC_MESSAGES/faugus-proton-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/nl/LC_MESSAGES/faugus-run.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/pl/LC_MESSAGES/faugus-launcher.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/pl/LC_MESSAGES/faugus-proton-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/pl/LC_MESSAGES/faugus-run.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/faugus-launcher.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/faugus-proton-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/faugus-run.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ru/LC_MESSAGES/faugus-launcher.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ru/LC_MESSAGES/faugus-proton-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ru/LC_MESSAGES/faugus-run.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/faugus-launcher.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/faugus-proton-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/faugus-run.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/faugus-launcher.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/faugus-proton-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/faugus-run.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/faugus-launcher.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/faugus-proton-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/faugus-run.mo</Path>
+            <Path fileType="data">/usr/share/metainfo/faugus-launcher.metainfo.xml</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2026-02-21</Date>
+            <Version>1.15.1</Version>
+            <Comment>Packaging update</Comment>
+            <Name>iferon44</Name>
+            <Email>iferon44@gmail.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
Depends on #8002

**Summary**
- Initial package for Faugus Launcher at v1.15.1.
- Added all required Python runtime dependencies.


**Test Plan**
- Verified local installation via `eopkg`.
- Confirmed the application launches successfully.
- The games are fully functional.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
