### PR TITLE
python-tornado: Update to v6.5.5

### DIFF
--- a/packages/py/python-tornado/package.yml
+++ b/packages/py/python-tornado/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-tornado
-version    : 6.5.4
-release    : 18
+version    : 6.5.5
+release    : 19
 source     :
-    - https://github.com/tornadoweb/tornado/archive/refs/tags/v6.5.4.tar.gz : 983f151603e388932ec2b6f5e0f5231c95d1ac8d1ac28fca834c0962ff9369e1
+    - https://github.com/tornadoweb/tornado/archive/refs/tags/v6.5.5.tar.gz : abd5473239228ea944b5b041d0531c26ac832d654db9044a44012a2e6f95fc61
 homepage   : https://www.tornadoweb.org/
 license    : Apache-2.0
 component  : programming.python

--- a/packages/py/python-tornado/pspec_x86_64.xml
+++ b/packages/py/python-tornado/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-tornado</Name>
         <Homepage>https://www.tornadoweb.org/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -20,11 +20,11 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/tornado-6.5.4.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/tornado-6.5.4.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/tornado-6.5.4.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/tornado-6.5.4.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/tornado-6.5.4.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/tornado-6.5.5.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/tornado-6.5.5.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/tornado-6.5.5.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/tornado-6.5.5.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/tornado-6.5.5.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/tornado/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/tornado/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/tornado/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -267,12 +267,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2026-01-24</Date>
-            <Version>6.5.4</Version>
+        <Update release="19">
+            <Date>2026-03-28</Date>
+            <Version>6.5.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://www.tornadoweb.org/en/stable/releases/v6.5.5.html).

**Security**
Includes fixes for:
- CVE-2026-31958

**Test Plan**

setup loop and curl localhost and see text. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
