### PR TITLE
croc: Update to v10.4.2

### DIFF
--- a/packages/c/croc/package.yml
+++ b/packages/c/croc/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : croc
-version    : 10.4.1
-release    : 2
+version    : 10.4.2
+release    : 3
 source     :
-    - https://github.com/schollz/croc/archive/refs/tags/v10.4.1.tar.gz : e544ff0c07166cab4e070d2a5af5105544d797a059879738075779775a19263d
+    - https://github.com/schollz/croc/archive/refs/tags/v10.4.2.tar.gz : 9ad752a5e87152c15698bac0f4157bcfa56918d49bc3947f3318e39e08be4f21
 homepage   : https://github.com/schollz/croc
 license    : MIT
 component  : network.clients

--- a/packages/c/croc/pspec_x86_64.xml
+++ b/packages/c/croc/pspec_x86_64.xml
@@ -28,9 +28,9 @@ It provides end-to-end encryption and enables easy cross-platform transfers.
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2026-03-07</Date>
-            <Version>10.4.1</Version>
+        <Update release="3">
+            <Date>2026-03-11</Date>
+            <Version>10.4.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/schollz/croc/releases/tag/v10.4.2).
- Fix: Progress bar width

**Test Plan**

transfer file using `croc` to windows machine. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
