### PR TITLE
freerdp: Update to v3.25.0

### DIFF
--- a/packages/f/freerdp/abi_symbols
+++ b/packages/f/freerdp/abi_symbols
@@ -829,6 +829,7 @@ libfreerdp3.so.3:freerdp_video_context_free
 libfreerdp3.so.3:freerdp_video_context_new
 libfreerdp3.so.3:freerdp_video_context_reconfigure
 libfreerdp3.so.3:freerdp_video_conversion_supported
+libfreerdp3.so.3:freerdp_video_format_string
 libfreerdp3.so.3:freerdp_video_sample_convert
 libfreerdp3.so.3:freerdp_write_four_byte_float
 libfreerdp3.so.3:freerdp_write_four_byte_signed_integer
@@ -2254,6 +2255,8 @@ libwinpr3.so.3:WINPR_JSON_version
 libwinpr3.so.3:WLog_AddStringLogFilters
 libwinpr3.so.3:WLog_CloseAppender
 libwinpr3.so.3:WLog_ConfigureAppender
+libwinpr3.so.3:WLog_Create
+libwinpr3.so.3:WLog_Discard
 libwinpr3.so.3:WLog_Get
 libwinpr3.so.3:WLog_GetLogAppender
 libwinpr3.so.3:WLog_GetLogLayout
@@ -2267,6 +2270,7 @@ libwinpr3.so.3:WLog_PrintMessageVA
 libwinpr3.so.3:WLog_PrintTextMessage
 libwinpr3.so.3:WLog_PrintTextMessageVA
 libwinpr3.so.3:WLog_SetContext
+libwinpr3.so.3:WLog_SetGlobalContext
 libwinpr3.so.3:WLog_SetLogAppenderType
 libwinpr3.so.3:WLog_SetLogLevel
 libwinpr3.so.3:WLog_SetStringLogLevel

--- a/packages/f/freerdp/abi_used_symbols
+++ b/packages/f/freerdp/abi_used_symbols
@@ -25,6 +25,7 @@ libSDL2-2.0.so.0:SDL_GetDisplayOrientation
 libSDL2-2.0.so.0:SDL_GetDisplayUsableBounds
 libSDL2-2.0.so.0:SDL_GetError
 libSDL2-2.0.so.0:SDL_GetGlobalMouseState
+libSDL2-2.0.so.0:SDL_GetKeyboardFocus
 libSDL2-2.0.so.0:SDL_GetModState
 libSDL2-2.0.so.0:SDL_GetMouseFocus
 libSDL2-2.0.so.0:SDL_GetMouseState
@@ -76,6 +77,7 @@ libSDL2-2.0.so.0:SDL_SetWindowSize
 libSDL2-2.0.so.0:SDL_SetWindowTitle
 libSDL2-2.0.so.0:SDL_ShowCursor
 libSDL2-2.0.so.0:SDL_ShowMessageBox
+libSDL2-2.0.so.0:SDL_ShowSimpleMessageBox
 libSDL2-2.0.so.0:SDL_ShowWindow
 libSDL2-2.0.so.0:SDL_StartTextInput
 libSDL2-2.0.so.0:SDL_StopTextInput
@@ -927,7 +929,6 @@ libkrb5.so.3:krb5_fwd_tgt_creds
 libkrb5.so.3:krb5_get_credentials
 libkrb5.so.3:krb5_get_default_realm
 libkrb5.so.3:krb5_get_error_message
-libkrb5.so.3:krb5_get_etype_info
 libkrb5.so.3:krb5_get_init_creds_keytab
 libkrb5.so.3:krb5_get_init_creds_opt_alloc
 libkrb5.so.3:krb5_get_init_creds_opt_free

--- a/packages/f/freerdp/package.yml
+++ b/packages/f/freerdp/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : freerdp
-version    : 3.24.2
-release    : 49
+version    : 3.25.0
+release    : 50
 source     :
-    - https://pub.freerdp.com/releases/freerdp-3.24.2.tar.xz : 653b273f2a428b8a31be1e157815b2c9ec552a4c376ff3ec28b311c8a74e99b3
+    - https://pub.freerdp.com/releases/freerdp-3.25.0.tar.xz : 460d6a993b9170a363f74a35eec68cd905813e7a80229e807a9dc550bd9708ec
 homepage   : https://www.freerdp.com/
 license    : Apache-2.0
 component  : network.util

--- a/packages/f/freerdp/pspec_x86_64.xml
+++ b/packages/f/freerdp/pspec_x86_64.xml
@@ -33,21 +33,21 @@
             <Path fileType="library">/usr/lib64/freerdp3/proxy/libproxy-demo-plugin.so</Path>
             <Path fileType="library">/usr/lib64/freerdp3/proxy/libproxy-dyn-channel-dump-plugin.so</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-client3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-client3.so.3.24.2</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-client3.so.3.25.0</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-server-proxy3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-server-proxy3.so.3.24.2</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-server-proxy3.so.3.25.0</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-server3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-server3.so.3.24.2</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-server3.so.3.25.0</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-shadow-subsystem3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-shadow-subsystem3.so.3.24.2</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-shadow-subsystem3.so.3.25.0</Path>
             <Path fileType="library">/usr/lib64/libfreerdp-shadow3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp-shadow3.so.3.24.2</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp-shadow3.so.3.25.0</Path>
             <Path fileType="library">/usr/lib64/libfreerdp3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libfreerdp3.so.3.24.2</Path>
+            <Path fileType="library">/usr/lib64/libfreerdp3.so.3.25.0</Path>
             <Path fileType="library">/usr/lib64/libwinpr-tools3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libwinpr-tools3.so.3.24.2</Path>
+            <Path fileType="library">/usr/lib64/libwinpr-tools3.so.3.25.0</Path>
             <Path fileType="library">/usr/lib64/libwinpr3.so.3</Path>
-            <Path fileType="library">/usr/lib64/libwinpr3.so.3.24.2</Path>
+            <Path fileType="library">/usr/lib64/libwinpr3.so.3.25.0</Path>
             <Path fileType="data">/usr/share/FreeRDP/images/test_icon.bmp</Path>
             <Path fileType="data">/usr/share/FreeRDP/images/test_icon.jpg</Path>
             <Path fileType="data">/usr/share/FreeRDP/images/test_icon.png</Path>
@@ -70,7 +70,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="49">freerdp</Dependency>
+            <Dependency release="50">freerdp</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/freerdp3/freerdp/addin.h</Path>
@@ -135,6 +135,7 @@
             <Path fileType="header">/usr/include/freerdp3/freerdp/client/utils/smartcard_cli.h</Path>
             <Path fileType="header">/usr/include/freerdp3/freerdp/client/video.h</Path>
             <Path fileType="header">/usr/include/freerdp3/freerdp/codec/audio.h</Path>
+            <Path fileType="header">/usr/include/freerdp3/freerdp/codec/av1.h</Path>
             <Path fileType="header">/usr/include/freerdp3/freerdp/codec/bitmap.h</Path>
             <Path fileType="header">/usr/include/freerdp3/freerdp/codec/bulk.h</Path>
             <Path fileType="header">/usr/include/freerdp3/freerdp/codec/clear.h</Path>
@@ -377,9 +378,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="49">
-            <Date>2026-03-25</Date>
-            <Version>3.24.2</Version>
+        <Update release="50">
+            <Date>2026-04-23</Date>
+            <Version>3.25.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://www.freerdp.com/2026/04/23/3_25_0-release).

**Security**
- CVE-2026-40254

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Built gnome-remote-desktop against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
