### PR TITLE
libssh: Update to v0.11.4

### DIFF
--- a/packages/l/libssh/abi_used_symbols
+++ b/packages/l/libssh/abi_used_symbols
@@ -35,6 +35,7 @@ libc.so.6:execv
 libc.so.6:exit
 libc.so.6:fclose
 libc.so.6:fcntl
+libc.so.6:fdopen
 libc.so.6:feof
 libc.so.6:ferror
 libc.so.6:fflush
@@ -108,6 +109,7 @@ libc.so.6:recv
 libc.so.6:rmdir
 libc.so.6:send
 libc.so.6:setsockopt
+libc.so.6:shutdown
 libc.so.6:signal
 libc.so.6:snprintf
 libc.so.6:socket

--- a/packages/l/libssh/package.yml
+++ b/packages/l/libssh/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libssh
-version    : 0.11.3
-release    : 18
+version    : 0.11.4
+release    : 19
 source     :
-    - https://www.libssh.org/files/0.11/libssh-0.11.3.tar.xz : 7d8a1361bb094ec3f511964e78a5a4dba689b5986e112afabe4f4d0d6c6125c3
+    - https://www.libssh.org/files/0.11/libssh-0.11.4.tar.xz : 002ac320e3d66c9e100ec6576e3e84aa0c48949efde3bf5b40a2802992297701
 homepage   : https://www.libssh.org/
 license    : LGPL-2.1-or-later
 component  : programming.library
@@ -18,6 +18,7 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING
 check      : |
     unset LD_PRELOAD
     %ninja_check

--- a/packages/l/libssh/pspec_x86_64.xml
+++ b/packages/l/libssh/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libssh</Name>
         <Homepage>https://www.libssh.org/</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>programming.library</PartOf>
@@ -21,7 +21,8 @@
         <PartOf>programming.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libssh.so.4</Path>
-            <Path fileType="library">/usr/lib64/libssh.so.4.10.3</Path>
+            <Path fileType="library">/usr/lib64/libssh.so.4.10.4</Path>
+            <Path fileType="data">/usr/share/licenses/libssh/COPYING</Path>
         </Files>
     </Package>
     <Package>
@@ -31,7 +32,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="18">libssh</Dependency>
+            <Dependency release="19">libssh</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libssh/callbacks.h</Path>
@@ -51,12 +52,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2025-09-13</Date>
-            <Version>0.11.3</Version>
+        <Update release="19">
+            <Date>2026-03-11</Date>
+            <Version>0.11.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- libssh-2026-sftp-extensions: Read buffer overrun when handling SFTP extensions
- Stability and compatibility improvements of ProxyJump

**Security**

- CVE-2026-0965
- CVE-2026-0966
- CVE-2026-0967
- CVE-2026-0968

**Test Plan**

- Built wireshark

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
