### PR TITLE
freerdp: Update to v3.23.0

### DIFF
--- a/packages/f/freerdp/abi_libs
+++ b/packages/f/freerdp/abi_libs
@@ -7,6 +7,5 @@ libfreerdp3.so.3
 libproxy-bitmap-filter-plugin.so
 libproxy-demo-plugin.so
 libproxy-dyn-channel-dump-plugin.so
-librdtk0.so.0
 libwinpr-tools3.so.3
 libwinpr3.so.3

--- a/packages/f/freerdp/abi_symbols
+++ b/packages/f/freerdp/abi_symbols
@@ -115,6 +115,7 @@ libfreerdp-client3.so.3:msusb_msinterface_write
 libfreerdp-client3.so.3:msusb_mspipes_replace
 libfreerdp-client3.so.3:rail_handshake_ex_flags_to_string
 libfreerdp-client3.so.3:rdpgfx_client_context_free
+libfreerdp-server-proxy3.so.3:StaticChannelContext_free
 libfreerdp-server-proxy3.so.3:intercept_context_entry_free
 libfreerdp-server-proxy3.so.3:pf_config_clone
 libfreerdp-server-proxy3.so.3:pf_config_get
@@ -609,6 +610,11 @@ libfreerdp3.so.3:freerdp_error_info
 libfreerdp3.so.3:freerdp_extract_key_value
 libfreerdp3.so.3:freerdp_focus_required
 libfreerdp3.so.3:freerdp_free
+libfreerdp3.so.3:freerdp_getApplicationDetailsProduct
+libfreerdp3.so.3:freerdp_getApplicationDetailsString
+libfreerdp3.so.3:freerdp_getApplicationDetailsStringW
+libfreerdp3.so.3:freerdp_getApplicationDetailsVendor
+libfreerdp3.so.3:freerdp_getApplicationDetailsVersion
 libfreerdp3.so.3:freerdp_get_build_config
 libfreerdp3.so.3:freerdp_get_build_revision
 libfreerdp3.so.3:freerdp_get_common_access_token
@@ -748,6 +754,7 @@ libfreerdp3.so.3:freerdp_register_addin_provider
 libfreerdp3.so.3:freerdp_send_error_info
 libfreerdp3.so.3:freerdp_server_license_issuers_copy
 libfreerdp3.so.3:freerdp_server_license_issuers_free
+libfreerdp3.so.3:freerdp_setApplicationDetails
 libfreerdp3.so.3:freerdp_set_common_access_token
 libfreerdp3.so.3:freerdp_set_error_info
 libfreerdp3.so.3:freerdp_set_focus
@@ -1174,15 +1181,6 @@ libfreerdp3.so.3:zgfx_decompress
 libproxy-bitmap-filter-plugin.so:proxy_module_entry_point
 libproxy-demo-plugin.so:proxy_module_entry_point
 libproxy-dyn-channel-dump-plugin.so:proxy_module_entry_point
-librdtk0.so.0:rdtk_button_draw
-librdtk0.so.0:rdtk_engine_free
-librdtk0.so.0:rdtk_engine_new
-librdtk0.so.0:rdtk_font_draw_text
-librdtk0.so.0:rdtk_label_draw
-librdtk0.so.0:rdtk_surface_fill
-librdtk0.so.0:rdtk_surface_free
-librdtk0.so.0:rdtk_surface_new
-librdtk0.so.0:rdtk_text_field_draw
 libwinpr-tools3.so.3:makecert_context_free
 libwinpr-tools3.so.3:makecert_context_new
 libwinpr-tools3.so.3:makecert_context_output_certificate_file
@@ -1427,6 +1425,8 @@ libwinpr3.so.3:FreeEnvironmentStringsA
 libwinpr3.so.3:FreeEnvironmentStringsW
 libwinpr3.so.3:FreeLibrary
 libwinpr3.so.3:GetCombinedPath
+libwinpr3.so.3:GetCombinedPathV
+libwinpr3.so.3:GetCombinedPathVA
 libwinpr3.so.3:GetCommConfig
 libwinpr3.so.3:GetCommMask
 libwinpr3.so.3:GetCommModemStatus
