### PR TITLE
grub2: Update to v2.14

### DIFF
--- a/packages/g/grub2/abi_used_libs
+++ b/packages/g/grub2/abi_used_libs
@@ -1,5 +1,5 @@
 libc.so.6
 libdevmapper.so.1.02
 libfreetype.so.6
-libfuse.so.2
+libfuse3.so.4
 liblzma.so.5

--- a/packages/g/grub2/abi_used_symbols
+++ b/packages/g/grub2/abi_used_symbols
@@ -5,6 +5,7 @@ libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
 libc.so.6:__isoc23_fscanf
 libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__isoc23_strtoul
 libc.so.6:__libc_start_main
 libc.so.6:__stack_chk_fail
@@ -158,6 +159,6 @@ libfreetype.so.6:FT_Load_Glyph
 libfreetype.so.6:FT_Load_Sfnt_Table
 libfreetype.so.6:FT_New_Face
 libfreetype.so.6:FT_Set_Pixel_Sizes
-libfuse.so.2:fuse_main_real
+libfuse3.so.4:fuse_main_real_versioned
 liblzma.so.5:lzma_code
 liblzma.so.5:lzma_stream_encoder

--- a/packages/g/grub2/package.yml
+++ b/packages/g/grub2/package.yml
@@ -1,45 +1,69 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : grub2
-version    : '2.12'
-release    : 40
+version    : '2.14'
+release    : 41
 source     :
-    - git|https://git.savannah.gnu.org/git/grub.git : 5ca9db22e8ed0dbebb2aec53722972de0680a463
+    - git|https://git.savannah.gnu.org/git/grub.git : d38d6a1a9b79427848976f53d474392cd29c2a71
+    - git|https://git.savannah.gnu.org/git/gnulib.git : 9f48fb992a3d7e96610c4ce8be969cff2d61a01b
 homepage   : https://www.gnu.org/software/grub/
 license    :
     - GPL-3.0-or-later
     # for included terminus fonts in redistributable BDF format
     - OFL-1.1
 component  : system.boot
-networking : true # Needed for bootstrap
 summary    : GRUB Boot Loader
 description: |
     GRUB Boot Loader
 builddeps  :
     - pkgconfig(devmapper)
     - pkgconfig(freetype2)
-    - pkgconfig(fuse)
+    - pkgconfig(fuse3)
     - pkgconfig(liblz4)
     - pkgconfig(liblzma)
-strip      : false
+    - autoconf-archive
+    - wget
 rundeps    :
     - os-prober
+networking : true # Needed for bootstrap
+strip      : false
 environment: |
     unset CFLAGS
     unset CXXFLAGS
     unset LDFLAGS
 setup      : |
+    cp -a ${sources}/gnulib.git ${workdir}/gnulib
+
+    reverts=(
+        # configure: Check linker for --image-base support
+        '1a5417f39a0ccefcdd5440f2a67f84d2d2e26960'
+        # configure: Print a more helpful error if autoconf-archive is not installed
+        'ac042f3f58d33ce9cd5ff61750f06da1a1d7b0eb'
+    )
+
+    echo "Applying reverts"
+    for _c in "${reverts[@]}"; do
+        if [[ "${_c}" == *..* ]]; then _l='--reverse'; else _l='--max-count=1'; fi
+        git log --oneline "${_l}" "${_c}"
+        git revert --mainline 1 --no-commit "${_c}"
+    done
+
     %apply_patches
-    PYTHON=python3 ./bootstrap
-    %autogen --disable-efiemu \
-             --disable-werror \
-             --enable-device-mapper \
-             --enable-grub-mount \
-             --target="i386" \
-             --with-platform="pc"
+
+    PYTHON=python3 ./bootstrap \
+        --gnulib-srcdir="${workdir}/gnulib"
+
+    %autogen \
+        --disable-efiemu \
+        --disable-werror \
+        --enable-device-mapper \
+        --enable-grub-mount \
+        --target="i386" \
+        --with-platform="pc"
 build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING
     install -Dm00755 $pkgfiles/update-grub  -t $installdir/usr/sbin
     install -Dm00755 $pkgfiles/update-grub2 -t $installdir/usr/sbin
     install -Dm00644 $pkgfiles/conf/grub    -t $installdir/etc/default

--- a/packages/g/grub2/pspec_x86_64.xml
+++ b/packages/g/grub2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>grub2</Name>
         <Homepage>https://www.gnu.org/software/grub/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <License>OFL-1.1</License>
