### PR TITLE
modem-manager: Add systemd system service preset

### DIFF
--- a/packages/m/modem-manager/files/20-modem-manager.preset
+++ b/packages/m/modem-manager/files/20-modem-manager.preset
@@ -1,0 +1,1 @@
+enable ModemManager.service

--- a/packages/m/modem-manager/package.yml
+++ b/packages/m/modem-manager/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : modem-manager
 version    : 1.22.0
-release    : 22
+release    : 23
 source     :
     - https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/archive/1.22.0/ModemManager-1.22.0.tar.gz : 6c8f8720737a3788e394c700f36236278c9de09d76069a079e6f1daaf08b2768
 license    :
@@ -25,8 +25,9 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING COPYING.LIB
 
-    # Enable modemmanager service by default
-    install -dm00755 $installdir/%libdir%/systemd/system/multi-user.target.wants
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-modem-manager.preset
+
+    install -dm00755 ${installdir}/%libdir%/systemd/system/
     ln -sv ModemManager.service $installdir/%libdir%/systemd/system/dbus-org.freedesktop.ModemManager1.service
-    ln -sv ../ModemManager.service $installdir/%libdir%/systemd/system/multi-user.target.wants

--- a/packages/m/modem-manager/pspec_x86_64.xml
+++ b/packages/m/modem-manager/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>modem-manager</Name>
         <Homepage>https://www.freedesktop.org/wiki/Software/ModemManager/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -78,8 +78,8 @@
             <Path fileType="library">/usr/lib64/girepository-1.0/ModemManager-1.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libmm-glib.so.0</Path>
             <Path fileType="library">/usr/lib64/libmm-glib.so.0.10.0</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-modem-manager.preset</Path>
             <Path fileType="library">/usr/lib64/systemd/system/dbus-org.freedesktop.ModemManager1.service</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/multi-user.target.wants/ModemManager.service</Path>
             <Path fileType="library">/usr/lib64/udev/rules.d/77-mm-broadmobi-port-types.rules</Path>
             <Path fileType="library">/usr/lib64/udev/rules.d/77-mm-cinterion-port-types.rules</Path>
             <Path fileType="library">/usr/lib64/udev/rules.d/77-mm-dell-port-types.rules</Path>
@@ -141,8 +141,9 @@
             <Path fileType="data">/usr/share/dbus-1/interfaces/org.freedesktop.ModemManager1.xml</Path>
             <Path fileType="data">/usr/share/dbus-1/system-services/org.freedesktop.ModemManager1.service</Path>
             <Path fileType="data">/usr/share/dbus-1/system.d/org.freedesktop.ModemManager1.conf</Path>
-            <Path fileType="data">/usr/share/gir-1.0/ModemManager-1.0.gir</Path>
             <Path fileType="data">/usr/share/icons/hicolor/22x22/apps/ModemManager.png</Path>
+            <Path fileType="data">/usr/share/licenses/modem-manager/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/modem-manager/COPYING.LIB</Path>
             <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/ModemManager.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/ModemManager.mo</Path>
             <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/ModemManager.mo</Path>
@@ -166,8 +167,8 @@
             <Path fileType="localedata">/usr/share/locale/tr/LC_MESSAGES/ModemManager.mo</Path>
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/ModemManager.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/ModemManager.mo</Path>
-            <Path fileType="man">/usr/share/man/man1/mmcli.1</Path>
-            <Path fileType="man">/usr/share/man/man8/ModemManager.8</Path>
+            <Path fileType="man">/usr/share/man/man1/mmcli.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/ModemManager.8.zst</Path>
             <Path fileType="data">/usr/share/polkit-1/actions/org.freedesktop.ModemManager1.policy</Path>
         </Files>
     </Package>
@@ -178,7 +179,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="22">modem-manager</Dependency>
+            <Dependency release="23">modem-manager</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/ModemManager/ModemManager-compat.h</Path>
@@ -254,15 +255,16 @@
             <Path fileType="library">/usr/lib64/libmm-glib.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/ModemManager.pc</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/mm-glib.pc</Path>
+            <Path fileType="data">/usr/share/gir-1.0/ModemManager-1.0.gir</Path>
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2024-03-28</Date>
+        <Update release="23">
+            <Date>2026-03-17</Date>
             <Version>1.22.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd system service preset file.

**Test Plan**

Run `systemctl status ModemManager.service` and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
