### PR TITLE
thermald: Add systemd system service preset

### DIFF
--- a/packages/t/thermald/abi_used_symbols
+++ b/packages/t/thermald/abi_used_symbols
@@ -111,6 +111,7 @@ libglib-2.0.so.0:g_bytes_get_data
 libglib-2.0.so.0:g_bytes_unref
 libglib-2.0.so.0:g_error_free
 libglib-2.0.so.0:g_free
+libglib-2.0.so.0:g_free_sized
 libglib-2.0.so.0:g_intern_static_string
 libglib-2.0.so.0:g_log
 libglib-2.0.so.0:g_log_set_handler

--- a/packages/t/thermald/files/20-thermald.preset
+++ b/packages/t/thermald/files/20-thermald.preset
@@ -1,0 +1,2 @@
+# Users may systemctl mask to turn it off.
+enable thermald.service

--- a/packages/t/thermald/package.yml
+++ b/packages/t/thermald/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : thermald
 version    : 2.5.11
-release    : 19
+release    : 20
 source     :
     - https://github.com/intel/thermal_daemon/archive/refs/tags/v2.5.11.tar.gz : 0f4d7371d2cadf12f868e4b56d0e70af07a1c3b7d883dbe541a3707e449ea1ad
 license    : GPL-2.0-or-later
@@ -17,13 +17,15 @@ builddeps  :
     - autoconf-archive
     - gtk-doc
 setup      : |
-    %autogen --with-dbus-sys-dir=/usr/share/dbus-1/system.d/
+    %autogen \
+        --with-dbus-sys-dir=/usr/share/dbus-1/system.d/ \
+        --with-systemdsystemunitdir=%libdir%/systemd/system/
 build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING
 
-    # Users may systemctl mask to turn it off.
-    install -d -D -m 00755 $installdir/%libdir%/systemd/system/multi-user.target.wants
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-thermald.preset
+
     ln -sv thermald.service $installdir/%libdir%/systemd/system/dbus-org.freedesktop.thermald.service
-    ln -sv ../thermald.service $installdir/%libdir%/systemd/system/multi-user.target.wants

--- a/packages/t/thermald/pspec_x86_64.xml
+++ b/packages/t/thermald/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>thermald</Name>
         <Homepage>https://github.com/intel/thermal_daemon</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -21,23 +21,24 @@
         <PartOf>system.utils</PartOf>
         <Files>
             <Path fileType="config">/etc/thermald/thermal-cpu-cdev-order.xml</Path>
-            <Path fileType="library">/usr/lib/systemd/system/thermald.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-thermald.preset</Path>
             <Path fileType="library">/usr/lib64/systemd/system/dbus-org.freedesktop.thermald.service</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/multi-user.target.wants/thermald.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/system/thermald.service</Path>
             <Path fileType="executable">/usr/sbin/thermald</Path>
             <Path fileType="data">/usr/share/dbus-1/system-services/org.freedesktop.thermald.service</Path>
             <Path fileType="data">/usr/share/dbus-1/system.d/org.freedesktop.thermald.conf</Path>
+            <Path fileType="data">/usr/share/licenses/thermald/COPYING</Path>
             <Path fileType="man">/usr/share/man/man5/thermal-conf.xml.5.zst</Path>
             <Path fileType="man">/usr/share/man/man8/thermald.8.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2026-02-26</Date>
+        <Update release="20">
+            <Date>2026-03-18</Date>
             <Version>2.5.11</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd system service preset file.

**Test Plan**

Run `systemctl status thermald.service` and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