@@ -21,7 +21,6 @@
 </Description>
         <PartOf>system.boot</PartOf>
         <Files>
-            <Path fileType="config">/etc/bash_completion.d/grub</Path>
             <Path fileType="config">/etc/default/grub</Path>
             <Path fileType="config">/etc/grub.d/00_header</Path>
             <Path fileType="config">/etc/grub.d/10_linux</Path>
@@ -67,6 +66,14 @@
             <Path fileType="library">/usr/lib64/grub/i386-pc/aout.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/archelp.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/archelp.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/argon2.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/argon2.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/argon2_test.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/argon2_test.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/asn1.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/asn1.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/asn1_test.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/asn1_test.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/at_keyboard.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/at_keyboard.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/ata.mod</Path>
@@ -83,6 +90,8 @@
             <Path fileType="library">/usr/lib64/grub/i386-pc/bitmap_scale.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/blocklist.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/blocklist.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/blsuki.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/blsuki.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/boot.image</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/boot.img</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/boot.mod</Path>
@@ -113,8 +122,6 @@
             <Path fileType="library">/usr/lib64/grub/i386-pc/cdboot.img</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/chain.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/chain.module</Path>
-            <Path fileType="library">/usr/lib64/grub/i386-pc/cmdline_cat_test.mod</Path>
-            <Path fileType="library">/usr/lib64/grub/i386-pc/cmdline_cat_test.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/cmosdump.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/cmosdump.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/cmostest.mod</Path>
@@ -138,6 +145,8 @@
             <Path fileType="library">/usr/lib64/grub/i386-pc/crypto.lst</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/crypto.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/crypto.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/crypto_cipher_mode_test.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/crypto_cipher_mode_test.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/cryptodisk.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/cryptodisk.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/cs5536.mod</Path>
@@ -164,6 +173,8 @@
             <Path fileType="library">/usr/lib64/grub/i386-pc/dm_nv.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/drivemap.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/drivemap.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/dsa_sexp_test.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/dsa_sexp_test.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/echo.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/echo.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/efiemu.mod</Path>
@@ -172,6 +183,8 @@
             <Path fileType="library">/usr/lib64/grub/i386-pc/ehci.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/elf.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/elf.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/erofs.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/erofs.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/eval.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/eval.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/exfat.mod</Path>
@@ -200,6 +213,10 @@
             <Path fileType="library">/usr/lib64/grub/i386-pc/functional_test.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_arcfour.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_arcfour.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_aria.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_aria.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_blake2.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_blake2.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_blowfish.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_blowfish.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_camellia.mod</Path>
@@ -212,8 +229,18 @@
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_des.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_dsa.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_dsa.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_gost28147.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_gost28147.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_gostr3411_94.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_gostr3411_94.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_hwfeatures.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_hwfeatures.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_idea.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_idea.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_kdf.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_kdf.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_keccak.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_keccak.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_md4.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_md4.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_md5.mod</Path>
@@ -226,6 +253,8 @@
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_rmd160.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_rsa.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_rsa.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_salsa20.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_salsa20.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_seed.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_seed.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_serpent.mod</Path>
@@ -236,6 +265,12 @@
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_sha256.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_sha512.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_sha512.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_sm3.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_sm3.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_sm4.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_sm4.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_stribog.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_stribog.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_tiger.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_tiger.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gcry_twofish.mod</Path>
@@ -256,8 +291,6 @@
             <Path fileType="library">/usr/lib64/grub/i386-pc/gfxterm.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gfxterm_background.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gfxterm_background.module</Path>
-            <Path fileType="library">/usr/lib64/grub/i386-pc/gfxterm_menu.mod</Path>
-            <Path fileType="library">/usr/lib64/grub/i386-pc/gfxterm_menu.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gptsync.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gptsync.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/gzio.mod</Path>
@@ -294,6 +327,8 @@
             <Path fileType="library">/usr/lib64/grub/i386-pc/json.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/kernel.exec</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/kernel.img</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/key_protector.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/key_protector.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/keylayouts.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/keylayouts.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/keystatus.mod</Path>
@@ -460,6 +495,8 @@
             <Path fileType="library">/usr/lib64/grub/i386-pc/procfs.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/progress.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/progress.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/pubkey.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/pubkey.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/pxe.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/pxe.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/pxeboot.image</Path>
