### PR TITLE
fzf: Update to 0.70.0

### DIFF
--- a/packages/f/fzf/package.yml
+++ b/packages/f/fzf/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : fzf
-version    : 0.68.0
-release    : 49
+version    : 0.70.0
+release    : 50
 source     :
-    - git|https://github.com/junegunn/fzf : v0.68.0
+    - git|https://github.com/junegunn/fzf : v0.70.0
 homepage   : https://github.com/junegunn/fzf
 license    : MIT
 component  : system.utils
@@ -24,8 +24,10 @@ install    : |
     install -Dm00644 man/man1/fzf-tmux.1 $installdir/usr/share/man/man1/fzf-tmux.1
     install -Dm00644 shell/completion.bash $installdir/usr/share/bash-completion/completions/fzf
     install -Dm00644 shell/completion.zsh $installdir/usr/share/zsh/site-functions/_fzf
+    install -Dm00644 shell/completion.fish $installdir/usr/share/fish/vendor_completions.d/fzf.fish
     install -Dm00644 plugin/fzf.vim $installdir/usr/share/vim/vimfiles/plugin/fzf.vim
     install -dm00755 $installdir/usr/share/nvim/plugin
     ln -sf /usr/share/vim/vimfiles/plugin/fzf.vim $installdir/usr/share/nvim/plugin/fzf.vim
     install -dm00755 $installdir/usr/share/fzf
     install -Dm00644 shell/key-bindings.* $installdir/usr/share/fzf
+    %install_license LICENSE

--- a/packages/f/fzf/pspec_x86_64.xml
+++ b/packages/f/fzf/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>fzf</Name>
         <Homepage>https://github.com/junegunn/fzf</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>clintre</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -23,9 +23,11 @@
             <Path fileType="executable">/usr/bin/fzf</Path>
             <Path fileType="executable">/usr/bin/fzf-tmux</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/fzf</Path>
+            <Path fileType="data">/usr/share/fish/vendor_completions.d/fzf.fish</Path>
             <Path fileType="data">/usr/share/fzf/key-bindings.bash</Path>
             <Path fileType="data">/usr/share/fzf/key-bindings.fish</Path>
             <Path fileType="data">/usr/share/fzf/key-bindings.zsh</Path>
+            <Path fileType="data">/usr/share/licenses/fzf/LICENSE</Path>
             <Path fileType="man">/usr/share/man/man1/fzf-tmux.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/fzf.1.zst</Path>
             <Path fileType="data">/usr/share/nvim/plugin/fzf.vim</Path>
@@ -34,12 +36,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="49">
-            <Date>2026-02-22</Date>
-            <Version>0.68.0</Version>
+        <Update release="50">
+            <Date>2026-03-05</Date>
+            <Version>0.70.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>clintre</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION

**Summary**

Bugfixes:
- Fixed nth attribute merge order to respect precedence hierarchy

Enhancements:
- Added change-with-nth action for dynamically changing the --with-nth option
- Added change-header-lines action for dynamically changing the --header-lines option
- Performance improvements (1.3x to 1.9x faster filtering depending on query)
- bash: Replaced printf with builtin printf to bypass local indirections

Full release notes:
- [0.70.0](https://github.com/junegunn/fzf/compare/v0.68.0...v0.70.0)


**Test Plan**

Updated on test VM and ran through functionality and with Solseek

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
