### PR TITLE
python-markdown: Update to v3.10.2

### DIFF
--- a/packages/py/python-markdown/package.yml
+++ b/packages/py/python-markdown/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-markdown
-version    : '3.7'
-release    : 15
+version    : 3.10.2
+release    : 16
 source     :
-    - https://github.com/Python-Markdown/markdown/archive/refs/tags/3.7.tar.gz : c736153e1c93246ec566d960d614abe308c6f5b80e89697105076af507bc47b3
+    - https://github.com/Python-Markdown/markdown/archive/refs/tags/3.10.2.tar.gz : 9f4cb524094839583fdaf7480e5da9b9fe92c45bc8c58286155e2d14b74d4f1e
 homepage   : https://github.com/Python-Markdown/markdown
 license    : BSD-3-Clause
 component  : programming.python

--- a/packages/py/python-markdown/pspec_x86_64.xml
+++ b/packages/py/python-markdown/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-markdown</Name>
         <Homepage>https://github.com/Python-Markdown/markdown</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -21,12 +21,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/markdown_py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown-3.7.dist-info/LICENSE.md</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown-3.7.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown-3.7.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown-3.7.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown-3.7.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown-3.7.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown-3.10.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown-3.10.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown-3.10.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown-3.10.2.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown-3.10.2.dist-info/licenses/LICENSE.md</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown-3.10.2.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/markdown/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/markdown/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/markdown/__meta__.py</Path>
@@ -129,12 +129,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2025-05-17</Date>
-            <Version>3.7</Version>
+        <Update release="16">
+            <Date>2026-03-06</Date>
+            <Version>3.10.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/Python-Markdown/markdown/blob/3.10.2/docs/changelog.md).

**Security**
- CVE-2025-69534

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Read the Help book thing in Calibre.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
