### PR TITLE
valkey: Update to v9.0.3

### DIFF
--- a/packages/v/valkey/MAINTAINERS.md
+++ b/packages/v/valkey/MAINTAINERS.md
@@ -1,4 +1,0 @@
-This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
-
-- Jakob Gezelius
-  - Email: jakob@knugen.nu

--- a/packages/v/valkey/abi_symbols
+++ b/packages/v/valkey/abi_symbols
@@ -1465,6 +1465,7 @@ valkey-server:ACLInitCommandCategories
 valkey-server:ACLLoadUsersAtStartup
 valkey-server:ACLLog
 valkey-server:ACLLogEntryCount
+valkey-server:ACLModuleHasCommandRules
 valkey-server:ACLRecomputeCommandBitsFromCommandRulesAllUsers
 valkey-server:ACLSetUser
 valkey-server:ACLSetUserStringError
@@ -3261,6 +3262,7 @@ valkey-server:addReplyErrorLength
 valkey-server:addReplyErrorObject
 valkey-server:addReplyErrorSds
 valkey-server:addReplyErrorSdsEx
+valkey-server:addReplyErrorSdsExSafe
 valkey-server:addReplyErrorSdsSafe
 valkey-server:addReplyFlagsForArg
 valkey-server:addReplyFlagsForCommand
@@ -4176,6 +4178,7 @@ valkey-server:freeClientBlockingState
 valkey-server:freeClientModuleData
 valkey-server:freeClientMultiState
 valkey-server:freeClientMultiStateCmds
+valkey-server:freeClientOrCloseLater
 valkey-server:freeClientOriginalArgv
 valkey-server:freeClientPubSubData
 valkey-server:freeClientReplicationData
@@ -5279,6 +5282,7 @@ valkey-server:moduleFreeArgs
 valkey-server:moduleFreeCommand
 valkey-server:moduleFreeContext
 valkey-server:moduleFreeModuleStructure
+valkey-server:moduleFromCommand
 valkey-server:moduleGILAfterLock
 valkey-server:moduleGILBeforeUnlock
 valkey-server:moduleGetACLLogEntryReason

--- a/packages/v/valkey/package.yml
+++ b/packages/v/valkey/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : valkey
-version    : 9.0.2
-release    : 10
+version    : 9.0.3
+release    : 11
 source     :
-    - https://github.com/valkey-io/valkey/archive/refs/tags/9.0.2.tar.gz : 0ebaa583659ab784ce19170627032cfab7793a5570b7262775f9dbf77c103ec7
+    - https://github.com/valkey-io/valkey/archive/refs/tags/9.0.3.tar.gz : e220f4b0143292ee6ea6d705aa40d45a0c8a77759b3e94c201cb5c25dbdca42f
 homepage   : https://valkey.io/
 license    : BSD-3-Clause
 component  : database

--- a/packages/v/valkey/pspec_x86_64.xml
+++ b/packages/v/valkey/pspec_x86_64.xml
@@ -40,9 +40,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2026-02-03</Date>
-            <Version>9.0.2</Version>
+        <Update release="11">
+            <Date>2026-02-26</Date>
+            <Version>9.0.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>
             <Email>jakob@knugen.nu</Email>


### PR DESCRIPTION
**Summary**
- Avoids crash during MODULE UNLOAD when ACL rules reference a module command and subcommand
- Fix server assert on ACL LOAD when current user loses permission to channels
- Fix bug causing no response flush sometimes when IO threads are busy

**Security**
Includes fixes for:
- CVE-2025-67733 RESP Protocol Injection via Lua error_reply
- CVE-2026-21863 Remote DoS with malformed Valkey Cluster bus message
- CVE-2026-27623 Reset request type after handling empty requests

<!-- Info on what this pull request updates/changes/etc -->

**Test Plan**
- Connected to the server.

**Checklist**

- [X] Package was built and tested against unstable
- [X] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
