### PR TITLE
python-rich: Update to v14.3.3

### DIFF
--- a/packages/py/python-rich/MAINTAINERS.md
+++ b/packages/py/python-rich/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- George K.
+  - Matrix: #georgeonsolus:matrix.org
+  - Email: gk_coder@icloud.com

--- a/packages/py/python-rich/package.yml
+++ b/packages/py/python-rich/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-rich
-version    : 13.9.4
-release    : 6
+version    : 14.3.3
+release    : 7
 source     :
-    - https://files.pythonhosted.org/packages/source/r/rich/rich-13.9.4.tar.gz : 439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098
+    - https://files.pythonhosted.org/packages/source/r/rich/rich-14.3.3.tar.gz : b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b
 homepage   : https://github.com/Textualize/rich
 license    : MIT
 component  : programming.python

--- a/packages/py/python-rich/pspec_x86_64.xml
+++ b/packages/py/python-rich/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-rich</Name>
         <Homepage>https://github.com/Textualize/rich</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>George K.</Name>
+            <Email>gk_coder@icloud.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,18 +20,16 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/rich-13.9.4.dist-info/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/rich-13.9.4.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/rich-13.9.4.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/rich-13.9.4.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich-14.3.3.dist-info/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich-14.3.3.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich-14.3.3.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich-14.3.3.dist-info/WHEEL</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/__pycache__/__init__.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/__pycache__/__main__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/__pycache__/__main__.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/__pycache__/_cell_widths.cpython-312.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/__pycache__/_cell_widths.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/__pycache__/_emoji_codes.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/__pycache__/_emoji_codes.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/__pycache__/_emoji_replace.cpython-312.opt-1.pyc</Path>
@@ -182,7 +180,6 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/__pycache__/traceback.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/__pycache__/tree.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/__pycache__/tree.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_cell_widths.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_emoji_codes.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_emoji_replace.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_export_format.py</Path>
@@ -198,6 +195,75 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_spinners.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_stack.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_timer.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/__init__.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/_versions.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/_versions.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode10-0-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode10-0-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode11-0-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode11-0-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode12-0-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode12-0-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode12-1-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode12-1-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode13-0-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode13-0-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode14-0-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode14-0-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode15-0-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode15-0-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode15-1-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode15-1-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode16-0-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode16-0-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode17-0-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode17-0-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode4-1-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode4-1-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode5-0-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode5-0-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode5-1-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode5-1-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode5-2-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode5-2-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode6-0-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode6-0-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode6-1-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode6-1-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode6-2-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode6-2-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode6-3-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode6-3-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode7-0-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode7-0-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode8-0-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode8-0-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode9-0-0.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/__pycache__/unicode9-0-0.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/_versions.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode10-0-0.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode11-0-0.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode12-0-0.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode12-1-0.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode13-0-0.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode14-0-0.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode15-0-0.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode15-1-0.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode16-0-0.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode17-0-0.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode4-1-0.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode5-0-0.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode5-1-0.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode5-2-0.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode6-0-0.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode6-1-0.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode6-2-0.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode6-3-0.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode7-0-0.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode8-0-0.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_unicode_data/unicode9-0-0.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_win32_console.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_windows.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/_windows_renderer.py</Path>
@@ -262,12 +328,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2025-05-15</Date>
-            <Version>13.9.4</Version>
+        <Update release="7">
+            <Date>2026-03-25</Date>
+            <Version>14.3.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>George K.</Name>
+            <Email>gk_coder@icloud.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Bugfixes:
- fix infinite loop in cells.split_grapheme
- IPython respects a Console instance passed to pretty.install

Enhancements:
- Python 3.14 support
- TTY_INTERACTIVE environment variable

Changelog:
- [rich changelog](https://github.com/Textualize/rich/blob/master/CHANGELOG.md)
- [14.3.3](https://github.com/Textualize/rich/releases/tag/v14.3.3)

**Test Plan**

1. Run python -m rich, check output 
2. Check if core rich functions and modules (print, pretty, Console, inspect, track) work.
3. Use importlib to check if the version is registered correctly. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
