### PR TITLE
keyd: Remove socket file from tmpfiles

### DIFF
--- a/packages/k/keyd/files/keyd.conf
+++ b/packages/k/keyd/files/keyd.conf
@@ -1,2 +1,1 @@
-f /run/keyd.socket 0664 - - -
 d /etc/keyd 0755 - - -

--- a/packages/k/keyd/package.yml
+++ b/packages/k/keyd/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : keyd
 version    : 2.6.0
-release    : 5
+release    : 6
 source     :
     - https://github.com/rvaiya/keyd/archive/refs/tags/v2.6.0.tar.gz : 697089681915b89d9e98caf93d870dbd4abce768af8a647d54650a6a90744e26
 homepage   : https://github.com/rvaiya/keyd

--- a/packages/k/keyd/pspec_x86_64.xml
+++ b/packages/k/keyd/pspec_x86_64.xml
@@ -155,8 +155,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2026-03-22</Date>
+        <Update release="6">
+            <Date>2026-03-25</Date>
             <Version>2.6.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
Remove socket file from tmpfiles. This file is created by the IPC daemon on start, and does not need to be created by the package. Doing so results in a tmpfiles error when `usysconf` runs because the file exists, and is not a normal file.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

1. `systemctl restart keyd.service`
2. `ls -l /run/keyd.socket` and see that the timestamp is when the service started
3. `systemctl status keyd.service` and see that the service is running

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
