### PR TITLE
Add ferrumc 0.3.0

### DIFF
--- a/packages/f/ferrumc/package.yml
+++ b/packages/f/ferrumc/package.yml
@@ -1,0 +1,14 @@
+name       : ferrumc
+version    : 0.3.0
+release    : 1
+source     :
+    - https://github.com/Ferrum-Language/Ferrum/releases/download/v0.3.0/ferrumc-v0.3.0-linux-x86_64.tar.gz : 2735cf702ff9c3f3bf9ad95140bde211f3e642590e9222800f81969727ea6029
+license    : GPL-3.0-only
+homepage   : https://ferrum-language.github.io/Ferrum/
+summary    : Ferrum-language compiler with compile-time memory safety
+description: |
+    Ferrum-language is a systems programming language with C syntax and
+    compile-time memory safety via a borrow checker and ownership model.
+    Compiled to native code through LLVM 18.
+install    :
+    - binary(ferrumc)


### PR DESCRIPTION
## New package: ferrumc

**Ferrum-language compiler** — systems programming with C syntax and compile-time memory safety via a borrow checker and ownership model. Compiled to native code through LLVM 18.

- **License:** GPL-3.0-only
- **Homepage:** https://ferrum-language.github.io/Ferrum/
- **Upstream:** https://github.com/Ferrum-Language/Ferrum/releases/tag/v0.3.0