### PR TITLE
openssh: Enable openssh server by default

### DIFF
--- a/packages/o/openssh/files/openssh-server.preset
+++ b/packages/o/openssh/files/openssh-server.preset
@@ -1,0 +1,1 @@
+enable sshd.service

--- a/packages/o/openssh/package.yml
+++ b/packages/o/openssh/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : openssh
 version    : 10.3_p1
-release    : 64
+release    : 65
 source     :
     - https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-10.3p1.tar.gz : 56682a36bb92dcf4b4f016fd8ec8e74059b79a8de25c15d670d731e7d18e45f4
 homepage   : https://www.openssh.com/
@@ -70,6 +70,9 @@ install    : |
     install -Dm 00644 $pkgfiles/openssh-server.tmpfiles $installdir/usr/lib/tmpfiles.d/openssh-server.conf
     install -Dm 00644 $pkgfiles/openssh.sysusers $installdir/usr/lib/sysusers.d/openssh.conf
 
+    # Enable openssh-server for the package
+    install -Dm0644 $pkgfiles/openssh-server.preset $installdir/usr/lib/systemd/system-preset/60-openssh.preset
+
     # Stateless
     install -dm00755 $installdir/usr/share/defaults/
     mv $installdir/etc/ssh $installdir/usr/share/defaults/
@@ -82,6 +85,7 @@ patterns   :
     - server :
         - /usr/sbin
         - /usr/lib/systemd/system
+        - /usr/lib/systemd/system-preset
         - /usr/lib/sysusers.d
         - /usr/lib/tmpfiles.d/openssh-server.conf
         - /usr/lib64/openssh/sftp*

--- a/packages/o/openssh/pspec_x86_64.xml
+++ b/packages/o/openssh/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>openssh</Name>
         <Homepage>https://www.openssh.com/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <License>BSD-3-Clause</License>
@@ -58,9 +58,10 @@
 </Description>
         <PartOf>network.clients</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="64">openssh</Dependency>
+            <Dependency releaseFrom="65">openssh</Dependency>
         </RuntimeDependencies>
         <Files>
+            <Path fileType="library">/usr/lib/systemd/system-preset/60-openssh.preset</Path>
             <Path fileType="library">/usr/lib/systemd/system/sshd-keygen.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/sshd.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/sshd@.service</Path>
@@ -79,12 +80,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="64">
-            <Date>2026-04-02</Date>
+        <Update release="65">
+            <Date>2026-04-30</Date>
             <Version>10.3_p1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Enables the `sshd.service` by default, as users that install the `openssh-server` package probably want an SSH server to be running on their system.

**Test Plan**

1. Install updated package.
2. Verify that the service is now `preset: enabled` instead of `disabled`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
