### PR TITLE
niri: Update to v26.04

### DIFF
--- a/packages/n/niri/abi_used_symbols
+++ b/packages/n/niri/abi_used_symbols
@@ -39,7 +39,6 @@ libc.so.6:getaddrinfo
 libc.so.6:getauxval
 libc.so.6:getcwd
 libc.so.6:getenv
-libc.so.6:geteuid
 libc.so.6:getgrouplist
 libc.so.6:getpeername
 libc.so.6:getpid
@@ -201,7 +200,9 @@ libgcc_s.so.1:_Unwind_Resume
 libgcc_s.so.1:_Unwind_SetGR
 libgcc_s.so.1:_Unwind_SetIP
 libglib-2.0.so.0:g_error_free
+libglib-2.0.so.0:g_filename_to_uri
 libglib-2.0.so.0:g_free
+libglib-2.0.so.0:g_quark_to_string
 libglib-2.0.so.0:g_strndup
 libgobject-2.0.so.0:g_object_ref_sink
 libgobject-2.0.so.0:g_object_unref
@@ -315,6 +316,9 @@ libinput.so.10:libinput_event_touch_get_x_transformed
 libinput.so.10:libinput_event_touch_get_y_transformed
 libinput.so.10:libinput_get_event
 libinput.so.10:libinput_get_fd
+libinput.so.10:libinput_plugin_system_append_default_paths
+libinput.so.10:libinput_plugin_system_append_path
+libinput.so.10:libinput_plugin_system_load_plugins
 libinput.so.10:libinput_ref
 libinput.so.10:libinput_resume
 libinput.so.10:libinput_suspend
@@ -332,6 +336,7 @@ libinput.so.10:libinput_tablet_tool_unref
 libinput.so.10:libinput_udev_assign_seat
 libinput.so.10:libinput_udev_create_context
 libinput.so.10:libinput_unref
+libm.so.6:atan2f
 libm.so.6:cosh
 libm.so.6:exp
 libm.so.6:exp2
@@ -366,6 +371,7 @@ libpango-1.0.so.0:pango_layout_set_text
 libpango-1.0.so.0:pango_parse_markup
 libpangocairo-1.0.so.0:pango_cairo_create_layout
 libpangocairo-1.0.so.0:pango_cairo_show_layout
+libpipewire-0.3.so.0:pw_check_library_version
 libpipewire-0.3.so.0:pw_context_connect
 libpipewire-0.3.so.0:pw_context_destroy
 libpipewire-0.3.so.0:pw_context_new

--- a/packages/n/niri/package.yml
+++ b/packages/n/niri/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : niri
-version    : '25.11'
-release    : 5
+version    : '26.04'
+release    : 6
 source     :
-    - https://github.com/YaLTeR/niri/archive/refs/tags/v25.11.tar.gz : 9a9a58dbe12e065776cc80424f22c89489f2662e881152ceae46e68bb8677d8c
-homepage   : https://github.com/YaLTeR/niri
+    - https://github.com/niri-wm/niri/archive/refs/tags/v26.04.tar.gz : 134c602d8e0d53413a52d6cd58f9ce7e79a07d03288ee0a51ba1abd5db1b1ad9
+homepage   : https://niri-wm.github.io/niri/
 license    : GPL-3.0-or-later
 component  : desktop
 summary    :
@@ -37,6 +37,7 @@ build      : |
     %cargo_build
 install    : |
     %cargo_install
+    %install_license LICENSE
 
     install -Dm00755 -t $installdir/usr/bin resources/niri-session
     install -Dm00644 -t $installdir/usr/share/wayland-sessions resources/niri.desktop

--- a/packages/n/niri/pspec_x86_64.xml
+++ b/packages/n/niri/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>niri</Name>
-        <Homepage>https://github.com/YaLTeR/niri</Homepage>
+        <Homepage>https://niri-wm.github.io/niri/</Homepage>
         <Packager>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>desktop</PartOf>
@@ -21,6 +21,7 @@
             <Path fileType="executable">/usr/bin/niri</Path>
             <Path fileType="library">/usr/lib/systemd/user/niri-shutdown.target</Path>
             <Path fileType="library">/usr/lib/systemd/user/niri.service</Path>
+            <Path fileType="data">/usr/share/licenses/niri/LICENSE</Path>
             <Path fileType="data">/usr/share/xdg-desktop-portal/niri-portals.conf</Path>
         </Files>
     </Package>
@@ -29,7 +30,7 @@
         <Summary xml:lang="en">Session files for Niri</Summary>
         <Description xml:lang="en">Session files for Niri.</Description>
         <RuntimeDependencies>
-            <Dependency releaseFrom="5">niri</Dependency>
+            <Dependency releaseFrom="6">niri</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/niri-session</Path>
@@ -37,12 +38,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2025-12-22</Date>
-            <Version>25.11</Version>
+        <Update release="6">
+            <Date>2026-04-30</Date>
+            <Version>26.04</Version>
             <Comment>Packaging update</Comment>
-            <Name>Gavin Zhao</Name>
-            <Email>me@gzgz.dev</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/niri-wm/niri/releases/tag/v26.04).

Fixes https://github.com/getsolus/packages/issues/8709

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new Niri session.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
