### PR TITLE
podman: Update to v5.8.2

### DIFF
--- a/packages/p/podman/abi_used_symbols
+++ b/packages/p/podman/abi_used_symbols
@@ -17,6 +17,7 @@ libc.so.6:abort
 libc.so.6:access
 libc.so.6:calloc
 libc.so.6:chdir
+libc.so.6:clearenv
 libc.so.6:close
 libc.so.6:closedir
 libc.so.6:dirfd

--- a/packages/p/podman/package.yml
+++ b/packages/p/podman/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : podman
-version    : 5.7.1
-release    : 45
+version    : 5.8.2
+release    : 46
 source     :
-    - https://github.com/containers/podman/archive/refs/tags/v5.7.1.tar.gz : c04c12f90d1bf410ccc4d27a30cff188d6a9361bddb5fceb19659ae08257cc6f
+    - https://github.com/containers/podman/archive/refs/tags/v5.8.2.tar.gz : b20ea65afc5a58ea1cea019bd51a5d84eb9042d25d3eb82c55010c8815732d84
     - https://github.com/openSUSE/catatonit/releases/download/v0.2.1/catatonit.tar.xz#catatonit.tar.gz: 9950425501af862e12f618bdc930ea755c46db6a16072a1462b4fc93b2bd59bc
 license    :
     - Apache-2.0 # podman

--- a/packages/p/podman/pspec_x86_64.xml
+++ b/packages/p/podman/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>podman</Name>
         <Homepage>https://podman.io/</Homepage>
         <Packager>
-            <Name>Mislav &#x10c;akari&#x107;</Name>
-            <Email>mcakaric@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>GPL-2.0-or-later</License>
@@ -293,12 +293,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="45">
-            <Date>2025-12-18</Date>
-            <Version>5.7.1</Version>
+        <Update release="46">
+            <Date>2026-04-26</Date>
+            <Version>5.8.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Mislav &#x10c;akari&#x107;</Name>
-            <Email>mcakaric@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/containers/podman/releases).

**Security**
Includes fixes for:
- CVE-2026-33414

**Test Plan**

`podman info` `podman version` `podman pull`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
