### PR TITLE
rio: Update to v0.3.3

### DIFF
--- a/packages/r/rio/package.yml
+++ b/packages/r/rio/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : rio
-version    : 0.3.2
-release    : 5
+version    : 0.3.3
+release    : 6
 source     :
-    - https://github.com/raphamorim/rio/archive/refs/tags/v0.3.2.tar.gz : 21c96402bd171b2b3349cc9ee2c8bf3ef0031b060816f6edffcde2bb8f9cf106
+    - https://github.com/raphamorim/rio/archive/refs/tags/v0.3.3.tar.gz : 6fc453e9e4c21a6da46b461dc8d3bc50bcfcc2c39a7da5c3b9e7c7f18cb51dd6
 homepage   : https://rioterm.com
 license    : MIT
 component  : system.utils

--- a/packages/r/rio/pspec_x86_64.xml
+++ b/packages/r/rio/pspec_x86_64.xml
@@ -31,9 +31,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2026-04-09</Date>
-            <Version>0.3.2</Version>
+        <Update release="6">
+            <Date>2026-04-10</Date>
+            <Version>0.3.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/raphamorim/rio/blob/main/docs/src/pages/changelog.mdx). 
- CPU rendering support by `renderer.use-cpu`

**Test Plan**

Push this commit with `rio`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
