### PR TITLE
wireplumber: Update to v0.5.13

### DIFF
--- a/packages/w/wireplumber/abi_symbols
+++ b/packages/w/wireplumber/abi_symbols
@@ -65,6 +65,7 @@ libwireplumber-0.5.so.0:wp_domain_library_quark
 libwireplumber-0.5.so.0:wp_event_collect_hooks
 libwireplumber-0.5.so.0:wp_event_dispatcher_get_instance
 libwireplumber-0.5.so.0:wp_event_dispatcher_get_type
+libwireplumber-0.5.so.0:wp_event_dispatcher_new_hooks_for_event_type_iterator
 libwireplumber-0.5.so.0:wp_event_dispatcher_new_hooks_iterator
 libwireplumber-0.5.so.0:wp_event_dispatcher_push_event
 libwireplumber-0.5.so.0:wp_event_dispatcher_register_hook
@@ -78,6 +79,7 @@ libwireplumber-0.5.so.0:wp_event_get_source
 libwireplumber-0.5.so.0:wp_event_get_subject
 libwireplumber-0.5.so.0:wp_event_get_type
 libwireplumber-0.5.so.0:wp_event_hook_finish
+libwireplumber-0.5.so.0:wp_event_hook_get_matching_event_types
 libwireplumber-0.5.so.0:wp_event_hook_get_name
 libwireplumber-0.5.so.0:wp_event_hook_get_runs_after_hooks
 libwireplumber-0.5.so.0:wp_event_hook_get_runs_before_hooks
@@ -181,6 +183,7 @@ libwireplumber-0.5.so.0:wp_object_get_id
 libwireplumber-0.5.so.0:wp_object_get_supported_features
 libwireplumber-0.5.so.0:wp_object_get_type
 libwireplumber-0.5.so.0:wp_object_interest_add_constraint
+libwireplumber-0.5.so.0:wp_object_interest_find_defined_constraint_values
 libwireplumber-0.5.so.0:wp_object_interest_get_type
 libwireplumber-0.5.so.0:wp_object_interest_matches
 libwireplumber-0.5.so.0:wp_object_interest_matches_full

--- a/packages/w/wireplumber/abi_used_symbols
+++ b/packages/w/wireplumber/abi_used_symbols
@@ -1,5 +1,6 @@
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
+libc.so.6:__getdelim
 libc.so.6:__isoc23_sscanf
 libc.so.6:__isoc23_strtol
 libc.so.6:__isoc23_strtoll
@@ -19,9 +20,9 @@ libc.so.6:close
 libc.so.6:dcgettext
 libc.so.6:dcngettext
 libc.so.6:fclose
+libc.so.6:fdopen
 libc.so.6:fflush
 libc.so.6:fileno
-libc.so.6:fopen64
 libc.so.6:free
 libc.so.6:fstat64
 libc.so.6:fwrite
@@ -37,6 +38,7 @@ libc.so.6:memset
 libc.so.6:mmap64
 libc.so.6:munmap
 libc.so.6:newlocale
+libc.so.6:open64
 libc.so.6:openat64
 libc.so.6:program_invocation_short_name
 libc.so.6:putchar
@@ -346,6 +348,8 @@ libglib-2.0.so.0:g_str_equal
 libglib-2.0.so.0:g_str_has_prefix
 libglib-2.0.so.0:g_str_has_suffix
 libglib-2.0.so.0:g_str_hash
+libglib-2.0.so.0:g_strchomp
+libglib-2.0.so.0:g_strchug
 libglib-2.0.so.0:g_strcmp0
 libglib-2.0.so.0:g_strconcat
 libglib-2.0.so.0:g_strdup
@@ -579,6 +583,7 @@ libgobject-2.0.so.0:g_weak_ref_set
 liblua.so.5.4:luaL_addstring
 liblua.so.5.4:luaL_argerror
 liblua.so.5.4:luaL_buffinit
+liblua.so.5.4:luaL_checkany
 liblua.so.5.4:luaL_checkinteger
 liblua.so.5.4:luaL_checklstring
 liblua.so.5.4:luaL_checktype
@@ -615,6 +620,7 @@ liblua.so.5.4:lua_gettable
 liblua.so.5.4:lua_gettop
 liblua.so.5.4:lua_isinteger
 liblua.so.5.4:lua_isnumber
