### PR TITLE
font-roboto-ttf: Update to 3.015

### DIFF
--- a/packages/f/font-roboto-ttf/files/LICENSE.txt
+++ b/packages/f/font-roboto-ttf/files/LICENSE.txt
@@ -1,0 +1,93 @@
+Copyright 2011 The Roboto Project Authors (https://github.com/googlefonts/roboto-classic)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/packages/f/font-roboto-ttf/package.yml
+++ b/packages/f/font-roboto-ttf/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : font-roboto-ttf
-version    : '3.008'
-release    : 7
+version    : '3.015'
+release    : 8
 source     :
-    - https://github.com/googlefonts/roboto-classic/releases/download/v3.008/Roboto_v3.008.zip : 64c51d5d69c36c9a71dca214cd80b699e637a57d1c19744ef46a23f91347bd24
+    - https://github.com/googlefonts/roboto-classic/releases/download/v3.015/Roboto_v3.015.zip : bee3e9334ea86dd63e184598f31fb16750881c2da1a6f097a66e0f66a95b3d54
 homepage   : https://fonts.google.com/specimen/Roboto
 license    : OFL-1.1
 component  : desktop.font
@@ -13,4 +13,4 @@ description: |
 install    : |
     install -Dm00644 hinted/static/*.ttf -t $installdir/usr/share/fonts/truetype/roboto
     install -Dm00644 $pkgfiles/roboto.metainfo.xml $installdir/usr/share/metainfo/roboto.metainfo.xml
-    %install_license LICENSE.txt
+    %install_license $pkgfiles/LICENSE.txt

--- a/packages/f/font-roboto-ttf/pspec_x86_64.xml
+++ b/packages/f/font-roboto-ttf/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>font-roboto-ttf</Name>
         <Homepage>https://fonts.google.com/specimen/Roboto</Homepage>
         <Packager>
-            <Name>clintre</Name>
-            <Email>clint@eschberger.info</Email>
+            <Name>George K.</Name>
+            <Email>gk_coder@icloud.com</Email>
         </Packager>
         <License>OFL-1.1</License>
         <PartOf>desktop.font</PartOf>
@@ -45,12 +45,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2026-02-01</Date>
-            <Version>3.008</Version>
+        <Update release="8">
+            <Date>2026-04-11</Date>
+            <Version>3.015</Version>
             <Comment>Packaging update</Comment>
-            <Name>clintre</Name>
-            <Email>clint@eschberger.info</Email>
+            <Name>George K.</Name>
+            <Email>gk_coder@icloud.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Enhancements:
- new Unicode symbols
- add blackCircle, whiteCircle, blackSquare glyphs

Full changelog:
- [3.015](https://github.com/googlefonts/roboto-3-classic/releases/tag/v3.015)
- [3.014](https://github.com/googlefonts/roboto-3-classic/releases/tag/v3.014)
- [3.013](https://github.com/googlefonts/roboto-3-classic/releases/tag/v3.013)
- [3.012](https://github.com/googlefonts/roboto-3-classic/releases/tag/v3.012)
- [3.011](https://github.com/googlefonts/roboto-3-classic/releases/tag/v3.011)
- [3.010](https://github.com/googlefonts/roboto-3-classic/releases/tag/v3.010)

**Test Plan**

- apply Roboto font via Budgie Desktop Settings
- write a document in LibreOffice Writer using Roboto with Unicode symbols

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
