### PR TITLE
bash-completion: Update to v2.17.0

### DIFF
--- a/packages/b/bash-completion/files/0001-Use-a-stateless-configuration.patch
+++ b/packages/b/bash-completion/files/0001-Use-a-stateless-configuration.patch
@@ -26,13 +26,13 @@ index 27366b7..61d864d 100644
  
  pkgconfigdir = $(datadir)/pkgconfig
 diff --git a/bash_completion b/bash_completion
-index 2f47a59..685928d 100644
+index 5aa3dfe6..70b2afac 100644
 --- a/bash_completion
 +++ b/bash_completion
-@@ -3422,14 +3422,14 @@ _comp__init_collect_startup_configs()
-     if [[ ${BASH_COMPLETION_COMPAT_DIR-} ]]; then
+@@ -3561,14 +3561,14 @@ _comp__init_collect_startup_configs()
          compat_dirs+=("$BASH_COMPLETION_COMPAT_DIR")
      else
+         # Keep in sync with Makefile.am install-data-hook
 -        compat_dirs+=(/etc/bash_completion.d)
 +        compat_dirs+=(/usr/share/bash-completion/bash_completion.d)
          # Similarly as for the "completions" dir, look up from relative to
@@ -46,6 +46,3 @@ index 2f47a59..685928d 100644
          else
              compat_dir=$_comp__base_directory/bash_completion.d
          fi
--- 
-2.47.0
-

--- a/packages/b/bash-completion/package.yml
+++ b/packages/b/bash-completion/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : bash-completion
-version    : 2.16.0
-release    : 26
+version    : 2.17.0
+release    : 27
 source     :
-    - https://github.com/scop/bash-completion/archive/refs/tags/2.16.0.tar.gz : c4d7edf0b035d8f6ed33294380326bde1fb8a4a8e24699566d545b4276141cc2
+    - https://github.com/scop/bash-completion/archive/refs/tags/2.17.0.tar.gz : 529374d730caf3c8911438c5d13663fbb6134d01253012fcb865f9d68744d276
 homepage   : https://github.com/scop/bash-completion
 license    : GPL-2.0-or-later
 component  :
@@ -24,5 +24,6 @@ install    : |
     install -dDm00755 $installdir/usr/share/bash-completion/completions
     %make_install
 
+    %install_license COPYING
     # provided by libsecret
     rm -fv $installdir/usr/share/bash-completion/completions/secret-tool

--- a/packages/b/bash-completion/pspec_x86_64.xml
+++ b/packages/b/bash-completion/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>bash-completion</Name>
         <Homepage>https://github.com/scop/bash-completion</Homepage>
         <Packager>
-            <Name>Hans K</Name>
-            <Email>hans@communitycomputing.net</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.base</PartOf>
@@ -48,12 +48,14 @@ of the programmable completion feature of Bash 2.04 and later
             <Path fileType="data">/usr/share/bash-completion/completions/_arduino-cli</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_argc</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_argo</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/_asdf</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_atlas</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_atmos</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_bao</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_bashbot</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_black</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_blackd</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/_bombadil</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_bosh</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_buf</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_caddy</Path>
@@ -93,6 +95,7 @@ of the programmable completion feature of Bash 2.04 and later
             <Path fileType="data">/usr/share/bash-completion/completions/_depot</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_devspace</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_diesel</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/_diffoci</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_dlv</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_dmesg</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_docker</Path>
@@ -117,10 +120,13 @@ of the programmable completion feature of Bash 2.04 and later
             <Path fileType="data">/usr/share/bash-completion/completions/_gitconfig</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_gitleaks</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_gitsign</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/_glab</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/_glances</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_glen</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_glow</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_go-licenses</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_golangci-lint</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/_gomarklint</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_gopass</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_gopherjs</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_goreleaser</Path>
