### PR TITLE
python-pillow: Update to v12.2.0

### DIFF
--- a/packages/py/python-pillow/abi_symbols
+++ b/packages/py/python-pillow/abi_symbols
@@ -133,6 +133,7 @@ _imaging.cpython-312-x86_64-linux-gnu.so:ImagingPackBGR
 _imaging.cpython-312-x86_64-linux-gnu.so:ImagingPackBGRA
 _imaging.cpython-312-x86_64-linux-gnu.so:ImagingPackBGRX
 _imaging.cpython-312-x86_64-linux-gnu.so:ImagingPackBGRa
+_imaging.cpython-312-x86_64-linux-gnu.so:ImagingPackCMYK2RGB
 _imaging.cpython-312-x86_64-linux-gnu.so:ImagingPackLAB
 _imaging.cpython-312-x86_64-linux-gnu.so:ImagingPackRGB
 _imaging.cpython-312-x86_64-linux-gnu.so:ImagingPackXBGR

--- a/packages/py/python-pillow/abi_used_symbols
+++ b/packages/py/python-pillow/abi_used_symbols
@@ -56,7 +56,7 @@ UNKNOWN:PyMem_Free
 UNKNOWN:PyMem_Malloc
 UNKNOWN:PyModuleDef_Init
 UNKNOWN:PyModule_AddIntConstant
-UNKNOWN:PyModule_AddObject
+UNKNOWN:PyModule_AddObjectRef
 UNKNOWN:PyModule_GetDict
 UNKNOWN:PyNumber_AsSsize_t
 UNKNOWN:PyNumber_Check

--- a/packages/py/python-pillow/package.yml
+++ b/packages/py/python-pillow/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-pillow
-version    : 12.1.1
-release    : 43
+version    : 12.2.0
+release    : 44
 source     :
-    - https://github.com/python-pillow/Pillow/archive/refs/tags/12.1.1.tar.gz : d29fefc0ba637833b59cafc7649e1237186741c31b210178b0a4e9cd9e01ffdf
+    - https://github.com/python-pillow/Pillow/archive/refs/tags/12.2.0.tar.gz : 15d08a03e16953813045ad24c5818e2909ef2141a0b97b2bd3bc8ec6f222cadb
 homepage   : https://python-pillow.github.io/
 license    : MIT-CMU
 component  : programming.python

--- a/packages/py/python-pillow/pspec_x86_64.xml
+++ b/packages/py/python-pillow/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-pillow</Name>
         <Homepage>https://python-pillow.github.io/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>MIT-CMU</License>
         <PartOf>programming.python</PartOf>
@@ -327,12 +327,12 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/PIL/features.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/PIL/py.typed</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/PIL/report.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pillow-12.1.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pillow-12.1.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pillow-12.1.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pillow-12.1.1.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pillow-12.1.1.dist-info/top_level.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pillow-12.1.1.dist-info/zip-safe</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pillow-12.2.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pillow-12.2.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pillow-12.2.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pillow-12.2.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pillow-12.2.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pillow-12.2.0.dist-info/zip-safe</Path>
         </Files>
     </Package>
     <Package>
@@ -342,7 +342,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="43">python-pillow</Dependency>
+            <Dependency release="44">python-pillow</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/python3.12/Arrow.h</Path>
@@ -369,12 +369,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="43">
-            <Date>2026-02-12</Date>
-            <Version>12.1.1</Version>
+        <Update release="44">
+            <Date>2026-04-23</Date>
+            <Version>12.2.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://pillow.readthedocs.io/en/stable/releasenotes/12.2.0.html).

**Security**
Includes fixes for:
- CVE-2026-40192

**Test Plan**

`python3 -c "from PIL import Image; print(Image.__version__)"`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
