### PR TITLE
repo_data: Deprecate network-manager-devel

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -3148,5 +3148,6 @@
 		<Package>gstreamer-1.0-plugins-ugly</Package>
 		<Package>gstreamer-1.0-plugins-ugly-dbginfo</Package>
 		<Package>gstreamer-1.0-plugins-ugly-devel</Package>
+		<Package>network-manager-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -4312,5 +4312,8 @@
 		<Package>gstreamer-1.0-plugins-ugly-dbginfo</Package>
 		<Package>gstreamer-1.0-plugins-ugly-devel</Package>
 
+		<!-- Renamed -->
+		<Package>network-manager-devel</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
**Summary**
The package contents were moved to `network-manager-libnm-devel`, and
should have been deprecated when that was done.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

n/a

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
