### PR TITLE
freetype2: Update to v2.14.3

### DIFF
--- a/packages/f/freetype2/package.yml
+++ b/packages/f/freetype2/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : freetype2
-version    : 2.14.2
-release    : 39
+version    : 2.14.3
+release    : 40
 source     :
     - https://download.savannah.gnu.org/releases/freetype/freetype-2.14.2.tar.xz : 4b62dcab4c920a1a860369933221814362e699e26f55792516d671e6ff55b5e1
 homepage   : https://freetype.org/

--- a/packages/f/freetype2/pspec_x86_64.xml
+++ b/packages/f/freetype2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>freetype2</Name>
         <Homepage>https://freetype.org/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>FTL</License>
         <License>GPL-2.0-only</License>
@@ -33,7 +33,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="39">freetype2</Dependency>
+            <Dependency release="40">freetype2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libfreetype.so.6</Path>
@@ -47,8 +47,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="39">freetype2-32bit</Dependency>
-            <Dependency release="39">freetype2-devel</Dependency>
+            <Dependency release="40">freetype2-devel</Dependency>
+            <Dependency release="40">freetype2-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libfreetype.so</Path>
@@ -62,7 +62,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="39">freetype2</Dependency>
+            <Dependency release="40">freetype2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/freetype-config</Path>
@@ -128,12 +128,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="39">
-            <Date>2026-03-02</Date>
-            <Version>2.14.2</Version>
+        <Update release="40">
+            <Date>2026-04-16</Date>
+            <Version>2.14.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Security issues were fixed. They did not elaborate.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebooted, saw that fonts still displayed correctly.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