@@ -1455,6 +1455,8 @@ libwinpr3.so.3:GetEnvironmentPath
 libwinpr3.so.3:GetEnvironmentStrings
 libwinpr3.so.3:GetEnvironmentStringsW
 libwinpr3.so.3:GetEnvironmentSubPath
+libwinpr3.so.3:GetEnvironmentSubPathV
+libwinpr3.so.3:GetEnvironmentSubPathVA
 libwinpr3.so.3:GetEnvironmentVariableA
 libwinpr3.so.3:GetEnvironmentVariableEBA
 libwinpr3.so.3:GetEnvironmentVariableW
@@ -1476,6 +1478,8 @@ libwinpr3.so.3:GetKeycodeFromVirtualKeyCode
 libwinpr3.so.3:GetKnownPath
 libwinpr3.so.3:GetKnownPathIdString
 libwinpr3.so.3:GetKnownSubPath
+libwinpr3.so.3:GetKnownSubPathV
+libwinpr3.so.3:GetKnownSubPathVA
 libwinpr3.so.3:GetLastError
 libwinpr3.so.3:GetLine
 libwinpr3.so.3:GetLocalTime
@@ -1654,6 +1658,7 @@ libwinpr3.so.3:MergeEnvironmentStrings
 libwinpr3.so.3:MessagePipe_Free
 libwinpr3.so.3:MessagePipe_New
 libwinpr3.so.3:MessagePipe_PostQuit
+libwinpr3.so.3:MessageQueue_Capacity
 libwinpr3.so.3:MessageQueue_Clear
 libwinpr3.so.3:MessageQueue_Dispatch
 libwinpr3.so.3:MessageQueue_Event
@@ -1793,6 +1798,7 @@ libwinpr3.so.3:PushEntryList
 libwinpr3.so.3:QueryCommDevice
 libwinpr3.so.3:QueryDepthSList
 libwinpr3.so.3:QueueUserAPC
+libwinpr3.so.3:Queue_Capacity
 libwinpr3.so.3:Queue_Clear
 libwinpr3.so.3:Queue_Contains
 libwinpr3.so.3:Queue_Count
@@ -2548,6 +2554,8 @@ libwinpr3.so.3:winpr_EnterSynchronizationBarrier
 libwinpr3.so.3:winpr_FIPSMode
 libwinpr3.so.3:winpr_FreeLibraryWhenCallbackReturns
 libwinpr3.so.3:winpr_GetConfigFilePath
+libwinpr3.so.3:winpr_GetConfigFilePathV
+libwinpr3.so.3:winpr_GetConfigFilePathVA
 libwinpr3.so.3:winpr_GetTickCount64
 libwinpr3.so.3:winpr_GetTickCount64NS
 libwinpr3.so.3:winpr_GetUnixTimeNS
@@ -2622,6 +2630,9 @@ libwinpr3.so.3:winpr_bitmap_write_ex
 libwinpr3.so.3:winpr_cipher_type_from_string
 libwinpr3.so.3:winpr_cipher_type_to_string
 libwinpr3.so.3:winpr_fopen
+libwinpr3.so.3:winpr_getApplicationDetailsProduct
+libwinpr3.so.3:winpr_getApplicationDetailsVendor
+libwinpr3.so.3:winpr_getApplicationDetailsVersion
 libwinpr3.so.3:winpr_get_build_config
 libwinpr3.so.3:winpr_get_build_revision
 libwinpr3.so.3:winpr_get_version
@@ -2642,6 +2653,7 @@ libwinpr3.so.3:winpr_log_backtrace
 libwinpr3.so.3:winpr_log_backtrace_ex
 libwinpr3.so.3:winpr_md_type_from_string
 libwinpr3.so.3:winpr_md_type_to_string
+libwinpr3.so.3:winpr_setApplicationDetails
 libwinpr3.so.3:winpr_str_append
 libwinpr3.so.3:winpr_str_url_decode
 libwinpr3.so.3:winpr_str_url_encode

