### PR TITLE
solseek: Update to 1.2.10

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 1.2.9
-release    : 29
+version    : 1.2.10
+release    : 30
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v1.2.9.tar.gz : 9ac0125b3bba32bb44dee53fbad1630a14545776b5a39b70b2f204ad38e31028
+    - https://github.com/clintre/solseek/archive/refs/tags/v1.2.10.tar.gz : b746f826d84b234ecbc9af8804086476d228740d175e867c2892dda4d83ac5ff
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -71,9 +71,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="29">
-            <Date>2026-04-21</Date>
-            <Version>1.2.9</Version>
+        <Update release="30">
+            <Date>2026-04-22</Date>
+            <Version>1.2.10</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**

Bugfix:
- Fix update checking mechanism to use pkgcli instead of pkcon due to change in upstream packagekit

Full Changelog:
https://github.com/clintre/solseek/releases/tag/v1.2.10

**Test Plan**

Install and test update check

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
