### PR TITLE
solseek: Update to 1.3.2

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 1.3.0
-release    : 32
+version    : 1.3.2
+release    : 33
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v1.3.0.tar.gz : c50cf2fd796a1445b20645d8ff2d1961f9d4a2a71c05ea1334fbaa7a48fbe6e7
+    - https://github.com/clintre/solseek/archive/refs/tags/v1.3.2.tar.gz : 2ec453fdf4eb59e009167bdd771db1129b2bea2da93f949805d0f5590cd1f7f7
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -71,9 +71,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="32">
-            <Date>2026-04-29</Date>
-            <Version>1.3.0</Version>
+        <Update release="33">
+            <Date>2026-04-30</Date>
+            <Version>1.3.2</Version>
             <Comment>Packaging update</Comment>
             <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**

Bugfixes:
- Fixed: Notifications not respecting desktop do not disturb mode
- Mitigated: File not found for generated cache file with proper fallback

Full Changelog:

https://github.com/clintre/solseek/compare/v1.3.0...v1.3.2

**Test Plan**

Install and test notifications when dnd is on

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
