### PR TITLE
freerdp: Update to v3.24.2

### DIFF
--- a/packages/f/freerdp/abi_symbols
+++ b/packages/f/freerdp/abi_symbols
@@ -1,4 +1,3 @@
-libfreerdp-client3.so.3:add_device
 libfreerdp-client3.so.3:channel_client_create_handler
 libfreerdp-client3.so.3:client_auto_reconnect
 libfreerdp-client3.so.3:client_auto_reconnect_ex
@@ -27,7 +26,6 @@ libfreerdp-client3.so.3:cliprdr_file_context_set_locally_available
 libfreerdp-client3.so.3:cliprdr_file_context_uninit
 libfreerdp-client3.so.3:cliprdr_file_context_update_client_data
 libfreerdp-client3.so.3:cliprdr_file_context_update_server_data
-libfreerdp-client3.so.3:del_device
 libfreerdp-client3.so.3:freerdp_channels_addin_list_free
 libfreerdp-client3.so.3:freerdp_channels_client_find_static_entry
 libfreerdp-client3.so.3:freerdp_channels_list_addins
@@ -103,16 +101,6 @@ libfreerdp-client3.so.3:freerdp_set_connection_type
 libfreerdp-client3.so.3:freerdp_smartcard_list
 libfreerdp-client3.so.3:mappedGeometryRef
 libfreerdp-client3.so.3:mappedGeometryUnref
-libfreerdp-client3.so.3:msusb_msconfig_dump
-libfreerdp-client3.so.3:msusb_msconfig_free
-libfreerdp-client3.so.3:msusb_msconfig_new
-libfreerdp-client3.so.3:msusb_msconfig_read
-libfreerdp-client3.so.3:msusb_msconfig_write
-libfreerdp-client3.so.3:msusb_msinterface_free
-libfreerdp-client3.so.3:msusb_msinterface_read
-libfreerdp-client3.so.3:msusb_msinterface_replace
-libfreerdp-client3.so.3:msusb_msinterface_write
-libfreerdp-client3.so.3:msusb_mspipes_replace
 libfreerdp-client3.so.3:rail_handshake_ex_flags_to_string
 libfreerdp-client3.so.3:rdpgfx_client_context_free
 libfreerdp-server-proxy3.so.3:StaticChannelContext_free
@@ -631,6 +619,7 @@ libfreerdp3.so.3:freerdp_get_error_info_category
 libfreerdp3.so.3:freerdp_get_error_info_name
 libfreerdp3.so.3:freerdp_get_error_info_string
 libfreerdp3.so.3:freerdp_get_event_handles
+libfreerdp3.so.3:freerdp_get_gateway_usage_method
 libfreerdp3.so.3:freerdp_get_io_callback_context
 libfreerdp3.so.3:freerdp_get_io_callbacks
 libfreerdp3.so.3:freerdp_get_keyboard_default_layout_for_locale
@@ -673,6 +662,8 @@ libfreerdp3.so.3:freerdp_image_fill
 libfreerdp3.so.3:freerdp_image_fill_ex
 libfreerdp3.so.3:freerdp_image_scale
 libfreerdp3.so.3:freerdp_input_keyboard_flags_string
+libfreerdp3.so.3:freerdp_input_keypress_flags_string
+libfreerdp3.so.3:freerdp_input_mouse_flags_string
 libfreerdp3.so.3:freerdp_input_send_extended_mouse_event
 libfreerdp3.so.3:freerdp_input_send_focus_in_event
 libfreerdp3.so.3:freerdp_input_send_keyboard_event
@@ -833,6 +824,12 @@ libfreerdp3.so.3:freerdp_utils_aad_get_wellknown_custom_string
 libfreerdp3.so.3:freerdp_utils_aad_get_wellknown_object
 libfreerdp3.so.3:freerdp_utils_aad_get_wellknown_string
 libfreerdp3.so.3:freerdp_utils_aad_wellknwon_value_name
+libfreerdp3.so.3:freerdp_video_available
+libfreerdp3.so.3:freerdp_video_context_free
+libfreerdp3.so.3:freerdp_video_context_new
+libfreerdp3.so.3:freerdp_video_context_reconfigure
+libfreerdp3.so.3:freerdp_video_conversion_supported
+libfreerdp3.so.3:freerdp_video_sample_convert
 libfreerdp3.so.3:freerdp_write_four_byte_float
 libfreerdp3.so.3:freerdp_write_four_byte_signed_integer
 libfreerdp3.so.3:gdi_BitBlt
