### PR TITLE
hidapi: Update to v0.15.0

### DIFF
--- a/packages/h/hidapi/abi_symbols
+++ b/packages/h/hidapi/abi_symbols
@@ -15,8 +15,10 @@ libhidapi-hidraw.so.0:hid_init
 libhidapi-hidraw.so.0:hid_open
 libhidapi-hidraw.so.0:hid_open_path
 libhidapi-hidraw.so.0:hid_read
+libhidapi-hidraw.so.0:hid_read_error
 libhidapi-hidraw.so.0:hid_read_timeout
 libhidapi-hidraw.so.0:hid_send_feature_report
+libhidapi-hidraw.so.0:hid_send_output_report
 libhidapi-hidraw.so.0:hid_set_nonblocking
 libhidapi-hidraw.so.0:hid_version
 libhidapi-hidraw.so.0:hid_version_str
@@ -40,8 +42,10 @@ libhidapi-libusb.so.0:hid_libusb_wrap_sys_device
 libhidapi-libusb.so.0:hid_open
 libhidapi-libusb.so.0:hid_open_path
 libhidapi-libusb.so.0:hid_read
+libhidapi-libusb.so.0:hid_read_error
 libhidapi-libusb.so.0:hid_read_timeout
 libhidapi-libusb.so.0:hid_send_feature_report
+libhidapi-libusb.so.0:hid_send_output_report
 libhidapi-libusb.so.0:hid_set_nonblocking
 libhidapi-libusb.so.0:hid_version
 libhidapi-libusb.so.0:hid_version_str

--- a/packages/h/hidapi/abi_symbols32
+++ b/packages/h/hidapi/abi_symbols32
@@ -15,8 +15,10 @@ libhidapi-hidraw.so.0:hid_init
 libhidapi-hidraw.so.0:hid_open
 libhidapi-hidraw.so.0:hid_open_path
 libhidapi-hidraw.so.0:hid_read
+libhidapi-hidraw.so.0:hid_read_error
 libhidapi-hidraw.so.0:hid_read_timeout
 libhidapi-hidraw.so.0:hid_send_feature_report
+libhidapi-hidraw.so.0:hid_send_output_report
 libhidapi-hidraw.so.0:hid_set_nonblocking
 libhidapi-hidraw.so.0:hid_version
 libhidapi-hidraw.so.0:hid_version_str
@@ -40,8 +42,10 @@ libhidapi-libusb.so.0:hid_libusb_wrap_sys_device
 libhidapi-libusb.so.0:hid_open
 libhidapi-libusb.so.0:hid_open_path
 libhidapi-libusb.so.0:hid_read
+libhidapi-libusb.so.0:hid_read_error
 libhidapi-libusb.so.0:hid_read_timeout
 libhidapi-libusb.so.0:hid_send_feature_report
+libhidapi-libusb.so.0:hid_send_output_report
 libhidapi-libusb.so.0:hid_set_nonblocking
 libhidapi-libusb.so.0:hid_version
 libhidapi-libusb.so.0:hid_version_str

--- a/packages/h/hidapi/abi_used_symbols
+++ b/packages/h/hidapi/abi_used_symbols
@@ -2,10 +2,12 @@ libc.so.6:__ctype_tolower_loc
 libc.so.6:__errno_location
 libc.so.6:__isoc99_sscanf
 libc.so.6:__memcpy_chk
+libc.so.6:__open_2
+libc.so.6:__poll_chk
 libc.so.6:__pthread_register_cancel
 libc.so.6:__pthread_unregister_cancel
+libc.so.6:__read_chk
 libc.so.6:__sigsetjmp
-libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__vsnprintf_chk
 libc.so.6:calloc
@@ -21,8 +23,6 @@ libc.so.6:malloc
 libc.so.6:mbstowcs
 libc.so.6:memcpy
 libc.so.6:memset
-libc.so.6:open
-libc.so.6:poll
 libc.so.6:pthread_barrier_destroy
 libc.so.6:pthread_barrier_init
 libc.so.6:pthread_barrier_wait
@@ -93,5 +93,6 @@ libusb-1.0.so.0:libusb_interrupt_transfer
 libusb-1.0.so.0:libusb_kernel_driver_active
 libusb-1.0.so.0:libusb_open
 libusb-1.0.so.0:libusb_release_interface
+libusb-1.0.so.0:libusb_set_interface_alt_setting
 libusb-1.0.so.0:libusb_submit_transfer
 libusb-1.0.so.0:libusb_wrap_sys_device

--- a/packages/h/hidapi/abi_used_symbols32
+++ b/packages/h/hidapi/abi_used_symbols32
@@ -2,10 +2,12 @@ libc.so.6:__ctype_tolower_loc
 libc.so.6:__errno_location
 libc.so.6:__isoc99_sscanf
 libc.so.6:__memcpy_chk
+libc.so.6:__open_2
+libc.so.6:__poll_chk
 libc.so.6:__pthread_register_cancel
 libc.so.6:__pthread_unregister_cancel
+libc.so.6:__read_chk
 libc.so.6:__sigsetjmp
-libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__vsnprintf_chk
 libc.so.6:calloc
