### PR TITLE
mako: Update to v1.3.12

### DIFF
--- a/packages/m/mako/package.yml
+++ b/packages/m/mako/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : mako
-version    : 1.3.2
-release    : 12
+version    : 1.3.12
+release    : 13
 source     :
-    - https://files.pythonhosted.org/packages/source/M/Mako/Mako-1.3.2.tar.gz : 2a0c8ad7f6274271b3bb7467dd37cf9cc6dab4bc19cb69a4ef10669402de698e
+    - https://files.pythonhosted.org/packages/source/m/mako/mako-1.3.12.tar.gz : 9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a
 homepage   : https://www.makotemplates.org/
 license    : MIT
 component  : programming.python
@@ -18,7 +18,6 @@ builddeps  :
     - python-wheel
 checkdeps  :
     - python-babel
-    - python-mock
     - python-pytest
 rundeps    :
     - python-markupsafe

--- a/packages/m/mako/pspec_x86_64.xml
+++ b/packages/m/mako/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mako</Name>
         <Homepage>https://www.makotemplates.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -21,12 +21,12 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/mako-render</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/mako-1.3.2.dist-info/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/mako-1.3.2.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/mako-1.3.2.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/mako-1.3.2.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/mako-1.3.2.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/mako-1.3.2.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/mako-1.3.12.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/mako-1.3.12.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/mako-1.3.12.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/mako-1.3.12.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/mako-1.3.12.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/mako-1.3.12.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/mako/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/mako/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/mako/__pycache__/__init__.cpython-312.pyc</Path>
@@ -129,12 +129,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2025-05-15</Date>
-            <Version>1.3.2</Version>
+        <Update release="13">
+            <Date>2026-04-29</Date>
+            <Version>1.3.12</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://docs.makotemplates.org/en/latest/changelog.html).

**Security**
Includes fixes for:
- CVE-2026-41205

**Test Plan**

`python3 -c "from mako.template import Template; print(Template('hello ${name}').render(name='world'))"
` 
See hello

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
