### PR TITLE
cups: Add systemd service preset

### DIFF
--- a/packages/c/cups/files/20-cups.preset
+++ b/packages/c/cups/files/20-cups.preset
@@ -1,0 +1,3 @@
+enable cups.service
+enable cups.path
+enable cups.socket

--- a/packages/c/cups/package.yml
+++ b/packages/c/cups/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : cups
 version    : 2.4.15
-release    : 41
+release    : 42
 source     :
     - https://github.com/OpenPrinting/cups/releases/download/v2.4.15/cups-2.4.15-source.tar.gz : eff0bbd48ff1abcbb8e46e28e85aefaffa391a1d9c4d8dc92ab3822a13008d7f
 homepage   : https://www.cups.org/
@@ -72,18 +72,10 @@ install    : |
         exit 0
     fi
 
-    install -D -m00644 $pkgfiles/cups.sysusers $installdir/%libdir%/sysusers.d/cups.conf
-    install -D -m00644 $pkgfiles/cups.tmpfiles $installdir/%libdir%/tmpfiles.d/cups.conf
+    install -Dm00644 $pkgfiles/cups.sysusers $installdir/%libdir%/sysusers.d/cups.conf
+    install -Dm00644 $pkgfiles/cups.tmpfiles $installdir/%libdir%/tmpfiles.d/cups.conf
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-cups.preset
 
-    # should be pre-enabled
-    install -D -d -m00755 $installdir/usr/lib/systemd/system/printer.target.wants
-    install -D -d -m00755 $installdir/usr/lib/systemd/system/sockets.target.wants
-    install -D -d -m00755 $installdir/usr/lib/systemd/system/multi-user.target.wants
-
-    ln -s ../cups.service $installdir/usr/lib/systemd/system/printer.target.wants/cups.service
-    ln -s ../cups.service $installdir/usr/lib/systemd/system/multi-user.target.wants/cups.service
-    ln -s ../cups.path    $installdir/usr/lib/systemd/system/multi-user.target.wants/cups.path
-    ln -s ../cups.socket  $installdir/usr/lib/systemd/system/sockets.target.wants/cups.socket
 
     # fix .desktop file
     sed -i 's|^Exec=htmlview http://localhost:631/|Exec=xdg-open http://localhost:631/|g' $installdir/usr/share/applications/cups.desktop
@@ -96,6 +88,8 @@ install    : |
     chmod a+r $installdir/usr/share/defaults/cups/*.conf
     rm -rfv $installdir/{etc,run,var}
     find $installdir -type d -empty -print -delete
+
+    %install_license LICENSE
 patterns   :
     - devel :
         - /usr/bin/cups-config

--- a/packages/c/cups/pspec_x86_64.xml
+++ b/packages/c/cups/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>cups</Name>
         <Homepage>https://www.cups.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0 WITH LLVM-exception</License>
         <License>BSD-2-Clause</License>
@@ -76,13 +76,10 @@
             <Path fileType="library">/usr/lib/systemd/system/cups.path</Path>
             <Path fileType="library">/usr/lib/systemd/system/cups.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/cups.socket</Path>
-            <Path fileType="library">/usr/lib/systemd/system/multi-user.target.wants/cups.path</Path>
-            <Path fileType="library">/usr/lib/systemd/system/multi-user.target.wants/cups.service</Path>
-            <Path fileType="library">/usr/lib/systemd/system/printer.target.wants/cups.service</Path>
-            <Path fileType="library">/usr/lib/systemd/system/sockets.target.wants/cups.socket</Path>
             <Path fileType="library">/usr/lib/systemd/system/system-cups.slice</Path>
             <Path fileType="library">/usr/lib64/libcups.so.2</Path>
             <Path fileType="library">/usr/lib64/libcupsimage.so.2</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-cups.preset</Path>
             <Path fileType="library">/usr/lib64/sysusers.d/cups.conf</Path>
             <Path fileType="library">/usr/lib64/tmpfiles.d/cups.conf</Path>
             <Path fileType="executable">/usr/sbin/cupsaccept</Path>
@@ -809,6 +806,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/16x16/apps/cups.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/32x32/apps/cups.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/cups.png</Path>
+            <Path fileType="data">/usr/share/licenses/cups/LICENSE</Path>
             <Path fileType="localedata">/usr/share/locale/ca/cups_ca.po</Path>
             <Path fileType="localedata">/usr/share/locale/cs/cups_cs.po</Path>
             <Path fileType="localedata">/usr/share/locale/da/cups_da.po</Path>
@@ -882,7 +880,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="41">cups</Dependency>
+            <Dependency release="42">cups</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libcups.so.2</Path>
@@ -896,8 +894,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="41">cups-32bit</Dependency>
-            <Dependency release="41">cups-devel</Dependency>
+            <Dependency release="42">cups-devel</Dependency>
+            <Dependency release="42">cups-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libcups.so</Path>
@@ -912,7 +910,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="41">cups</Dependency>
+            <Dependency release="42">cups</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/cups-config</Path>
@@ -938,12 +936,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="41">
-            <Date>2026-01-17</Date>
+        <Update release="42">
+            <Date>2026-03-15</Date>
             <Version>2.4.15</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd system service preset file.

**Test Plan**

Run `systemctl status` on the enabled items, see that they are enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
