### PR TITLE
opensnitch: Add systemd system service preset

### DIFF
--- a/packages/o/opensnitch/abi_used_symbols
+++ b/packages/o/opensnitch/abi_used_symbols
@@ -4,6 +4,7 @@ libc.so.6:__stack_chk_fail
 libc.so.6:abort
 libc.so.6:bind
 libc.so.6:calloc
+libc.so.6:clearenv
 libc.so.6:close
 libc.so.6:dlerror
 libc.so.6:dlinfo

--- a/packages/o/opensnitch/files/20-opensnitch.preset
+++ b/packages/o/opensnitch/files/20-opensnitch.preset
@@ -1,0 +1,1 @@
+enable opensnitchd.service

--- a/packages/o/opensnitch/package.yml
+++ b/packages/o/opensnitch/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : opensnitch
 version    : 1.6.8
-release    : 6
+release    : 7
 source     :
     - https://github.com/evilsocket/opensnitch/archive/refs/tags/v1.6.8.tar.gz : 3c44f585a6a78f63c86f331da099bd001cd199b3c907c262cc6645bf9b3a1825
 homepage   : https://github.com/evilsocket/opensnitch
@@ -51,14 +51,14 @@ build      : |
 install    : |
     %make_install PREFIX=%PREFIX%
 
-    # start automatically
-    install -dm00755 $installdir/usr/lib64/systemd/system/multi-user.target.wants/
-    ln -sv ../opensnitchd.service $installdir/usr/lib64/systemd/system/multi-user.target.wants/opensnitchd.service
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-opensnitch.preset
 
     # install the ui separately
     pushd ui
     %python3_install
     popd
+
+    %install_license LICENSE
 
     # remove test files
     rm -rfv $installdir/usr/lib/python%python3_version%/site-packages/tests/

--- a/packages/o/opensnitch/pspec_x86_64.xml
+++ b/packages/o/opensnitch/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>opensnitch</Name>
         <Homepage>https://github.com/evilsocket/opensnitch</Homepage>
         <Packager>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.util</PartOf>
@@ -167,7 +167,7 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/opensnitch_ui-1.6.8-py3.12.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/sysusers.d/opensnitch.conf</Path>
             <Path fileType="library">/usr/lib/tmpfiles.d/opensnitch.conf</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/multi-user.target.wants/opensnitchd.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-opensnitch.preset</Path>
             <Path fileType="library">/usr/lib64/systemd/system/opensnitchd.service</Path>
             <Path fileType="data">/usr/share/applications/opensnitch_ui.desktop</Path>
             <Path fileType="data">/usr/share/defaults/etc/opensnitchd/default-config.json</Path>
@@ -177,16 +177,17 @@
             <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/opensnitch-ui.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/opensnitch-ui.svg</Path>
             <Path fileType="data">/usr/share/kservices5/kcm_opensnitch.desktop</Path>
+            <Path fileType="data">/usr/share/licenses/opensnitch/LICENSE</Path>
             <Path fileType="data">/usr/share/metainfo/io.github.evilsocket.opensnitch.appdata.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2025-08-24</Date>
+        <Update release="7">
+            <Date>2026-03-17</Date>
             <Version>1.6.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd system service preset file.

**Test Plan**

Run `systemctl status opensnitch.service` and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
