### PR TITLE
python-openssl: Update to v26.0.0

### DIFF
--- a/packages/py/python-openssl/package.yml
+++ b/packages/py/python-openssl/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-openssl
-version    : 25.3.0
-release    : 22
+version    : 26.0.0
+release    : 23
 source     :
-    - https://pypi.debian.net/pyOpenSSL/pyopenssl-25.3.0.tar.gz : c981cb0a3fd84e8602d7afc209522773b94c1c2446a3c710a75b06fe1beae329
+    - https://pypi.debian.net/pyOpenSSL/pyopenssl-26.0.0.tar.gz : f293934e52936f2e3413b89c6ce36df66a0b34ae1ea3a053b8c5020ff2f513fc
 homepage   : https://pyopenssl.org/
 license    : Apache-2.0
 component  : programming.python
@@ -28,4 +28,6 @@ build      : |
 install    : |
     %python3_install
 check      : |
-    %python3_test py.test -v
+    # https://github.com/pyca/pyopenssl/issues/1455
+    %python3_test py.test -v \
+        --deselect tests/test_ssl.py::TestOCSP::test_client_receives_servers_data

--- a/packages/py/python-openssl/pspec_x86_64.xml
+++ b/packages/py/python-openssl/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-openssl</Name>
         <Homepage>https://pyopenssl.org/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -42,20 +42,20 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/OpenSSL/py.typed</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/OpenSSL/rand.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/OpenSSL/version.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyopenssl-25.3.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyopenssl-25.3.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyopenssl-25.3.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyopenssl-25.3.0.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyopenssl-25.3.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyopenssl-26.0.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyopenssl-26.0.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyopenssl-26.0.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyopenssl-26.0.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyopenssl-26.0.0.dist-info/top_level.txt</Path>
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2026-02-28</Date>
-            <Version>25.3.0</Version>
+        <Update release="23">
+            <Date>2026-03-29</Date>
+            <Version>26.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://www.pyopenssl.org/en/latest/changelog.html).

**Security**
Includes fixes for:
- CVE-2026-27448
- CVE-2026-27459

**Test Plan**

Smoke test. `python3 -c "from OpenSSL import SSL; print(SSL.SSLeay_version(0).decode())"`, read output. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
