### PR TITLE
tv-lite: fix missing rundep

### DIFF
--- a/packages/t/tv-lite/package.yml
+++ b/packages/t/tv-lite/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : TV-Lite
 version    : 0.8.1
-release    : 9
+release    : 10
 source     :
     - https://gitlab.com/cburneci/tv-lite/-/archive/0.8.1/tv-lite-0.8.1.tar.gz : 4303be9c37a8c721ddc5a34d6c6793936e97f18f5856bf782a56be5b61297781
 homepage   : https://tv-lite.com
@@ -14,9 +14,11 @@ builddeps  :
     - pkgconfig(RapidJSON)
     - pkgconfig(gtk+-3.0)
     - pkgconfig(libcurl)
+    - pkgconfig(libvlc)
     - pkgconfig(sqlite3)
-    - vlc-devel
     - wxwidgets-devel
+rundeps    :
+    - vlc
 setup      : |
     pushd src/
     %cmake_ninja

--- a/packages/t/tv-lite/pspec_x86_64.xml
+++ b/packages/t/tv-lite/pspec_x86_64.xml
@@ -38,8 +38,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2026-01-31</Date>
+        <Update release="10">
+            <Date>2026-04-02</Date>
             <Version>0.8.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>


### PR DESCRIPTION
**Summary**
- Resolves https://github.com/getsolus/packages/issues/8409

**Test Plan**
- Removed VLC got only audio. Reinstalled VLC and got video and audio.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
