### PR TITLE
tlp: Split package, add preset, add conflict

### DIFF
--- a/packages/t/tlp/files/20-tlp.preset
+++ b/packages/t/tlp/files/20-tlp.preset
@@ -1,0 +1,2 @@
+# Enable by default, users can disable now with systemctl mask tlp
+enable tlp.service

--- a/packages/t/tlp/package.yml
+++ b/packages/t/tlp/package.yml
@@ -1,43 +1,86 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : tlp
 version    : 1.9.1
-release    : 23
+release    : 24
 source     :
     - https://github.com/linrunner/TLP/archive/refs/tags/1.9.1.tar.gz : 6f7c69a8c56706f83bc3566377caf846c2ccbd8f2621fe8e56c6d1e684d15156
 homepage   : https://linrunner.de/tlp/
 license    : GPL-2.0-only
-component  : system.utils
-summary    : Linux Advanced Power Management
-description: |
-    Linux Advanced Power Management, customized for Solus:
-    - Disabled Wi-Fi power saving mode on battery
-    - Disabled audio power saving for Intel HDA, AC97 devices
-    - Disabled  USB autosuspend feature
+component  :
+    - pd : system.utils
+    - rdw : system.utils
+    - system.utils
+summary    :
+    - pd : Linux Advanced Power Management - Power Profiles Daemon
+    - rdw : Linux Advanced Power Management - Radio Device Wizard
+    - Linux Advanced Power Management
+description:
+    - pd : Linux Advanced Power Management - Power Profiles Daemon
+    - rdw : Linux Advanced Power Management - Radio Device Wizard
+    - "Linux Advanced Power Management, customized for Solus:\n
+       - Disabled Wi-Fi power saving mode on battery\n
+       - Disabled audio power saving for Intel HDA, AC97 devices\n
+       - Disabled  USB autosuspend feature"
 builddeps  :
     - hdparm
     - iw
 rundeps    :
     - linux-tools-x86_energy_perf_policy
+    - pd :
+        - python-dbus
+        - python-gobject
+        - python-shtab
+        - tlp
+    - rdw :
+        - network-manager
+        - tlp
+
 setup      : |
     %apply_patches
 build      : |
     export TLP_LIBDIR='%libdir%'
     export TLP_SBIN='/usr/sbin'
     export TLP_ULIB='%libdir%/udev/'
+
     %make
 install    : |
+    export TLP_SDSL='%libdir%/systemd/system-sleep'
     export TLP_NO_INIT='1'
     export TLP_SYSD='%libdir%/systemd/system/'
     export TLP_ULIB='%libdir%/udev/'
     export TLP_WITH_ELOGIND='0'
-    %make_install install-man
-    rm -rf $installdir/var
 
+    %make_install install-man
     %install_license COPYING LICENSE
 
-    # Enable by default, users can disable now with systemctl mask tlp
-    install -Ddm 00755 $installdir/%libdir%/systemd/system/multi-user.target.wants
-    ln -sv ../tlp.service $installdir/%libdir%/systemd/system/multi-user.target.wants
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-tlp.preset
 
-    mv $installdir/usr/lib/systemd/system-sleep $installdir/usr/lib64/systemd
-    rm -rf $installdir/usr/lib
+    rm -rf $installdir/var
+conflicts  :
+    - pd :
+        - power-profiles-daemon
+patterns   :
+    - pd :
+        - /usr/bin/tlp-pd
+        - /usr/bin/tlpctl
+        - /usr/lib64/systemd/system/tlp-pd.service
+        - /usr/share/bash-completion/completions/tlpctl
+        - /usr/share/dbus-1/system-services/net.hadess.PowerProfiles.service
+        - /usr/share/dbus-1/system-services/org.freedesktop.UPower.PowerProfiles.service
+        - /usr/share/dbus-1/system.d/net.hadess.PowerProfiles.conf
+        - /usr/share/dbus-1/system.d/org.freedesktop.UPower.PowerProfiles.conf
+        - /usr/share/fish/vendor_completions.d/tlpctl.fish
+        - /usr/share/man/man1/tlpctl.1.*
+        - /usr/share/man/man8/tlp-pd.8.*
+        - /usr/share/man/man8/tlp-pd.service.8.*
+        - /usr/share/polkit-1/actions/tlp-pd.policy
+        - /usr/share/zsh/site-functions/_tlpctl
+    - rdw :
+        - /usr/bin/tlp-rdw
+        - /usr/lib/NetworkManager/dispatcher.d/99tlp-rdw-nm
+        - /usr/lib64/udev/rules.d/85-tlp-rdw.rules
+        - /usr/lib64/udev/tlp-rdw-udev
+        - /usr/share/bash-completion/completions/tlp-rdw
+        - /usr/share/fish/vendor_completions.d/tlp-rdw.fish
+        - /usr/share/man/man8/tlp-rdw.8.gz
+        - /usr/share/zsh/site-functions/_tlp-rdw

