### PR TITLE
python-tabulate: update to 0.10.0

### DIFF
--- a/packages/py/python-tabulate/package.yml
+++ b/packages/py/python-tabulate/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-tabulate
-version    : 0.9.0
-release    : 8
+version    : 0.10.0
+release    : 9
 source     :
-    - https://files.pythonhosted.org/packages/source/t/tabulate/tabulate-0.9.0.tar.gz : 0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c
+    - https://files.pythonhosted.org/packages/source/t/tabulate/tabulate-0.10.0.tar.gz : e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d
 homepage   : https://github.com/astanin/python-tabulate
 license    : MIT
 component  : programming.python

--- a/packages/py/python-tabulate/pspec_x86_64.xml
+++ b/packages/py/python-tabulate/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-tabulate</Name>
         <Homepage>https://github.com/astanin/python-tabulate</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>George K.</Name>
+            <Email>gk_coder@icloud.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -21,27 +21,24 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/tabulate</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/tabulate-0.9.0.dist-info/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/tabulate-0.9.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/tabulate-0.9.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/tabulate-0.9.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/tabulate-0.9.0.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/tabulate-0.9.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/tabulate-0.10.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/tabulate-0.10.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/tabulate-0.10.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/tabulate-0.10.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/tabulate-0.10.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/tabulate-0.10.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/tabulate/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/tabulate/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/tabulate/__pycache__/__init__.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/tabulate/__pycache__/version.cpython-312.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/tabulate/__pycache__/version.cpython-312.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/tabulate/version.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2025-05-17</Date>
-            <Version>0.9.0</Version>
+        <Update release="9">
+            <Date>2026-04-11</Date>
+            <Version>0.10.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>George K.</Name>
+            <Email>gk_coder@icloud.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Enhancements:
- Python 3.12 support
- colon_grid table format support
- better type deduction

Bugfixes:
- separating lines fix
- intfmt problem fix

Full changelog:
- [0.9-0.10](https://github.com/astanin/python-tabulate/compare/v0.9.0...v0.10.0)

**Test Plan**

1. check version with importlib.metadata.version()
2. make tables using tabulate
3. also make one using colon_grid
4. Use tabulate CLI command in terminal

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
