### PR TITLE
fzf: Update to 0.72.0

### DIFF
--- a/packages/f/fzf/package.yml
+++ b/packages/f/fzf/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : fzf
-version    : 0.70.0
-release    : 50
+version    : 0.72.0
+release    : 51
 source     :
-    - git|https://github.com/junegunn/fzf : v0.70.0
+    - git|https://github.com/junegunn/fzf : v0.72.0
 homepage   : https://github.com/junegunn/fzf
 license    : MIT
 component  : system.utils

--- a/packages/f/fzf/pspec_x86_64.xml
+++ b/packages/f/fzf/pspec_x86_64.xml
@@ -3,7 +3,7 @@
         <Name>fzf</Name>
         <Homepage>https://github.com/junegunn/fzf</Homepage>
         <Packager>
-            <Name>clintre</Name>
+            <Name>Clint Eschberger</Name>
             <Email>clint@eschberger.info</Email>
         </Packager>
         <License>MIT</License>
@@ -36,11 +36,11 @@
         </Files>
     </Package>
     <History>
-        <Update release="50">
-            <Date>2026-03-05</Date>
-            <Version>0.70.0</Version>
+        <Update release="51">
+            <Date>2026-04-26</Date>
+            <Version>0.72.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>clintre</Name>
+            <Name>Clint Eschberger</Name>
             <Email>clint@eschberger.info</Email>
         </Update>
     </History>


### PR DESCRIPTION
**Summary**

Bugfixes:
- Fixed gutter display in --style=minimal
- Fixed arrow keys / Home / End without modifiers being ignored under the kitty keyboard protocol
- bash: Persist history deletion when histappend is on

Enhancements:
- Border style enhancements including new dashed border style
- vim: Move and resize popup window when detecting VimResized event

Fixes getsolus/packages#8662


[Full Change Log](https://github.com/junegunn/fzf/releases/tag/v0.72.0)

**Test Plan**

Install and tested

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
