### PR TITLE
libpng: Update to v1.6.56

### DIFF
--- a/packages/l/libpng/package.yml
+++ b/packages/l/libpng/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libpng
-version    : 1.6.55
-release    : 34
+version    : 1.6.56
+release    : 35
 source     :
-    - https://sourceforge.net/projects/libpng/files/libpng16/1.6.55/libpng-1.6.55.tar.gz : 4b0abab6d219e95690ebe4db7fc9aa95f4006c83baaa022373c0c8442271283d
+    - https://sourceforge.net/projects/libpng/files/libpng16/1.6.56/libpng-1.6.56.tar.gz : 8f91e941a07fb1069ebb3855278f82a849e6af14ca05821e14ec3d5348697ea5
 homepage   : https://www.libpng.org/pub/png/
 license    : Libpng
 component  : multimedia.library

--- a/packages/l/libpng/pspec_x86_64.xml
+++ b/packages/l/libpng/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libpng</Name>
         <Homepage>https://www.libpng.org/pub/png/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Libpng</License>
         <PartOf>multimedia.library</PartOf>
@@ -23,9 +23,9 @@
             <Path fileType="executable">/usr/bin/png-fix-itxt</Path>
             <Path fileType="executable">/usr/bin/pngfix</Path>
             <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libpng16.so.16</Path>
-            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libpng16.so.16.55.0</Path>
+            <Path fileType="library">/usr/lib64/glibc-hwcaps/x86-64-v3/libpng16.so.16.56.0</Path>
             <Path fileType="library">/usr/lib64/libpng16.so.16</Path>
-            <Path fileType="library">/usr/lib64/libpng16.so.16.55.0</Path>
+            <Path fileType="library">/usr/lib64/libpng16.so.16.56.0</Path>
             <Path fileType="data">/usr/share/licenses/libpng/LICENSE</Path>
             <Path fileType="man">/usr/share/man/man5/png.5.zst</Path>
         </Files>
@@ -37,11 +37,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="34">libpng</Dependency>
+            <Dependency release="35">libpng</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpng16.so.16</Path>
-            <Path fileType="library">/usr/lib32/libpng16.so.16.55.0</Path>
+            <Path fileType="library">/usr/lib32/libpng16.so.16.56.0</Path>
         </Files>
     </Package>
     <Package>
@@ -51,8 +51,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="34">libpng-devel</Dependency>
-            <Dependency release="34">libpng-32bit</Dependency>
+            <Dependency release="35">libpng-32bit</Dependency>
+            <Dependency release="35">libpng-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libpng.so</Path>
@@ -68,7 +68,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="34">libpng</Dependency>
+            <Dependency release="35">libpng</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/libpng-config</Path>
@@ -88,12 +88,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="34">
-            <Date>2026-02-11</Date>
-            <Version>1.6.55</Version>
+        <Update release="35">
+            <Date>2026-03-26</Date>
+            <Version>1.6.56</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/pnggroup/libpng/blob/v1.6.56/ANNOUNCE).

**Security**
- CVE-2026-33416
- CVE-2026-33636

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Open a PNG image in an image viewer.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
