### PR TITLE
solseek: Update to 1.2.11

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 1.2.10
-release    : 30
+version    : 1.2.11
+release    : 31
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v1.2.10.tar.gz : b746f826d84b234ecbc9af8804086476d228740d175e867c2892dda4d83ac5ff
+    - https://github.com/clintre/solseek/archive/refs/tags/v1.2.11.tar.gz : 7840337991e050838db24e22b90cfbd507a4d3697db9cb72b2da6b4a0b1732e6
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -71,9 +71,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="30">
-            <Date>2026-04-22</Date>
-            <Version>1.2.10</Version>
+        <Update release="31">
+            <Date>2026-04-23</Date>
+            <Version>1.2.11</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**
Sorry for rapid second version. the Packagkit change did not just swap commands but changed output formatting as well.

Bugfix:
- Fix 2: change grep for update checking using pkgcli instead of pkcon due to change in upstream packagekit.


Full Changelog:
https://github.com/clintre/solseek/releases/tag/v1.2.11


**Test Plan**

Install tested with updates available this time

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
