### PR TITLE
halloy: Update to v2026.4

### DIFF
--- a/packages/h/halloy/package.yml
+++ b/packages/h/halloy/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : halloy
-version    : '2026.3'
-release    : 10
+version    : '2026.4'
+release    : 11
 source     :
-    - https://github.com/squidowl/halloy/archive/refs/tags/2026.3.tar.gz : a6e9519f800e6dc7bcab0b4f3678c5a89c11a7ae2de2bafe1dce430e9351f946
+    - https://github.com/squidowl/halloy/archive/refs/tags/2026.4.tar.gz : fa9a95668717677de7f30c98b019b74451fdd2e5b0287a56574d7e953ef5c800
 homepage   : https://halloy.squidowl.org/
 license    : GPL-3.0-or-later
 component  : network.im

--- a/packages/h/halloy/pspec_x86_64.xml
+++ b/packages/h/halloy/pspec_x86_64.xml
@@ -36,9 +36,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2026-02-25</Date>
-            <Version>2026.3</Version>
+        <Update release="11">
+            <Date>2026-03-03</Date>
+            <Version>2026.4</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://github.com/squidowl/halloy/releases/tag/2026.4)

**Test Plan**

- Join a room

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
