### PR TITLE
solseek: Update to 0.12.1

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 0.12.0
-release    : 17
+version    : 0.12.1
+release    : 18
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v0.12.0.tar.gz : fb8cad23b6d06a8a1c1dc4318fe7fa8f027b65be708a19f2ea2fcd1196a2c5b6
+    - https://github.com/clintre/solseek/archive/refs/tags/v0.12.1.tar.gz : 7c6669241c798fcdeb49cc1c4dec6495e6ada12b26d6dbfb2f04d301fb84a725
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -59,9 +59,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2026-03-03</Date>
-            <Version>0.12.0</Version>
+        <Update release="18">
+            <Date>2026-03-04</Date>
+            <Version>0.12.1</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION

**Summary**

Bugfixes:
- Correct flatpak cache check, causing installed flatpaks not to be found

Full release notes:
- [0.12.1](https://github.com/clintre/solseek/compare/v0.11.0...v0.12.1)


**Test Plan**

Test to make sure installed flatpaks were properly handled

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
