### PR TITLE
chafa: Update to v1.18.2

### DIFF
--- a/packages/c/chafa/abi_used_symbols
+++ b/packages/c/chafa/abi_used_symbols
@@ -113,6 +113,7 @@ libglib-2.0.so.0:g_file_error_quark
 libglib-2.0.so.0:g_file_get_contents
 libglib-2.0.so.0:g_file_set_contents
 libglib-2.0.so.0:g_free
+libglib-2.0.so.0:g_free_sized
 libglib-2.0.so.0:g_get_current_time
 libglib-2.0.so.0:g_get_environ
 libglib-2.0.so.0:g_get_host_name

--- a/packages/c/chafa/package.yml
+++ b/packages/c/chafa/package.yml
@@ -1,15 +1,19 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : chafa
-version    : 1.18.1
-release    : 1
+version    : 1.18.2
+release    : 2
 source     :
-    - https://github.com/hpjansson/chafa/archive/refs/tags/1.18.1.tar.gz : 2f7c82fc144d2ddfed9ee863bbbb201953c2e4e0cc97e541fde25171cab7b826
+    - https://github.com/hpjansson/chafa/archive/refs/tags/1.18.2.tar.gz : 9bdeba46446ac64ed61704fc54b5458cf0dca08b44031b26fbda7b78591984b8
 homepage   : https://hpjansson.org/chafa/
 license    :
     - LGPL-3.0-or-later
     - GPL-3.0-or-later
-component  : system.utils
-summary    : Image-to-text converter for terminal display
+component  :
+    - system.utils
+    - libs : programming.library
+summary    :
+    - Image-to-text converter for terminal display
+    - libs : Shared libraries for Chafa
 description: |
     Chafa is a command-line utility that converts image data, including animated GIFs,
     into graphics formats or ANSI/Unicode character art suitable for display in a
@@ -28,6 +32,9 @@ builddeps  :
     - pkgconfig(libwebp)
     - pkgconfig(libwebpdemux)
     - docbook-xml
+rundeps    :
+    - devel :
+        - chafa-libs
 setup      : |
     %autogen --disable-static --enable-man
 build      : |
@@ -37,9 +44,11 @@ install    : |
     %install_license COPYING*
 
     # Install completions
-    install -Dm00644 tools/completions/bash-completion.sh $installdir/usr/share/bash-completion/completions/chafa
-    install -Dm00644 tools/completions/zsh-completion.zsh $installdir/usr/share/zsh/site-functions/_chafa
-    install -Dm00644 tools/completions/fish-completion.fish $installdir/usr/share/fish/vendor_completions.d/chafa.fish
+    install -Dm00644 tools/completions/bash-completion.sh ${installdir}/usr/share/bash-completion/completions/chafa
+    install -Dm00644 tools/completions/zsh-completion.zsh ${installdir}/usr/share/zsh/site-functions/_chafa
+    install -Dm00644 tools/completions/fish-completion.fish ${installdir}/usr/share/fish/vendor_completions.d/chafa.fish
 patterns   :
+    - libs :
+        - /usr/lib64/lib*.so.*
     - devel :
         - /usr/lib64/chafa/include/chafaconfig.h

--- a/packages/c/chafa/pspec_x86_64.xml
+++ b/packages/c/chafa/pspec_x86_64.xml
@@ -26,10 +26,11 @@ terminal. It supports a wide range of symbols and palettes, transparency,
 animations, and many image formats (JPEG, PNG, WebP, SVG, TIFF, AVIF, HEIF, JPEG XL).
 </Description>
         <PartOf>system.utils</PartOf>
+        <RuntimeDependencies>
+            <Dependency release="2">chafa-libs</Dependency>
+        </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/chafa</Path>
-            <Path fileType="library">/usr/lib64/libchafa.so.0</Path>
-            <Path fileType="library">/usr/lib64/libchafa.so.0.11.1</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/chafa</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/chafa.fish</Path>
             <Path fileType="data">/usr/share/licenses/chafa/COPYING</Path>
@@ -48,7 +49,8 @@ animations, and many image formats (JPEG, PNG, WebP, SVG, TIFF, AVIF, HEIF, JPEG
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="1">chafa</Dependency>
+            <Dependency release="2">chafa</Dependency>
+            <Dependency release="2">chafa-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/chafa/chafa-canvas-config.h</Path>
@@ -70,10 +72,24 @@ animations, and many image formats (JPEG, PNG, WebP, SVG, TIFF, AVIF, HEIF, JPEG
             <Path fileType="data">/usr/lib64/pkgconfig/chafa.pc</Path>
         </Files>
     </Package>
+    <Package>
+        <Name>chafa-libs</Name>
+        <Summary xml:lang="en">Shared libraries for Chafa</Summary>
+        <Description xml:lang="en">Chafa is a command-line utility that converts image data, including animated GIFs,
+into graphics formats or ANSI/Unicode character art suitable for display in a
+terminal. It supports a wide range of symbols and palettes, transparency,
+animations, and many image formats (JPEG, PNG, WebP, SVG, TIFF, AVIF, HEIF, JPEG XL).
+</Description>
+        <PartOf>programming.library</PartOf>
+        <Files>
+            <Path fileType="library">/usr/lib64/libchafa.so.0</Path>
+            <Path fileType="library">/usr/lib64/libchafa.so.0.11.2</Path>
+        </Files>
+    </Package>
     <History>
-        <Update release="1">
-            <Date>2026-02-26</Date>
-            <Version>1.18.1</Version>
+        <Update release="2">
+            <Date>2026-04-30</Date>
+            <Version>1.18.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/hpjansson/chafa/releases/tag/1.18.2).
- Bug Fixes

**Test Plan**

`chafa example.png`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