+liblua.so.5.4:lua_isstring
 liblua.so.5.4:lua_isuserdata
 liblua.so.5.4:lua_len
 liblua.so.5.4:lua_newuserdatauv

--- a/packages/w/wireplumber/files/20-wireplumber.preset
+++ b/packages/w/wireplumber/files/20-wireplumber.preset
@@ -1,0 +1,1 @@
+enable wireplumber.service

--- a/packages/w/wireplumber/package.yml
+++ b/packages/w/wireplumber/package.yml
@@ -1,12 +1,12 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : wireplumber
-version    : 0.5.12
-release    : 37
+version    : 0.5.13
+release    : 38
 source     :
-    - https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/0.5.12/wireplumber-0.5.12.tar.gz : 0ce5cd48087bc5b559d7e1a947e9e0adb2a9b6f1dabd984af801f30fbba5e19c
+    - https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/0.5.13/wireplumber-0.5.13.tar.gz : 904e4219dacfc6070e13fcb41846b085c61aa1c1cbb0dcc59e1ab982adc8968a
+homepage   : https://pipewire.pages.freedesktop.org/wireplumber/
 license    : MIT
 component  : multimedia.library
-homepage   : https://pipewire.pages.freedesktop.org/wireplumber/
 summary    : Session / policy manager implementation for PipeWire
 description: |
     WirePlumber is a modular session / policy manager for PipeWire and a GObject-based high-level library that wraps PipeWire's API, providing convenience for writing the daemon's modules as well as external tools for managing PipeWire.
@@ -21,8 +21,6 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license LICENSE
 
-    # Enable user service by default
-    install -dm0644 $installdir/usr/lib/systemd/user/pipewire.service.wants
-    ln -s wireplumber.service $installdir/usr/lib/systemd/user/pipewire-session-manager.service
-    ln -s ../wireplumber.service $installdir/usr/lib/systemd/user/pipewire.service.wants/wireplumber.service
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/user-preset/ ${pkgfiles}/20-wireplumber.preset

--- a/packages/w/wireplumber/pspec_x86_64.xml
+++ b/packages/w/wireplumber/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>wireplumber</Name>
         <Homepage>https://pipewire.pages.freedesktop.org/wireplumber/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>multimedia.library</PartOf>
@@ -23,13 +23,12 @@
             <Path fileType="executable">/usr/bin/wireplumber</Path>
             <Path fileType="executable">/usr/bin/wpctl</Path>
             <Path fileType="executable">/usr/bin/wpexec</Path>
-            <Path fileType="library">/usr/lib/systemd/user/pipewire-session-manager.service</Path>
-            <Path fileType="library">/usr/lib/systemd/user/pipewire.service.wants/wireplumber.service</Path>
             <Path fileType="library">/usr/lib/systemd/user/wireplumber.service</Path>
             <Path fileType="library">/usr/lib/systemd/user/wireplumber@.service</Path>
             <Path fileType="library">/usr/lib64/girepository-1.0/Wp-0.5.typelib</Path>
             <Path fileType="library">/usr/lib64/libwireplumber-0.5.so.0</Path>
-            <Path fileType="library">/usr/lib64/libwireplumber-0.5.so.0.512.0</Path>
+            <Path fileType="library">/usr/lib64/libwireplumber-0.5.so.0.513.0</Path>
+            <Path fileType="library">/usr/lib64/systemd/user-preset/20-wireplumber.preset</Path>
             <Path fileType="library">/usr/lib64/wireplumber-0.5/libwireplumber-module-dbus-connection.so</Path>
             <Path fileType="library">/usr/lib64/wireplumber-0.5/libwireplumber-module-default-nodes-api.so</Path>
             <Path fileType="library">/usr/lib64/wireplumber-0.5/libwireplumber-module-file-monitor-api.so</Path>
