### PR TITLE
lact: Add systemd system service preset

### DIFF
--- a/packages/l/lact/files/20-lact.preset
+++ b/packages/l/lact/files/20-lact.preset
@@ -1,0 +1,1 @@
+enable lactd.service

--- a/packages/l/lact/package.yml
+++ b/packages/l/lact/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : lact
 version    : 0.8.4
-release    : 13
+release    : 14
 source     :
     - git|https://github.com/ilya-zlobintsev/LACT.git : v0.8.4
 homepage   : https://github.com/ilya-zlobintsev/LACT
@@ -31,9 +31,7 @@ build      : |
 install    : |
     %make_install PREFIX=/usr
 
-    # Start service by default
-    install -dm00755 $installdir/usr/lib/systemd/system/multi-user.target.wants
-    ln -sv ../lactd.service $installdir/usr/lib/systemd/system/multi-user.target.wants/lactd.service
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-lact.preset
 
     # Allow amdgpu users to overclock their GPUs by default
     install -Dm00644 $pkgfiles/kernel-lact.cmdline $installdir/usr/lib64/kernel/cmdline.d/50_lact.conf

--- a/packages/l/lact/pspec_x86_64.xml
+++ b/packages/l/lact/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>lact</Name>
         <Homepage>https://github.com/ilya-zlobintsev/LACT</Homepage>
         <Packager>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -22,8 +22,8 @@
         <Files>
             <Path fileType="executable">/usr/bin/lact</Path>
             <Path fileType="library">/usr/lib/systemd/system/lactd.service</Path>
-            <Path fileType="library">/usr/lib/systemd/system/multi-user.target.wants/lactd.service</Path>
             <Path fileType="library">/usr/lib64/kernel/cmdline.d/50_lact.conf</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-lact.preset</Path>
             <Path fileType="data">/usr/share/applications/io.github.ilya_zlobintsev.LACT.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/512x512/apps/io.github.ilya_zlobintsev.LACT.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/io.github.ilya_zlobintsev.LACT.svg</Path>
@@ -32,12 +32,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2026-02-13</Date>
+        <Update release="14">
+            <Date>2026-03-17</Date>
             <Version>0.8.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd system service preset file.

**Test Plan**

Run `systemctl status lactd.service` and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
