### PR TITLE
composer: Update to v2.9.5

### DIFF
--- a/packages/c/composer/package.yml
+++ b/packages/c/composer/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : composer
-version    : 2.9.2
-release    : 8
+version    : 2.9.5
+release    : 9
 source     :
-    - git|https://github.com/composer/composer.git : 2.9.2
+    - git|https://github.com/composer/composer.git : 2.9.5
 homepage   : https://getcomposer.org/
 license    : MIT
 component  : programming.tools

--- a/packages/c/composer/pspec_x86_64.xml
+++ b/packages/c/composer/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>composer</Name>
         <Homepage>https://getcomposer.org/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.tools</PartOf>
@@ -24,12 +24,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2025-12-04</Date>
-            <Version>2.9.2</Version>
+        <Update release="9">
+            <Date>2026-02-28</Date>
+            <Version>2.9.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/composer/composer/releases).

**Security**
Includes fixes for:
- CVE-2025-67746

**Test Plan**

```php composer.phar --version```

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
