### PR TITLE
openssl: Update to v3.6.2

### DIFF
--- a/packages/o/openssl/package.yml
+++ b/packages/o/openssl/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : openssl
-version    : 3.6.1
-release    : 57
+version    : 3.6.2
+release    : 58
 source     :
-    - https://github.com/openssl/openssl/releases/download/openssl-3.6.1/openssl-3.6.1.tar.gz : b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e
+    - https://github.com/openssl/openssl/releases/download/openssl-3.6.2/openssl-3.6.2.tar.gz : aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f
 homepage   : https://www.openssl.org/
 license    : OpenSSL
 summary    : Cryptographic tools required by many packages

--- a/packages/o/openssl/pspec_x86_64.xml
+++ b/packages/o/openssl/pspec_x86_64.xml
@@ -415,7 +415,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="57">openssl</Dependency>
+            <Dependency release="58">openssl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/engines-3/afalg.so</Path>
@@ -434,8 +434,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="57">openssl-32bit</Dependency>
-            <Dependency release="57">openssl-devel</Dependency>
+            <Dependency release="58">openssl-32bit</Dependency>
+            <Dependency release="58">openssl-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/cmake/OpenSSL/OpenSSLConfig.cmake</Path>
@@ -456,7 +456,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="57">openssl</Dependency>
+            <Dependency release="58">openssl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/openssl/aes.h</Path>
@@ -5635,6 +5635,8 @@
             <Path fileType="man">/usr/share/man/man3/USERNOTICE_new.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/X509V3_EXT_d2i.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/X509V3_EXT_i2d.3ossl</Path>
+            <Path fileType="man">/usr/share/man/man3/X509V3_EXT_print.3ossl.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/X509V3_EXT_print_fp.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/X509V3_add1_i2d.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/X509V3_get_d2i.3ossl.zst</Path>
             <Path fileType="man">/usr/share/man/man3/X509V3_set_ctx.3ossl.zst</Path>
@@ -6803,9 +6805,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="57">
-            <Date>2026-03-12</Date>
-            <Version>3.6.1</Version>
+        <Update release="58">
+            <Date>2026-04-07</Date>
+            <Version>3.6.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/openssl/openssl/releases/tag/openssl-3.6.2).

**Security**
- CVE-2026-31790
- CVE-2026-2673
- CVE-2026-28386
- CVE-2026-28387
- CVE-2026-28388
- CVE-2026-28389
- CVE-2026-28390
- CVE-2026-31789

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build `wget` against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
