### PR TITLE
feh: Update to v3.11.4

### DIFF
--- a/packages/f/feh/package.yml
+++ b/packages/f/feh/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : feh
-version    : 3.11.3
-release    : 52
+version    : 3.11.4
+release    : 53
 source     :
-    - https://feh.finalrewind.org/feh-3.11.3.tar.bz2 : f2cca3592a433922c0db7a9365fd63e5402c121d932a9327e279c71be6501063
+    - https://feh.finalrewind.org/feh-3.11.4.tar.bz2 : 0f689c8e48b1ca662e0b44af61c020b1f26135aa898dc4ff5928e2f630917cb6
 homepage   : https://feh.finalrewind.org/
 license    : MIT
 component  : multimedia.graphics

--- a/packages/f/feh/pspec_x86_64.xml
+++ b/packages/f/feh/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>feh</Name>
         <Homepage>https://feh.finalrewind.org/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>multimedia.graphics</PartOf>
@@ -44,12 +44,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="52">
-            <Date>2026-02-25</Date>
-            <Version>3.11.3</Version>
+        <Update release="53">
+            <Date>2026-04-04</Date>
+            <Version>3.11.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://feh.finalrewind.org/archive/3.11.4/).
- Fix formatting in man page for groff 1.23.0+
- Do not skip URLs when --sort mtime or similar are used
- Define _GNU_SOURCE macro for mkstemps usage (if enabled)

**Test Plan**

`feh` a picture and look at the picture

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
