### PR TITLE
weechat: Update to v4.8.2

### DIFF
--- a/packages/w/weechat/package.yml
+++ b/packages/w/weechat/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : weechat
-version    : 4.8.1
-release    : 100
+version    : 4.8.2
+release    : 101
 source     :
-    - https://github.com/weechat/weechat/archive/refs/tags/v4.8.1.tar.gz : ff5677d3fa37ded130288cc9d4a254311c9e7c41ce48fc9101e0df1caa28f9fd
+    - https://github.com/weechat/weechat/archive/refs/tags/v4.8.2.tar.gz : 16f61a75db8f2d661bb1ceaea5d82d7fffb6a0e20db95f49130fe965007110b1
 homepage   : https://weechat.org
 license    : GPL-3.0-or-later
 summary    : WeeChat is a fast, light and extensible chat client.
@@ -37,3 +37,4 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING LICENSES/*

--- a/packages/w/weechat/pspec_x86_64.xml
+++ b/packages/w/weechat/pspec_x86_64.xml
@@ -50,6 +50,8 @@
             <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/weechat.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/512x512/apps/weechat.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/weechat.png</Path>
+            <Path fileType="data">/usr/share/licenses/weechat/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/weechat/GPL-3.0-or-later.txt</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/weechat.mo</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/weechat.mo</Path>
             <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/weechat.mo</Path>
@@ -90,7 +92,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="100">weechat</Dependency>
+            <Dependency release="101">weechat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/weechat/weechat-plugin.h</Path>
@@ -98,9 +100,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="100">
-            <Date>2025-12-04</Date>
-            <Version>4.8.1</Version>
+        <Update release="101">
+            <Date>2026-03-12</Date>
+            <Version>4.8.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/weechat/weechat/releases/tag/v4.8.2).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Connect to Libera.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
