### PR TITLE
mullvad: Add systemd service preset, Add early boot blocking service

### DIFF
--- a/packages/m/mullvad/files/20-mullvad-daemon.preset
+++ b/packages/m/mullvad/files/20-mullvad-daemon.preset
@@ -1,0 +1,2 @@
+enable mullvad-daemon.service
+enable mullvad-early-boot-blocking.service

--- a/packages/m/mullvad/package.yml
+++ b/packages/m/mullvad/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : mullvad
 version    : '2025.14'
-release    : 22
+release    : 23
 source     :
     - git|https://github.com/mullvad/mullvadvpn-app.git : 2025.14
 license    : GPL-3.0-or-later
@@ -38,6 +38,8 @@ install    : |
     install -Dm00644 graphics/icon.svg $installdir/usr/share/icons/hicolor/scalable/apps/mullvad-vpn.svg
 
     install -Dm00644 dist-assets/linux/mullvad-daemon.service $installdir/%libdir%/systemd/system/mullvad-daemon.service
+    install -Dm00644 dist-assets/linux/mullvad-early-boot-blocking.service $installdir/%libdir%/systemd/system/mullvad-early-boot-blocking.service
     sed -i 's/\/opt\/Mullvad.*VPN/\/usr\/share\/mullvad/g' $installdir/%libdir%/systemd/system/mullvad-daemon.service
+    install -Dm00644 $pkgfiles/20-mullvad-daemon.preset ${installdir}/%libdir%/systemd/system-preset/20-mullvad-daemon.preset
 
     %install_license LICENSE.md

--- a/packages/m/mullvad/pspec_x86_64.xml
+++ b/packages/m/mullvad/pspec_x86_64.xml
@@ -23,7 +23,9 @@
             <Path fileType="executable">/usr/bin/mullvad</Path>
             <Path fileType="executable">/usr/bin/mullvad-daemon</Path>
             <Path fileType="executable">/usr/bin/mullvad-exclude</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-mullvad-daemon.preset</Path>
             <Path fileType="library">/usr/lib64/systemd/system/mullvad-daemon.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/system/mullvad-early-boot-blocking.service</Path>
             <Path fileType="data">/usr/share/applications/mullvad-vpn.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/mullvad-vpn.svg</Path>
             <Path fileType="data">/usr/share/licenses/mullvad/LICENSE.md</Path>
@@ -112,8 +114,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2025-12-10</Date>
+        <Update release="23">
+            <Date>2026-03-14</Date>
             <Version>2025.14</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>


### PR DESCRIPTION
**Summary**

- Add early boot blocking service
- The blocking service is described in comments: "Systemd service unit file to block all traffic during early boot..."
- Mullvad must be configured to block non-vpn traffic before this service has any effect
- Enable services on install


**Test Plan**

- See services enabled, started on reboot

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
