### PR TITLE
typos: Update to 1.45.1

### DIFF
--- a/packages/t/typos/package.yml
+++ b/packages/t/typos/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : typos
-version    : 1.45.0
-release    : 3
+version    : 1.45.1
+release    : 4
 source     :
-    - https://github.com/crate-ci/typos/archive/refs/tags/v1.45.0.tar.gz : f7bd2b353818b4e6a2710c30b11f9d4ec62672d6f0c0f7186f6e84140f290d2a
+    - https://github.com/crate-ci/typos/archive/refs/tags/v1.45.1.tar.gz : 0def3b2c9398257bc26818b008eabf4ab1aaf49fb3383abb25c46fc0aeb1ee10
 license    :
     - Apache-2.0
     - MIT

--- a/packages/t/typos/pspec_x86_64.xml
+++ b/packages/t/typos/pspec_x86_64.xml
@@ -3,7 +3,7 @@
         <Name>typos</Name>
         <Homepage>https://github.com/crate-ci/typos</Homepage>
         <Packager>
-            <Name>clintre</Name>
+            <Name>Clint Eschberger</Name>
             <Email>clint@eschberger.info</Email>
         </Packager>
         <License>Apache-2.0</License>
@@ -27,11 +27,11 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2026-04-02</Date>
-            <Version>1.45.0</Version>
+        <Update release="4">
+            <Date>2026-04-19</Date>
+            <Version>1.45.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>clintre</Name>
+            <Name>Clint Eschberger</Name>
             <Email>clint@eschberger.info</Email>
         </Update>
     </History>


### PR DESCRIPTION
**Summary**
Bugfix: (action) Use a temp dir for caching

[Full Change Log](https://github.com/crate-ci/typos/releases/tag/v1.45.1)

**Test Plan**

Install and test

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
