### PR TITLE
solseek: Update to 1.1.3

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 1.1.2
-release    : 23
+version    : 1.1.3
+release    : 24
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v1.1.2.tar.gz : 36cfb59c2ca0aaab260ab150b4a3b39156c5612cdcd179510ca28f06b3b89d5d
+    - https://github.com/clintre/solseek/archive/refs/tags/v1.1.3.tar.gz : 513a8bf812bcefe864d31d5a895e904cdce9ca9fd0c9fb273540643ba9a70fb4
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -69,9 +69,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2026-03-25</Date>
-            <Version>1.1.2</Version>
+        <Update release="24">
+            <Date>2026-03-31</Date>
+            <Version>1.1.3</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**

Bugfixes:
- Fix critical bug causing tmpfs to run out of space due to an issue between how solseek and eopkg work together.

Full Changelog:
https://github.com/clintre/solseek/compare/v1.1.2...v1.1.3


**Test Plan**

Install and make sure that it is not leaving garbage behind when scrolling through packages

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
