### PR TITLE
snapd: Add systemd system service preset

### DIFF
--- a/packages/s/snapd/abi_used_symbols
+++ b/packages/s/snapd/abi_used_symbols
@@ -25,6 +25,7 @@ libc.so.6:calloc
 libc.so.6:chdir
 libc.so.6:chmod
 libc.so.6:chown
+libc.so.6:clearenv
 libc.so.6:close
 libc.so.6:closedir
 libc.so.6:dirfd

--- a/packages/s/snapd/files/20-snap.preset
+++ b/packages/s/snapd/files/20-snap.preset
@@ -1,0 +1,1 @@
+enable snapd.socket

--- a/packages/s/snapd/package.yml
+++ b/packages/s/snapd/package.yml
@@ -2,7 +2,7 @@
 name       : snapd
 version    : '2.74'
 homepage   : https://snapcraft.io/
-release    : 92
+release    : 93
 source     :
     - https://github.com/canonical/snapd/releases/download/2.74/snapd_2.74.vendor.tar.xz : ed034744915fe538b3b67d9bcaf4d28cf5fe8bf75914da4a887ae393d9931ebc
 license    : GPL-3.0-only
@@ -86,8 +86,7 @@ install    : |
     # satisfy bindmounts in confinement
     install -Ddm00755 $installdir/usr/src
 
-    install -dm00755 $installdir/%libdir%/systemd/system/sockets.target.wants
-    ln -sv ../snapd.socket $installdir/%libdir%/systemd/system/sockets.target.wants/snapd.socket
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-snap.preset
 
     install -Dm00644 data/info $installdir/%libdir%/$package/info
     install -Dm00644 data/polkit/io.snapcraft.snapd.policy $installdir/usr/share/polkit-1/actions/io.snapcraft.snapd.policy
@@ -124,3 +123,5 @@ install    : |
     rm -rvf $installdir/usr/bin/ubuntu-core-launcher
     rm -rvf $installdir/%libdir%/snapd/{system-shutdown,snapd.core-fixup.sh}
     rm -rvf $installdir/%libdir%/systemd/system/{snapd.system-shutdown.service,snapd.autoimport.service,snapd.snap-repair.*,snapd.core-fixup.*}
+
+    %install_license COPYING

--- a/packages/s/snapd/pspec_x86_64.xml
+++ b/packages/s/snapd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>snapd</Name>
         <Homepage>https://snapcraft.io/</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-only</License>
         <PartOf>desktop</PartOf>
@@ -47,6 +47,7 @@
             <Path fileType="library">/usr/lib64/snapd/snapd</Path>
             <Path fileType="library">/usr/lib64/snapd/snapd-apparmor</Path>
             <Path fileType="library">/usr/lib64/snapd/snapd.run-from-snap</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-snap.preset</Path>
             <Path fileType="library">/usr/lib64/systemd/system/snapd.apparmor.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/snapd.failure.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/snapd.gpio-chardev-setup.target</Path>
@@ -56,7 +57,6 @@
             <Path fileType="library">/usr/lib64/systemd/system/snapd.seeded.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/snapd.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/snapd.socket</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/sockets.target.wants/snapd.socket</Path>
             <Path fileType="library">/usr/lib64/tmpfiles.d/snapd.conf</Path>
             <Path fileType="data">/usr/share/applications/io.snapcraft.SessionAgent.desktop</Path>
             <Path fileType="data">/usr/share/applications/snap-handle-link.desktop</Path>
@@ -68,6 +68,7 @@
             <Path fileType="data">/usr/share/dbus-1/system.d/snapd.system-services.conf</Path>
             <Path fileType="data">/usr/share/defaults/etc/profile.d/70-snapd.sh</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/snapd.fish</Path>
+            <Path fileType="data">/usr/share/licenses/snapd/COPYING</Path>
             <Path fileType="man">/usr/share/man/man8/snap-confine.8.zst</Path>
             <Path fileType="man">/usr/share/man/man8/snap-discard-ns.8.zst</Path>
             <Path fileType="man">/usr/share/man/man8/snapd-env-generator.8.zst</Path>
@@ -79,12 +80,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="92">
-            <Date>2026-03-03</Date>
+        <Update release="93">
+            <Date>2026-03-15</Date>
             <Version>2.74</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd system service preset file.

**Test Plan**

Run `systemctl status snapd.socket` and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
