### PR TITLE
systemd: Clean up enabled service files

### DIFF
--- a/packages/s/systemd/package.yml
+++ b/packages/s/systemd/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : systemd
 version    : '257.10'
-release    : 184
+release    : 185
 source     :
     - https://github.com/systemd/systemd/archive/refs/tags/v257.10.tar.gz : 5a2f477e6268630f6e2829c7bb3e442017549798a4122635817934eaa0c6ac10
 license    :
@@ -254,24 +254,7 @@ install    : |
     # Default to BFQ scheduler for rotational drives, and kyber for sata/nvme SSDs
     install -Dm00644 -t $installdir/usr/lib/udev/rules.d/ $pkgfiles/configs/60-block-scheduler.rules
 
-    # Enable systemd-resolved by default
-    ln -sv ../systemd-resolved.service $installdir/usr/lib/systemd/system/sysinit.target.wants/systemd-resolved.service
-
-    # Enable systemd-timesyncd by default
-    ln -sv ../systemd-timesyncd.service $installdir/usr/lib/systemd/system/sysinit.target.wants/systemd-timesyncd.service
     ln -sv systemd-timesyncd.service $installdir/usr/lib/systemd/system/dbus-org.freedesktop.timesync1.service
-
-    # Enable audit collection by default
-    install -dm00755 $installdir/usr/lib/systemd/system/systemd-journald.service.wants/
-    ln -sv ../systemd-journald-audit.socket $installdir/usr/lib/systemd/system/systemd-journald.service.wants/systemd-journald-audit.socket
-    ln -sv ../systemd-journald-audit.socket $installdir/usr/lib/systemd/system/sockets.target.wants/systemd-journald-audit.socket
-
-    # Enable user tmpfiles cleanup by default
-    install -dm00755 $installdir/usr/lib/systemd/user/timers.target.wants/
-    ln -sv ../systemd-tmpfiles-clean.timer $installdir/usr/lib/systemd/user/timers.target.wants/
-
-    # Enable remote-fs.target by default, allowing users to have mounts in their fstabs
-    ln -sv ../remote-fs.target $installdir/usr/lib/systemd/system/multi-user.target.wants/remote-fs.target
 
     # Install compat dirs
     install -dm00755 $installdir/{,usr/}lib64/udev

--- a/packages/s/systemd/pspec_x86_64.xml
+++ b/packages/s/systemd/pspec_x86_64.xml
@@ -245,7 +245,6 @@
             <Path fileType="library">/usr/lib/systemd/system/modprobe@.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/multi-user.target</Path>
             <Path fileType="library">/usr/lib/systemd/system/multi-user.target.wants/getty.target</Path>
-            <Path fileType="library">/usr/lib/systemd/system/multi-user.target.wants/remote-fs.target</Path>
             <Path fileType="library">/usr/lib/systemd/system/multi-user.target.wants/systemd-ask-password-wall.path</Path>
             <Path fileType="library">/usr/lib/systemd/system/multi-user.target.wants/systemd-logind.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/multi-user.target.wants/systemd-user-sessions.service</Path>
@@ -283,7 +282,6 @@
             <Path fileType="library">/usr/lib/systemd/system/sockets.target.wants/systemd-creds.socket</Path>
             <Path fileType="library">/usr/lib/systemd/system/sockets.target.wants/systemd-hostnamed.socket</Path>
             <Path fileType="library">/usr/lib/systemd/system/sockets.target.wants/systemd-importd.socket</Path>
-            <Path fileType="library">/usr/lib/systemd/system/sockets.target.wants/systemd-journald-audit.socket</Path>
             <Path fileType="library">/usr/lib/systemd/system/sockets.target.wants/systemd-journald-dev-log.socket</Path>
             <Path fileType="library">/usr/lib/systemd/system/sockets.target.wants/systemd-journald.socket</Path>
             <Path fileType="library">/usr/lib/systemd/system/sockets.target.wants/systemd-pcrextend.socket</Path>
@@ -330,10 +328,8 @@
             <Path fileType="library">/usr/lib/systemd/system/sysinit.target.wants/systemd-pcrphase.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/sysinit.target.wants/systemd-random-seed.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/sysinit.target.wants/systemd-repart.service</Path>
-            <Path fileType="library">/usr/lib/systemd/system/sysinit.target.wants/systemd-resolved.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/sysinit.target.wants/systemd-sysctl.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/sysinit.target.wants/systemd-sysusers.service</Path>
-            <Path fileType="library">/usr/lib/systemd/system/sysinit.target.wants/systemd-timesyncd.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup-dev-early.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup-dev.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup.service</Path>
@@ -400,7 +396,6 @@
             <Path fileType="library">/usr/lib/systemd/system/systemd-journald-sync@.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/systemd-journald-varlink@.socket</Path>
             <Path fileType="library">/usr/lib/systemd/system/systemd-journald.service</Path>
-            <Path fileType="library">/usr/lib/systemd/system/systemd-journald.service.wants/systemd-journald-audit.socket</Path>
             <Path fileType="library">/usr/lib/systemd/system/systemd-journald.socket</Path>
             <Path fileType="library">/usr/lib/systemd/system/systemd-journald@.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/systemd-journald@.socket</Path>
@@ -603,7 +598,6 @@
             <Path fileType="library">/usr/lib/systemd/user/systemd-tmpfiles-clean.timer</Path>
             <Path fileType="library">/usr/lib/systemd/user/systemd-tmpfiles-setup.service</Path>
             <Path fileType="library">/usr/lib/systemd/user/timers.target</Path>
-            <Path fileType="library">/usr/lib/systemd/user/timers.target.wants/systemd-tmpfiles-clean.timer</Path>
             <Path fileType="library">/usr/lib/systemd/user/xdg-desktop-autostart.target</Path>
             <Path fileType="library">/usr/lib/sysusers.d/README</Path>
             <Path fileType="library">/usr/lib/sysusers.d/basic.conf</Path>
@@ -1334,7 +1328,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="184">systemd</Dependency>
+            <Dependency release="185">systemd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnss_myhostname.so.2</Path>
@@ -1357,8 +1351,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="184">systemd-32bit</Dependency>
-            <Dependency release="184">systemd-devel</Dependency>
+            <Dependency release="185">systemd-devel</Dependency>
+            <Dependency release="185">systemd-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/lib32/pkgconfig/libsystemd.pc</Path>
@@ -1372,7 +1366,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="184">systemd</Dependency>
+            <Dependency release="185">systemd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libudev.h</Path>
@@ -2192,8 +2186,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="184">
-            <Date>2026-03-13</Date>
+        <Update release="185">
+            <Date>2026-03-15</Date>
             <Version>257.10</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
These services are already started by default via systemd's upstream preset file.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

I can't actually test this because I need the secureboot keys. I did verify that the services were already enabled before removing these files.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
