### PR TITLE
msedit: Fix ICU SONAME

### DIFF
--- a/packages/m/msedit/files/0001-Use-versioned-ICU-SONAMEs.patch
+++ b/packages/m/msedit/files/0001-Use-versioned-ICU-SONAMEs.patch
@@ -2,7 +2,7 @@
 +++ b/src/sys/unix.rs
 @@ -267,1 +267,1 @@
 -    unsafe { load_library(c"libicuuc.so") }
-+    unsafe { load_library(c"libicuuc.so.76") }
++    unsafe { load_library(c"libicuuc.so.78") }
 @@ -275,1 +275,1 @@
 -    unsafe { load_library(c"libicui18n.so") }
-+    unsafe { load_library(c"libicui18n.so.76") }
++    unsafe { load_library(c"libicui18n.so.78") }

--- a/packages/m/msedit/package.yml
+++ b/packages/m/msedit/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : msedit
 version    : 1.2.1
-release    : 3
+release    : 4
 source     :
     - https://github.com/microsoft/edit/archive/refs/tags/v1.2.1.tar.gz : 41c719b08212fa4ab6e434a53242b2718ba313e8d24d090f244bb857d6a9d0fd
 homepage   : https://github.com/microsoft/edit

--- a/packages/m/msedit/pspec_x86_64.xml
+++ b/packages/m/msedit/pspec_x86_64.xml
@@ -35,8 +35,8 @@ easily use.
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2026-02-09</Date>
+        <Update release="4">
+            <Date>2026-03-09</Date>
             <Version>1.2.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>


### PR DESCRIPTION
**Summary**
- Update ICU SONAME to ICU 78

**Test Plan**

Tested against updated libicu78 and replace works in ```msedit```

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
