### PR TITLE
vc: Update to v1.4.5

### DIFF
--- a/packages/v/vc/package.yml
+++ b/packages/v/vc/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : vc
-version    : 1.4.3
-release    : 6
+version    : 1.4.5
+release    : 7
 source     :
-    - https://github.com/VcDevel/Vc/releases/download/1.4.3/Vc-1.4.3.tar.gz : 988ea0053f3fbf17544ca776a2749c097b3139089408b0286fa4e9e8513e037f
+    - https://github.com/VcDevel/Vc/archive/refs/tags/1.4.5.tar.gz : eb734ef4827933fcd67d4c74aef54211b841c350a867c681c73003eb6d511a48
 homepage   : https://github.com/VcDevel/Vc
 license    : BSD-3-Clause
 component  : programming
@@ -22,3 +22,5 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license LICENSE
+    rm $installdir/usr/lib64/libVc.a

--- a/packages/v/vc/pspec_x86_64.xml
+++ b/packages/v/vc/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>vc</Name>
         <Homepage>https://github.com/VcDevel/Vc</Homepage>
         <Packager>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">SIMD Vector Classes for C++</Summary>
         <Description xml:lang="en">SIMD Vector Classes for C++
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>vc</Name>
@@ -183,16 +183,16 @@
             <Path fileType="library">/usr/lib64/cmake/Vc/VcMacros.cmake</Path>
             <Path fileType="library">/usr/lib64/cmake/Vc/VcTargets-relwithdebinfo.cmake</Path>
             <Path fileType="library">/usr/lib64/cmake/Vc/VcTargets.cmake</Path>
-            <Path fileType="library">/usr/lib64/libVc.a</Path>
+            <Path fileType="data">/usr/share/licenses/vc/LICENSE</Path>
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2022-10-26</Date>
-            <Version>1.4.3</Version>
+        <Update release="7">
+            <Date>2026-04-02</Date>
+            <Version>1.4.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- [1.4.5](https://github.com/VcDevel/Vc/releases/tag/1.4.5)
- [1.4.4](https://github.com/VcDevel/Vc/releases/tag/1.4.5)

**Test Plan**

- Only rev-dep I see is krita
- Rebuild krita with new vc, no changes
- Current krita runs with new vc

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
