### PR TITLE
solseek: Update to 1.2.9

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 1.2.8
-release    : 28
+version    : 1.2.9
+release    : 29
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v1.2.8.tar.gz : cd7d0a6dfa5b61b11654e7751be487bcb72a3ea640bcd4205b6451e551de8723
+    - https://github.com/clintre/solseek/archive/refs/tags/v1.2.9.tar.gz : 9ac0125b3bba32bb44dee53fbad1630a14545776b5a39b70b2f204ad38e31028
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -38,6 +38,7 @@
             <Path fileType="data">/usr/share/solseek/lang/es.ini</Path>
             <Path fileType="data">/usr/share/solseek/lang/fr.ini</Path>
             <Path fileType="data">/usr/share/solseek/lang/pl.ini</Path>
+            <Path fileType="data">/usr/share/solseek/lang/pt.ini</Path>
             <Path fileType="data">/usr/share/solseek/lang/sl.ini</Path>
             <Path fileType="data">/usr/share/solseek/modules/install-flatpak</Path>
             <Path fileType="data">/usr/share/solseek/modules/install-pkg</Path>
@@ -70,9 +71,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="28">
-            <Date>2026-04-12</Date>
-            <Version>1.2.8</Version>
+        <Update release="29">
+            <Date>2026-04-21</Date>
+            <Version>1.2.9</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**
- Added Portuguese language

Full Changelog:
https://github.com/clintre/solseek/releases/tag/v1.2.9

**Test Plan**

Install, set language to Portuguese, and test.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
