### PR TITLE
calamares: Show autologin option during user creation

### DIFF
--- a/packages/c/calamares/files/install/modules/users.conf
+++ b/packages/c/calamares/files/install/modules/users.conf
@@ -19,6 +19,8 @@ defaultGroups:
       must_exist: true
       system: true
 
+displayAutoLogin: true
+
 doAutoLogin: false
 
 setRootPassword: false

--- a/packages/c/calamares/package.yml
+++ b/packages/c/calamares/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : calamares
 version    : 3.4.2
-release    : 48
+release    : 49
 source     :
     - https://codeberg.org/Calamares/calamares/releases/download/v3.4.2/calamares-3.4.2.tar.gz : 733bbbb00dc9f84874bd5c22960952f317ea2537565431179fa2152b2fbfdccc
 homepage   : https://calamares.io

--- a/packages/c/calamares/pspec_x86_64.xml
+++ b/packages/c/calamares/pspec_x86_64.xml
@@ -304,7 +304,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="48">calamares</Dependency>
+            <Dependency release="49">calamares</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libcalamares/Branding.h</Path>
@@ -423,8 +423,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="48">
-            <Date>2026-03-29</Date>
+        <Update release="49">
+            <Date>2026-04-11</Date>
             <Version>3.4.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**

Upstream changed the default, and didn't mention it in the changelog, so this got missed earlier.

**Test Plan**

Will be tested by automated testing.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
