### PR TITLE
imagemagick: Update to v7.1.2.18

### DIFF
--- a/packages/i/imagemagick/abi_used_symbols
+++ b/packages/i/imagemagick/abi_used_symbols
@@ -621,6 +621,7 @@ libjxl.so.0.11:JxlDecoderGetBoxSizeRaw
 libjxl.so.0.11:JxlDecoderGetBoxType
 libjxl.so.0.11:JxlDecoderGetColorAsEncodedProfile
 libjxl.so.0.11:JxlDecoderGetColorAsICCProfile
+libjxl.so.0.11:JxlDecoderGetFrameHeader
 libjxl.so.0.11:JxlDecoderGetICCProfileSize
 libjxl.so.0.11:JxlDecoderImageOutBufferSize
 libjxl.so.0.11:JxlDecoderProcessInput

--- a/packages/i/imagemagick/package.yml
+++ b/packages/i/imagemagick/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : imagemagick
-version    : 7.1.2.17
-release    : 209
+version    : 7.1.2.18
+release    : 210
 source     :
-    - https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-17.tar.gz : 4ff65e73c3642481e9e3db0d80a646288a5be77e3372ba2ddc49d869657ca0c6
+    - https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-18.tar.gz : 2db8a1f9bac19831c76574e4fd514ecb80a71a49911ee5dc8c1f3fb6d9d550df
 homepage   : https://imagemagick.org/
 license    : Apache-2.0
 component  : multimedia.graphics

--- a/packages/i/imagemagick/pspec_x86_64.xml
+++ b/packages/i/imagemagick/pspec_x86_64.xml
@@ -94,7 +94,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="209">imagemagick</Dependency>
+            <Dependency release="210">imagemagick</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/ImageMagick-7/Magick++.h</Path>
@@ -593,9 +593,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="209">
-            <Date>2026-03-16</Date>
-            <Version>7.1.2.17</Version>
+        <Update release="210">
+            <Date>2026-03-26</Date>
+            <Version>7.1.2.18</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/ImageMagick/Website/blob/main/ChangeLog.md).

**Security**
Includes fixes for:
- GHSA-9r56-3gjq-hqf7
- GHSA-6p22-q7w5-33pg
- CVE-2026-33536
- CVE-2026-33535

**Test Plan**

`magick identify example.png` read the info.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
