### PR TITLE
solseek: Update to 1.0.1

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 1.0.0
-release    : 19
+version    : 1.0.1
+release    : 20
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v1.0.0.tar.gz : 8b47d3e5c4ce9294fa9eebeebfad778c38e8334e28473700495295090921f49a
+    - https://github.com/clintre/solseek/archive/refs/tags/v1.0.1.tar.gz : 4c627e3561cf898fee71a6811f68ae2ddc307125f68ba945b7e519fd4e95c793
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -69,9 +69,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2026-03-09</Date>
-            <Version>1.0.0</Version>
+        <Update release="20">
+            <Date>2026-03-11</Date>
+            <Version>1.0.1</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION

**Summary**

Bugfixes:
- Fixed assume yes for flatpak repair, which does not use that flag
- Fixed issue with Cofniguration pane where it would try to import file that no longer existed

**Full Changelog**: https://github.com/clintre/solseek/compare/v0.12.1...v1.0.1

**Test Plan**

Tested on VM

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
