### PR TITLE
libgcrypt: Update to v1.12.2

### DIFF
--- a/packages/l/libgcrypt/package.yml
+++ b/packages/l/libgcrypt/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libgcrypt
-version    : 1.12.1
-release    : 31
+version    : 1.12.2
+release    : 32
 source     :
-    - https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.12.1.tar.bz2 : 7df5c08d952ba33f9b6bdabdb06a61a78b2cf62d2122c2d1d03a91a79832aa3c
+    - https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.12.2.tar.bz2 : 7ce33c2492221a0436f96a8500215e9f3e3dcb5fd26a757cd415e7a843babd5e
 license    :
     - GPL-2.0-or-later
     - LGPL-2.1-or-later
@@ -27,5 +27,6 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING COPYING.LIB LICENSES
 check      : |
     %make check

--- a/packages/l/libgcrypt/pspec_x86_64.xml
+++ b/packages/l/libgcrypt/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libgcrypt</Name>
         <Homepage>https://gnupg.org/software/libgcrypt/index.html</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -26,10 +26,13 @@
             <Path fileType="executable">/usr/bin/libgcrypt-config</Path>
             <Path fileType="executable">/usr/bin/mpicalc</Path>
             <Path fileType="library">/usr/lib64/libgcrypt.so.20</Path>
-            <Path fileType="library">/usr/lib64/libgcrypt.so.20.7.1</Path>
+            <Path fileType="library">/usr/lib64/libgcrypt.so.20.7.2</Path>
             <Path fileType="info">/usr/share/info/gcrypt.info-1.zst</Path>
             <Path fileType="info">/usr/share/info/gcrypt.info-2.zst</Path>
             <Path fileType="info">/usr/share/info/gcrypt.info.zst</Path>
+            <Path fileType="data">/usr/share/licenses/libgcrypt/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/libgcrypt/COPYING.LIB</Path>
+            <Path fileType="data">/usr/share/licenses/libgcrypt/LICENSES</Path>
             <Path fileType="man">/usr/share/man/man1/hmac256.1.zst</Path>
         </Files>
     </Package>
@@ -40,11 +43,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="31">libgcrypt</Dependency>
+            <Dependency release="32">libgcrypt</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libgcrypt.so.20</Path>
-            <Path fileType="library">/usr/lib32/libgcrypt.so.20.7.1</Path>
+            <Path fileType="library">/usr/lib32/libgcrypt.so.20.7.2</Path>
         </Files>
     </Package>
     <Package>
@@ -54,8 +57,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="31">libgcrypt-devel</Dependency>
-            <Dependency release="31">libgcrypt-32bit</Dependency>
+            <Dependency release="32">libgcrypt-devel</Dependency>
+            <Dependency release="32">libgcrypt-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libgcrypt.so</Path>
@@ -69,7 +72,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="31">libgcrypt</Dependency>
+            <Dependency release="32">libgcrypt</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gcrypt.h</Path>
@@ -79,12 +82,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2026-02-22</Date>
-            <Version>1.12.1</Version>
+        <Update release="32">
+            <Date>2026-04-21</Date>
+            <Version>1.12.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://dev.gnupg.org/T8114).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build `abiword` against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