@@ -1081,6 +1078,7 @@ libfreerdp3.so.3:smartcard_call_cancel_context
 libfreerdp3.so.3:smartcard_call_context_add
 libfreerdp3.so.3:smartcard_call_context_free
 libfreerdp3.so.3:smartcard_call_context_new
+libfreerdp3.so.3:smartcard_call_context_new_with_context
 libfreerdp3.so.3:smartcard_call_context_signal_stop
 libfreerdp3.so.3:smartcard_call_get_context
 libfreerdp3.so.3:smartcard_call_is_configured
@@ -2422,6 +2420,7 @@ libwinpr3.so.3:WinPrAsn1EncStreamSize
 libwinpr3.so.3:WinPrAsn1EncToStream
 libwinpr3.so.3:WinPrAsn1EncUtcTime
 libwinpr3.so.3:WinPrAsn1Encoder_Free
+libwinpr3.so.3:WinPrAsn1Encoder_FreeNoNull
 libwinpr3.so.3:WinPrAsn1Encoder_New
 libwinpr3.so.3:WinPrAsn1Encoder_Reset
 libwinpr3.so.3:WinPrAsn1FreeOID
@@ -2620,6 +2619,7 @@ libwinpr3.so.3:winpr_aligned_offset_recalloc
 libwinpr3.so.3:winpr_aligned_realloc
 libwinpr3.so.3:winpr_aligned_recalloc
 libwinpr3.so.3:winpr_asprintf
+libwinpr3.so.3:winpr_atexit
 libwinpr3.so.3:winpr_backtrace
 libwinpr3.so.3:winpr_backtrace_free
 libwinpr3.so.3:winpr_backtrace_symbols

--- a/packages/f/freerdp/abi_used_symbols
+++ b/packages/f/freerdp/abi_used_symbols
@@ -340,6 +340,8 @@ libavutil.so.59:av_hwframe_ctx_alloc
 libavutil.so.59:av_hwframe_ctx_init
 libavutil.so.59:av_hwframe_get_buffer
 libavutil.so.59:av_hwframe_transfer_data
+libavutil.so.59:av_image_fill_linesizes
+libavutil.so.59:av_image_fill_pointers
 libavutil.so.59:av_opt_set
 libavutil.so.59:av_opt_set_int
 libavutil.so.59:av_samples_copy
@@ -452,7 +454,6 @@ libc.so.6:gmtime_r
 libc.so.6:inet_addr
 libc.so.6:inet_ntoa
 libc.so.6:inet_ntop
-libc.so.6:inet_pton
 libc.so.6:initgroups
 libc.so.6:ioctl
 libc.so.6:kill
@@ -881,6 +882,7 @@ libjson-c.so.5:json_tokener_parse_ex
 libjson-c.so.5:json_util_get_last_err
 libk5crypto.so.3:krb5_c_crypto_length
 libk5crypto.so.3:krb5_c_crypto_length_iov
+libk5crypto.so.3:krb5_enctype_to_string
 libk5crypto.so.3:krb5_k_decrypt_iov
 libk5crypto.so.3:krb5_k_encrypt_iov
 libk5crypto.so.3:krb5_k_free_key
@@ -925,6 +927,7 @@ libkrb5.so.3:krb5_fwd_tgt_creds
 libkrb5.so.3:krb5_get_credentials
 libkrb5.so.3:krb5_get_default_realm
 libkrb5.so.3:krb5_get_error_message
+libkrb5.so.3:krb5_get_etype_info
 libkrb5.so.3:krb5_get_init_creds_keytab
 libkrb5.so.3:krb5_get_init_creds_opt_alloc
 libkrb5.so.3:krb5_get_init_creds_opt_free
@@ -1064,6 +1067,7 @@ libstdc++.so.6:_ZNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEEC1ERK
 libstdc++.so.6:_ZNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt7__cxx117collateIcE2idE
 libstdc++.so.6:_ZNSt8ios_baseD2Ev
+libstdc++.so.6:_ZNSt9exceptionD1Ev
 libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
 libstdc++.so.6:_ZSt16__throw_bad_castv
 libstdc++.so.6:_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
@@ -1089,6 +1093,7 @@ libstdc++.so.6:_ZTVN10__cxxabiv120__si_class_type_infoE
 libstdc++.so.6:_ZTVNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEEE
 libstdc++.so.6:_ZTVSt11regex_error
 libstdc++.so.6:_ZTVSt15basic_streambufIcSt11char_traitsIcEE
+libstdc++.so.6:_ZTVSt9exception
 libstdc++.so.6:_ZdaPv
 libstdc++.so.6:_ZdlPvm
 libstdc++.so.6:_Znam

