### PR TITLE
python-maturin: Update to v1.12.6

### DIFF
--- a/packages/py/python-maturin/abi_used_symbols
+++ b/packages/py/python-maturin/abi_used_symbols
@@ -1,7 +1,6 @@
 ld-linux-x86-64.so.2:__tls_get_addr
 libc.so.6:__errno_location
 libc.so.6:__libc_start_main
-libc.so.6:__register_atfork
 libc.so.6:__res_init
 libc.so.6:__stack_chk_fail
 libc.so.6:__xpg_strerror_r
@@ -45,7 +44,6 @@ libc.so.6:getenv
 libc.so.6:getpeername
 libc.so.6:getpid
 libc.so.6:getpwuid_r
-libc.so.6:getsockname
 libc.so.6:getsockopt
 libc.so.6:getuid
 libc.so.6:gnu_get_libc_version
@@ -167,6 +165,7 @@ libcrypto.so.3:ERR_lib_error_string
 libcrypto.so.3:ERR_reason_error_string
 libcrypto.so.3:EVP_PKEY_free
 libcrypto.so.3:OpenSSL_version_num
+libcrypto.so.3:PEM_read_bio_PrivateKey
 libcrypto.so.3:PEM_read_bio_X509
 libcrypto.so.3:X509_STORE_add_cert
 libcrypto.so.3:X509_STORE_new
@@ -176,6 +175,7 @@ libcrypto.so.3:X509_VERIFY_PARAM_set_hostflags
 libcrypto.so.3:X509_free
 libcrypto.so.3:X509_up_ref
 libcrypto.so.3:X509_verify_cert_error_string
+libcrypto.so.3:d2i_X509
 libgcc_s.so.1:_Unwind_Backtrace
 libgcc_s.so.1:_Unwind_DeleteException
 libgcc_s.so.1:_Unwind_FindEnclosingFunction
@@ -224,6 +224,5 @@ libssl.so.3:SSL_read_ex
 libssl.so.3:SSL_set_bio
 libssl.so.3:SSL_set_ex_data
 libssl.so.3:SSL_set_verify
-libssl.so.3:SSL_state_string_long
 libssl.so.3:SSL_write_ex
 libssl.so.3:TLS_method

--- a/packages/py/python-maturin/package.yml
+++ b/packages/py/python-maturin/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-maturin
-version    : 1.11.5
-release    : 67
+version    : 1.12.6
+release    : 68
 source     :
-    - https://github.com/PyO3/maturin/archive/refs/tags/v1.11.5.tar.gz : 4edf379859d0126ed860c1f1905da304ce4aea37f3ad58ede294a3920cb9e3aa
+    - https://github.com/PyO3/maturin/archive/refs/tags/v1.12.6.tar.gz : d9fb69fb10a4574032feb93da3f98cbfbf4e652340135c968781845aa1f53147
 license    :
     - Apache-2.0
     - MIT

--- a/packages/py/python-maturin/pspec_x86_64.xml
+++ b/packages/py/python-maturin/pspec_x86_64.xml
@@ -22,12 +22,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/maturin</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.11.5.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.11.5.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.11.5.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.11.5.dist-info/licenses/license-apache</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.11.5.dist-info/licenses/license-mit</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.11.5.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.12.6.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.12.6.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.12.6.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.12.6.dist-info/licenses/license-apache</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.12.6.dist-info/licenses/license-mit</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/maturin-1.12.6.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/maturin/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -40,9 +40,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="67">
-            <Date>2026-01-09</Date>
-            <Version>1.11.5</Version>
+        <Update release="68">
+            <Date>2026-03-29</Date>
+            <Version>1.12.6</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Release notes:
- [1.12.6](https://github.com/PyO3/maturin/releases/tag/v1.12.6)
- [1.12.5](https://github.com/PyO3/maturin/releases/tag/v1.12.5)
- [1.12.4](https://github.com/PyO3/maturin/releases/tag/v1.12.4)
- [1.12.3](https://github.com/PyO3/maturin/releases/tag/v1.12.3)
- [1.12.2](https://github.com/PyO3/maturin/releases/tag/v1.12.2)
- [1.12.1](https://github.com/PyO3/maturin/releases/tag/v1.12.1)
- [1.12.0](https://github.com/PyO3/maturin/releases/tag/v1.12.0)

**Test Plan**

Successfully built `python-orjson` (minus the currently failing tests due to unrelated issue) 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
