### PR TITLE
cups-browsed: Add systemd service preset

### DIFF
--- a/packages/c/cups-browsed/abi_used_symbols
+++ b/packages/c/cups-browsed/abi_used_symbols
@@ -22,6 +22,7 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_toupper_loc
 libc.so.6:__errno_location
 libc.so.6:__getdelim
+libc.so.6:__inet_pton_chk
 libc.so.6:__isoc23_fscanf
 libc.so.6:__isoc23_strtol
 libc.so.6:__isoc23_strtoul
@@ -56,7 +57,6 @@ libc.so.6:getifaddrs
 libc.so.6:getnameinfo
 libc.so.6:if_indextoname
 libc.so.6:inet_aton
-libc.so.6:inet_pton
 libc.so.6:malloc
 libc.so.6:memcpy
 libc.so.6:memmove
@@ -271,7 +271,7 @@ libglib-2.0.so.0:g_str_hash
 libglib-2.0.so.0:g_strdup
 libglib-2.0.so.0:g_timeout_add_seconds
 libglib-2.0.so.0:g_variant_builder_end
-libglib-2.0.so.0:g_variant_builder_init
+libglib-2.0.so.0:g_variant_builder_init_static
 libglib-2.0.so.0:g_variant_get
 libglib-2.0.so.0:g_variant_iter_free
 libglib-2.0.so.0:g_variant_iter_init

--- a/packages/c/cups-browsed/files/20-cups-browsed.preset
+++ b/packages/c/cups-browsed/files/20-cups-browsed.preset
@@ -1,0 +1,1 @@
+enable cups-browsed.service

--- a/packages/c/cups-browsed/package.yml
+++ b/packages/c/cups-browsed/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : cups-browsed
 version    : 2.1.1
-release    : 5
+release    : 6
 source     :
     - https://github.com/OpenPrinting/cups-browsed/releases/download/2.1.1/cups-browsed-2.1.1.tar.gz : bc9ed54ef6940a6ee076f8627458fbc3cfed9b2f7bf4ef6e865be7644a51ce8f
 homepage   : https://github.com/OpenPrinting/cups-browsed
@@ -27,13 +27,12 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING LICENSE
 
     # Install the cups-browsed.service systemd unit file from the upstream sources
     install -Dm00644 daemon/cups-browsed.service $installdir/usr/lib/systemd/system/cups-browsed.service
 
-    # Enable to start on boot
-    install -dm00755 $installdir/usr/lib/systemd/system/multi-user.target.wants
-    ln -sv ../cups-browsed.service $installdir/usr/lib/systemd/system/multi-user.target.wants/.
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-cups-browsed.preset
 
     rm -rf $installdir/usr/share/doc
 ## Hangs

--- a/packages/c/cups-browsed/pspec_x86_64.xml
+++ b/packages/c/cups-browsed/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>cups-browsed</Name>
         <Homepage>https://github.com/OpenPrinting/cups-browsed</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0 WITH LLVM-exception</License>
         <PartOf>desktop.core</PartOf>
@@ -22,20 +22,22 @@
         <Files>
             <Path fileType="library">/usr/lib/cups/backend/implicitclass</Path>
             <Path fileType="library">/usr/lib/systemd/system/cups-browsed.service</Path>
-            <Path fileType="library">/usr/lib/systemd/system/multi-user.target.wants/cups-browsed.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-cups-browsed.preset</Path>
             <Path fileType="executable">/usr/sbin/cups-browsed</Path>
             <Path fileType="data">/usr/share/defaults/cups/cups-browsed.conf</Path>
-            <Path fileType="man">/usr/share/man/man5/cups-browsed.conf.5</Path>
-            <Path fileType="man">/usr/share/man/man8/cups-browsed.8</Path>
+            <Path fileType="data">/usr/share/licenses/cups-browsed/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/cups-browsed/LICENSE</Path>
+            <Path fileType="man">/usr/share/man/man5/cups-browsed.conf.5.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/cups-browsed.8.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2025-01-29</Date>
+        <Update release="6">
+            <Date>2026-03-15</Date>
             <Version>2.1.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd system service preset file.

**Test Plan**

Run `systemctl status cups-browsed.service` and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
