### PR TITLE
bubblewrap: Update to v0.11.2

### DIFF
--- a/packages/b/bubblewrap/abi_symbols
+++ b/packages/b/bubblewrap/abi_symbols
@@ -1,1 +1,2 @@
+bwrap:_IO_stdin_used
 bwrap:pivot_root

--- a/packages/b/bubblewrap/abi_used_symbols
+++ b/packages/b/bubblewrap/abi_used_symbols
@@ -48,7 +48,6 @@ libc.so.6:isatty
 libc.so.6:lstat64
 libc.so.6:malloc
 libc.so.6:memchr
-libc.so.6:memcpy
 libc.so.6:mkdir
 libc.so.6:mkstemp64
 libc.so.6:mount
@@ -68,13 +67,13 @@ libc.so.6:recvmsg
 libc.so.6:sendmsg
 libc.so.6:sendto
 libc.so.6:setenv
-libc.so.6:setfsuid
 libc.so.6:setgid
 libc.so.6:sethostname
 libc.so.6:setns
 libc.so.6:setsid
 libc.so.6:setsockopt
 libc.so.6:setuid
+libc.so.6:sigaction
 libc.so.6:sigaddset
 libc.so.6:sigemptyset
 libc.so.6:signalfd

--- a/packages/b/bubblewrap/package.yml
+++ b/packages/b/bubblewrap/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : bubblewrap
-version    : 0.11.0
-release    : 21
+version    : 0.11.2
+release    : 22
 source     :
-    - https://github.com/containers/bubblewrap/releases/download/v0.11.0/bubblewrap-0.11.0.tar.xz : 988fd6b232dafa04b8b8198723efeaccdb3c6aa9c1c7936219d5791a8b7a8646
+    - https://github.com/containers/bubblewrap/releases/download/v0.11.2/bubblewrap-0.11.2.tar.xz : 69abc30005d2186baf7737feacd8da35633b93cf5af38838ecff17c5f8e924f6
 license    : LGPL-2.0-or-later
 component  : security
 homepage   : https://github.com/containers/bubblewrap/
@@ -20,3 +20,6 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING
+check      : |
+    %ninja_check

--- a/packages/b/bubblewrap/pspec_x86_64.xml
+++ b/packages/b/bubblewrap/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>bubblewrap</Name>
         <Homepage>https://github.com/containers/bubblewrap/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.0-or-later</License>
         <PartOf>security</PartOf>
@@ -22,17 +22,18 @@
         <Files>
             <Path fileType="executable">/usr/bin/bwrap</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/bwrap</Path>
-            <Path fileType="man">/usr/share/man/man1/bwrap.1</Path>
+            <Path fileType="data">/usr/share/licenses/bubblewrap/COPYING</Path>
+            <Path fileType="man">/usr/share/man/man1/bwrap.1.zst</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_bwrap</Path>
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2024-11-14</Date>
-            <Version>0.11.0</Version>
+        <Update release="22">
+            <Date>2026-04-23</Date>
+            <Version>0.11.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelogs:
- [0.11.1](https://github.com/containers/bubblewrap/releases/tag/v0.11.1)
- [0.11.2](https://github.com/containers/bubblewrap/releases/tag/v0.11.2)

**Security**
- CVE-2026-41163

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

TBD

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
