### PR TITLE
python-path: update to 17.1.1

### DIFF
--- a/packages/py/python-path/package.yml
+++ b/packages/py/python-path/package.yml
@@ -1,8 +1,8 @@
 name       : python-path
-version    : 17.1.0
-release    : 1
+version    : 17.1.1
+release    : 2
 source     :
-    - https://files.pythonhosted.org/packages/source/p/path/path-17.1.0.tar.gz : d41e05ed4fa1d4f6d702df3c1e0a1a255d7b544287432456455dc7c51e5f98e9
+    - https://files.pythonhosted.org/packages/source/p/path/path-17.1.1.tar.gz : 2dfcbfec8b4d960f3469c52acf133113c2a8bf12ac7b98d629fa91af87248d42
 homepage   : https://github.com/jaraco/path
 license    : MIT
 component  : programming.python
@@ -13,6 +13,7 @@ description: |
     Implements path objects as first-class entities, allowing common operations on files to be invoked on those path objects directly.
 builddeps  :
     - python-build
+    - python-coherent-licensed
     - python-installer
     - python-setuptools
     - python-setuptools-scm

--- a/packages/py/python-path/pspec_x86_64.xml
+++ b/packages/py/python-path/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-path</Name>
         <Homepage>https://github.com/jaraco/path</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>George K.</Name>
+            <Email>gk_coder@icloud.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -24,11 +24,11 @@ Implements path objects as first-class entities, allowing common operations on f
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/path-17.1.0.dist-info/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/path-17.1.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/path-17.1.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/path-17.1.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/path-17.1.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/path-17.1.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/path-17.1.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/path-17.1.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/path-17.1.1.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/path-17.1.1.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/path/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/path/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/path/__pycache__/__init__.cpython-312.pyc</Path>
@@ -48,12 +48,12 @@ Implements path objects as first-class entities, allowing common operations on f
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2025-06-08</Date>
-            <Version>17.1.0</Version>
+        <Update release="2">
+            <Date>2026-04-14</Date>
+            <Version>17.1.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>George K.</Name>
+            <Email>gk_coder@icloud.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Enhancements:
- add traversal to \__all__
- consistent isort sorting

Changelog:
- [17.1.1](https://github.com/jaraco/path/compare/v17.1.0...v17.1.1)

**Test Plan**

1. check version using importlib
2. import and use path in Python

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
