### PR TITLE
python-ujson: Update to v5.12.0

### DIFF
--- a/packages/py/python-ujson/package.yml
+++ b/packages/py/python-ujson/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-ujson
-version    : 5.11.0
-release    : 15
+version    : 5.12.0
+release    : 16
 source     :
-    - https://files.pythonhosted.org/packages/source/u/ujson/ujson-5.11.0.tar.gz : e204ae6f909f099ba6b6b942131cee359ddda2b6e4ea39c12eb8b991fe2010e0
+    - https://files.pythonhosted.org/packages/source/u/ujson/ujson-5.12.0.tar.gz : 14b2e1eb528d77bc0f4c5bd1a7ebc05e02b5b41beefb7e8567c9675b8b13bcf4
 homepage   : https://github.com/ultrajson/ultrajson
 license    : BSD-3-Clause
 component  : programming.python

--- a/packages/py/python-ujson/pspec_x86_64.xml
+++ b/packages/py/python-ujson/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-ujson</Name>
         <Homepage>https://github.com/ultrajson/ultrajson</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -20,22 +20,22 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-5.11.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-5.11.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-5.11.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-5.11.0.dist-info/licenses/LICENSE.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-5.11.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-5.12.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-5.12.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-5.12.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-5.12.0.dist-info/licenses/LICENSE.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-5.12.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-stubs/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ujson.cpython-312-x86_64-linux-gnu.so</Path>
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2025-10-23</Date>
-            <Version>5.11.0</Version>
+        <Update release="16">
+            <Date>2026-03-29</Date>
+            <Version>5.12.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/ultrajson/ultrajson/releases/tag/5.12.0).

**Security**
Includes fixes for:
- CVE-2026-32874
- CVE-2026-32875

**Test Plan**

`python -c "import ujson; x={'a':1}; print(ujson.loads(ujson.dumps(x)))"`, read correct output. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
