### PR TITLE
udisks: Add systemd system service preset

### DIFF
--- a/packages/u/udisks/files/20-udisks.preset
+++ b/packages/u/udisks/files/20-udisks.preset
@@ -1,0 +1,1 @@
+enable udisks2.service

--- a/packages/u/udisks/package.yml
+++ b/packages/u/udisks/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : udisks
 version    : 2.11.1
-release    : 32
+release    : 33
 source     :
     - https://github.com/storaged-project/udisks/releases/download/udisks-2.11.1/udisks-2.11.1.tar.bz2 : e88c52bae02fa13414604bbef42c6bb91c2e24177ee0057ed55c6bd7451bcb6d
 homepage   : https://github.com/storaged-project/udisks
@@ -35,12 +35,12 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING
+
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-udisks.preset
+
     # Polkit rules file
     install -Dm00644 $pkgfiles/org.freedesktop.UDisks2.rules $installdir/usr/share/polkit-1/rules.d/org.freedesktop.UDisks2.rules
-
-    # Start it by default
-    install -dm00755 $installdir/usr/lib/systemd/system/graphical.target.wants
-    ln -sv ../udisks2.service $installdir/usr/lib/systemd/system/graphical.target.wants
 
     # Stateless
     install -D udisks/udisks2.conf $installdir/usr/share/defaults/etc/udisks2/udisks2.conf

--- a/packages/u/udisks/pspec_x86_64.xml
+++ b/packages/u/udisks/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>udisks</Name>
         <Homepage>https://github.com/storaged-project/udisks</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.core</PartOf>
@@ -21,12 +21,12 @@
         <PartOf>desktop.core</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/udisksctl</Path>
-            <Path fileType="library">/usr/lib/systemd/system/graphical.target.wants/udisks2.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/udisks2.service</Path>
             <Path fileType="library">/usr/lib/tmpfiles.d/udisks2.conf</Path>
             <Path fileType="library">/usr/lib64/girepository-1.0/UDisks-2.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libudisks2.so.0</Path>
             <Path fileType="library">/usr/lib64/libudisks2.so.0.0.0</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-udisks.preset</Path>
             <Path fileType="library">/usr/lib64/udev/rules.d/80-udisks2.rules</Path>
             <Path fileType="library">/usr/lib64/udisks/udisks2/udisksd</Path>
             <Path fileType="library">/usr/lib64/udisks2/modules/libudisks2_btrfs.so</Path>
@@ -36,6 +36,7 @@
             <Path fileType="data">/usr/share/dbus-1/system-services/org.freedesktop.UDisks2.service</Path>
             <Path fileType="data">/usr/share/dbus-1/system.d/org.freedesktop.UDisks2.conf</Path>
             <Path fileType="data">/usr/share/defaults/etc/udisks2/udisks2.conf</Path>
+            <Path fileType="data">/usr/share/licenses/udisks/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/udisks2.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/udisks2.mo</Path>
             <Path fileType="localedata">/usr/share/locale/as/LC_MESSAGES/udisks2.mo</Path>
@@ -120,7 +121,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="32">udisks</Dependency>
+            <Dependency release="33">udisks</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/udisks2/udisks/udisks-generated.h</Path>
@@ -289,12 +290,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2026-02-26</Date>
+        <Update release="33">
+            <Date>2026-03-15</Date>
             <Version>2.11.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd system service preset file.

**Test Plan**

Run `systemctl status udisks2.service` and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
