### PR TITLE
nghttp2: Update to v1.68.1

### DIFF
--- a/packages/n/nghttp2/abi_symbols
+++ b/packages/n/nghttp2/abi_symbols
@@ -36,6 +36,7 @@ libnghttp2.so.14:nghttp2_nv_compare_name
 libnghttp2.so.14:nghttp2_option_del
 libnghttp2.so.14:nghttp2_option_new
 libnghttp2.so.14:nghttp2_option_set_builtin_recv_extension_type
+libnghttp2.so.14:nghttp2_option_set_glitch_rate_limit
 libnghttp2.so.14:nghttp2_option_set_max_continuations
 libnghttp2.so.14:nghttp2_option_set_max_deflate_dynamic_table_size
 libnghttp2.so.14:nghttp2_option_set_max_outbound_ack
@@ -85,6 +86,7 @@ libnghttp2.so.14:nghttp2_session_callbacks_set_on_invalid_header_callback2
 libnghttp2.so.14:nghttp2_session_callbacks_set_on_stream_close_callback
 libnghttp2.so.14:nghttp2_session_callbacks_set_pack_extension_callback
 libnghttp2.so.14:nghttp2_session_callbacks_set_pack_extension_callback2
+libnghttp2.so.14:nghttp2_session_callbacks_set_rand_callback
 libnghttp2.so.14:nghttp2_session_callbacks_set_recv_callback
 libnghttp2.so.14:nghttp2_session_callbacks_set_recv_callback2
 libnghttp2.so.14:nghttp2_session_callbacks_set_select_padding_callback

--- a/packages/n/nghttp2/abi_symbols32
+++ b/packages/n/nghttp2/abi_symbols32
@@ -36,6 +36,7 @@ libnghttp2.so.14:nghttp2_nv_compare_name
 libnghttp2.so.14:nghttp2_option_del
 libnghttp2.so.14:nghttp2_option_new
 libnghttp2.so.14:nghttp2_option_set_builtin_recv_extension_type
+libnghttp2.so.14:nghttp2_option_set_glitch_rate_limit
 libnghttp2.so.14:nghttp2_option_set_max_continuations
 libnghttp2.so.14:nghttp2_option_set_max_deflate_dynamic_table_size
 libnghttp2.so.14:nghttp2_option_set_max_outbound_ack
@@ -85,6 +86,7 @@ libnghttp2.so.14:nghttp2_session_callbacks_set_on_invalid_header_callback2
 libnghttp2.so.14:nghttp2_session_callbacks_set_on_stream_close_callback
 libnghttp2.so.14:nghttp2_session_callbacks_set_pack_extension_callback
 libnghttp2.so.14:nghttp2_session_callbacks_set_pack_extension_callback2
+libnghttp2.so.14:nghttp2_session_callbacks_set_rand_callback
 libnghttp2.so.14:nghttp2_session_callbacks_set_recv_callback
 libnghttp2.so.14:nghttp2_session_callbacks_set_recv_callback2
 libnghttp2.so.14:nghttp2_session_callbacks_set_select_padding_callback

--- a/packages/n/nghttp2/package.yml
+++ b/packages/n/nghttp2/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : nghttp2
-version    : 1.65.0
-release    : 18
+version    : 1.68.1
+release    : 19
 source     :
-    - https://github.com/nghttp2/nghttp2/releases/download/v1.65.0/nghttp2-1.65.0.tar.xz : f1b9df5f02e9942b31247e3d415483553bc4ac501c87aa39340b6d19c92a9331
+    - https://github.com/nghttp2/nghttp2/releases/download/v1.68.1/nghttp2-1.68.1.tar.xz : 6abd7ab0a7f1580d5914457cb3c85eb80455657ee5119206edbd7f848c14f0b2
 license    : MIT
 component  : system.base
 emul32     : true
@@ -21,6 +21,7 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING
 
     rm -rf $installdir/usr/share/doc \
            $installdir/usr/share/man

--- a/packages/n/nghttp2/pspec_x86_64.xml
+++ b/packages/n/nghttp2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nghttp2</Name>
         <Homepage>https://nghttp2.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.base</PartOf>
@@ -21,8 +21,8 @@
         <PartOf>system.base</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libnghttp2.so.14</Path>
-            <Path fileType="library">/usr/lib64/libnghttp2.so.14.28.4</Path>
-            <Path fileType="data">/usr/share/nghttp2/fetch-ocsp-response</Path>
+            <Path fileType="library">/usr/lib64/libnghttp2.so.14.29.3</Path>
+            <Path fileType="data">/usr/share/licenses/nghttp2/COPYING</Path>
         </Files>
     </Package>
     <Package>
@@ -32,11 +32,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="18">nghttp2</Dependency>
+            <Dependency release="19">nghttp2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnghttp2.so.14</Path>
-            <Path fileType="library">/usr/lib32/libnghttp2.so.14.28.4</Path>
+            <Path fileType="library">/usr/lib32/libnghttp2.so.14.29.3</Path>
         </Files>
     </Package>
     <Package>
@@ -46,12 +46,10 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="18">nghttp2-32bit</Dependency>
-            <Dependency release="18">nghttp2-devel</Dependency>
+            <Dependency release="19">nghttp2-32bit</Dependency>
+            <Dependency release="19">nghttp2-devel</Dependency>
         </RuntimeDependencies>
         <Files>
-            <Path fileType="library">/usr/lib32/cmake/nghttp2/nghttp2-targets-relwithdebinfo.cmake</Path>
-            <Path fileType="library">/usr/lib32/cmake/nghttp2/nghttp2-targets.cmake</Path>
             <Path fileType="library">/usr/lib32/libnghttp2.so</Path>
             <Path fileType="data">/usr/lib32/pkgconfig/libnghttp2.pc</Path>
         </Files>
@@ -63,24 +61,26 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="18">nghttp2</Dependency>
+            <Dependency release="19">nghttp2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/nghttp2/nghttp2.h</Path>
             <Path fileType="header">/usr/include/nghttp2/nghttp2ver.h</Path>
-            <Path fileType="library">/usr/lib64/cmake/nghttp2/nghttp2-targets-relwithdebinfo.cmake</Path>
-            <Path fileType="library">/usr/lib64/cmake/nghttp2/nghttp2-targets.cmake</Path>
+            <Path fileType="library">/usr/lib/cmake/nghttp2/nghttp2Config.cmake</Path>
+            <Path fileType="library">/usr/lib/cmake/nghttp2/nghttp2ConfigVersion.cmake</Path>
+            <Path fileType="library">/usr/lib/cmake/nghttp2/nghttp2Targets-relwithdebinfo.cmake</Path>
+            <Path fileType="library">/usr/lib/cmake/nghttp2/nghttp2Targets.cmake</Path>
             <Path fileType="library">/usr/lib64/libnghttp2.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/libnghttp2.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2025-04-08</Date>
-            <Version>1.65.0</Version>
+        <Update release="19">
+            <Date>2026-03-18</Date>
+            <Version>1.68.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/nghttp2/nghttp2/releases/tag/v1.68.1).

**Security**
- CVE-2026-27135

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Download the source tarball with `wget`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
