### PR TITLE
curl: Update to v8.20.0

### DIFF
--- a/packages/c/curl/abi_used_symbols
+++ b/packages/c/curl/abi_used_symbols
@@ -75,6 +75,11 @@ libc.so.6:open
 libc.so.6:opendir
 libc.so.6:pipe
 libc.so.6:poll
+libc.so.6:pthread_cond_destroy
+libc.so.6:pthread_cond_init
+libc.so.6:pthread_cond_signal
+libc.so.6:pthread_cond_timedwait
+libc.so.6:pthread_cond_wait
 libc.so.6:pthread_create
 libc.so.6:pthread_detach
 libc.so.6:pthread_join
@@ -158,9 +163,6 @@ libcrypto.so.3:BN_clear_free
 libcrypto.so.3:BN_num_bits
 libcrypto.so.3:BN_print
 libcrypto.so.3:CRYPTO_free
-libcrypto.so.3:DES_ecb_encrypt
-libcrypto.so.3:DES_set_key_unchecked
-libcrypto.so.3:DES_set_odd_parity
 libcrypto.so.3:ENGINE_by_id
 libcrypto.so.3:ENGINE_ctrl
 libcrypto.so.3:ENGINE_ctrl_cmd
@@ -191,9 +193,11 @@ libcrypto.so.3:EVP_PKEY_get0_type_name
 libcrypto.so.3:EVP_PKEY_get1_RSA
 libcrypto.so.3:EVP_PKEY_get_bits
 libcrypto.so.3:EVP_PKEY_get_bn_param
+libcrypto.so.3:EVP_PKEY_get_default_digest_name
 libcrypto.so.3:EVP_PKEY_get_group_name
 libcrypto.so.3:EVP_PKEY_get_id
 libcrypto.so.3:EVP_PKEY_get_security_bits
+libcrypto.so.3:EVP_PKEY_is_a
 libcrypto.so.3:EVP_get_digestbyname
 libcrypto.so.3:EVP_sha1
 libcrypto.so.3:EVP_sha256
@@ -202,7 +206,6 @@ libcrypto.so.3:GENERAL_NAMES_free
 libcrypto.so.3:MD5_Final
 libcrypto.so.3:MD5_Init
 libcrypto.so.3:MD5_Update
-libcrypto.so.3:OBJ_find_sigid_algs
 libcrypto.so.3:OBJ_nid2sn
 libcrypto.so.3:OBJ_obj2txt
 libcrypto.so.3:OCSP_BASICRESP_free
@@ -294,7 +297,7 @@ libcrypto.so.3:X509_get_ext_d2i
 libcrypto.so.3:X509_get_issuer_name
 libcrypto.so.3:X509_get_pubkey
 libcrypto.so.3:X509_get_serialNumber
-libcrypto.so.3:X509_get_signature_nid
+libcrypto.so.3:X509_get_signature_info
 libcrypto.so.3:X509_get_subject_name
 libcrypto.so.3:X509_get_version
 libcrypto.so.3:X509_load_crl_file
@@ -402,11 +405,6 @@ libidn2.so.0:idn2_check_version
 libidn2.so.0:idn2_free
 libidn2.so.0:idn2_lookup_ul
 libidn2.so.0:idn2_to_unicode_8z8z
-libnettle.so.8:nettle_des_encrypt
-libnettle.so.8:nettle_des_set_key
-libnettle.so.8:nettle_md4_digest
-libnettle.so.8:nettle_md4_init
-libnettle.so.8:nettle_md4_update
 libnettle.so.8:nettle_md5_digest
 libnettle.so.8:nettle_md5_init
 libnettle.so.8:nettle_md5_update

--- a/packages/c/curl/abi_used_symbols32
+++ b/packages/c/curl/abi_used_symbols32
@@ -21,6 +21,7 @@ libc.so.6:fclose
 libc.so.6:fcntl64
 libc.so.6:fdopen
 libc.so.6:feof
+libc.so.6:ferror
 libc.so.6:fflush
 libc.so.6:fgets
 libc.so.6:fileno
@@ -63,6 +64,11 @@ libc.so.6:memset
 libc.so.6:open64
 libc.so.6:opendir
 libc.so.6:poll
+libc.so.6:pthread_cond_destroy
+libc.so.6:pthread_cond_init
+libc.so.6:pthread_cond_signal
+libc.so.6:pthread_cond_timedwait
+libc.so.6:pthread_cond_wait
 libc.so.6:pthread_create
 libc.so.6:pthread_detach
 libc.so.6:pthread_join
