### PR TITLE
clinfo: update to 3.0.25.02.14

### DIFF
--- a/packages/c/clinfo/package.yml
+++ b/packages/c/clinfo/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : clinfo
-version    : 3.0.23.01.25
-release    : 9
+version    : 3.0.25.02.14
+release    : 10
 source     :
-    - https://github.com/Oblomov/clinfo/archive/refs/tags/3.0.23.01.25.tar.gz : 6dcdada6c115873db78c7ffc62b9fc1ee7a2d08854a3bccea396df312e7331e3
+    - https://github.com/Oblomov/clinfo/archive/refs/tags/3.0.25.02.14.tar.gz : 48b77dc33315e6f760791a2984f98ea4bff28504ff37d460d8291585f49fcd3a
 license    : CC0-1.0
 component  : programming.tools
 homepage   : https://github.com/Oblomov/clinfo/
@@ -17,3 +17,4 @@ build      : |
 install    : |
     install -Dm 00755 clinfo $installdir/usr/bin/clinfo
     install -Dm 00644 man1/clinfo.1 $installdir/usr/share/man/man1/clinfo.1
+    %install_license LICENSE

--- a/packages/c/clinfo/pspec_x86_64.xml
+++ b/packages/c/clinfo/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>clinfo</Name>
         <Homepage>https://github.com/Oblomov/clinfo/</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>clintre</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>CC0-1.0</License>
         <PartOf>programming.tools</PartOf>
         <Summary xml:lang="en">Tool that enumerates all system OpenCL platform and device properties</Summary>
         <Description xml:lang="en">A simple OpenCL application that enumerates all possible platform and device properties on the system. Inspired by AMD&apos;s program of the same name, it is coded in pure C99 and it tries to output all possible information, including that provided by platform-specific extensions, and not to crash on platform-unsupported properties (e.g. 1.2 properties on 1.1 platforms).
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>clinfo</Name>
@@ -21,16 +21,17 @@
         <PartOf>programming.tools</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/clinfo</Path>
-            <Path fileType="man">/usr/share/man/man1/clinfo.1</Path>
+            <Path fileType="data">/usr/share/licenses/clinfo/LICENSE</Path>
+            <Path fileType="man">/usr/share/man/man1/clinfo.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2023-04-26</Date>
-            <Version>3.0.23.01.25</Version>
+        <Update release="10">
+            <Date>2026-03-03</Date>
+            <Version>3.0.25.02.14</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>clintre</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION


**Summary**

Bugfixes:
- Fix Valgrind invalid read in platform device output

Other:
- Added License macro


**Test Plan**

Test install and run clinfo
Checked version

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
