### PR TITLE
python-pdm-backend: update to 2.4.8

### DIFF
--- a/packages/py/python-pdm-backend/package.yml
+++ b/packages/py/python-pdm-backend/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-pdm-backend
-version    : 2.4.3
-release    : 2
+version    : 2.4.8
+release    : 3
 source     :
-    - https://files.pythonhosted.org/packages/source/p/pdm-backend/pdm_backend-2.4.3.tar.gz : dbd9047a7ac10d11a5227e97163b617ad5d665050476ff63867d971758200728
+    - https://files.pythonhosted.org/packages/source/p/pdm-backend/pdm_backend-2.4.8.tar.gz : d8ef85d2c4306ee67195412d701fae9983e84ec6574598e26798ae26b7b3c7e0
 homepage   : https://github.com/pdm-project/pdm-backend
 license    : MIT
 component  : programming.python

--- a/packages/py/python-pdm-backend/pspec_x86_64.xml
+++ b/packages/py/python-pdm-backend/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-pdm-backend</Name>
         <Homepage>https://github.com/pdm-project/pdm-backend</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>George K.</Name>
+            <Email>gk_coder@icloud.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -163,23 +163,23 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/pdm/backend/structures.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pdm/backend/utils.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/pdm/backend/wheel.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pdm_backend-2.4.3.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pdm_backend-2.4.3.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pdm_backend-2.4.3.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pdm_backend-2.4.3.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pdm_backend-2.4.3.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pdm_backend-2.4.8.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pdm_backend-2.4.8.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pdm_backend-2.4.8.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pdm_backend-2.4.8.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pdm_backend-2.4.8.dist-info/licenses/LICENSE</Path>
         </Files>
         <Replaces>
             <Package>python-pdm-pep517</Package>
         </Replaces>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2025-05-17</Date>
-            <Version>2.4.3</Version>
+        <Update release="3">
+            <Date>2026-04-15</Date>
+            <Version>2.4.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>George K.</Name>
+            <Email>gk_coder@icloud.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Features:
- support ommiting source in version table when path declared
- allow to override wheel with tags

Bugfixes:
- env for calling Python apps
- no warning emitting when fallback_version is used

Full changelog:
- [changelog](http://github.com/pdm-project/pdm-backend)

**Test Plan**

1. check version using importlib.metadata
2. build a sample Python project using pdm.backend

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
