### PR TITLE
python-pyjwt: Update to v2.12.1

### DIFF
--- a/packages/py/python-pyjwt/package.yml
+++ b/packages/py/python-pyjwt/package.yml
@@ -1,16 +1,15 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-pyjwt
-version    : 2.10.1
-release    : 16
+version    : 2.12.1
+release    : 17
 source     :
-    - https://files.pythonhosted.org/packages/source/P/PyJWT/pyjwt-2.10.1.tar.gz : 3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953
+    - https://files.pythonhosted.org/packages/source/P/PyJWT/pyjwt-2.12.1.tar.gz : c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b
 homepage   : https://github.com/jpadilla/pyjwt
 license    : MIT
 component  : programming.python
 summary    : JSON Web Token implementation in Python
 description: |
     PyJWT is a Python library which allows you to encode and decode JSON Web Tokens (JWT). JWT is an open, industry-standard (RFC 7519) for representing claims securely between two parties.
-networking : true # check
 builddeps  :
     - python-build
     - python-installer

--- a/packages/py/python-pyjwt/pspec_x86_64.xml
+++ b/packages/py/python-pyjwt/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-pyjwt</Name>
         <Homepage>https://github.com/jpadilla/pyjwt</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -57,21 +57,21 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/jwt/types.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/jwt/utils.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/jwt/warnings.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.10.1.dist-info/AUTHORS.rst</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.10.1.dist-info/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.10.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.10.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.10.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.10.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.12.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.12.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.12.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.12.1.dist-info/licenses/AUTHORS.rst</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.12.1.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.12.1.dist-info/top_level.txt</Path>
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2025-05-17</Date>
-            <Version>2.10.1</Version>
+        <Update release="17">
+            <Date>2026-03-29</Date>
+            <Version>2.12.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://pyjwt.readthedocs.io/en/stable/changelog.html).

**Security**
Includes fixes for:
- CVE-2025-45768
- CVE-2026-32597

**Test Plan**

dummy secret smoke test. test version `python3 -c "from importlib.metadata import version; print(version('PyJWT'))"`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
