### PR TITLE
avahi: Add systemd service preset

### DIFF
--- a/packages/a/avahi/files/20-avahi.preset
+++ b/packages/a/avahi/files/20-avahi.preset
@@ -1,0 +1,2 @@
+enable avahi-daemon.socket
+enable avahi-daemon.service

--- a/packages/a/avahi/package.yml
+++ b/packages/a/avahi/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : avahi
 version    : '0.8'
-release    : 27
+release    : 28
 source     :
     # - https://github.com/avahi/avahi/archive/refs/tags/v0.8.tar.gz : c15e750ef7c6df595fb5f2ce10cac0fee2353649600e6919ad08ae8871e4945f
     # Use git source until v0.9 releases:
@@ -48,6 +48,7 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license LICENSE
 
     if [[ -z "${EMUL32BUILD}" ]]; then
         ln -s /usr/include/avahi-compat-libdns_sd/dns_sd.h $installdir/usr/include/dns_sd.h
@@ -56,14 +57,12 @@ install    : |
         install -D -m 00644 $pkgfiles/avahi.tmpfiles $installdir%libdir%/tmpfiles.d/avahi.conf
 
         # Pre-enable
-        install -D -d -m 00755 $installdir/%libdir%/systemd/system/sockets.target.wants
-        install -D -d -m 00755 $installdir/%libdir%/systemd/system/multi-user.target.wants
-        ln -sv ../avahi-daemon.socket -t $installdir/%libdir%/systemd/system/sockets.target.wants
+        install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-avahi.preset
         ln -sv avahi-daemon.service $installdir/%libdir%/systemd/system/dbus-org.freedesktop.Avahi.service
-        ln -sv ../avahi-daemon.service $installdir/%libdir%/systemd/system/multi-user.target.wants/avahi-daemon.service
     else
         rm -rfv $installdir/%libdir%/systemd
     fi
+
     # Move files to stateless path
     install -dm00644 $installdir/usr/share/defaults
     mv $installdir/etc/avahi $installdir/usr/share/defaults/avahi

--- a/packages/a/avahi/pspec_x86_64.xml
+++ b/packages/a/avahi/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>avahi</Name>
         <Homepage>https://www.avahi.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>desktop.core</PartOf>
@@ -49,12 +49,11 @@
             <Path fileType="library">/usr/lib64/libdns_sd.so</Path>
             <Path fileType="library">/usr/lib64/libdns_sd.so.1</Path>
             <Path fileType="library">/usr/lib64/libdns_sd.so.1.0.0</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-avahi.preset</Path>
             <Path fileType="library">/usr/lib64/systemd/system/avahi-daemon.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/avahi-daemon.socket</Path>
             <Path fileType="library">/usr/lib64/systemd/system/avahi-dnsconfd.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/dbus-org.freedesktop.Avahi.service</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/multi-user.target.wants/avahi-daemon.service</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/sockets.target.wants/avahi-daemon.socket</Path>
             <Path fileType="library">/usr/lib64/sysusers.d/avahi.conf</Path>
             <Path fileType="library">/usr/lib64/tmpfiles.d/avahi.conf</Path>
             <Path fileType="executable">/usr/sbin/avahi-autoipd</Path>
@@ -84,8 +83,7 @@
             <Path fileType="data">/usr/share/defaults/avahi/hosts</Path>
             <Path fileType="data">/usr/share/defaults/avahi/services/sftp-ssh.service</Path>
             <Path fileType="data">/usr/share/defaults/avahi/services/ssh.service</Path>
-            <Path fileType="data">/usr/share/gir-1.0/Avahi-0.6.gir</Path>
-            <Path fileType="data">/usr/share/gir-1.0/AvahiCore-0.6.gir</Path>
+            <Path fileType="data">/usr/share/licenses/avahi/LICENSE</Path>
             <Path fileType="localedata">/usr/share/locale/ach/LC_MESSAGES/avahi.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/avahi.mo</Path>
             <Path fileType="localedata">/usr/share/locale/bg/LC_MESSAGES/avahi.mo</Path>
@@ -132,22 +130,22 @@
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/avahi.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/avahi.mo</Path>
             <Path fileType="man">/usr/share/man/man1/avahi-browse-domains.1</Path>
-            <Path fileType="man">/usr/share/man/man1/avahi-browse.1</Path>
+            <Path fileType="man">/usr/share/man/man1/avahi-browse.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/avahi-publish-address.1</Path>
             <Path fileType="man">/usr/share/man/man1/avahi-publish-service.1</Path>
-            <Path fileType="man">/usr/share/man/man1/avahi-publish.1</Path>
+            <Path fileType="man">/usr/share/man/man1/avahi-publish.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/avahi-resolve-address.1</Path>
             <Path fileType="man">/usr/share/man/man1/avahi-resolve-host-name.1</Path>
-            <Path fileType="man">/usr/share/man/man1/avahi-resolve.1</Path>
-            <Path fileType="man">/usr/share/man/man1/avahi-set-host-name.1</Path>
-            <Path fileType="man">/usr/share/man/man5/avahi-daemon.conf.5</Path>
-            <Path fileType="man">/usr/share/man/man5/avahi.hosts.5</Path>
-            <Path fileType="man">/usr/share/man/man5/avahi.service.5</Path>
-            <Path fileType="man">/usr/share/man/man8/avahi-autoipd.8</Path>
-            <Path fileType="man">/usr/share/man/man8/avahi-autoipd.action.8</Path>
-            <Path fileType="man">/usr/share/man/man8/avahi-daemon.8</Path>
-            <Path fileType="man">/usr/share/man/man8/avahi-dnsconfd.8</Path>
-            <Path fileType="man">/usr/share/man/man8/avahi-dnsconfd.action.8</Path>
+            <Path fileType="man">/usr/share/man/man1/avahi-resolve.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/avahi-set-host-name.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man5/avahi-daemon.conf.5.zst</Path>
+            <Path fileType="man">/usr/share/man/man5/avahi.hosts.5.zst</Path>
+            <Path fileType="man">/usr/share/man/man5/avahi.service.5.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/avahi-autoipd.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/avahi-autoipd.action.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/avahi-daemon.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/avahi-dnsconfd.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/avahi-dnsconfd.action.8.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -157,7 +155,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="27">avahi</Dependency>
+            <Dependency release="28">avahi</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/girepository-1.0/Avahi-0.6.typelib</Path>
@@ -189,8 +187,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="27">avahi-devel</Dependency>
-            <Dependency release="27">avahi-32bit</Dependency>
+            <Dependency release="28">avahi-32bit</Dependency>
+            <Dependency release="28">avahi-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/lib32/pkgconfig/avahi-client.pc</Path>
@@ -207,7 +205,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="27">avahi</Dependency>
+            <Dependency release="28">avahi</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/avahi-client/client.h</Path>
@@ -249,15 +247,17 @@
             <Path fileType="data">/usr/lib64/pkgconfig/avahi-core.pc</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/avahi-glib.pc</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/avahi-gobject.pc</Path>
+            <Path fileType="data">/usr/share/gir-1.0/Avahi-0.6.gir</Path>
+            <Path fileType="data">/usr/share/gir-1.0/AvahiCore-0.6.gir</Path>
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2024-07-20</Date>
+        <Update release="28">
+            <Date>2026-03-14</Date>
             <Version>0.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd service preset file.

**Test Plan**

Run `systemctl status avahi-daemon.socket` and `systemctl status avahi-daemon.service`, and see that both are enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
