### PR TITLE
sudo-rs: Update to v0.2.13

### DIFF
--- a/packages/s/sudo-rs/abi_used_symbols
+++ b/packages/s/sudo-rs/abi_used_symbols
@@ -25,6 +25,7 @@ libc.so.6:dup2
 libc.so.6:environ
 libc.so.6:execvp
 libc.so.6:exit
+libc.so.6:faccessat
 libc.so.6:fchmod
 libc.so.6:fchown
 libc.so.6:fcntl

--- a/packages/s/sudo-rs/package.yml
+++ b/packages/s/sudo-rs/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : sudo-rs
-version    : 0.2.12
-release    : 1
+version    : 0.2.13
+release    : 2
 source     :
-    - https://github.com/trifectatechfoundation/sudo-rs/archive/refs/tags/v0.2.12.tar.gz : 1f4a0577df3ae64fd35d75d30ece458fa18d57bdc7bc777aea3bfdfcb841dbeb
+    - https://github.com/trifectatechfoundation/sudo-rs/archive/refs/tags/v0.2.13.tar.gz : 79becefc504d14ffccc7cab18d42f8d892e78b2d13d9c5bb887c5f02a2721eaf
 homepage   : https://github.com/trifectatechfoundation/sudo-rs
 license    :
     - Apache-2.0

--- a/packages/s/sudo-rs/pspec_x86_64.xml
+++ b/packages/s/sudo-rs/pspec_x86_64.xml
@@ -40,9 +40,9 @@ sudo utility while providing improved security through memory safety guarantees.
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2026-02-09</Date>
-            <Version>0.2.12</Version>
+        <Update release="2">
+            <Date>2026-03-11</Date>
+            <Version>0.2.13</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/trifectatechfoundation/sudo-rs/releases/tag/v0.2.13).
- `pwfeedback` on by default — visual password feedback (asterisks as you type) is now enabled out of the box, no sudoers config needed
- `-i / --login` env fix — HOME, SHELL, USER, and LOGNAME are now always set to the target user when using --login, even if those vars were in `env_keep`
- `SUDO_EDITOR` argument support fixed — arguments passed inside SUDO_EDITOR were previously ignored; now they work correctly

**Test Plan**

`sudo-rs eopkg up` to update. See asterisks as I type. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
