### PR TITLE
tidal-hifi: Update to v6.3.1

### DIFF
--- a/packages/t/tidal-hifi/files/tidal-hifi.sh
+++ b/packages/t/tidal-hifi/files/tidal-hifi.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+# Launch tidal-hifi with optional user flags.
+
+set -e
+
+XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-${HOME}/.config}"
+TIDAL_HIFI_FLAGS="--no-sandbox"
+
+if [ -r "${XDG_CONFIG_HOME}/tidal-hifi-flags.conf" ]; then
+    TIDAL_HIFI_FLAGS="$(cat "${XDG_CONFIG_HOME}/tidal-hifi-flags.conf")"
+fi
+
+if [ -z "${ELECTRON_OZONE_PLATFORM_HINT+set}" ]; then
+    export ELECTRON_OZONE_PLATFORM_HINT="auto"
+fi
+
+# shellcheck disable=SC2086
+exec /usr/share/tidal-hifi/tidal-hifi $TIDAL_HIFI_FLAGS "$@"

--- a/packages/t/tidal-hifi/package.yml
+++ b/packages/t/tidal-hifi/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : tidal-hifi
-version    : 6.3.0
-release    : 3
+version    : 6.3.1
+release    : 4
 source     :
-    - https://github.com/Mastermindzh/tidal-hifi/archive/refs/tags/6.3.0-Mavy.tar.gz : 79837b33b5d288b4ebeba24a1719940cc623fa99158ad115fcfac72908c68491
+    - https://github.com/Mastermindzh/tidal-hifi/archive/refs/tags/6.3.1-Mavy.tar.gz : 4d8ce96576f6fc71edb4621ab233f85c1f2b8b5a947c2fe8ec6e2c539a61f336
 homepage   : https://github.com/Mastermindzh/tidal-hifi
 license    : MIT
 component  : multimedia.audio
@@ -30,8 +30,8 @@ install    : |
     cp -a dist/linux-unpacked/. $installdir/usr/share/tidal-hifi/
     chmod +x $installdir/usr/share/tidal-hifi/tidal-hifi
 
-    install -dm00755 $installdir/usr/bin
-    ln -sv /usr/share/tidal-hifi/tidal-hifi $installdir/usr/bin/tidal-hifi
+    # Wrapper launcher so users can tune flags and avoid sandbox-related zygote crashes.
+    install -Dm00755 $pkgfiles/tidal-hifi.sh $installdir/usr/bin/tidal-hifi
 
     install -Dm00644 assets/icon.png $installdir/usr/share/icons/hicolor/512x512/apps/tidal-hifi.png
     install -Dm00644 $pkgfiles/tidal-hifi.desktop $installdir/usr/share/applications/tidal-hifi.desktop

--- a/packages/t/tidal-hifi/pspec_x86_64.xml
+++ b/packages/t/tidal-hifi/pspec_x86_64.xml
@@ -143,9 +143,9 @@ A desktop client for Tidal streaming music service with high-fidelity audio supp
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2026-03-16</Date>
-            <Version>6.3.0</Version>
+        <Update release="4">
+            <Date>2026-03-27</Date>
+            <Version>6.3.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/Mastermindzh/tidal-hifi/releases/tag/6.3.1-Mavy).
- Replace symlink with wrapper to avoid zygote crash

**Test Plan**

Tested wrapper and opened `tidal-hifi` several times to ensure no crash. Listened to music. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
