### PR TITLE
uv: update to 0.10.7

### DIFF
--- a/packages/u/uv/package.yml
+++ b/packages/u/uv/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : uv
-version    : 0.10.2
-release    : 10
+version    : 0.10.7
+release    : 11
 source     :
-    - https://github.com/astral-sh/uv/archive/refs/tags/0.10.2.tar.gz : e2568df6596c743f583f65e764e60709d974494c2a12a2b3f1e67ec28a6448d3
+    - https://github.com/astral-sh/uv/archive/refs/tags/0.10.7.tar.gz : 8714b69fb97e144ac0dbea17106f4223fcd991d4d7623bebd2f59cbf9d454b76
 homepage   : https://docs.astral.sh/uv
 license    :
     - Apache-2.0

--- a/packages/u/uv/pspec_x86_64.xml
+++ b/packages/u/uv/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>uv</Name>
         <Homepage>https://docs.astral.sh/uv</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Matthias Homann</Name>
+            <Email>palto@mailbox.org</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>MIT</License>
@@ -23,11 +23,11 @@
         <Files>
             <Path fileType="executable">/usr/bin/uv</Path>
             <Path fileType="executable">/usr/bin/uvx</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.10.2.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.10.2.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.10.2.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.10.2.dist-info/licenses/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.10.2.dist-info/licenses/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.10.7.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.10.7.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.10.7.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.10.7.dist-info/licenses/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.10.7.dist-info/licenses/LICENSE-MIT</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/uv/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/uv/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/uv/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -45,12 +45,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2026-02-21</Date>
-            <Version>0.10.2</Version>
+        <Update release="11">
+            <Date>2026-02-28</Date>
+            <Version>0.10.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Matthias Homann</Name>
+            <Email>palto@mailbox.org</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

This release series stabilizes the major v0.10.x branch, introducing filesystem optimizations for Linux and refining project resolution logic.

- Release notes:
  - [v0.10.7](https://github.com/astral-sh/uv/releases/tag/0.10.7)
  - [v0.10.6](https://github.com/astral-sh/uv/releases/tag/0.10.6)
  - [v0.10.5](https://github.com/astral-sh/uv/releases/tag/0.10.5)
  - [v0.10.4](https://github.com/astral-sh/uv/releases/tag/0.10.4)
  - [v0.10.3](https://github.com/astral-sh/uv/releases/tag/0.10.3)

**Test Plan**

- Run smoke tests defined in source
- Installed locally and run some commands.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
