### PR TITLE
util-linux: Update to v2.41.3

### DIFF
--- a/packages/u/util-linux/files/20-util-linux.preset
+++ b/packages/u/util-linux/files/20-util-linux.preset
@@ -1,0 +1,2 @@
+enable uuidd.socket
+enable fstrim.timer

--- a/packages/u/util-linux/package.yml
+++ b/packages/u/util-linux/package.yml
@@ -1,11 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : util-linux
-version    : 2.41.2
-release    : 55
+version    : 2.41.3
+release    : 56
 source     :
-    - https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.2.tar.xz : 6062a1d89b571a61932e6fc0211f36060c4183568b81ee866cf363bce9f6583e
-    # Missing from tarball, check me next release!
-    - https://raw.githubusercontent.com/util-linux/util-linux/refs/tags/v2.41.2/bash-completion/bits : 4c335c0b42d600d5ee7382aaedc5712f4338f7b2562b955ec3a5fbbc09e7e9ac
+    - https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.3.tar.xz : 3330d873f0fceb5560b89a7dc14e4f3288bbd880e96903ed9b50ec2b5799e58b
 homepage   : https://github.com/util-linux/util-linux
 license    :
     - BSD-3-Clause
@@ -48,9 +46,6 @@ rundeps    :
 setup      : |
     # Fix usage with musl
     export CFLAGS="${CFLAGS/-D_FORTIFY_SOURCE=2/}"
-
-    # Missing from tarball WTF? check me next release
-    cp $sources/bits $workdir/bash-completion/bits
 
     if [ -n "${EMUL32BUILD+set}" ]; then
         %meson_configure \
@@ -111,20 +106,18 @@ install    : |
         mv $installdir/usr/lib/* $installdir/usr/lib64
         rmdir $installdir/usr/lib
 
-        # Create necessary systemd directories
-        install -D -d -m 00755 $installdir/%libdir%/systemd/system/{sockets,timers}.target.wants
-
         # Ensure that uuid daemon works
         install -Dm00644 $pkgfiles/util-linux.sysusers $installdir/%libdir%/sysusers.d/util-linux.conf
-        ln -sv ../uuidd.socket -t $installdir/%libdir%/systemd/system/sockets.target.wants
 
-        # Enable fstrim.timer by default
-        ln -sv ../fstrim.timer $installdir/%libdir%/systemd/system/timers.target.wants/fstrim.timer
+        # Install systemd service presets
+        install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-util-linux.preset
 
         # PAM
         install -dm00755 $installdir/usr/share/defaults/etc/pam.d
         install -m00644 $pkgfiles/pam.d/* -t $installdir/usr/share/defaults/etc/pam.d
     fi
+
+    %install_license COPYING
 # Tests compile but they are not run because of
 # "Ignore util-linux test suite [non-root UID expected]."
 # check      : |

--- a/packages/u/util-linux/pspec_x86_64.xml
+++ b/packages/u/util-linux/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>util-linux</Name>
         <Homepage>https://github.com/util-linux/util-linux</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>BSD-4-Clause-UC</License>
@@ -128,11 +128,10 @@
             <Path fileType="library">/usr/lib64/libuuid.so.1</Path>
             <Path fileType="library">/usr/lib64/libuuid.so.1.3.0</Path>
             <Path fileType="library">/usr/lib64/security/pam_lastlog2.so</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-util-linux.preset</Path>
             <Path fileType="library">/usr/lib64/systemd/system/fstrim.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/fstrim.timer</Path>
             <Path fileType="library">/usr/lib64/systemd/system/lastlog2-import.service</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/sockets.target.wants/uuidd.socket</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/timers.target.wants/fstrim.timer</Path>
             <Path fileType="library">/usr/lib64/systemd/system/uuidd.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/uuidd.socket</Path>
             <Path fileType="library">/usr/lib64/sysusers.d/util-linux.conf</Path>
@@ -187,6 +186,7 @@
             <Path fileType="data">/usr/share/bash-completion/completions/bits</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/blkdiscard</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/blkid</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/blkpr</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/blkzone</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/blockdev</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/cal</Path>
@@ -240,6 +240,7 @@
             <Path fileType="data">/usr/share/bash-completion/completions/lsblk</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/lsclocks</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/lscpu</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/lsfd</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/lsipc</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/lsirq</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/lslocks</Path>
@@ -311,6 +312,7 @@
             <Path fileType="data">/usr/share/defaults/etc/pam.d/su-l</Path>
             <Path fileType="doc">/usr/share/doc/util-linux/getopt-example.bash</Path>
             <Path fileType="doc">/usr/share/doc/util-linux/getopt-example.tcsh</Path>
+            <Path fileType="data">/usr/share/licenses/util-linux/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/util-linux.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/util-linux.mo</Path>
             <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/util-linux.mo</Path>
@@ -1040,6 +1042,7 @@
             <Path fileType="man">/usr/share/man/sr/man1/wall.1.zst</Path>
             <Path fileType="man">/usr/share/man/sr/man1/whereis.1.zst</Path>
             <Path fileType="man">/usr/share/man/sr/man1/write.1.zst</Path>
+            <Path fileType="man">/usr/share/man/sr/man3/lastlog2.3.zst</Path>
             <Path fileType="man">/usr/share/man/sr/man3/libblkid.3.zst</Path>
             <Path fileType="man">/usr/share/man/sr/man3/ll2_import_lastlog.3.zst</Path>
             <Path fileType="man">/usr/share/man/sr/man3/ll2_read_all.3.zst</Path>
@@ -1247,7 +1250,7 @@
         <Description xml:lang="en">Util-linux is a suite of essential tools for any Linux system, such as chsh, kill, cfdisk, mkfs, mount, and more.</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="55">util-linux</Dependency>
+            <Dependency release="56">util-linux</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libblkid.so.1</Path>
@@ -1268,8 +1271,8 @@
         <Description xml:lang="en">Util-linux is a suite of essential tools for any Linux system, such as chsh, kill, cfdisk, mkfs, mount, and more.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="55">util-linux-32bit</Dependency>
-            <Dependency release="55">util-linux-devel</Dependency>
+            <Dependency release="56">util-linux-32bit</Dependency>
+            <Dependency release="56">util-linux-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/lib_fdisk.a</Path>
@@ -1307,7 +1310,7 @@
         <Description xml:lang="en">Util-linux is a suite of essential tools for any Linux system, such as chsh, kill, cfdisk, mkfs, mount, and more.</Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="55">util-linux</Dependency>
+            <Dependency release="56">util-linux</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/blkid/blkid.h</Path>
@@ -1355,12 +1358,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="55">
-            <Date>2025-10-27</Date>
-            <Version>2.41.2</Version>
+        <Update release="56">
+            <Date>2026-03-14</Date>
+            <Version>2.41.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/util-linux/util-linux/blob/v2.41.3/NEWS).
Add systemd service preset file.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `lsblk`, run `systemctl status uuidd.socket` and `systemctl status fstrim.timer` and see that both are enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
