### PR TITLE
lrzip: Update to v0.660

### DIFF
--- a/packages/l/lrzip/abi_used_symbols
+++ b/packages/l/lrzip/abi_used_symbols
@@ -9,6 +9,7 @@ libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
 libc.so.6:__read_chk
+libc.so.6:__sched_cpucount
 libc.so.6:__snprintf_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
@@ -25,11 +26,11 @@ libc.so.6:fdopen
 libc.so.6:feof
 libc.so.6:ferror
 libc.so.6:fflush
-libc.so.6:fgetc
 libc.so.6:fgets
 libc.so.6:fileno
 libc.so.6:fopen
 libc.so.6:fputc
+libc.so.6:fread
 libc.so.6:free
 libc.so.6:fstat
 libc.so.6:fstatvfs
@@ -74,12 +75,12 @@ libc.so.6:pthread_mutex_init
 libc.so.6:pthread_mutex_lock
 libc.so.6:pthread_mutex_unlock
 libc.so.6:pthread_self
-libc.so.6:putc
 libc.so.6:random
 libc.so.6:read
 libc.so.6:readdir
 libc.so.6:realloc
 libc.so.6:rewind
+libc.so.6:sched_getaffinity
 libc.so.6:sem_init
 libc.so.6:sem_post
 libc.so.6:sem_wait

--- a/packages/l/lrzip/package.yml
+++ b/packages/l/lrzip/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : lrzip
-version    : '0.651'
-release    : 7
+version    : '0.660'
+release    : 8
 source     :
-    - https://github.com/ckolivas/lrzip/archive/refs/tags/v0.651.tar.gz : f4c84de778a059123040681fd47c17565fcc4fec0ccc68fcf32d97fad16cd892
+    - https://github.com/ckolivas/lrzip/archive/refs/tags/v0.660.tar.gz : fd2cb18fc166e565a23f3415306d71a0f9151e0f1d7016d9a2c7eb038cd3c159
 homepage   : https://github.com/ckolivas/lrzip
 license    : GPL-2.0-or-later
 component  : system.utils

--- a/packages/l/lrzip/pspec_x86_64.xml
+++ b/packages/l/lrzip/pspec_x86_64.xml
@@ -57,9 +57,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2026-03-31</Date>
-            <Version>0.651</Version>
+        <Update release="8">
+            <Date>2026-04-01</Date>
+            <Version>0.660</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Address multiple potential security issues with crafted or corrupt archives.
- Accept password usage as a parameter on decompressing encrypted files.
- Fix CPU detection not respecting affinity.
- Fix segfault with zpaq and incompressible blocks.
- Fix inappropriate warnings being displayed.

**Test Plan**

- Open, create archives in ark (a rev-dep)

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
