### PR TITLE
glow: Update to v2.1.2

### DIFF
--- a/packages/g/glow/MAINTAINERS.md
+++ b/packages/g/glow/MAINTAINERS.md
@@ -1,4 +1,5 @@
 This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
 
-- Selwyn Versteeg
-  - Email: talk@selwyn.cc
+- Jared Cervantes
+  - Matrix: @jaredy89:matrix.org
+  - Email: jared@jaredcervantes.com

--- a/packages/g/glow/abi_used_symbols
+++ b/packages/g/glow/abi_used_symbols
@@ -1,6 +1,7 @@
 libc.so.6:__errno_location
 libc.so.6:__libc_start_main
 libc.so.6:abort
+libc.so.6:clearenv
 libc.so.6:fprintf
 libc.so.6:fputc
 libc.so.6:free

--- a/packages/g/glow/package.yml
+++ b/packages/g/glow/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : glow
-version    : 2.1.1
-release    : 6
+version    : 2.1.2
+release    : 7
 source     :
-    - https://github.com/charmbracelet/glow/archive/refs/tags/v2.1.1.tar.gz : f13e1d6be1ab4baf725a7fedc4cd240fc7e5c7276af2d92f199e590e1ef33967
+    - https://github.com/charmbracelet/glow/archive/refs/tags/v2.1.2.tar.gz : 1b933139da1d08647bf5b3f112cab9548fdc2b40c056c7fa3d84d8706de5265a
 homepage   : https://github.com/charmbracelet/glow
 license    : MIT
 component  : office.notes

--- a/packages/g/glow/pspec_x86_64.xml
+++ b/packages/g/glow/pspec_x86_64.xml
@@ -28,9 +28,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2026-02-25</Date>
-            <Version>2.1.1</Version>
+        <Update release="7">
+            <Date>2026-04-09</Date>
+            <Version>2.1.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/charmbracelet/glow/releases/tag/v2.1.2).
- `showLineNumbers` on config file now works
- Improved `$PAGER`

**Test Plan**

`glow MAINTAINERS.md` See nice `.md` file. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
