### PR TITLE
feishin: Update to v1.9.0

### DIFF
--- a/packages/f/feishin/package.yml
+++ b/packages/f/feishin/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : feishin
-version    : 1.6.0
-release    : 5
+version    : 1.9.0
+release    : 6
 source     :
-    - https://github.com/jeffvli/feishin/archive/refs/tags/v1.6.0.tar.gz : 40946745f69d6d01d71b8c545ed6e5ae0e74e2e63c970d40c5d517159efc9e5f
+    - https://github.com/jeffvli/feishin/archive/refs/tags/v1.9.0.tar.gz : f0707859723642ec992edb78799967d34eac2237d9810866627e7464a213b5ee
 homepage   : https://github.com/jeffvli/feishin
 license    : GPL-3.0-or-later
 component  : multimedia.audio

--- a/packages/f/feishin/pspec_x86_64.xml
+++ b/packages/f/feishin/pspec_x86_64.xml
@@ -106,13 +106,18 @@
             <Path fileType="data">/usr/share/feishin/resources/assets/fonts/Poppins-Medium.woff2</Path>
             <Path fileType="data">/usr/share/feishin/resources/assets/fonts/Poppins-Regular.woff2</Path>
             <Path fileType="data">/usr/share/feishin/resources/assets/fonts/Poppins-SemiBold.woff2</Path>
+            <Path fileType="data">/usr/share/feishin/resources/assets/fonts/Symbola.woff2</Path>
             <Path fileType="data">/usr/share/feishin/resources/assets/icons/1024x1024.png</Path>
             <Path fileType="data">/usr/share/feishin/resources/assets/icons/128x128.png</Path>
             <Path fileType="data">/usr/share/feishin/resources/assets/icons/16x16.png</Path>
+            <Path fileType="data">/usr/share/feishin/resources/assets/icons/24x24.png</Path>
             <Path fileType="data">/usr/share/feishin/resources/assets/icons/256x256.png</Path>
             <Path fileType="data">/usr/share/feishin/resources/assets/icons/32x32.png</Path>
+            <Path fileType="data">/usr/share/feishin/resources/assets/icons/48x48.png</Path>
             <Path fileType="data">/usr/share/feishin/resources/assets/icons/512x512.png</Path>
             <Path fileType="data">/usr/share/feishin/resources/assets/icons/64x64.png</Path>
+            <Path fileType="data">/usr/share/feishin/resources/assets/icons/72x72.png</Path>
+            <Path fileType="data">/usr/share/feishin/resources/assets/icons/96x96.png</Path>
             <Path fileType="data">/usr/share/feishin/resources/assets/icons/IconTemplate.png</Path>
             <Path fileType="data">/usr/share/feishin/resources/assets/icons/IconTemplate@2x.png</Path>
             <Path fileType="data">/usr/share/feishin/resources/assets/icons/favicon.ico</Path>
@@ -132,9 +137,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2026-02-24</Date>
-            <Version>1.6.0</Version>
+        <Update release="6">
+            <Date>2026-04-02</Date>
+            <Version>1.9.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Hans K</Name>
             <Email>hans@communitycomputing.net</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/jeffvli/feishin/releases/v1.9.0)
- We're back on the latest Feishin version after skipping v1.8.0 due to an electron build issue!

**Test Plan**
- Build and install Feishin from this PR.
- See that it still works.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