--- a/packages/t/tlp/pspec_x86_64.xml
+++ b/packages/t/tlp/pspec_x86_64.xml
@@ -10,20 +10,18 @@
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">Linux Advanced Power Management</Summary>
         <Description xml:lang="en">Linux Advanced Power Management, customized for Solus:
-- Disabled Wi-Fi power saving mode on battery
-- Disabled audio power saving for Intel HDA, AC97 devices
-- Disabled  USB autosuspend feature
-</Description>
+ - Disabled Wi-Fi power saving mode on battery
+ - Disabled audio power saving for Intel HDA, AC97 devices
+ - Disabled  USB autosuspend feature</Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>tlp</Name>
         <Summary xml:lang="en">Linux Advanced Power Management</Summary>
         <Description xml:lang="en">Linux Advanced Power Management, customized for Solus:
-- Disabled Wi-Fi power saving mode on battery
-- Disabled audio power saving for Intel HDA, AC97 devices
-- Disabled  USB autosuspend feature
-</Description>
+ - Disabled Wi-Fi power saving mode on battery
+ - Disabled audio power saving for Intel HDA, AC97 devices
+ - Disabled  USB autosuspend feature</Description>
         <PartOf>system.utils</PartOf>
         <Files>
             <Path fileType="config">/etc/tlp.conf</Path>
@@ -33,18 +31,13 @@
             <Path fileType="executable">/usr/bin/nfc</Path>
             <Path fileType="executable">/usr/bin/run-on-ac</Path>
             <Path fileType="executable">/usr/bin/run-on-bat</Path>
-            <Path fileType="executable">/usr/bin/tlp-rdw</Path>
             <Path fileType="executable">/usr/bin/tlp-stat</Path>
-            <Path fileType="executable">/usr/bin/tlpctl</Path>
             <Path fileType="executable">/usr/bin/wifi</Path>
             <Path fileType="executable">/usr/bin/wwan</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/20-tlp.preset</Path>
             <Path fileType="library">/usr/lib64/systemd/system-sleep/tlp</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/multi-user.target.wants/tlp.service</Path>
-            <Path fileType="library">/usr/lib64/systemd/system/tlp-pd.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/tlp.service</Path>
-            <Path fileType="library">/usr/lib64/udev/rules.d/85-tlp-rdw.rules</Path>
             <Path fileType="library">/usr/lib64/udev/rules.d/85-tlp.rules</Path>
-            <Path fileType="library">/usr/lib64/udev/tlp-rdw-udev</Path>
             <Path fileType="library">/usr/lib64/udev/tlp-usb-udev</Path>
             <Path fileType="executable">/usr/sbin/tlp</Path>
             <Path fileType="executable">/usr/sbin/tlp-pd</Path>
@@ -53,23 +46,15 @@
             <Path fileType="data">/usr/share/bash-completion/completions/run-on-ac</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/run-on-bat</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/tlp</Path>
-            <Path fileType="data">/usr/share/bash-completion/completions/tlp-rdw</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/tlp-stat</Path>
-            <Path fileType="data">/usr/share/bash-completion/completions/tlpctl</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/wifi</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/wwan</Path>
-            <Path fileType="data">/usr/share/dbus-1/system-services/net.hadess.PowerProfiles.service</Path>
-            <Path fileType="data">/usr/share/dbus-1/system-services/org.freedesktop.UPower.PowerProfiles.service</Path>
-            <Path fileType="data">/usr/share/dbus-1/system.d/net.hadess.PowerProfiles.conf</Path>
-            <Path fileType="data">/usr/share/dbus-1/system.d/org.freedesktop.UPower.PowerProfiles.conf</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/bluetooth.fish</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/nfc.fish</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/run-on-ac.fish</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/run-on-bat.fish</Path>
-            <Path fileType="data">/usr/share/fish/vendor_completions.d/tlp-rdw.fish</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/tlp-stat.fish</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/tlp.fish</Path>
-            <Path fileType="data">/usr/share/fish/vendor_completions.d/tlpctl.fish</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/wifi.fish</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/wwan.fish</Path>
             <Path fileType="data">/usr/share/licenses/tlp/COPYING</Path>
