### PR TITLE
libolm: Update to v3.2.16

### DIFF
--- a/packages/l/libolm/abi_used_symbols
+++ b/packages/l/libolm/abi_used_symbols
@@ -1,11 +1,12 @@
-libc.so.6:__cxa_atexit
 libc.so.6:__memcpy_chk
 libc.so.6:__stack_chk_fail
+libc.so.6:__vsnprintf_chk
 libc.so.6:free
 libc.so.6:malloc
 libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memset
-libc.so.6:snprintf
-libstdc++.so.6:_ZNSt8ios_base4InitC1Ev
-libstdc++.so.6:_ZNSt8ios_base4InitD1Ev
+libstdc++.so.6:_ZSt21ios_base_library_initv
+libstdc++.so.6:_ZSt9terminatev
+libstdc++.so.6:__cxa_begin_catch
+libstdc++.so.6:__gxx_personality_v0

--- a/packages/l/libolm/files/fix-clang.patch
+++ b/packages/l/libolm/files/fix-clang.patch
@@ -1,0 +1,12 @@
+diff '--color=auto' -pruN a/include/olm/list.hh b/include/olm/list.hh
+--- a/include/olm/list.hh	2023-11-23 12:38:51.000000000 -0500
++++ b/include/olm/list.hh	2026-04-21 19:33:44.751709571 -0400
+@@ -99,7 +99,7 @@ public:
+             return *this;
+         }
+         T * this_pos = _data;
+-        T * const other_pos = other._data;
++        T * other_pos = other._data;
+         while (other_pos != other._end) {
+             *this_pos = *other;
+             ++this_pos;

--- a/packages/l/libolm/package.yml
+++ b/packages/l/libolm/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libolm
-version    : 3.2.14
-release    : 2
+version    : 3.2.16
+release    : 3
 source     :
-    - https://gitlab.matrix.org/matrix-org/olm/-/archive/3.2.14/olm-3.2.14.tar.gz : 221e2e33230e8644da89d2064851124b04e9caf846cad2aaa3626b876b42d14a
+    - https://gitlab.matrix.org/matrix-org/olm/-/archive/3.2.16/olm-3.2.16.tar.gz : 1e90f9891009965fd064be747616da46b232086fe270b77605ec9bda34272a68
 license    : Apache-2.0
 homepage   : https://gitlab.matrix.org/matrix-org/olm
 component  : security.library
@@ -14,8 +14,12 @@ builddeps  :
     - pkgconfig(libsodium)
 clang      : true
 setup      : |
-    %cmake_ninja
+    %patch -p1 -i ${pkgfiles}/fix-clang.patch
+
+    %cmake_ninja \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license LICENSE

--- a/packages/l/libolm/pspec_x86_64.xml
+++ b/packages/l/libolm/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>libolm</Name>
         <Homepage>https://gitlab.matrix.org/matrix-org/olm</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>security.library</PartOf>
         <Summary xml:lang="en">Implementation of the Olm and Megolm cryptographic ratchets</Summary>
         <Description xml:lang="en">Implementation of the Olm and Megolm cryptographic ratchets
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>libolm</Name>
@@ -21,7 +21,8 @@
         <PartOf>security.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libolm.so.3</Path>
-            <Path fileType="library">/usr/lib64/libolm.so.3.2.14</Path>
+            <Path fileType="library">/usr/lib64/libolm.so.3.2.16</Path>
+            <Path fileType="data">/usr/share/licenses/libolm/LICENSE</Path>
         </Files>
     </Package>
     <Package>
@@ -31,7 +32,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="2">libolm</Dependency>
+            <Dependency release="3">libolm</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/olm/error.h</Path>
@@ -50,12 +51,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2023-04-20</Date>
-            <Version>3.2.14</Version>
+        <Update release="3">
+            <Date>2026-04-21</Date>
+            <Version>3.2.16</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelogs:
- [3.2.15](https://gitlab.matrix.org/matrix-org/olm/-/releases/3.2.15)
- [3.2.16](https://gitlab.matrix.org/matrix-org/olm/-/releases/3.2.16)

Fixes https://github.com/getsolus/packages/issues/4028

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Successfully launch and use Nheko.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
