### PR TITLE
ydotool: Add user systemd preset

### DIFF
--- a/packages/y/ydotool/files/20-ydotool.preset
+++ b/packages/y/ydotool/files/20-ydotool.preset
@@ -1,0 +1,2 @@
+# Users may systemctl --user mask to turn it off.
+enable ydotool.service

--- a/packages/y/ydotool/package.yml
+++ b/packages/y/ydotool/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : ydotool
 version    : 1.0.4
-release    : 1
+release    : 2
 source     :
     - https://github.com/ReimuNotMoe/ydotool/archive/refs/tags/v1.0.4.tar.gz : ba075a43aa6ead51940e892ecffa4d0b8b40c241e4e2bc4bd9bd26b61fde23bd
 homepage   : https://github.com/ReimuNotMoe/ydotool
@@ -23,4 +23,9 @@ build      : |
 install    : |
     %ninja_install
     %install_license LICENSE
+
+    # udev rule so ydotoold can use /dev/uinput when permitted by group membership
     install -Dm00644 $pkgfiles/80-uinput.rules $installdir/%libdir%/udev/rules.d/80-uinput.rules
+
+    # Default-enabled user preset for ydotool.service (override with systemctl --user mask)
+    install -Dm00644 -t ${installdir}/%libdir%/systemd/user-preset/ ${pkgfiles}/20-ydotool.preset

--- a/packages/y/ydotool/pspec_x86_64.xml
+++ b/packages/y/ydotool/pspec_x86_64.xml
@@ -27,6 +27,7 @@ useful for automation on Wayland, text consoles, and other environments without 
             <Path fileType="executable">/usr/bin/ydotool</Path>
             <Path fileType="executable">/usr/bin/ydotoold</Path>
             <Path fileType="library">/usr/lib/systemd/user/ydotool.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/user-preset/20-ydotool.preset</Path>
             <Path fileType="library">/usr/lib64/udev/rules.d/80-uinput.rules</Path>
             <Path fileType="data">/usr/share/licenses/ydotool/LICENSE</Path>
             <Path fileType="man">/usr/share/man/man1/ydotool.1.zst</Path>
@@ -34,8 +35,8 @@ useful for automation on Wayland, text consoles, and other environments without 
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2026-01-11</Date>
+        <Update release="2">
+            <Date>2026-03-22</Date>
             <Version>1.0.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>


### PR DESCRIPTION
**Summary**
- Add user systemd preset
- Resolves: #8269 

**Test Plan**

Install `ydotool` and `systemctl --user status ydotool.service`. See that `ydotool` is enabled. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
