### PR TITLE
lsof: Update to v4.99.6

### DIFF
--- a/packages/l/lsof/abi_used_symbols
+++ b/packages/l/lsof/abi_used_symbols
@@ -3,11 +3,13 @@ libc.so.6:__ctype_get_mb_cur_max
 libc.so.6:__ctype_tolower_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoul
+libc.so.6:__isoc23_strtoull
 libc.so.6:__libc_start_main
 libc.so.6:__longjmp_chk
-libc.so.6:__memset_chk
 libc.so.6:__printf_chk
-libc.so.6:__read_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__strncpy_chk
@@ -18,6 +20,8 @@ libc.so.6:alarm
 libc.so.6:calloc
 libc.so.6:close
 libc.so.6:closedir
+libc.so.6:closefrom
+libc.so.6:dup2
 libc.so.6:endservent
 libc.so.6:exit
 libc.so.6:fclose
@@ -96,9 +100,6 @@ libc.so.6:strncasecmp
 libc.so.6:strncmp
 libc.so.6:strncpy
 libc.so.6:strrchr
-libc.so.6:strtol
-libc.so.6:strtoul
-libc.so.6:strtoull
 libc.so.6:time
 libc.so.6:umask
 libc.so.6:wait

--- a/packages/l/lsof/files/lsof-man-page-section.patch
+++ b/packages/l/lsof/files/lsof-man-page-section.patch
@@ -1,0 +1,10 @@
+diff -up ./Lsof.8.ori ./Lsof.8
+--- ./Lsof.8.ori	2022-09-20 19:46:03.560004892 +0200
++++ ./Lsof.8	2022-09-20 19:46:17.578086787 +0200
+@@ -1,5 +1,5 @@
+ .so ./version
+-.TH LSOF 8 Revision-\*(VN
++.TH LSOF 1 Revision-\*(VN
+ .\" Register )P is used neither by this file nor any groff macro.  However,
+ .\" some versions of nroff require it.
+ .if !\n(.g \{\

--- a/packages/l/lsof/package.yml
+++ b/packages/l/lsof/package.yml
@@ -1,23 +1,29 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : lsof
-version    : 4.94.0
-release    : 5
+version    : 4.99.6
+release    : 6
 source     :
-    - https://github.com/lsof-org/lsof/releases/download/4.94.0/lsof_4.94.0.linux.tar.bz2 : c41709c2543ecf9de1e950795790a9786a2f225e51c3cc53d6a9a256f872472b
+    - https://github.com/lsof-org/lsof/archive/refs/tags/4.99.6.tar.gz : 2ce65158694e9c44dfc54916f5b843d887763c03128e0a1c77d62ae106537009
 homepage   : https://github.com/lsof-org/lsof
 license    : BSD-4-Clause-UC
 component  : system.utils
-summary    : lsof (for LiSt Open Files) displays information about files open to Unix
-    processes
+summary    : lsof (for LiSt Open Files) displays information about files open to Unix processes
 description: |
     lsof (for LiSt Open Files) displays information about files open to Unix processes
 builddeps  :
     - pkgconfig(libtirpc)
+    - groff
 setup      : |
-    sed -i 's|\.so \./version|.ds VN %version%|' lsof.8
-    LSOF_CC="${CC}" LSOF_CFGF="${CFLAGS}" LSOF_CFGL="${LDFLAGS}" ./Configure -n linux
+    %patch -p1 -i $pkgfiles/lsof-man-page-section.patch
+    
+    %reconfigure \
+        --prefix=/usr \
+        --enable-security \
+        --enable-no-sock-security \
+        --with-libtirpc
 build      : |
     %make
 install    : |
     install -Dm00755 lsof $installdir/usr/bin/lsof
-    install -Dm00644 lsof.8 $installdir/usr/share/man/man8/lsof.8
+    install -Dm00644 Lsof.8 $installdir/usr/share/man/man8/lsof.8
+    %install_license COPYING

--- a/packages/l/lsof/pspec_x86_64.xml
+++ b/packages/l/lsof/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>lsof</Name>
         <Homepage>https://github.com/lsof-org/lsof</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>BSD-4-Clause-UC</License>
         <PartOf>system.utils</PartOf>
         <Summary xml:lang="en">lsof (for LiSt Open Files) displays information about files open to Unix processes</Summary>
         <Description xml:lang="en">lsof (for LiSt Open Files) displays information about files open to Unix processes
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>lsof</Name>
@@ -21,16 +21,17 @@
         <PartOf>system.utils</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/lsof</Path>
-            <Path fileType="man">/usr/share/man/man8/lsof.8</Path>
+            <Path fileType="data">/usr/share/licenses/lsof/COPYING</Path>
+            <Path fileType="man">/usr/share/man/man8/lsof.8.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2021-06-14</Date>
-            <Version>4.94.0</Version>
+        <Update release="6">
+            <Date>2026-03-26</Date>
+            <Version>4.99.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Generally refresh this old build
- Too many releases, see [releases page](https://github.com/lsof-org/lsof/releases)

**Test Plan**

- Run lsof, see files listed

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