@@ -78,17 +63,13 @@
             <Path fileType="man">/usr/share/man/man1/nfc.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/run-on-ac.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/run-on-bat.1.zst</Path>
-            <Path fileType="man">/usr/share/man/man1/tlpctl.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/wifi.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/wwan.1.zst</Path>
-            <Path fileType="man">/usr/share/man/man8/tlp-pd.8.zst</Path>
-            <Path fileType="man">/usr/share/man/man8/tlp-pd.service.8.zst</Path>
             <Path fileType="man">/usr/share/man/man8/tlp-rdw.8.zst</Path>
             <Path fileType="man">/usr/share/man/man8/tlp-stat.8.zst</Path>
             <Path fileType="man">/usr/share/man/man8/tlp.8.zst</Path>
             <Path fileType="man">/usr/share/man/man8/tlp.service.8.zst</Path>
             <Path fileType="data">/usr/share/metainfo/de.linrunner.tlp.metainfo.xml</Path>
-            <Path fileType="data">/usr/share/polkit-1/actions/tlp-pd.policy</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/05-thinkpad</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/10-thinkpad-legacy</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/15-lenovo</Path>
@@ -127,15 +108,58 @@
             <Path fileType="data">/usr/share/tlp/tlp-usblist</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_tlp</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_tlp-radio-device</Path>
-            <Path fileType="data">/usr/share/zsh/site-functions/_tlp-rdw</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_tlp-run-on</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_tlp-stat</Path>
+        </Files>
+    </Package>
+    <Package>
+        <Name>tlp-pd</Name>
+        <Summary xml:lang="en">Linux Advanced Power Management - Power Profiles Daemon</Summary>
+        <Description xml:lang="en">Linux Advanced Power Management - Power Profiles Daemon</Description>
+        <PartOf>system.utils</PartOf>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="24">tlp</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="executable">/usr/bin/tlpctl</Path>
+            <Path fileType="library">/usr/lib64/systemd/system/tlp-pd.service</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/tlpctl</Path>
+            <Path fileType="data">/usr/share/dbus-1/system-services/net.hadess.PowerProfiles.service</Path>
+            <Path fileType="data">/usr/share/dbus-1/system-services/org.freedesktop.UPower.PowerProfiles.service</Path>
+            <Path fileType="data">/usr/share/dbus-1/system.d/net.hadess.PowerProfiles.conf</Path>
+            <Path fileType="data">/usr/share/dbus-1/system.d/org.freedesktop.UPower.PowerProfiles.conf</Path>
+            <Path fileType="data">/usr/share/fish/vendor_completions.d/tlpctl.fish</Path>
+            <Path fileType="man">/usr/share/man/man1/tlpctl.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/tlp-pd.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/tlp-pd.service.8.zst</Path>
+            <Path fileType="data">/usr/share/polkit-1/actions/tlp-pd.policy</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_tlpctl</Path>
+        </Files>
+        <Conflicts>
+            <Package>power-profiles-daemon</Package>
+        </Conflicts>
+    </Package>
+    <Package>
+        <Name>tlp-rdw</Name>
+        <Summary xml:lang="en">Linux Advanced Power Management - Radio Device Wizard</Summary>
+        <Description xml:lang="en">Linux Advanced Power Management - Radio Device Wizard</Description>
+        <PartOf>system.utils</PartOf>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="24">tlp</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="executable">/usr/bin/tlp-rdw</Path>
+            <Path fileType="library">/usr/lib/NetworkManager/dispatcher.d/99tlp-rdw-nm</Path>
+            <Path fileType="library">/usr/lib64/udev/rules.d/85-tlp-rdw.rules</Path>
+            <Path fileType="library">/usr/lib64/udev/tlp-rdw-udev</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/tlp-rdw</Path>
+            <Path fileType="data">/usr/share/fish/vendor_completions.d/tlp-rdw.fish</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_tlp-rdw</Path>
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2026-01-07</Date>
+        <Update release="24">
+            <Date>2026-03-18</Date>
             <Version>1.9.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
TLP now ships dbus service files and configs that conflict with `power-profiles-daemon`. These files have been split to the `tlp-pd` package, which conflicts with `power-profiles-daemon`. Given that `p-p-d` is a dependency of most (all?) desktop environments, I'm not sure `tlp-pd` can actually be installed by anyone, but oh well.

A systemd system service preset file has also been added.

Probably fixes https://github.com/getsolus/packages/issues/7821

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Installed `tlp`, ran `systemctl status tlp.service`, see that it is enabled.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
