### PR TITLE
xed: Update to v3.8.9

### DIFF
--- a/packages/x/xed/package.yml
+++ b/packages/x/xed/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : xed
-version    : 3.8.7
-release    : 8
+version    : 3.8.9
+release    : 9
 source     :
-    - https://github.com/linuxmint/xed/archive/refs/tags/3.8.7.tar.gz : 90af3453844ca5c835da2467025737b8eaa5d4c61a6066dcb3e347a26e2fe1a4
+    - https://github.com/linuxmint/xed/archive/refs/tags/3.8.9.tar.gz : 59b7e75297b55a8330c89ff79b31fbd3129818b2149a7f13721d6333b442186a
 homepage   : https://github.com/linuxmint/xed
 license    : GPL-2.0-or-later
 component  : desktop

--- a/packages/x/xed/pspec_x86_64.xml
+++ b/packages/x/xed/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xed</Name>
         <Homepage>https://github.com/linuxmint/xed</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop</PartOf>
@@ -321,7 +321,7 @@ xed supports most standard editing features, plus several not found in your aver
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="8">xed</Dependency>
+            <Dependency release="9">xed</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/xed/xed-app-activatable.h</Path>
@@ -348,12 +348,12 @@ xed supports most standard editing features, plus several not found in your aver
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2025-12-13</Date>
-            <Version>3.8.7</Version>
+        <Update release="9">
+            <Date>2026-03-04</Date>
+            <Version>3.8.9</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Enhancements:

 - Update translations
 - Lighten xed theme right-margin line to improve visibility

Release notes can be found [here](https://github.com/linuxmint/xed/releases/tag/3.8.9).

Fixes getsolus/packages#8084

**Test Plan**

- Installed the resulting .eopkg file locally.
- Opened the application and verified that it works.


**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
