### PR TITLE
plasma-workspace: Remove dependency on vala-panel-appmenu

### DIFF
--- a/packages/p/plasma-workspace/package.yml
+++ b/packages/p/plasma-workspace/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : plasma-workspace
 version    : 6.6.4
-release    : 206
+release    : 207
 source     :
     - https://download.kde.org/stable/plasma/6.6.4/plasma-workspace-6.6.4.tar.xz : c68a70f33b3f638eccccd51f842491cc45abc6f143f5cae4a14b180b94a83ea2
 homepage   : https://www.kde.org/workspaces/plasmadesktop/
@@ -125,7 +125,6 @@ rundeps    :
     - pipewire
     - plasma-keyboard
     - udisks
-    - vala-panel-appmenu
     - xdg-desktop-portal-kde
     - xdg-user-dirs
     - xdg-utils

--- a/packages/p/plasma-workspace/pspec_x86_64.xml
+++ b/packages/p/plasma-workspace/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>plasma-workspace</Name>
         <Homepage>https://www.kde.org/workspaces/plasmadesktop/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <License>BSD-3-Clause</License>
@@ -5644,7 +5644,7 @@
         <Description xml:lang="en">KDE Plasma x11 session (DEPRECATED)</Description>
         <PartOf>desktop.kde</PartOf>
         <RuntimeDependencies>
-            <Dependency release="206">plasma-workspace</Dependency>
+            <Dependency release="207">plasma-workspace</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/startplasma-x11</Path>
@@ -5657,7 +5657,7 @@
         <Description xml:lang="en">This package provides the interface and basic tools for the Plasma workspace.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="206">plasma-workspace</Dependency>
+            <Dependency release="207">plasma-workspace</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/klookandfeel/klookandfeel.h</Path>
@@ -5739,12 +5739,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="206">
-            <Date>2026-04-08</Date>
+        <Update release="207">
+            <Date>2026-04-09</Date>
             <Version>6.6.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
It was added way back when because it was needed to make GTK applications work with a global appmenu on Plasma. Today, it only works on X11, which is no longer available by default, and will soon be removed entirely. Given that, and that relatively few applications support global appmenu anyways, it no longer makes sense for it to be a forced dependency of `plasma-workspace`.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See that `vala-panel-appmenu` is no longer a dependency.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
