### PR TITLE
solseek: Update to 1.3.0

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 1.2.11
-release    : 31
+version    : 1.3.0
+release    : 32
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v1.2.11.tar.gz : 7840337991e050838db24e22b90cfbd507a4d3697db9cb72b2da6b4a0b1732e6
+    - https://github.com/clintre/solseek/archive/refs/tags/v1.3.0.tar.gz : c50cf2fd796a1445b20645d8ff2d1961f9d4a2a71c05ea1334fbaa7a48fbe6e7
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -71,9 +71,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2026-04-23</Date>
-            <Version>1.2.11</Version>
+        <Update release="32">
+            <Date>2026-04-29</Date>
+            <Version>1.3.0</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**

Enhancements:
- Added enhanced cli search command. Search eopkg or use -a to search both eopkg and flatpak or -f to search flatpak
- Enhanced local cache which should speed things up
- Enhanced search using details from eopkg and flatpak
- Local index cache now has more details for future api changes
- Updated help for enhanced search and made options easier to understand


Config Changes:
- SS_EOPKG_LCACHE is deperecated as local cache is now the default
- SS_EOPKG_DCACHE is added in case there is a reason to disable local cache


[Full Changelog](https://github.com/clintre/solseek/releases/tag/v1.3.0)


**Test Plan**

Install and test

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
