### PR TITLE
rio: Fix config editor opening

### DIFF
--- a/packages/r/rio/files/0002-Fix-shell-args-ignored-when-use-fork-true.patch
+++ b/packages/r/rio/files/0002-Fix-shell-args-ignored-when-use-fork-true.patch
@@ -1,0 +1,91 @@
+Fix configured arguments for spawned shells being ignored when use-fork = true.
+When opening the config editor (e.g. Ctrl+Shift+,), the editor would open with
+a scratch buffer instead of the config file. Wire shell args through
+create_pty_with_fork and default_shell_command.
+
+See: https://github.com/raphamorim/rio/pull/1303
+
+--- a/frontends/rioterm/src/context/mod.rs	2026-03-03 21:18:59.400647428 -0500
++++ b/frontends/rioterm/src/context/mod.rs	2026-03-03 21:19:10.065204541 -0500
+@@ -235,6 +235,7 @@
+                 tracing::info!("rio -> teletypewriter: create_pty_with_fork");
+                 pty = match create_pty_with_fork(
+                     &Cow::Borrowed(&config.shell.program),
++                    &config.shell.args,
+                     cols,
+                     rows,
+                 ) {
+
+--- a/teletypewriter/examples/spawn.rs	2026-03-03 21:18:59.412351275 -0500
++++ b/teletypewriter/examples/spawn.rs	2026-03-03 21:19:11.026211479 -0500
+@@ -10,7 +10,7 @@
+     use teletypewriter::{create_pty_with_fork, ProcessReadWrite, Pty};
+ 
+     let shell = Cow::Borrowed("bash");
+-    let mut process: Pty = create_pty_with_fork(&shell, 80, 25)?;
++    let mut process: Pty = create_pty_with_fork(&shell, &[], 80, 25)?;
+ 
+     process.writer().write_all(b"1").unwrap();
+     process.writer().write_all(b"2").unwrap();
+
+--- a/teletypewriter/src/unix/mod.rs	2026-03-03 21:18:59.412306565 -0500
++++ b/teletypewriter/src/unix/mod.rs	2026-03-03 21:19:08.668194456 -0500
+@@ -61,29 +61,19 @@
+     fn ptsname(fd: *mut libc::c_int) -> *mut libc::c_char;
+ }
+ 
+-#[cfg(target_os = "macos")]
+-fn default_shell_command(shell: &str) {
+-    let command_shell_string = CString::new(shell).unwrap();
+-    let command_pointer = command_shell_string.as_ptr();
+-    let args = CString::new("--login").unwrap();
+-    let args_pointer = args.as_ptr();
+-    unsafe {
+-        libc::execvp(command_pointer, vec![args_pointer].as_ptr());
++fn default_shell_command(shell: &str, args: &[String]) {
++    let program = CString::new(shell).unwrap();
++    let c_args: Vec<CString> = args
++        .iter()
++        .filter_map(|a| CString::new(a.as_str()).ok())
++        .collect();
++    let mut argv: Vec<*const libc::c_char> = vec![program.as_ptr()];
++    for c in &c_args {
++        argv.push(c.as_ptr());
+     }
+-}
+-
+-#[cfg(not(target_os = "macos"))]
+-fn default_shell_command(shell: &str) {
+-    let command_shell_string = CString::new(shell).unwrap();
+-    let command_pointer = command_shell_string.as_ptr();
+-    // let home = std::env::var("HOME").unwrap();
+-    // let args = CString::new(home).unwrap();
+-    // let args_pointer = args.as_ptr() as *const i8;
++    argv.push(std::ptr::null());
+     unsafe {
+-        libc::execvp(
+-            command_pointer,
+-            vec![command_pointer, std::ptr::null()].as_ptr(),
+-        );
++        libc::execvp(program.as_ptr(), argv.as_ptr());
+     }
+ }
+ 
+@@ -621,7 +611,7 @@
+ ///
+ /// It returns two [`Pty`] along with respective process name [`String`] and process id (`libc::pid_`)
+ ///
+-pub fn create_pty_with_fork(shell: &str, columns: u16, rows: u16) -> Result<Pty, Error> {
++pub fn create_pty_with_fork(shell: &str, args: &[String], columns: u16, rows: u16) -> Result<Pty, Error> {
+     let mut main = 0;
+     let winsize = Winsize {
+         ws_row: rows as libc::c_ushort,
+@@ -657,7 +647,7 @@
+         )
+     } {
+         0 => {
+-            default_shell_command(shell_program);
++            default_shell_command(shell_program, args);
+             Err(Error::other(format!(
+                 "forkpty has reach unreachable with {shell_program}"
+             )))

--- a/packages/r/rio/package.yml
+++ b/packages/r/rio/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : rio
 version    : 0.2.37
-release    : 3
+release    : 4
 source     :
     - https://github.com/raphamorim/rio/archive/refs/tags/v0.2.37.tar.gz : f52bcd0fb3c669cae016c614a77a95547c2769e6a98a17d7bbc703b6e72af169
 homepage   : https://rioterm.com
@@ -21,6 +21,7 @@ builddeps  :
     - rust
 setup      : |
     %patch -p1 -i $pkgfiles/0001-Default-config-editor-to-nano.patch
+    %patch -p1 -i $pkgfiles/0002-Fix-shell-args-ignored-when-use-fork-true.patch
 
     # Generate man pages
     for fname in rio.1 rio.5 rio-bindings.5; do

--- a/packages/r/rio/pspec_x86_64.xml
+++ b/packages/r/rio/pspec_x86_64.xml
@@ -31,8 +31,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2026-02-13</Date>
+        <Update release="4">
+            <Date>2026-03-04</Date>
             <Version>0.2.37</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>


### PR DESCRIPTION
**Summary**
- Apply patch for shell args with use-fork

**Test Plan**

Use ```Ctrl+Shift+,``` and see that it opens correct config file directory in nano. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
