### PR TITLE
goverlay: Update to v1.7.4

### DIFF
--- a/packages/g/goverlay/abi_used_symbols
+++ b/packages/g/goverlay/abi_used_symbols
@@ -329,6 +329,7 @@ libQt6Pas.so.6:QFont_styleStrategy
 libQt6Pas.so.6:QFont_underline
 libQt6Pas.so.6:QFont_weight
 libQt6Pas.so.6:QFrame_Create
+libQt6Pas.so.6:QFrame_setFrameShadow
 libQt6Pas.so.6:QFrame_setFrameShape
 libQt6Pas.so.6:QGradient_Destroy
 libQt6Pas.so.6:QGradient_setColorAt
@@ -442,12 +443,14 @@ libQt6Pas.so.6:QLCLMessageEvent_getMsgResult
 libQt6Pas.so.6:QLCLMessageEvent_getWParam
 libQt6Pas.so.6:QLCLMessageEvent_setMsgResult
 libQt6Pas.so.6:QLCLTabWidget_tabBarHandle
+libQt6Pas.so.6:QLabel_Create
 libQt6Pas.so.6:QLabel_Create2
 libQt6Pas.so.6:QLabel_setAlignment
 libQt6Pas.so.6:QLabel_setPixmap
 libQt6Pas.so.6:QLabel_setScaledContents
 libQt6Pas.so.6:QLabel_setText
 libQt6Pas.so.6:QLabel_setWordWrap
+libQt6Pas.so.6:QLabel_text
 libQt6Pas.so.6:QLayout_addWidget
 libQt6Pas.so.6:QLayout_invalidate
 libQt6Pas.so.6:QLayout_setContentsMargins
@@ -1210,6 +1213,7 @@ libc.so.6:iconv_open
 libc.so.6:mbrlen
 libc.so.6:mbrtowc
 libc.so.6:nl_langinfo
+libc.so.6:sched_yield
 libc.so.6:setlocale
 libc.so.6:strcoll
 libc.so.6:towlower

--- a/packages/g/goverlay/package.yml
+++ b/packages/g/goverlay/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : goverlay
-version    : 1.6.1
-release    : 22
+version    : 1.7.4
+release    : 23
 source     :
-    - https://github.com/benjamimgois/goverlay/archive/refs/tags/1.6.1.tar.gz : 5f5a6a82158f70d266a3fb15e227e7bc0c89e06600d7420f48fafeb117ecd1c0
+    - https://github.com/benjamimgois/goverlay/archive/refs/tags/1.7.4.tar.gz : 6738e895eece09776368c2ee8bcf32e3c9c073eeda72705575cd8198e1cad20b
 homepage   : https://github.com/benjamimgois/goverlay
 license    : GPL-3.0-only
 component  : system.utils
@@ -19,9 +19,11 @@ rundeps    :
     - git
     - mangohud
     - mesa-demos
+    - p7zip
     - vkbasalt
     - vulkan-tools
 build      : |
     lazbuild --lazarusdir=%libdir%/lazarus --bm=Release goverlay.lpi
 install    : |
     %make_install prefix=/usr
+    %install_license LICENSE

--- a/packages/g/goverlay/pspec_x86_64.xml
+++ b/packages/g/goverlay/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>goverlay</Name>
         <Homepage>https://github.com/benjamimgois/goverlay</Homepage>
         <Packager>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <PartOf>system.utils</PartOf>
@@ -25,20 +25,21 @@ It also serves as an alternative to Nvidia Shadowplay, alowing you to record gam
             <Path fileType="executable">/usr/bin/goverlay</Path>
             <Path fileType="executable">/usr/libexec/goverlay</Path>
             <Path fileType="data">/usr/share/applications/io.github.benjamimgois.goverlay.desktop</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/goverlay.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/goverlay.png</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/512x512/apps/goverlay.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/128x128/apps/io.github.benjamimgois.goverlay.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/io.github.benjamimgois.goverlay.png</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/512x512/apps/io.github.benjamimgois.goverlay.png</Path>
+            <Path fileType="data">/usr/share/licenses/goverlay/LICENSE</Path>
             <Path fileType="man">/usr/share/man/man1/goverlay.1.zst</Path>
             <Path fileType="data">/usr/share/metainfo/io.github.benjamimgois.goverlay.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2025-11-20</Date>
-            <Version>1.6.1</Version>
+        <Update release="23">
+            <Date>2026-02-26</Date>
+            <Version>1.7.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/benjamimgois/goverlay/releases).
- Resolves: #8035 

**Test Plan**

Played with OptiScaler, Watched the cube spin. Downloaded effects. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