@@ -186,6 +192,7 @@ of the programmable completion feature of Bash 2.04 and later
             <Path fileType="data">/usr/share/bash-completion/completions/_limactl</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_linkerd</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_look</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/_mado</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_mattermost</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_mdbook</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_melange</Path>
@@ -248,7 +255,9 @@ of the programmable completion feature of Bash 2.04 and later
             <Path fileType="data">/usr/share/bash-completion/completions/_runuser</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_rustic</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_rustup</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/_secret-tool</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_sentry-cli</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/_shtab</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_sinker</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_skaffold</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_slackpkg</Path>
@@ -279,9 +288,15 @@ of the programmable completion feature of Bash 2.04 and later
             <Path fileType="data">/usr/share/bash-completion/completions/_timoni</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_tkn</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_tkn-pac</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/_tldr</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_todoist</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_tofu</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_tokio-console</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/_trash</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/_trash-empty</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/_trash-list</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/_trash-put</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/_trash-restore</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_trivy</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_udevadm</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/_umount</Path>
@@ -364,6 +379,8 @@ of the programmable completion feature of Bash 2.04 and later
             <Path fileType="data">/usr/share/bash-completion/completions/bind</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/bk</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/bmake</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/brave</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/brave-browser</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/brctl</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/bsdtar</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/btdownloadcurses.py</Path>
@@ -403,6 +420,7 @@ of the programmable completion feature of Bash 2.04 and later
             <Path fileType="data">/usr/share/bash-completion/completions/civclient</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/civserver</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/cksfv</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/cksum</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/cleanarch</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/clisp</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/clone_member</Path>
@@ -486,12 +504,15 @@ of the programmable completion feature of Bash 2.04 and later
             <Path fileType="data">/usr/share/bash-completion/completions/fprintd-enroll</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/fprintd-list</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/fprintd-verify</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/free</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/freeciv</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/freeciv-gtk2</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/freeciv-gtk3</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/freeciv-sdl</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/freeciv-server</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/freeciv-xaw</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/fsnotifywait</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/fsnotifywatch</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/function</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/fusermount</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/g++</Path>
@@ -753,6 +774,7 @@ of the programmable completion feature of Bash 2.04 and later
             <Path fileType="data">/usr/share/bash-completion/completions/newlist</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/newusers</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/ngrep</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/nload</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/nmap</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/nproc</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/nslookup</Path>
@@ -980,6 +1002,7 @@ of the programmable completion feature of Bash 2.04 and later
             <Path fileType="data">/usr/share/bash-completion/completions/tightvncviewer</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/timeout</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/tipc</Path>
+            <Path fileType="data">/usr/share/bash-completion/completions/tmux</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/tox</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/tracepath</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/tracepath6</Path>
@@ -1069,6 +1092,7 @@ of the programmable completion feature of Bash 2.04 and later
             <Path fileType="data">/usr/share/bash-completion/helpers/perl</Path>
             <Path fileType="data">/usr/share/bash-completion/helpers/python</Path>
             <Path fileType="data">/usr/share/defaults/etc/profile.d/bash_completion.sh</Path>
+            <Path fileType="data">/usr/share/licenses/bash-completion/COPYING</Path>
         </Files>
     </Package>
     <Package>
@@ -1079,7 +1103,7 @@ of the programmable completion feature of Bash 2.04 and later
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="26">bash-completion</Dependency>
+            <Dependency release="27">bash-completion</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/cmake/bash-completion/bash-completion-config-version.cmake</Path>
@@ -1088,12 +1112,12 @@ of the programmable completion feature of Bash 2.04 and later
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2025-08-09</Date>
-            <Version>2.16.0</Version>
+        <Update release="27">
+            <Date>2026-04-07</Date>
+            <Version>2.17.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Hans K</Name>
-            <Email>hans@communitycomputing.net</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- install license
- changelog can be found [here](https://github.com/scop/bash-completion/releases/tag/2.17.0)

**Test Plan**

autocomplete some commands 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
