### PR TITLE
repo_data: Deprecate cura and curaengine

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -3085,5 +3085,19 @@
 		<Package>vinagre-dbginfo</Package>
 		<Package>lime3ds</Package>
 		<Package>lime3ds-dbginfo</Package>
+		<Package>cura</Package>
+		<Package>curaengine</Package>
+		<Package>curaengine-dbginfo</Package>
+		<Package>fdm-materials</Package>
+		<Package>libarcus-dbginfo</Package>
+		<Package>libarcus-devel</Package>
+		<Package>libarcus</Package>
+		<Package>libsavitar-dbginfo</Package>
+		<Package>libsavitar-devel</Package>
+		<Package>libsavitar</Package>
+		<Package>python-arcus</Package>
+		<Package>python-savitar</Package>
+		<Package>python-shapely</Package>
+		<Package>python-uranium</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -4235,5 +4235,20 @@
 		<Package>lime3ds</Package>
 		<Package>lime3ds-dbginfo</Package>
 
+		<!-- Constant build issues -->
+		<Package>cura</Package>
+		<Package>curaengine</Package>
+		<Package>curaengine-dbginfo</Package>
+		<Package>fdm-materials</Package>
+		<Package>libarcus-dbginfo</Package>
+		<Package>libarcus-devel</Package>
+		<Package>libarcus</Package>
+		<Package>libsavitar-dbginfo</Package>
+		<Package>libsavitar-devel</Package>
+		<Package>libsavitar</Package>
+		<Package>python-arcus</Package>
+		<Package>python-savitar</Package>
+		<Package>python-shapely</Package>
+		<Package>python-uranium</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
**Summary**

Too many build issues. Solus will no longer provide this package.

Usage of the flatpak or AppImage is recommended.

Resolves getsolus/packages#924

**Test Plan**

N/A

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
