### PR TITLE
pcsc-lite: Update to v2.4.1

### DIFF
--- a/packages/p/pcsc-lite/files/20-pcsc-lite.preset
+++ b/packages/p/pcsc-lite/files/20-pcsc-lite.preset
@@ -1,0 +1,1 @@
+enable pcscd.socket

--- a/packages/p/pcsc-lite/package.yml
+++ b/packages/p/pcsc-lite/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : pcsc-lite
-version    : 2.4.0
-release    : 19
+version    : 2.4.1
+release    : 20
 source     :
-    - https://github.com/LudovicRousseau/PCSC/archive/refs/tags/2.4.0.tar.gz : 3d20f3d23c29260fed9195529d30ec3e9f1db60a8a835b4be68716d97751f2e7
+    - https://github.com/LudovicRousseau/PCSC/archive/refs/tags/2.4.1.tar.gz : e7b6737f68c3b9a763fb0b0370d899cea091cced9d762ca8a6032c959576d5be
 homepage   : https://pcsclite.apdu.fr/
 license    :
     - BSD-3-Clause
@@ -24,15 +24,12 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING GPL-3.0.txt
 
-    # Enable the socket by default
-    install -dm00755 $installdir/usr/lib/systemd/system/sockets.target.wants
-    ln -sv ../pcscd.socket -t $installdir/usr/lib/systemd/system/sockets.target.wants
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-pcsc-lite.preset
 
     # Polkit policy file
     install -D -m0644 doc/org.debian.pcsc-lite.policy -t $installdir/usr/share/polkit-1/actions/
-    # License files
-    install -D -m0644 COPYING -t $installdir/usr/share/licenses/pcsc-lite
 
     # Remove /etc, it was added to suppress harmless warning https://github.com/LudovicRousseau/PCSC/issues/211
     rm -fr $installdir/etc

--- a/packages/p/pcsc-lite/pspec_x86_64.xml
+++ b/packages/p/pcsc-lite/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pcsc-lite</Name>
         <Homepage>https://pcsclite.apdu.fr/</Homepage>
         <Packager>
-            <Name>Matthias Homann</Name>
-            <Email>palto@mailbox.org</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>GPL-3.0-or-later</License>
@@ -24,14 +24,15 @@
             <Path fileType="executable">/usr/bin/pcsc-spy</Path>
             <Path fileType="library">/usr/lib/systemd/system/pcscd.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/pcscd.socket</Path>
-            <Path fileType="library">/usr/lib/systemd/system/sockets.target.wants/pcscd.socket</Path>
             <Path fileType="library">/usr/lib/sysusers.d/pcscd-sysusers.conf</Path>
             <Path fileType="library">/usr/lib64/libpcsclite.so.1</Path>
             <Path fileType="library">/usr/lib64/libpcsclite_real.so.1</Path>
             <Path fileType="library">/usr/lib64/libpcscspy.so.0</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-pcsc-lite.preset</Path>
             <Path fileType="executable">/usr/sbin/pcscd</Path>
             <Path fileType="doc">/usr/share/doc/pcsc-lite/setup_spy.sh</Path>
             <Path fileType="data">/usr/share/licenses/pcsc-lite/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/pcsc-lite/GPL-3.0.txt</Path>
             <Path fileType="man">/usr/share/man/man1/pcsc-spy.1.zst</Path>
             <Path fileType="man">/usr/share/man/man5/reader.conf.5.zst</Path>
             <Path fileType="man">/usr/share/man/man8/pcscd.8.zst</Path>
@@ -46,7 +47,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="19">pcsc-lite</Dependency>
+            <Dependency release="20">pcsc-lite</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/PCSC/debuglog.h</Path>
@@ -62,12 +63,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2025-12-07</Date>
-            <Version>2.4.0</Version>
+        <Update release="20">
+            <Date>2026-03-15</Date>
+            <Version>2.4.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Matthias Homann</Name>
-            <Email>palto@mailbox.org</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/LudovicRousseau/PCSC/blob/2.4.1/ChangeLog).
Add systemd system service preset file.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `systemctl status pcscd.socket` and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
