### PR TITLE
wl-clipboard: Update to v2.3.0

### DIFF
--- a/packages/w/wl-clipboard/abi_used_symbols
+++ b/packages/w/wl-clipboard/abi_used_symbols
@@ -25,6 +25,7 @@ libc.so.6:fdopen
 libc.so.6:fflush
 libc.so.6:fgets
 libc.so.6:fileno
+libc.so.6:fnmatch
 libc.so.6:fopen64
 libc.so.6:fork
 libc.so.6:fputc
@@ -35,6 +36,7 @@ libc.so.6:getenv
 libc.so.6:getopt_long
 libc.so.6:lseek64
 libc.so.6:malloc
+libc.so.6:memcpy
 libc.so.6:mkdtemp
 libc.so.6:open64
 libc.so.6:openlog

--- a/packages/w/wl-clipboard/package.yml
+++ b/packages/w/wl-clipboard/package.yml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : wl-clipboard
-version    : 2.2.1
-release    : 1
+version    : 2.3.0
+release    : 2
 source     :
-    - https://github.com/bugaevc/wl-clipboard/archive/refs/tags/v2.2.1.tar.gz : 6eb8081207fb5581d1d82c4bcd9587205a31a3d47bea3ebeb7f41aa1143783eb
+    - https://github.com/bugaevc/wl-clipboard/archive/refs/tags/v2.3.0.tar.gz : b4dc560973f0cd74e02f817ffa2fd44ba645a4f1ea94b7b9614dacc9f895f402
 homepage   : https://github.com/bugaevc/wl-clipboard
 license    : GPL-3.0-or-later
 component  : system.utils
-summary    : Command-line copy/paste utilities for Wayland 
+summary    : Command-line copy/paste utilities for Wayland
 description: |
     This project implements two command-line Wayland clipboard utilities, wl-copy and wl-paste, that let you easily copy data between the clipboard and Unix pipes, sockets, files and so on.
 builddeps  :
@@ -19,3 +19,4 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING

--- a/packages/w/wl-clipboard/pspec_x86_64.xml
+++ b/packages/w/wl-clipboard/pspec_x86_64.xml
@@ -26,17 +26,18 @@
             <Path fileType="data">/usr/share/bash-completion/completions/wl-paste</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/wl-copy.fish</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/wl-paste.fish</Path>
-            <Path fileType="man">/usr/share/man/man1/wl-clipboard.1</Path>
-            <Path fileType="man">/usr/share/man/man1/wl-copy.1</Path>
-            <Path fileType="man">/usr/share/man/man1/wl-paste.1</Path>
+            <Path fileType="data">/usr/share/licenses/wl-clipboard/COPYING</Path>
+            <Path fileType="man">/usr/share/man/man1/wl-clipboard.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/wl-copy.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/wl-paste.1.zst</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_wl-copy</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_wl-paste</Path>
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2024-08-02</Date>
-            <Version>2.2.1</Version>
+        <Update release="2">
+            <Date>2026-03-24</Date>
+            <Version>2.3.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Robert Gonzalez</Name>
             <Email>uni.dos12@outlook.com</Email>


### PR DESCRIPTION
**Summary**
- changelog can be found [here](https://github.com/bugaevc/wl-clipboard/releases/tag/v2.3.0)
- mostly bug fixes

**Test Plan**

Copy and paste text

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
