### PR TITLE
feh: Update to v3.12.1

### DIFF
--- a/packages/f/feh/package.yml
+++ b/packages/f/feh/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : feh
-version    : 3.11.4
-release    : 53
+version    : 3.12.1
+release    : 54
 source     :
-    - https://feh.finalrewind.org/feh-3.11.4.tar.bz2 : 0f689c8e48b1ca662e0b44af61c020b1f26135aa898dc4ff5928e2f630917cb6
+    - https://feh.finalrewind.org/feh-3.12.1.tar.bz2 : 6772f48e7956a16736e4c165a8367f357efc413b895f5b04133366e01438f95d
 homepage   : https://feh.finalrewind.org/
 license    : MIT
 component  : multimedia.graphics

--- a/packages/f/feh/pspec_x86_64.xml
+++ b/packages/f/feh/pspec_x86_64.xml
@@ -44,9 +44,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="53">
-            <Date>2026-04-04</Date>
-            <Version>3.11.4</Version>
+        <Update release="54">
+            <Date>2026-04-07</Date>
+            <Version>3.12.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://feh.finalrewind.org/archive/).

**Test Plan**

`feh example.png` See image. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
