### PR TITLE
gdu: Update to 5.35

### DIFF
--- a/packages/g/gdu/monitoring.yaml
+++ b/packages/g/gdu/monitoring.yaml
@@ -2,4 +2,5 @@ releases:
   id: 141586
   rss: https://github.com/dundee/gdu/releases.atom
 security:
-  cpe: ~ # Last checked 2026-22-03
+  cpe: ~ # Last checked 2026-31-03
+  

--- a/packages/g/gdu/package.yml
+++ b/packages/g/gdu/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gdu
-version    : 5.34.2
-release    : 3
+version    : 5.35
+release    : 4
 source     :
-    - https://github.com/dundee/gdu/releases/download/v5.34.2/gdu-5.34.2.tgz: 36eb7b815188c3c3bc05d04ed7dd0c14340bbad3485c2e423e92c9a2f92680b0
+    - https://github.com/dundee/gdu/releases/download/v5.35.0/gdu-5.35.0.tgz: 5e1e836a96721c777bea56cb305b1fe01086fa89ef51349bae4e43ebb57d8191
 homepage   : https://github.com/dundee/gdu
 license    : MIT
 component  : system.utils

--- a/packages/g/gdu/pspec_x86_64.xml
+++ b/packages/g/gdu/pspec_x86_64.xml
@@ -26,9 +26,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2026-03-10</Date>
-            <Version>5.34.0</Version>
+        <Update release="4">
+            <Date>2026-03-31</Date>
+            <Version>5.35</Version>
             <Comment>Packaging update</Comment>
             <Name>DinimixisDEMZ</Name>
             <Email>dinimixis@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**

- Update **gdu** from `5.34.2` to `5.35.0`

- Changelog:
     - [`v5.35.0`](https://github.com/dundee/gdu/releases/tag/v5.35.0)

**Test Plan**

- Install and check the application runs correctly.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged 
