### PR TITLE
yubikey-manager: Add systemd system service preset

### DIFF
--- a/packages/y/yubikey-manager/files/20-yubikey-manager.preset
+++ b/packages/y/yubikey-manager/files/20-yubikey-manager.preset
@@ -1,0 +1,1 @@
+enable pcscd.socket

--- a/packages/y/yubikey-manager/package.yml
+++ b/packages/y/yubikey-manager/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : yubikey-manager
 version    : 5.8.0
-release    : 46
+release    : 47
 source     :
     - https://github.com/Yubico/yubikey-manager/releases/download/5.8.0/yubikey_manager-5.8.0.tar.gz : 3af0da65e1fdd46763c94ee74e2da55a4b6e7771da776c197f5f4b4581738560
 homepage   : https://developers.yubico.com/yubikey-manager/
@@ -37,9 +37,8 @@ build      : |
     _YKMAN_COMPLETE=zsh_source completion-env/bin/ykman > _ykman
 install    : |
     %python3_install
-    # Vendor enable pcscd.socket so this works OOTB.
-    install -dm00755 $installdir/%libdir%/systemd/system/sockets.target.wants
-    ln -sv ../pcscd.socket $installdir/%libdir%/systemd/system/sockets.target.wants/pcscd.socket
+
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/service-preset/ ${pkgfiles}/20-yubikey-manager.preset
 
     # Manpages
     install -Dm00644 man/ykman.1 -t "$installdir/usr/share/man/man1/"
@@ -49,4 +48,4 @@ install    : |
     install -Dm0644 _ykman -t "$installdir/usr/share/zsh/site-functions/"
 
     # Include copyright notice as required by the license
-    install -Dm0644 -t "$installdir/usr/share/licenses/$package/" COPYING 
+    %install_license COPYING

--- a/packages/y/yubikey-manager/pspec_x86_64.xml
+++ b/packages/y/yubikey-manager/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>yubikey-manager</Name>
         <Homepage>https://developers.yubico.com/yubikey-manager/</Homepage>
         <Packager>
-            <Name>Matthias Homann</Name>
-            <Email>palto@mailbox.org</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <PartOf>security</PartOf>
@@ -211,7 +211,7 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/yubikit/securitydomain.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/yubikit/support.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/yubikit/yubiotp.py</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/sockets.target.wants/pcscd.socket</Path>
+            <Path fileType="library">/usr/lib64/systemd/service-preset/20-yubikey-manager.preset</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/ykman.bash</Path>
             <Path fileType="data">/usr/share/licenses/yubikey-manager/COPYING</Path>
             <Path fileType="man">/usr/share/man/man1/ykman.1.zst</Path>
@@ -219,12 +219,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="46">
-            <Date>2025-11-03</Date>
+        <Update release="47">
+            <Date>2026-03-18</Date>
             <Version>5.8.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Matthias Homann</Name>
-            <Email>palto@mailbox.org</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add systemd system service preset file.

**Test Plan**

Run `systemctl status thing.service` (I forgot the name and already closed my editor), and see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
