### PR TITLE
python-hatchling: update to 1.29.0

### DIFF
--- a/packages/py/python-hatchling/package.yml
+++ b/packages/py/python-hatchling/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-hatchling
-version    : 1.27.0
-release    : 11
+version    : 1.29.0
+release    : 12
 source     :
-    - https://files.pythonhosted.org/packages/source/h/hatchling/hatchling-1.27.0.tar.gz : 971c296d9819abb3811112fc52c7a9751c8d381898f36533bb16f9791e941fd6
+    - https://files.pythonhosted.org/packages/source/h/hatchling/hatchling-1.29.0.tar.gz : 793c31816d952cee405b83488ce001c719f325d9cda69f1fc4cd750527640ea6
 homepage   : https://hatch.pypa.io/
 license    : MIT
 component  : programming.python

--- a/packages/py/python-hatchling/pspec_x86_64.xml
+++ b/packages/py/python-hatchling/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-hatchling</Name>
         <Homepage>https://hatch.pypa.io/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>George K.</Name>
+            <Email>gk_coder@icloud.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -21,11 +21,11 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/hatchling</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/hatchling-1.27.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/hatchling-1.27.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/hatchling-1.27.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/hatchling-1.27.0.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/hatchling-1.27.0.dist-info/licenses/LICENSE.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/hatchling-1.29.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/hatchling-1.29.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/hatchling-1.29.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/hatchling-1.29.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/hatchling-1.29.0.dist-info/licenses/LICENSE.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/hatchling/__about__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/hatchling/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/hatchling/__main__.py</Path>
@@ -231,12 +231,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2025-05-15</Date>
-            <Version>1.27.0</Version>
+        <Update release="12">
+            <Date>2026-04-13</Date>
+            <Version>1.29.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>George K.</Name>
+            <Email>gk_coder@icloud.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Bugfixes:
- Source Date Epoch no longer fails when date < 1980

Changes:
- sbom-files build data option added

Full changelog: [hatchling changelog](https://github.com/pypa/hatch/blob/master/docs/history/hatchling.md)

(Note: this is a revised PR of PR8413.)
**Test Plan**

1. use importlib.metadata.version() to check version
2. use the hatchling command to check metadata
3. build a dummy project using hatchling

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
