### PR TITLE
network-manager: Remove rundep from network-manager-livecd

### DIFF
--- a/packages/n/network-manager/package.yml
+++ b/packages/n/network-manager/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : network-manager
 version    : 1.54.3
-release    : 89
+release    : 90
 source     :
     - https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/archive/1.54.3/NetworkManager-1.54.3.tar.bz2 : e38d55611af8127e1a2b1a7b4952bded1f61917cbc49d4ee7a272ec3fcd7b51b
 homepage   : https://gitlab.freedesktop.org/NetworkManager/NetworkManager
@@ -85,8 +85,6 @@ rundeps    :
     - libnm-32bit-devel :
         - network-manager-libnm-32bit
         - network-manager-libnm-devel
-    - livecd :
-        - network-manager
 emul32     : true
 environment: |
     unset LD_AS_NEEDED

--- a/packages/n/network-manager/pspec_x86_64.xml
+++ b/packages/n/network-manager/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>network-manager</Name>
         <Homepage>https://gitlab.freedesktop.org/NetworkManager/NetworkManager</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>GFDL-1.1-or-later</License>
         <License>GPL-2.0-or-later</License>
@@ -20,7 +20,7 @@
         <Description xml:lang="en">NetworkManager attempts to keep an active network connection available at all times. The point of NetworkManager is to make networking configuration and setup as painless and automatic as possible. NetworkManager is intended to replace default route, replace other routes, set IP addresses, and in general configure networking as NM sees fit (with the possibility of manual override as necessary). In effect, the goal of NetworkManager is to make networking Just Work with a minimum of user hassle, but still allow customization and a high level of manual network control.</Description>
         <PartOf>network.base</PartOf>
         <RuntimeDependencies>
-            <Dependency release="89">network-manager-libnm</Dependency>
+            <Dependency release="90">network-manager-libnm</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/nm-online</Path>
@@ -161,7 +161,7 @@
         <Description xml:lang="en">Bluetooth device plugin for NetworkManager</Description>
         <PartOf>network.base</PartOf>
         <RuntimeDependencies>
-            <Dependency release="89">network-manager</Dependency>
+            <Dependency release="90">network-manager</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/NetworkManager/1.54.3-solus/libnm-device-plugin-bluetooth.so</Path>
@@ -484,7 +484,7 @@
         <Description xml:lang="en">Installing this will switch to using iwd as the wifi backend in place of wpa_supplicant</Description>
         <PartOf>network.base</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="89">network-manager</Dependency>
+            <Dependency releaseFrom="90">network-manager</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib/NetworkManager/conf.d/10-iwd-wifi-backend.conf</Path>
@@ -507,7 +507,7 @@
         <Description xml:lang="en">32-bit libraries for NetworkManager</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="89">network-manager-libnm</Dependency>
+            <Dependency releaseFrom="90">network-manager-libnm</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnm.so.0</Path>
@@ -523,8 +523,8 @@
         <Description xml:lang="en">Development files for network-manager-libnm-32bit</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="89">network-manager-libnm-32bit</Dependency>
-            <Dependency releaseFrom="89">network-manager-libnm-devel</Dependency>
+            <Dependency releaseFrom="90">network-manager-libnm-32bit</Dependency>
+            <Dependency releaseFrom="90">network-manager-libnm-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnm.so</Path>
@@ -540,7 +540,7 @@
         <Description xml:lang="en">Development files for network-manager-libnm</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="89">network-manager-libnm</Dependency>
+            <Dependency releaseFrom="90">network-manager-libnm</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libnm/NetworkManager.h</Path>
@@ -743,7 +743,7 @@
         <Description xml:lang="en">NetworkManager curses-based UI</Description>
         <PartOf>network.util</PartOf>
         <RuntimeDependencies>
-            <Dependency release="89">network-manager-libnm</Dependency>
+            <Dependency release="90">network-manager-libnm</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/nmtui</Path>
@@ -757,12 +757,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="89">
-            <Date>2025-12-16</Date>
+        <Update release="90">
+            <Date>2026-02-23</Date>
             <Version>1.54.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Hans K</Name>
+            <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
This rundep causes eopkg to think network-manager was only installed because it was a dep of network-manager-livecd, which means that network-manager gets uninstalled by our calamares scripts.

Oops.

Reverse dependency resolution is fun.

Fixes #7871.

**Test Plan**
- Download a recent snapshot or build a local smoketest ISO.
- Boot it.
- Run `eopkg rmf network-manager-livecd`.
- See that eopkg attempts to remove basically the whole networking stack. 
- !
- Apply this PR.
- Build this package and copy it to your local repo.
- Build a local smoketest ISO.
- Boot it.
- Run `eopkg rmf network-manager-livecd`. 
- See that eopkg now only attempts to remove the package you specified.
- Yay!

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
