### PR TITLE
gjs: Backport patch

### DIFF
--- a/packages/g/gjs/abi_used_symbols
+++ b/packages/g/gjs/abi_used_symbols
@@ -459,6 +459,7 @@ libglib-2.0.so.0:g_filename_from_utf8
 libglib-2.0.so.0:g_filename_to_utf8
 libglib-2.0.so.0:g_fprintf
 libglib-2.0.so.0:g_free
+libglib-2.0.so.0:g_free_sized
 libglib-2.0.so.0:g_get_current_dir
 libglib-2.0.so.0:g_get_monotonic_time
 libglib-2.0.so.0:g_get_system_data_dirs
@@ -1132,6 +1133,7 @@ libmozjs-140.so:_ZN2js2gc19NewMemoryInfoObjectEP9JSContext
 libmozjs-140.so:_ZN2js2gc29PerformIncrementalReadBarrierEN2JS9GCCellPtrE
 libmozjs-140.so:_ZN2js7RunJobsEP9JSContext
 libmozjs-140.so:_ZN2js8DumpHeapEP9JSContextP8_IO_FILENS_24DumpHeapNurseryBehaviourEPFmPKvE
+libmozjs-140.so:_ZN7mozilla6detail23InvalidArrayIndex_CRASHEmm
 libmozjs-140.so:_ZNK2js13StringPrinter6lengthEv
 libmozjs-140.so:_ZNK2js15TempAllocPolicy19reportAllocOverflowEv
 libmozjs-140.so:abort

--- a/packages/g/gjs/files/0001-gi-Allow-optional-inout-arguments-to-be-null.patch
+++ b/packages/g/gjs/files/0001-gi-Allow-optional-inout-arguments-to-be-null.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Florian=20M=C3=BCllner?= <fmuellner@gnome.org>
+Date: Fri, 21 Nov 2025 19:40:43 +0100
+Subject: [PATCH] gi: Allow optional inout arguments to be null
+
+When checking whether a provided argument can be null, we currently
+only consider the `nullable` annotation.
+
+While that is correct for "in" parameters, for "inout" parameters
+it is the `optional` annotation that indicates that the argument
+itself can be null (like for "out" parameters), while `nullable`
+means that the argument may *point* to null.
+
+It should be valid to pass `null` for optional "inout" parameters
+(like it is in C), so explicitly handle this case.
+---
+ gi/arg-cache.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/gi/arg-cache.cpp b/gi/arg-cache.cpp
+index d11e8ed3a4ff..1bc325c07e4f 100644
+--- a/gi/arg-cache.cpp
++++ b/gi/arg-cache.cpp
+@@ -3642,6 +3642,9 @@ void ArgsCache::build_arg(uint8_t gi_index, GIDirection direction,
+     GjsArgumentFlags flags = GjsArgumentFlags::NONE;
+     if (arg.may_be_null())
+         flags |= GjsArgumentFlags::MAY_BE_NULL;
++    if ((direction == GI_DIRECTION_OUT || direction == GI_DIRECTION_INOUT) &&
++        arg.is_optional())
++        flags |= GjsArgumentFlags::MAY_BE_NULL;
+     if (arg.caller_allocates())
+         flags |= GjsArgumentFlags::CALLER_ALLOCATES;
+ 

--- a/packages/g/gjs/package.yml
+++ b/packages/g/gjs/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gjs
 version    : 1.86.0
-release    : 66
+release    : 67
 source     :
     - https://download.gnome.org/sources/gjs/1.86/gjs-1.86.0.tar.xz : 63448f7a57804d4c2a8d0c7f5e90e224d04d4eb2d560142c076c65a8eda00799
 component  : desktop.gnome.core
@@ -20,6 +20,7 @@ builddeps  :
 rundeps    :
     - mozjs
 setup      : |
+    %patch -p1 -i $pkgfiles/0001-gi-Allow-optional-inout-arguments-to-be-null.patch
     %meson_configure -Dinstalled_tests=false
 build      : |
     %ninja_build

--- a/packages/g/gjs/pspec_x86_64.xml
+++ b/packages/g/gjs/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gjs</Name>
         <Homepage>https://gjs.guide/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Packager>
         <License>MIT OR LGPL-2.0-or-later</License>
         <PartOf>desktop.gnome.core</PartOf>
@@ -45,7 +45,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="66">gjs</Dependency>
+            <Dependency release="67">gjs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gjs-1.0/gjs/context.h</Path>
@@ -60,12 +60,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="66">
-            <Date>2025-09-18</Date>
+        <Update release="67">
+            <Date>2026-03-21</Date>
             <Version>1.86.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>malfisya.dev@hotmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- This patch fix `gjs` to work better with Gstreamer 1.28.x
- This patch solves Screencast not working and Decibles not launching

**Test Plan**

<!-- Short description of how the package was tested -->
Install package and make sure all the aboves are true

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
