### PR TITLE
upower: Add systemd system service preset

### DIFF
--- a/packages/u/upower/files/20-upower.preset
+++ b/packages/u/upower/files/20-upower.preset
@@ -1,0 +1,1 @@
+enable upower.service

--- a/packages/u/upower/package.yml
+++ b/packages/u/upower/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : upower
 version    : 1.90.10
-release    : 29
+release    : 30
 source     :
     - https://gitlab.freedesktop.org/upower/upower/-/archive/v1.90.10/upower-v1.90.10.tar.gz : 7fcd51bece2526dbee5170feb3ffd1adab5b0cd023575f1fd119d969b73f4b90
 homepage   : https://upower.freedesktop.org/
@@ -28,10 +28,9 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING
 
-    # Start it by default
-    install -dm00755 $installdir/usr/lib/systemd/system/graphical.target.wants
-    ln -sv ../upower.service $installdir/usr/lib/systemd/system/graphical.target.wants
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-upower.preset
 
     # Remove installed tests
     rm -rfv $installdir/usr/share/installed-tests

--- a/packages/u/upower/pspec_x86_64.xml
+++ b/packages/u/upower/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>upower</Name>
         <Homepage>https://upower.freedesktop.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.0-or-later</License>
         <PartOf>desktop.core</PartOf>
@@ -21,7 +21,6 @@
         <PartOf>desktop.core</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/upower</Path>
-            <Path fileType="library">/usr/lib/systemd/system/graphical.target.wants/upower.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/upower.service</Path>
             <Path fileType="library">/usr/lib/udev/hwdb.d/60-upower-battery.hwdb</Path>
             <Path fileType="library">/usr/lib/udev/hwdb.d/95-upower-hid.hwdb</Path>
@@ -31,6 +30,7 @@
             <Path fileType="library">/usr/lib64/girepository-1.0/UPowerGlib-1.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libupower-glib.so.3</Path>
             <Path fileType="library">/usr/lib64/libupower-glib.so.3.1.0</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-upower.preset</Path>
             <Path fileType="library">/usr/lib64/upower/upower/integration-test.py</Path>
             <Path fileType="library">/usr/lib64/upower/upower/output_checker.py</Path>
             <Path fileType="library">/usr/lib64/upower/upower/tests/logitech-g903.device</Path>
@@ -47,6 +47,7 @@
             <Path fileType="data">/usr/share/dbus-1/system-services/org.freedesktop.UPower.service</Path>
             <Path fileType="data">/usr/share/dbus-1/system.d/org.freedesktop.UPower.conf</Path>
             <Path fileType="data">/usr/share/defaults/etc/UPower/UPower.conf</Path>
+            <Path fileType="data">/usr/share/licenses/upower/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/upower.mo</Path>
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/upower.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/upower.mo</Path>
@@ -63,7 +64,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="29">upower</Dependency>
+            <Dependency release="30">upower</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libupower-glib/up-autocleanups.h</Path>
@@ -80,12 +81,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="29">
-            <Date>2025-09-12</Date>
+        <Update release="30">
+            <Date>2026-03-15</Date>
             <Version>1.90.10</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd system service preset file.

**Test Plan**

Run `systemctl status upower.service` and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
