### PR TITLE
gcr-4: Add systemd user service preset

### DIFF
--- a/packages/g/gcr-4/abi_used_symbols
+++ b/packages/g/gcr-4/abi_used_symbols
@@ -2,6 +2,8 @@ libc.so.6:__assert_fail
 libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoul
 libc.so.6:__libc_start_main
 libc.so.6:__stack_chk_fail
 libc.so.6:accept
@@ -41,8 +43,6 @@ libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strspn
-libc.so.6:strtol
-libc.so.6:strtoul
 libc.so.6:time
 libc.so.6:write
 libgio-2.0.so.0:g_application_add_main_option_entries

--- a/packages/g/gcr-4/files/20-gcr4.preset
+++ b/packages/g/gcr-4/files/20-gcr4.preset
@@ -1,0 +1,1 @@
+enable gcr-ssh-agent.socket

--- a/packages/g/gcr-4/package.yml
+++ b/packages/g/gcr-4/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gcr-4
 version    : 4.4.0.1
-release    : 10
+release    : 11
 source     :
     - https://download.gnome.org/sources/gcr/4.4/gcr-4.4.0.1.tar.xz : 0c3c341e49f9f4f2532a4884509804190a0c2663e6120360bb298c5d174a8098
 homepage   : https://gitlab.gnome.org/GNOME/gcr
@@ -24,6 +24,6 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING
 
-    install -dm00644 $installdir/usr/lib/systemd/user/sockets.target.wants
-    ln -sv ../gcr-ssh-agent.socket $installdir/usr/lib/systemd/user/sockets.target.wants/
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/user-preset/ ${pkgfiles}/20-gcr4.preset

--- a/packages/g/gcr-4/pspec_x86_64.xml
+++ b/packages/g/gcr-4/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gcr-4</Name>
         <Homepage>https://gitlab.gnome.org/GNOME/gcr</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop.gnome.core</PartOf>
@@ -23,7 +23,6 @@
             <Path fileType="executable">/usr/bin/gcr-viewer-gtk4</Path>
             <Path fileType="library">/usr/lib/systemd/user/gcr-ssh-agent.service</Path>
             <Path fileType="library">/usr/lib/systemd/user/gcr-ssh-agent.socket</Path>
-            <Path fileType="library">/usr/lib/systemd/user/sockets.target.wants/gcr-ssh-agent.socket</Path>
             <Path fileType="library">/usr/lib64/gcr-4/gcr-ssh-agent</Path>
             <Path fileType="library">/usr/lib64/gcr-4/gcr4-ssh-askpass</Path>
             <Path fileType="library">/usr/lib64/girepository-1.0/Gck-2.typelib</Path>
@@ -32,6 +31,8 @@
             <Path fileType="library">/usr/lib64/libgck-2.so.2.4.0</Path>
             <Path fileType="library">/usr/lib64/libgcr-4.so.4</Path>
             <Path fileType="library">/usr/lib64/libgcr-4.so.4.4.0</Path>
+            <Path fileType="library">/usr/lib64/systemd/user-preset/20-gcr4.preset</Path>
+            <Path fileType="data">/usr/share/licenses/gcr-4/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/ab/LC_MESSAGES/gcr-4.mo</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/gcr-4.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/gcr-4.mo</Path>
@@ -131,7 +132,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">gcr-4</Dependency>
+            <Dependency release="11">gcr-4</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gck-2/gck/gck-enum-types.h</Path>
@@ -181,12 +182,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2025-04-04</Date>
+        <Update release="11">
+            <Date>2026-03-15</Date>
             <Version>4.4.0.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd user service preset file.

**Test Plan**

Run `systemctl status gcr-ssh-agent.socket`, and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
