### PR TITLE
python-cairosvg: Update to v2.9.0

### DIFF
--- a/packages/py/python-cairosvg/package.yml
+++ b/packages/py/python-cairosvg/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-cairosvg
-version    : 2.7.1
-release    : 4
+version    : 2.9.0
+release    : 5
 source     :
-    - https://github.com/Kozea/CairoSVG/archive/refs/tags/2.7.1.tar.gz : 4f548e67c5dd313e4b8913790b445003799234c4a8e84ec2d9939e4e4308bdb8
+    - https://github.com/Kozea/CairoSVG/archive/refs/tags/2.9.0.tar.gz : d42ade287050d1385bdd701c011c8e9e3b0af72669362a420aaccdb06b31141d
 homepage   : https://cairosvg.org/
 license    : LGPL-3.0-or-later
 component  : programming.python

--- a/packages/py/python-cairosvg/pspec_x86_64.xml
+++ b/packages/py/python-cairosvg/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-cairosvg</Name>
         <Homepage>https://cairosvg.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>LGPL-3.0-or-later</License>
         <PartOf>programming.python</PartOf>
@@ -21,11 +21,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/cairosvg</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/cairosvg-2.7.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/cairosvg-2.7.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/cairosvg-2.7.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/cairosvg-2.7.1.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/cairosvg-2.7.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/cairosvg-2.9.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/cairosvg-2.9.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/cairosvg-2.9.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/cairosvg-2.9.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/cairosvg-2.9.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/cairosvg-2.9.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/cairosvg/VERSION</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/cairosvg/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/cairosvg/__main__.py</Path>
@@ -81,12 +82,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2025-05-15</Date>
-            <Version>2.7.1</Version>
+        <Update release="5">
+            <Date>2026-03-28</Date>
+            <Version>2.9.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/Kozea/CairoSVG/blob/main/NEWS.rst).

**Security**
Includes fixes for:
- CVE-2026-31899

**Test Plan**

`python-cairosvg example.svg -o example.png` See that it made a `.png`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
