### PR TITLE
gnome-contacts: Rebuild for gstreamer

### DIFF
--- a/packages/g/gnome-contacts/abi_used_symbols
+++ b/packages/g/gnome-contacts/abi_used_symbols
@@ -469,6 +469,7 @@ libglib-2.0.so.0:g_file_error_quark
 libglib-2.0.so.0:g_file_get_contents
 libglib-2.0.so.0:g_file_set_contents
 libglib-2.0.so.0:g_free
+libglib-2.0.so.0:g_free_sized
 libglib-2.0.so.0:g_get_application_name
 libglib-2.0.so.0:g_get_system_data_dirs
 libglib-2.0.so.0:g_get_user_config_dir

--- a/packages/g/gnome-contacts/package.yml
+++ b/packages/g/gnome-contacts/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gnome-contacts
 version    : '49.0'
-release    : 24
+release    : 25
 source     :
     - https://download.gnome.org/sources/gnome-contacts/49/gnome-contacts-49.0.tar.xz : 25f21c67bc29d77def2d9cd3e22d28460d12b47ff248a2017731b54db485e4af
 homepage   : https://apps.gnome.org/Contacts/
@@ -20,6 +20,7 @@ builddeps  :
     - pkgconfig(gnome-desktop-3.0)
     - pkgconfig(goa-1.0)
     - pkgconfig(gobject-introspection-1.0)
+    - pkgconfig(gstreamer-1.0)
     - pkgconfig(gtk+-3.0)
     - pkgconfig(libadwaita-1)
     - pkgconfig(libcanberra)
@@ -38,3 +39,4 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING

--- a/packages/g/gnome-contacts/pspec_x86_64.xml
+++ b/packages/g/gnome-contacts/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-contacts</Name>
         <Homepage>https://apps.gnome.org/Contacts/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>office</PartOf>
@@ -31,6 +31,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/org.gnome.Contacts.Devel.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/org.gnome.Contacts.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/symbolic/apps/org.gnome.Contacts-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/licenses/gnome-contacts/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/ab/LC_MESSAGES/gnome-contacts.mo</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/gnome-contacts.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/gnome-contacts.mo</Path>
@@ -114,12 +115,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2025-09-18</Date>
+        <Update release="25">
+            <Date>2026-03-26</Date>
             <Version>49.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Rebuild for gstreamer, add explicit builddep so it doesn't get missed again.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Open the generated eopkg in Ark, open `metadata.xml`, see that `gstreamer` is listed as a dependency, not `gstreamer-1.0`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
