### PR TITLE
network-manager: Update to v1.56.0

### DIFF
--- a/packages/n/network-manager/abi_symbols
+++ b/packages/n/network-manager/abi_symbols
@@ -323,6 +323,7 @@ NetworkManager:nm_setting_get_secret_flags
 NetworkManager:nm_setting_gsm_get_apn
 NetworkManager:nm_setting_gsm_get_auto_config
 NetworkManager:nm_setting_gsm_get_device_id
+NetworkManager:nm_setting_gsm_get_device_uid
 NetworkManager:nm_setting_gsm_get_home_only
 NetworkManager:nm_setting_gsm_get_initial_eps_apn
 NetworkManager:nm_setting_gsm_get_initial_eps_config
@@ -633,9 +634,11 @@ libnm.so.0:libnm_1_4_0
 libnm.so.0:libnm_1_50_0
 libnm.so.0:libnm_1_50_4
 libnm.so.0:libnm_1_52_0
+libnm.so.0:libnm_1_52_2
 libnm.so.0:libnm_1_54_0
 libnm.so.0:libnm_1_54_2
 libnm.so.0:libnm_1_54_3
+libnm.so.0:libnm_1_56_0
 libnm.so.0:libnm_1_6_0
 libnm.so.0:libnm_1_8_0
 libnm.so.0:nm_802_11_ap_flags_get_type
@@ -1124,6 +1127,7 @@ libnm.so.0:nm_dns_entry_get_priority
 libnm.so.0:nm_dns_entry_get_type
 libnm.so.0:nm_dns_entry_get_vpn
 libnm.so.0:nm_dns_entry_unref
+libnm.so.0:nm_dns_server_validate
 libnm.so.0:nm_ethtool_optname_is_channels
 libnm.so.0:nm_ethtool_optname_is_coalesce
 libnm.so.0:nm_ethtool_optname_is_eee
@@ -1496,6 +1500,7 @@ libnm.so.0:nm_setting_connection_add_secondary
 libnm.so.0:nm_setting_connection_autoconnect_slaves_get_type
 libnm.so.0:nm_setting_connection_clear_ip_ping_addresses
 libnm.so.0:nm_setting_connection_dns_over_tls_get_type
+libnm.so.0:nm_setting_connection_dnssec_get_type
 libnm.so.0:nm_setting_connection_down_on_poweroff_get_type
 libnm.so.0:nm_setting_connection_get_auth_retries
 libnm.so.0:nm_setting_connection_get_autoconnect
@@ -1506,6 +1511,7 @@ libnm.so.0:nm_setting_connection_get_autoconnect_slaves
 libnm.so.0:nm_setting_connection_get_connection_type
 libnm.so.0:nm_setting_connection_get_controller
 libnm.so.0:nm_setting_connection_get_dns_over_tls
+libnm.so.0:nm_setting_connection_get_dnssec
 libnm.so.0:nm_setting_connection_get_down_on_poweroff
 libnm.so.0:nm_setting_connection_get_gateway_ping_timeout
 libnm.so.0:nm_setting_connection_get_id
@@ -1595,6 +1601,7 @@ libnm.so.0:nm_setting_get_type
 libnm.so.0:nm_setting_gsm_get_apn
 libnm.so.0:nm_setting_gsm_get_auto_config
 libnm.so.0:nm_setting_gsm_get_device_id
+libnm.so.0:nm_setting_gsm_get_device_uid
 libnm.so.0:nm_setting_gsm_get_home_only
 libnm.so.0:nm_setting_gsm_get_initial_eps_apn
 libnm.so.0:nm_setting_gsm_get_initial_eps_config

--- a/packages/n/network-manager/abi_symbols32
+++ b/packages/n/network-manager/abi_symbols32
@@ -42,9 +42,11 @@ libnm.so.0:libnm_1_4_0
 libnm.so.0:libnm_1_50_0
 libnm.so.0:libnm_1_50_4
 libnm.so.0:libnm_1_52_0
+libnm.so.0:libnm_1_52_2
 libnm.so.0:libnm_1_54_0
 libnm.so.0:libnm_1_54_2
 libnm.so.0:libnm_1_54_3
