### PR TITLE
python-nbconvert: Update to v7.17.0

### DIFF
--- a/packages/py/python-nbconvert/package.yml
+++ b/packages/py/python-nbconvert/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-nbconvert
-version    : 7.16.6
-release    : 20
+version    : 7.17.0
+release    : 21
 source     :
-    - https://files.pythonhosted.org/packages/source/n/nbconvert/nbconvert-7.16.6.tar.gz : 576a7e37c6480da7b8465eefa66c17844243816ce1ccc372633c6b71c3c0f582
+    - https://files.pythonhosted.org/packages/source/n/nbconvert/nbconvert-7.17.0.tar.gz : 1b2696f1b5be12309f6c7d707c24af604b87dfaf6d950794c7b07acab96dda78
 homepage   : https://github.com/jupyter/nbconvert
 license    : BSD-3-Clause
 component  : programming.python

--- a/packages/py/python-nbconvert/pspec_x86_64.xml
+++ b/packages/py/python-nbconvert/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-nbconvert</Name>
         <Homepage>https://github.com/jupyter/nbconvert</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -22,11 +22,11 @@
         <Files>
             <Path fileType="executable">/usr/bin/jupyter-dejavu</Path>
             <Path fileType="executable">/usr/bin/jupyter-nbconvert</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert-7.16.6.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert-7.16.6.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert-7.16.6.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert-7.16.6.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert-7.16.6.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert-7.17.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert-7.17.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert-7.17.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert-7.17.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert-7.17.0.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -300,12 +300,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2025-05-17</Date>
-            <Version>7.16.6</Version>
+        <Update release="21">
+            <Date>2026-03-29</Date>
+            <Version>7.17.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://nbconvert.readthedocs.io/en/latest/changelog.html).

**Security**
Includes fixes for:
- CVE-2025-53000

**Test Plan**

Smoke test. Convert `.ipynb` to `.md`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
