### PR TITLE
libvirt: Add systemd system service preset

### DIFF
--- a/packages/l/libvirt/files/20-libvirt.preset
+++ b/packages/l/libvirt/files/20-libvirt.preset
@@ -1,0 +1,4 @@
+enable virtlockd.socket
+enable virtlogd.socket
+enable libvirtd.socket
+enable libvirtd-ro.socket

--- a/packages/l/libvirt/package.yml
+++ b/packages/l/libvirt/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libvirt
 version    : 12.1.0
-release    : 81
+release    : 82
 source     :
     - https://libvirt.org/sources/libvirt-12.1.0.tar.xz : 3b60040a3670ec014d058ed021ae641e9fa6d3b5c4b56e63e8928f1804ef4b9b
 license    :
@@ -60,6 +60,7 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING COPYING.LESSER
 
     # Install sysusers and tmpfiles, overriding the files that libvirt ships
     install -Dm00644 $pkgfiles/libvirt.sysusers $installdir/usr/lib/sysusers.d/libvirt-qemu.conf
@@ -73,13 +74,7 @@ install    : |
 
     rm -rf $installdir/usr/share/doc
 
-    # ensure that .sockets will be always be activated after a (re)boot
-    # TODO: .sockets currently stay de-activated even after a `systemctl daemon-reexec`
-    install -dm00755 $installdir/usr/lib/systemd/system/sockets.target.wants
-    ln -svf ../virtlockd.socket $installdir/usr/lib/systemd/system/sockets.target.wants/
-    ln -svf ../virtlogd.socket $installdir/usr/lib/systemd/system/sockets.target.wants/
-    ln -svf ../libvirtd.socket $installdir/usr/lib/systemd/system/sockets.target.wants/
-    ln -svf ../libvirtd-ro.socket $installdir/usr/lib/systemd/system/sockets.target.wants/
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-libvirt.preset
 
     # Fix virt-secret-init-encryption.service not starting because of a missing directory
     install -Dm0644 $pkgfiles/virt-secret-init-encryption.service \

--- a/packages/l/libvirt/pspec_x86_64.xml
+++ b/packages/l/libvirt/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libvirt</Name>
         <Homepage>https://libvirt.org/</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -101,10 +101,6 @@
             <Path fileType="library">/usr/lib/systemd/system/libvirtd-tls.socket</Path>
             <Path fileType="library">/usr/lib/systemd/system/libvirtd.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/libvirtd.socket</Path>
-            <Path fileType="library">/usr/lib/systemd/system/sockets.target.wants/libvirtd-ro.socket</Path>
-            <Path fileType="library">/usr/lib/systemd/system/sockets.target.wants/libvirtd.socket</Path>
-            <Path fileType="library">/usr/lib/systemd/system/sockets.target.wants/virtlockd.socket</Path>
-            <Path fileType="library">/usr/lib/systemd/system/sockets.target.wants/virtlogd.socket</Path>
             <Path fileType="library">/usr/lib/systemd/system/virt-guest-shutdown.target</Path>
             <Path fileType="library">/usr/lib/systemd/system/virt-secret-init-encryption.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/virt-secret-init-encryption.service.d/50-create-dir.conf</Path>
@@ -193,6 +189,7 @@
             <Path fileType="library">/usr/lib64/libvirt/storage-backend/libvirt_storage_backend_vstorage.so</Path>
             <Path fileType="library">/usr/lib64/libvirt/storage-file</Path>
             <Path fileType="library">/usr/lib64/libvirt/virt-login-shell-helper</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-libvirt.preset</Path>
             <Path fileType="executable">/usr/sbin/libvirtd</Path>
             <Path fileType="executable">/usr/sbin/virtinterfaced</Path>
             <Path fileType="executable">/usr/sbin/virtlockd</Path>
@@ -471,6 +468,8 @@
             <Path fileType="data">/usr/share/libvirt/schemas/sysinfo.rng</Path>
             <Path fileType="data">/usr/share/libvirt/schemas/sysinfocommon.rng</Path>
             <Path fileType="data">/usr/share/libvirt/test-screenshot.png</Path>
+            <Path fileType="data">/usr/share/licenses/libvirt/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/libvirt/COPYING.LESSER</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/libvirt.mo</Path>
             <Path fileType="localedata">/usr/share/locale/as/LC_MESSAGES/libvirt.mo</Path>
             <Path fileType="localedata">/usr/share/locale/bg/LC_MESSAGES/libvirt.mo</Path>
@@ -569,7 +568,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="81">libvirt</Dependency>
+            <Dependency release="82">libvirt</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libvirt/libvirt-admin.h</Path>
@@ -601,12 +600,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="81">
-            <Date>2026-03-02</Date>
+        <Update release="82">
+            <Date>2026-03-15</Date>
             <Version>12.1.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd system service preset file.

**Test Plan**

Run `systemctl status` with all 4 enabled sockets, and see that all 4 are enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
