### PR TITLE
freetype2: Update to v2.14.2

### DIFF
--- a/packages/f/freetype2/package.yml
+++ b/packages/f/freetype2/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : freetype2
-version    : 2.14.1
-release    : 38
+version    : 2.14.2
+release    : 39
 source     :
-    - https://download.savannah.gnu.org/releases/freetype/freetype-2.14.1.tar.xz : 32427e8c471ac095853212a37aef816c60b42052d4d9e48230bab3bdf2936ccc
+    - https://download.savannah.gnu.org/releases/freetype/freetype-2.14.2.tar.xz : 4b62dcab4c920a1a860369933221814362e699e26f55792516d671e6ff55b5e1
 homepage   : https://freetype.org/
 license    :
     - FTL

--- a/packages/f/freetype2/pspec_x86_64.xml
+++ b/packages/f/freetype2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>freetype2</Name>
         <Homepage>https://freetype.org/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>FTL</License>
         <License>GPL-2.0-only</License>
@@ -22,7 +22,7 @@
         <PartOf>desktop.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libfreetype.so.6</Path>
-            <Path fileType="library">/usr/lib64/libfreetype.so.6.20.4</Path>
+            <Path fileType="library">/usr/lib64/libfreetype.so.6.20.5</Path>
             <Path fileType="data">/usr/share/licenses/freetype2/LICENSE.TXT</Path>
         </Files>
     </Package>
@@ -33,11 +33,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="38">freetype2</Dependency>
+            <Dependency release="39">freetype2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libfreetype.so.6</Path>
-            <Path fileType="library">/usr/lib32/libfreetype.so.6.20.4</Path>
+            <Path fileType="library">/usr/lib32/libfreetype.so.6.20.5</Path>
         </Files>
     </Package>
     <Package>
@@ -47,8 +47,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="38">freetype2-32bit</Dependency>
-            <Dependency release="38">freetype2-devel</Dependency>
+            <Dependency release="39">freetype2-32bit</Dependency>
+            <Dependency release="39">freetype2-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libfreetype.so</Path>
@@ -62,7 +62,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="38">freetype2</Dependency>
+            <Dependency release="39">freetype2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/freetype-config</Path>
@@ -128,12 +128,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="38">
-            <Date>2026-01-19</Date>
-            <Version>2.14.1</Version>
+        <Update release="39">
+            <Date>2026-03-02</Date>
+            <Version>2.14.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://sourceforge.net/projects/freetype/files/freetype2/2.14.2/)

**Security**

- CVE-2026-23865

**Test Plan**

- Installed. No drama.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
