### PR TITLE
keyd: Add systemd system service preset

### DIFF
--- a/packages/k/keyd/files/20-keyd.preset
+++ b/packages/k/keyd/files/20-keyd.preset
@@ -1,0 +1,1 @@
+enable keyd.service

--- a/packages/k/keyd/package.yml
+++ b/packages/k/keyd/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : keyd
 version    : 2.6.0
-release    : 3
+release    : 4
 source     :
     - https://github.com/rvaiya/keyd/archive/refs/tags/v2.6.0.tar.gz : 697089681915b89d9e98caf93d870dbd4abce768af8a647d54650a6a90744e26
 homepage   : https://github.com/rvaiya/keyd
@@ -16,13 +16,14 @@ build      : |
     %make
 install    : |
     %make_install PREFIX=/usr SOCKET_PATH=/run/keyd.socket
+
     sed -e "s#@PREFIX@#%PREFIX%#" -e 's#multi-user.target#systemd-udev.service#' keyd.service.in > keyd.service
     install -Dm00644 keyd.service -t $installdir/usr/lib/systemd/system/
 
     install -Dm00644 $pkgfiles/keyd.sysusers  $installdir/%libdir%/sysusers.d/keyd.conf
-    # Start service by default
-    install -dm00755 $installdir/usr/lib/systemd/system/multi-user.target.wants
-    ln -sv ../keyd.service $installdir/usr/lib/systemd/system/multi-user.target.wants/keyd.service
+
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-keyd.preset
+
     rm -rv $installdir/etc/
 
     %install_license LICENSE

--- a/packages/k/keyd/pspec_x86_64.xml
+++ b/packages/k/keyd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>keyd</Name>
         <Homepage>https://github.com/rvaiya/keyd</Homepage>
         <Packager>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -23,7 +23,7 @@
             <Path fileType="executable">/usr/bin/keyd</Path>
             <Path fileType="executable">/usr/bin/keyd-application-mapper</Path>
             <Path fileType="library">/usr/lib/systemd/system/keyd.service</Path>
-            <Path fileType="library">/usr/lib/systemd/system/multi-user.target.wants/keyd.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-keyd.preset</Path>
             <Path fileType="library">/usr/lib64/sysusers.d/keyd.conf</Path>
             <Path fileType="doc">/usr/share/doc/keyd/CHANGELOG.md</Path>
             <Path fileType="doc">/usr/share/doc/keyd/DESIGN.md</Path>
@@ -154,12 +154,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2026-01-06</Date>
+        <Update release="4">
+            <Date>2026-03-17</Date>
             <Version>2.6.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd system service preset file.

**Test Plan**

Run `systemctl status keyd.service` and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
