### PR TITLE
appstream-catalog: Update to latest catalog

### DIFF
--- a/packages/a/appstream-catalog/package.yml
+++ b/packages/a/appstream-catalog/package.yml
@@ -1,14 +1,14 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : appstream-catalog
-version    : '20260403'
-release    : 50
+version    : '20260410'
+release    : 51
 source     :
-    - https://appstream.getsol.us/data/unstable/main/Components-x86_64.xml.gz: f86aeeeb5c3a7293d246884a54ecde482664b09c19b35ac235007121d285dd5e
-    - https://appstream.getsol.us/data/unstable/main/icons-128x128.tar.gz: 033f3377a35948b79824fa3e98beaeefc4649efd6d2cc694668dd81828c13076
+    - https://appstream.getsol.us/data/unstable/main/Components-x86_64.xml.gz: a602c27852e03a20c890e52a33abdfc7a51b29ea4727d3073022d7b9b843f82e
+    - https://appstream.getsol.us/data/unstable/main/icons-128x128.tar.gz: 5eab996ca13ed4c8b71ad24997e08f6f777fc4149b3585ee9d5a3bc9cee458ee
     - https://appstream.getsol.us/data/unstable/main/icons-128x128@2.tar.gz: cfebee1f9d89d02082aa64b907ab5c4614dc92cc7d2f739d620cc61f4846b972
-    - https://appstream.getsol.us/data/unstable/main/icons-48x48.tar.gz: 5dce926c39a167783c34b45cb3e2ec9093050afc448302b1d385baf4e491d3fd
+    - https://appstream.getsol.us/data/unstable/main/icons-48x48.tar.gz: 9cf4392730c5e314af4e966729804e9b30cd01f72b1777c8cca5c1b03c63b336
     - https://appstream.getsol.us/data/unstable/main/icons-48x48@2.tar.gz: 88769127dc2ae40511ed9a8146beae536e1a39de83bcee6884acf208eda1b1ba
-    - https://appstream.getsol.us/data/unstable/main/icons-64x64.tar.gz: 1000be31272e087d4c39f6777e0e861e13db9d9b312a912a42307d56d157f36a
+    - https://appstream.getsol.us/data/unstable/main/icons-64x64.tar.gz: 0043edb187851c003d9ef937234655630766edaea5559d1141541c1266706362
     - https://appstream.getsol.us/data/unstable/main/icons-64x64@2.tar.gz: 9868435523e7213959a80ca21243ad07939100f05af92a94f11938951cfabe1a
 homepage   : https://www.freedesktop.org/wiki/Distributions/AppStream/
 license    :

--- a/packages/a/appstream-catalog/pspec_x86_64.xml
+++ b/packages/a/appstream-catalog/pspec_x86_64.xml
@@ -658,6 +658,7 @@
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/surfer_com.gitlab.surferproject.surfer.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/syncthing-gtk_syncthing-gtk.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/syncthing_syncthing.png</Path>
+            <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/syncthingtray_syncthingtray.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/synfigstudio_org.synfig.SynfigStudio.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/sysprof_org.gnome.Sysprof.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/128x128/system-config-printer_printer.png</Path>
@@ -1437,6 +1438,7 @@
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/supertuxkart_supertuxkart.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/syncthing-gtk_syncthing-gtk.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/syncthing_syncthing.png</Path>
+            <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/syncthingtray_syncthingtray.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/synfigstudio_org.synfig.SynfigStudio.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/sysprof_org.gnome.Sysprof.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/48x48/system-config-printer_printer.png</Path>
@@ -2303,6 +2305,7 @@
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/surfer_com.gitlab.surferproject.surfer.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/syncthing-gtk_syncthing-gtk.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/syncthing_syncthing.png</Path>
+            <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/syncthingtray_syncthingtray.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/synfigstudio_org.synfig.SynfigStudio.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/sysprof_org.gnome.Sysprof.png</Path>
             <Path fileType="data">/usr/share/swcatalog/icons/solus-unstable-main/64x64/system-config-printer_printer.png</Path>
@@ -2475,9 +2478,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="50">
-            <Date>2026-04-03</Date>
-            <Version>20260403</Version>
+        <Update release="51">
+            <Date>2026-04-10</Date>
+            <Version>20260410</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**

Update Appstream Catalog

**Test Plan**

See that syncthingtray and the associated Dolphin plugin and Plasmoid are available in Discover.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
