### PR TITLE
clr-boot-manager: Add systemd service preset

### DIFF
--- a/packages/c/clr-boot-manager/files/20-clr-boot-manager.preset
+++ b/packages/c/clr-boot-manager/files/20-clr-boot-manager.preset
@@ -1,0 +1,1 @@
+enable clr-boot-manager-booted.service

--- a/packages/c/clr-boot-manager/package.yml
+++ b/packages/c/clr-boot-manager/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : clr-boot-manager
 version    : 3.6.0
-release    : 38
+release    : 39
 source     :
     - https://github.com/getsolus/clr-boot-manager/releases/download/solus-3.6.0/clr-boot-manager-3.6.0.tar.xz : f05cafc9fe808adbe9532a734551497d4810a163877cb316cb2fb12613fdc49e
 homepage   : https://www.clearlinux.org
@@ -34,6 +34,6 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
-    # Pre-enable the booted service
-    install -Ddm00755 $installdir/usr/lib/systemd/system/multi-user.target.wants
-    ln -sv ../clr-boot-manager-booted.service $installdir/usr/lib/systemd/system/multi-user.target.wants/.
+    %install_license LICENSE.LGPL2.1
+
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-clr-boot-manager.preset

--- a/packages/c/clr-boot-manager/pspec_x86_64.xml
+++ b/packages/c/clr-boot-manager/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>clr-boot-manager</Name>
         <Homepage>https://www.clearlinux.org</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>system.base</PartOf>
@@ -31,19 +31,20 @@ Most importantly, clr-boot-manager provides a simple mechanism to provide kernel
             <Path fileType="executable">/usr/bin/clr-boot-manager</Path>
             <Path fileType="library">/usr/lib/systemd/system/clr-boot-manager-booted.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/clr-boot-manager-mount-boot.service</Path>
-            <Path fileType="library">/usr/lib/systemd/system/multi-user.target.wants/clr-boot-manager-booted.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-clr-boot-manager.preset</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/clr-boot-manager</Path>
-            <Path fileType="man">/usr/share/man/man1/clr-boot-manager.1</Path>
+            <Path fileType="data">/usr/share/licenses/clr-boot-manager/LICENSE.LGPL2.1</Path>
+            <Path fileType="man">/usr/share/man/man1/clr-boot-manager.1.zst</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_clr-boot-manager</Path>
         </Files>
     </Package>
     <History>
-        <Update release="38">
-            <Date>2025-01-16</Date>
+        <Update release="39">
+            <Date>2026-03-14</Date>
             <Version>3.6.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add a systemd service preset file.

**Test Plan**

Run `systemctl status clr-boot-manager-booted.service` and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
