### PR TITLE
solseek: Update to 1.2.0

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 1.1.4
-release    : 25
+version    : 1.2.0
+release    : 26
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v1.1.4.tar.gz : 804815dc0fa99539365c9336826656da138b1323c0dd2d747543bcdf953f57c8
+    - https://github.com/clintre/solseek/archive/refs/tags/v1.2.0.tar.gz : 4889f25cb38a00c0583f9991f8d4a6cc69af3b76aa2d7a1363c27cedd3dbb0ab
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils
@@ -15,10 +15,12 @@ rundeps    :
     - font-firacode-nerd
     - fzf
     - packagekit
+    - python3
 install    : |-
     install -Dm00755 $workdir/package/bin/solseek $installdir/usr/bin/solseek
     install -dm00755 $installdir/usr/share
     cp -r $workdir/package/share/solseek $installdir/usr/share/
+    chmod 00755 $installdir/usr/share/solseek/helpers/eopkg-info.py
     install -Dm00644 $workdir/package/share/applications/Solseek.desktop $installdir/usr/share/applications/Solseek.desktop
     install -Dm00644 $workdir/package/share/icons/hicolor/scalable/apps/solseek.svg $installdir/usr/share/icons/hicolor/scalable/apps/solseek.svg
     install -Dm00644 $workdir/package/share/metainfo/solseek.metainfo.xml $installdir/usr/share/metainfo/solseek.metainfo.xml

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -32,6 +32,7 @@
             <Path fileType="data">/usr/share/solseek/core/defaults</Path>
             <Path fileType="data">/usr/share/solseek/core/menus</Path>
             <Path fileType="data">/usr/share/solseek/core/pkg_functions</Path>
+            <Path fileType="data">/usr/share/solseek/helpers/eopkg-info.py</Path>
             <Path fileType="data">/usr/share/solseek/lang/de.ini</Path>
             <Path fileType="data">/usr/share/solseek/lang/en.ini</Path>
             <Path fileType="data">/usr/share/solseek/lang/es.ini</Path>
@@ -69,9 +70,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="25">
-            <Date>2026-03-31</Date>
-            <Version>1.1.4</Version>
+        <Update release="26">
+            <Date>2026-04-01</Date>
+            <Version>1.2.0</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**

This does not need to be cherry picked or rushed

Bugfixes:
- Added additional cleanup for the history rollback section and other areas that may hit eopkg too fast.

Enhancements:
- Added a new Python helper script for getting package info from the local eopkg-index if.xml or eopkg-index if.xml.xz exists. This drastically reduces calls to eopkg info, which is a heavy process to be scrolling through on a huge list.

Full Changelog:
https://github.com/clintre/solseek/compare/v1.1.2...v1.2.0


**Test Plan**

Test the package list with new helper script
Check for tmpfs and memory for issues

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
