### PR TITLE
opentabletdriver: Add systemd user service preset

### DIFF
--- a/packages/o/opentabletdriver/files/20-opentabletdriver.preset
+++ b/packages/o/opentabletdriver/files/20-opentabletdriver.preset
@@ -1,0 +1,1 @@
+enable opentabletdriver.service

--- a/packages/o/opentabletdriver/package.yml
+++ b/packages/o/opentabletdriver/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : opentabletdriver
 version    : 0.6.5.1
-release    : 7
+release    : 8
 source     :
     - https://github.com/OpenTabletDriver/OpenTabletDriver/archive/refs/tags/v0.6.5.1.tar.gz : 682cea127a583b9e4a2fceaf8ec92557502a25ce7d34b18b085ba790c911f0cb
 homepage   : https://opentabletdriver.net/
@@ -26,9 +26,10 @@ rundeps    :
 build      : |
     ./eng/linux/package.sh --package Generic
 install    : |
-    install -dm 755 $installdir
+    install -dm00755 $installdir
     cp -a dist/files/* $installdir
     mv $installdir/usr/lib{,64}
-    install -dm 644 $installdir/usr/lib64/systemd/user/graphical-session.target.wants
-    ln -s /usr/lib64/systemd/user/opentabletdriver.service $installdir/usr/lib64/systemd/user/graphical-session.target.wants/opentabletdriver.service
-    install -Dm 644 $pkgfiles/net.opentabletdriver.OpenTabletDriver.metainfo.xml -t $installdir/usr/share/metainfo
+
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/user-preset/ ${pkgfiles}/20-opentabletdriver.preset
+
+    install -Dm00644 $pkgfiles/net.opentabletdriver.OpenTabletDriver.metainfo.xml -t $installdir/usr/share/metainfo

--- a/packages/o/opentabletdriver/pspec_x86_64.xml
+++ b/packages/o/opentabletdriver/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>opentabletdriver</Name>
         <Homepage>https://opentabletdriver.net/</Homepage>
         <Packager>
-            <Name>nelson</Name>
-            <Email>nelson@truran.dev</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-3.0-only</License>
         <PartOf>multimedia.graphics</PartOf>
@@ -28,7 +28,7 @@
             <Path fileType="library">/usr/lib64/opentabletdriver/OpenTabletDriver.Console</Path>
             <Path fileType="library">/usr/lib64/opentabletdriver/OpenTabletDriver.Daemon</Path>
             <Path fileType="library">/usr/lib64/opentabletdriver/OpenTabletDriver.UX.Gtk</Path>
-            <Path fileType="library">/usr/lib64/systemd/user/graphical-session.target.wants/opentabletdriver.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/user-preset/20-opentabletdriver.preset</Path>
             <Path fileType="library">/usr/lib64/systemd/user/opentabletdriver.service</Path>
             <Path fileType="library">/usr/lib64/udev/rules.d/70-opentabletdriver.rules</Path>
             <Path fileType="data">/usr/share/applications/opentabletdriver.desktop</Path>
@@ -41,12 +41,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2026-02-12</Date>
+        <Update release="8">
+            <Date>2026-03-17</Date>
             <Version>0.6.5.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>nelson</Name>
-            <Email>nelson@truran.dev</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd user service preset file.

**Test Plan**

Run `systemctl status --user opentabletdriver` and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
