### PR TITLE
python-aiohttp: Update to v3.13.5

### DIFF
--- a/packages/py/python-aiohttp/abi_used_symbols
+++ b/packages/py/python-aiohttp/abi_used_symbols
@@ -151,6 +151,7 @@ UNKNOWN:PyObject_Vectorcall
 UNKNOWN:PyObject_VectorcallDict
 UNKNOWN:PyObject_VectorcallMethod
 UNKNOWN:PySequence_Contains
+UNKNOWN:PySequence_GetSlice
 UNKNOWN:PySet_Add
 UNKNOWN:PySet_Contains
 UNKNOWN:PySet_New
@@ -171,6 +172,7 @@ UNKNOWN:PyType_Modified
 UNKNOWN:PyType_Ready
 UNKNOWN:PyType_Type
 UNKNOWN:PyUnicode_Concat
+UNKNOWN:PyUnicode_Contains
 UNKNOWN:PyUnicode_Decode
 UNKNOWN:PyUnicode_DecodeASCII
 UNKNOWN:PyUnicode_DecodeLatin1

--- a/packages/py/python-aiohttp/package.yml
+++ b/packages/py/python-aiohttp/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-aiohttp
-version    : 3.13.3
-release    : 23
+version    : 3.13.5
+release    : 24
 source     :
-    - https://files.pythonhosted.org/packages/source/a/aiohttp/aiohttp-3.13.3.tar.gz : a949eee43d3782f2daae4f4a2819b2cb9b0c5d3b7f7a927067cc84dafdbb9f88
+    - https://files.pythonhosted.org/packages/source/a/aiohttp/aiohttp-3.13.5.tar.gz : 9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1
 homepage   : https://docs.aiohttp.org/
 license    : Apache-2.0
 component  : programming.python

--- a/packages/py/python-aiohttp/pspec_x86_64.xml
+++ b/packages/py/python-aiohttp/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-aiohttp</Name>
         <Homepage>https://docs.aiohttp.org/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -20,12 +20,12 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.3.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.3.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.3.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.3.dist-info/licenses/LICENSE.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.3.dist-info/licenses/vendor/llhttp/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.3.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.5.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.5.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.5.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.5.dist-info/licenses/LICENSE.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.5.dist-info/licenses/vendor/llhttp/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp-3.13.5.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp/.hash/_cparser.pxd.hash</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp/.hash/_find_header.pxd.hash</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/aiohttp/.hash/_http_parser.pyx.hash</Path>
@@ -215,12 +215,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2026-01-05</Date>
-            <Version>3.13.3</Version>
+        <Update release="24">
+            <Date>2026-04-10</Date>
+            <Version>3.13.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/aio-libs/aiohttp/releases).
- Resolves: #8510 

**Security**
Includes fixes for:
- CVE-2026-22815

**Test Plan**

`python3 -c "import aiohttp; print(aiohttp.__version__)"`, Also did an outbound HTTPS GET (an HTTP client request) via aiohttp

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
