### PR TITLE
gparted: Update to v1.8.1

### DIFF
--- a/packages/g/gparted/abi_used_symbols
+++ b/packages/g/gparted/abi_used_symbols
@@ -914,9 +914,7 @@ libstdc++.so.6:_ZTVSt14basic_ifstreamIcSt11char_traitsIcEE
 libstdc++.so.6:_ZTVSt14basic_ofstreamIcSt11char_traitsIcEE
 libstdc++.so.6:_ZTVSt15basic_streambufIcSt11char_traitsIcEE
 libstdc++.so.6:_ZTVSt9basic_iosIcSt11char_traitsIcEE
-libstdc++.so.6:_ZdaPv
 libstdc++.so.6:_ZdlPvm
-libstdc++.so.6:_Znam
 libstdc++.so.6:_Znwm
 libstdc++.so.6:__cxa_allocate_exception
 libstdc++.so.6:__cxa_begin_catch

--- a/packages/g/gparted/package.yml
+++ b/packages/g/gparted/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gparted
-version    : 1.8.0
-release    : 31
+version    : 1.8.1
+release    : 32
 source     :
-    - https://sourceforge.net/projects/gparted/files/gparted/gparted-1.8.0/gparted-1.8.0.tar.gz : f584ed4be7fd09c2cf6a784778a8540970d985f0ac8e5a7bd0628528a3ab5609
+    - https://sourceforge.net/projects/gparted/files/gparted/gparted-1.8.1/gparted-1.8.1.tar.gz : 67388ac405f9fe92a40636cb03b0e1e0bb6403ad89ccc174b2ff190ef6f32349
 homepage   : https://gparted.org/
 license    : GPL-2.0-or-later
 component  : desktop.gnome

--- a/packages/g/gparted/pspec_x86_64.xml
+++ b/packages/g/gparted/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gparted</Name>
         <Homepage>https://gparted.org/</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.gnome</PartOf>
@@ -103,12 +103,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2026-02-22</Date>
-            <Version>1.8.0</Version>
+        <Update release="32">
+            <Date>2026-03-21</Date>
+            <Version>1.8.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Implement blkid false detection of whole disk ZFS workaround
- Release notes [here](https://sourceforge.net/projects/gparted/files/gparted/gparted-1.8.1/)

**Test Plan**

- Format a USB drive

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
