### PR TITLE
jansson: Update to v2.15.0

### DIFF
--- a/packages/j/jansson/abi_symbols
+++ b/packages/j/jansson/abi_symbols
@@ -21,6 +21,7 @@ libjansson.so.4:json_dumps
 libjansson.so.4:json_equal
 libjansson.so.4:json_false
 libjansson.so.4:json_get_alloc_funcs
+libjansson.so.4:json_get_alloc_funcs2
 libjansson.so.4:json_integer
 libjansson.so.4:json_integer_set
 libjansson.so.4:json_integer_value
@@ -62,6 +63,7 @@ libjansson.so.4:json_real
 libjansson.so.4:json_real_set
 libjansson.so.4:json_real_value
 libjansson.so.4:json_set_alloc_funcs
+libjansson.so.4:json_set_alloc_funcs2
 libjansson.so.4:json_sprintf
 libjansson.so.4:json_string
 libjansson.so.4:json_string_length

--- a/packages/j/jansson/abi_symbols32
+++ b/packages/j/jansson/abi_symbols32
@@ -21,6 +21,7 @@ libjansson.so.4:json_dumps
 libjansson.so.4:json_equal
 libjansson.so.4:json_false
 libjansson.so.4:json_get_alloc_funcs
+libjansson.so.4:json_get_alloc_funcs2
 libjansson.so.4:json_integer
 libjansson.so.4:json_integer_set
 libjansson.so.4:json_integer_value
@@ -62,6 +63,7 @@ libjansson.so.4:json_real
 libjansson.so.4:json_real_set
 libjansson.so.4:json_real_value
 libjansson.so.4:json_set_alloc_funcs
+libjansson.so.4:json_set_alloc_funcs2
 libjansson.so.4:json_sprintf
 libjansson.so.4:json_string
 libjansson.so.4:json_string_length

--- a/packages/j/jansson/abi_used_symbols
+++ b/packages/j/jansson/abi_used_symbols
@@ -1,6 +1,8 @@
 libc.so.6:__assert_fail
 libc.so.6:__errno_location
+libc.so.6:__isoc23_strtoll
 libc.so.6:__snprintf_chk
+libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__vsnprintf_chk
 libc.so.6:close
@@ -11,15 +13,16 @@ libc.so.6:free
 libc.so.6:fwrite
 libc.so.6:getpid
 libc.so.6:gettimeofday
-libc.so.6:localeconv
 libc.so.6:malloc
 libc.so.6:memchr
 libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
+libc.so.6:memset
 libc.so.6:open
 libc.so.6:qsort
 libc.so.6:read
+libc.so.6:realloc
 libc.so.6:sched_yield
 libc.so.6:stdin
 libc.so.6:strchr
@@ -28,5 +31,4 @@ libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncpy
 libc.so.6:strtod
-libc.so.6:strtoll
 libc.so.6:write

--- a/packages/j/jansson/abi_used_symbols32
+++ b/packages/j/jansson/abi_used_symbols32
@@ -1,6 +1,8 @@
 libc.so.6:__assert_fail
 libc.so.6:__errno_location
+libc.so.6:__isoc23_strtoll
 libc.so.6:__snprintf_chk
+libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__vsnprintf_chk
 libc.so.6:close
@@ -11,15 +13,16 @@ libc.so.6:free
 libc.so.6:fwrite
 libc.so.6:getpid
 libc.so.6:gettimeofday
-libc.so.6:localeconv
 libc.so.6:malloc
 libc.so.6:memchr
 libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
+libc.so.6:memset
 libc.so.6:open
 libc.so.6:qsort
 libc.so.6:read
+libc.so.6:realloc
 libc.so.6:sched_yield
 libc.so.6:stdin
 libc.so.6:strchr
@@ -28,5 +31,4 @@ libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncpy
 libc.so.6:strtod
-libc.so.6:strtoll
 libc.so.6:write

--- a/packages/j/jansson/package.yml
+++ b/packages/j/jansson/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : jansson
-version    : '2.14'
-release    : 10
+version    : 2.15.0
+release    : 11
 source     :
-    - https://github.com/akheron/jansson/releases/download/v2.14/jansson-2.14.tar.bz2 : fba956f27c6ae56ce6dfd52fbf9d20254aad42821f74fa52f83957625294afb9
+    - https://github.com/akheron/jansson/releases/download/v2.15.0/jansson-2.15.0.tar.bz2 : a7eac7765000373165f9373eb748be039c10b2efc00be9af3467ec92357d8954
 homepage   : https://github.com/akheron/jansson
 license    : MIT
 component  : system.base
@@ -17,3 +17,5 @@ build      : |
     %make
 install    : |
     %make_install
+check      : |
+    make check

--- a/packages/j/jansson/pspec_x86_64.xml
+++ b/packages/j/jansson/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>jansson</Name>
         <Homepage>https://github.com/akheron/jansson</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.base</PartOf>
@@ -21,7 +21,7 @@
         <PartOf>system.base</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libjansson.so.4</Path>
-            <Path fileType="library">/usr/lib64/libjansson.so.4.14.0</Path>
+            <Path fileType="library">/usr/lib64/libjansson.so.4.15.0</Path>
         </Files>
     </Package>
     <Package>
@@ -31,11 +31,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">jansson</Dependency>
+            <Dependency release="11">jansson</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libjansson.so.4</Path>
-            <Path fileType="library">/usr/lib32/libjansson.so.4.14.0</Path>
+            <Path fileType="library">/usr/lib32/libjansson.so.4.15.0</Path>
         </Files>
     </Package>
     <Package>
@@ -45,8 +45,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">jansson-devel</Dependency>
-            <Dependency release="10">jansson-32bit</Dependency>
+            <Dependency release="11">jansson-devel</Dependency>
+            <Dependency release="11">jansson-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libjansson.so</Path>
@@ -60,7 +60,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">jansson</Dependency>
+            <Dependency release="11">jansson</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/jansson.h</Path>
@@ -70,12 +70,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2023-10-11</Date>
-            <Version>2.14</Version>
+        <Update release="11">
+            <Date>2026-03-01</Date>
+            <Version>2.15.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
   -  New features:
        - Add support for `realloc` by adding `json_set_alloc_funcs2`, `json_get_alloc_funcs2`
   - Fixes:
        - Optimize serialization
        - Fix docstrings in `hashtable.h`
   - Build
        -Use target-based cmake settings

**Test Plan**
Enabled and ran the test suite at build.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