@@ -21,8 +23,6 @@ libc.so.6:malloc
 libc.so.6:mbstowcs
 libc.so.6:memcpy
 libc.so.6:memset
-libc.so.6:open
-libc.so.6:poll
 libc.so.6:pthread_barrier_destroy
 libc.so.6:pthread_barrier_init
 libc.so.6:pthread_barrier_wait
@@ -93,5 +93,6 @@ libusb-1.0.so.0:libusb_interrupt_transfer
 libusb-1.0.so.0:libusb_kernel_driver_active
 libusb-1.0.so.0:libusb_open
 libusb-1.0.so.0:libusb_release_interface
+libusb-1.0.so.0:libusb_set_interface_alt_setting
 libusb-1.0.so.0:libusb_submit_transfer
 libusb-1.0.so.0:libusb_wrap_sys_device

--- a/packages/h/hidapi/package.yml
+++ b/packages/h/hidapi/package.yml
@@ -1,10 +1,13 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : hidapi
-version    : 0.14.0
-release    : 9
+version    : 0.15.0
+release    : 10
 source     :
-    - https://github.com/libusb/hidapi/archive/refs/tags/hidapi-0.14.0.tar.gz : a5714234abe6e1f53647dd8cba7d69f65f71c558b7896ed218864ffcf405bcbd
-license    : GPL-3.0-or-later
+    - https://github.com/libusb/hidapi/archive/refs/tags/hidapi-0.15.0.tar.gz : 5d84dec684c27b97b921d2f3b73218cb773cf4ea915caee317ac8fc73cef8136
+license    :
+    - BSD-3-Clause
+    - HIDAPI
+    - GPL-3.0-or-later
 component  : programming
 homepage   : https://github.com/libusb/hidapi/
 summary    : Simple library for communicating with USB and Bluetooth HID devices
@@ -21,5 +24,5 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
-    # Remove all the doc stuff, it's just licensing
-    rm -rf $installdir/usr/share/
+    
+    %install_license LICENSE-bsd.txt LICENSE-gpl3.txt LICENSE-orig.txt

--- a/packages/h/hidapi/pspec_x86_64.xml
+++ b/packages/h/hidapi/pspec_x86_64.xml
@@ -3,9 +3,11 @@
         <Name>hidapi</Name>
         <Homepage>https://github.com/libusb/hidapi/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Packager>
+        <License>BSD-3-Clause</License>
+        <License>HIDAPI</License>
         <License>GPL-3.0-or-later</License>
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Simple library for communicating with USB and Bluetooth HID devices</Summary>
@@ -21,9 +23,12 @@
         <PartOf>programming</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libhidapi-hidraw.so.0</Path>
-            <Path fileType="library">/usr/lib64/libhidapi-hidraw.so.0.14.0</Path>
+            <Path fileType="library">/usr/lib64/libhidapi-hidraw.so.0.15.0</Path>
             <Path fileType="library">/usr/lib64/libhidapi-libusb.so.0</Path>
-            <Path fileType="library">/usr/lib64/libhidapi-libusb.so.0.14.0</Path>
+            <Path fileType="library">/usr/lib64/libhidapi-libusb.so.0.15.0</Path>
+            <Path fileType="data">/usr/share/licenses/hidapi/LICENSE-bsd.txt</Path>
+            <Path fileType="data">/usr/share/licenses/hidapi/LICENSE-gpl3.txt</Path>
+            <Path fileType="data">/usr/share/licenses/hidapi/LICENSE-orig.txt</Path>
         </Files>
     </Package>
     <Package>
@@ -33,13 +38,13 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="9">hidapi</Dependency>
+            <Dependency release="10">hidapi</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libhidapi-hidraw.so.0</Path>
-            <Path fileType="library">/usr/lib32/libhidapi-hidraw.so.0.14.0</Path>
+            <Path fileType="library">/usr/lib32/libhidapi-hidraw.so.0.15.0</Path>
             <Path fileType="library">/usr/lib32/libhidapi-libusb.so.0</Path>
-            <Path fileType="library">/usr/lib32/libhidapi-libusb.so.0.14.0</Path>
+            <Path fileType="library">/usr/lib32/libhidapi-libusb.so.0.15.0</Path>
         </Files>
     </Package>
     <Package>
@@ -49,8 +54,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="9">hidapi-devel</Dependency>
-            <Dependency release="9">hidapi-32bit</Dependency>
+            <Dependency release="10">hidapi-32bit</Dependency>
+            <Dependency release="10">hidapi-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/cmake/hidapi/hidapi-config-version.cmake</Path>
@@ -70,7 +75,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="9">hidapi</Dependency>
+            <Dependency release="10">hidapi</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/hidapi/hidapi.h</Path>
@@ -86,12 +91,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2023-11-04</Date>
-            <Version>0.14.0</Version>
+        <Update release="10">
+            <Date>2026-04-26</Date>
+            <Version>0.15.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Robert Gonzalez</Name>
+            <Email>uni.dos12@outlook.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- install licenses
- changelog can be found [here](https://github.com/libusb/hidapi/releases/tag/hidapi-0.15.0)

**Test Plan**

launch application that uses library

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
