### PR TITLE
feishin: Update to v1.6.0

### DIFF
--- a/packages/f/feishin/package.yml
+++ b/packages/f/feishin/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : feishin
-version    : 1.5.0
-release    : 4
+version    : 1.6.0
+release    : 5
 source     :
-    - https://github.com/jeffvli/feishin/archive/refs/tags/v1.5.0.tar.gz : 0d868fed3f68a437e40199ad56c672454955e7df0e72781957c02607aa5efde2
+    - https://github.com/jeffvli/feishin/archive/refs/tags/v1.6.0.tar.gz : 40946745f69d6d01d71b8c545ed6e5ae0e74e2e63c970d40c5d517159efc9e5f
 homepage   : https://github.com/jeffvli/feishin
 license    : GPL-3.0-or-later
 component  : multimedia.audio

--- a/packages/f/feishin/pspec_x86_64.xml
+++ b/packages/f/feishin/pspec_x86_64.xml
@@ -132,9 +132,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2026-02-11</Date>
-            <Version>1.5.0</Version>
+        <Update release="5">
+            <Date>2026-02-24</Date>
+            <Version>1.6.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Hans K</Name>
             <Email>hans@communitycomputing.net</Email>


### PR DESCRIPTION
**Summary**
- Changelog available [here](https://github.com/jeffvli/feishin/releases/v1.6.0)

**Test Plan**
- Build and install Feishin from this repo.
- See that it still works with a Navidrome server.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
