### PR TITLE
thinkfan: Add systemd system service preset

### DIFF
--- a/packages/t/thinkfan/files/20-thinkfan.preset
+++ b/packages/t/thinkfan/files/20-thinkfan.preset
@@ -1,0 +1,2 @@
+# Enable by default, users can disable now with systemctl mask tlp
+enable thinkfan.service

--- a/packages/t/thinkfan/package.yml
+++ b/packages/t/thinkfan/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : thinkfan
 version    : 2.0.0
-release    : 1
+release    : 2
 source     :
     - https://github.com/vmatare/thinkfan/archive/refs/tags/2.0.0.tar.gz : 0fc94eb378dcba8c889e91f41dab3a8d6eebc7324a59a0704cc39aa66551987e
 homepage   : https://github.com/vmatare/thinkfan
@@ -21,11 +21,9 @@ install    : |
     %ninja_install
 
     # Correct libdir
-    mv $installdir/usr/lib $installdir/%libdir%
+    mv $installdir/usr/lib $installdir/usr/lib64
+
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-thinkfan.preset
 
     # Remove non-stateless files
     rm -rf $installdir/etc
-
-    # Enable by default, users can disable now with systemctl mask tlp
-    install -Ddm 00755 $installdir/%libdir%/systemd/system/multi-user.target.wants
-    ln -sv ../thinkfan.service $installdir/%libdir%/systemd/system/multi-user.target.wants

--- a/packages/t/thinkfan/pspec_x86_64.xml
+++ b/packages/t/thinkfan/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>thinkfan</Name>
         <Homepage>https://github.com/vmatare/thinkfan</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -20,7 +20,7 @@
 </Description>
         <PartOf>system.utils</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib64/systemd/system/multi-user.target.wants/thinkfan.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-thinkfan.preset</Path>
             <Path fileType="library">/usr/lib64/systemd/system/thinkfan-sleep.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/thinkfan-wakeup.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/thinkfan.service</Path>
@@ -34,12 +34,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2026-03-12</Date>
+        <Update release="2">
+            <Date>2026-03-17</Date>
             <Version>2.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd system service preset file.

**Test Plan**

Run `systemctl status thinkfan.service` and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
