### PR TITLE
solseek: Update to 1.2.8

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 1.2.5
-release    : 27
+version    : 1.2.8
+release    : 28
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v1.2.5.tar.gz : 11a64c719b91b3bdffd148da3df8f7d0889cb20fd3ea3305eb272e7c31db0d6c
+    - https://github.com/clintre/solseek/archive/refs/tags/v1.2.8.tar.gz : cd7d0a6dfa5b61b11654e7751be487bcb72a3ea640bcd4205b6451e551de8723
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -70,9 +70,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2026-04-06</Date>
-            <Version>1.2.5</Version>
+        <Update release="28">
+            <Date>2026-04-12</Date>
+            <Version>1.2.8</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**

Bugfixes:
- Fixed issue where language setting was not recognized
- Fixed a potential cache clear issue

Enhancements:
- Update German translation
- Added a keybind for viewing eopkg info for a package for more detailed information.

Full Changelog:
https://github.com/clintre/solseek/releases/tag/v1.2.8

**Test Plan**

Install, change language, and test

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
