### PR TITLE
stress-ng: Update to v0.21.00

### DIFF
--- a/packages/s/stress-ng/abi_used_symbols
+++ b/packages/s/stress-ng/abi_used_symbols
@@ -82,10 +82,13 @@ libc.so.6:__getdelim
 libc.so.6:__getdomainname_chk
 libc.so.6:__getgroups_chk
 libc.so.6:__gethostname_chk
+libc.so.6:__inet_pton_chk
 libc.so.6:__isoc23_fscanf
 libc.so.6:__isoc23_sscanf
 libc.so.6:__isoc23_strtol
 libc.so.6:__isoc23_strtoll
+libc.so.6:__isoc23_strtoul
+libc.so.6:__isoc23_strtoull
 libc.so.6:__libc_current_sigrtmax
 libc.so.6:__libc_current_sigrtmin
 libc.so.6:__libc_start_main
@@ -103,7 +106,6 @@ libc.so.6:__sched_cpucount
 libc.so.6:__sigsetjmp
 libc.so.6:__stack_chk_fail
 libc.so.6:__strlcat_chk
-libc.so.6:__sysconf
 libc.so.6:__vfprintf_chk
 libc.so.6:__vprintf_chk
 libc.so.6:__vsnprintf_chk
@@ -198,8 +200,11 @@ libc.so.6:fork
 libc.so.6:free
 libc.so.6:freeifaddrs
 libc.so.6:fremovexattr
+libc.so.6:fsconfig
 libc.so.6:fseek
 libc.so.6:fsetxattr
+libc.so.6:fsmount
+libc.so.6:fsopen
 libc.so.6:fstat64
 libc.so.6:fstatat64
 libc.so.6:fstatfs64
@@ -259,7 +264,6 @@ libc.so.6:in6addr_loopback
 libc.so.6:index
 libc.so.6:inet_addr
 libc.so.6:inet_ntoa
-libc.so.6:inet_pton
 libc.so.6:inotify_add_watch
 libc.so.6:inotify_init
 libc.so.6:inotify_init1
@@ -306,7 +310,7 @@ libc.so.6:mknodat
 libc.so.6:mlock
 libc.so.6:mlockall
 libc.so.6:mmap64
-libc.so.6:mount
+libc.so.6:move_mount
 libc.so.6:mprotect
 libc.so.6:mq_close
 libc.so.6:mq_getattr
@@ -337,6 +341,7 @@ libc.so.6:nice
 libc.so.6:open64
 libc.so.6:open_by_handle_at
 libc.so.6:open_memstream
+libc.so.6:open_tree
 libc.so.6:openat64
 libc.so.6:opendir
 libc.so.6:openlog
@@ -360,6 +365,7 @@ libc.so.6:posix_fadvise64
 libc.so.6:posix_fallocate64
 libc.so.6:posix_madvise
 libc.so.6:posix_memalign
+libc.so.6:posix_openpt
 libc.so.6:posix_spawn
 libc.so.6:ppoll
 libc.so.6:prctl
@@ -370,8 +376,6 @@ libc.so.6:prlimit64
 libc.so.6:process_vm_readv
 libc.so.6:process_vm_writev
 libc.so.6:pselect
-libc.so.6:pthread_attr_init
-libc.so.6:pthread_attr_setstack
 libc.so.6:pthread_barrier_destroy
 libc.so.6:pthread_barrier_init
 libc.so.6:pthread_barrier_wait
@@ -533,16 +537,22 @@ libc.so.6:strcoll
 libc.so.6:strcspn
 libc.so.6:strdup
 libc.so.6:strerror
+libc.so.6:strfromd
+libc.so.6:strfromf
+libc.so.6:strfroml
 libc.so.6:strftime
 libc.so.6:strlen
 libc.so.6:strncasecmp
 libc.so.6:strncat
 libc.so.6:strncmp
-libc.so.6:strncpy
+libc.so.6:strnlen
 libc.so.6:strrchr
 libc.so.6:strsignal
 libc.so.6:strstr
+libc.so.6:strtod
+libc.so.6:strtof
 libc.so.6:strtok
+libc.so.6:strtold
 libc.so.6:strxfrm
 libc.so.6:swapcontext
 libc.so.6:swapoff
@@ -605,6 +615,7 @@ libc.so.6:wcslen
 libc.so.6:wcsncasecmp
 libc.so.6:wcsncat
 libc.so.6:wcsncmp
+libc.so.6:wcsrchr
 libc.so.6:wcsxfrm
 libc.so.6:write
 libc.so.6:writev
@@ -618,8 +629,11 @@ libgcc_s.so.1:__extendhfsf2
 libgcc_s.so.1:__extendxftf2
 libgcc_s.so.1:__modti3
 libgcc_s.so.1:__multf3
+libgcc_s.so.1:__subtf3
+libgcc_s.so.1:__truncsfbf2
 libgcc_s.so.1:__truncsfhf2
 libgcc_s.so.1:__trunctfxf2
+libgcc_s.so.1:__truncxfbf2
 libgcc_s.so.1:__truncxfhf2
 libgcc_s.so.1:__udivti3
 libgcc_s.so.1:__umodti3
@@ -649,6 +663,7 @@ libjpeg.so.8:jpeg_std_error
 libjpeg.so.8:jpeg_stdio_dest
 libjpeg.so.8:jpeg_write_scanlines
 liblzma.so.5:lzma_code
+liblzma.so.5:lzma_end
 liblzma.so.5:lzma_stream_decoder
 libm.so.6:cabs
 libm.so.6:cabsl
@@ -725,6 +740,7 @@ libm.so.6:log10f
 libm.so.6:log10l
 libm.so.6:log2
 libm.so.6:log2f
+libm.so.6:log2l
 libm.so.6:logb
 libm.so.6:logbf
 libm.so.6:logbl

--- a/packages/s/stress-ng/package.yml
+++ b/packages/s/stress-ng/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : stress-ng
-version    : 0.19.05
-release    : 17
+version    : 0.21.00
+release    : 18
 source     :
-    - https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V0.19.05.tar.gz : 9712c5505602c6db8017c15a2659a3185f5a4f81ddde745e9f45f9e10a9f86c4
+    - https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V0.21.00.tar.gz : 1339cbc6ccbff7e2ee2177bf0fd67e7b94e8ff7b07fe89bcfaec0280d800cf34
 license    : GPL-2.0-or-later
 component  : system.utils
 homepage   : https://github.com/ColinIanKing/stress-ng
@@ -33,3 +33,4 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING

--- a/packages/s/stress-ng/pspec_x86_64.xml
+++ b/packages/s/stress-ng/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>stress-ng</Name>
         <Homepage>https://github.com/ColinIanKing/stress-ng</Homepage>
         <Packager>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -22,6 +22,7 @@
         <Files>
             <Path fileType="executable">/usr/bin/stress-ng</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/stress-ng</Path>
+            <Path fileType="data">/usr/share/licenses/stress-ng/COPYING</Path>
             <Path fileType="man">/usr/share/man/man1/stress-ng.1.gz</Path>
             <Path fileType="data">/usr/share/stress-ng/example-jobs/cpu-cache.job</Path>
             <Path fileType="data">/usr/share/stress-ng/example-jobs/cpu.job</Path>
@@ -41,12 +42,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2025-10-07</Date>
-            <Version>0.19.05</Version>
+        <Update release="18">
+            <Date>2026-04-04</Date>
+            <Version>0.21.00</Version>
             <Comment>Packaging update</Comment>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- changelog can be found [here](https://github.com/ColinIanKing/stress-ng/releases/tag/V0.21.00)
- install license 

**Test Plan**

Run s-tui

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
