### PR TITLE
shim-signed: Update to v16.1

### DIFF
--- a/packages/s/shim-signed/package.yml
+++ b/packages/s/shim-signed/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : shim-signed
-version    : '15.8'
-release    : 7
+version    : '16.1'
+release    : 8
 source     :
-    - https://kojipkgs.fedoraproject.org/packages/shim/15.8/3/x86_64/shim-x64-15.8-3.x86_64.rpm : 28958d75333c42b0341b727a2b697edf02f0cfaec18dbd25ae62c9a8164faabe
+    - https://kojipkgs.fedoraproject.org/packages/shim/16.1/7/x86_64/shim-x64-16.1-7.x86_64.rpm : 0a119f3488e5da27ca55c1864ee8e131afa5ecf27689385ba09b805eb00dd608
 homepage   : https://github.com/rhboot/shim
 license    : BSD-2-Clause
 component  : system.base
@@ -11,9 +11,9 @@ summary    : Initial UEFI bootloader that handles chaining to a trusted full boo
 description: |
     Initial UEFI bootloader that handles chaining to a trusted full bootloader under secure boot environments. This package contains the version signed by the UEFI signing service.
 install    : |
-    install -Dm00700 $workdir/boot/efi/EFI/fedora/shim.efi $installdir/%libdir%/shim/shimx64.efi
-    install -Dm00700 $workdir/boot/efi/EFI/fedora/mmx64.efi $installdir/%libdir%/shim/mmx64.efi
-    install -Dm00700 $workdir/boot/efi/EFI/BOOT/fbx64.efi $installdir/%libdir%/shim/fbx64.efi
+    install -Dm00700 $workdir/usr/lib/efi/shim/16.1-7/EFI/fedora/shim.efi $installdir/%libdir%/shim/shimx64.efi
+    install -Dm00700 $workdir/usr/lib/efi/shim/16.1-7/EFI/fedora/mmx64.efi $installdir/%libdir%/shim/mmx64.efi
+    install -Dm00700 $workdir/usr/lib/efi/shim/16.1-7/EFI/BOOT/fbx64.efi $installdir/%libdir%/shim/fbx64.efi
 
     # BOOT.CSV is a UCS-2 LE formatted CSV file. See https://github.com/rhboot/shim/blob/shim-15.5/README.fallback#L48
     install -Dm00700 $pkgfiles/boot.csv $installdir/%libdir%/shim/BOOTX64.CSV

--- a/packages/s/shim-signed/pspec_x86_64.xml
+++ b/packages/s/shim-signed/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2024-04-24</Date>
-            <Version>15.8</Version>
+        <Update release="8">
+            <Date>2026-04-15</Date>
+            <Version>16.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Joey Riches</Name>
             <Email>josephriches@gmail.com</Email>


### PR DESCRIPTION
**Changelog**

[16.1](https://github.com/rhboot/shim/releases/tag/16.1)
[16.0](https://github.com/rhboot/shim/releases/tag/16.0)

**Security**
- CVE-2024-2312

**Test Plan**

Update shim locally, verified updated assets were copied to ESP and rebooted with secure boot enabled

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
