### PR TITLE
glibc: Update to 2.43+git.ce1013a1

### DIFF
--- a/packages/g/glibc/package.yml
+++ b/packages/g/glibc/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : glibc
 version    : '2.43'
-release    : 138
+release    : 139
 source     :
     # release/2.43/master
-    - git|https://sourceware.org/git/glibc.git : 305ce0b58809869295e62c3caa7eda4c8e41134f
+    - git|https://sourceware.org/git/glibc.git : ce1013a197eb4a3b8ff2b07e0672f4d0b976ce7c
 homepage   : https://www.gnu.org/software/libc/
 license    :
     - GPL-2.0-or-later

--- a/packages/g/glibc/pspec_x86_64.xml
+++ b/packages/g/glibc/pspec_x86_64.xml
@@ -7020,7 +7020,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="138">glibc</Dependency>
+            <Dependency release="139">glibc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib32/ld-linux.so.2</Path>
@@ -7321,8 +7321,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="138">glibc-devel</Dependency>
-            <Dependency release="138">glibc-32bit</Dependency>
+            <Dependency release="139">glibc-devel</Dependency>
+            <Dependency release="139">glibc-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/Mcrt1.o</Path>
@@ -7856,7 +7856,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="138">glibc</Dependency>
+            <Dependency release="139">glibc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/mtrace</Path>
@@ -8376,8 +8376,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="138">
-            <Date>2026-03-12</Date>
+        <Update release="139">
+            <Date>2026-04-10</Date>
             <Version>2.43</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
- resolv: Count records correctly
- resolv: Check hostname for validity
- elf: parse /proc/self/maps as the last resort
- elf: Use dl-symbol-redir-ifunc.h instead _dl_strlen

**Security**
- CVE-2026-4437
- CVE-2026-4438

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build Budgie Desktop with this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
