### PR TITLE
python-cryptography: Update to v46.0.6

### DIFF
--- a/packages/py/python-cryptography/abi_used_symbols
+++ b/packages/py/python-cryptography/abi_used_symbols
@@ -141,7 +141,6 @@ libc.so.6:__xpg_strerror_r
 libc.so.6:abort
 libc.so.6:bcmp
 libc.so.6:calloc
-libc.so.6:clock_gettime
 libc.so.6:close
 libc.so.6:dl_iterate_phdr
 libc.so.6:free

--- a/packages/py/python-cryptography/files/fix-installing-stray-files.patch
+++ b/packages/py/python-cryptography/files/fix-installing-stray-files.patch
@@ -1,0 +1,48 @@
+From 43eb178ee3aae8d0060221118437b03c23570a41 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@gentoo.org>
+Date: Sun, 15 Feb 2026 18:01:37 +0100
+Subject: [PATCH] Fix installing stray files into site-packages (#14319)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fix the `include` pattern in `pyproject.toml` not to install stray files
+such as `CHANGELOG.rst`, `CONTRIBUTING.rst`, `docs` and `tests` straight
+into site-packages.  Apparently Maturin did not install them before due
+to a bug, but it was fixed in maturin 1.12.0, leading to the files being
+suddenly installed.
+
+Originally reported as https://bugs.gentoo.org/970090.
+
+Signed-off-by: Michał Górny <mgorny@gentoo.org>
+---
+ pyproject.toml | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index e26b386280a5..8640cb6e5951 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -106,10 +106,10 @@ module-name = "cryptography.hazmat.bindings._rust"
+ locked = true
+ sdist-generator = "git"
+ include = [
+-    "CHANGELOG.rst",
+-    "CONTRIBUTING.rst",
++    { path = "CHANGELOG.rst", format = "sdist" },
++    { path = "CONTRIBUTING.rst", format = "sdist" },
+ 
+-    "docs/**/*",
++    { path = "docs/**/*", format = "sdist" },
+ 
+     { path = "src/_cffi_src/**/*.py", format = "sdist" },
+     { path = "src/_cffi_src/**/*.c", format = "sdist" },
+@@ -121,7 +121,7 @@ include = [
+     { path = "src/rust/**/Cargo.lock", format = "sdist" },
+     { path = "src/rust/**/*.rs", format = "sdist" },
+ 
+-    "tests/**/*.py",
++    { path = "tests/**/*.py", format = "sdist" },
+ ]
+ exclude = [
+     "vectors/**/*",

--- a/packages/py/python-cryptography/package.yml
+++ b/packages/py/python-cryptography/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-cryptography
-version    : 46.0.5
-release    : 34
+version    : 46.0.6
+release    : 35
 source     :
-    - https://github.com/pyca/cryptography/archive/refs/tags/46.0.5.tar.gz : 7571f0e09a6d6eb22168993f94d35867b4dcbd0d34224e0eb7b392b905b3f12f
+    - https://github.com/pyca/cryptography/archive/refs/tags/46.0.6.tar.gz : 234935d92ba2320836036c281163ea64837455dd7e0aaa0f034e574ccc7b4c64
 homepage   : https://cryptography.io
 license    : Apache-2.0
 component  : programming.python
@@ -41,6 +41,8 @@ environment: |
     CARGO_PROFILE_RELEASE_LTO="off"; export CARGO_PROFILE_RELEASE_LTO;
     CARGO_PROFILE_RELEASE_STRIP="none"; export CARGO_PROFILE_RELEASE_STRIP;
 setup      : |
+    %patch -p1 -i ${pkgfiles}/fix-installing-stray-files.patch
+
     %cargo_fetch
 build      : |
     %python3_setup --skip-dependency-check

--- a/packages/py/python-cryptography/pspec_x86_64.xml
+++ b/packages/py/python-cryptography/pspec_x86_64.xml
@@ -20,12 +20,13 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/cryptography-46.0.5.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/cryptography-46.0.5.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/cryptography-46.0.5.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/cryptography-46.0.5.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/cryptography-46.0.5.dist-info/licenses/LICENSE.APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/cryptography-46.0.5.dist-info/licenses/LICENSE.BSD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/cryptography-46.0.6.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/cryptography-46.0.6.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/cryptography-46.0.6.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/cryptography-46.0.6.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/cryptography-46.0.6.dist-info/licenses/LICENSE.APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/cryptography-46.0.6.dist-info/licenses/LICENSE.BSD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/cryptography-46.0.6.dist-info/sboms/cryptography-rust.cyclonedx.json</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/cryptography/__about__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/cryptography/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/cryptography/__pycache__/__about__.cpython-312.opt-1.pyc</Path>
@@ -274,9 +275,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="34">
-            <Date>2026-02-21</Date>
-            <Version>46.0.5</Version>
+        <Update release="35">
+            <Date>2026-03-31</Date>
+            <Version>46.0.6</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/pyca/cryptography/blob/46.0.6/CHANGELOG.rst).

**Security**
- CVE-2026-34073

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that the test suite passed.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
