### PR TITLE
extension-manager: Add at v0.6.5

### DIFF
--- a/packages/e/extension-manager/MAINTAINERS.md
+++ b/packages/e/extension-manager/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Lazaros Tsompani
+  - Matrix: @dev64:matrix.org
+  - Email: lazarecobani@gmail.com

--- a/packages/e/extension-manager/monitoring.yaml
+++ b/packages/e/extension-manager/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 380117
+  rss: https://github.com/mjakeman/extension-manager/tags.atom
+ # No known CPE, checked 2026-03-25
+security:
+  cpe: ~

--- a/packages/e/extension-manager/package.yml
+++ b/packages/e/extension-manager/package.yml
@@ -1,0 +1,25 @@
+name: extension-manager
+version: 0.6.5
+release: 1
+source:
+    - https://github.com/mjakeman/extension-manager/archive/refs/tags/v0.6.5.tar.gz : 5a43c7b9570775948a35f402b1c1d5f0f0401e339ab2144d466f75eae26ef9de
+homepage: https://mattjakeman.com/apps/extension-manager
+license: GPL-3.0-or-later
+component: desktop.gnome
+summary: Browse, install, and manage GNOME Extensions with ease.
+description: |
+    A native tool for browsing, installing, and managing GNOME Shell Extensions in one app.
+builddeps:
+    - pkgconfig(gtk4)
+    - pkgconfig(json-glib-1.0)
+    - pkgconfig(libadwaita-1)
+    - pkgconfig(libsoup-3.0)
+    - blueprint-compiler
+    - desktop-file-utils
+setup: |
+    %meson_configure -Dbacktrace=false
+build: |
+    %ninja_build
+install: |
+    %ninja_install
+    %install_license COPYING

--- a/packages/e/extension-manager/pspec_x86_64.xml
+++ b/packages/e/extension-manager/pspec_x86_64.xml
@@ -1,0 +1,79 @@
+<PISI>
+    <Source>
+        <Name>extension-manager</Name>
+        <Homepage>https://mattjakeman.com/apps/extension-manager</Homepage>
+        <Packager>
+            <Name>Lazaros Tsompani</Name>
+            <Email>lazarecobani@gmail.com</Email>
+        </Packager>
+        <License>GPL-3.0-or-later</License>
+        <PartOf>desktop.gnome</PartOf>
+        <Summary xml:lang="en">Browse, install, and manage GNOME Extensions with ease.</Summary>
+        <Description xml:lang="en">A native tool for browsing, installing, and managing GNOME Shell Extensions in one app.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>extension-manager</Name>
+        <Summary xml:lang="en">Browse, install, and manage GNOME Extensions with ease.</Summary>
+        <Description xml:lang="en">A native tool for browsing, installing, and managing GNOME Shell Extensions in one app.
+</Description>
+        <PartOf>desktop.gnome</PartOf>
+        <Files>
+            <Path fileType="executable">/usr/bin/extension-manager</Path>
+            <Path fileType="data">/usr/share/applications/com.mattjakeman.ExtensionManager.desktop</Path>
+            <Path fileType="data">/usr/share/glib-2.0/schemas/com.mattjakeman.ExtensionManager.gschema.xml</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/com.mattjakeman.ExtensionManager.svg</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/symbolic/apps/com.mattjakeman.ExtensionManager-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/licenses/extension-manager/COPYING</Path>
+            <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/be/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/bg/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/el/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/et/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/eu/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/fa/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/fi/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ga/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/hi/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/hr/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/hu/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/id_ID/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/kk/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ko/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/nb/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/nl/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/nn/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/oc/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/pl/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/pt/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ru_RU/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ta/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/tr/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/vi_VN/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/extension-manager.mo</Path>
+            <Path fileType="data">/usr/share/metainfo/com.mattjakeman.ExtensionManager.metainfo.xml</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2026-03-26</Date>
+            <Version>0.6.5</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Lazaros Tsompani</Name>
+            <Email>lazarecobani@gmail.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**
Add a new package, extension-manager.
Resolves #8314

**Summary**

Adds a new package, extension-manager. An application for GNOME users to easily manage, install, remove and browse GNOME Shell extensions, in one single app.

**Test Plan**

Every function of the app was tested. Installing, managing, removing an extension. Search feature, order results by, dark/light theme, and extension page. Works as expected.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
