### PR TITLE
repo_data: Deprecate bsdiff-devel

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -3100,5 +3100,6 @@
 		<Package>python-shapely</Package>
 		<Package>python-uranium</Package>
 		<Package>fcitx-mozc</Package>
+		<Package>bsdiff-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -4254,5 +4254,7 @@
 		<!-- Removed in favor of Fcitx5 support -->
 		<Package>fcitx-mozc</Package>
 
+		<!-- devel package no longer exists -->
+		<Package>bsdiff-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
**Summary**

bsdiff-devel no longer exists https://github.com/getsolus/packages/commit/da82326815d70795a795050216f52f85f3c5ffda#diff-62b39dc9f2b51882121f32b43578bda061cc3e1753ae1989410d5cac858c42d3L33

Resolves getsolus/packages#8172