### PR TITLE
libinput: Update to v1.31.1

### DIFF
--- a/packages/l/libinput/package.yml
+++ b/packages/l/libinput/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libinput
-version    : 1.31.0
-release    : 53
+version    : 1.31.1
+release    : 54
 source     :
-    - https://gitlab.freedesktop.org/libinput/libinput/-/archive/1.31.0/libinput-1.31.0.tar.gz : 5f95a8ce039b3b2b4560a60bbdb920518d41baa9419344e5878c94bd841d5a54
+    - https://gitlab.freedesktop.org/libinput/libinput/-/archive/1.31.1/libinput-1.31.1.tar.gz : e010b02021b8fe9f3e696a4a2059c0243f0c90f2f9d4bcf4c88d2f9613c52b0b
 license    : MIT
 component  : desktop.library
 homepage   : https://www.freedesktop.org/wiki/Software/libinput/
@@ -18,7 +18,8 @@ builddeps  :
     - pyparsing
     - python-pytest
 setup      : |
-    %meson_configure -Ddebug-gui=false \
+    %meson_configure \
+        -Ddebug-gui=false \
         -Ddocumentation=false \
         -Dtests=false \
         -Dudev-dir=%libdir%/udev
@@ -26,6 +27,8 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING
+
     # Empty
     rm -fr $installdir/etc/
 check      : |

--- a/packages/l/libinput/pspec_x86_64.xml
+++ b/packages/l/libinput/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libinput</Name>
         <Homepage>https://www.freedesktop.org/wiki/Software/libinput/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>desktop.library</PartOf>
@@ -97,6 +97,7 @@
             <Path fileType="data">/usr/share/libinput/50-system-starlabs.quirks</Path>
             <Path fileType="data">/usr/share/libinput/50-system-system76.quirks</Path>
             <Path fileType="data">/usr/share/libinput/50-system-toshiba.quirks</Path>
+            <Path fileType="data">/usr/share/licenses/libinput/COPYING</Path>
             <Path fileType="man">/usr/share/man/man1/libinput-analyze-buttons.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/libinput-analyze-per-slot-delta.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/libinput-analyze-recording.1.zst</Path>
@@ -130,7 +131,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="53">libinput</Dependency>
+            <Dependency release="54">libinput</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libinput.h</Path>
@@ -139,12 +140,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="53">
-            <Date>2026-03-21</Date>
-            <Version>1.31.0</Version>
+        <Update release="54">
+            <Date>2026-04-02</Date>
+            <Version>1.31.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://gitlab.freedesktop.org/libinput/libinput/-/releases/1.31.1).

**Security**
- CVE-2026-35093
- CVE-2026-35094

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build `wlroots` against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
