### PR TITLE
usysconf-epoch: Add systemd service preset

### DIFF
--- a/packages/u/usysconf-epoch/files/20-usysconf-epoch.preset
+++ b/packages/u/usysconf-epoch/files/20-usysconf-epoch.preset
@@ -1,0 +1,2 @@
+enable usr-merge.service
+enable epoch.service

--- a/packages/u/usysconf-epoch/package.yml
+++ b/packages/u/usysconf-epoch/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : usysconf-epoch
 version    : 1.0.0
-release    : 25
+release    : 26
 source     :
     # We need something for a source
     - https://getsol.us/sources/hotspot.txt : a12b7cb43c9d9134b5bb1b35e9096b66775d9e92e7611d1cc92b02edd6782a87
@@ -13,9 +13,6 @@ summary    : Temporary package for hosting epoch and usr-merge scripts
 description: |
     Temporary package for hosting the epoch script
 install    : |
-    install -Dm00755 -t $installdir/usr/lib64/usysconf/      $pkgfiles/*.sh
-    install -Dm00644 -t $installdir/%libdir%/systemd/system/ $pkgfiles/*.service
-
-    install -Ddm00755 $installdir/%libdir%/systemd/system/{sysinit,multi-user}.target.wants
-    ln -srv $installdir/%libdir%/systemd/system/usr-merge.service $installdir/%libdir%/systemd/system/sysinit.target.wants/usr-merge.service
-    ln -srv $installdir/%libdir%/systemd/system/epoch.service     $installdir/%libdir%/systemd/system/multi-user.target.wants/epoch.service
+    install -Dm00755 -t ${installdir}/%libdir%/usysconf/              ${pkgfiles}/*.sh
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system/        ${pkgfiles}/*.service
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-usysconf-epoch.preset

--- a/packages/u/usysconf-epoch/pspec_x86_64.xml
+++ b/packages/u/usysconf-epoch/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>usysconf-epoch</Name>
         <Homepage>https://github.com/getsolus/usysconf/</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>system.base</PartOf>
@@ -20,21 +20,20 @@
 </Description>
         <PartOf>system.base</PartOf>
         <Files>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-usysconf-epoch.preset</Path>
             <Path fileType="library">/usr/lib64/systemd/system/epoch.service</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/multi-user.target.wants/epoch.service</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/sysinit.target.wants/usr-merge.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/usr-merge.service</Path>
             <Path fileType="library">/usr/lib64/usysconf/epoch.sh</Path>
             <Path fileType="library">/usr/lib64/usysconf/usr-merge.sh</Path>
         </Files>
     </Package>
     <History>
-        <Update release="25">
-            <Date>2025-10-27</Date>
+        <Update release="26">
+            <Date>2026-03-14</Date>
             <Version>1.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd system service preset file.

**Test Plan**

Run `systemctl status usr-merge.service` and `systemctl status epoch.service`, and see that both are enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
