### PR TITLE
python-joblib: Update to v1.5.3

### DIFF
--- a/packages/py/python-joblib/package.yml
+++ b/packages/py/python-joblib/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-joblib
-version    : 1.4.2
-release    : 11
+version    : 1.5.3
+release    : 12
 source     :
-    - https://github.com/joblib/joblib/archive/refs/tags/1.4.2.tar.gz : 1d95f5f3ab303be89aa4666956bf05a589f56e52c29b836267c8e3885223ff90
+    - https://github.com/joblib/joblib/archive/refs/tags/1.5.3.tar.gz : 7de874013042e7c4dfd14e34c81a0fec19ab7cd8f08bf447b773488e96770fa2
 homepage   : https://joblib.readthedocs.io
 license    : BSD-3-Clause
 component  : programming.python

--- a/packages/py/python-joblib/pspec_x86_64.xml
+++ b/packages/py/python-joblib/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-joblib</Name>
         <Homepage>https://joblib.readthedocs.io</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -26,11 +26,11 @@ In particular:
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/joblib-1.4.2.dist-info/LICENSE.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/joblib-1.4.2.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/joblib-1.4.2.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/joblib-1.4.2.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/joblib-1.4.2.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/joblib-1.5.3.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/joblib-1.5.3.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/joblib-1.5.3.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/joblib-1.5.3.dist-info/licenses/LICENSE.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/joblib-1.5.3.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/joblib/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/joblib/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/joblib/__pycache__/__init__.cpython-312.pyc</Path>
@@ -318,12 +318,12 @@ In particular:
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2025-05-17</Date>
-            <Version>1.4.2</Version>
+        <Update release="12">
+            <Date>2026-03-28</Date>
+            <Version>1.5.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/joblib/joblib/blob/main/CHANGES.rst).

**Security**
Includes fixes for:
- CVE-2024-34997

**Test Plan**

smoke test. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
