### PR TITLE
mu: Update to v1.14.0

### DIFF
--- a/packages/m/mu/abi_used_symbols
+++ b/packages/m/mu/abi_used_symbols
@@ -13,7 +13,6 @@ libc.so.6:__stack_chk_fail
 libc.so.6:access
 libc.so.6:close
 libc.so.6:closedir
-libc.so.6:creat64
 libc.so.6:fclose
 libc.so.6:ferror
 libc.so.6:fflush
@@ -46,6 +45,7 @@ libc.so.6:memmove
 libc.so.6:memset
 libc.so.6:mkdir
 libc.so.6:nanosleep
+libc.so.6:open64
 libc.so.6:opendir
 libc.so.6:pthread_mutex_lock
 libc.so.6:pthread_mutex_unlock
@@ -77,9 +77,6 @@ libc.so.6:wordexp
 libc.so.6:wordfree
 libgcc_s.so.1:_Unwind_Resume
 libgcc_s.so.1:__udivti3
-libgio-2.0.so.0:g_cancellable_cancel
-libgio-2.0.so.0:g_cancellable_is_cancelled
-libgio-2.0.so.0:g_cancellable_new
 libgio-2.0.so.0:g_file_is_native
 libgio-2.0.so.0:g_file_new_for_path
 libgio-2.0.so.0:g_memory_output_stream_get_data
@@ -173,9 +170,6 @@ libglib-2.0.so.0:g_string_insert_c
 libglib-2.0.so.0:g_string_sized_new
 libglib-2.0.so.0:g_strndup
 libglib-2.0.so.0:g_test_config_vars
-libglib-2.0.so.0:g_thread_join
-libglib-2.0.so.0:g_thread_new
-libglib-2.0.so.0:g_thread_yield
 libglib-2.0.so.0:g_time_zone_get_identifier
 libglib-2.0.so.0:g_time_zone_new_local
 libglib-2.0.so.0:g_time_zone_unref
@@ -188,7 +182,6 @@ libglib-2.0.so.0:g_unichar_to_utf8
 libglib-2.0.so.0:g_unichar_tolower
 libglib-2.0.so.0:g_unlink
 libglib-2.0.so.0:g_unsetenv
-libglib-2.0.so.0:g_usleep
 libglib-2.0.so.0:g_utf8_get_char
 libglib-2.0.so.0:g_utf8_make_valid
 libglib-2.0.so.0:g_utf8_normalize
@@ -309,21 +302,18 @@ libgmime-3.0.so.0:internet_address_mailbox_get_addr
 libgmime-3.0.so.0:internet_address_mailbox_get_type
 libgmime-3.0.so.0:internet_address_mailbox_new
 libgmime-3.0.so.0:internet_address_to_string
-libgobject-2.0.so.0:g_object_get_data
 libgobject-2.0.so.0:g_object_ref
-libgobject-2.0.so.0:g_object_set_data
-libgobject-2.0.so.0:g_object_set_data_full
 libgobject-2.0.so.0:g_object_unref
 libgobject-2.0.so.0:g_type_check_instance_is_a
 libgobject-2.0.so.0:g_type_check_instance_is_fundamentally_a
 libm.so.6:log2
+libstdc++.so.6:_ZNKRSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE3strEv
 libstdc++.so.6:_ZNKSt10filesystem7__cxx114path5_List13_Impl_deleterclEPNS2_5_ImplE
 libstdc++.so.6:_ZNKSt12__basic_fileIcE7is_openEv
 libstdc++.so.6:_ZNKSt13runtime_error4whatEv
 libstdc++.so.6:_ZNKSt5ctypeIcE13_M_widen_initEv
 libstdc++.so.6:_ZNKSt6locale2id5_M_idEv
 libstdc++.so.6:_ZNKSt6localeeqERKS_
-libstdc++.so.6:_ZNKSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE3strEv
 libstdc++.so.6:_ZNKSt8__detail20_Prime_rehash_policy11_M_next_bktEm
 libstdc++.so.6:_ZNKSt8__detail20_Prime_rehash_policy14_M_need_rehashEmmm
 libstdc++.so.6:_ZNSdD2Ev
