### PR TITLE
systemd: Disable networkd service

### DIFF
--- a/packages/s/systemd/files/60-systemd.preset
+++ b/packages/s/systemd/files/60-systemd.preset
@@ -1,0 +1,3 @@
+# Solus uses NetworkManager instead
+disable systemd-networkd.service
+disable systemd-networkd-wait-online.service

--- a/packages/s/systemd/package.yml
+++ b/packages/s/systemd/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : systemd
 version    : '257.10'
-release    : 185
+release    : 186
 source     :
     - https://github.com/systemd/systemd/archive/refs/tags/v257.10.tar.gz : 5a2f477e6268630f6e2829c7bb3e442017549798a4122635817934eaa0c6ac10
 license    :
@@ -243,6 +243,9 @@ install    : |
     install -Dm00644 -t $installdir/usr/lib/systemd/system.conf.d/ $pkgfiles/configs/timeouts.conf
     install -Dm00644 -t $installdir/usr/lib/systemd/journald.conf.d/ $pkgfiles/configs/journald.conf
     install -Dm00644 -t $installdir/usr/lib/systemd/system/service.d/ $pkgfiles/configs/10-timeout-abort.conf
+
+    # Disable networkd in favor of NetworkManager
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/60-systemd.preset
 
     # Disable services by default, unless explicitly enabled
     install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/99-default.preset

--- a/packages/s/systemd/pspec_x86_64.xml
+++ b/packages/s/systemd/pspec_x86_64.xml
@@ -730,6 +730,7 @@
             <Path fileType="library">/usr/lib64/security/pam_systemd_loadkey.so</Path>
             <Path fileType="library">/usr/lib64/systemd/libsystemd-core-257.so</Path>
             <Path fileType="library">/usr/lib64/systemd/libsystemd-shared-257.so</Path>
+            <Path fileType="library">/usr/lib64/systemd/system-preset/60-systemd.preset</Path>
             <Path fileType="library">/usr/lib64/systemd/system-preset/99-default.preset</Path>
             <Path fileType="library">/usr/lib64/systemd/user-preset/99-default.preset</Path>
             <Path fileType="library">/usr/lib64/udev/udevd</Path>
@@ -1328,7 +1329,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="185">systemd</Dependency>
+            <Dependency release="186">systemd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnss_myhostname.so.2</Path>
@@ -1351,8 +1352,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="185">systemd-devel</Dependency>
-            <Dependency release="185">systemd-32bit</Dependency>
+            <Dependency release="186">systemd-devel</Dependency>
+            <Dependency release="186">systemd-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/lib32/pkgconfig/libsystemd.pc</Path>
@@ -1366,7 +1367,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="185">systemd</Dependency>
+            <Dependency release="186">systemd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libudev.h</Path>
@@ -2186,8 +2187,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="185">
-            <Date>2026-03-15</Date>
+        <Update release="186">
+            <Date>2026-03-19</Date>
             <Version>257.10</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
We use NetworkManager instead, and only one should be enabled at a time.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `systemctl systemd-networkd.service` and see that it is disabled.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
