### PR TITLE
imagemagick: Update to v7.1.2.21

### DIFF
--- a/packages/i/imagemagick/abi_symbols
+++ b/packages/i/imagemagick/abi_symbols
@@ -2616,6 +2616,7 @@ libMagickCore-7.Q16HDRI.so.10:.gomp_critical_user_MagickCore_GetMEPPSimilarity
 libMagickCore-7.Q16HDRI.so.10:.gomp_critical_user_MagickCore_GetMSESimilarity
 libMagickCore-7.Q16HDRI.so.10:.gomp_critical_user_MagickCore_GetNCCSimilarity
 libMagickCore-7.Q16HDRI.so.10:.gomp_critical_user_MagickCore_GetPASimilarity
+libMagickCore-7.Q16HDRI.so.10:.gomp_critical_user_MagickCore_GetPDCSimilarity
 libMagickCore-7.Q16HDRI.so.10:.gomp_critical_user_MagickCore_GetPHASESimilarity
 libMagickCore-7.Q16HDRI.so.10:.gomp_critical_user_MagickCore_GetSSIMSimularity
 libMagickCore-7.Q16HDRI.so.10:.gomp_critical_user_MagickCore_GetSimilarityMetric

--- a/packages/i/imagemagick/abi_used_symbols
+++ b/packages/i/imagemagick/abi_used_symbols
@@ -308,6 +308,7 @@ libc.so.6:gmtime_r
 libc.so.6:isatty
 libc.so.6:listen
 libc.so.6:lseek
+libc.so.6:lstat
 libc.so.6:malloc
 libc.so.6:memcmp
 libc.so.6:memcpy
@@ -504,7 +505,7 @@ libgomp.so.1:omp_get_num_threads
 libgomp.so.1:omp_get_thread_num
 libgomp.so.1:omp_init_lock
 libgomp.so.1:omp_set_lock
-libgomp.so.1:omp_set_nested
+libgomp.so.1:omp_set_max_active_levels
 libgomp.so.1:omp_unset_lock
 libgs.so.10:gsapi_delete_instance
 libgs.so.10:gsapi_exit
@@ -971,7 +972,6 @@ libtiff.so.6:TIFFReadEncodedStrip
 libtiff.so.6:TIFFReadGPSDirectory
 libtiff.so.6:TIFFReadRGBAImage
 libtiff.so.6:TIFFReadRawStrip
-libtiff.so.6:TIFFReadScanline
 libtiff.so.6:TIFFReadTile
 libtiff.so.6:TIFFScanlineSize
 libtiff.so.6:TIFFSetDirectory

--- a/packages/i/imagemagick/package.yml
+++ b/packages/i/imagemagick/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : imagemagick
-version    : 7.1.2.19
-release    : 213
+version    : 7.1.2.21
+release    : 214
 source     :
-    - https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-19.tar.gz : 91ffe35706ef01d0fc9630e3a81b168b9bdb10b5e1e0b0983c287063cce21210
+    - https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-21.tar.gz : 4ba5b81797910efa93e65fb5a02b496284b8069d64513c6d2687c80d180dd70f
 homepage   : https://imagemagick.org/
 license    : Apache-2.0
 component  : multimedia.graphics

--- a/packages/i/imagemagick/pspec_x86_64.xml
+++ b/packages/i/imagemagick/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>imagemagick</Name>
         <Homepage>https://imagemagick.org/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>multimedia.graphics</PartOf>
@@ -94,7 +94,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="213">imagemagick</Dependency>
+            <Dependency release="214">imagemagick</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/ImageMagick-7/Magick++.h</Path>
@@ -593,12 +593,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="213">
-            <Date>2026-04-21</Date>
-            <Version>7.1.2.19</Version>
+        <Update release="214">
+            <Date>2026-04-22</Date>
+            <Version>7.1.2.21</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/ImageMagick/Website/blob/main/ChangeLog.md).

**Security**
Includes fixes for:
- GHSA-7mxf-ff4f-jj7p

**Test Plan**

`magick identify example.png`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
