### PR TITLE
python-openssl: Update to v25.3.0

### DIFF
--- a/packages/py/python-openssl/package.yml
+++ b/packages/py/python-openssl/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-openssl
-version    : 25.1.0
-release    : 21
+version    : 25.3.0
+release    : 22
 source     :
-    - https://pypi.debian.net/pyOpenSSL/pyopenssl-25.1.0.tar.gz : 8d031884482e0c67ee92bf9a4d8cceb08d92aba7136432ffb0703c5280fc205b
+    - https://pypi.debian.net/pyOpenSSL/pyopenssl-25.3.0.tar.gz : c981cb0a3fd84e8602d7afc209522773b94c1c2446a3c710a75b06fe1beae329
 homepage   : https://pyopenssl.org/
 license    : Apache-2.0
 component  : programming.python

--- a/packages/py/python-openssl/pspec_x86_64.xml
+++ b/packages/py/python-openssl/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-openssl</Name>
         <Homepage>https://pyopenssl.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -42,20 +42,20 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/OpenSSL/py.typed</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/OpenSSL/rand.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/OpenSSL/version.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyopenssl-25.1.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyopenssl-25.1.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyopenssl-25.1.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyopenssl-25.1.0.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyopenssl-25.1.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyopenssl-25.3.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyopenssl-25.3.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyopenssl-25.3.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyopenssl-25.3.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyopenssl-25.3.0.dist-info/top_level.txt</Path>
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2025-06-25</Date>
-            <Version>25.1.0</Version>
+        <Update release="22">
+            <Date>2026-02-28</Date>
+            <Version>25.3.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Maximum supported cryptography version is now 46.x.

**Test Plan**
- Installed, tried to start Deluge that failed to start because of an earlier version of this. Noticed it starts fine now.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
