### PR TITLE
expat: Update to v2.7.5

### DIFF
--- a/packages/e/expat/package.yml
+++ b/packages/e/expat/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : expat
-version    : 2.7.4
-release    : 36
+version    : 2.7.5
+release    : 37
 source     :
-    - https://github.com/libexpat/libexpat/releases/download/R_2_7_4/expat-2.7.4.tar.bz2 : e6af11b01e32e5ef64906a5cca8809eabc4beb7ff2f9a0e6aabbd42e825135d0
+    - https://github.com/libexpat/libexpat/releases/download/R_2_7_5/expat-2.7.5.tar.bz2 : 386a423d40580f1e392e8b512b7635cac5083fe0631961e74e036b0a7a830d77
 homepage   : https://libexpat.github.io/
 license    : MIT
 component  :

--- a/packages/e/expat/pspec_x86_64.xml
+++ b/packages/e/expat/pspec_x86_64.xml
@@ -22,7 +22,7 @@
         <Files>
             <Path fileType="executable">/usr/bin/xmlwf</Path>
             <Path fileType="library">/usr/lib64/libexpat.so.1</Path>
-            <Path fileType="library">/usr/lib64/libexpat.so.1.11.2</Path>
+            <Path fileType="library">/usr/lib64/libexpat.so.1.11.3</Path>
             <Path fileType="doc">/usr/share/doc/expat/AUTHORS</Path>
             <Path fileType="doc">/usr/share/doc/expat/changelog</Path>
             <Path fileType="data">/usr/share/licenses/expat/COPYING</Path>
@@ -36,11 +36,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="36">expat</Dependency>
+            <Dependency release="37">expat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libexpat.so.1</Path>
-            <Path fileType="library">/usr/lib32/libexpat.so.1.11.2</Path>
+            <Path fileType="library">/usr/lib32/libexpat.so.1.11.3</Path>
         </Files>
     </Package>
     <Package>
@@ -50,14 +50,14 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="36">expat-32bit</Dependency>
-            <Dependency release="36">expat-devel</Dependency>
+            <Dependency release="37">expat-32bit</Dependency>
+            <Dependency release="37">expat-devel</Dependency>
         </RuntimeDependencies>
         <Files>
-            <Path fileType="library">/usr/lib32/cmake/expat-2.7.4/expat-config-version.cmake</Path>
-            <Path fileType="library">/usr/lib32/cmake/expat-2.7.4/expat-config.cmake</Path>
-            <Path fileType="library">/usr/lib32/cmake/expat-2.7.4/expat-noconfig.cmake</Path>
-            <Path fileType="library">/usr/lib32/cmake/expat-2.7.4/expat.cmake</Path>
+            <Path fileType="library">/usr/lib32/cmake/expat-2.7.5/expat-config-version.cmake</Path>
+            <Path fileType="library">/usr/lib32/cmake/expat-2.7.5/expat-config.cmake</Path>
+            <Path fileType="library">/usr/lib32/cmake/expat-2.7.5/expat-noconfig.cmake</Path>
+            <Path fileType="library">/usr/lib32/cmake/expat-2.7.5/expat.cmake</Path>
             <Path fileType="library">/usr/lib32/libexpat.so</Path>
             <Path fileType="data">/usr/lib32/pkgconfig/expat.pc</Path>
         </Files>
@@ -69,24 +69,24 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="36">expat</Dependency>
+            <Dependency release="37">expat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/expat.h</Path>
             <Path fileType="header">/usr/include/expat_config.h</Path>
             <Path fileType="header">/usr/include/expat_external.h</Path>
-            <Path fileType="library">/usr/lib64/cmake/expat-2.7.4/expat-config-version.cmake</Path>
-            <Path fileType="library">/usr/lib64/cmake/expat-2.7.4/expat-config.cmake</Path>
-            <Path fileType="library">/usr/lib64/cmake/expat-2.7.4/expat-noconfig.cmake</Path>
-            <Path fileType="library">/usr/lib64/cmake/expat-2.7.4/expat.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/expat-2.7.5/expat-config-version.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/expat-2.7.5/expat-config.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/expat-2.7.5/expat-noconfig.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/expat-2.7.5/expat.cmake</Path>
             <Path fileType="library">/usr/lib64/libexpat.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/expat.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2026-01-31</Date>
-            <Version>2.7.4</Version>
+        <Update release="37">
+            <Date>2026-03-18</Date>
+            <Version>2.7.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/libexpat/libexpat/blob/R_2_7_5/expat/Changes).

**Security**
- CVE-2026-32776
- CVE-2026-32777
- CVE-2026-32778

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build `gdb` against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