@@ -337,6 +327,7 @@ libstdc++.so.6:_ZNSo9_M_insertIdEERSoT_
 libstdc++.so.6:_ZNSo9_M_insertIlEERSoT_
 libstdc++.so.6:_ZNSo9_M_insertImEERSoT_
 libstdc++.so.6:_ZNSolsEi
+libstdc++.so.6:_ZNSt10filesystem10remove_allERKNS_7__cxx114pathERSt10error_code
 libstdc++.so.6:_ZNSt10filesystem6statusERKNS_7__cxx114pathERSt10error_code
 libstdc++.so.6:_ZNSt10filesystem7__cxx114path14_M_split_cmptsEv
 libstdc++.so.6:_ZNSt10filesystem7__cxx114path5_ListC1Ev
@@ -519,9 +510,12 @@ libxapian.so.30:_ZN6Xapian5QueryC1ENS0_2opERKNSt7__cxx1112basic_stringIcSt11char
 libxapian.so.30:_ZN6Xapian5QueryC1ENS0_2opEjRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
 libxapian.so.30:_ZN6Xapian5QueryC1ENS0_2opEjRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_
 libxapian.so.30:_ZN6Xapian5QueryC1ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEjj
+libxapian.so.30:_ZN6Xapian6WeightD2Ev
 libxapian.so.30:_ZN6Xapian7Enquire10set_cutoffEid
+libxapian.so.30:_ZN6Xapian7Enquire15set_docid_orderENS0_11docid_orderE
 libxapian.so.30:_ZN6Xapian7Enquire15set_sort_by_keyEPNS_8KeyMakerEb
 libxapian.so.30:_ZN6Xapian7Enquire17set_sort_by_valueEjb
+libxapian.so.30:_ZN6Xapian7Enquire20set_weighting_schemeERKNS_6WeightE
 libxapian.so.30:_ZN6Xapian7Enquire9set_queryERKNS_5QueryEj
 libxapian.so.30:_ZN6Xapian7EnquireC1ERKNS_8DatabaseE
 libxapian.so.30:_ZN6Xapian7EnquireD1Ev
@@ -561,4 +555,5 @@ libxapian.so.30:_ZNK6Xapian8Document9get_docidEv
 libxapian.so.30:_ZNK6Xapian8Document9get_valueB5cxx11Ej
 libxapian.so.30:_ZTIN6Xapian12MatchDeciderE
 libxapian.so.30:_ZTIN6Xapian8KeyMakerE
+libxapian.so.30:_ZTVN6Xapian10BoolWeightE
 libxapian.so.30:_ZTVN6Xapian16WritableDatabaseE

--- a/packages/m/mu/package.yml
+++ b/packages/m/mu/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : mu
-version    : 1.12.15
-release    : 32
+version    : 1.14.0
+release    : 33
 source     :
-    - https://github.com/djcb/mu/releases/download/v1.12.15/mu-1.12.15.tar.xz : 49d75622acff9d8a552622eba29d8abe49ae26d7fe80d835898f75f43e673ee3
+    - https://github.com/djcb/mu/releases/download/v1.14.0/mu-1.14.0.tar.xz : c5d338ee81664c29d18de757017942b14d01fe313d6fea82f8b7c66c6fd4354a
 license    : GPL-3.0-only
 homepage   : https://www.djcbsoftware.nl/code/mu/
 component  : editor

--- a/packages/m/mu/pspec_x86_64.xml
+++ b/packages/m/mu/pspec_x86_64.xml
@@ -118,9 +118,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2026-02-06</Date>
-            <Version>1.12.15</Version>
+        <Update release="33">
+            <Date>2026-03-29</Date>
+            <Version>1.14.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/djcb/mu/releases/tag/v1.14.0).

**Test Plan**

`mu init --muhome=/tmp/mu-smoke --maildir="$(pwd)/testdata"` and see datatable 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
