### PR TITLE
qol-assist: Add systemd system service preset

### DIFF
--- a/packages/q/qol-assist/abi_used_symbols
+++ b/packages/q/qol-assist/abi_used_symbols
@@ -1,6 +1,7 @@
 libc.so.6:__errno_location
 libc.so.6:__libc_start_main
 libc.so.6:abort
+libc.so.6:clearenv
 libc.so.6:endgrent
 libc.so.6:endpwent
 libc.so.6:endusershell

--- a/packages/q/qol-assist/files/20-qol-assist.preset
+++ b/packages/q/qol-assist/files/20-qol-assist.preset
@@ -1,0 +1,1 @@
+enable qol-assist-migration.service

--- a/packages/q/qol-assist/package.yml
+++ b/packages/q/qol-assist/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : qol-assist
 version    : 0.9.0
-release    : 20
+release    : 21
 source     :
     - https://github.com/getsolus/qol-assist/releases/download/v0.9.0/qol-assist-v0.9.0.tar.gz : c62a112ad5e9511ec2c8e51bf0cb6f7896092114be92b0069203b4ff8a6547c4
 homepage   : https://github.com/getsolus/qol-assist
@@ -31,5 +31,6 @@ install    : |
         install -Dm00644 ${i} $installdir/usr/share/defaults/qol-assist.d/`basename ${i}`
     done
 
-    install -D -d -m 00755 $installdir/usr/lib/systemd/system/sysinit.target.wants
-    ln -sv ../qol-assist-migration.service $installdir/usr/lib/systemd/system/sysinit.target.wants/.
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-qol-assist.preset
+
+    %install_license LICENSE

--- a/packages/q/qol-assist/pspec_x86_64.xml
+++ b/packages/q/qol-assist/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>qol-assist</Name>
         <Homepage>https://github.com/getsolus/qol-assist</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>system.base</PartOf>
@@ -21,7 +21,7 @@
         <PartOf>system.base</PartOf>
         <Files>
             <Path fileType="library">/usr/lib/systemd/system/qol-assist-migration.service</Path>
-            <Path fileType="library">/usr/lib/systemd/system/sysinit.target.wants/qol-assist-migration.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-qol-assist.preset</Path>
             <Path fileType="executable">/usr/sbin/qol-assist</Path>
             <Path fileType="data">/usr/share/defaults/qol-assist.d/audio_group.toml</Path>
             <Path fileType="data">/usr/share/defaults/qol-assist.d/fuse_group.toml</Path>
@@ -32,16 +32,17 @@
             <Path fileType="data">/usr/share/defaults/qol-assist.d/users_group_update.toml</Path>
             <Path fileType="data">/usr/share/defaults/qol-assist.d/wheel_group_admin.toml</Path>
             <Path fileType="data">/usr/share/defaults/qol-assist.d/wheel_group_gid.toml</Path>
+            <Path fileType="data">/usr/share/licenses/qol-assist/LICENSE</Path>
             <Path fileType="man">/usr/share/man/man1/qol-assist.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2026-01-17</Date>
+        <Update release="21">
+            <Date>2026-03-14</Date>
             <Version>0.9.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd system service preset file.

**Test Plan**

Run `systemctl status qol-assist-migration.service` and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