+libnm.so.0:libnm_1_56_0
 libnm.so.0:libnm_1_6_0
 libnm.so.0:libnm_1_8_0
 libnm.so.0:nm_802_11_ap_flags_get_type
@@ -533,6 +535,7 @@ libnm.so.0:nm_dns_entry_get_priority
 libnm.so.0:nm_dns_entry_get_type
 libnm.so.0:nm_dns_entry_get_vpn
 libnm.so.0:nm_dns_entry_unref
+libnm.so.0:nm_dns_server_validate
 libnm.so.0:nm_ethtool_optname_is_channels
 libnm.so.0:nm_ethtool_optname_is_coalesce
 libnm.so.0:nm_ethtool_optname_is_eee
@@ -905,6 +908,7 @@ libnm.so.0:nm_setting_connection_add_secondary
 libnm.so.0:nm_setting_connection_autoconnect_slaves_get_type
 libnm.so.0:nm_setting_connection_clear_ip_ping_addresses
 libnm.so.0:nm_setting_connection_dns_over_tls_get_type
+libnm.so.0:nm_setting_connection_dnssec_get_type
 libnm.so.0:nm_setting_connection_down_on_poweroff_get_type
 libnm.so.0:nm_setting_connection_get_auth_retries
 libnm.so.0:nm_setting_connection_get_autoconnect
@@ -915,6 +919,7 @@ libnm.so.0:nm_setting_connection_get_autoconnect_slaves
 libnm.so.0:nm_setting_connection_get_connection_type
 libnm.so.0:nm_setting_connection_get_controller
 libnm.so.0:nm_setting_connection_get_dns_over_tls
+libnm.so.0:nm_setting_connection_get_dnssec
 libnm.so.0:nm_setting_connection_get_down_on_poweroff
 libnm.so.0:nm_setting_connection_get_gateway_ping_timeout
 libnm.so.0:nm_setting_connection_get_id
@@ -1004,6 +1009,7 @@ libnm.so.0:nm_setting_get_type
 libnm.so.0:nm_setting_gsm_get_apn
 libnm.so.0:nm_setting_gsm_get_auto_config
 libnm.so.0:nm_setting_gsm_get_device_id
+libnm.so.0:nm_setting_gsm_get_device_uid
 libnm.so.0:nm_setting_gsm_get_home_only
 libnm.so.0:nm_setting_gsm_get_initial_eps_apn
 libnm.so.0:nm_setting_gsm_get_initial_eps_config

--- a/packages/n/network-manager/abi_used_symbols
+++ b/packages/n/network-manager/abi_used_symbols
@@ -152,6 +152,7 @@ libc.so.6:memset
 libc.so.6:mkdir
 libc.so.6:mkdirat
 libc.so.6:mkstemp64
+libc.so.6:name_to_handle_at
 libc.so.6:nl_langinfo
 libc.so.6:open64
 libc.so.6:openat64
@@ -767,6 +768,7 @@ libglib-2.0.so.0:g_strndup
 libglib-2.0.so.0:g_strnfill
 libglib-2.0.so.0:g_strrstr
 libglib-2.0.so.0:g_strsplit
+libglib-2.0.so.0:g_strsplit_set
 libglib-2.0.so.0:g_strv_contains
 libglib-2.0.so.0:g_strv_length
 libglib-2.0.so.0:g_test_config_vars
@@ -1101,6 +1103,7 @@ libmm-glib.so.0:mm_modem_disable_finish
 libmm-glib.so.0:mm_modem_enable
 libmm-glib.so.0:mm_modem_enable_finish
 libmm-glib.so.0:mm_modem_get_current_capabilities
+libmm-glib.so.0:mm_modem_get_device
 libmm-glib.so.0:mm_modem_get_device_identifier
 libmm-glib.so.0:mm_modem_get_drivers
 libmm-glib.so.0:mm_modem_get_primary_port

--- a/packages/n/network-manager/abi_used_symbols32
+++ b/packages/n/network-manager/abi_used_symbols32
@@ -355,6 +355,7 @@ libglib-2.0.so.0:g_strlcat
 libglib-2.0.so.0:g_strlcpy
 libglib-2.0.so.0:g_strndup
 libglib-2.0.so.0:g_strsplit
