### PR TITLE
python-markdown-it-py: update to 4.0.0

### DIFF
--- a/packages/py/python-markdown-it-py/package.yml
+++ b/packages/py/python-markdown-it-py/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-markdown-it-py
-version    : 3.0.0
-release    : 3
+version    : 4.0.0
+release    : 4
 source     :
-    - https://files.pythonhosted.org/packages/source/m/markdown-it-py/markdown-it-py-3.0.0.tar.gz : e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb
+    - https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz : cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3
 homepage   : https://github.com/executablebooks/markdown-it-py
 license    : MIT
 component  : programming.python

--- a/packages/py/python-markdown-it-py/pspec_x86_64.xml
+++ b/packages/py/python-markdown-it-py/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-markdown-it-py</Name>
         <Homepage>https://github.com/executablebooks/markdown-it-py</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>George K.</Name>
+            <Email>gk_coder@icloud.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -221,21 +221,21 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/markdown_it/token.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/markdown_it/tree.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/markdown_it/utils.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown_it_py-3.0.0.dist-info/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown_it_py-3.0.0.dist-info/LICENSE.markdown-it</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown_it_py-3.0.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown_it_py-3.0.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown_it_py-3.0.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown_it_py-3.0.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown_it_py-4.0.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown_it_py-4.0.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown_it_py-4.0.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown_it_py-4.0.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown_it_py-4.0.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/markdown_it_py-4.0.0.dist-info/licenses/LICENSE.markdown-it</Path>
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2025-05-17</Date>
-            <Version>3.0.0</Version>
+        <Update release="4">
+            <Date>2026-04-14</Date>
+            <Version>4.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>George K.</Name>
+            <Email>gk_coder@icloud.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
- **python-markdown-it-py: Update to 4.0.0**

**Summary**
Enhancements:
- improve performance of "text" rule
- fix quadratic complexity
    
Bugfixes:
- fix emphasis in raw links
  
Full changelog:
- [4.0.0](https://github.com/executablebooks/markdown-it-py/releases/tag/v4.0.0)


**Test Plan**

1. use importlib.metadata.version() to check version
2. use markdown-it-py to render markdown
3. check compability with markdown-it-py plugins

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
