### PR TITLE
cups: Update to v2.4.19

### DIFF
--- a/packages/c/cups/package.yml
+++ b/packages/c/cups/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : cups
-version    : 2.4.18
-release    : 43
+version    : 2.4.19
+release    : 44
 source     :
-    - https://github.com/OpenPrinting/cups/releases/download/v2.4.18/cups-2.4.18-source.tar.gz : 8fe23bf4905f8889f4bd5ebf375e81916e84754bfc59eccc88cfd7b1e97a741b
-homepage   : https://openprinting.github.io/cups/index.html
+    - https://github.com/OpenPrinting/cups/releases/download/v2.4.19/cups-2.4.19-source.tar.gz : 820984b12a67f98705785aae2dd1347fe0ac097828001d4583ff64574aed6389
+homepage   : https://openprinting.github.io/cups/
 license    :
     - Apache-2.0 WITH LLVM-exception
     - BSD-2-Clause

--- a/packages/c/cups/pspec_x86_64.xml
+++ b/packages/c/cups/pspec_x86_64.xml
@@ -1,7 +1,7 @@
 <PISI>
     <Source>
         <Name>cups</Name>
-        <Homepage>https://openprinting.github.io/cups/index.html</Homepage>
+        <Homepage>https://openprinting.github.io/cups/</Homepage>
         <Packager>
             <Name>Robert Gonzalez</Name>
             <Email>uni.dos12@outlook.com</Email>
@@ -880,7 +880,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="43">cups</Dependency>
+            <Dependency release="44">cups</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libcups.so.2</Path>
@@ -894,8 +894,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="43">cups-devel</Dependency>
-            <Dependency release="43">cups-32bit</Dependency>
+            <Dependency release="44">cups-32bit</Dependency>
+            <Dependency release="44">cups-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libcups.so</Path>
@@ -910,7 +910,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="43">cups</Dependency>
+            <Dependency release="44">cups</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/cups-config</Path>
@@ -936,9 +936,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="43">
-            <Date>2026-04-25</Date>
-            <Version>2.4.18</Version>
+        <Update release="44">
+            <Date>2026-04-29</Date>
+            <Version>2.4.19</Version>
             <Comment>Packaging update</Comment>
             <Name>Robert Gonzalez</Name>
             <Email>uni.dos12@outlook.com</Email>


### PR DESCRIPTION
**Summary**
- fix a regression in shared printing from non-local accounts

**Test Plan**

launch cups administration page

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
