### PR TITLE
systemd: Add default service preset

### DIFF
--- a/packages/s/systemd/abi_used_symbols
+++ b/packages/s/systemd/abi_used_symbols
@@ -631,7 +631,7 @@ libcrypto.so.3:EVP_MAC_free
 libcrypto.so.3:EVP_MAC_init
 libcrypto.so.3:EVP_MAC_update
 libcrypto.so.3:EVP_MD_CTX_free
-libcrypto.so.3:EVP_MD_CTX_get0_md
+libcrypto.so.3:EVP_MD_CTX_get_size_ex
 libcrypto.so.3:EVP_MD_CTX_new
 libcrypto.so.3:EVP_MD_fetch
 libcrypto.so.3:EVP_MD_free

--- a/packages/s/systemd/files/99-default.preset
+++ b/packages/s/systemd/files/99-default.preset
@@ -1,0 +1,1 @@
+disable *

--- a/packages/s/systemd/package.yml
+++ b/packages/s/systemd/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : systemd
 version    : '257.10'
-release    : 183
+release    : 184
 source     :
     - https://github.com/systemd/systemd/archive/refs/tags/v257.10.tar.gz : 5a2f477e6268630f6e2829c7bb3e442017549798a4122635817934eaa0c6ac10
 license    :
@@ -83,6 +83,9 @@ rundeps    :
     - font-terminus-console
     - kernel-glue
     - libgcrypt
+environment: |
+    # TODO: Maybe one day this wont be needed
+    export CFLAGS="${CFLAGS} -Wno-incompatible-pointer-types-discards-qualifiers"
 setup      : |
     # Downstream patches
     %patch -p1 -i $pkgfiles/patches/downstream/0001-tmpfiles-Make-var-cache-ldconfig-world-readable.patch
@@ -240,6 +243,10 @@ install    : |
     install -Dm00644 -t $installdir/usr/lib/systemd/system.conf.d/ $pkgfiles/configs/timeouts.conf
     install -Dm00644 -t $installdir/usr/lib/systemd/journald.conf.d/ $pkgfiles/configs/journald.conf
     install -Dm00644 -t $installdir/usr/lib/systemd/system/service.d/ $pkgfiles/configs/10-timeout-abort.conf
+
+    # Disable services by default, unless explicitly enabled
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/99-default.preset
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/user-preset/ ${pkgfiles}/99-default.preset
 
     # User config defaults
     install -Dm00644 -t $installdir/usr/lib/systemd/user.conf.d/ $pkgfiles/configs/timeouts.conf

--- a/packages/s/systemd/pspec_x86_64.xml
+++ b/packages/s/systemd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>systemd</Name>
         <Homepage>https://www.github.com/systemd/systemd</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <License>GPL-2.0-or-later</License>
@@ -105,7 +105,6 @@
             <Path fileType="library">/usr/lib/systemd/boot/efi/addonx64.efi.stub</Path>
             <Path fileType="library">/usr/lib/systemd/boot/efi/linuxx64.efi.stub</Path>
             <Path fileType="library">/usr/lib/systemd/boot/efi/systemd-bootx64.efi</Path>
-            <Path fileType="library">/usr/lib/systemd/boot/solus-mok.cer</Path>
             <Path fileType="library">/usr/lib/systemd/catalog/systemd.be.catalog</Path>
             <Path fileType="library">/usr/lib/systemd/catalog/systemd.be@latin.catalog</Path>
             <Path fileType="library">/usr/lib/systemd/catalog/systemd.bg.catalog</Path>
@@ -737,6 +736,8 @@
             <Path fileType="library">/usr/lib64/security/pam_systemd_loadkey.so</Path>
             <Path fileType="library">/usr/lib64/systemd/libsystemd-core-257.so</Path>
             <Path fileType="library">/usr/lib64/systemd/libsystemd-shared-257.so</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/99-default.preset</Path>
+            <Path fileType="library">/usr/lib64/systemd/user-preset/99-default.preset</Path>
             <Path fileType="library">/usr/lib64/udev/udevd</Path>
             <Path fileType="executable">/usr/sbin/halt</Path>
             <Path fileType="executable">/usr/sbin/init</Path>
@@ -1333,7 +1334,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="183">systemd</Dependency>
+            <Dependency release="184">systemd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnss_myhostname.so.2</Path>
@@ -1356,8 +1357,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="183">systemd-32bit</Dependency>
-            <Dependency release="183">systemd-devel</Dependency>
+            <Dependency release="184">systemd-32bit</Dependency>
+            <Dependency release="184">systemd-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/lib32/pkgconfig/libsystemd.pc</Path>
@@ -1371,7 +1372,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="183">systemd</Dependency>
+            <Dependency release="184">systemd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libudev.h</Path>
@@ -2191,12 +2192,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="183">
-            <Date>2026-02-09</Date>
+        <Update release="184">
+            <Date>2026-03-13</Date>
             <Version>257.10</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Disables all systemd services by default unless explicitly enabled.

Ignore the removed secure boot file, the actual build on the server will have it.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

I can't test the package because I use secure boot, but the mechanism of adding the preset file was tested manually.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
