### PR TITLE
libuv: Update to v1.52.1

### DIFF
--- a/packages/l/libuv/abi_symbols
+++ b/packages/l/libuv/abi_symbols
@@ -248,6 +248,7 @@ libuv.so.1:uv_tcp_getsockname
 libuv.so.1:uv_tcp_init
 libuv.so.1:uv_tcp_init_ex
 libuv.so.1:uv_tcp_keepalive
+libuv.so.1:uv_tcp_keepalive_ex
 libuv.so.1:uv_tcp_nodelay
 libuv.so.1:uv_tcp_open
 libuv.so.1:uv_tcp_simultaneous_accepts
@@ -289,6 +290,7 @@ libuv.so.1:uv_udp_getsockname
 libuv.so.1:uv_udp_init
 libuv.so.1:uv_udp_init_ex
 libuv.so.1:uv_udp_open
+libuv.so.1:uv_udp_open_ex
 libuv.so.1:uv_udp_recv_start
 libuv.so.1:uv_udp_recv_stop
 libuv.so.1:uv_udp_send

--- a/packages/l/libuv/abi_used_symbols
+++ b/packages/l/libuv/abi_used_symbols
@@ -56,6 +56,7 @@ libc.so.6:fstatfs64
 libc.so.6:fsync
 libc.so.6:ftruncate64
 libc.so.6:futimens
+libc.so.6:fwrite
 libc.so.6:getaddrinfo
 libc.so.6:getcwd
 libc.so.6:getenv

--- a/packages/l/libuv/package.yml
+++ b/packages/l/libuv/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libuv
-version    : 1.51.0
-release    : 21
+version    : 1.52.1
+release    : 22
 source     :
-    - https://github.com/libuv/libuv/archive/refs/tags/v1.51.0.tar.gz : 27e55cf7083913bfb6826ca78cde9de7647cded648d35f24163f2d31bb9f51cd
+    - https://github.com/libuv/libuv/archive/refs/tags/v1.52.1.tar.gz : 478baf2599bfbc882c355288c9cb6f92e0e7dda435fa04031fa5b607cf3f414c
 homepage   : https://libuv.org
 license    : MIT
 component  : programming.library

--- a/packages/l/libuv/pspec_x86_64.xml
+++ b/packages/l/libuv/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libuv</Name>
         <Homepage>https://libuv.org</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.library</PartOf>
@@ -33,7 +33,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="21">libuv</Dependency>
+            <Dependency release="22">libuv</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/uv.h</Path>
@@ -52,6 +52,7 @@
             <Path fileType="header">/usr/include/uv/win.h</Path>
             <Path fileType="library">/usr/lib64/cmake/libuv/libuvConfig-relwithdebinfo.cmake</Path>
             <Path fileType="library">/usr/lib64/cmake/libuv/libuvConfig.cmake</Path>
+            <Path fileType="library">/usr/lib64/cmake/libuv/libuvConfigVersion.cmake</Path>
             <Path fileType="library">/usr/lib64/libuv.a</Path>
             <Path fileType="library">/usr/lib64/libuv.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/libuv-static.pc</Path>
@@ -59,12 +60,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2025-05-31</Date>
-            <Version>1.51.0</Version>
+        <Update release="22">
+            <Date>2026-03-20</Date>
+            <Version>1.52.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://github.com/libuv/libuv/releases/tag/v1.52.1)

**Security**

- https://github.com/libuv/libuv/security/advisories/GHSA-4prr-4742-3ccf

**Test Plan**

- Run neovim

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