--- a/packages/f/freerdp/package.yml
+++ b/packages/f/freerdp/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : freerdp
-version    : 3.23.0
-release    : 48
+version    : 3.24.2
+release    : 49
 source     :
-    - https://pub.freerdp.com/releases/freerdp-3.23.0.tar.gz : 929273003f35b0b4f211e48d5abed4ebcef99da94784a50b6dc85cd0b7e257b1
+    - https://pub.freerdp.com/releases/freerdp-3.24.2.tar.xz : 653b273f2a428b8a31be1e157815b2c9ec552a4c376ff3ec28b311c8a74e99b3
 homepage   : https://www.freerdp.com/
 license    : Apache-2.0
 component  : network.util

--- a/packages/f/freerdp/pspec_x86_64.xml
+++ b/packages/f/freerdp/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>freerdp</Name>
         <Homepage>https://www.freerdp.com/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>network.util</PartOf>
@@ -33,21 +33,21 @@
             <Path fileType="library">/usr/lib64/freerdp3/proxy/libproxy-demo-plugin.so</Path>
             <Path fileType="library">/usr/lib64/freerdp3/proxy/libproxy-dyn-channel-dump-plugin.so</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-client3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-client3.so.3.23.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-client3.so.3.24.2</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-server-proxy3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-server-proxy3.so.3.23.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-server-proxy3.so.3.24.2</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-server3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-server3.so.3.23.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-server3.so.3.24.2</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-shadow-subsystem3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-shadow-subsystem3.so.3.23.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-shadow-subsystem3.so.3.24.2</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-shadow3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-shadow3.so.3.23.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-shadow3.so.3.24.2</Path>
             <Path fileType="library">/usr/lib64/libfreerdp3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp3.so.3.23.0</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp3.so.3.24.2</Path>
             <Path fileType="library">/usr/lib64/libwinpr-tools3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libwinpr-tools3.so.3.23.0</Path>
+            <Path fileType="library">/usr/lib64/libwinpr-tools3.so.3.24.2</Path>
             <Path fileType="library">/usr/lib64/libwinpr3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libwinpr3.so.3.23.0</Path>
+            <Path fileType="library">/usr/lib64/libwinpr3.so.3.24.2</Path>
             <Path fileType="data">/usr/share/FreeRDP/images/test_icon.bmp</Path>
             <Path fileType="data">/usr/share/FreeRDP/images/test_icon.jpg</Path>
             <Path fileType="data">/usr/share/FreeRDP/images/test_icon.png</Path>
@@ -70,7 +70,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="48">freerdp</Dependency>
+            <Dependency release="49">freerdp</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/freerdp3/freerdp/addin.h</Path>
@@ -148,6 +148,7 @@
             <Path fileType="header">/usr/include/freerdp3/freerdp/codec/progressive.h</Path>
             <Path fileType="header">/usr/include/freerdp3/freerdp/codec/region.h</Path>
             <Path fileType="header">/usr/include/freerdp3/freerdp/codec/rfx.h</Path>
+            <Path fileType="header">/usr/include/freerdp3/freerdp/codec/video.h</Path>
             <Path fileType="header">/usr/include/freerdp3/freerdp/codec/yuv.h</Path>
             <Path fileType="header">/usr/include/freerdp3/freerdp/codec/zgfx.h</Path>
             <Path fileType="header">/usr/include/freerdp3/freerdp/codecs.h</Path>
@@ -260,6 +261,7 @@
             <Path fileType="header">/usr/include/winpr3/winpr/asn1.h</Path>
             <Path fileType="header">/usr/include/winpr3/winpr/assert-api.h</Path>
             <Path fileType="header">/usr/include/winpr3/winpr/assert.h</Path>
+            <Path fileType="header">/usr/include/winpr3/winpr/atexit.h</Path>
             <Path fileType="header">/usr/include/winpr3/winpr/bcrypt.h</Path>
             <Path fileType="header">/usr/include/winpr3/winpr/bitstream.h</Path>
             <Path fileType="header">/usr/include/winpr3/winpr/build-config.h</Path>
@@ -375,12 +377,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="48">
-            <Date>2026-03-01</Date>
-            <Version>3.23.0</Version>
+        <Update release="49">
+            <Date>2026-03-25</Date>
+            <Version>3.24.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://www.freerdp.com/2026/03/25/3_24_2-release).

**Security**
- CVE-2026-29774
- CVE-2026-29775
- CVE-2026-29776
- CVE-2026-31806
- CVE-2026-31883
- CVE-2026-31884
- CVE-2026-31885
- CVE-2026-31897

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Built gnome-remote-desktop against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
