### PR TITLE
weechat: Update to v4.9.0

### DIFF
--- a/packages/w/weechat/abi_symbols
+++ b/packages/w/weechat/abi_symbols
@@ -3989,6 +3989,7 @@ typing.so:typing_bar_item_typing
 typing.so:typing_buffer_closing_signal_cb
 typing.so:typing_config_change_enabled
 typing.so:typing_config_change_item_max_length
+typing.so:typing_config_change_item_text
 typing.so:typing_config_file
 typing.so:typing_config_free
 typing.so:typing_config_init
@@ -3999,6 +4000,7 @@ typing.so:typing_config_look_enabled_nicks
 typing.so:typing_config_look_enabled_self
 typing.so:typing_config_look_input_min_chars
 typing.so:typing_config_look_item_max_length
+typing.so:typing_config_look_item_text
 typing.so:typing_config_read
 typing.so:typing_config_reload
 typing.so:typing_config_section_look

--- a/packages/w/weechat/package.yml
+++ b/packages/w/weechat/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : weechat
-version    : 4.8.2
-release    : 101
+version    : 4.9.0
+release    : 102
 source     :
-    - https://github.com/weechat/weechat/archive/refs/tags/v4.8.2.tar.gz : 16f61a75db8f2d661bb1ceaea5d82d7fffb6a0e20db95f49130fe965007110b1
+    - https://github.com/weechat/weechat/archive/refs/tags/v4.9.0.tar.gz : 337fc24c0a4c00aa2c47262f123014b23d55c5cf02785ecfdf204f96ccef5c65
 homepage   : https://weechat.org
 license    : GPL-3.0-or-later
 summary    : WeeChat is a fast, light and extensible chat client.

--- a/packages/w/weechat/pspec_x86_64.xml
+++ b/packages/w/weechat/pspec_x86_64.xml
@@ -92,7 +92,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="101">weechat</Dependency>
+            <Dependency release="102">weechat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/weechat/weechat-plugin.h</Path>
@@ -100,9 +100,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="101">
-            <Date>2026-03-12</Date>
-            <Version>4.8.2</Version>
+        <Update release="102">
+            <Date>2026-03-30</Date>
+            <Version>4.9.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/weechat/weechat/releases/tag/v4.9.0).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Connect to Libera.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
