### PR TITLE
incus: Update to 6.0.6

### DIFF
--- a/packages/i/incus/abi_symbols
+++ b/packages/i/incus/abi_symbols
@@ -10,6 +10,7 @@ incus-benchmark:crosscall2
 incus-user:_cgo_panic
 incus-user:_cgo_topofstack
 incus-user:crosscall2
+incusd:_IO_stdin_used
 incusd:_cgo_panic
 incusd:_cgo_topofstack
 incusd:authorizerTrampoline
@@ -23,6 +24,7 @@ incusd:preUpdateHookTrampoline
 incusd:rollbackHookTrampoline
 incusd:stepTrampoline
 incusd:updateHookTrampoline
+lxc-to-incus:_IO_stdin_used
 lxc-to-incus:_cgo_panic
 lxc-to-incus:_cgo_topofstack
 lxc-to-incus:crosscall2

--- a/packages/i/incus/abi_used_symbols
+++ b/packages/i/incus/abi_used_symbols
@@ -21,6 +21,7 @@ libc.so.6:calloc
 libc.so.6:chdir
 libc.so.6:chmod
 libc.so.6:chroot
+libc.so.6:clearenv
 libc.so.6:clone
 libc.so.6:close
 libc.so.6:closedir
@@ -86,6 +87,7 @@ libc.so.6:pthread_attr_destroy
 libc.so.6:pthread_attr_getstack
 libc.so.6:pthread_attr_getstacksize
 libc.so.6:pthread_attr_init
+libc.so.6:pthread_attr_setdetachstate
 libc.so.6:pthread_cond_broadcast
 libc.so.6:pthread_cond_wait
 libc.so.6:pthread_create

--- a/packages/i/incus/monitoring.yaml
+++ b/packages/i/incus/monitoring.yaml
@@ -2,5 +2,6 @@ releases:
   id: 369938
   rss: https://github.com/lxc/incus/tags.atom
 security:
-  # No known CPE, last checked 2024-09-17
-  cpe: ~
+  cpe:
+  - vendor: linuxcontainers
+    product: incus

--- a/packages/i/incus/package.yml
+++ b/packages/i/incus/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : incus
-version    : 6.0.3
-release    : 2
+version    : 6.0.6
+release    : 3
 source     :
-    - https://linuxcontainers.org/downloads/incus/incus-6.0.3.tar.xz : 63696e16ac2412aefe96d678b051232db643fbd92d61de7161ec777b5347298a
+    - https://linuxcontainers.org/downloads/incus/incus-6.0.6.tar.xz : 129a1323605d427c46c8358844f5f9447d7e2cebe0f4ada242c93cf002fb44ea
 license    : Apache-2.0
 homepage   : https://linuxcontainers.org/incus/
 component  : virt
@@ -25,9 +25,13 @@ rundeps    :
     - lxcfs
     - qemu
     - rsync
+    - squashfs-tools
 setup      : |
-    %patch -p1 -i $pkgfiles/0001-Fix-path-to-socket.patch
-
+    # Dynamically replace VarPath with RunPath for LXC hooks
+    sed -i '/callhook/s/internalUtil.VarPath/internalUtil.RunPath/g' internal/server/instance/drivers/driver_lxc.go
+    
+    # Dynamically replace VarDir with RunDir for the daemon UNIX socket
+    sed -i 's/s.VarDir, "unix.socket"/s.RunDir, "unix.socket"/g' internal/server/sys/os.go
     mkdir bin
 build      : |
     export GOFLAGS="-buildmode=pie -trimpath -modcacherw"
@@ -54,6 +58,7 @@ install    : |
     install -Dm00644 $pkgfiles/incus.tmpfiles $installdir/%libdir%/tmpfiles.d/incus.conf
     install -Dm00644 $pkgfiles/incus.service $installdir/%libdir%/systemd/system/incus.service
     install -Dm00644 $pkgfiles/incus.socket $installdir/%libdir%/systemd/system/incus.socket
+    %install_license COPYING
 replaces   :
     - lxd
     - dbginfo :

--- a/packages/i/incus/pspec_x86_64.xml
+++ b/packages/i/incus/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>incus</Name>
         <Homepage>https://linuxcontainers.org/incus/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>clintre</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>virt</PartOf>
@@ -34,6 +34,7 @@
             <Path fileType="library">/usr/lib64/tmpfiles.d/incus.conf</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/incus</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/incus.fish</Path>
+            <Path fileType="data">/usr/share/licenses/incus/COPYING</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_incus</Path>
         </Files>
         <Replaces>
@@ -41,12 +42,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2024-12-21</Date>
-            <Version>6.0.3</Version>
+        <Update release="3">
+            <Date>2026-04-14</Date>
+            <Version>6.0.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>clintre</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Security updates and compatibility with qemu 10.x

Fixes getsolus/packages#8210

Security Fixes:

- CVE-2026-28384
- CVE-2025-64507
- CVE-2026-23954
- CVE-2026-23953

[Full Changelog](https://discuss.linuxcontainers.org/t/incus-6-0-6-lts-has-been-released/26380)

**Test Plan**

Install, start service, run through admin init

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
