### PR TITLE
fastfetch: Update to v2.62.1

### DIFF
--- a/packages/f/fastfetch/package.yml
+++ b/packages/f/fastfetch/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : fastfetch
-version    : 2.62.0
-release    : 71
+version    : 2.62.1
+release    : 72
 source     :
-    - https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/2.62.0.tar.gz : b3b18ba33e0d1af732716a28dc6c17bcb29ef1286d929f8a0aec3f7c57ffb010
+    - https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/2.62.1.tar.gz : 8c4833e55b8b445a32c7cb7570007b5e10a9ee4cee74a494004ba61e88b12b26
 homepage   : https://github.com/fastfetch-cli/fastfetch
 license    : MIT
 component  : system.utils

--- a/packages/f/fastfetch/pspec_x86_64.xml
+++ b/packages/f/fastfetch/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>fastfetch</Name>
         <Homepage>https://github.com/fastfetch-cli/fastfetch</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -67,12 +67,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="71">
-            <Date>2026-04-22</Date>
-            <Version>2.62.0</Version>
+        <Update release="72">
+            <Date>2026-04-26</Date>
+            <Version>2.62.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/fastfetch-cli/fastfetch/releases/tag/2.62.1).
- Fixes Host module not working on some devices (Host, Linux)
- Regression from v2.61.0

**Test Plan**

`fastfetch` and saw output. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
