### PR TITLE
network-manager: Add systemd service preset

### DIFF
--- a/packages/n/network-manager/files/20-network-manager.preset
+++ b/packages/n/network-manager/files/20-network-manager.preset
@@ -1,0 +1,2 @@
+enable NetworkManager.service
+enable NetworkManager-wait-online.service

--- a/packages/n/network-manager/package.yml
+++ b/packages/n/network-manager/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : network-manager
 version    : 1.54.3
-release    : 90
+release    : 91
 source     :
     - https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/archive/1.54.3/NetworkManager-1.54.3.tar.bz2 : e38d55611af8127e1a2b1a7b4952bded1f61917cbc49d4ee7a272ec3fcd7b51b
 homepage   : https://gitlab.freedesktop.org/NetworkManager/NetworkManager
@@ -135,11 +135,10 @@ install    : |
                 $installdir/%libdir%/NetworkManager
     else
 
-        # Enable by default
-        install -dm00755 $installdir/usr/lib/systemd/system/{multi-user,network-online}.target.wants
-        ln -sv ../NetworkManager.service $installdir/usr/lib/systemd/system/multi-user.target.wants/NetworkManager.service
-        ln -sv NetworkManager-dispatcher.service $installdir/usr/lib/systemd/system/dbus-org.freedesktop.nm-dispatcher.service
-        ln -sv ../NetworkManager-wait-online.service $installdir/usr/lib/systemd/system/network-online.target.wants/NetworkManager-wait-online.service
+        # Install service preset file
+        install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-network-manager.preset
+
+        ln -sv NetworkManager-dispatcher.service $installdir/%libdir%/systemd/system/dbus-org.freedesktop.nm-dispatcher.service
 
         # Configuration
         install -Dm00644 $pkgfiles/NetworkManager.conf $installdir/usr/lib/NetworkManager/conf.d/NetworkManager.conf

--- a/packages/n/network-manager/pspec_x86_64.xml
+++ b/packages/n/network-manager/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>network-manager</Name>
         <Homepage>https://gitlab.freedesktop.org/NetworkManager/NetworkManager</Homepage>
         <Packager>
-            <Name>Hans K</Name>
-            <Email>hans@communitycomputing.net</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GFDL-1.1-or-later</License>
         <License>GPL-2.0-or-later</License>
@@ -20,7 +20,7 @@
         <Description xml:lang="en">NetworkManager attempts to keep an active network connection available at all times. The point of NetworkManager is to make networking configuration and setup as painless and automatic as possible. NetworkManager is intended to replace default route, replace other routes, set IP addresses, and in general configure networking as NM sees fit (with the possibility of manual override as necessary). In effect, the goal of NetworkManager is to make networking Just Work with a minimum of user hassle, but still allow customization and a high level of manual network control.</Description>
         <PartOf>network.base</PartOf>
         <RuntimeDependencies>
-            <Dependency release="90">network-manager-libnm</Dependency>
+            <Dependency release="91">network-manager-libnm</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/nm-online</Path>
@@ -33,9 +33,6 @@
             <Path fileType="library">/usr/lib/NetworkManager/dispatcher.d/pre-up.d</Path>
             <Path fileType="library">/usr/lib/NetworkManager/system-connections</Path>
             <Path fileType="library">/usr/lib/firewalld/zones/nm-shared.xml</Path>
-            <Path fileType="library">/usr/lib/systemd/system/dbus-org.freedesktop.nm-dispatcher.service</Path>
-            <Path fileType="library">/usr/lib/systemd/system/multi-user.target.wants/NetworkManager.service</Path>
-            <Path fileType="library">/usr/lib/systemd/system/network-online.target.wants/NetworkManager-wait-online.service</Path>
             <Path fileType="library">/usr/lib/udev/rules.d/84-nm-drivers.rules</Path>
             <Path fileType="library">/usr/lib/udev/rules.d/85-nm-unmanaged.rules</Path>
             <Path fileType="library">/usr/lib/udev/rules.d/90-nm-thunderbolt.rules</Path>
@@ -52,6 +49,7 @@
             <Path fileType="library">/usr/lib64/network-manager/nm-libnm-helper</Path>
             <Path fileType="library">/usr/lib64/network-manager/nm-priv-helper</Path>
             <Path fileType="library">/usr/lib64/pppd/2.5.1/nm-pppd-plugin.so</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-network-manager.preset</Path>
             <Path fileType="library">/usr/lib64/systemd/system/NetworkManager-config-initrd.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/NetworkManager-dispatcher.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/NetworkManager-initrd.service</Path>
@@ -59,6 +57,7 @@
             <Path fileType="library">/usr/lib64/systemd/system/NetworkManager-wait-online.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/NetworkManager.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/NetworkManager.service.d/NetworkManager-ovs.conf</Path>
+            <Path fileType="library">/usr/lib64/systemd/system/dbus-org.freedesktop.nm-dispatcher.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/nm-priv-helper.service</Path>
             <Path fileType="library">/usr/lib64/tmpfiles.d/NetworkManager.conf</Path>
             <Path fileType="executable">/usr/sbin/NetworkManager</Path>
@@ -161,7 +160,7 @@
         <Description xml:lang="en">Bluetooth device plugin for NetworkManager</Description>
         <PartOf>network.base</PartOf>
         <RuntimeDependencies>
-            <Dependency release="90">network-manager</Dependency>
+            <Dependency release="91">network-manager</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/NetworkManager/1.54.3-solus/libnm-device-plugin-bluetooth.so</Path>
@@ -484,7 +483,7 @@
         <Description xml:lang="en">Installing this will switch to using iwd as the wifi backend in place of wpa_supplicant</Description>
         <PartOf>network.base</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="90">network-manager</Dependency>
+            <Dependency releaseFrom="91">network-manager</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib/NetworkManager/conf.d/10-iwd-wifi-backend.conf</Path>
@@ -507,7 +506,7 @@
         <Description xml:lang="en">32-bit libraries for NetworkManager</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="90">network-manager-libnm</Dependency>
+            <Dependency releaseFrom="91">network-manager-libnm</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnm.so.0</Path>
@@ -523,8 +522,8 @@
         <Description xml:lang="en">Development files for network-manager-libnm-32bit</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="90">network-manager-libnm-32bit</Dependency>
-            <Dependency releaseFrom="90">network-manager-libnm-devel</Dependency>
+            <Dependency releaseFrom="91">network-manager-libnm-32bit</Dependency>
+            <Dependency releaseFrom="91">network-manager-libnm-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnm.so</Path>
@@ -540,7 +539,7 @@
         <Description xml:lang="en">Development files for network-manager-libnm</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="90">network-manager-libnm</Dependency>
+            <Dependency releaseFrom="91">network-manager-libnm</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libnm/NetworkManager.h</Path>
@@ -743,7 +742,7 @@
         <Description xml:lang="en">NetworkManager curses-based UI</Description>
         <PartOf>network.util</PartOf>
         <RuntimeDependencies>
-            <Dependency release="90">network-manager-libnm</Dependency>
+            <Dependency release="91">network-manager-libnm</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/nmtui</Path>
@@ -757,12 +756,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="90">
-            <Date>2026-02-23</Date>
+        <Update release="91">
+            <Date>2026-03-14</Date>
             <Version>1.54.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Hans K</Name>
-            <Email>hans@communitycomputing.net</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add a systemd service preset file.

**Test Plan**

Run `systemctl status NetworkManager.service`, along with the other one, and see that both are enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
