### PR TITLE
usysconf: Update to v0.5.10

### DIFF
--- a/packages/u/usysconf/package.yml
+++ b/packages/u/usysconf/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : usysconf
-version    : 0.5.9
-release    : 45
+version    : 0.5.10
+release    : 46
 source     :
-    - https://github.com/getsolus/usysconf/releases/download/v0.5.9/usysconf-v0.5.9.tar.xz : a82798d3d90c71606a7c8d1b285e78b2077ea5fb091f416df07dbdc50ac6fd8c
+    - https://github.com/getsolus/usysconf/releases/download/v0.5.10/usysconf-v0.5.10.tar.xz : 6aa26187f7a900ff519cca59278cde3a84f7876205c51f8ac6654fe688e0d87a
 homepage   : https://github.com/getsolus/usysconf/
 license    : GPL-2.0-only
 component  : system.base

--- a/packages/u/usysconf/pspec_x86_64.xml
+++ b/packages/u/usysconf/pspec_x86_64.xml
@@ -40,9 +40,9 @@ usysconf is a Solus project.
         </Files>
     </Package>
     <History>
-        <Update release="45">
-            <Date>2026-03-13</Date>
-            <Version>0.5.9</Version>
+        <Update release="46">
+            <Date>2026-03-16</Date>
+            <Version>0.5.10</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/getsolus/usysconf/releases/tag/v0.5.10).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build and install packages that ship service and preset files, and see that the preset trigger runs on all service files.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
