### PR TITLE
obs-vkcapture: Update to v1.5.5

### DIFF
--- a/packages/o/obs-vkcapture/abi_used_symbols
+++ b/packages/o/obs-vkcapture/abi_used_symbols
@@ -78,6 +78,7 @@ libobs.so.30:gs_get_linear_srgb
 libobs.so.30:gs_matrix_pop
 libobs.so.30:gs_matrix_push
 libobs.so.30:gs_matrix_translate3f
+libobs.so.30:gs_set_linear_srgb
 libobs.so.30:gs_texture_create
 libobs.so.30:gs_texture_create_from_dmabuf
 libobs.so.30:gs_texture_destroy

--- a/packages/o/obs-vkcapture/package.yml
+++ b/packages/o/obs-vkcapture/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : obs-vkcapture
-version    : 1.5.3
-release    : 13
+version    : 1.5.5
+release    : 14
 source     :
-    - https://github.com/nowrep/obs-vkcapture/archive/refs/tags/v1.5.3.tar.gz : 33ac77427ba30f8d4bdd0921b04ad47385afcf2d52575e7023047c7b17ddd858
+    - https://github.com/nowrep/obs-vkcapture/archive/refs/tags/v1.5.5.tar.gz : 02e79385f5afd6fcc0dbbcdb35adb653a111bf3a0d4d4d7edd82297222f80637
 license    : GPL-2.0-or-later
 homepage   : https://github.com/nowrep/obs-vkcapture
 component  : multimedia.video
@@ -17,6 +17,7 @@ builddeps  :
     - pkgconfig32(vulkan)
     - pkgconfig32(wayland-client)
     - pkgconfig(libobs)
+    - pkgconfig(simde)
 setup      : |
     if [[ ! -z $EMUL32BUILD ]]; then
         %cmake_ninja -DCMAKE_INSTALL_LIBDIR=lib32 -DBUILD_PLUGIN=$OFF

--- a/packages/o/obs-vkcapture/pspec_x86_64.xml
+++ b/packages/o/obs-vkcapture/pspec_x86_64.xml
@@ -48,7 +48,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="13">obs-vkcapture</Dependency>
+            <Dependency release="14">obs-vkcapture</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libVkLayer_obs_vkcapture.so</Path>
@@ -56,9 +56,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2025-09-07</Date>
-            <Version>1.5.3</Version>
+        <Update release="14">
+            <Date>2026-03-31</Date>
+            <Version>1.5.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Improve handling of multiple clients
- Fix duplicate detection logic
- Make HDR work with VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT
- Remove 'Force HDR' option

**Test Plan**

Captured some gameplay footage using `obs-studio`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