@@ -137,9 +143,6 @@ libcrypto.so.3:BN_clear_free
 libcrypto.so.3:BN_num_bits
 libcrypto.so.3:BN_print
 libcrypto.so.3:CRYPTO_free
-libcrypto.so.3:DES_ecb_encrypt
-libcrypto.so.3:DES_set_key_unchecked
-libcrypto.so.3:DES_set_odd_parity
 libcrypto.so.3:ENGINE_by_id
 libcrypto.so.3:ENGINE_ctrl
 libcrypto.so.3:ENGINE_ctrl_cmd
@@ -170,9 +173,11 @@ libcrypto.so.3:EVP_PKEY_get0_type_name
 libcrypto.so.3:EVP_PKEY_get1_RSA
 libcrypto.so.3:EVP_PKEY_get_bits
 libcrypto.so.3:EVP_PKEY_get_bn_param
+libcrypto.so.3:EVP_PKEY_get_default_digest_name
 libcrypto.so.3:EVP_PKEY_get_group_name
 libcrypto.so.3:EVP_PKEY_get_id
 libcrypto.so.3:EVP_PKEY_get_security_bits
+libcrypto.so.3:EVP_PKEY_is_a
 libcrypto.so.3:EVP_get_digestbyname
 libcrypto.so.3:EVP_sha1
 libcrypto.so.3:EVP_sha256
@@ -181,7 +186,6 @@ libcrypto.so.3:GENERAL_NAMES_free
 libcrypto.so.3:MD5_Final
 libcrypto.so.3:MD5_Init
 libcrypto.so.3:MD5_Update
-libcrypto.so.3:OBJ_find_sigid_algs
 libcrypto.so.3:OBJ_nid2sn
 libcrypto.so.3:OBJ_obj2txt
 libcrypto.so.3:OCSP_BASICRESP_free
@@ -273,7 +277,7 @@ libcrypto.so.3:X509_get_ext_d2i
 libcrypto.so.3:X509_get_issuer_name
 libcrypto.so.3:X509_get_pubkey
 libcrypto.so.3:X509_get_serialNumber
-libcrypto.so.3:X509_get_signature_nid
+libcrypto.so.3:X509_get_signature_info
 libcrypto.so.3:X509_get_subject_name
 libcrypto.so.3:X509_get_version
 libcrypto.so.3:X509_load_crl_file
@@ -381,11 +385,6 @@ libidn2.so.0:idn2_check_version
 libidn2.so.0:idn2_free
 libidn2.so.0:idn2_lookup_ul
 libidn2.so.0:idn2_to_unicode_8z8z
-libnettle.so.8:nettle_des_encrypt
-libnettle.so.8:nettle_des_set_key
-libnettle.so.8:nettle_md4_digest
-libnettle.so.8:nettle_md4_init
-libnettle.so.8:nettle_md4_update
 libnettle.so.8:nettle_md5_digest
 libnettle.so.8:nettle_md5_init
 libnettle.so.8:nettle_md5_update

--- a/packages/c/curl/package.yml
+++ b/packages/c/curl/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : curl
-version    : 8.19.0
-release    : 114
+version    : 8.20.0
+release    : 115
 source     :
-    - https://github.com/curl/curl/releases/download/curl-8_19_0/curl-8.19.0.tar.bz2 : eba3230c1b659211a7afa0fbf475978cbf99c412e4d72d9aa92d020c460742d4
+    - https://github.com/curl/curl/releases/download/curl-8_20_0/curl-8.20.0.tar.xz : 63fe2dc148ba0ceae89922ef838f7e5c946272c2e78b7c59fab4b79d3ce2b896
 extract    : false
 homepage   : https://curl.se
 license    : MIT
@@ -48,8 +48,8 @@ checkdeps  :
     - openssh-server
 setup      : |
     mkdir main gnutls
