### PR TITLE
fuse: Update to v3.18.2

### DIFF
--- a/packages/f/fuse/abi_symbols
+++ b/packages/f/fuse/abi_symbols
@@ -2,6 +2,8 @@ libfuse3.so.4:FUSE_3.0
 libfuse3.so.4:FUSE_3.1
 libfuse3.so.4:FUSE_3.12
 libfuse3.so.4:FUSE_3.17
+libfuse3.so.4:FUSE_3.17.3
+libfuse3.so.4:FUSE_3.18
 libfuse3.so.4:FUSE_3.2
 libfuse3.so.4:FUSE_3.3
 libfuse3.so.4:FUSE_3.4
@@ -19,6 +21,7 @@ libfuse3.so.4:fuse_buf_copy
 libfuse3.so.4:fuse_buf_size
 libfuse3.so.4:fuse_clean_cache
 libfuse3.so.4:fuse_cmdline_help
+libfuse3.so.4:fuse_convert_to_conn_want_ext
 libfuse3.so.4:fuse_daemonize
 libfuse3.so.4:fuse_destroy
 libfuse3.so.4:fuse_exit
@@ -59,6 +62,7 @@ libfuse3.so.4:fuse_fs_rename
 libfuse3.so.4:fuse_fs_rmdir
 libfuse3.so.4:fuse_fs_setxattr
 libfuse3.so.4:fuse_fs_statfs
+libfuse3.so.4:fuse_fs_statx
 libfuse3.so.4:fuse_fs_symlink
 libfuse3.so.4:fuse_fs_truncate
 libfuse3.so.4:fuse_fs_unlink
@@ -66,6 +70,7 @@ libfuse3.so.4:fuse_fs_utimens
 libfuse3.so.4:fuse_fs_write
 libfuse3.so.4:fuse_fs_write_buf
 libfuse3.so.4:fuse_get_context
+libfuse3.so.4:fuse_get_feature_flag
 libfuse3.so.4:fuse_get_session
 libfuse3.so.4:fuse_getgroups
 libfuse3.so.4:fuse_interrupted
@@ -88,6 +93,7 @@ libfuse3.so.4:fuse_loop_mt_32
 libfuse3.so.4:fuse_lowlevel_help
 libfuse3.so.4:fuse_lowlevel_notify_delete
 libfuse3.so.4:fuse_lowlevel_notify_expire_entry
+libfuse3.so.4:fuse_lowlevel_notify_increment_epoch
 libfuse3.so.4:fuse_lowlevel_notify_inval_entry
 libfuse3.so.4:fuse_lowlevel_notify_inval_inode
 libfuse3.so.4:fuse_lowlevel_notify_poll
@@ -136,12 +142,15 @@ libfuse3.so.4:fuse_reply_open
 libfuse3.so.4:fuse_reply_poll
 libfuse3.so.4:fuse_reply_readlink
 libfuse3.so.4:fuse_reply_statfs
+libfuse3.so.4:fuse_reply_statx
 libfuse3.so.4:fuse_reply_write
 libfuse3.so.4:fuse_reply_xattr
 libfuse3.so.4:fuse_req_ctx
+libfuse3.so.4:fuse_req_get_payload
 libfuse3.so.4:fuse_req_getgroups
 libfuse3.so.4:fuse_req_interrupt_func
 libfuse3.so.4:fuse_req_interrupted
+libfuse3.so.4:fuse_req_is_uring
 libfuse3.so.4:fuse_req_userdata
 libfuse3.so.4:fuse_session_custom_io
 libfuse3.so.4:fuse_session_custom_io_30
@@ -163,9 +172,11 @@ libfuse3.so.4:fuse_session_receive_buf
 libfuse3.so.4:fuse_session_reset
 libfuse3.so.4:fuse_session_unmount
 libfuse3.so.4:fuse_set_fail_signal_handlers
+libfuse3.so.4:fuse_set_feature_flag
 libfuse3.so.4:fuse_set_log_func
 libfuse3.so.4:fuse_set_signal_handlers
 libfuse3.so.4:fuse_start_cleanup_thread
 libfuse3.so.4:fuse_stop_cleanup_thread
 libfuse3.so.4:fuse_unmount
