### PR TITLE
flatpak: Update to v1.16.6

### DIFF
--- a/packages/f/flatpak/package.yml
+++ b/packages/f/flatpak/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : flatpak
-version    : 1.16.5
-release    : 86
+version    : 1.16.6
+release    : 87
 source     :
-    - https://github.com/flatpak/flatpak/releases/download/1.16.5/flatpak-1.16.5.tar.xz : a320e9581649766c264a97304b1563c3d04d87dcc1115427860b658083cbc156
+    - https://github.com/flatpak/flatpak/releases/download/1.16.6/flatpak-1.16.6.tar.xz : 1e63e7f3fe44b602f34d92a6fe46fd8a3bc6be9460c03c2681e57976c658eec3
 homepage   : https://flatpak.org/
 license    : LGPL-2.1-or-later
 component  : desktop

--- a/packages/f/flatpak/pspec_x86_64.xml
+++ b/packages/f/flatpak/pspec_x86_64.xml
@@ -39,7 +39,7 @@
             <Path fileType="library">/usr/lib64/flatpak/revokefs-fuse</Path>
             <Path fileType="library">/usr/lib64/girepository-1.0/Flatpak-1.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libflatpak.so.0</Path>
-            <Path fileType="library">/usr/lib64/libflatpak.so.0.11605.0</Path>
+            <Path fileType="library">/usr/lib64/libflatpak.so.0.11606.0</Path>
             <Path fileType="library">/usr/lib64/systemd/system/flatpak-update.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/flatpak-update.timer</Path>
             <Path fileType="library">/usr/lib64/systemd/user/flatpak-update.service</Path>
@@ -155,7 +155,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="86">flatpak</Dependency>
+            <Dependency release="87">flatpak</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/flatpak/flatpak-bundle-ref.h</Path>
@@ -224,9 +224,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="86">
-            <Date>2026-04-09</Date>
-            <Version>1.16.5</Version>
+        <Update release="87">
+            <Date>2026-04-10</Date>
+            <Version>1.16.6</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/flatpak/flatpak/releases/tag/1.16.6).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run `flatpak update`, open Chrome flatpak, navigate to a website and see that it displays correctly.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
