### PR TITLE
gleam: Update to v1.15.2

### DIFF
--- a/packages/g/gleam/MAINTAINERS.md
+++ b/packages/g/gleam/MAINTAINERS.md
@@ -3,3 +3,7 @@ This file is used to indicate primary maintainership for this package. A package
 - Ian M. Jones
   - Matrix: @ianmjones:matrix.org
   - Email: ian@ianmjones.com
+
+- Jared Cervantes
+  - Matrix: @jaredy89:matrix.org
+  - Email: jared@jaredcervantes.com

--- a/packages/g/gleam/abi_used_symbols
+++ b/packages/g/gleam/abi_used_symbols
@@ -12,6 +12,7 @@ libc.so.6:bind
 libc.so.6:calloc
 libc.so.6:chdir
 libc.so.6:chmod
+libc.so.6:chroot
 libc.so.6:clock_gettime
 libc.so.6:close
 libc.so.6:closedir
@@ -19,6 +20,7 @@ libc.so.6:connect
 libc.so.6:dirfd
 libc.so.6:dl_iterate_phdr
 libc.so.6:dlsym
+libc.so.6:dup
 libc.so.6:dup2
 libc.so.6:environ
 libc.so.6:epoll_create1
@@ -116,12 +118,16 @@ libc.so.6:recv
 libc.so.6:recvmsg
 libc.so.6:sched_getaffinity
 libc.so.6:sched_yield
+libc.so.6:sem_init
+libc.so.6:sem_post
+libc.so.6:sem_wait
 libc.so.6:send
 libc.so.6:sendfile64
 libc.so.6:sendmsg
 libc.so.6:setgid
 libc.so.6:setgroups
 libc.so.6:setpgid
+libc.so.6:setsid
 libc.so.6:setsockopt
 libc.so.6:setuid
 libc.so.6:shutdown
@@ -160,7 +166,5 @@ libgcc_s.so.1:_Unwind_RaiseException
 libgcc_s.so.1:_Unwind_Resume
 libgcc_s.so.1:_Unwind_SetGR
 libgcc_s.so.1:_Unwind_SetIP
-libm.so.6:ceil
-libm.so.6:fmod
 libm.so.6:log2
 libm.so.6:pow

--- a/packages/g/gleam/package.yml
+++ b/packages/g/gleam/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gleam
-version    : 1.11.1
-release    : 12
+version    : 1.15.2
+release    : 13
 source     :
-    - https://github.com/gleam-lang/gleam/archive/refs/tags/v1.11.1.tar.gz : 34dfdc397835849bc56ac01bf45e68ee9cfc3c99609fb7b3ab02910930a8c40d
+    - https://github.com/gleam-lang/gleam/archive/refs/tags/v1.15.2.tar.gz : 6fe365a52660d854a73d56e0752fc9ff47fdaa19b0ddc9edbcaa1fb935685eca
 homepage   : https://gleam.run
 license    : Apache-2.0
 component  : programming
@@ -25,3 +25,4 @@ build      : |
     %cargo_build
 install    : |
     %cargo_install
+    %install_license LICENCE

--- a/packages/g/gleam/pspec_x86_64.xml
+++ b/packages/g/gleam/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gleam</Name>
         <Homepage>https://gleam.run</Homepage>
         <Packager>
-            <Name>Ian M. Jones</Name>
-            <Email>ian@ianmjones.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming</PartOf>
@@ -29,15 +29,16 @@ Gleam can additionally compile to JavaScript, enabling you to use your code in t
         <PartOf>programming</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/gleam</Path>
+            <Path fileType="data">/usr/share/licenses/gleam/LICENCE</Path>
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2025-06-06</Date>
-            <Version>1.11.1</Version>
+        <Update release="13">
+            <Date>2026-03-28</Date>
+            <Version>1.15.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Ian M. Jones</Name>
-            <Email>ian@ianmjones.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/gleam-lang/gleam/blob/v1.15.2/CHANGELOG.md).
- Resolves: #8324 

**Test Plan**

`gleam new hello`, `cd hello`, `gleam test`. Passed tests, no failures. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