-    tar --strip-components=1 -xf $sources/curl-%version%.tar.bz2 -C main
-    tar --strip-components=1 -xf $sources/curl-%version%.tar.bz2 -C gnutls
+    tar --strip-components=1 -xf $sources/curl-%version%.tar.xz -C main
+    tar --strip-components=1 -xf $sources/curl-%version%.tar.xz -C gnutls
 
     common="\
         --disable-static \
@@ -100,6 +100,8 @@ install    : |
         done
     popd
     cp -a $workdir/gnutlsinst/* $installdir
+
+    %install_license main/COPYING
 check      : |
     # ccache breaks some tests if enabled
     export CCACHE_DISABLE=1

--- a/packages/c/curl/pspec_x86_64.xml
+++ b/packages/c/curl/pspec_x86_64.xml
@@ -24,6 +24,7 @@
             <Path fileType="library">/usr/lib64/libcurl.so.4</Path>
             <Path fileType="library">/usr/lib64/libcurl.so.4.8.0</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/curl.fish</Path>
+            <Path fileType="data">/usr/share/licenses/curl/COPYING</Path>
             <Path fileType="man">/usr/share/man/man1/curl-config.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/curl.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/wcurl.1.zst</Path>
@@ -36,7 +37,7 @@
         <Description xml:lang="en">curl is a client to get files from servers using any of the supported protocols. The command is designed to work without user interaction or any kind of interactivity. curl offers a busload of useful tricks like proxy support, user authentication, ftp upload, HTTP post, file transfer resume and more.</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="114">curl</Dependency>
+            <Dependency release="115">curl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libcurl.so.4</Path>
@@ -49,8 +50,8 @@
         <Description xml:lang="en">curl is a client to get files from servers using any of the supported protocols. The command is designed to work without user interaction or any kind of interactivity. curl offers a busload of useful tricks like proxy support, user authentication, ftp upload, HTTP post, file transfer resume and more.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="114">curl-32bit</Dependency>
-            <Dependency release="114">curl-devel</Dependency>
+            <Dependency release="115">curl-32bit</Dependency>
+            <Dependency release="115">curl-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libcurl.so</Path>
@@ -63,7 +64,7 @@
         <Description xml:lang="en">curl is a client to get files from servers using any of the supported protocols. The command is designed to work without user interaction or any kind of interactivity. curl offers a busload of useful tricks like proxy support, user authentication, ftp upload, HTTP post, file transfer resume and more.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="114">curl</Dependency>
+            <Dependency release="115">curl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/curl/curl.h</Path>
@@ -140,6 +141,7 @@
             <Path fileType="man">/usr/share/man/man3/CURLINFO_RTSP_SERVER_CSEQ.3.zst</Path>
             <Path fileType="man">/usr/share/man/man3/CURLINFO_RTSP_SESSION_ID.3.zst</Path>
             <Path fileType="man">/usr/share/man/man3/CURLINFO_SCHEME.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/CURLINFO_SIZE_DELIVERED.3.zst</Path>
             <Path fileType="man">/usr/share/man/man3/CURLINFO_SIZE_DOWNLOAD.3.zst</Path>
             <Path fileType="man">/usr/share/man/man3/CURLINFO_SIZE_DOWNLOAD_T.3.zst</Path>
             <Path fileType="man">/usr/share/man/man3/CURLINFO_SIZE_UPLOAD.3.zst</Path>
@@ -178,6 +180,8 @@
             <Path fileType="man">/usr/share/man/man3/CURLMOPT_PIPELINING_SITE_BL.3.zst</Path>
             <Path fileType="man">/usr/share/man/man3/CURLMOPT_PUSHDATA.3.zst</Path>
             <Path fileType="man">/usr/share/man/man3/CURLMOPT_PUSHFUNCTION.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/CURLMOPT_QUICK_EXIT.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/CURLMOPT_RESOLVE_THREADS_MAX.3.zst</Path>
             <Path fileType="man">/usr/share/man/man3/CURLMOPT_SOCKETDATA.3.zst</Path>
             <Path fileType="man">/usr/share/man/man3/CURLMOPT_SOCKETFUNCTION.3.zst</Path>
             <Path fileType="man">/usr/share/man/man3/CURLMOPT_TIMERDATA.3.zst</Path>
@@ -623,9 +627,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="114">
-            <Date>2026-03-14</Date>
-            <Version>8.19.0</Version>
+        <Update release="115">
+            <Date>2026-04-29</Date>
+            <Version>8.20.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://daniel.haxx.se/blog/2026/04/29/curl-8-20-0/).

**Security**
- CVE-2026-7168
- CVE-2026-7009
- CVE-2026-6429
- CVE-2026-6276
- CVE-2026-6253
- CVE-2026-5773
- CVE-2026-5545
- CVE-2026-4873

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Download a file with `curl`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
