### PR TITLE
solseek: Update to 1.2.5

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 1.2.0
-release    : 26
+version    : 1.2.5
+release    : 27
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v1.2.0.tar.gz : 4889f25cb38a00c0583f9991f8d4a6cc69af3b76aa2d7a1363c27cedd3dbb0ab
+    - https://github.com/clintre/solseek/archive/refs/tags/v1.2.5.tar.gz : 11a64c719b91b3bdffd148da3df8f7d0889cb20fd3ea3305eb272e7c31db0d6c
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -70,9 +70,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2026-04-01</Date>
-            <Version>1.2.0</Version>
+        <Update release="27">
+            <Date>2026-04-06</Date>
+            <Version>1.2.5</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**

Enhancements:
- Changed the eopkg info Python to generate a proper cache file instead of parsing the xml.xz file every time. This reduces CPU load and removes the Python tax, as it is called with normal caching.
- Package info now uses the cache created by the Python script using native awk, which has drastically reduced latency and overhead.
- Changed the boot script to only run through all the checks and setting most vars on the parent script launch. It now sets a session cache for the subscripts to use, reducing overhead.


Full Changelog:
https://github.com/clintre/solseek/releases/tag/v1.2.5


**Test Plan**

Install and test

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
