### PR TITLE
feishin: Update to v1.10.0

### DIFF
--- a/packages/f/feishin/package.yml
+++ b/packages/f/feishin/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : feishin
-version    : 1.9.0
-release    : 6
+version    : 1.10.0
+release    : 7
 source     :
-    - https://github.com/jeffvli/feishin/archive/refs/tags/v1.9.0.tar.gz : f0707859723642ec992edb78799967d34eac2237d9810866627e7464a213b5ee
+    - https://github.com/jeffvli/feishin/archive/refs/tags/v1.10.0.tar.gz : a73baf91459b8c38deea0617d206dafbd015378f3de75c303efc0f048c45e4cf
 homepage   : https://github.com/jeffvli/feishin
 license    : GPL-3.0-or-later
 component  : multimedia.audio

--- a/packages/f/feishin/pspec_x86_64.xml
+++ b/packages/f/feishin/pspec_x86_64.xml
@@ -137,9 +137,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2026-04-02</Date>
-            <Version>1.9.0</Version>
+        <Update release="7">
+            <Date>2026-04-06</Date>
+            <Version>1.10.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Hans K</Name>
             <Email>hans@communitycomputing.net</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/jeffvli/feishin/releases/tag/v1.10.0).

**Test Plan**
- Build and install Feshin from this PR. 
- See that it still plays music from a Navidrome server.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
