### PR TITLE
libdecor: Update to v0.2.5

### DIFF
--- a/packages/l/libdecor/package.yml
+++ b/packages/l/libdecor/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libdecor
-version    : 0.2.2
-release    : 4
+version    : 0.2.5
+release    : 5
 source     :
-    - https://gitlab.freedesktop.org/libdecor/libdecor/-/archive/0.2.2/libdecor-0.2.2.tar.gz : 40a1d8be07d8b1f66e8fb98a1f4a84549ca6bf992407198a5055952be80a8525
+    - https://gitlab.freedesktop.org/libdecor/libdecor/-/archive/0.2.5/libdecor-0.2.5.tar.gz : 39c109a9a7eae943ba34d18a282c447d5729f9c486c8bc05ea305e4acd341522
 homepage   : https://gitlab.freedesktop.org/libdecor/libdecor
 license    : MIT
 component  : desktop.library
@@ -22,3 +22,4 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license LICENSE

--- a/packages/l/libdecor/pspec_x86_64.xml
+++ b/packages/l/libdecor/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libdecor</Name>
         <Homepage>https://gitlab.freedesktop.org/libdecor/libdecor</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>desktop.library</PartOf>
@@ -21,8 +21,9 @@
         <PartOf>desktop.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libdecor-0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libdecor-0.so.0.200.2</Path>
+            <Path fileType="library">/usr/lib64/libdecor-0.so.0.200.5</Path>
             <Path fileType="library">/usr/lib64/libdecor/plugins-1/libdecor-cairo.so</Path>
+            <Path fileType="data">/usr/share/licenses/libdecor/LICENSE</Path>
         </Files>
     </Package>
     <Package>
@@ -32,11 +33,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="4">libdecor</Dependency>
+            <Dependency release="5">libdecor</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libdecor-0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libdecor-0.so.0.200.2</Path>
+            <Path fileType="library">/usr/lib32/libdecor-0.so.0.200.5</Path>
             <Path fileType="library">/usr/lib32/libdecor/plugins-1/libdecor-cairo.so</Path>
         </Files>
     </Package>
@@ -47,8 +48,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="4">libdecor-32bit</Dependency>
-            <Dependency release="4">libdecor-devel</Dependency>
+            <Dependency release="5">libdecor-32bit</Dependency>
+            <Dependency release="5">libdecor-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libdecor-0.so</Path>
@@ -62,7 +63,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="4">libdecor</Dependency>
+            <Dependency release="5">libdecor</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libdecor-0/libdecor.h</Path>
@@ -71,12 +72,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-02-13</Date>
-            <Version>0.2.2</Version>
+        <Update release="5">
+            <Date>2026-04-20</Date>
+            <Version>0.2.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- install license
- update to latest

**Test Plan**

Install and launch lite-xl and retroarch. make sure they launched

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
