### PR TITLE
virtualbox: Add systemd system service preset

### DIFF
--- a/packages/v/virtualbox/files/20-virtualbox-guest.preset
+++ b/packages/v/virtualbox/files/20-virtualbox-guest.preset
@@ -1,0 +1,1 @@
+enable vboxservice.service

--- a/packages/v/virtualbox/files/20-virtualbox.preset
+++ b/packages/v/virtualbox/files/20-virtualbox.preset
@@ -1,0 +1,1 @@
+enable vboxdrv.service

--- a/packages/v/virtualbox/package.yml
+++ b/packages/v/virtualbox/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : virtualbox
 version    : 7.2.6
-release    : 372
+release    : 373
 source     :
     - https://download.virtualbox.org/virtualbox/7.2.6/VirtualBox-7.2.6.tar.bz2 : c58443a0e6fcc7fc7e84c1011a10823b3540c6a2b8f2e27c4d8971272baf09f7
     - https://download.virtualbox.org/virtualbox/7.2.6/VBoxGuestAdditions_7.2.6.iso : 740e9a729c944180a165188fd426f9a2e1a2581d654402a1b856f9755a1ffc97
@@ -114,7 +114,7 @@ patterns   :
         - /usr/lib64/modules-load.d/vboxguest.conf
         - /usr/lib64/sysusers.d/vboxguest.conf
         - /usr/lib64/systemd/system/vboxservice.service
-        - /usr/lib64/systemd/system/multi-user.target.wants/vboxservice.service
+        - /usr/lib64/systemd/system-preset/20-virtualbox-guest.preset
         - /usr/share/xdg
     - guest-additions-iso :
         - /usr/share/virtualbox/VBoxGuestAdditions.iso
@@ -230,8 +230,7 @@ install    : |
     install -Dm00644 $pkgfiles/60-vboxdrv.rules $installdir/%libdir%/udev/rules.d/60-vboxdrv.rules
     install -Dm00755 $pkgfiles/vboxdrv.sh $installdir/%libdir%/virtualbox/vboxdrv.sh
     install -Dm00644 $pkgfiles/vboxdrv.service $installdir/%libdir%/systemd/system/vboxdrv.service
-    install -dm00755 $installdir/%libdir%/systemd/system/multi-user.target.wants
-    ln -sv ../vboxdrv.service $installdir/%libdir%/systemd/system/multi-user.target.wants/.
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-virtualbox.preset
 
     ##### Guest #####
     cd additions
@@ -261,7 +260,7 @@ install    : |
     install -Dm00644 $pkgfiles/vboxguest.sysusers $installdir/%libdir%/sysusers.d/vboxguest.conf
     install -Dm00644 $pkgfiles/60-vboxguest.rules $installdir/%libdir%/udev/rules.d/60-vboxguest.rules
     install -Dm00644 $pkgfiles/vboxservice.service $installdir/%libdir%/systemd/system/vboxservice.service
-    ln -sv ../vboxservice.service $installdir/%libdir%/systemd/system/multi-user.target.wants/.
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-virtualbox-guest.preset
 
     # Compress modules with zstd
     find "$installdir" -name '*.ko' -exec strip --strip-debug {} \; -exec zstd {} \; -exec rm -v {} \;

--- a/packages/v/virtualbox/pspec_x86_64.xml
+++ b/packages/v/virtualbox/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>virtualbox</Name>
         <Homepage>https://www.virtualbox.org</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>virt</PartOf>
@@ -24,7 +24,7 @@ Installation Guide: https://help.getsol.us/docs/user/software/virtualization/vir
 </Description>
         <PartOf>virt</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="372">virtualbox-common</Dependency>
+            <Dependency releaseFrom="373">virtualbox-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.12.74-280.lts/extra/vboxdrv.ko.zst</Path>
@@ -55,7 +55,7 @@ Installation Guide: https://help.getsol.us/docs/user/software/virtualization/vir
             <Path fileType="executable">/usr/bin/VBoxVRDP</Path>
             <Path fileType="executable">/usr/bin/VirtualBox</Path>
             <Path fileType="library">/usr/lib/modprobe.d/virtualbox.conf</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/multi-user.target.wants/vboxdrv.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-virtualbox.preset</Path>
             <Path fileType="library">/usr/lib64/systemd/system/vboxdrv.service</Path>
             <Path fileType="library">/usr/lib64/sysusers.d/virtualbox.conf</Path>
             <Path fileType="library">/usr/lib64/udev/rules.d/60-vboxdrv.rules</Path>
@@ -315,7 +315,7 @@ Installation Guide: https://help.getsol.us/docs/user/software/virtualization/vir
 </Description>
         <PartOf>virt</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="372">virtualbox-common</Dependency>
+            <Dependency releaseFrom="373">virtualbox-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.18.13-330.current/extra/vboxdrv.ko.zst</Path>
@@ -335,8 +335,8 @@ Installation Guide: https://help.getsol.us/docs/user/software/virtualization/vir
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="372">virtualbox</Dependency>
-            <Dependency releaseFrom="372">virtualbox-common</Dependency>
+            <Dependency release="373">virtualbox</Dependency>
+            <Dependency releaseFrom="373">virtualbox-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib/python3.12/site-packages/vboxapi-1-py3.12.egg-info/PKG-INFO</Path>
@@ -627,7 +627,7 @@ Installation Guide: https://help.getsol.us/docs/user/software/virtualization/vir
 </Description>
         <PartOf>virt</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="372">virtualbox-guest-common</Dependency>
+            <Dependency releaseFrom="373">virtualbox-guest-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.12.74-280.lts/misc/vboxguest.ko.zst</Path>
@@ -664,7 +664,7 @@ Installation Guide: https://help.getsol.us/docs/user/software/virtualization/vir
             <Path fileType="executable">/usr/bin/VBoxControl</Path>
             <Path fileType="library">/usr/lib64/modules-load.d/vboxguest.conf</Path>
             <Path fileType="library">/usr/lib64/security/pam_vbox.so</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/multi-user.target.wants/vboxservice.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-virtualbox-guest.preset</Path>
             <Path fileType="library">/usr/lib64/systemd/system/vboxservice.service</Path>
             <Path fileType="library">/usr/lib64/sysusers.d/vboxguest.conf</Path>
             <Path fileType="library">/usr/lib64/udev/rules.d/60-vboxguest.rules</Path>
@@ -682,7 +682,7 @@ Installation Guide: https://help.getsol.us/docs/user/software/virtualization/vir
 </Description>
         <PartOf>virt</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="372">virtualbox-guest-common</Dependency>
+            <Dependency releaseFrom="373">virtualbox-guest-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.18.13-330.current/misc/vboxguest.ko.zst</Path>
@@ -694,12 +694,12 @@ Installation Guide: https://help.getsol.us/docs/user/software/virtualization/vir
         </Files>
     </Package>
     <History>
-        <Update release="372">
-            <Date>2026-02-21</Date>
+        <Update release="373">
+            <Date>2026-03-15</Date>
             <Version>7.2.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd system service preset file.

**Test Plan**

Run `systemctl status vboxdrv.service` and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
