### PR TITLE
solseek: Update to 1.1.4

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 1.1.3
-release    : 24
+version    : 1.1.4
+release    : 25
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v1.1.3.tar.gz : 513a8bf812bcefe864d31d5a895e904cdce9ca9fd0c9fb273540643ba9a70fb4
+    - https://github.com/clintre/solseek/archive/refs/tags/v1.1.4.tar.gz : 804815dc0fa99539365c9336826656da138b1323c0dd2d747543bcdf953f57c8
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -69,9 +69,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
+        <Update release="25">
             <Date>2026-03-31</Date>
-            <Version>1.1.3</Version>
+            <Version>1.1.4</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**


Bugfixes:
- Critical fix for the remaining tempfs issue with the package listing of eopkg due to how fzf handles the preview and eopkg creating large directories in tmpfs for the eopkg info call. Now as it scrolls through the list, it will clean the onefile_ directory if eopkg did not clean up.


Full Changelog:
https://github.com/clintre/solseek/compare/v1.1.2...v1.1.4


**Test Plan**

Tested to make sure that if it does create the folders in tempfs it cleans them up as user traverses list


**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
