### PR TITLE
mathjax: Update to v4.1.1

### DIFF
--- a/packages/m/mathjax/package.yml
+++ b/packages/m/mathjax/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : mathjax
-version    : 3.2.2
-release    : 1
+version    : 4.1.1
+release    : 2
 source     :
-    - https://github.com/mathjax/MathJax/archive/refs/tags/3.2.2.tar.gz : 4206b9645a97f431018d0b6c4021c98607d49ba4dc129f4f2ecce675e2fcba11
+    - https://github.com/mathjax/MathJax/archive/refs/tags/4.1.1.tar.gz : 0f234da8c0198576101cad9646753bce10e3c9db6f323220403eca7a819271c9
 homepage   : https://www.mathjax.org/
 license    : Apache-2.0
 component  : office.scientific
@@ -12,4 +12,4 @@ description: |
     MathJax is an open-source JavaScript display engine for LaTeX, MathML, and AsciiMath notation that works in all modern browsers. It was designed with the goal of consolidating the recent advances in web technologies into a single, definitive, math-on-the-web platform supporting the major browsers and operating systems. It requires no setup on the part of the user (no plugins to download or software to install), so the page author can write web documents that include mathematics and be confident that users will be able to view it naturally and easily. Simply include MathJax and some mathematics in a web page, and MathJax does the rest.
 install    : |
     install -dm00644 $installdir/usr/share/mathjax
