### PR TITLE
solseek: Update to 1.1.2

### DIFF
--- a/packages/s/solseek/monitoring.yaml
+++ b/packages/s/solseek/monitoring.yaml
@@ -1,5 +1,5 @@
 releases:
-  id: ~
+  id: 388217
   rss: https://github.com/clintre/solseek/tags.atom
  # No known CPE, checked 2025-10-25
 security:

--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 1.1.0
-release    : 22
+version    : 1.1.2
+release    : 23
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v1.1.0.tar.gz : f5c8738cd0a3f463f1882003294f6eb2cecd0c1d2bfaf25d382014858fe29594
+    - https://github.com/clintre/solseek/archive/refs/tags/v1.1.2.tar.gz : 36cfb59c2ca0aaab260ab150b4a3b39156c5612cdcd179510ca28f06b3b89d5d
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -69,9 +69,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2026-03-19</Date>
-            <Version>1.1.0</Version>
+        <Update release="23">
+            <Date>2026-03-25</Date>
+            <Version>1.1.2</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION

**Summary**

Bugfixes:
- Fix issue where flatpak mask was not respected during update checks.

Full Changelog:
https://github.com/clintre/solseek/compare/v1.1.0...v1.1.2


**Test Plan**

Tested on VM
used flatpak mask on a flatpak
verified the update check respected the mask

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
