### PR TITLE
openttd: Update to v15.2

### DIFF
--- a/packages/o/openttd/abi_used_symbols
+++ b/packages/o/openttd/abi_used_symbols
@@ -193,10 +193,13 @@ libcurl.so.4:curl_global_init
 libcurl.so.4:curl_slist_append
 libcurl.so.4:curl_slist_free_all
 libcurl.so.4:curl_version_info
+libfluidsynth.so.3:delete_fluid_cmd_handler
 libfluidsynth.so.3:delete_fluid_player
 libfluidsynth.so.3:delete_fluid_settings
 libfluidsynth.so.3:delete_fluid_synth
 libfluidsynth.so.3:fluid_free
+libfluidsynth.so.3:fluid_get_sysconf
+libfluidsynth.so.3:fluid_get_userconf
 libfluidsynth.so.3:fluid_is_soundfont
 libfluidsynth.so.3:fluid_player_add
 libfluidsynth.so.3:fluid_player_get_status
@@ -205,10 +208,12 @@ libfluidsynth.so.3:fluid_player_stop
 libfluidsynth.so.3:fluid_settings_dupstr
 libfluidsynth.so.3:fluid_settings_setint
 libfluidsynth.so.3:fluid_settings_setnum
+libfluidsynth.so.3:fluid_source
 libfluidsynth.so.3:fluid_synth_all_sounds_off
 libfluidsynth.so.3:fluid_synth_sfload
 libfluidsynth.so.3:fluid_synth_system_reset
 libfluidsynth.so.3:fluid_synth_write_s16
+libfluidsynth.so.3:new_fluid_cmd_handler2
 libfluidsynth.so.3:new_fluid_player
 libfluidsynth.so.3:new_fluid_settings
 libfluidsynth.so.3:new_fluid_synth

--- a/packages/o/openttd/package.yml
+++ b/packages/o/openttd/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : openttd
-version    : '15.1'
-release    : 46
+version    : '15.2'
+release    : 47
 source     :
-    - https://cdn.openttd.org/openttd-releases/15.1/openttd-15.1-source.tar.xz : 22466afe047ca2b77f18e7d4890d3b38f1c1b27f15c795ec20cc1e7045a9b169
+    - https://cdn.openttd.org/openttd-releases/15.2/openttd-15.2-source.tar.xz : d29ab617b7c0faa56ec4f8f13663c690a1b85e9212dd01717cc214c720d3ff76
 homepage   : https://www.openttd.org/
 license    : GPL-2.0-or-later
 component  : games.strategy

--- a/packages/o/openttd/pspec_x86_64.xml
+++ b/packages/o/openttd/pspec_x86_64.xml
@@ -178,9 +178,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="46">
-            <Date>2026-01-31</Date>
-            <Version>15.1</Version>
+        <Update release="47">
+            <Date>2026-02-21</Date>
+            <Version>15.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fix: Crashed zeppelin not blocking runway
- Fix: Crash when building drive-through stop on unowned one-way road
- Fix: Crash when handling invalid sprite in OpenGL cursor sprite system
- Fix: Czech townname generation causing crashes
- Fix: Incorrect ground type test when placing towns
- Fix: Town supplied cargo history incorrectly clamped to 16 bit values
- Fix: Crash when GUI scale changes before video driver is fully initialised
- Fix: Articulated road vehicle following with immediately sequential u-turns
- Fix: Foundations missing adjacent to NewGRF objects without foundation
- Fix: [Fluidsynth] Read settings from config files if available
- Fix: Badge filter toggles no longer worked

**Test Plan**

Started a new game and built some random rail lines

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