-    cp -a es5/* $installdir/usr/share/mathjax
+    cp -a * $installdir/usr/share/mathjax

--- a/packages/m/mathjax/pspec_x86_64.xml
+++ b/packages/m/mathjax/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>mathjax</Name>
         <Homepage>https://www.mathjax.org/</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>office.scientific</PartOf>
         <Summary xml:lang="en">Beautiful and accessible math in all browsers</Summary>
         <Description xml:lang="en">MathJax is an open-source JavaScript display engine for LaTeX, MathML, and AsciiMath notation that works in all modern browsers. It was designed with the goal of consolidating the recent advances in web technologies into a single, definitive, math-on-the-web platform supporting the major browsers and operating systems. It requires no setup on the part of the user (no plugins to download or software to install), so the page author can write web documents that include mathematics and be confident that users will be able to view it naturally and easily. Simply include MathJax and some mathematics in a web page, and MathJax does the rest.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>mathjax</Name>
@@ -20,12 +20,20 @@
 </Description>
         <PartOf>office.scientific</PartOf>
         <Files>
+            <Path fileType="data">/usr/share/mathjax/CONTRIBUTING.md</Path>
+            <Path fileType="data">/usr/share/mathjax/LICENSE</Path>
+            <Path fileType="data">/usr/share/mathjax/README.md</Path>
             <Path fileType="data">/usr/share/mathjax/a11y/assistive-mml.js</Path>
             <Path fileType="data">/usr/share/mathjax/a11y/complexity.js</Path>
             <Path fileType="data">/usr/share/mathjax/a11y/explorer.js</Path>
             <Path fileType="data">/usr/share/mathjax/a11y/semantic-enrich.js</Path>
+            <Path fileType="data">/usr/share/mathjax/a11y/speech.js</Path>
             <Path fileType="data">/usr/share/mathjax/a11y/sre.js</Path>
+            <Path fileType="data">/usr/share/mathjax/adaptors/jsdom.js</Path>
+            <Path fileType="data">/usr/share/mathjax/adaptors/linkedom.js</Path>
             <Path fileType="data">/usr/share/mathjax/adaptors/liteDOM.js</Path>
+            <Path fileType="data">/usr/share/mathjax/bower.json</Path>
+            <Path fileType="data">/usr/share/mathjax/composer.json</Path>
             <Path fileType="data">/usr/share/mathjax/core.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/asciimath.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/mml.js</Path>
@@ -33,14 +41,15 @@
             <Path fileType="data">/usr/share/mathjax/input/mml/extensions/mml3.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/mml/extensions/mml3.sef.json</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex-base.js</Path>
-            <Path fileType="data">/usr/share/mathjax/input/tex-full.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/action.js</Path>
-            <Path fileType="data">/usr/share/mathjax/input/tex/extensions/all-packages.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/ams.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/amscd.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/autoload.js</Path>
+            <Path fileType="data">/usr/share/mathjax/input/tex/extensions/bbm.js</Path>
+            <Path fileType="data">/usr/share/mathjax/input/tex/extensions/bboldx.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/bbox.js</Path>
+            <Path fileType="data">/usr/share/mathjax/input/tex/extensions/begingroup.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/boldsymbol.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/braket.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/bussproofs.js</Path>
@@ -51,6 +60,7 @@
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/colortbl.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/colorv2.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/configmacros.js</Path>
+            <Path fileType="data">/usr/share/mathjax/input/tex/extensions/dsfont.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/empheq.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/enclose.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/extpfeil.js</Path>
@@ -65,76 +75,67 @@
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/require.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/setoptions.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/tagformat.js</Path>
+            <Path fileType="data">/usr/share/mathjax/input/tex/extensions/texhtml.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/textcomp.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/textmacros.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/unicode.js</Path>
+            <Path fileType="data">/usr/share/mathjax/input/tex/extensions/units.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/upgreek.js</Path>
             <Path fileType="data">/usr/share/mathjax/input/tex/extensions/verb.js</Path>
-            <Path fileType="data">/usr/share/mathjax/latest.js</Path>
             <Path fileType="data">/usr/share/mathjax/loader.js</Path>
+            <Path fileType="data">/usr/share/mathjax/mml-chtml-nofont.js</Path>
             <Path fileType="data">/usr/share/mathjax/mml-chtml.js</Path>
+            <Path fileType="data">/usr/share/mathjax/mml-svg-nofont.js</Path>
             <Path fileType="data">/usr/share/mathjax/mml-svg.js</Path>
+            <Path fileType="data">/usr/share/mathjax/node-main-setup.cjs</Path>
+            <Path fileType="data">/usr/share/mathjax/node-main.cjs</Path>
             <Path fileType="data">/usr/share/mathjax/node-main.js</Path>
+            <Path fileType="data">/usr/share/mathjax/node-main.mjs</Path>
             <Path fileType="data">/usr/share/mathjax/output/chtml.js</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/tex.js</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_AMS-Regular.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_Calligraphic-Bold.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_Calligraphic-Regular.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_Fraktur-Bold.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_Fraktur-Regular.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_Main-Bold.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_Main-Italic.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_Main-Regular.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_Math-BoldItalic.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_Math-Italic.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_Math-Regular.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_SansSerif-Bold.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_SansSerif-Italic.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_SansSerif-Regular.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_Script-Regular.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_Size1-Regular.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_Size2-Regular.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_Size3-Regular.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_Size4-Regular.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_Typewriter-Regular.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_Vector-Bold.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_Vector-Regular.woff</Path>
-            <Path fileType="data">/usr/share/mathjax/output/chtml/fonts/woff-v2/MathJax_Zero.woff</Path>
             <Path fileType="data">/usr/share/mathjax/output/svg.js</Path>
-            <Path fileType="data">/usr/share/mathjax/output/svg/fonts/tex.js</Path>
+            <Path fileType="data">/usr/share/mathjax/package.json</Path>
+            <Path fileType="data">/usr/share/mathjax/require.mjs</Path>
+            <Path fileType="data">/usr/share/mathjax/sre/mathmaps/af.json</Path>
             <Path fileType="data">/usr/share/mathjax/sre/mathmaps/base.json</Path>
             <Path fileType="data">/usr/share/mathjax/sre/mathmaps/ca.json</Path>
             <Path fileType="data">/usr/share/mathjax/sre/mathmaps/da.json</Path>
             <Path fileType="data">/usr/share/mathjax/sre/mathmaps/de.json</Path>
             <Path fileType="data">/usr/share/mathjax/sre/mathmaps/en.json</Path>
             <Path fileType="data">/usr/share/mathjax/sre/mathmaps/es.json</Path>
+            <Path fileType="data">/usr/share/mathjax/sre/mathmaps/euro.json</Path>
             <Path fileType="data">/usr/share/mathjax/sre/mathmaps/fr.json</Path>
             <Path fileType="data">/usr/share/mathjax/sre/mathmaps/hi.json</Path>
             <Path fileType="data">/usr/share/mathjax/sre/mathmaps/it.json</Path>
+            <Path fileType="data">/usr/share/mathjax/sre/mathmaps/ko.json</Path>
             <Path fileType="data">/usr/share/mathjax/sre/mathmaps/nb.json</Path>
             <Path fileType="data">/usr/share/mathjax/sre/mathmaps/nemeth.json</Path>
             <Path fileType="data">/usr/share/mathjax/sre/mathmaps/nn.json</Path>
             <Path fileType="data">/usr/share/mathjax/sre/mathmaps/sv.json</Path>
+            <Path fileType="data">/usr/share/mathjax/sre/require.d.mts</Path>
+            <Path fileType="data">/usr/share/mathjax/sre/require.mjs</Path>
+            <Path fileType="data">/usr/share/mathjax/sre/speech-worker.js</Path>
             <Path fileType="data">/usr/share/mathjax/startup.js</Path>
-            <Path fileType="data">/usr/share/mathjax/tex-chtml-full-speech.js</Path>
-            <Path fileType="data">/usr/share/mathjax/tex-chtml-full.js</Path>
+            <Path fileType="data">/usr/share/mathjax/tex-chtml-nofont.js</Path>
             <Path fileType="data">/usr/share/mathjax/tex-chtml.js</Path>
+            <Path fileType="data">/usr/share/mathjax/tex-mml-chtml-nofont.js</Path>
             <Path fileType="data">/usr/share/mathjax/tex-mml-chtml.js</Path>
+            <Path fileType="data">/usr/share/mathjax/tex-mml-svg-nofont.js</Path>
             <Path fileType="data">/usr/share/mathjax/tex-mml-svg.js</Path>
-            <Path fileType="data">/usr/share/mathjax/tex-svg-full.js</Path>
+            <Path fileType="data">/usr/share/mathjax/tex-svg-nofont.js</Path>
             <Path fileType="data">/usr/share/mathjax/tex-svg.js</Path>
             <Path fileType="data">/usr/share/mathjax/ui/lazy.js</Path>
             <Path fileType="data">/usr/share/mathjax/ui/menu.js</Path>
+            <Path fileType="data">/usr/share/mathjax/ui/no-dark-mode.js</Path>
             <Path fileType="data">/usr/share/mathjax/ui/safe.js</Path>
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2022-09-03</Date>
-            <Version>3.2.2</Version>
+        <Update release="2">
+            <Date>2026-04-01</Date>
+            <Version>4.1.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- [4.1.1](https://github.com/mathjax/MathJax/releases/tag/4.1.1)
- [4.1.0](https://github.com/mathjax/MathJax/releases/tag/4.1.0)
- [4.0.0](https://github.com/mathjax/MathJax/releases/tag/4.0.0)

**Test Plan**

- calibre and sigil both use mathjax as a run-dep and build-dep
- No change when building against new mathjax
- Old packages run with new mathjax

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
