### PR TITLE
plocate: Add systemd system service preset

### DIFF
--- a/packages/p/plocate/files/20-plocate.preset
+++ b/packages/p/plocate/files/20-plocate.preset
@@ -1,0 +1,1 @@
+enable plocate-updatedb.timer

--- a/packages/p/plocate/package.yml
+++ b/packages/p/plocate/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : plocate
 version    : 1.1.22
-release    : 9
+release    : 10
 source     :
     - https://plocate.sesse.net/download/plocate-1.1.22.tar.gz : 3b7e4741b4aa2ec044e53eff06474a32a3fb1e928b9382351fe79d4c27fb0049
 homepage   : https://plocate.sesse.net/
@@ -27,6 +27,7 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING
 
     chgrp 21 $installdir/usr/bin/plocate
     chmod 2755 $installdir/usr/bin/plocate
@@ -41,9 +42,7 @@ install    : |
 
     install -Dm00644 $pkgfiles/locate_group_update.toml $installdir/usr/share/defaults/qol-assist.d/locate_group_update.toml
 
-    # Vendor enable update-db timer
-    install -Ddm00755 $installdir/usr/lib/systemd/system/timers.target.wants
-    ln -sv ../plocate-updatedb.timer $installdir/usr/lib/systemd/system/timers.target.wants
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-plocate.preset
 
     # Add legacy symlinks
     ln -sv plocate $installdir/usr/bin/locate

--- a/packages/p/plocate/pspec_x86_64.xml
+++ b/packages/p/plocate/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>plocate</Name>
         <Homepage>https://plocate.sesse.net/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -25,14 +25,15 @@
             <Path fileType="executable">/usr/bin/plocate</Path>
             <Path fileType="library">/usr/lib/systemd/system/plocate-updatedb.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/plocate-updatedb.timer</Path>
-            <Path fileType="library">/usr/lib/systemd/system/timers.target.wants/plocate-updatedb.timer</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-plocate.preset</Path>
             <Path fileType="library">/usr/lib64/sysusers.d/plocate.conf</Path>
             <Path fileType="library">/usr/lib64/tmpfiles.d/plocate.conf</Path>
             <Path fileType="executable">/usr/sbin/updatedb</Path>
             <Path fileType="data">/usr/share/defaults/etc/updatedb.conf</Path>
             <Path fileType="data">/usr/share/defaults/qol-assist.d/locate_group_update.toml</Path>
-            <Path fileType="man">/usr/share/man/man1/plocate.1</Path>
-            <Path fileType="man">/usr/share/man/man5/updatedb.conf.5</Path>
+            <Path fileType="data">/usr/share/licenses/plocate/COPYING</Path>
+            <Path fileType="man">/usr/share/man/man1/plocate.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man5/updatedb.conf.5.zst</Path>
             <Path fileType="data">/var/db/locate/CACHEDIR.TAG</Path>
         </Files>
         <Replaces>
@@ -40,12 +41,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2024-09-08</Date>
+        <Update release="10">
+            <Date>2026-03-17</Date>
             <Version>1.1.22</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd system service preset file.

**Test Plan**

Run `systemctl status plocate-updatedb.timer` and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
