### PR TITLE
uv: update to 0.12.0

### DIFF
--- a/packages/u/uv/abi_used_symbols
+++ b/packages/u/uv/abi_used_symbols
@@ -2,6 +2,9 @@ ld-linux-x86-64.so.2:__tls_get_addr
 libc.so.6:__assert_fail
 libc.so.6:__cxa_atexit
 libc.so.6:__errno_location
+libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_current_sigrtmax
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
@@ -9,9 +12,11 @@ libc.so.6:__register_atfork
 libc.so.6:__res_init
 libc.so.6:__sched_cpucount
 libc.so.6:__stack_chk_fail
+libc.so.6:__vsnprintf_chk
 libc.so.6:__xpg_strerror_r
 libc.so.6:_exit
 libc.so.6:abort
+libc.so.6:access
 libc.so.6:bcmp
 libc.so.6:bind
 libc.so.6:calloc
@@ -54,7 +59,6 @@ libc.so.6:getaddrinfo
 libc.so.6:getauxval
 libc.so.6:getcwd
 libc.so.6:getenv
-libc.so.6:geteuid
 libc.so.6:getgrouplist
 libc.so.6:getpeername
 libc.so.6:getpgid
@@ -93,6 +97,7 @@ libc.so.6:open64
 libc.so.6:openat64
 libc.so.6:opendir
 libc.so.6:pause
+libc.so.6:perror
 libc.so.6:pipe2
 libc.so.6:poll
 libc.so.6:posix_memalign
@@ -118,6 +123,7 @@ libc.so.6:pthread_cond_wait
 libc.so.6:pthread_create
 libc.so.6:pthread_detach
 libc.so.6:pthread_getattr_np
+libc.so.6:pthread_getspecific
 libc.so.6:pthread_join
 libc.so.6:pthread_key_create
 libc.so.6:pthread_key_delete
@@ -128,6 +134,12 @@ libc.so.6:pthread_mutex_unlock
 libc.so.6:pthread_mutexattr_destroy
 libc.so.6:pthread_mutexattr_init
 libc.so.6:pthread_mutexattr_settype
+libc.so.6:pthread_once
+libc.so.6:pthread_rwlock_destroy
+libc.so.6:pthread_rwlock_init
+libc.so.6:pthread_rwlock_rdlock
+libc.so.6:pthread_rwlock_unlock
+libc.so.6:pthread_rwlock_wrlock
 libc.so.6:pthread_self
 libc.so.6:pthread_setname_np
 libc.so.6:pthread_setspecific
@@ -173,13 +185,16 @@ libc.so.6:signal
 libc.so.6:socket
 libc.so.6:socketpair
 libc.so.6:splice
+libc.so.6:stat
 libc.so.6:stat64
+libc.so.6:stderr
 libc.so.6:strchr
 libc.so.6:strcmp
 libc.so.6:strerror_r
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strncpy
+libc.so.6:strtol
 libc.so.6:symlink
 libc.so.6:syscall
 libc.so.6:sysconf

--- a/packages/u/uv/package.yml
+++ b/packages/u/uv/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : uv
-version    : 0.10.10
-release    : 12
+version    : 0.11.2
+release    : 13
 source     :
-    - https://github.com/astral-sh/uv/archive/refs/tags/0.10.10.tar.gz : ba4082c92c97e0cc5ac0bc48a2783bc5026c8a14a768ecfb5f7012223a5e90ac
+    - https://github.com/astral-sh/uv/archive/refs/tags/0.11.2.tar.gz : 12f5f6ce0c4e1e80424329098786dd33195df1c342c926f499f8599d1d2ec694
 homepage   : https://docs.astral.sh/uv
 license    :
     - Apache-2.0

--- a/packages/u/uv/pspec_x86_64.xml
+++ b/packages/u/uv/pspec_x86_64.xml
@@ -23,11 +23,11 @@
         <Files>
             <Path fileType="executable">/usr/bin/uv</Path>
             <Path fileType="executable">/usr/bin/uvx</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.10.10.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.10.10.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.10.10.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.10.10.dist-info/licenses/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.10.10.dist-info/licenses/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.2.dist-info/licenses/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.2.dist-info/licenses/LICENSE-MIT</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/uv/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/uv/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/uv/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -45,9 +45,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2026-03-14</Date>
-            <Version>0.10.10</Version>
+        <Update release="13">
+            <Date>2026-03-29</Date>
+            <Version>0.11.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>


### PR DESCRIPTION
**Summary**

- Breaking: switch to updated networking stack (reqwest 0.13) which may affect TLS certificate validation
- Release notes:
  - [v0.11.2](https://github.com/astral-sh/uv/releases/tag/0.11.2)
  - [v0.11.1](https://github.com/astral-sh/uv/releases/tag/0.11.1)
  - [v0.11.0](https://github.com/astral-sh/uv/releases/tag/0.11.0)
  - [v0.10.12](https://github.com/astral-sh/uv/releases/tag/0.10.12)
  - [v0.10.11](https://github.com/astral-sh/uv/releases/tag/0.10.11)

**Test Plan**

- Run smoke tests defined in source
- Installed locally and run some commands.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
