### PR TITLE
nvidia-vaapi-driver: Update to v0.0.16

### DIFF
--- a/packages/n/nvidia-vaapi-driver/package.yml
+++ b/packages/n/nvidia-vaapi-driver/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : nvidia-vaapi-driver
-version    : 0.0.15
-release    : 19
+version    : 0.0.16
+release    : 20
 homepage   : https://github.com/elFarto/nvidia-vaapi-driver
 source     :
-    - https://github.com/elFarto/nvidia-vaapi-driver/archive/refs/tags/v0.0.15.tar.gz : 2118a0f37c415adfadad53ef3aab3f53c54164f8a4b0c2d4de9e0b61e5ece536
+    - https://github.com/elFarto/nvidia-vaapi-driver/archive/refs/tags/v0.0.16.tar.gz : 799244cab5ace62b6354e429bd56faa83045470c438fbea13690b4d06754eb8b
 license    : MIT
 component  : xorg.display
 summary    : A VA-API implemention using NVIDIA's NVDEC as the backend (UNSUPPORTED)

--- a/packages/n/nvidia-vaapi-driver/pspec_x86_64.xml
+++ b/packages/n/nvidia-vaapi-driver/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Conflicts>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2026-01-30</Date>
-            <Version>0.0.15</Version>
+        <Update release="20">
+            <Date>2026-02-26</Date>
+            <Version>0.0.16</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Fix nvGetConfigAttributes by adding a missing check for entrypoint

**Test Plan**

Confirmed video acceleration is working in `firefox`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
