### PR TITLE
fresh: Update to v0.2.21

### DIFF
--- a/packages/f/fresh/abi_used_symbols
+++ b/packages/f/fresh/abi_used_symbols
@@ -61,7 +61,10 @@ libc.so.6:gai_strerror
 libc.so.6:getaddrinfo
 libc.so.6:getauxval
 libc.so.6:getcwd
+libc.so.6:getegid
 libc.so.6:getenv
+libc.so.6:geteuid
+libc.so.6:getgroups
 libc.so.6:getmntent
 libc.so.6:getpeername
 libc.so.6:getpid

--- a/packages/f/fresh/package.yml
+++ b/packages/f/fresh/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : fresh
-version    : 0.2.13
-release    : 3
+version    : 0.2.21
+release    : 4
 source     :
-    - https://github.com/sinelaw/fresh/archive/refs/tags/v0.2.13.tar.gz : ce83badda8f7b9705f2de45eba2ffb669982617a157f7f18ab2b035c012f67e2
+    - https://github.com/sinelaw/fresh/archive/refs/tags/v0.2.21.tar.gz : 578036ffc1dde76aa0bfd7f5f1ae675268f42e09aa7f4d2b824856e282bcc758
 homepage   : https://getfresh.dev
 license    : GPL-2.0-or-later
 component  : editor

--- a/packages/f/fresh/pspec_x86_64.xml
+++ b/packages/f/fresh/pspec_x86_64.xml
@@ -36,9 +36,9 @@ efficient handling of very large files with low memory overhead.
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2026-03-06</Date>
-            <Version>0.2.13</Version>
+        <Update release="4">
+            <Date>2026-03-31</Date>
+            <Version>0.2.21</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/sinelaw/fresh/releases).
- Metainfo fixed upstream

**Test Plan**

Edited this commit using `fresh`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
