### PR TITLE
solseek: Update to 1.0.0

### DIFF
--- a/packages/s/solseek/MAINTAINERS.md
+++ b/packages/s/solseek/MAINTAINERS.md
@@ -1,5 +1,5 @@
 This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
 
-- Name Surname
+- Clint Eschberger
   - Matrix: @clintre:matrix.org
   - Email: clint@original-syn.com

--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 0.12.1
-release    : 18
+version    : 1.0.0
+release    : 19
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v0.12.1.tar.gz : 7c6669241c798fcdeb49cc1c4dec6495e6ada12b26d6dbfb2f04d301fb84a725
+    - https://github.com/clintre/solseek/archive/refs/tags/v1.0.0.tar.gz : 8b47d3e5c4ce9294fa9eebeebfad778c38e8334e28473700495295090921f49a
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils
@@ -14,6 +14,7 @@ rundeps    :
     - appstream
     - font-firacode-nerd
     - fzf
+    - packagekit
 install    : |-
     install -Dm00755 $workdir/package/bin/solseek $installdir/usr/bin/solseek
     install -dm00755 $installdir/usr/share

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -32,6 +32,7 @@
             <Path fileType="data">/usr/share/solseek/core/defaults</Path>
             <Path fileType="data">/usr/share/solseek/core/menus</Path>
             <Path fileType="data">/usr/share/solseek/core/pkg_functions</Path>
+            <Path fileType="data">/usr/share/solseek/lang/de.ini</Path>
             <Path fileType="data">/usr/share/solseek/lang/en.ini</Path>
             <Path fileType="data">/usr/share/solseek/lang/es.ini</Path>
             <Path fileType="data">/usr/share/solseek/lang/fr.ini</Path>
@@ -45,6 +46,15 @@
             <Path fileType="data">/usr/share/solseek/modules/panel-help</Path>
             <Path fileType="data">/usr/share/solseek/modules/panel-pkginfo</Path>
             <Path fileType="data">/usr/share/solseek/modules/tools</Path>
+            <Path fileType="data">/usr/share/solseek/modules/ui_appstream_catalog</Path>
+            <Path fileType="data">/usr/share/solseek/modules/ui_appstream_category</Path>
+            <Path fileType="data">/usr/share/solseek/modules/ui_drivers</Path>
+            <Path fileType="data">/usr/share/solseek/modules/ui_eopkg</Path>
+            <Path fileType="data">/usr/share/solseek/modules/ui_flatpak</Path>
+            <Path fileType="data">/usr/share/solseek/modules/ui_main</Path>
+            <Path fileType="data">/usr/share/solseek/modules/ui_rollback</Path>
+            <Path fileType="data">/usr/share/solseek/modules/ui_tools</Path>
+            <Path fileType="data">/usr/share/solseek/modules/ui_update</Path>
             <Path fileType="data">/usr/share/solseek/modules/update-runner</Path>
             <Path fileType="data">/usr/share/solseek/solseek-uc.service</Path>
             <Path fileType="data">/usr/share/solseek/solseek-uc.timer</Path>
@@ -59,9 +69,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2026-03-04</Date>
-            <Version>0.12.1</Version>
+        <Update release="19">
+            <Date>2026-03-09</Date>
+            <Version>1.0.0</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION

**Summary**

This is the official release of 1.0.0! Thanks to the community for the support and contributions, now up to 6 languages.


Bugfixes:
- Fixed issue where the first two items in the eopkg installed list were not showing. 
- Fixed Flatpak cache issue where the wrong cache file was checked, causing a small performance hit. 
- Fixed typos in en.ini

Enhancements
- Add German language support, fix typos in en.ini by 
- Backend: all code is not modularized, allowing for easier maintenance as well as routing for future moss support


**Full Changelog**: https://github.com/clintre/solseek/compare/v0.12.1...v1.0.0


**Test Plan**

Installed in VM lab and tested basic features and new language

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
