### PR TITLE
imagemagick: Update to v7.1.2.19

### DIFF
--- a/packages/i/imagemagick/abi_libs
+++ b/packages/i/imagemagick/abi_libs
@@ -3,3 +3,4 @@ Q16HDRI.so
 libMagick++-7.Q16HDRI.so.5
 libMagickCore-7.Q16HDRI.so.10
 libMagickWand-7.Q16HDRI.so.10
+magick

--- a/packages/i/imagemagick/abi_symbols
+++ b/packages/i/imagemagick/abi_symbols
@@ -4535,3 +4535,4 @@ libMagickWand-7.Q16HDRI.so.10:StreamImageCommand
 libMagickWand-7.Q16HDRI.so.10:TransferWandViewIterator
 libMagickWand-7.Q16HDRI.so.10:UpdateWandViewIterator
 libMagickWand-7.Q16HDRI.so.10:VERS_10.0
+magick:_IO_stdin_used

--- a/packages/i/imagemagick/abi_used_symbols
+++ b/packages/i/imagemagick/abi_used_symbols
@@ -522,6 +522,7 @@ libgvc.so.6:gvRenderFilename
 libheif.so.1:heif_check_filetype
 libheif.so.1:heif_context_add_XMP_metadata
 libheif.so.1:heif_context_add_exif_metadata
+libheif.so.1:heif_context_add_visual_sequence_track
 libheif.so.1:heif_context_alloc
 libheif.so.1:heif_context_encode_image
 libheif.so.1:heif_context_free
@@ -532,7 +533,10 @@ libheif.so.1:heif_context_get_number_of_top_level_images
 libheif.so.1:heif_context_get_primary_image_ID
 libheif.so.1:heif_context_get_primary_image_handle
 libheif.so.1:heif_context_get_security_limits
+libheif.so.1:heif_context_get_track
+libheif.so.1:heif_context_has_sequence
 libheif.so.1:heif_context_read_from_file
+libheif.so.1:heif_context_set_sequence_timescale
 libheif.so.1:heif_context_write
 libheif.so.1:heif_decode_image
 libheif.so.1:heif_decoding_options_alloc
@@ -549,6 +553,8 @@ libheif.so.1:heif_have_decoder_for_format
 libheif.so.1:heif_have_encoder_for_format
 libheif.so.1:heif_image_add_plane
 libheif.so.1:heif_image_create
+libheif.so.1:heif_image_get_bits_per_pixel_range
+libheif.so.1:heif_image_get_duration
 libheif.so.1:heif_image_get_height
 libheif.so.1:heif_image_get_plane
 libheif.so.1:heif_image_get_plane_readonly
@@ -570,6 +576,7 @@ libheif.so.1:heif_image_handle_has_alpha_channel
 libheif.so.1:heif_image_handle_has_depth_image
 libheif.so.1:heif_image_handle_release
 libheif.so.1:heif_image_release
+libheif.so.1:heif_image_set_duration
 libheif.so.1:heif_image_set_nclx_color_profile
 libheif.so.1:heif_image_set_raw_color_profile
 libheif.so.1:heif_init
@@ -582,6 +589,18 @@ libheif.so.1:heif_nclx_color_profile_free
 libheif.so.1:heif_nclx_color_profile_set_color_primaries
 libheif.so.1:heif_nclx_color_profile_set_matrix_coefficients
 libheif.so.1:heif_nclx_color_profile_set_transfer_characteristics
+libheif.so.1:heif_sequence_encoding_options_alloc
+libheif.so.1:heif_sequence_encoding_options_release
+libheif.so.1:heif_track_decode_next_image
+libheif.so.1:heif_track_encode_end_of_sequence
+libheif.so.1:heif_track_encode_sequence_image
+libheif.so.1:heif_track_get_image_resolution
+libheif.so.1:heif_track_get_timescale
+libheif.so.1:heif_track_has_alpha_channel
+libheif.so.1:heif_track_options_alloc
+libheif.so.1:heif_track_options_release
+libheif.so.1:heif_track_options_set_timescale
+libheif.so.1:heif_track_release
 libjpeg.so.8:jpeg12_read_scanlines
 libjpeg.so.8:jpeg12_write_scanlines
 libjpeg.so.8:jpeg16_read_scanlines
