### PR TITLE
w3m: Update to v0.5.6

### DIFF
--- a/packages/w/w3m/abi_symbols
+++ b/packages/w/w3m/abi_symbols
@@ -5,7 +5,6 @@ w3m:addch
 w3m:addnstr
 w3m:addstr
 w3m:clear
-w3m:clrtobot
 w3m:clrtoeol
 w3m:getch
 w3m:initscr

--- a/packages/w/w3m/abi_used_symbols
+++ b/packages/w/w3m/abi_used_symbols
@@ -33,11 +33,11 @@ libc.so.6:__isoc23_fscanf
 libc.so.6:__isoc23_sscanf
 libc.so.6:__isoc23_strtol
 libc.so.6:__isoc23_strtoll
-libc.so.6:__isoc99_sscanf
 libc.so.6:__libc_start_main
 libc.so.6:__longjmp_chk
 libc.so.6:__memset_chk
 libc.so.6:__printf_chk
+libc.so.6:__read_chk
 libc.so.6:__sigsetjmp
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
@@ -152,7 +152,6 @@ libc.so.6:strchr
 libc.so.6:strcmp
 libc.so.6:strcpy
 libc.so.6:strcspn
-libc.so.6:strdup
 libc.so.6:strerror
 libc.so.6:strftime
 libc.so.6:strlen
@@ -164,7 +163,6 @@ libc.so.6:strspn
 libc.so.6:strstr
 libc.so.6:strtod
 libc.so.6:strtok
-libc.so.6:strtol
 libc.so.6:symlink
 libc.so.6:system
 libc.so.6:tcgetattr
@@ -185,7 +183,12 @@ libcrypto.so.3:BIO_new
 libcrypto.so.3:BIO_s_mem
 libcrypto.so.3:ERR_error_string
 libcrypto.so.3:ERR_get_error
-libcrypto.so.3:MD5
+libcrypto.so.3:EVP_DigestFinal_ex
+libcrypto.so.3:EVP_DigestInit_ex
+libcrypto.so.3:EVP_DigestUpdate
+libcrypto.so.3:EVP_MD_CTX_free
+libcrypto.so.3:EVP_MD_CTX_new
+libcrypto.so.3:EVP_md5
 libcrypto.so.3:OPENSSL_sk_free
 libcrypto.so.3:OPENSSL_sk_num
 libcrypto.so.3:OPENSSL_sk_value
@@ -213,6 +216,8 @@ libgc.so.1:GC_realloc
 libgc.so.1:GC_set_oom_fn
 libgc.so.1:GC_set_warn_proc
 libm.so.6:atan2
+libm.so.6:ceil
+libm.so.6:floor
 libm.so.6:log
 libm.so.6:sqrt
 libncursesw.so.6:tgetent

--- a/packages/w/w3m/package.yml
+++ b/packages/w/w3m/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : w3m
-version    : 0.5.3.20230121
-release    : 12
+version    : 0.5.6
+release    : 13
 source     :
-    - https://github.com/tats/w3m/archive/refs/tags/debian/0.5.3+git20230121-2.tar.gz : fe47a8c13b2ba8d873fd6c58da96e1d9b1a9c366eddf69a62b5a6ab8f2dd6311
+    - https://git.sr.ht/~rkta/w3m/archive/v0.5.6.tar.gz : 8dd652cd3f31817d68c7263c34eeffb50118c80be19e1159bf8cbf763037095e
 homepage   : https://github.com/tats/w3m
 license    : MIT
 component  : network.web.browser
@@ -16,14 +16,16 @@ builddeps  :
     - pkgconfig(imlib2)
     - pkgconfig(xext)
 setup      : |
-    sed -i 's/file_handle/file_foo/' istream.{c,h}
     %configure --libexecdir=/usr/lib64 \
+               --enable-image=x11,fb \
                --sysconfdir=/etc \
                --with-imagelib=imlib2 \
-               --with-termlib=ncurses
+               --with-termlib=ncurses \
+               --disable-w3mmailer
 build      : |
     %make -j1
 install    : |
     %make_install
     install -Dm 00644 doc/keymap.default $installdir/etc/w3m/keymap
     install -Dm 00644 doc/menu.default $installdir/etc/w3m/menu
+    %install_license COPYING

--- a/packages/w/w3m/pspec_x86_64.xml
+++ b/packages/w/w3m/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>w3m</Name>
         <Homepage>https://github.com/tats/w3m</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>network.web.browser</PartOf>
@@ -35,17 +35,12 @@
             <Path fileType="library">/usr/lib64/w3m/inflate</Path>
             <Path fileType="library">/usr/lib64/w3m/w3mimgdisplay</Path>
             <Path fileType="library">/usr/lib64/w3m/xface2xpm</Path>
-            <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/w3m.mo</Path>
-            <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/w3m.mo</Path>
-            <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/w3m.mo</Path>
-            <Path fileType="localedata">/usr/share/locale/sv_SE/LC_MESSAGES/w3m.mo</Path>
-            <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/w3m.mo</Path>
-            <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/w3m.mo</Path>
-            <Path fileType="man">/usr/share/man/de/man1/w3m.1</Path>
-            <Path fileType="man">/usr/share/man/de/man1/w3mman.1</Path>
-            <Path fileType="man">/usr/share/man/ja/man1/w3m.1</Path>
-            <Path fileType="man">/usr/share/man/man1/w3m.1</Path>
-            <Path fileType="man">/usr/share/man/man1/w3mman.1</Path>
+            <Path fileType="data">/usr/share/licenses/w3m/COPYING</Path>
+            <Path fileType="man">/usr/share/man/de/man1/w3m.1.zst</Path>
+            <Path fileType="man">/usr/share/man/de/man1/w3mman.1.zst</Path>
+            <Path fileType="man">/usr/share/man/ja/man1/w3m.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/w3m.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/w3mman.1.zst</Path>
             <Path fileType="data">/usr/share/w3m/w3mhelp-funcdesc.de.pl</Path>
             <Path fileType="data">/usr/share/w3m/w3mhelp-funcdesc.en.pl</Path>
             <Path fileType="data">/usr/share/w3m/w3mhelp-funcdesc.ja.pl</Path>
@@ -54,12 +49,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2023-10-30</Date>
-            <Version>0.5.3.20230121</Version>
+        <Update release="13">
+            <Date>2026-04-01</Date>
+            <Version>0.5.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Switch to active for used by Arch and others
- [0.5.6](https://git.sr.ht/~rkta/w3m/refs/v0.5.6)
- [0.5.5](https://git.sr.ht/~rkta/w3m/refs/v0.5.5)
- [0.5.4](https://git.sr.ht/~rkta/w3m/refs/v0.5.4)

**Test Plan**

- Browse a webpage

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
