### PR TITLE
proton-vpn-gtk-app: Update to v4.15.1

### DIFF
--- a/packages/p/proton-vpn-gtk-app/files/0001-fix-sni-and-dbusmenu-typing.patch
+++ b/packages/p/proton-vpn-gtk-app/files/0001-fix-sni-and-dbusmenu-typing.patch
@@ -1,0 +1,180 @@
+From fcbe89fe37145ec241b79b4f946e7b5e8658cfbf Mon Sep 17 00:00:00 2001
+From: dragonleopardpig <dragonleopardpig@gmail.com>
+Date: Sun, 22 Mar 2026 15:20:42 +0800
+Subject: [PATCH] fix: make tray SNI and DBusMenu responses type-correct
+
+---
+ proton/vpn/app/gtk/widgets/main/tray_icon.py | 112 +++++++++++--------
+ 1 file changed, 65 insertions(+), 47 deletions(-)
+
+diff --git a/proton/vpn/app/gtk/widgets/main/tray_icon.py b/proton/vpn/app/gtk/widgets/main/tray_icon.py
+index db905e2..d131ce4 100644
+--- a/proton/vpn/app/gtk/widgets/main/tray_icon.py
++++ b/proton/vpn/app/gtk/widgets/main/tray_icon.py
+@@ -104,12 +104,18 @@ class MenuObject:
+ 
+     def to_dbus(self) -> dbus.Dictionary:
+         """Converts and returns the object to dbus friendly format."""
+-        return dbus.Dictionary({
++        data = {
+             "type": dbus.String(self.type.value),
+-            "label": dbus.String(self.label),
+-            "enabled": dbus.Boolean(self.enabled),
+-            "visible": dbus.Boolean(self.visible)
+-        }, signature="sv")
++            "visible": dbus.Boolean(self.visible),
++        }
++
++        if self.type == MenuType.ITEM:
++            data.update({
++                "label": dbus.String(self.label),
++                "enabled": dbus.Boolean(self.enabled),
++            })
++
++        return dbus.Dictionary(data, signature="sv")
+ 
+ 
+ class _DBusMenuService(dbus.service.Object):
+@@ -138,11 +144,20 @@ def _build_menu_structure(self):
+ 
+         return structure
+ 
+-    def _build_layout(
+-        self, parent_id, properties, menu: list[dict[int, dbus.Dictionary]] = None
+-    ):
+-        """Build layout for GetLayout."""
++    def _empty_layout_children(self) -> dbus.Array:
++        return dbus.Array([], signature="v")
+ 
++    def _layout_item_properties(self, item) -> dbus.Dictionary:
++        if not item:
++            return dbus.Dictionary({}, signature="sv")
++
++        return dbus.Dictionary(
++            {key: value for key, value in item.items() if key != "children"},
++            signature="sv"
++        )
++
++    def _build_layout(self, parent_id, properties, menu=None):  # pylint: disable=unused-argument
++        """Build a correctly-typed DBusMenu layout tree for GetLayout."""
+         if menu is None:
+             menu = self._build_menu_structure()
+ 
+@@ -150,28 +165,21 @@ def _build_layout(
+             return (
+                 dbus.Int32(parent_id),
+                 dbus.Dictionary({}, signature="sv"),
+-                dbus.Array([], signature="(ia{sv}av)")
++                self._empty_layout_children(),
+             )
+ 
+-        item: dbus.Dictionary = menu[parent_id]
+-
+-        children = dbus.Array([], signature="(ia{sv}av)")
+-        if "children" in item:
+-            for child_id in item["children"]:
+-                child_layout = self._build_layout(child_id, properties, menu)
+-                child_id_dbus = child_layout[0]
+-                child_props = child_layout[1] \
+-                    if child_layout[1] else dbus.Dictionary({}, signature="sv")
+-                child_children = child_layout[2] \
+-                    if child_layout[2] else dbus.Array([], signature="(ia{sv}av)")
+-                children.append(
+-                    dbus.Struct(
+-                        (child_id_dbus, child_props, child_children),
+-                        signature="(ia{sv}av)"
+-                    )
+-                )
+-
+-        return (dbus.Int32(parent_id), item, children)
++        item = menu[parent_id]
++        children = self._empty_layout_children()
++
++        for child_id in item.get("children", []):
++            child_layout = self._build_layout(child_id, properties, menu)
++            children.append(dbus.Struct(child_layout))
++
++        return (
++            dbus.Int32(parent_id),
++            self._layout_item_properties(item),
++            children,
++        )
+ 
+     @dbus.service.method(
+         dbus_interface=DBUSMENU_INTERFACE,
+@@ -214,7 +222,7 @@ def Event(self, item_id, event_type, _data, _timestamp):  # pylint: disable=unus
+         item = [
+             item for item in self.menu_items
+             if item.id == item_id
+-            and item.type != MenuType.SEPARATOR.value
++            and item.type != MenuType.SEPARATOR
+             and item.callback
+         ]
+ 
+@@ -278,7 +286,24 @@ def Get(self, interface: str, prop: str):  # pylint: disable=invalid-name
+             # dbus library can encode a valid value (None cannot be encoded).
+             return dbus.String("")
+ 
+-        available_options = {
++        available_options = self._get_sni_properties()
++
++        # Unknown property: return a valid D-Bus string variant instead of None.
++        return available_options.get(prop, dbus.String(""))
++
++    def _get_sni_properties(self):
++        """Return all standard SNI properties with correctly-typed D-Bus values."""
++        empty_pixmap = dbus.Array([], signature="(iiay)")
++        empty_tooltip = dbus.Struct(
++            (
++                dbus.String(""),
++                dbus.Array([], signature="(iiay)"),
++                dbus.String(""),
++                dbus.String(""),
++            )
++        )
++
++        return {
+             StatusNotifierItemProperty.STATUS.value: dbus.String(self.tray.status),
+             StatusNotifierItemProperty.CATEGORY.value: dbus.String("ApplicationStatus"),
+             StatusNotifierItemProperty.ID.value: dbus.String(self.tray.app_id),
+@@ -289,12 +314,16 @@ def Get(self, interface: str, prop: str):  # pylint: disable=invalid-name
+             StatusNotifierItemProperty.ICON_ACCESSIBLE_DESCRIPTION.value: dbus.String(
+                 self.tray.icon_desc
+             ),
++            "IconPixmap": empty_pixmap,
++            "OverlayIconName": dbus.String(""),
++            "OverlayIconPixmap": empty_pixmap,
++            "AttentionIconName": dbus.String(""),
++            "AttentionIconPixmap": empty_pixmap,
++            "AttentionMovieName": dbus.String(""),
++            "ToolTip": empty_tooltip,
++            "WindowId": dbus.UInt32(0),
+         }
+ 
+-        # Unknown property: return empty DBus string variant to avoid
+-        # "Don't know which D-Bus type to use to encode type NoneType" errors.
+-        return available_options.get(prop, "")
+-
+     @dbus.service.method(
+         dbus_interface="org.freedesktop.DBus.Properties",
+         in_signature="s",
+@@ -305,18 +334,7 @@ def GetAll(self, interface: str) -> dbus.Dictionary:  # pylint: disable=invalid-
+         if interface != SNI_INTERFACE:
+             return {}
+ 
+-        return {
+-            StatusNotifierItemProperty.STATUS.value: dbus.String(self.tray.status),
+-            StatusNotifierItemProperty.CATEGORY.value: dbus.String("ApplicationStatus"),
+-            StatusNotifierItemProperty.ID.value: dbus.String(self.tray.app_id),
+-            StatusNotifierItemProperty.TITLE.value: dbus.String(self.tray.title),
+-            StatusNotifierItemProperty.ICON_NAME.value: dbus.String(self.tray.icon_name),
+-            StatusNotifierItemProperty.MENU.value: dbus.ObjectPath(DBUSMENU_PATH),
+-            StatusNotifierItemProperty.ITEM_IS_MENU.value: dbus.Boolean(True),
+-            StatusNotifierItemProperty.ICON_ACCESSIBLE_DESCRIPTION.value: dbus.String(
+-                self.tray.icon_desc
+-            )
+-        }
++        return self._get_sni_properties()
+ 
+     @dbus.service.method(dbus_interface=SNI_INTERFACE, in_signature="ii", out_signature="")
+     def Activate(self, _x_pos, _y_pos):  # pylint: disable=unused-argument, invalid-name, line-too-long # noqa: E501

--- a/packages/p/proton-vpn-gtk-app/files/0002-improve-tray-host-detection.patch
+++ b/packages/p/proton-vpn-gtk-app/files/0002-improve-tray-host-detection.patch
@@ -1,0 +1,106 @@
+From 9b7fc0672e8aa3ab9896c19841112cce4de3b714 Mon Sep 17 00:00:00 2001
+From: dragonleopardpig <dragonleopardpig@gmail.com>
+Date: Sun, 22 Mar 2026 15:20:42 +0800
+Subject: [PATCH] fix: improve tray detection outside GNOME
+
+---
+ .../app/gtk/widgets/main/tray_indicator.py    | 66 ++++++++++++++++++-
+ 1 file changed, 63 insertions(+), 3 deletions(-)
+
+diff --git a/proton/vpn/app/gtk/widgets/main/tray_indicator.py b/proton/vpn/app/gtk/widgets/main/tray_indicator.py
+index 3e78693..01014f4 100644
+--- a/proton/vpn/app/gtk/widgets/main/tray_indicator.py
++++ b/proton/vpn/app/gtk/widgets/main/tray_indicator.py
+@@ -28,7 +28,7 @@
+ from proton.vpn.app.gtk.assets.icons import ICONS_PATH
+ from proton.vpn.app.gtk.controller import Controller
+ from proton.vpn.app.gtk.widgets.main.main_window import MainWindow
+-from proton.vpn.app.gtk.widgets.main.tray_icon import TrayIcon
++from proton.vpn.app.gtk.widgets.main.tray_icon import TrayIcon, SNW_BUS_NAME
+ 
+ logger = logging.getLogger(__name__)
+ 
+@@ -159,7 +159,12 @@ def setup(self, main_window: MainWindow):
+ 
+         if self._tray is None:
+             self._tray = TrayIcon()
+-            self._tray.setup()
++            try:
++                self._tray.setup()
++            except Exception as exc:
++                raise TrayIndicatorNotSupported(
++                    f"Failed to set up system tray: {exc}"
++                ) from exc
+ 
+         self.status_update(self._controller.current_connection_status)
+         self._controller.register_connection_status_subscriber(self)
+@@ -169,13 +174,68 @@ def _can_tray_be_used(self):
+         # If gnome shell is not running then it's another DE and
+         # we assume tray works by default.
+         if self._gnome_tray_detection.is_gnome_shell_running():
+-            self._app_indicator_available |= self._gnome_tray_detection.is_extension_active()
++            gnome_extensions = self._gnome_tray_detection._gnome_shell_list_extensions()
++            if gnome_extensions is None:
++                self._app_indicator_available = self._is_status_notifier_watcher_available()
++            else:
++                ubuntu_extension = gnome_extensions.get(UBUNTU_INDICATOR_EXTENSION)
++                default_extension = gnome_extensions.get(DEFAULT_INDICATOR_EXTENSION)
++
++                enable_for_ubuntu = (
++                    ubuntu_extension and ubuntu_extension.get("state") == ACTIVE_STATE
++                )
++                enable_for_default = (
++                    default_extension
++                    and not self._disabled_user_extension()
++                    and default_extension.get("state") == ACTIVE_STATE
++                )
++
++                if enable_for_ubuntu or enable_for_default:
++                    self._app_indicator_available = True
+         else:
+             self._app_indicator_available = True
+             logger.warning("Tray icon enabled on an unsupported desktop environment")
+ 
+         return self._app_indicator_available
+ 
++    def _is_status_notifier_watcher_available(self, timeout_ms: int = 300) -> bool:
++        """Return True if the StatusNotifierWatcher D-Bus service is running."""
++        try:
++            bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
++            dbus_proxy = Gio.DBusProxy.new_sync(
++                bus,
++                Gio.DBusProxyFlags.DO_NOT_LOAD_PROPERTIES,
++                None,
++                "org.freedesktop.DBus",
++                "/org/freedesktop/DBus",
++                "org.freedesktop.DBus",
++                None,
++            )
++            (has_owner,) = dbus_proxy.call_sync(
++                "NameHasOwner",
++                GLib.Variant("(s)", (SNW_BUS_NAME,)),
++                Gio.DBusCallFlags.NONE,
++                timeout_ms,
++                None,
++            ).unpack()
++            return bool(has_owner)
++        except GLib.Error:
++            logger.exception("Unable to check for StatusNotifierWatcher")
++            return False
++
++    def _disabled_user_extension(self) -> Optional[bool]:
++        source = Gio.SettingsSchemaSource.get_default()
++        if not source:
++            return None
++
++        schema = source.lookup("org.gnome.shell", True)
++        if not schema:
++            return None
++
++        settings = Gio.Settings.new_full(schema, None, None)
++        disabled_extensions = settings.get_strv("disabled-extensions")
++        return DEFAULT_INDICATOR_EXTENSION in disabled_extensions
++
+     def _set_main_window(self, main_window: MainWindow):
+         """Sets the main window for the tray indicator."""
+         self._main_window = main_window

--- a/packages/p/proton-vpn-gtk-app/files/0003-clean-up-tray-menu-state.patch
+++ b/packages/p/proton-vpn-gtk-app/files/0003-clean-up-tray-menu-state.patch
@@ -1,0 +1,111 @@
+From f6d45b288d5e94ae87fdbf0e1287bc29d722e023 Mon Sep 17 00:00:00 2001
+From: dragonleopardpig <dragonleopardpig@gmail.com>
+Date: Sun, 22 Mar 2026 15:21:13 +0800
+Subject: [PATCH] fix: keep tray menu state aligned with window visibility
+
+---
+ .../app/gtk/widgets/main/tray_indicator.py    | 52 ++++++++++++++-----
+ 1 file changed, 39 insertions(+), 13 deletions(-)
+
+diff --git a/proton/vpn/app/gtk/widgets/main/tray_indicator.py b/proton/vpn/app/gtk/widgets/main/tray_indicator.py
+index 01014f4..bb4e585 100644
+--- a/proton/vpn/app/gtk/widgets/main/tray_indicator.py
++++ b/proton/vpn/app/gtk/widgets/main/tray_indicator.py
+@@ -28,7 +28,7 @@
+ from proton.vpn.app.gtk.assets.icons import ICONS_PATH
+ from proton.vpn.app.gtk.controller import Controller
+ from proton.vpn.app.gtk.widgets.main.main_window import MainWindow
+-from proton.vpn.app.gtk.widgets.main.tray_icon import TrayIcon, SNW_BUS_NAME
++from proton.vpn.app.gtk.widgets.main.tray_icon import MenuType, TrayIcon, SNW_BUS_NAME
+ 
+ logger = logging.getLogger(__name__)
+ 
+@@ -240,6 +240,11 @@ def _set_main_window(self, main_window: MainWindow):
+         """Sets the main window for the tray indicator."""
+         self._main_window = main_window
+         self._build_menu()
++        self._main_window.connect("show", self._on_main_window_visibility_changed)
++        self._main_window.connect("hide", self._on_main_window_visibility_changed)
++        self._main_window.connect(
++            "notify::visible", self._on_main_window_visibility_changed
++        )
+ 
+         self._main_window.main_widget.login_widget.connect(
+             "user-logged-in", self._on_user_logged_in
+@@ -269,18 +274,34 @@ def _build_menu(self):
+         self._tray.menu_items.clear()
+ 
+         self._setup_connection_handler_entries()
+-        self._tray.add_menu_separator()
++        self._append_separator_if_needed()
+ 
+         if self._controller.user_logged_in:
+             self.display_pinned_servers = True
+             self._setup_pinned_server_entries()
+ 
++        self._append_separator_if_needed()
+         self._setup_main_window_visibility_toggle_entry()
+-        self._tray.add_menu_separator()
++        self._append_separator_if_needed()
+         self._setup_quit_entry()
+ 
+         self._tray.update_menu()
+ 
++    def _append_separator_if_needed(self):
++        if not self._tray.menu_items:
++            return
++
++        if self._tray.menu_items[-1].type == MenuType.SEPARATOR:
++            return
++
++        if not any(
++            item.type == MenuType.ITEM and item.visible
++            for item in self._tray.menu_items
++        ):
++            return
++
++        self._tray.add_menu_separator()
++
+     def _setup_pinned_server_entries(self):
+         tray_pinned_servers = self._controller.get_app_configuration().tray_pinned_servers
+         if not tray_pinned_servers or not self.display_pinned_servers:
+@@ -292,17 +313,19 @@ def _setup_pinned_server_entries(self):
+                 label=f"{servername}",
+                 callback=lambda server=servername: self._on_connect_to_pinned_entry_clicked(server))
+ 
+-        self._tray.add_menu_separator()
+-
+     def _setup_connection_handler_entries(self):
+-        self._tray.add_menu_item("Quick Connect",
+-                                 self._on_connect_entry_clicked,
+-                                 self.enable_connect_entry,
+-                                 self.display_connect_entry)
+-        self._tray.add_menu_item("Disconnect",
+-                                 self._on_disconnect_entry_clicked,
+-                                 self.enable_disconnect_entry,
+-                                 self.display_disconnect_entry)
++        if self.display_connect_entry:
++            self._tray.add_menu_item(
++                "Quick Connect",
++                self._on_connect_entry_clicked,
++                self.enable_connect_entry,
++            )
++        if self.display_disconnect_entry:
++            self._tray.add_menu_item(
++                "Disconnect",
++                self._on_disconnect_entry_clicked,
++                self.enable_disconnect_entry,
++            )
+ 
+     def _setup_main_window_visibility_toggle_entry(self):
+         toggle_label = "Show" if not self._main_window.get_visible() else "Hide"
+@@ -328,6 +351,9 @@ def _on_toggle_app_visibility_menu_entry_clicked(self, *_):
+             self._main_window.present()
+         self._update()
+ 
++    def _on_main_window_visibility_changed(self, *_):
++        self._update()
++
+     def _on_exit_app_menu_entry_clicked(self, *_):
+         self._main_window.header_bar.menu.quit_button_click()
+ 

--- a/packages/p/proton-vpn-gtk-app/files/0004-re-register-tray-item-when-tray-host-restarts.patch
+++ b/packages/p/proton-vpn-gtk-app/files/0004-re-register-tray-item-when-tray-host-restarts.patch
@@ -1,0 +1,61 @@
+From 619269ff2faefbe60763f2096442865f96c65211 Mon Sep 17 00:00:00 2001
+From: dragonleopardpig <dragonleopardpig@gmail.com>
+Date: Wed, 25 Mar 2026 17:17:04 +0800
+Subject: [PATCH] fix: re-register tray item when tray host restarts
+
+---
+ proton/vpn/app/gtk/widgets/main/tray_icon.py | 24 ++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/proton/vpn/app/gtk/widgets/main/tray_icon.py b/proton/vpn/app/gtk/widgets/main/tray_icon.py
+index db905e2..caeb91b 100644
+--- a/proton/vpn/app/gtk/widgets/main/tray_icon.py
++++ b/proton/vpn/app/gtk/widgets/main/tray_icon.py
+@@ -237,6 +237,7 @@ class _StatusNotifierItem(dbus.service.Object):
+     def __init__(self, tray_icon, bus, object_path):
+         self.tray = tray_icon
+         self.bus = bus
++        self._watcher_owner = None
+ 
+         # Generate unique bus name
+         self.bus_name_str = f"org.kde.StatusNotifierItem-{tray_icon.app_id}-{id(self)}"
+@@ -247,9 +248,31 @@ def __init__(self, tray_icon, bus, object_path):
+         # Create DBusMenu
+         self.menu = _DBusMenuService(bus, tray_icon.menu_items)
+ 
++        # Re-register if the tray host disappears and comes back.
++        self._subscribe_watcher_changes()
+         # Register with watcher
+         self._register_to_watcher()
+ 
++    def _subscribe_watcher_changes(self):
++        self.bus.add_signal_receiver(
++            self._on_name_owner_changed,
++            signal_name="NameOwnerChanged",
++            dbus_interface="org.freedesktop.DBus",
++            bus_name="org.freedesktop.DBus",
++            path="/org/freedesktop/DBus",
++            arg0=SNW_BUS_NAME,
++        )
++
++    def _on_name_owner_changed(self, name, old_owner, new_owner):
++        if name != SNW_BUS_NAME:
++            return
++
++        if new_owner and new_owner != self._watcher_owner:
++            self._watcher_owner = str(new_owner)
++            self._register_to_watcher()
++        elif not new_owner:
++            self._watcher_owner = None
++
+     def _register_to_watcher(self):
+         """Register with StatusNotifierWatcher"""
+         try:
+@@ -258,6 +281,7 @@ def _register_to_watcher(self):
+                 self.bus_name_str,
+                 dbus_interface=SNW_INTERFACE
+             )
++            self._watcher_owner = str(self.bus.get_name_owner(SNW_BUS_NAME))
+         except dbus.exceptions.DBusException:
+             # Silent fail, will still work on some DEs,
+             # see https://specifications.freedesktop.org/status-notifier-item-spec/status-notifier-item-spec-latest.html#registration  # pylint: disable=line-too-long # noqa: E501

--- a/packages/p/proton-vpn-gtk-app/package.yml
+++ b/packages/p/proton-vpn-gtk-app/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : proton-vpn-gtk-app
-version    : 4.15.0
-release    : 34
+version    : 4.15.1
+release    : 35
 source     :
-    - https://github.com/ProtonVPN/proton-vpn-gtk-app/archive/refs/tags/v4.15.0.tar.gz : 07eb8ce24c506898aa293030bb25c88585978c3f91e40c3fb2514fbf5b018880
+    - https://github.com/ProtonVPN/proton-vpn-gtk-app/archive/refs/tags/v4.15.1.tar.gz : b6f50486e593846810ba385ff298f5c0fec66c6d278db110b345e9e206d1b6e7
 homepage   : https://protonvpn.com/download-linux
 license    : GPL-3.0-or-later
 component  : network.clients
@@ -36,6 +36,11 @@ rundeps    :
     - python-requests
     - python-sentry-sdk
     - python3-dbus
+setup      : |
+    %patch -p1 -i ${pkgfiles}/0001-fix-sni-and-dbusmenu-typing.patch
+    %patch -p1 -i ${pkgfiles}/0002-improve-tray-host-detection.patch
+    %patch -p1 -i ${pkgfiles}/0003-clean-up-tray-menu-state.patch
+    %patch -p1 -i ${pkgfiles}/0004-re-register-tray-item-when-tray-host-restarts.patch
 build      : |
     %python3_setup
 install    : |

--- a/packages/p/proton-vpn-gtk-app/pspec_x86_64.xml
+++ b/packages/p/proton-vpn-gtk-app/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>proton-vpn-gtk-app</Name>
         <Homepage>https://protonvpn.com/download-linux</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.clients</PartOf>
@@ -543,12 +543,14 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/__pycache__/country.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/__pycache__/expandable_row.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/__pycache__/expandable_row.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/__pycache__/hover_box.cpython-312.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/__pycache__/hover_box.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/__pycache__/hover_stack.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/__pycache__/hover_stack.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/__pycache__/row_content.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/__pycache__/row_content.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/__pycache__/secure_core.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/__pycache__/secure_core.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/__pycache__/server_list_header_row.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/__pycache__/server_list_header_row.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/__pycache__/serverlist.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/__pycache__/serverlist.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/__pycache__/utils.cpython-312.opt-1.pyc</Path>
@@ -556,9 +558,10 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/city.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/country.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/expandable_row.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/hover_box.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/hover_stack.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/row_content.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/secure_core.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/server_list_header_row.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/serverlist.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/city_view/utils.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/country.py</Path>
@@ -566,13 +569,13 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/server.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/serverlist/serverlist.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/proton/vpn/app/gtk/widgets/vpn/vpn_widget.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/proton_vpn_gtk_app-4.15.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/proton_vpn_gtk_app-4.15.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/proton_vpn_gtk_app-4.15.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/proton_vpn_gtk_app-4.15.0.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/proton_vpn_gtk_app-4.15.0.dist-info/licenses/COPYING.md</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/proton_vpn_gtk_app-4.15.0.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/proton_vpn_gtk_app-4.15.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/proton_vpn_gtk_app-4.15.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/proton_vpn_gtk_app-4.15.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/proton_vpn_gtk_app-4.15.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/proton_vpn_gtk_app-4.15.1.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/proton_vpn_gtk_app-4.15.1.dist-info/licenses/COPYING.md</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/proton_vpn_gtk_app-4.15.1.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/proton_vpn_gtk_app-4.15.1.dist-info/top_level.txt</Path>
             <Path fileType="data">/usr/share/applications/proton.vpn.app.gtk.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/36x36/apps/proton-vpn-logo.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/proton-vpn-logo.svg</Path>
@@ -586,12 +589,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="34">
-            <Date>2026-03-15</Date>
-            <Version>4.15.0</Version>
+        <Update release="35">
+            <Date>2026-03-26</Date>
+            <Version>4.15.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
No changelog provided.

Added four patches from upstream for system tray fixes.

Ref https://github.com/ProtonVPN/proton-vpn-gtk-app/pull/152
Ref https://github.com/ProtonVPN/proton-vpn-gtk-app/pull/153
Ref https://github.com/ProtonVPN/proton-vpn-gtk-app/pull/154
Ref https://github.com/ProtonVPN/proton-vpn-gtk-app/pull/157

Fixes #8278 

**Test Plan**

Open `Proton VPN` from the Budgie menu, see that the tray icon appears without crashing the panel. Right-click the tray icon, click quit, and see that ProtonVPN successfully closes.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