+libfuse3.so.4:fuse_unset_feature_flag
 libfuse3.so.4:fuse_version

--- a/packages/f/fuse/abi_used_symbols
+++ b/packages/f/fuse/abi_used_symbols
@@ -4,6 +4,7 @@ libc.so.6:__environ
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
 libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__isoc23_strtoul
 libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
@@ -13,9 +14,8 @@ libc.so.6:__realpath_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
-libc.so.6:__syslog_chk
 libc.so.6:__vfprintf_chk
-libc.so.6:__vsnprintf_chk
+libc.so.6:__vsyslog_chk
 libc.so.6:_exit
 libc.so.6:abort
 libc.so.6:access
@@ -165,7 +165,6 @@ libc.so.6:strrchr
 libc.so.6:strstr
 libc.so.6:strtok
 libc.so.6:strtok_r
-libc.so.6:strtol
 libc.so.6:syscall
 libc.so.6:sysconf
 libc.so.6:umask

--- a/packages/f/fuse/package.yml
+++ b/packages/f/fuse/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : fuse
-version    : 3.17.1
-release    : 18
+version    : 3.18.2
+release    : 19
 source     :
-    - https://github.com/libfuse/libfuse/releases/download/fuse-3.17.1/fuse-3.17.1.tar.gz : 2d8ae87a4525fbfa1db5e5eb010ff6f38140627a7004554ed88411c1843d51b2
+    - https://github.com/libfuse/libfuse/releases/download/fuse-3.18.2/fuse-3.18.2.tar.gz : f01de85717e20adf5f98aff324acd85dd73d61a5ca3834d573dcf0bd6e54a298
 license    :
     - GPL-2.0-only
     - LGPL-2.1-only
@@ -14,9 +14,6 @@ description: |
     File Systems in User Space
 builddeps  :
     - libiconv-devel
-patterns   :
-    - common :
-        - /usr/share/defaults/fuse
 rundeps    :
     - fuse-common
 setup      : |
@@ -27,6 +24,12 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license LICENSE GPL2.txt LGPL2.txt
+
     install -Dm0644 $pkgfiles/fuse.conf $installdir/usr/share/defaults/fuse/fuse.conf
+
     rm -rfv $installdir/etc
     rm -rfv $installdir/dev
+patterns   :
+    - common :
+        - /usr/share/defaults/fuse

--- a/packages/f/fuse/pspec_x86_64.xml
+++ b/packages/f/fuse/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>fuse</Name>
         <Homepage>https://github.com/libfuse/libfuse</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <License>LGPL-2.1-only</License>
@@ -21,16 +21,19 @@
 </Description>
         <PartOf>system.utils</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="18">fuse-common</Dependency>
+            <Dependency releaseFrom="19">fuse-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/fusermount3</Path>
-            <Path fileType="library">/usr/lib64/libfuse3.so.3.17.1</Path>
+            <Path fileType="library">/usr/lib64/libfuse3.so.3.18.2</Path>
             <Path fileType="library">/usr/lib64/libfuse3.so.4</Path>
             <Path fileType="library">/usr/lib64/udev/rules.d/99-fuse3.rules</Path>
             <Path fileType="executable">/usr/sbin/mount.fuse3</Path>
-            <Path fileType="man">/usr/share/man/man1/fusermount3.1</Path>
-            <Path fileType="man">/usr/share/man/man8/mount.fuse3.8</Path>
+            <Path fileType="data">/usr/share/licenses/fuse/GPL2.txt</Path>
+            <Path fileType="data">/usr/share/licenses/fuse/LGPL2.txt</Path>
+            <Path fileType="data">/usr/share/licenses/fuse/LICENSE</Path>
+            <Path fileType="man">/usr/share/man/man1/fusermount3.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/mount.fuse3.8.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -49,7 +52,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="18">fuse</Dependency>
+            <Dependency release="19">fuse</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/fuse3/cuse_lowlevel.h</Path>
@@ -64,12 +67,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2025-04-09</Date>
-            <Version>3.17.1</Version>
+        <Update release="19">
+            <Date>2026-03-25</Date>
+            <Version>3.18.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/libfuse/libfuse/blob/fuse-3.18.2/ChangeLog.rst).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build `sshfs-fuse` against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