+libglib-2.0.so.0:g_strsplit_set
 libglib-2.0.so.0:g_strv_contains
 libglib-2.0.so.0:g_strv_length
 libglib-2.0.so.0:g_timeout_add_seconds

--- a/packages/n/network-manager/package.yml
+++ b/packages/n/network-manager/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : network-manager
-version    : 1.54.3
-release    : 91
+version    : 1.56.0
+release    : 92
 source     :
-    - https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/archive/1.54.3/NetworkManager-1.54.3.tar.bz2 : e38d55611af8127e1a2b1a7b4952bded1f61917cbc49d4ee7a272ec3fcd7b51b
+    - https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/archive/1.56.0/NetworkManager-1.56.0.tar.bz2 : 589281aed255b5872c0899240bb0ded1883cd7221aa5b54d42a90dffcb57fdec
 homepage   : https://gitlab.freedesktop.org/NetworkManager/NetworkManager
 license    :
     - GFDL-1.1-or-later
@@ -66,25 +66,25 @@ builddeps  :
     - python-gobject-devel
     - vala
 rundeps    :
-    - iptables
-    - mobile-broadband-provider-info
-    - ppp
-    - usb-modeswitch
-    - wireless-tools
-    - wpa_supplicant
     - bluetooth :
         - bluez
         - network-manager
+    - iptables
     - iwd :
         - iwd
         - network-manager
-    - libnm-devel :
-        - network-manager-libnm
     - libnm-32bit :
         - network-manager-libnm
     - libnm-32bit-devel :
         - network-manager-libnm-32bit
         - network-manager-libnm-devel
+    - libnm-devel :
+        - network-manager-libnm
+    - mobile-broadband-provider-info
+    - ppp
+    - usb-modeswitch
+    - wireless-tools
+    - wpa_supplicant
 emul32     : true
 environment: |
     unset LD_AS_NEEDED
@@ -108,6 +108,7 @@ setup      : |
         -Diptables=/usr/sbin/iptables \
         -Diwd=true \
         -Dlibaudit=no \
+        -Dman=${_IS_64BIT_BOOL} \
         -Dmodem_manager=${_IS_64BIT_BOOL} \
         -Dmodify_system=true \
         -Dnft=/usr/sbin/nft \

--- a/packages/n/network-manager/pspec_x86_64.xml
+++ b/packages/n/network-manager/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>network-manager</Name>
         <Homepage>https://gitlab.freedesktop.org/NetworkManager/NetworkManager</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Packager>
         <License>GFDL-1.1-or-later</License>
         <License>GPL-2.0-or-later</License>
@@ -20,7 +20,7 @@
         <Description xml:lang="en">NetworkManager attempts to keep an active network connection available at all times. The point of NetworkManager is to make networking configuration and setup as painless and automatic as possible. NetworkManager is intended to replace default route, replace other routes, set IP addresses, and in general configure networking as NM sees fit (with the possibility of manual override as necessary). In effect, the goal of NetworkManager is to make networking Just Work with a minimum of user hassle, but still allow customization and a high level of manual network control.</Description>
         <PartOf>network.base</PartOf>
         <RuntimeDependencies>
-            <Dependency release="91">network-manager-libnm</Dependency>
+            <Dependency release="92">network-manager-libnm</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/nm-online</Path>
@@ -36,12 +36,12 @@
             <Path fileType="library">/usr/lib/udev/rules.d/84-nm-drivers.rules</Path>
             <Path fileType="library">/usr/lib/udev/rules.d/85-nm-unmanaged.rules</Path>
             <Path fileType="library">/usr/lib/udev/rules.d/90-nm-thunderbolt.rules</Path>
