### PR TITLE
xdg-dbus-proxy: Update to v0.1.7

### DIFF
--- a/packages/x/xdg-dbus-proxy/abi_used_symbols
+++ b/packages/x/xdg-dbus-proxy/abi_used_symbols
@@ -71,6 +71,7 @@ libglib-2.0.so.0:g_direct_hash
 libglib-2.0.so.0:g_error_free
 libglib-2.0.so.0:g_error_matches
 libglib-2.0.so.0:g_free
+libglib-2.0.so.0:g_free_sized
 libglib-2.0.so.0:g_hash_table_destroy
 libglib-2.0.so.0:g_hash_table_insert
 libglib-2.0.so.0:g_hash_table_iter_init

--- a/packages/x/xdg-dbus-proxy/package.yml
+++ b/packages/x/xdg-dbus-proxy/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : xdg-dbus-proxy
-version    : 0.1.6
-release    : 6
+version    : 0.1.7
+release    : 7
 source     :
-    - https://github.com/flatpak/xdg-dbus-proxy/releases/download/0.1.6/xdg-dbus-proxy-0.1.6.tar.xz : 131bf59fce7c7ee7ecbc5d9106d6750f4f597bfe609966573240f7e4952973a1
+    - https://github.com/flatpak/xdg-dbus-proxy/releases/download/0.1.7/xdg-dbus-proxy-0.1.7.tar.xz : 3ad3d27ba574e178acb5e4d438ba36ace25e3564f899c36f31c56f82c7adbbe7
 license    : LGPL-2.1-or-later
 component  : security
 homepage   : https://github.com/flatpak/xdg-dbus-proxy
@@ -18,3 +18,6 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING
+check      : |
+    %ninja_check

--- a/packages/x/xdg-dbus-proxy/pspec_x86_64.xml
+++ b/packages/x/xdg-dbus-proxy/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xdg-dbus-proxy</Name>
         <Homepage>https://github.com/flatpak/xdg-dbus-proxy</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>security</PartOf>
@@ -21,16 +21,17 @@
         <PartOf>security</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/xdg-dbus-proxy</Path>
-            <Path fileType="man">/usr/share/man/man1/xdg-dbus-proxy.1</Path>
+            <Path fileType="data">/usr/share/licenses/xdg-dbus-proxy/COPYING</Path>
+            <Path fileType="man">/usr/share/man/man1/xdg-dbus-proxy.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2024-12-19</Date>
-            <Version>0.1.6</Version>
+        <Update release="7">
+            <Date>2026-04-10</Date>
+            <Version>0.1.7</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/flatpak/xdg-dbus-proxy/releases/tag/0.1.7).

**Security**
- GHSA-vjp5-hjfm-7677

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See test pass.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
