### PR TITLE
usysconf: Update to v0.5.12

### DIFF
--- a/packages/u/usysconf/package.yml
+++ b/packages/u/usysconf/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : usysconf
-version    : 0.5.11
-release    : 47
+version    : 0.5.12
+release    : 48
 source     :
-    - https://github.com/getsolus/usysconf/releases/download/v0.5.11/usysconf-v0.5.11.tar.xz : 52e9b4b851181282295b96232479985634e8e2eedf03bd0daba8668c79fca39f
+    - https://github.com/getsolus/usysconf/releases/download/v0.5.12/usysconf-v0.5.12.tar.xz : 39272a1f45956d7c88ec55f5be31bc850544558ba2808d9b165a4048069d70f5
 homepage   : https://github.com/getsolus/usysconf/
 license    : GPL-2.0-only
 component  : system.base

--- a/packages/u/usysconf/pspec_x86_64.xml
+++ b/packages/u/usysconf/pspec_x86_64.xml
@@ -40,9 +40,9 @@ usysconf is a Solus project.
         </Files>
     </Package>
     <History>
-        <Update release="47">
-            <Date>2026-03-18</Date>
-            <Version>0.5.11</Version>
+        <Update release="48">
+            <Date>2026-03-19</Date>
+            <Version>0.5.12</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/getsolus/usysconf/releases/tag/v0.5.12).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

1. Create a new VM.
2. Update to latest Polaris.
3. Reboot.
4. Copy usysconf from host into a directory.
5. Create a local repo in said directory.
6. Add Unstable repository.
7. `sudo eopkg up -y`
8. Pray.
9. Run `systemctl status qol-migration-assist.service` or whatever it's called, and see it is enabled.
10. Reboot, and successfully run `sudo ls`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
