### PR TITLE
solseek: Update to 1.0.2

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 1.0.1
-release    : 20
+version    : 1.0.2
+release    : 21
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v1.0.1.tar.gz : 4c627e3561cf898fee71a6811f68ae2ddc307125f68ba945b7e519fd4e95c793
+    - https://github.com/clintre/solseek/archive/refs/tags/v1.0.2.tar.gz : 52751588e0419b7833dceed70b57ca5c3ec174d662e09e8802621b729ca21825
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -69,9 +69,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2026-03-11</Date>
-            <Version>1.0.1</Version>
+        <Update release="21">
+            <Date>2026-03-16</Date>
+            <Version>1.0.2</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**

Bugfixes:
- Fix issue with Flatpak showing incorrect count when no flatpak's are installed due to adding "empty" as entry.
- Fix issue where appstream-catalog has no flatpaks in it until Discover or Gnome Software is run. Added built in function to add and update the catalog in Solseek during cache update.

Full Changelog:
https://github.com/clintre/solseek/compare/v1.0.1...v1.0.2


**Test Plan**

Test on VM. Install and run

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
