### PR TITLE
imagemagick: Update to v7.1.2.16

### DIFF
--- a/packages/i/imagemagick/package.yml
+++ b/packages/i/imagemagick/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : imagemagick
-version    : 7.1.2.15
-release    : 207
+version    : 7.1.2.16
+release    : 208
 source     :
-    - https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-15.tar.gz : bf646e7fffdf50b7d886eec6bbe51c3ced1c4d68fbabfcc534e014575359fe7f
+    - https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-16.tar.gz : aadfa67a104d14a35339de0f2cc286c973a0f43329770c69e9667a22208750fb
 homepage   : https://imagemagick.org/
 license    : Apache-2.0
 component  : multimedia.graphics

--- a/packages/i/imagemagick/pspec_x86_64.xml
+++ b/packages/i/imagemagick/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>imagemagick</Name>
         <Homepage>https://imagemagick.org/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>multimedia.graphics</PartOf>
@@ -94,7 +94,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="207">imagemagick</Dependency>
+            <Dependency release="208">imagemagick</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/ImageMagick-7/Magick++.h</Path>
@@ -593,12 +593,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="207">
-            <Date>2026-02-26</Date>
-            <Version>7.1.2.15</Version>
+        <Update release="208">
+            <Date>2026-03-12</Date>
+            <Version>7.1.2.16</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/ImageMagick/Website/blob/main/ChangeLog.md).

**Security**
Includes fixes for:
- CVE-2026-28690
- CVE-2026-28691
- CVE-2026-28692
- CVE-2026-28693
- CVE-2026-30935
- CVE-2026-30936

**Test Plan**

```magick identify example.png``` read the info. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
