### PR TITLE
flatpak: Update to v1.16.4

### DIFF
--- a/packages/f/flatpak/abi_libs
+++ b/packages/f/flatpak/abi_libs
@@ -1,1 +1,5 @@
+flatpak
+flatpak-oci-authenticator
+flatpak-portal
+flatpak-system-helper
 libflatpak.so.0

--- a/packages/f/flatpak/abi_symbols
+++ b/packages/f/flatpak/abi_symbols
@@ -1,3 +1,7 @@
+flatpak:_IO_stdin_used
+flatpak-oci-authenticator:_IO_stdin_used
+flatpak-portal:_IO_stdin_used
+flatpak-system-helper:_IO_stdin_used
 libflatpak.so.0:flatpak_bundle_ref_get_appstream
 libflatpak.so.0:flatpak_bundle_ref_get_file
 libflatpak.so.0:flatpak_bundle_ref_get_icon

--- a/packages/f/flatpak/abi_used_symbols
+++ b/packages/f/flatpak/abi_used_symbols
@@ -42,6 +42,7 @@ libc.so.6:__isoc23_sscanf
 libc.so.6:__isoc23_strtol
 libc.so.6:__isoc23_strtoul
 libc.so.6:__libc_start_main
+libc.so.6:__open64_2
 libc.so.6:__openat64_2
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
@@ -125,7 +126,6 @@ libc.so.6:localeconv
 libc.so.6:localtime
 libc.so.6:lseek64
 libc.so.6:lsetxattr
-libc.so.6:lstat64
 libc.so.6:memchr
 libc.so.6:memcmp
 libc.so.6:memcpy
@@ -202,6 +202,7 @@ libc.so.6:strtok_r
 libc.so.6:symlink
 libc.so.6:symlinkat
 libc.so.6:syncfs
+libc.so.6:syscall
 libc.so.6:sysconf
 libc.so.6:tcgetattr
 libc.so.6:tcsetattr
@@ -486,6 +487,7 @@ libglib-2.0.so.0:g_checksum_reset
 libglib-2.0.so.0:g_checksum_update
 libglib-2.0.so.0:g_child_watch_add_full
 libglib-2.0.so.0:g_clear_error
+libglib-2.0.so.0:g_close
 libglib-2.0.so.0:g_compute_checksum_for_bytes
 libglib-2.0.so.0:g_compute_checksum_for_data
 libglib-2.0.so.0:g_cond_clear
@@ -536,6 +538,7 @@ libglib-2.0.so.0:g_find_program_in_path
 libglib-2.0.so.0:g_format_size
 libglib-2.0.so.0:g_format_size_full
 libglib-2.0.so.0:g_free
+libglib-2.0.so.0:g_free_sized
 libglib-2.0.so.0:g_get_application_name
 libglib-2.0.so.0:g_get_current_time
 libglib-2.0.so.0:g_get_environ
@@ -715,9 +718,14 @@ libglib-2.0.so.0:g_ptr_array_unref
 libglib-2.0.so.0:g_quark_from_static_string
 libglib-2.0.so.0:g_quark_to_string
 libglib-2.0.so.0:g_quark_try_string
+libglib-2.0.so.0:g_queue_clear
+libglib-2.0.so.0:g_queue_foreach
 libglib-2.0.so.0:g_queue_free
+libglib-2.0.so.0:g_queue_init
 libglib-2.0.so.0:g_queue_new
+libglib-2.0.so.0:g_queue_peek_tail
 libglib-2.0.so.0:g_queue_pop_head
+libglib-2.0.so.0:g_queue_pop_tail
 libglib-2.0.so.0:g_queue_push_tail
 libglib-2.0.so.0:g_random_int
 libglib-2.0.so.0:g_random_int_range

--- a/packages/f/flatpak/package.yml
+++ b/packages/f/flatpak/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : flatpak
-version    : 1.16.3
-release    : 84
+version    : 1.16.4
+release    : 85
 source     :
-    - https://github.com/flatpak/flatpak/archive/refs/tags/1.16.3.tar.gz : b1f778a392cefc1a936fb7158da046f02348d1866245ad383ba482446d1a3c4a
+    - https://github.com/flatpak/flatpak/archive/refs/tags/1.16.4.tar.gz : 5a00c154d865d518f2c4d5a67194f775fafe2ffac349fdf4f49ca6dbdb5d0cf9
 homepage   : https://flatpak.org/
 license    : LGPL-2.1-or-later
 component  : desktop

--- a/packages/f/flatpak/pspec_x86_64.xml
+++ b/packages/f/flatpak/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>flatpak</Name>
         <Homepage>https://flatpak.org/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>desktop</PartOf>
@@ -39,7 +39,7 @@
             <Path fileType="library">/usr/lib64/flatpak/revokefs-fuse</Path>
             <Path fileType="library">/usr/lib64/girepository-1.0/Flatpak-1.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libflatpak.so.0</Path>
-            <Path fileType="library">/usr/lib64/libflatpak.so.0.11603.0</Path>
+            <Path fileType="library">/usr/lib64/libflatpak.so.0.11604.0</Path>
             <Path fileType="library">/usr/lib64/systemd/system/flatpak-update.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/flatpak-update.timer</Path>
             <Path fileType="library">/usr/lib64/systemd/user/flatpak-update.service</Path>
@@ -155,7 +155,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="84">flatpak</Dependency>
+            <Dependency release="85">flatpak</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/flatpak/flatpak-bundle-ref.h</Path>
@@ -224,12 +224,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="84">
-            <Date>2026-01-24</Date>
-            <Version>1.16.3</Version>
+        <Update release="85">
+            <Date>2026-04-07</Date>
+            <Version>1.16.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- has security fixes
- changelog can be found [here](https://github.com/flatpak/flatpak/releases/tag/1.16.4)

**Security**
- CVE-2026-34078
- CVE-2026-34079
- GHSA-2fxp-43j9-pwvc
- GHSA-89xm-3m96-w3jg

**Test Plan**

Launch flatpak discord

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