-            <Path fileType="library">/usr/lib64/NetworkManager/1.54.3-solus/libnm-device-plugin-adsl.so</Path>
-            <Path fileType="library">/usr/lib64/NetworkManager/1.54.3-solus/libnm-device-plugin-ovs.so</Path>
-            <Path fileType="library">/usr/lib64/NetworkManager/1.54.3-solus/libnm-device-plugin-wifi.so</Path>
-            <Path fileType="library">/usr/lib64/NetworkManager/1.54.3-solus/libnm-device-plugin-wwan.so</Path>
-            <Path fileType="library">/usr/lib64/NetworkManager/1.54.3-solus/libnm-ppp-plugin.so</Path>
-            <Path fileType="library">/usr/lib64/NetworkManager/1.54.3-solus/libnm-wwan.so</Path>
+            <Path fileType="library">/usr/lib64/NetworkManager/1.56.0-solus/libnm-device-plugin-adsl.so</Path>
+            <Path fileType="library">/usr/lib64/NetworkManager/1.56.0-solus/libnm-device-plugin-ovs.so</Path>
+            <Path fileType="library">/usr/lib64/NetworkManager/1.56.0-solus/libnm-device-plugin-wifi.so</Path>
+            <Path fileType="library">/usr/lib64/NetworkManager/1.56.0-solus/libnm-device-plugin-wwan.so</Path>
+            <Path fileType="library">/usr/lib64/NetworkManager/1.56.0-solus/libnm-ppp-plugin.so</Path>
+            <Path fileType="library">/usr/lib64/NetworkManager/1.56.0-solus/libnm-wwan.so</Path>
             <Path fileType="library">/usr/lib64/network-manager/nm-daemon-helper</Path>
             <Path fileType="library">/usr/lib64/network-manager/nm-dhcp-helper</Path>
             <Path fileType="library">/usr/lib64/network-manager/nm-dispatcher</Path>
@@ -160,10 +160,10 @@
         <Description xml:lang="en">Bluetooth device plugin for NetworkManager</Description>
         <PartOf>network.base</PartOf>
         <RuntimeDependencies>
-            <Dependency release="91">network-manager</Dependency>
+            <Dependency release="92">network-manager</Dependency>
         </RuntimeDependencies>
         <Files>
-            <Path fileType="library">/usr/lib64/NetworkManager/1.54.3-solus/libnm-device-plugin-bluetooth.so</Path>
+            <Path fileType="library">/usr/lib64/NetworkManager/1.56.0-solus/libnm-device-plugin-bluetooth.so</Path>
         </Files>
     </Package>
     <Package>
@@ -483,7 +483,7 @@
         <Description xml:lang="en">Installing this will switch to using iwd as the wifi backend in place of wpa_supplicant</Description>
         <PartOf>network.base</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="91">network-manager</Dependency>
+            <Dependency releaseFrom="92">network-manager</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib/NetworkManager/conf.d/10-iwd-wifi-backend.conf</Path>
@@ -506,7 +506,7 @@
         <Description xml:lang="en">32-bit libraries for NetworkManager</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="91">network-manager-libnm</Dependency>
+            <Dependency releaseFrom="92">network-manager-libnm</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnm.so.0</Path>
@@ -522,8 +522,8 @@
         <Description xml:lang="en">Development files for network-manager-libnm-32bit</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="91">network-manager-libnm-32bit</Dependency>
-            <Dependency releaseFrom="91">network-manager-libnm-devel</Dependency>
+            <Dependency releaseFrom="92">network-manager-libnm-32bit</Dependency>
+            <Dependency releaseFrom="92">network-manager-libnm-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libnm.so</Path>
@@ -539,7 +539,7 @@
         <Description xml:lang="en">Development files for network-manager-libnm</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="91">network-manager-libnm</Dependency>
+            <Dependency releaseFrom="92">network-manager-libnm</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libnm/NetworkManager.h</Path>
@@ -742,7 +742,7 @@
         <Description xml:lang="en">NetworkManager curses-based UI</Description>
         <PartOf>network.util</PartOf>
         <RuntimeDependencies>
-            <Dependency release="91">network-manager-libnm</Dependency>
+            <Dependency release="92">network-manager-libnm</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/nmtui</Path>
@@ -756,12 +756,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="91">
-            <Date>2026-03-14</Date>
-            <Version>1.54.3</Version>
+        <Update release="92">
+            <Date>2026-04-11</Date>
+            <Version>1.56.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- changelog can be found [here](https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/releases/1.56.0/downloads/NEWS)

**Test Plan**

Install and connect to internet

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
