### PR TITLE
python-nbconvert: Update to v7.17.1

### DIFF
--- a/packages/py/python-nbconvert/package.yml
+++ b/packages/py/python-nbconvert/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-nbconvert
-version    : 7.17.0
-release    : 21
+version    : 7.17.1
+release    : 22
 source     :
-    - https://files.pythonhosted.org/packages/source/n/nbconvert/nbconvert-7.17.0.tar.gz : 1b2696f1b5be12309f6c7d707c24af604b87dfaf6d950794c7b07acab96dda78
+    - https://files.pythonhosted.org/packages/source/n/nbconvert/nbconvert-7.17.1.tar.gz : 34d0d0a7e73ce3cbab6c5aae8f4f468797280b01fd8bd2ca746da8569eddd7d2
 homepage   : https://github.com/jupyter/nbconvert
 license    : BSD-3-Clause
 component  : programming.python

--- a/packages/py/python-nbconvert/pspec_x86_64.xml
+++ b/packages/py/python-nbconvert/pspec_x86_64.xml
@@ -22,11 +22,11 @@
         <Files>
             <Path fileType="executable">/usr/bin/jupyter-dejavu</Path>
             <Path fileType="executable">/usr/bin/jupyter-nbconvert</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert-7.17.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert-7.17.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert-7.17.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert-7.17.0.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert-7.17.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert-7.17.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert-7.17.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert-7.17.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert-7.17.1.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert-7.17.1.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/nbconvert/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -300,9 +300,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2026-03-29</Date>
-            <Version>7.17.0</Version>
+        <Update release="22">
+            <Date>2026-04-24</Date>
+            <Version>7.17.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://nbconvert.readthedocs.io/en/latest/changelog.html).

**Security**
Includes fixes for:
- CVE-2026-39377
- CVE-2026-39378

**Test Plan**

Convert .ipynb to .md

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
