### PR TITLE
python-rich: update to 15.0.0

### DIFF
--- a/packages/py/python-rich/package.yml
+++ b/packages/py/python-rich/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-rich
-version    : 14.3.3
-release    : 7
+version    : 15.0.0
+release    : 8
 source     :
-    - https://files.pythonhosted.org/packages/source/r/rich/rich-14.3.3.tar.gz : b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b
+    - https://files.pythonhosted.org/packages/source/r/rich/rich-15.0.0.tar.gz : edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36
 homepage   : https://github.com/Textualize/rich
 license    : MIT
 component  : programming.python

--- a/packages/py/python-rich/pspec_x86_64.xml
+++ b/packages/py/python-rich/pspec_x86_64.xml
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/rich-14.3.3.dist-info/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/rich-14.3.3.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/rich-14.3.3.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/rich-14.3.3.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich-15.0.0.dist-info/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich-15.0.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich-15.0.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/rich-15.0.0.dist-info/WHEEL</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/rich/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -328,9 +328,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2026-03-25</Date>
-            <Version>14.3.3</Version>
+        <Update release="8">
+            <Date>2026-04-17</Date>
+            <Version>15.0.0</Version>
             <Comment>Packaging update</Comment>
             <Name>George K.</Name>
             <Email>gk_coder@icloud.com</Email>


### PR DESCRIPTION
**Summary**
Changes:
- Python 3.8 support dropped

Bugfixes:
- empty text ignoring end param
- Text.from_ansi removing newlines
- inline code in md table cells fixes

Full changelog:
- [15.0.0](https://github.com/Textualize/rich/releases/tag/v15.0.0)

**Test Plan**

1. check version with importlib
2. see if core functions of rich work properly
3. test output of python3 -m rich

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
