### PR TITLE
[NFC] appstream-catalog: Taskfile: Use `git add .`

### DIFF
--- a/packages/a/appstream-catalog/Taskfile.yml
+++ b/packages/a/appstream-catalog/Taskfile.yml
@@ -10,6 +10,6 @@ tasks:
     desc: "Create a new branch (appstream-catalog-update); commit appstream-catalog update; push to github."
     cmds:
       - "git checkout -B appstream-catalog-update"
-      - "git add package.yml pspec_x86_64.xml"
+      - "git add ."
       - "git commit -m \"appstream-catalog: Update to latest catalog\" -m \"**Summary**\" -m \"Update Appstream Catalog\""
       - "git push origin appstream-catalog-update:appstream-catalog-update"


### PR DESCRIPTION
**Summary**
Now that there's a files directory, it's much more likely that new changes there would be left behind by `go-task appstream-commit-and-push`. Using `git add .` and relying on our hooks and `.gitignore` to make sure no unwanted files get in is more sane here.

**Test Plan**

Ran `task appstream-commit-and-push` and nothing untoward got staged for commit.

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
