### PR TITLE
libcdio: Update to v2.3.0

### DIFF
--- a/packages/l/libcdio/abi_symbols
+++ b/packages/l/libcdio/abi_symbols
@@ -422,5 +422,6 @@ libudf.so.0:udf_opendir
 libudf.so.0:udf_read_block
 libudf.so.0:udf_read_sectors
 libudf.so.0:udf_readdir
+libudf.so.0:udf_setpos
 libudf.so.0:udf_stamp_to_time
 libudf.so.0:udf_timespec_to_stamp

--- a/packages/l/libcdio/package.yml
+++ b/packages/l/libcdio/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libcdio
-version    : 2.2.0
-release    : 10
+version    : 2.3.0
+release    : 11
 source     :
-    - https://github.com/libcdio/libcdio/releases/download/2.2.0/libcdio-2.2.0.tar.bz2 : 6f8fbdf4d189cf63f2a7a1549c516cd720c7b222c7aaadbc924a26e745a48539
+    - https://github.com/libcdio/libcdio/releases/download/2.3.0/libcdio-2.3.0.tar.bz2 : 53e83d284667535a767fd2d31edad1a6701591960459df373a10f1f21e80a7ed
 homepage   : https://www.gnu.org/software/libcdio/
 license    : GPL-3.0-or-later
 component  : multimedia.library
@@ -19,6 +19,7 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING
 
     # remove the architecture information from version.h
     sed -i -e "s|${version//./\\.}.*$|${version}\\\"|g" $installdir/usr/include/cdio/version.h

--- a/packages/l/libcdio/pspec_x86_64.xml
+++ b/packages/l/libcdio/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libcdio</Name>
         <Homepage>https://www.gnu.org/software/libcdio/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>multimedia.library</PartOf>
@@ -30,7 +30,7 @@
             <Path fileType="library">/usr/lib64/libcdio++.so.1</Path>
             <Path fileType="library">/usr/lib64/libcdio++.so.1.0.0</Path>
             <Path fileType="library">/usr/lib64/libcdio.so.19</Path>
-            <Path fileType="library">/usr/lib64/libcdio.so.19.0.0</Path>
+            <Path fileType="library">/usr/lib64/libcdio.so.19.1.0</Path>
             <Path fileType="library">/usr/lib64/libiso9660++.so.1</Path>
             <Path fileType="library">/usr/lib64/libiso9660++.so.1.0.0</Path>
             <Path fileType="library">/usr/lib64/libiso9660.so.12</Path>
@@ -38,6 +38,7 @@
             <Path fileType="library">/usr/lib64/libudf.so.0</Path>
             <Path fileType="library">/usr/lib64/libudf.so.0.0.0</Path>
             <Path fileType="info">/usr/share/info/libcdio.info.zst</Path>
+            <Path fileType="data">/usr/share/licenses/libcdio/COPYING</Path>
             <Path fileType="man">/usr/share/man/man1/cd-drive.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/cd-info.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/cd-read.1.zst</Path>
@@ -52,7 +53,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">libcdio</Dependency>
+            <Dependency release="11">libcdio</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/cdio++/cdio.hpp</Path>
@@ -111,12 +112,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2025-10-30</Date>
-            <Version>2.2.0</Version>
+        <Update release="11">
+            <Date>2026-04-07</Date>
+            <Version>2.3.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/libcdio/libcdio/releases/tag/2.3.0).

**Security**
Includes fixes for:
- CVE-2024-36600

**Test Plan**

No idea how to test. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