--- a/packages/f/freerdp/abi_used_symbols
+++ b/packages/f/freerdp/abi_used_symbols
@@ -123,6 +123,7 @@ libX11.so.6:XDeleteProperty
 libX11.so.6:XDestroyIC
 libX11.so.6:XDestroyRegion
 libX11.so.6:XDestroyWindow
+libX11.so.6:XDisplayKeycodes
 libX11.so.6:XDisplayName
 libX11.so.6:XDrawLines
 libX11.so.6:XDrawString
@@ -214,6 +215,7 @@ libX11.so.6:XkbFreeKeyboard
 libX11.so.6:XkbGetMap
 libX11.so.6:XkbGetNames
 libX11.so.6:XkbGetState
+libX11.so.6:XkbKeycodeToKeysym
 libX11.so.6:XkbLibraryVersion
 libX11.so.6:XkbLockModifiers
 libX11.so.6:XkbQueryExtension
@@ -350,7 +352,6 @@ libc.so.6:__fdelt_chk
 libc.so.6:__gethostname_chk
 libc.so.6:__inet_ntop_chk
 libc.so.6:__inet_pton_chk
-libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_single_threaded
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
@@ -1072,6 +1073,7 @@ libstdc++.so.6:_ZSt19__throw_regex_errorNSt15regex_constants10error_typeE
 libstdc++.so.6:_ZSt20__throw_length_errorPKc
 libstdc++.so.6:_ZSt20__throw_system_errori
 libstdc++.so.6:_ZSt21ios_base_library_initv
+libstdc++.so.6:_ZSt24__throw_out_of_range_fmtPKcz
 libstdc++.so.6:_ZSt25__throw_bad_function_callv
 libstdc++.so.6:_ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_
 libstdc++.so.6:_ZSt4cout

--- a/packages/f/freerdp/package.yml
+++ b/packages/f/freerdp/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : freerdp
-version    : 3.22.0
-release    : 46
+version    : 3.23.0
+release    : 47
 source     :
-    - https://pub.freerdp.com/releases/freerdp-3.22.0.tar.gz : 656670f3aac2c995cb4b1ba181549cc122cc9c95ec31be68a582c1182f474376
+    - https://pub.freerdp.com/releases/freerdp-3.23.0.tar.gz : 929273003f35b0b4f211e48d5abed4ebcef99da94784a50b6dc85cd0b7e257b1
 homepage   : https://www.freerdp.com/
 license    : Apache-2.0
 component  : network.util

--- a/packages/f/freerdp/pspec_x86_64.xml
+++ b/packages/f/freerdp/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>freerdp</Name>
         <Homepage>https://www.freerdp.com/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>network.util</PartOf>
@@ -33,23 +33,21 @@
             <Path fileType="library">/usr/lib64/freerdp3/proxy/libproxy-demo-plugin.so</Path>
             <Path fileType="library">/usr/lib64/freerdp3/proxy/libproxy-dyn-channel-dump-plugin.so</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-client3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-client3.so.3.22.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-client3.so.3.23.0</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-server-proxy3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-server-proxy3.so.3.22.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-server-proxy3.so.3.23.0</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-server3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-server3.so.3.22.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-server3.so.3.23.0</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-shadow-subsystem3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-shadow-subsystem3.so.3.22.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-shadow-subsystem3.so.3.23.0</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-shadow3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-shadow3.so.3.22.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-shadow3.so.3.23.0</Path>
             <Path fileType="library">/usr/lib64/libfreerdp3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp3.so.3.22.0</Path>
-            <Path fileType="library">/usr/lib64/librdtk0.so.0</Path>
-            <Path fileType="library">/usr/lib64/librdtk0.so.0.2.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp3.so.3.23.0</Path>
             <Path fileType="library">/usr/lib64/libwinpr-tools3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libwinpr-tools3.so.3.22.0</Path>
+            <Path fileType="library">/usr/lib64/libwinpr-tools3.so.3.23.0</Path>
             <Path fileType="library">/usr/lib64/libwinpr3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libwinpr3.so.3.22.0</Path>
