### PR TITLE
eopkg: Update to v4.4.2

### DIFF
--- a/packages/e/eopkg/package.yml
+++ b/packages/e/eopkg/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : eopkg
-version    : 4.4.1
-release    : 34
+version    : 4.4.2
+release    : 35
 source     :
-    - https://github.com/getsolus/eopkg/archive/refs/tags/v4.4.1.tar.gz : 945b2a12971dcec45a049b004e30187b1d362aee4f37b7559f0f57831e6483a8
+    - https://github.com/getsolus/eopkg/archive/refs/tags/v4.4.2.tar.gz : bc2073bdad9f011aeb865ceb7e5e8ed5f5f5f6b6227465099d93913e84d1c603
     - git|https://github.com/getsolus/PackageKit.git : 9b0f17c1ba6addc1c85bff34b64efad6a905ca50
 homepage   : https://github.com/getsolus/eopkg
 license    : GPL-2.0-or-later

--- a/packages/e/eopkg/pspec_x86_64.xml
+++ b/packages/e/eopkg/pspec_x86_64.xml
@@ -3,7 +3,7 @@
         <Name>eopkg</Name>
         <Homepage>https://github.com/getsolus/eopkg</Homepage>
         <Packager>
-            <Name>Hans Kelson</Name>
+            <Name>Hans K</Name>
             <Email>hans@communitycomputing.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
@@ -463,11 +463,11 @@
         </Files>
     </Package>
     <History>
-        <Update release="34">
-            <Date>2026-01-09</Date>
-            <Version>4.4.1</Version>
+        <Update release="35">
+            <Date>2026-03-04</Date>
+            <Version>4.4.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Hans Kelson</Name>
+            <Name>Hans K</Name>
             <Email>hans@communitycomputing.net</Email>
         </Update>
     </History>


### PR DESCRIPTION
**Summary**
 - Fixes the errors. As in, makes the errors work again. Changelog [here](https://github.com/getsolus/eopkg/releases/tag/v4.4.2)

**Test Plan**
- Don't need to describe how to reproduce the issues this fixes. **we all know.**
- Build and install eopkg from this PR.
- Try some things that create errors (like Joey's example): `sudo eopkg it dannae-exist`.
- See that you get a real error now. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
