### PR TITLE
fcitx5: Fix deps and stateless

### DIFF
--- a/packages/f/fcitx5/package.yml
+++ b/packages/f/fcitx5/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : fcitx5
 version    : 5.1.17
-release    : 2
+release    : 3
 source     :
     - https://github.com/fcitx/fcitx5/archive/refs/tags/5.1.17.tar.gz : 84a927fa5f3a3c713c9388a126a2e9b516f6ca7e6402b140cd82ff6614e61eaa
 homepage   : https://github.com/fcitx/fcitx5
@@ -32,6 +32,8 @@ builddeps  :
     - pkgconfig(xkeyboard-config)
     - extra-cmake-modules
 rundeps    :
+    - devel :
+        - fcitx5-libs
     - fcitx5-libs
 setup      : |
     %cmake_ninja
@@ -39,9 +41,14 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license LICENSES/*
     install -Dm00644 ${pkgfiles}/fcitx5.sh ${installdir}/usr/share/defaults/etc/profile.d/fcitx5.sh
 
-    %install_license LICENSES/*
+    # Fix paths for stateless
+    install -Dm00644 ${installdir}/etc/xdg/autostart/org.fcitx.Fcitx5.desktop ${installdir}/usr/share/xdg/autostart/org.fcitx.Fcitx5.desktop
+    install -Dm00644 ${installdir}/etc/xdg/Xwayland-session.d/20-fcitx-x11 ${installdir}/usr/share/xdg/Xwayland-session.d/20-fcitx-x11
+
+    rm -rf ${installdir}/etc
 check     : |
     %ninja_check
 conflicts :

--- a/packages/f/fcitx5/pspec_x86_64.xml
+++ b/packages/f/fcitx5/pspec_x86_64.xml
@@ -20,11 +20,9 @@
 </Description>
         <PartOf>desktop.core</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">fcitx5-libs</Dependency>
+            <Dependency release="3">fcitx5-libs</Dependency>
         </RuntimeDependencies>
         <Files>
-            <Path fileType="config">/etc/xdg/Xwayland-session.d/20-fcitx-x11</Path>
-            <Path fileType="config">/etc/xdg/autostart/org.fcitx.Fcitx5.desktop</Path>
             <Path fileType="executable">/usr/bin/fcitx5</Path>
             <Path fileType="executable">/usr/bin/fcitx5-configtool</Path>
             <Path fileType="executable">/usr/bin/fcitx5-diagnose</Path>
@@ -310,6 +308,8 @@
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/fcitx5.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/fcitx5.mo</Path>
             <Path fileType="data">/usr/share/metainfo/org.fcitx.Fcitx5.metainfo.xml</Path>
+            <Path fileType="data">/usr/share/xdg/Xwayland-session.d/20-fcitx-x11</Path>
+            <Path fileType="data">/usr/share/xdg/autostart/org.fcitx.Fcitx5.desktop</Path>
         </Files>
         <Conflicts>
             <Package>fcitx</Package>
@@ -322,7 +322,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">fcitx5</Dependency>
+            <Dependency release="3">fcitx5</Dependency>
+            <Dependency releaseFrom="3">fcitx5-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/Fcitx5/Config/fcitx-config/configuration.h</Path>
@@ -492,7 +493,7 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
+        <Update release="3">
             <Date>2026-03-09</Date>
             <Version>5.1.17</Version>
             <Comment>Packaging update</Comment>


### PR DESCRIPTION
**Summary**
- Move files out of `/etc`
- Make -devel package depend on libs package

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

It builds.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
