### PR TITLE
scx-tools: Add systemd system service preset

### DIFF
--- a/packages/s/scx-tools/files/20-scx-tools.preset
+++ b/packages/s/scx-tools/files/20-scx-tools.preset
@@ -1,0 +1,1 @@
+enable scx_loader.service

--- a/packages/s/scx-tools/package.yml
+++ b/packages/s/scx-tools/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : scx-tools
 version    : 1.1.0
-release    : 3
+release    : 4
 source     :
     - https://github.com/sched-ext/scx-loader/archive/refs/tags/v1.1.0.tar.gz : 14f23108f95126958c4c54be9a02f0d1cc746b0e8a0e6572123cdf48f6c98100
 homepage   : https://github.com/sched-ext/scx-loader
@@ -26,6 +26,8 @@ install    : |
 
     ./target/release/xtask install --destdir "$installdir/"
 
+    %install_license LICENSE
+
     # Useless stuff not needed
     rm -v $installdir/usr/bin/xtask
 
@@ -36,6 +38,4 @@ install    : |
     # Install our default config
     install -Dm00644 $pkgfiles/config.toml -t ${installdir}/${VENDORDIR}/scx_loader
 
-    # Enable service
-    install -Ddm00755 $installdir/usr/lib/systemd/system/sysinit.target.wants
-    ln -sv ../scx_loader.service $installdir/usr/lib/systemd/system/sysinit.target.wants/scx_loader.service
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-scx-tools.preset

--- a/packages/s/scx-tools/pspec_x86_64.xml
+++ b/packages/s/scx-tools/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>scx-tools</Name>
         <Homepage>https://github.com/sched-ext/scx-loader</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>system.utils</PartOf>
@@ -23,21 +23,22 @@
             <Path fileType="executable">/usr/bin/scx_loader</Path>
             <Path fileType="executable">/usr/bin/scxctl</Path>
             <Path fileType="library">/usr/lib/systemd/system/scx_loader.service</Path>
-            <Path fileType="library">/usr/lib/systemd/system/sysinit.target.wants/scx_loader.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-scx-tools.preset</Path>
             <Path fileType="data">/usr/share/dbus-1/interfaces/org.scx.Loader.xml</Path>
             <Path fileType="data">/usr/share/dbus-1/system-services/org.scx.Loader.service</Path>
             <Path fileType="data">/usr/share/dbus-1/system.d/org.scx.Loader.conf</Path>
             <Path fileType="data">/usr/share/defaults/scx_loader/config.toml</Path>
+            <Path fileType="data">/usr/share/licenses/scx-tools/LICENSE</Path>
             <Path fileType="data">/usr/share/polkit-1/actions/org.scx.Loader.policy</Path>
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2026-03-08</Date>
+        <Update release="4">
+            <Date>2026-03-15</Date>
             <Version>1.1.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd system service preset file.

**Test Plan**

Run `systemctl status scx_loader.service` and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