@@ -644,10 +663,12 @@ libjxl.so.0.11:JxlEncoderDestroy
 libjxl.so.0.11:JxlEncoderFrameSettingsCreate
 libjxl.so.0.11:JxlEncoderFrameSettingsSetOption
 libjxl.so.0.11:JxlEncoderInitBasicInfo
+libjxl.so.0.11:JxlEncoderInitBlendInfo
 libjxl.so.0.11:JxlEncoderInitFrameHeader
 libjxl.so.0.11:JxlEncoderProcessOutput
 libjxl.so.0.11:JxlEncoderSetBasicInfo
 libjxl.so.0.11:JxlEncoderSetColorEncoding
+libjxl.so.0.11:JxlEncoderSetExtraChannelBlendInfo
 libjxl.so.0.11:JxlEncoderSetFrameDistance
 libjxl.so.0.11:JxlEncoderSetFrameHeader
 libjxl.so.0.11:JxlEncoderSetFrameLossless

--- a/packages/i/imagemagick/package.yml
+++ b/packages/i/imagemagick/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : imagemagick
-version    : 7.1.2.18
-release    : 211
+version    : 7.1.2.19
+release    : 212
 source     :
-    - https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-18.tar.gz : 2db8a1f9bac19831c76574e4fd514ecb80a71a49911ee5dc8c1f3fb6d9d550df
+    - https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-19.tar.gz : 91ffe35706ef01d0fc9630e3a81b168b9bdb10b5e1e0b0983c287063cce21210
 homepage   : https://imagemagick.org/
 license    : Apache-2.0
 component  : multimedia.graphics

--- a/packages/i/imagemagick/pspec_x86_64.xml
+++ b/packages/i/imagemagick/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>imagemagick</Name>
         <Homepage>https://imagemagick.org/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>multimedia.graphics</PartOf>
@@ -49,7 +49,6 @@
             <Path fileType="library">/usr/lib64/perl5/vendor_perl/5.38/x86_64-linux-thread-multi/auto/Image/Magick/Magick.so</Path>
             <Path fileType="library">/usr/lib64/perl5/vendor_perl/5.38/x86_64-linux-thread-multi/auto/Image/Magick/Q16HDRI/Q16HDRI.so</Path>
             <Path fileType="library">/usr/lib64/perl5/vendor_perl/5.38/x86_64-linux-thread-multi/auto/Image/Magick/Q16HDRI/autosplit.ix</Path>
-            <Path fileType="library">/usr/lib64/perl5/vendor_perl/5.38/x86_64-linux-thread-multi/auto/Image/Magick/autosplit.ix</Path>
             <Path fileType="data">/usr/share/ImageMagick-7/english.xml</Path>
             <Path fileType="data">/usr/share/ImageMagick-7/francais.xml</Path>
             <Path fileType="data">/usr/share/ImageMagick-7/locale.xml</Path>
@@ -94,7 +93,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="211">imagemagick</Dependency>
+            <Dependency release="212">imagemagick</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/ImageMagick-7/Magick++.h</Path>
@@ -593,12 +592,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="211">
-            <Date>2026-03-27</Date>
-            <Version>7.1.2.18</Version>
+        <Update release="212">
+            <Date>2026-04-12</Date>
+            <Version>7.1.2.19</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/ImageMagick/Website/blob/main/ChangeLog.md).

**Security**
Includes fixes for:
- GHSA-v67w-737x-v2c9
- GHSA-x9h5-r9v2-vcww
- GHSA-f4qm-vj5j-9xpw
- GHSA-fwvm-ggf6-2p4x
- GHSA-pcvx-ph33-r5vv
- GHSA-cr67-pvmx-2pp2
- GHSA-w54j-7wpm-crhj
- GHSA-q8h3-jv9v-57qx
- GHSA-26qp-ffjh-2x4v
- GHSA-8vfj-q2cp-5m5j
- GHSA-98cp-rj9f-6v5g
- GHSA-pmpg-6pww-fg6q
- GHSA-5592-p365-24xh
- GHSA-x928-4434-crqj
- GHSA-pwg5-6jfc-crvh
- GHSA-2442-cq27-vf6x
- GHSA-r83h-crwp-3vm7
- GHSA-5xg3-585r-9jh5
- GHSA-jvgr-9ph5-m8v4
- GHSA-qvhr-jj4p-j2qr

**Test Plan**

`magick identify example.png` Read info. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
