### PR TITLE
repo_data: Deprecate gstreamer-vaapi

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -3148,6 +3148,7 @@
 		<Package>gstreamer-1.0-plugins-ugly</Package>
 		<Package>gstreamer-1.0-plugins-ugly-dbginfo</Package>
 		<Package>gstreamer-1.0-plugins-ugly-devel</Package>
+		<Package>gstreamer-vaapi</Package>
 		<Package>network-manager-devel</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -4312,6 +4312,9 @@
 		<Package>gstreamer-1.0-plugins-ugly-dbginfo</Package>
 		<Package>gstreamer-1.0-plugins-ugly-devel</Package>
 
+		<!-- Removed upstream -->
+		<Package>gstreamer-vaapi</Package>
+
 		<!-- Renamed -->
 		<Package>network-manager-devel</Package>
 


### PR DESCRIPTION
**Summary**
This has been removed upstream.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

n/a

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