@@ -47,10 +46,12 @@
             <Path fileType="library">/usr/lib64/wireplumber-0.5/libwireplumber-module-si-node.so</Path>
             <Path fileType="library">/usr/lib64/wireplumber-0.5/libwireplumber-module-si-standard-link.so</Path>
             <Path fileType="library">/usr/lib64/wireplumber-0.5/libwireplumber-module-standard-event-source.so</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/wpctl</Path>
             <Path fileType="doc">/usr/share/doc/wireplumber/examples/wireplumber.conf.d/access.conf</Path>
             <Path fileType="doc">/usr/share/doc/wireplumber/examples/wireplumber.conf.d/alsa.conf</Path>
             <Path fileType="doc">/usr/share/doc/wireplumber/examples/wireplumber.conf.d/bluetooth.conf</Path>
             <Path fileType="doc">/usr/share/doc/wireplumber/examples/wireplumber.conf.d/device.conf</Path>
+            <Path fileType="doc">/usr/share/doc/wireplumber/examples/wireplumber.conf.d/filter-graph.conf</Path>
             <Path fileType="doc">/usr/share/doc/wireplumber/examples/wireplumber.conf.d/libcamera.conf</Path>
             <Path fileType="doc">/usr/share/doc/wireplumber/examples/wireplumber.conf.d/linking.conf</Path>
             <Path fileType="doc">/usr/share/doc/wireplumber/examples/wireplumber.conf.d/log.conf</Path>
@@ -59,6 +60,7 @@
             <Path fileType="doc">/usr/share/doc/wireplumber/examples/wireplumber.conf.d/smart-equalizer.conf</Path>
             <Path fileType="doc">/usr/share/doc/wireplumber/examples/wireplumber.conf.d/stream.conf</Path>
             <Path fileType="doc">/usr/share/doc/wireplumber/examples/wireplumber.conf.d/v4l2.conf</Path>
+            <Path fileType="data">/usr/share/licenses/wireplumber/LICENSE</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/wireplumber.mo</Path>
             <Path fileType="localedata">/usr/share/locale/as/LC_MESSAGES/wireplumber.mo</Path>
             <Path fileType="localedata">/usr/share/locale/be/LC_MESSAGES/wireplumber.mo</Path>
@@ -147,6 +149,7 @@
             <Path fileType="data">/usr/share/wireplumber/scripts/linking/find-default-target.lua</Path>
             <Path fileType="data">/usr/share/wireplumber/scripts/linking/find-defined-target.lua</Path>
             <Path fileType="data">/usr/share/wireplumber/scripts/linking/find-filter-target.lua</Path>
+            <Path fileType="data">/usr/share/wireplumber/scripts/linking/find-media-role-sink-target.lua</Path>
             <Path fileType="data">/usr/share/wireplumber/scripts/linking/find-media-role-target.lua</Path>
             <Path fileType="data">/usr/share/wireplumber/scripts/linking/find-user-target.lua.example</Path>
             <Path fileType="data">/usr/share/wireplumber/scripts/linking/get-filter-from-target.lua</Path>
@@ -173,6 +176,8 @@
             <Path fileType="data">/usr/share/wireplumber/scripts/node/audio-group.lua</Path>
             <Path fileType="data">/usr/share/wireplumber/scripts/node/create-item.lua</Path>
             <Path fileType="data">/usr/share/wireplumber/scripts/node/filter-forward-format.lua</Path>
+            <Path fileType="data">/usr/share/wireplumber/scripts/node/filter-graph.lua</Path>
+            <Path fileType="data">/usr/share/wireplumber/scripts/node/find-media-role-default-volume.lua</Path>
             <Path fileType="data">/usr/share/wireplumber/scripts/node/software-dsp.lua</Path>
             <Path fileType="data">/usr/share/wireplumber/scripts/node/state-stream.lua</Path>
             <Path fileType="data">/usr/share/wireplumber/scripts/node/suspend-node.lua</Path>
@@ -190,7 +195,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="37">wireplumber</Dependency>
+            <Dependency release="38">wireplumber</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/wireplumber-0.5/wp/base-dirs.h</Path>
@@ -240,12 +245,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="37">
-            <Date>2025-10-22</Date>
-            <Version>0.5.12</Version>
+        <Update release="38">
+            <Date>2026-03-14</Date>
+            <Version>0.5.13</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://gitlab.freedesktop.org/pipewire/wireplumber/-/releases/0.5.13).
Add systemd user service preset file.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Play audio through Bluetooth earbuds, run `systemctl status --user wireplumber.service`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
