### PR TITLE
lightdm-gtk-greeter-settings: Fix resource path resolution

### DIFF
--- a/packages/l/lightdm-gtk-greeter-settings/package.yml
+++ b/packages/l/lightdm-gtk-greeter-settings/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : lightdm-gtk-greeter-settings
 version    : 1.2.3
-release    : 10
+release    : 11
 source     :
     - https://github.com/Xubuntu/lightdm-gtk-greeter-settings/releases/download/lightdm-gtk-greeter-settings-1.2.3/lightdm-gtk-greeter-settings-1.2.3.tar.gz : 77482a95cb7cc23d78d3c95810a965deddce62cb70349cd03c7a79fe000e740f
 homepage   : https://github.com/Xubuntu/lightdm-gtk-greeter-settings
@@ -17,9 +17,12 @@ builddeps  :
     - python-installer
     - python-setuptools
 rundeps    :
+    - lightdm-gtk-greeter
     - python-gobject
 setup      : |
     %patch -p1 -i $pkgfiles/0001-Add-support-for-stateless-lightdm-gtk-greeter.patch
+    # Removing setup.cfg. setup.cfg causes our macros to incorrectly use the PEP517 path and not the legacy setup.py path.
+    rm setup.cfg
 build      : |
     %python3_setup
 install    : |

--- a/packages/l/lightdm-gtk-greeter-settings/pspec_x86_64.xml
+++ b/packages/l/lightdm-gtk-greeter-settings/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>lightdm-gtk-greeter-settings</Name>
         <Homepage>https://github.com/Xubuntu/lightdm-gtk-greeter-settings</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -22,11 +22,10 @@
         <Files>
             <Path fileType="executable">/usr/bin/lightdm-gtk-greeter-settings</Path>
             <Path fileType="executable">/usr/bin/lightdm-gtk-greeter-settings-pkexec</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings-1.2.3.dist-info/COPYING</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings-1.2.3.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings-1.2.3.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings-1.2.3.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings-1.2.3.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings-1.2.3-py3.12.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings-1.2.3-py3.12.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings-1.2.3-py3.12.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings-1.2.3-py3.12.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/Config.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/GtkGreeterSettingsWindow.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/IconChooserDialog.py</Path>
@@ -39,34 +38,19 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/OptionGroup.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/PositionEntry.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__init__.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/Config.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/Config.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/GtkGreeterSettingsWindow.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/GtkGreeterSettingsWindow.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/IconChooserDialog.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/IconChooserDialog.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/IconEntry.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/IconEntry.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/IndicatorPropertiesDialog.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/IndicatorPropertiesDialog.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/IndicatorsEntry.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/IndicatorsEntry.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/MonitorsGroup.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/MonitorsGroup.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/MultiheadSetupDialog.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/MultiheadSetupDialog.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/OptionEntry.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/OptionEntry.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/OptionGroup.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/OptionGroup.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/PositionEntry.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/PositionEntry.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/__init__.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/helpers.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/helpers.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/installation_config.cpython-312.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/__pycache__/installation_config.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/helpers.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/lightdm_gtk_greeter_settings/installation_config.py</Path>
             <Path fileType="data">/usr/share/applications/lightdm-gtk-greeter-settings.desktop</Path>
@@ -121,12 +105,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2025-05-29</Date>
+        <Update release="11">
+            <Date>2026-03-29</Date>
             <Version>1.2.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
    
The standard %python3_setup/install macros failed to generate the
installation_config module, leading to broken relative paths.
Switching to manual setup.py calls with %python3_version macros
restores functional resource lookups.
    
Fixes getsolus/packages#7103
    
 **Test Plan**
    
- Install lightdm-gtk-greeter-settings
- Open the application and verify that it launches.
    
 **Checklist**
    
- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->