### PR TITLE
moby: Fix systemd preset file name

### DIFF
--- a/packages/m/moby/abi_used_symbols
+++ b/packages/m/moby/abi_used_symbols
@@ -1,6 +1,7 @@
 libc.so.6:__errno_location
 libc.so.6:__libc_start_main
 libc.so.6:abort
+libc.so.6:clearenv
 libc.so.6:closedir
 libc.so.6:dirfd
 libc.so.6:fprintf

--- a/packages/m/moby/package.yml
+++ b/packages/m/moby/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : moby
 version    : 28.0.4
-release    : 26
+release    : 27
 source     :
     - https://github.com/moby/moby/archive/v28.0.4.tar.gz : 4b347a2b83221952cab93197f6e9bc7ffe54dd4bd0a9644c176aecde551721ca
 license    : Apache-2.0
@@ -54,14 +54,10 @@ install    : |
     install -Dm00644 $pkgfiles/docker.service -t $installdir/%libdir%/systemd/system/
     install -Dm00644 contrib/init/systemd/docker.socket -t $installdir/%libdir%/systemd/system/
 
-    install -Dm644 $pkgfiles/docker.preset $installdir/usr/lib/systemd/system-preset/docker.preset
+    install -Dm644 $pkgfiles/docker.preset $installdir/usr/lib/systemd/system-preset/20-docker.preset
 
     # udev rules
     install -Dm00644 contrib/udev/80-docker.rules -t $installdir/%libdir%/udev/rules.d
-
-    # Enable socket activation by default
-    install -Ddm00755 $installdir/%libdir%/systemd/system/sockets.target.wants
-    ln -sv ../docker.socket $installdir/%libdir%/systemd/system/sockets.target.wants/docker.socket
 
     # Add the docker group
     install -Dm00644 $pkgfiles/docker.sysusers $installdir/%libdir%/sysusers.d/docker.conf

--- a/packages/m/moby/pspec_x86_64.xml
+++ b/packages/m/moby/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>moby</Name>
         <Homepage>https://www.docker.com</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>virt</PartOf>
@@ -23,22 +23,21 @@
             <Path fileType="executable">/usr/bin/docker-init</Path>
             <Path fileType="executable">/usr/bin/docker-proxy</Path>
             <Path fileType="executable">/usr/bin/dockerd</Path>
-            <Path fileType="library">/usr/lib/systemd/system-preset/docker.preset</Path>
+            <Path fileType="library">/usr/lib/systemd/system-preset/20-docker.preset</Path>
             <Path fileType="library">/usr/lib64/systemd/system/docker.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/docker.socket</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/sockets.target.wants/docker.socket</Path>
             <Path fileType="library">/usr/lib64/sysusers.d/docker.conf</Path>
             <Path fileType="library">/usr/lib64/udev/rules.d/80-docker.rules</Path>
-            <Path fileType="man">/usr/share/man/man8/dockerd.8</Path>
+            <Path fileType="man">/usr/share/man/man8/dockerd.8.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2025-04-11</Date>
+        <Update release="27">
+            <Date>2026-03-17</Date>
             <Version>28.0.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Fix systemd preset file name.

**Test Plan**

Run `systemctl status docker.service` and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
