### PR TITLE
ntfs-3g: Update to v2026.2.25

### DIFF
--- a/packages/n/ntfs-3g/abi_used_symbols
+++ b/packages/n/ntfs-3g/abi_used_symbols
@@ -74,6 +74,7 @@ libc.so.6:getpass
 libc.so.6:getpid
 libc.so.6:getpwnam
 libc.so.6:getpwuid
+libc.so.6:gettimeofday
 libc.so.6:getuid
 libc.so.6:getxattr
 libc.so.6:gmtime

--- a/packages/n/ntfs-3g/files/build.patch
+++ b/packages/n/ntfs-3g/files/build.patch
@@ -1,0 +1,216 @@
+diff --git a/libfuse-lite/fuse.c b/libfuse-lite/fuse.c
+index 3d653e6..c291496 100644
+--- a/libfuse-lite/fuse.c
++++ b/libfuse-lite/fuse.c
+@@ -6,10 +6,8 @@
+     See the file COPYING.LIB
+ */
+ 
+-#ifdef __SOLARIS__
+-/* For pthread_rwlock_t */
+-#define _GNU_SOURCE
+-#endif /* __SOLARIS__ */
++#define __GNU_SOURCE
++
+ 
+ #include "config.h"
+ #include "fuse_i.h"
+@@ -542,13 +540,13 @@ static char *get_path_name(struct fuse *f, fuse_ino_t nodeid, const char *name)
+ 
+     if (node == NULL || s == NULL)
+         goto out_free;
+-    
++
+     if (s[0])
+             memmove(buf, s, bufsize - (s - buf));
+     else
+             strcpy(buf, "/");
+     return buf;
+-    
++
+ out_free:
+     free(buf);
+     return NULL;
+@@ -1207,7 +1205,7 @@ static struct fuse_context_i *fuse_get_context_internal(void)
+         if (c == NULL) {
+             /* This is hard to deal with properly, so just abort.  If
+                memory is so low that the context cannot be allocated,
+-               there's not much hope for the filesystem anyway */ 
++               there's not much hope for the filesystem anyway */
+             fprintf(stderr, "fuse: failed to allocate thread specific data\n");
+             abort();
+         }
+@@ -1348,7 +1346,7 @@ static void fuse_lib_lookup(fuse_req_t req, fuse_ino_t parent,
+         struct fuse_intr_data d;
+         if (f->conf.debug)
+             fprintf(stderr, "LOOKUP %s\n", path);
+-        fuse_prepare_interrupt(f, req, &d); 
++        fuse_prepare_interrupt(f, req, &d);
+         err = lookup_path(f, parent, name, path, &e, NULL);
+         if (err == -ENOENT && f->conf.negative_timeout != 0.0) {
+             e.ino = 0;
+@@ -1435,9 +1433,9 @@ static void fuse_lib_setattr(fuse_req_t req, fuse_ino_t ino, struct stat *attr,
+         if (!err && (valid & FUSE_SET_ATTR_MODE))
+             err = fuse_fs_chmod(f->fs, path, attr->st_mode);
+         if (!err && (valid & (FUSE_SET_ATTR_UID | FUSE_SET_ATTR_GID))) {
+-            uid_t uid = 
++            uid_t uid =
+                 (valid & FUSE_SET_ATTR_UID) ? attr->st_uid : (uid_t) -1;
+-            gid_t gid = 
++            gid_t gid =
+                 (valid & FUSE_SET_ATTR_GID) ? attr->st_gid : (gid_t) -1;
+             err = fuse_fs_chown(f->fs, path, uid, gid);
+         }
+@@ -1842,7 +1840,7 @@ static void fuse_lib_create(fuse_req_t req, fuse_ino_t parent,
+ static double diff_timespec(const struct timespec *t1,
+                             const struct timespec *t2)
+ {
+-    return (t1->tv_sec - t2->tv_sec) + 
++    return (t1->tv_sec - t2->tv_sec) +
+         ((double) t1->tv_nsec - (double) t2->tv_nsec) / 1000000000.0;
+ }
+ 
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 8d98408..4651ee0 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -67,8 +67,8 @@ endif
+ if ENABLE_MOUNT_HELPER
+ install-exec-local:	install-rootbinPROGRAMS
+ 	$(MKDIR_P) "$(DESTDIR)/sbin"
+-	$(LN_S) -f "$(rootbindir)/ntfs-3g" "$(DESTDIR)/sbin/mount.ntfs-3g"
+-	$(LN_S) -f "$(rootbindir)/lowntfs-3g" "$(DESTDIR)/sbin/mount.lowntfs-3g"
++	$(LN_S) -f "$(rootbindir)/ntfs-3g" "$(DESTDIR)/usr/sbin/mount.ntfs-3g"
++	$(LN_S) -f "$(rootbindir)/lowntfs-3g" "$(DESTDIR)/usr/sbin/mount.lowntfs-3g"
+ 
+ install-data-local:	install-man8
+ 	$(LN_S) -f ntfs-3g.8 "$(DESTDIR)$(man8dir)/mount.ntfs-3g.8"
+@@ -76,7 +76,7 @@ install-data-local:	install-man8
+ 
+ uninstall-local:
+ 	$(RM) -f "$(DESTDIR)$(man8dir)/mount.ntfs-3g.8"
+-	$(RM) -f "$(DESTDIR)/sbin/mount.ntfs-3g" "$(DESTDIR)/sbin/mount.lowntfs-3g"
++	$(RM) -f "$(DESTDIR)/sbin/mount.ntfs-3g" "$(DESTDIR)/usr/sbin/mount.lowntfs-3g"
+ endif
+ 
+ endif # ENABLE_NTFS_3G
+diff --git a/src/ntfs-3g_common.c b/src/ntfs-3g_common.c
+index 29021df..ab4a962 100644
+--- a/src/ntfs-3g_common.c
++++ b/src/ntfs-3g_common.c
+@@ -20,6 +20,8 @@
+  * Foundation,Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  */
+ 
++#define __GNU_SOURCE
++
+ #ifdef HAVE_CONFIG_H
+ #include "config.h"
+ #endif
+@@ -28,9 +30,7 @@
+ #include <stdlib.h>
+ #endif
+ 
+-#ifdef HAVE_DLFCN_H
+ #include <dlfcn.h>
+-#endif
+ 
+ #ifdef HAVE_STRING_H
+ #include <string.h>
+@@ -142,7 +142,7 @@ int ntfs_strappend(char **dest, const char *append)
+ {
+ 	char *p;
+ 	size_t size_append, size_dest = 0;
+-	
++
+ 	if (!dest)
+ 		return -1;
+ 	if (!append)
+@@ -151,22 +151,22 @@ int ntfs_strappend(char **dest, const char *append)
+ 	size_append = strlen(append);
+ 	if (*dest)
+ 		size_dest = strlen(*dest);
+-	
++
+ 	if (strappend_is_large(size_dest) || strappend_is_large(size_append)) {
+ 		errno = EOVERFLOW;
+ 		ntfs_log_perror("%s: Too large input buffer", EXEC_NAME);
+ 		return -1;
+ 	}
+-	
++
+ 	p = (char*)realloc(*dest, size_dest + size_append + 1);
+     	if (!p) {
+ 		ntfs_log_perror("%s: Memory realloction failed", EXEC_NAME);
+ 		return -1;
+ 	}
+-	
++
+ 	*dest = p;
+ 	strcpy(*dest + size_dest, append);
+-	
++
+ 	return 0;
+ }
+ 
+@@ -180,7 +180,7 @@ int ntfs_strinsert(char **dest, const char *append)
+ {
+ 	char *p, *q;
+ 	size_t size_append, size_dest = 0;
+-	
++
+ 	if (!dest)
+ 		return -1;
+ 	if (!append)
+@@ -189,13 +189,13 @@ int ntfs_strinsert(char **dest, const char *append)
+ 	size_append = strlen(append);
+ 	if (*dest)
+ 		size_dest = strlen(*dest);
+-	
++
+ 	if (strappend_is_large(size_dest) || strappend_is_large(size_append)) {
+ 		errno = EOVERFLOW;
+ 		ntfs_log_perror("%s: Too large input buffer", EXEC_NAME);
+ 		return -1;
+ 	}
+-	
++
+ 	p = (char*)malloc(size_dest + size_append + 1);
+ 	if (!p) {
+ 		ntfs_log_perror("%s: Memory reallocation failed", EXEC_NAME);
+@@ -259,7 +259,7 @@ char *parse_mount_options(ntfs_fuse_context_t *ctx,
+ 		ntfs_log_perror("%s: strdup failed", EXEC_NAME);
+ 		return NULL;
+ 	}
+-	
++
+ 	s = options;
+ 	while (s && *s && (val = strsep(&s, ","))) {
+ 		opt = strsep(&val, "=");
+@@ -561,7 +561,7 @@ char *parse_mount_options(ntfs_fuse_context_t *ctx,
+ 		goto err_exit;
+ 	else if (ctx->atime == ATIME_DISABLED && ntfs_strappend(&ret, "noatime,"))
+ 		goto err_exit;
+-	
++
+ 	if (ntfs_strappend(&ret, "fsname="))
+ 		goto err_exit;
+ 	if (ntfs_strappend(&ret, popts->device))
+@@ -616,7 +616,7 @@ int ntfs_parse_options(struct ntfs_options *popts, void (*usage)(void),
+ 				popts->device = ntfs_malloc(PATH_MAX + 1);
+ 				if (!popts->device)
+ 					return -1;
+-				
++
+ 				/* Canonicalize device name (mtab, etc) */
+ 				popts->arg_device = optarg;
+ 				if (!ntfs_realpath_canonicalize(optarg,
+@@ -663,7 +663,7 @@ int ntfs_parse_options(struct ntfs_options *popts, void (*usage)(void),
+ 			 */
+ 			break;
+ 		case 'V':
+-			ntfs_log_info("%s %s %s %d\n", EXEC_NAME, VERSION, 
++			ntfs_log_info("%s %s %s %d\n", EXEC_NAME, VERSION,
+ 				      FUSE_TYPE, fuse_version());
+ 			exit(0);
+ 		default:

--- a/packages/n/ntfs-3g/monitoring.yaml
+++ b/packages/n/ntfs-3g/monitoring.yaml
@@ -1,6 +1,6 @@
 releases:
   id: 2504
-  rss: ~
+  rss: https://github.com/tuxera/ntfs-3g/tags.atom
 security:
   cpe:
   - vendor: tuxera

--- a/packages/n/ntfs-3g/package.yml
+++ b/packages/n/ntfs-3g/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : ntfs-3g
-version    : 2022.10.3
-release    : 20
+version    : 2026.2.25
+release    : 21
 source     :
-    - https://tuxera.com/opensource/ntfs-3g_ntfsprogs-2022.10.3.tgz : f20e36ee68074b845e3629e6bced4706ad053804cbaf062fbae60738f854170c
+    - https://github.com/tuxera/ntfs-3g/archive/refs/tags/2026.2.25.tar.gz : 47de1260fa3fb1aa27d239a637f1178d29a04dd6add6ddff4ea5e47b806731f8
 homepage   : https://github.com/tuxera/ntfs-3g/wiki
 license    : GPL-2.0-or-later
 component  : system.utils
@@ -16,32 +16,23 @@ builddeps  :
     - pkgconfig(libacl)
     - pkgconfig(libattr)
 setup      : |
-    %configure --disable-static \
-               --disable-ldconfig \
-               --enable-crypto \
-               --enable-extras \
-               --enable-posix-acls \
-               --enable-xattr-mappings \
-               --with-fuse=external
+    %patch -p1 -i ${pkgfiles}/build.patch
+
+    %reconfigure \
+        --disable-static \
+        --disable-ldconfig \
+        --enable-crypto \
+        --enable-extras \
+        --enable-posix-acls \
+        --enable-xattr-mappings \
+        --with-fuse=external \
+        --sbin=/usr/sbin
 build      : |
     %make
 install    : |
     %make_install rootbindir=/usr/bin rootsbindir=/usr/sbin rootlibdir=%libdir%
-    rm -rvf $installdir/usr/share/doc
+    %install_license COPYING COPYING.LIB
 
-    # Make existing symlinks relative
-    mv $installdir/sbin/* $installdir/usr/sbin/
-    rmdir -v $installdir/sbin
-    for TOP in {bin,sbin}; do
-        pushd $installdir/usr/$TOP
-        for FILE in *; do
-            if [ -L $FILE ]; then
-                target=$(readlink $FILE)
-                ln -srvf $installdir/$target $FILE
-            fi
-        done
-        popd
-    done
+    rmdir ${installdir}/sbin -v
 
     ln -srv $installdir/usr/bin/ntfs-3g $installdir/usr/sbin/mount.ntfs
-

--- a/packages/n/ntfs-3g/pspec_x86_64.xml
+++ b/packages/n/ntfs-3g/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ntfs-3g</Name>
         <Homepage>https://github.com/tuxera/ntfs-3g/wiki</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -48,6 +48,9 @@
             <Path fileType="executable">/usr/sbin/ntfslabel</Path>
             <Path fileType="executable">/usr/sbin/ntfsresize</Path>
             <Path fileType="executable">/usr/sbin/ntfsundelete</Path>
+            <Path fileType="doc">/usr/share/doc/ntfs-3g/README</Path>
+            <Path fileType="data">/usr/share/licenses/ntfs-3g/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/ntfs-3g/COPYING.LIB</Path>
             <Path fileType="man">/usr/share/man/man8/mkfs.ntfs.8</Path>
             <Path fileType="man">/usr/share/man/man8/mkntfs.8.zst</Path>
             <Path fileType="man">/usr/share/man/man8/mount.lowntfs-3g.8</Path>
@@ -82,7 +85,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="20">ntfs-3g</Dependency>
+            <Dependency release="21">ntfs-3g</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/ntfs-3g/acls.h</Path>
@@ -129,12 +132,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2025-10-25</Date>
-            <Version>2022.10.3</Version>
+        <Update release="21">
+            <Date>2026-04-21</Date>
+            <Version>2026.2.25</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/tuxera/ntfs-3g/wiki/NTFS-3G-Release-History#stable-version-2026225-april-21-2026).

**Security**
- CVE-2026-40706

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build `testdisk` against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
