### PR TITLE
nova-dock: Update to v0.2.0

### DIFF
--- a/packages/n/nova-dock/abi_used_symbols
+++ b/packages/n/nova-dock/abi_used_symbols
@@ -2,7 +2,6 @@ libc.so.6:__fprintf_chk
 libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__stack_chk_fail
-libc.so.6:fwrite
 libc.so.6:stderr
 libc.so.6:strlen
 libc.so.6:strstr
@@ -245,15 +244,16 @@ libgtk-3.so.0:gtk_label_set_justify
 libgtk-3.so.0:gtk_label_set_max_width_chars
 libgtk-3.so.0:gtk_label_set_use_markup
 libgtk-3.so.0:gtk_link_button_new_with_label
+libgtk-3.so.0:gtk_list_box_get_row_at_index
 libgtk-3.so.0:gtk_list_box_new
+libgtk-3.so.0:gtk_list_box_row_get_index
+libgtk-3.so.0:gtk_list_box_select_row
 libgtk-3.so.0:gtk_list_box_set_selection_mode
 libgtk-3.so.0:gtk_menu_item_new_with_label
 libgtk-3.so.0:gtk_menu_new
 libgtk-3.so.0:gtk_menu_popup_at_pointer
 libgtk-3.so.0:gtk_menu_shell_append
 libgtk-3.so.0:gtk_message_dialog_new
-libgtk-3.so.0:gtk_notebook_append_page
-libgtk-3.so.0:gtk_notebook_new
 libgtk-3.so.0:gtk_range_get_value
 libgtk-3.so.0:gtk_range_set_value
 libgtk-3.so.0:gtk_scale_new_with_range
@@ -269,6 +269,11 @@ libgtk-3.so.0:gtk_show_uri_on_window
 libgtk-3.so.0:gtk_spin_button_get_value
 libgtk-3.so.0:gtk_spin_button_new_with_range
 libgtk-3.so.0:gtk_spin_button_set_value
+libgtk-3.so.0:gtk_stack_add_named
+libgtk-3.so.0:gtk_stack_new
+libgtk-3.so.0:gtk_stack_set_transition_duration
+libgtk-3.so.0:gtk_stack_set_transition_type
+libgtk-3.so.0:gtk_stack_set_visible_child_name
 libgtk-3.so.0:gtk_style_context_add_class
 libgtk-3.so.0:gtk_style_context_add_provider_for_screen
 libgtk-3.so.0:gtk_switch_get_active
@@ -277,7 +282,6 @@ libgtk-3.so.0:gtk_switch_set_active
 libgtk-3.so.0:gtk_widget_destroy
 libgtk-3.so.0:gtk_widget_get_allocated_height
 libgtk-3.so.0:gtk_widget_get_allocated_width
-libgtk-3.so.0:gtk_widget_get_mapped
 libgtk-3.so.0:gtk_widget_get_style_context
 libgtk-3.so.0:gtk_widget_get_visible
 libgtk-3.so.0:gtk_widget_get_window
@@ -335,6 +339,7 @@ libwnck-3.so.0:wnck_screen_get_active_workspace
 libwnck-3.so.0:wnck_screen_get_default
 libwnck-3.so.0:wnck_screen_get_windows
 libwnck-3.so.0:wnck_screen_toggle_showing_desktop
+libwnck-3.so.0:wnck_set_client_type
 libwnck-3.so.0:wnck_window_activate
 libwnck-3.so.0:wnck_window_close
 libwnck-3.so.0:wnck_window_get_application

--- a/packages/n/nova-dock/package.yml
+++ b/packages/n/nova-dock/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : nova-dock
-version    : 0.1.3
-release    : 1
+version    : 0.2.0
+release    : 2
 source     :
-    - https://github.com/novik133/NovaDock/archive/refs/tags/v0.1.3.tar.gz : eedb58db26c683695f24e622fad680543a03b17a760924c8ca6fe93cce72f4b7
+    - https://github.com/novik133/NovaDock/archive/refs/tags/v0.2.0.tar.gz : e604d7a2da77ccbd7cd67d49abf8cc82bff6e995d3a5e74d2c20ed4826fb434a
 homepage   : https://github.com/novik133/NovaDock
 license    : GPL-3.0-or-later
 component  : desktop.xfce
@@ -11,11 +11,11 @@ summary    : Modern XFCE4 dock & launchpad
 description: |
     Modern XFCE4 dock & launchpad with magnification effects, plugin support, and custom themes. Written in Vala, powered by GTK3 and libwnck.
 builddeps  :
-  - pkgconfig(gtk+-3.0)
-  - pkgconfig(gtk-layer-shell-0)
-  - pkgconfig(keybinder-3.0)
-  - pkgconfig(libwnck-3.0)
-  - vala
+    - pkgconfig(gtk+-3.0)
+    - pkgconfig(gtk-layer-shell-0)
+    - pkgconfig(keybinder-3.0)
+    - pkgconfig(libwnck-3.0)
+    - vala
 setup      : |
     %meson_configure
 build      : |

--- a/packages/n/nova-dock/pspec_x86_64.xml
+++ b/packages/n/nova-dock/pspec_x86_64.xml
@@ -28,9 +28,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2026-02-18</Date>
-            <Version>0.1.3</Version>
+        <Update release="2">
+            <Date>2026-03-11</Date>
+            <Version>0.2.0</Version>
             <Comment>Packaging update</Comment>
             <Name>SnowsSky</Name>
             <Email>snowsky473@gmail.com</Email>


### PR DESCRIPTION
**Summary**
- Resolves a bug with auto hide, + new features. 
- Release notes can be found [here](https://github.com/novik133/NovaDock/releases/tag/v0.2.0).

**Test Plan**

Main utility tested.

**Checklist**

- [x] Package was built and tested against unstable
- [x] Basic usage tested
- [x] AutoHide working  
- [ ] This change could gainfully be listed in the weekly sync notes once merged  
