### PR TITLE
packagekit: fix build

### DIFF
--- a/packages/p/packagekit/package.yml
+++ b/packages/p/packagekit/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : packagekit
 version    : 1.3.1
-release    : 36
+release    : 37
 source     :
     - git|https://github.com/getsolus/PackageKit.git : dd7ff1c2d345e9bb190596db3210c0fb0dd9101a
 license    : GPL-2.0-or-later
@@ -12,7 +12,6 @@ description: |
     PackageKit is a DBUS abstraction layer that allows the session user to manage packages in a secure way using a cross-distro, cross-architecture API.
 builddeps  :
     - pkgconfig(appstream)
-    - pkgconfig(appstream-glib)
     - pkgconfig(bash-completion)
     - pkgconfig(gio-2.0)
     - pkgconfig(gmodule-2.0)

--- a/packages/p/packagekit/pspec_x86_64.xml
+++ b/packages/p/packagekit/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>packagekit</Name>
         <Homepage>https://www.freedesktop.org/software/PackageKit/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>programming.library</PartOf>
@@ -132,8 +132,8 @@
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/PackageKit.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_HK/LC_MESSAGES/PackageKit.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/PackageKit.mo</Path>
-            <Path fileType="man">/usr/share/man/man1/pkcon.1</Path>
-            <Path fileType="man">/usr/share/man/man1/pkmon.1</Path>
+            <Path fileType="man">/usr/share/man/man1/pkcon.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/pkmon.1.zst</Path>
             <Path fileType="data">/usr/share/metainfo/org.freedesktop.packagekit.metainfo.xml</Path>
             <Path fileType="data">/usr/share/polkit-1/actions/org.freedesktop.packagekit.policy</Path>
             <Path fileType="data">/usr/share/polkit-1/rules.d/org.freedesktop.packagekit.rules</Path>
@@ -146,7 +146,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="36">packagekit</Dependency>
+            <Dependency release="37">packagekit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/PackageKit/packagekit-glib2/packagekit.h</Path>
@@ -194,12 +194,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2025-06-12</Date>
+        <Update release="37">
+            <Date>2026-02-22</Date>
             <Version>1.3.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Removed appstream-glib as dependency as it has been deprecated.

**Test Plan**
- Built it.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
