### PR TITLE
Prep for Solus 4.9 release

### DIFF
--- a/packages/c/calamares/files/install/branding/solus/branding.desc
+++ b/packages/c/calamares/files/install/branding/solus/branding.desc
@@ -113,10 +113,10 @@ navigation: widget
 strings:
     productName:         "Solus"
     shortProductName:    "Solus"
-    version:             "4.8 Opportunity"
-    shortVersion:        "4.8"
-    versionedName:       "Solus 4.8 Opportunity"
-    shortVersionedName:  "Solus 4.8"
+    version:             "4.9 Serenity"
+    shortVersion:        "4.9"
+    versionedName:       "Solus 4.9 Serenity"
+    shortVersionedName:  "Solus 4.9"
     bootloaderEntryName: "Solus"
     productUrl:          https://getsol.us
     supportUrl:          https://help.getsol.us

--- a/packages/c/calamares/package.yml
+++ b/packages/c/calamares/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : calamares
 version    : 3.4.2
-release    : 50
+release    : 51
 source     :
     - https://codeberg.org/Calamares/calamares/releases/download/v3.4.2/calamares-3.4.2.tar.gz : 733bbbb00dc9f84874bd5c22960952f317ea2537565431179fa2152b2fbfdccc
 homepage   : https://calamares.io

--- a/packages/c/calamares/pspec_x86_64.xml
+++ b/packages/c/calamares/pspec_x86_64.xml
@@ -304,7 +304,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="50">calamares</Dependency>
+            <Dependency release="51">calamares</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libcalamares/Branding.h</Path>
@@ -423,8 +423,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="50">
-            <Date>2026-04-12</Date>
+        <Update release="51">
+            <Date>2026-04-13</Date>
             <Version>3.4.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>

--- a/packages/o/os-release/files/os-release
+++ b/packages/o/os-release/files/os-release
@@ -1,9 +1,9 @@
 NAME="Solus"
-VERSION="4.8"
+VERSION="4.9"
 ID="solus"
-VERSION_CODENAME=opportunity
-VERSION_ID="4.8"
-PRETTY_NAME="Solus 4.8 Opportunity"
+VERSION_CODENAME=serenity
+VERSION_ID="4.9"
+PRETTY_NAME="Solus 4.9 Serenity"
 ANSI_COLOR="1;34"
 HOME_URL="https://getsol.us"
 SUPPORT_URL="https://help.getsol.us/docs/user/contributing/getting-involved"

--- a/packages/o/os-release/files/solus-release
+++ b/packages/o/os-release/files/solus-release
@@ -1,1 +1,1 @@
-Solus 4.8
+Solus 4.9

--- a/packages/o/os-release/package.yml
+++ b/packages/o/os-release/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : os-release
-version    : '4.8'
-release    : 4
+version    : '4.9'
+release    : 5
 source     :
     # We need something for a source
     - https://getsol.us/sources/hotspot.txt : a12b7cb43c9d9134b5bb1b35e9096b66775d9e92e7611d1cc92b02edd6782a87

--- a/packages/o/os-release/pspec_x86_64.xml
+++ b/packages/o/os-release/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>os-release</Name>
         <Homepage>https://getsol.us</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.base</PartOf>
@@ -24,12 +24,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2025-11-16</Date>
-            <Version>4.8</Version>
+        <Update release="5">
+            <Date>2026-04-13</Date>
+            <Version>4.9</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>malfisya.dev@hotmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- **os-release: Update to v4.9**
- **calamares: Update branding for Solus 4.9**

**Test Plan**

Built smoketest ISOs, and verified that `/etc/release` was correct, and Calamares showed the correct version strings.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
