### PR TITLE
python-werkzeug: Update to v3.1.7

### DIFF
--- a/packages/py/python-werkzeug/package.yml
+++ b/packages/py/python-werkzeug/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-werkzeug
-version    : 3.1.3
-release    : 15
+version    : 3.1.7
+release    : 16
 source     :
-    - https://github.com/pallets/werkzeug/archive/refs/tags/3.1.3.tar.gz : bee857f4423d7ebf0d6d8bf76c90c70470cc5acecd1187e9484f6dc899487d6d
+    - https://github.com/pallets/werkzeug/archive/refs/tags/3.1.7.tar.gz : 260b373773188f9d61926dacef1ccdd232e6d3d4b011d3db7efdc1612cd8b1cb
 homepage   : https://palletsprojects.com/p/werkzeug/
 license    : BSD-3-Clause
 component  : programming.python

--- a/packages/py/python-werkzeug/pspec_x86_64.xml
+++ b/packages/py/python-werkzeug/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-werkzeug</Name>
         <Homepage>https://palletsprojects.com/p/werkzeug/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/werkzeug-3.1.3.dist-info/LICENSE.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/werkzeug-3.1.3.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/werkzeug-3.1.3.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/werkzeug-3.1.3.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/werkzeug-3.1.7.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/werkzeug-3.1.7.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/werkzeug-3.1.7.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/werkzeug-3.1.7.dist-info/licenses/LICENSE.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/werkzeug/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/werkzeug/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/werkzeug/__pycache__/__init__.cpython-312.pyc</Path>
@@ -190,12 +190,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2025-05-15</Date>
-            <Version>3.1.3</Version>
+        <Update release="16">
+            <Date>2026-03-29</Date>
+            <Version>3.1.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://werkzeug.palletsprojects.com/en/stable/changes/#changes).

**Security**
Includes fixes for:
- CVE-2025-66221
- CVE-2026-21860
- CVE-2026-27199

**Test Plan**

`python3 -c "from importlib.metadata import version; print(version('werkzeug'))"`, read correct output. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
