### PR TITLE
xdg-user-dirs: Add systemd user service preset

### DIFF
--- a/packages/x/xdg-user-dirs/files/20-xdg-user-dirs.preset
+++ b/packages/x/xdg-user-dirs/files/20-xdg-user-dirs.preset
@@ -1,0 +1,1 @@
+enable xdg-user-dirs.service

--- a/packages/x/xdg-user-dirs/files/xdg-user-dirs.service
+++ b/packages/x/xdg-user-dirs/files/xdg-user-dirs.service
@@ -1,9 +1,0 @@
-[Unit]
-Description=Initialise XDG User Directories
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/xdg-user-dirs-update
-
-[Install]
-WantedBy=default.target

--- a/packages/x/xdg-user-dirs/package.yml
+++ b/packages/x/xdg-user-dirs/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : xdg-user-dirs
 version    : '0.19'
-release    : 12
+release    : 13
 source     :
     - https://gitlab.freedesktop.org/xdg/xdg-user-dirs/-/archive/v0.19/xdg-user-dirs-v0.19.tar.gz : aa18765c6f48b6c61f2fb426656dba640920f8436a04733965146af4c9a1f5e1
 homepage   : https://www.freedesktop.org/wiki/Software/xdg-user-dirs/
@@ -23,6 +23,6 @@ build      : |
     %make
 install    : |
     %make_install
-    install -m 00644 -D $pkgfiles/xdg-user-dirs.service $installdir/usr/lib/systemd/user/xdg-user-dirs.service
-    install -D -d -m 00755 $installdir/usr/lib/systemd/user/default.target.wants
-    ln -sv ../xdg-user-dirs.service $installdir/usr/lib/systemd/user/default.target.wants/xdg-user-dirs.service
+    %install_license COPYING
+
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/user-preset/ ${pkgfiles}/20-xdg-user-dirs.preset

--- a/packages/x/xdg-user-dirs/pspec_x86_64.xml
+++ b/packages/x/xdg-user-dirs/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xdg-user-dirs</Name>
         <Homepage>https://www.freedesktop.org/wiki/Software/xdg-user-dirs/</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>desktop.core</PartOf>
@@ -22,8 +22,9 @@
         <Files>
             <Path fileType="executable">/usr/bin/xdg-user-dir</Path>
             <Path fileType="executable">/usr/bin/xdg-user-dirs-update</Path>
-            <Path fileType="library">/usr/lib/systemd/user/default.target.wants/xdg-user-dirs.service</Path>
             <Path fileType="library">/usr/lib/systemd/user/xdg-user-dirs.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/user-preset/20-xdg-user-dirs.preset</Path>
+            <Path fileType="data">/usr/share/licenses/xdg-user-dirs/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/ab/LC_MESSAGES/xdg-user-dirs.mo</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/xdg-user-dirs.mo</Path>
             <Path fileType="localedata">/usr/share/locale/an/LC_MESSAGES/xdg-user-dirs.mo</Path>
@@ -110,12 +111,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2025-11-07</Date>
+        <Update release="13">
+            <Date>2026-03-14</Date>
             <Version>0.19</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd user service preset file.

**Test Plan**

Run `systemctl status --user xdg-user-dirs.service` and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
