### PR TITLE
broot: Update to v1.56.2

### DIFF
--- a/packages/b/broot/package.yml
+++ b/packages/b/broot/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : broot
-version    : 1.56.1
-release    : 32
+version    : 1.56.2
+release    : 33
 source     :
-    - https://github.com/Canop/broot/archive/refs/tags/v1.56.1.tar.gz : 0d29cd855b7a0de5de3d3c191ff43ed9d447f7097c6ca40abc0686d539a9923c
+    - https://github.com/Canop/broot/archive/refs/tags/v1.56.2.tar.gz : 3e7be4252c76565f6d71b34bd07d26e1444b9ac2e1c8271c724f6e866fe75565
 homepage   : https://dystroy.org/broot/
 license    : MIT
 component  : system.utils
@@ -31,5 +31,5 @@ install    : |
 
     # Install font
     install -Dm00644 resources/icons/vscode/vscode.ttf $installdir/usr/share/fonts/truetype/vscode.ttf
-check     : |
+check      : |
     %cargo_test

--- a/packages/b/broot/pspec_x86_64.xml
+++ b/packages/b/broot/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2026-03-20</Date>
-            <Version>1.56.1</Version>
+        <Update release="33">
+            <Date>2026-03-26</Date>
+            <Version>1.56.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/Canop/broot/releases/tag/v1.56.2).
- Bug fixes

**Test Plan**

`broot`, search all `.eopkg` files. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
