### PR TITLE
broot: Update to v1.56.1

### DIFF
--- a/packages/b/broot/package.yml
+++ b/packages/b/broot/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : broot
-version    : 1.55.0
-release    : 31
+version    : 1.56.1
+release    : 32
 source     :
-    - https://github.com/Canop/broot/archive/refs/tags/v1.55.0.tar.gz : 3049d055f37bfdc3b2057a3e2186cfdb58b596e1586b6b129698b350a80cfda3
+    - https://github.com/Canop/broot/archive/refs/tags/v1.56.1.tar.gz : 0d29cd855b7a0de5de3d3c191ff43ed9d447f7097c6ca40abc0686d539a9923c
 homepage   : https://dystroy.org/broot/
 license    : MIT
 component  : system.utils
@@ -31,3 +31,5 @@ install    : |
 
     # Install font
     install -Dm00644 resources/icons/vscode/vscode.ttf $installdir/usr/share/fonts/truetype/vscode.ttf
+check     : |
+    %cargo_test

--- a/packages/b/broot/pspec_x86_64.xml
+++ b/packages/b/broot/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2026-02-09</Date>
-            <Version>1.55.0</Version>
+        <Update release="32">
+            <Date>2026-03-20</Date>
+            <Version>1.56.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/Canop/broot/releases/tag/v1.56.1).
- Release notes can be found [here](https://github.com/Canop/broot/releases/tag/v1.56.0).

**Test Plan**

`broot`, fuzzily found files named `files`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
