### PR TITLE
aa-lsm-hook: Add systemd preset for service

### DIFF
--- a/packages/a/aa-lsm-hook/files/20-aa-lsm-hook.preset
+++ b/packages/a/aa-lsm-hook/files/20-aa-lsm-hook.preset
@@ -1,0 +1,1 @@
+enable aa-lsm-hook.service

--- a/packages/a/aa-lsm-hook/package.yml
+++ b/packages/a/aa-lsm-hook/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : aa-lsm-hook
 version    : 0.1.5
-release    : 19
+release    : 20
 source     :
     - https://github.com/getsolus/aa-lsm-hook/archive/refs/tags/0.1.5.tar.gz : 1e2e6fc25bd6d949a2c30d7555ea02de2b44ec78f11924f792d77079135fcc96
 homepage   : https://github.com/getsolus/aa-lsm-hook/
@@ -20,7 +20,8 @@ build      : |
     %make
 install    : |
     %make_install
+
     # Pre-enable service for Solus users
-    install -D -d -m 00755 $installdir/usr/lib/systemd/system/sysinit.target.wants
-    ln -sv ../aa-lsm-hook.service $installdir/usr/lib/systemd/system/sysinit.target.wants/aa-lsm-hook.service
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-aa-lsm-hook.preset
+
     %install_license LICENSE

--- a/packages/a/aa-lsm-hook/pspec_x86_64.xml
+++ b/packages/a/aa-lsm-hook/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>aa-lsm-hook</Name>
         <Homepage>https://github.com/getsolus/aa-lsm-hook/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>security.library</PartOf>
@@ -21,19 +21,19 @@
         <PartOf>security.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib/systemd/system/aa-lsm-hook.service</Path>
-            <Path fileType="library">/usr/lib/systemd/system/sysinit.target.wants/aa-lsm-hook.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-aa-lsm-hook.preset</Path>
             <Path fileType="executable">/usr/sbin/aa-lsm-hook</Path>
             <Path fileType="data">/usr/share/defaults/etc/aa-lsm-hook.conf</Path>
             <Path fileType="data">/usr/share/licenses/aa-lsm-hook/LICENSE</Path>
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2026-01-25</Date>
+        <Update release="20">
+            <Date>2026-03-14</Date>
             <Version>0.1.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd preset for service.

**Test Plan**

`systemctl status aa-lsm-hook`, see the service is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