+            <Path fileType="library">/usr/lib64/libwinpr3.so.3.23.0</Path>
             <Path fileType="data">/usr/share/FreeRDP/images/test_icon.bmp</Path>
             <Path fileType="data">/usr/share/FreeRDP/images/test_icon.jpg</Path>
             <Path fileType="data">/usr/share/FreeRDP/images/test_icon.png</Path>
@@ -72,7 +70,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="46">freerdp</Dependency>
+            <Dependency release="47">freerdp</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/freerdp3/freerdp/addin.h</Path>
@@ -259,12 +257,6 @@
             <Path fileType="header">/usr/include/freerdp3/freerdp/utils/string.h</Path>
             <Path fileType="header">/usr/include/freerdp3/freerdp/version.h</Path>
             <Path fileType="header">/usr/include/freerdp3/freerdp/window.h</Path>
-            <Path fileType="header">/usr/include/rdtk0/rdtk/api.h</Path>
-            <Path fileType="header">/usr/include/rdtk0/rdtk/build-config.h</Path>
-            <Path fileType="header">/usr/include/rdtk0/rdtk/buildflags.h</Path>
-            <Path fileType="header">/usr/include/rdtk0/rdtk/config.h</Path>
-            <Path fileType="header">/usr/include/rdtk0/rdtk/rdtk.h</Path>
-            <Path fileType="header">/usr/include/rdtk0/rdtk/version.h</Path>
             <Path fileType="header">/usr/include/winpr3/winpr/asn1.h</Path>
             <Path fileType="header">/usr/include/winpr3/winpr/assert-api.h</Path>
             <Path fileType="header">/usr/include/winpr3/winpr/assert.h</Path>
@@ -365,17 +357,12 @@
             <Path fileType="library">/usr/lib64/cmake/WinPR3/WinPRConfigVersion.cmake</Path>
             <Path fileType="library">/usr/lib64/cmake/WinPR3/WinPRTargets-relwithdebinfo.cmake</Path>
             <Path fileType="library">/usr/lib64/cmake/WinPR3/WinPRTargets.cmake</Path>
-            <Path fileType="library">/usr/lib64/cmake/rdtk0/rdtk-relwithdebinfo.cmake</Path>
-            <Path fileType="library">/usr/lib64/cmake/rdtk0/rdtk.cmake</Path>
-            <Path fileType="library">/usr/lib64/cmake/rdtk0/rdtkConfig.cmake</Path>
-            <Path fileType="library">/usr/lib64/cmake/rdtk0/rdtkConfigVersion.cmake</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-client3.so</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-server-proxy3.so</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-server3.so</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-shadow-subsystem3.so</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-shadow3.so</Path>
             <Path fileType="library">/usr/lib64/libfreerdp3.so</Path>
-            <Path fileType="library">/usr/lib64/librdtk0.so</Path>
             <Path fileType="library">/usr/lib64/libwinpr-tools3.so</Path>
             <Path fileType="library">/usr/lib64/libwinpr3.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/freerdp-client3.pc</Path>
@@ -383,18 +370,17 @@
             <Path fileType="data">/usr/lib64/pkgconfig/freerdp-server3.pc</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/freerdp-shadow3.pc</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/freerdp3.pc</Path>
-            <Path fileType="data">/usr/lib64/pkgconfig/rdtk0.pc</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/winpr-tools3.pc</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/winpr3.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="46">
-            <Date>2026-02-11</Date>
-            <Version>3.22.0</Version>
+        <Update release="47">
+            <Date>2026-02-28</Date>
+            <Version>3.23.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://www.freerdp.com/2026/02/25/3_23_0-release).

**Security**
Includes fixes for:
- CVE-2026-25941
- CVE-2026-25942
- CVE-2026-25952
- CVE-2026-25953
- CVE-2026-25954
- CVE-2026-25955
- CVE-2026-25959
- CVE-2026-25997
- CVE-2026-26271
- CVE-2026-26955
- CVE-2026-26965
- CVE-2026-26986
- CVE-2026-27015
- CVE-2026-27950
- CVE-2026-27951
- GHSA-qcfc-ghxr-h927

**Test Plan**

```xfreerdp``` into host.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