@@ -486,6 +523,8 @@
             <Path fileType="library">/usr/lib64/grub/i386-pc/relocator.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/romfs.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/romfs.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/rsa_sexp_test.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/rsa_sexp_test.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/scsi.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/scsi.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/search.mod</Path>
@@ -624,6 +663,8 @@
             <Path fileType="library">/usr/lib64/grub/i386-pc/zfsinfo.module</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/zstd.mod</Path>
             <Path fileType="library">/usr/lib64/grub/i386-pc/zstd.module</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/zstdio.mod</Path>
+            <Path fileType="library">/usr/lib64/grub/i386-pc/zstdio.module</Path>
             <Path fileType="executable">/usr/sbin/grub-bios-setup</Path>
             <Path fileType="executable">/usr/sbin/grub-install</Path>
             <Path fileType="executable">/usr/sbin/grub-macbless</Path>
@@ -636,24 +677,82 @@
             <Path fileType="executable">/usr/sbin/update-grub</Path>
             <Path fileType="executable">/usr/sbin/update-grub2</Path>
             <Path fileType="data">/usr/share/backgrounds/splash.tga</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/grub</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/grub-bios-setup</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/grub-editenv</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/grub-install</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/grub-mkconfig</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/grub-mkfont</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/grub-mkimage</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/grub-mkpasswd-pbkdf2</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/grub-mkrescue</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/grub-probe</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/grub-reboot</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/grub-script-check</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/grub-set-default</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/grub-sparc64-setup</Path>
             <Path fileType="data">/usr/share/grub/grub-mkconfig_lib</Path>
             <Path fileType="data">/usr/share/grub/ter-32b.pf2</Path>
             <Path fileType="data">/usr/share/grub/ter-32n.pf2</Path>
             <Path fileType="data">/usr/share/grub/unicode-8x16.pf2</Path>
             <Path fileType="data">/usr/share/grub/unicode.pf2</Path>
-            <Path fileType="info">/usr/share/info/grub-dev.info</Path>
-            <Path fileType="info">/usr/share/info/grub.info</Path>
-            <Path fileType="info">/usr/share/info/grub.info-1</Path>
-            <Path fileType="info">/usr/share/info/grub.info-2</Path>
+            <Path fileType="info">/usr/share/info/grub-dev.info.zst</Path>
+            <Path fileType="info">/usr/share/info/grub.info-1.zst</Path>
+            <Path fileType="info">/usr/share/info/grub.info-2.zst</Path>
+            <Path fileType="info">/usr/share/info/grub.info.zst</Path>
+            <Path fileType="data">/usr/share/licenses/grub2/COPYING</Path>
+            <Path fileType="localedata">/usr/share/locale/ast/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/de@hebrew/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/de_CH/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/en@arabic/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/en@cyrillic/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/en@greek/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/en@hebrew/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/en@piglatin/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/en@quot/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/eo/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/es/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/fi/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/gl/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/he/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/hr/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/hu/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ko/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/lg/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/lt/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/nb/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/nl/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/pa/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/pl/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/pt/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/pt_BR/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ro/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ru/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sl/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sr/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/sv/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/tr/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/vi/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/grub.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/grub.mo</Path>
         </Files>
     </Package>
     <History>
-        <Update release="40">
-            <Date>2024-06-05</Date>
-            <Version>2.12</Version>
+        <Update release="41">
+            <Date>2026-03-28</Date>
+            <Version>2.14</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
* libgcrypt 1.11.
* LVM LV integrity and cachevol support.
* EROFS support.
* GRUB environment block inside the Btrfs header support.
* NX support for EFI platforms.
* shim loader protocol support.
* BLS and UKI support.
* Argon2 KDF support.
* TPM2 key protector support.
* Appended Signature Secure Boot Support for PowerPC.
* New option to block command line interface.
* Support dates outside of 1901..2038 range.
* zstdio decompression support.
* EFI code improvements and fixes.
* TPM driver fixes.
* Filesystems fixes.
* CVE and Coverity fixes.
* Tests improvements.
* Documentation improvements.
* ... and tons of other fixes and cleanups...

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

1. Create a fresh VM, install Solus 4.8, change repo to Unstable, and `sudo eopkg up -y`
2. Reboot VM
3. Install the new package
4. Run `sudo grub-install --boot-directory=/boot/ --target=i386-pc --recheck --force /dev/sdX`
5. Reboot VM

After the reboot, see that the GRUB menu shows version 2.14, and that I can boot to the desktop successfully.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
