### PR TITLE
gstreamer: Update to v1.28.2

### DIFF
--- a/packages/g/gstreamer/abi_symbols
+++ b/packages/g/gstreamer/abi_symbols
@@ -2089,6 +2089,7 @@ libgstcuda-1.0.so.0:CuDeviceGet
 libgstcuda-1.0.so.0:CuDeviceGetAttribute
 libgstcuda-1.0.so.0:CuDeviceGetCount
 libgstcuda-1.0.so.0:CuDeviceGetName
+libgstcuda-1.0.so.0:CuDeviceGetUuid
 libgstcuda-1.0.so.0:CuDriverGetVersion
 libgstcuda-1.0.so.0:CuEventCreate
 libgstcuda-1.0.so.0:CuEventDestroy
@@ -2186,6 +2187,7 @@ libgstcuda-1.0.so.0:gst_cuda_buffer_copy_type_to_string
 libgstcuda-1.0.so.0:gst_cuda_buffer_pool_get_type
 libgstcuda-1.0.so.0:gst_cuda_buffer_pool_new
 libgstcuda-1.0.so.0:gst_cuda_context_can_access_peer
+libgstcuda-1.0.so.0:gst_cuda_context_find_dxgi_adapter_luid
 libgstcuda-1.0.so.0:gst_cuda_context_get_handle
 libgstcuda-1.0.so.0:gst_cuda_context_get_texture_alignment
 libgstcuda-1.0.so.0:gst_cuda_context_get_type

--- a/packages/g/gstreamer/abi_used_symbols
+++ b/packages/g/gstreamer/abi_used_symbols
@@ -2350,9 +2350,7 @@ libglib-2.0.so.0:g_markup_parse_context_parse
 libglib-2.0.so.0:g_markup_printf_escaped
 libglib-2.0.so.0:g_match_info_fetch
 libglib-2.0.so.0:g_match_info_fetch_named
-libglib-2.0.so.0:g_match_info_fetch_pos
 libglib-2.0.so.0:g_match_info_free
-libglib-2.0.so.0:g_match_info_matches
 libglib-2.0.so.0:g_memdup2
 libglib-2.0.so.0:g_mkdir_with_parents
 libglib-2.0.so.0:g_mkstemp
@@ -4000,6 +3998,7 @@ libsrtp2.so.1:srtp_remove_stream
 libsrtp2.so.1:srtp_set_stream_roc
 libsrtp2.so.1:srtp_unprotect_mki
 libsrtp2.so.1:srtp_unprotect_rtcp_mki
+libsrtp2.so.1:srtp_update_stream
 libssl.so.3:DTLS_method
 libssl.so.3:SSL_CTX_check_private_key
 libssl.so.3:SSL_CTX_ctrl

--- a/packages/g/gstreamer/abi_used_symbols32
+++ b/packages/g/gstreamer/abi_used_symbols32
@@ -834,10 +834,6 @@ libglib-2.0.so.0:g_markup_parse_context_free
 libglib-2.0.so.0:g_markup_parse_context_new
 libglib-2.0.so.0:g_markup_parse_context_parse
 libglib-2.0.so.0:g_markup_printf_escaped
-libglib-2.0.so.0:g_match_info_fetch
-libglib-2.0.so.0:g_match_info_fetch_pos
-libglib-2.0.so.0:g_match_info_free
-libglib-2.0.so.0:g_match_info_matches
 libglib-2.0.so.0:g_memdup2
 libglib-2.0.so.0:g_mkdir_with_parents
 libglib-2.0.so.0:g_mkstemp

--- a/packages/g/gstreamer/package.yml
+++ b/packages/g/gstreamer/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gstreamer
-version    : 1.28.1
-release    : 134
+version    : 1.28.2
+release    : 135
 source     :
-    - https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/1.28.1/gstreamer-1.28.1.tar.gz : 97fee2ed866d087cd0f0cecbb3b955d18145bda22c8ae4d3a04603c6a055e8a6
+    - https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/1.28.2/gstreamer-1.28.2.tar.gz : c221bcac5c954d8ac7a02d3ea34d5466058f073c43d48b7b317a7b0a78595ec3
 license    : LGPL-2.1-or-later
 homepage   : https://gstreamer.freedesktop.org/
 component  :

--- a/packages/g/gstreamer/pspec_x86_64.xml
+++ b/packages/g/gstreamer/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gstreamer</Name>
         <Homepage>https://gstreamer.freedesktop.org/</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>multimedia.gstreamer</PartOf>
@@ -35,15 +35,15 @@
             <Path fileType="library">/usr/lib64/gstreamer/gstreamer-1.0/gst-plugins-doc-cache-generator</Path>
             <Path fileType="library">/usr/lib64/gstreamer/gstreamer-1.0/gst-ptp-helper</Path>
             <Path fileType="library">/usr/lib64/libgstbase-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstbase-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstbase-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstcheck-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstcheck-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstcheck-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstcontroller-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstcontroller-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstcontroller-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstnet-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstnet-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstnet-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstreamer-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstreamer-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstreamer-1.0.so.0.2802.0</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/gst-inspect-1.0</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/gst-launch-1.0</Path>
             <Path fileType="data">/usr/share/bash-completion/helpers/gst</Path>
@@ -73,6 +73,7 @@
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/gstreamer-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/gstreamer-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/gstreamer-1.0.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/kk/LC_MESSAGES/gstreamer-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ko/LC_MESSAGES/gstreamer-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lt/LC_MESSAGES/gstreamer-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lv/LC_MESSAGES/gstreamer-1.0.mo</Path>
@@ -108,7 +109,7 @@
         <Description xml:lang="en">GStreamer is a streaming media framework that enables applications to share a common set of plugins for things like video encoding and decoding, audio encoding and decoding, audio and video filters, audio visualisation, web streaming and anything else that streams in real-time or otherwise. This package only provides base functionality and libraries. You may need at least gst-plugins-base and one of Good, Bad, Ugly or Libav plugins.</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="134">gstreamer</Dependency>
+            <Dependency release="135">gstreamer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/gstreamer-1.0/libgstcoreelements.so</Path>
@@ -118,15 +119,15 @@
             <Path fileType="library">/usr/lib32/gstreamer/gstreamer-1.0/gst-plugin-scanner</Path>
             <Path fileType="library">/usr/lib32/gstreamer/gstreamer-1.0/gst-plugins-doc-cache-generator</Path>
             <Path fileType="library">/usr/lib32/libgstbase-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstbase-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib32/libgstbase-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib32/libgstcheck-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstcheck-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib32/libgstcheck-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib32/libgstcontroller-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstcontroller-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib32/libgstcontroller-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib32/libgstnet-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstnet-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib32/libgstnet-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib32/libgstreamer-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstreamer-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib32/libgstreamer-1.0.so.0.2802.0</Path>
         </Files>
         <Replaces>
             <Package>gstreamer-1.0-32bit</Package>
@@ -138,8 +139,8 @@
         <Description xml:lang="en">GStreamer is a streaming media framework that enables applications to share a common set of plugins for things like video encoding and decoding, audio encoding and decoding, audio and video filters, audio visualisation, web streaming and anything else that streams in real-time or otherwise. This package only provides base functionality and libraries. You may need at least gst-plugins-base and one of Good, Bad, Ugly or Libav plugins.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="134">gstreamer-32bit</Dependency>
-            <Dependency release="134">gstreamer-devel</Dependency>
+            <Dependency release="135">gstreamer-devel</Dependency>
+            <Dependency release="135">gstreamer-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libgstbase-1.0.so</Path>
@@ -163,9 +164,9 @@
         <Description xml:lang="en">GStreamer python overrides for the gobject-introspection-based pygst bindings.</Description>
         <PartOf>programming.python</PartOf>
         <RuntimeDependencies>
-            <Dependency release="134">gstreamer-plugins-bad-libs</Dependency>
-            <Dependency release="134">gstreamer</Dependency>
-            <Dependency releaseFrom="134">gstreamer-plugins-base</Dependency>
+            <Dependency release="135">gstreamer</Dependency>
+            <Dependency release="135">gstreamer-plugins-bad-libs</Dependency>
+            <Dependency releaseFrom="135">gstreamer-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib/python3.12/site-packages/gi/overrides/Gst.py</Path>
@@ -195,7 +196,7 @@
         <Description xml:lang="en">GStreamer is a streaming media framework that enables applications to share a common set of plugins for things like video encoding and decoding, audio encoding and decoding, audio and video filters, audio visualisation, web streaming and anything else that streams in real-time or otherwise. This package only provides base functionality and libraries. You may need at least gst-plugins-base and one of Good, Bad, Ugly or Libav plugins.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="134">gstreamer</Dependency>
+            <Dependency release="135">gstreamer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gstreamer-1.0/gst/base/base-prelude.h</Path>
@@ -337,8 +338,8 @@
             <Path fileType="data">/usr/lib64/pkgconfig/gstreamer-net-1.0.pc</Path>
             <Path fileType="data">/usr/share/aclocal/gst-element-check-1.0.m4</Path>
             <Path fileType="data">/usr/share/cmake/FindGStreamer.cmake</Path>
-            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib32/libgstreamer-1.0.so.0.2801.0-gdb.py</Path>
-            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib64/libgstreamer-1.0.so.0.2801.0-gdb.py</Path>
+            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib32/libgstreamer-1.0.so.0.2802.0-gdb.py</Path>
+            <Path fileType="data">/usr/share/gdb/auto-load/usr/lib64/libgstreamer-1.0.so.0.2802.0-gdb.py</Path>
             <Path fileType="data">/usr/share/gir-1.0/Gst-1.0.gir</Path>
             <Path fileType="data">/usr/share/gir-1.0/GstBase-1.0.gir</Path>
             <Path fileType="data">/usr/share/gir-1.0/GstCheck-1.0.gir</Path>
@@ -357,9 +358,9 @@
         <Description xml:lang="en">GStreamer editing services</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="134">gstreamer-plugins-base</Dependency>
-            <Dependency release="134">gstreamer</Dependency>
-            <Dependency releaseFrom="134">python-gstreamer</Dependency>
+            <Dependency release="135">gstreamer</Dependency>
+            <Dependency release="135">gstreamer-plugins-base</Dependency>
+            <Dependency releaseFrom="135">python-gstreamer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/ges-launch-1.0</Path>
@@ -369,7 +370,7 @@
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstges.so</Path>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstnle.so</Path>
             <Path fileType="library">/usr/lib64/libges-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libges-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libges-1.0.so.0.2802.0</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/ges-launch-1.0</Path>
             <Path fileType="man">/usr/share/man/man1/ges-launch-1.0.1.zst</Path>
         </Files>
@@ -380,9 +381,9 @@
         <Description xml:lang="en">Development files for gstreamer-editing-services</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="134">gstreamer-devel</Dependency>
-            <Dependency release="134">gstreamer-plugins-base-devel</Dependency>
-            <Dependency releaseFrom="134">gstreamer-editing-services</Dependency>
+            <Dependency release="135">gstreamer-devel</Dependency>
+            <Dependency release="135">gstreamer-plugins-base-devel</Dependency>
+            <Dependency releaseFrom="135">gstreamer-editing-services</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gstreamer-1.0/ges/ges-asset.h</Path>
@@ -462,8 +463,8 @@
         <Description xml:lang="en">GStreamer FFmpeg/LibAV plugin</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="134">gstreamer-plugins-base</Dependency>
-            <Dependency release="134">gstreamer</Dependency>
+            <Dependency release="135">gstreamer</Dependency>
+            <Dependency release="135">gstreamer-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstlibav.so</Path>
@@ -479,13 +480,13 @@
         <Description xml:lang="en">GStreamer &quot;bad&quot; plugins OpenCV plugin</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="134">gstreamer-plugins-base</Dependency>
-            <Dependency release="134">gstreamer</Dependency>
+            <Dependency release="135">gstreamer</Dependency>
+            <Dependency release="135">gstreamer-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstopencv.so</Path>
             <Path fileType="library">/usr/lib64/libgstopencv-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstopencv-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstopencv-1.0.so.0.2802.0</Path>
         </Files>
         <Replaces>
             <Package>gstreamer-1.0-plugin-opencv</Package>
@@ -498,7 +499,7 @@
         <Description xml:lang="en">Development files for gstreamer-1.0-plugins-opencv</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="134">gstreamer-plugin-opencv</Dependency>
+            <Dependency releaseFrom="135">gstreamer-plugin-opencv</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gstreamer-1.0/gst/opencv/gstopencvutils.h</Path>
@@ -517,9 +518,9 @@
         <Description xml:lang="en">GStreamer streaming media framework &quot;bad&quot; plugins</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="134">gstreamer-plugins-bad-libs</Dependency>
-            <Dependency release="134">gstreamer</Dependency>
-            <Dependency release="134">gstreamer-plugins-base</Dependency>
+            <Dependency release="135">gstreamer</Dependency>
+            <Dependency release="135">gstreamer-plugins-base</Dependency>
+            <Dependency release="135">gstreamer-plugins-bad-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/gst-transcoder-1.0</Path>
@@ -688,6 +689,7 @@
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/gst-plugins-bad-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/gst-plugins-bad-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/gst-plugins-bad-1.0.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/kk/LC_MESSAGES/gst-plugins-bad-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ky/LC_MESSAGES/gst-plugins-bad-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lt/LC_MESSAGES/gst-plugins-bad-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lv/LC_MESSAGES/gst-plugins-bad-1.0.mo</Path>
@@ -721,11 +723,11 @@
         <Description xml:lang="en">Development files for gstreamer-1.0-plugins-bad</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="134">gstreamer-plugins-bad-libs</Dependency>
-            <Dependency release="134">gstreamer-plugins-base-devel</Dependency>
-            <Dependency release="134">gstreamer-devel</Dependency>
-            <Dependency releaseFrom="134">gstreamer-plugins-bad</Dependency>
-            <Dependency releaseFrom="134">gstreamer-plugins-bad-extras</Dependency>
+            <Dependency release="135">gstreamer-devel</Dependency>
+            <Dependency release="135">gstreamer-plugins-base-devel</Dependency>
+            <Dependency release="135">gstreamer-plugins-bad-libs</Dependency>
+            <Dependency releaseFrom="135">gstreamer-plugins-bad</Dependency>
+            <Dependency releaseFrom="135">gstreamer-plugins-bad-extras</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gstreamer-1.0/gst/analytics/analytics-meta-prelude.h</Path>
@@ -999,9 +1001,9 @@
         <Description xml:lang="en">GStreamer streaming media framework &quot;bad&quot; plugins</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="134">gstreamer-plugins-bad-libs</Dependency>
-            <Dependency release="134">gstreamer-plugins-base</Dependency>
-            <Dependency release="134">gstreamer</Dependency>
+            <Dependency release="135">gstreamer</Dependency>
+            <Dependency release="135">gstreamer-plugins-base</Dependency>
+            <Dependency release="135">gstreamer-plugins-bad-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstaom.so</Path>
@@ -1023,8 +1025,8 @@
         <Description xml:lang="en">GStreamer streaming media framework &quot;bad&quot; plugins - libs</Description>
         <PartOf>programming.library</PartOf>
         <RuntimeDependencies>
-            <Dependency release="134">gstreamer-plugins-base</Dependency>
-            <Dependency release="134">gstreamer</Dependency>
+            <Dependency release="135">gstreamer</Dependency>
+            <Dependency release="135">gstreamer-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/girepository-1.0/CudaGst-1.0.typelib</Path>
@@ -1048,50 +1050,50 @@
             <Path fileType="library">/usr/lib64/girepository-1.0/GstVulkanXCB-1.0.typelib</Path>
             <Path fileType="library">/usr/lib64/girepository-1.0/GstWebRTC-1.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libgstadaptivedemux-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstadaptivedemux-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstadaptivedemux-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstanalytics-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstanalytics-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstanalytics-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstbadaudio-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstbadaudio-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstbadaudio-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstbasecamerabinsrc-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstbasecamerabinsrc-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstbasecamerabinsrc-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstcodecparsers-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstcodecparsers-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstcodecparsers-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstcodecs-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstcodecs-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstcodecs-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstcuda-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstcuda-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstcuda-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstdxva-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstdxva-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstdxva-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgsthip.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgsthip.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgsthip.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstinsertbin-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstinsertbin-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstinsertbin-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstisoff-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstisoff-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstisoff-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstmpegts-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstmpegts-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstmpegts-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstmse-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstmse-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstmse-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstphotography-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstphotography-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstphotography-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstplay-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstplay-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstplay-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstplayer-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstplayer-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstplayer-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstsctp-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstsctp-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstsctp-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgsttranscoder-1.0.so.0</Path>
             <Path fileType="library">/usr/lib64/libgsturidownloader-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgsturidownloader-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgsturidownloader-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstva-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstva-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstva-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstvulkan-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstvulkan-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstvulkan-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstwayland-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstwayland-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstwayland-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstwebrtc-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstwebrtc-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstwebrtc-1.0.so.0.2802.0</Path>
         </Files>
         <Replaces>
             <Package>gstreamer-1.0-plugins-bad-libs</Package>
@@ -1103,7 +1105,7 @@
         <Description xml:lang="en">GStreamer streaming media framework base plugins</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="134">gstreamer</Dependency>
+            <Dependency release="135">gstreamer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/gst-device-monitor-1.0</Path>
@@ -1155,29 +1157,29 @@
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstximagesink.so</Path>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgstxvimagesink.so</Path>
             <Path fileType="library">/usr/lib64/libgstallocators-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstallocators-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstallocators-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstapp-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstapp-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstapp-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstaudio-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstaudio-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstaudio-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstfft-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstfft-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstfft-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstgl-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstgl-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstgl-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstpbutils-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstpbutils-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstpbutils-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstriff-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstriff-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstriff-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstrtp-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstrtp-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstrtp-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstrtsp-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstrtsp-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstrtsp-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstsdp-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstsdp-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstsdp-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgsttag-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgsttag-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgsttag-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib64/libgstvideo-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstvideo-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstvideo-1.0.so.0.2802.0</Path>
             <Path fileType="data">/usr/share/gst-plugins-base/1.0/license-translations.dict</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/gst-plugins-base-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/gst-plugins-base-1.0.mo</Path>
@@ -1202,6 +1204,7 @@
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/gst-plugins-base-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/gst-plugins-base-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/gst-plugins-base-1.0.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/kk/LC_MESSAGES/gst-plugins-base-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lt/LC_MESSAGES/gst-plugins-base-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lv/LC_MESSAGES/gst-plugins-base-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/nb/LC_MESSAGES/gst-plugins-base-1.0.mo</Path>
@@ -1234,7 +1237,7 @@
         <Description xml:lang="en">GStreamer is a streaming media framework that enables applications to share a common set of plugins for things like video encoding and decoding, audio encoding and decoding, audio and video filters, audio visualisation, web streaming and anything else that streams in real-time or otherwise. This package only provides base functionality and libraries. You may need at least gst-plugins-base and one of Good, Bad, Ugly or Libav plugins.</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="134">gstreamer-32bit</Dependency>
+            <Dependency release="135">gstreamer-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/gstreamer-1.0/libgstadder.so</Path>
@@ -1270,29 +1273,29 @@
             <Path fileType="library">/usr/lib32/gstreamer-1.0/libgstximagesink.so</Path>
             <Path fileType="library">/usr/lib32/gstreamer-1.0/libgstxvimagesink.so</Path>
             <Path fileType="library">/usr/lib32/libgstallocators-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstallocators-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib32/libgstallocators-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib32/libgstapp-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstapp-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib32/libgstapp-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib32/libgstaudio-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstaudio-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib32/libgstaudio-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib32/libgstfft-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstfft-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib32/libgstfft-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib32/libgstgl-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstgl-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib32/libgstgl-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib32/libgstpbutils-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstpbutils-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib32/libgstpbutils-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib32/libgstriff-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstriff-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib32/libgstriff-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib32/libgstrtp-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstrtp-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib32/libgstrtp-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib32/libgstrtsp-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstrtsp-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib32/libgstrtsp-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib32/libgstsdp-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstsdp-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib32/libgstsdp-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib32/libgsttag-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgsttag-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib32/libgsttag-1.0.so.0.2802.0</Path>
             <Path fileType="library">/usr/lib32/libgstvideo-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib32/libgstvideo-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib32/libgstvideo-1.0.so.0.2802.0</Path>
         </Files>
         <Replaces>
             <Package>gstreamer-1.0-plugins-base-32bit</Package>
@@ -1304,9 +1307,9 @@
         <Description xml:lang="en">GStreamer is a streaming media framework that enables applications to share a common set of plugins for things like video encoding and decoding, audio encoding and decoding, audio and video filters, audio visualisation, web streaming and anything else that streams in real-time or otherwise. This package only provides base functionality and libraries. You may need at least gst-plugins-base and one of Good, Bad, Ugly or Libav plugins.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="134">gstreamer-32bit-devel</Dependency>
-            <Dependency releaseFrom="134">gstreamer-plugins-base-32bit</Dependency>
-            <Dependency releaseFrom="134">gstreamer-plugins-base-devel</Dependency>
+            <Dependency release="135">gstreamer-32bit-devel</Dependency>
+            <Dependency releaseFrom="135">gstreamer-plugins-base-32bit</Dependency>
+            <Dependency releaseFrom="135">gstreamer-plugins-base-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/gstreamer-1.0/include/gst/gl/gstglconfig.h</Path>
@@ -1350,8 +1353,8 @@
         <Description xml:lang="en">Development files for gstreamer-1.0-plugins-base</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="134">gstreamer-devel</Dependency>
-            <Dependency releaseFrom="134">gstreamer-plugins-base</Dependency>
+            <Dependency release="135">gstreamer-devel</Dependency>
+            <Dependency releaseFrom="135">gstreamer-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gstreamer-1.0/gst/allocators/allocators-prelude.h</Path>
@@ -1611,8 +1614,8 @@
         <Description xml:lang="en">GStreamer streaming media framework &quot;good&quot; plugins</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="134">gstreamer</Dependency>
-            <Dependency release="134">gstreamer-plugins-base</Dependency>
+            <Dependency release="135">gstreamer</Dependency>
+            <Dependency release="135">gstreamer-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgst1394.so</Path>
@@ -1717,6 +1720,7 @@
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/gst-plugins-good-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/gst-plugins-good-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/gst-plugins-good-1.0.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/kk/LC_MESSAGES/gst-plugins-good-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ky/LC_MESSAGES/gst-plugins-good-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lt/LC_MESSAGES/gst-plugins-good-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lv/LC_MESSAGES/gst-plugins-good-1.0.mo</Path>
@@ -1750,8 +1754,8 @@
         <Description xml:lang="en">GStreamer streaming media framework &quot;ugly&quot; plugins</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="134">gstreamer-plugins-base</Dependency>
-            <Dependency release="134">gstreamer</Dependency>
+            <Dependency release="135">gstreamer</Dependency>
+            <Dependency release="135">gstreamer-plugins-base</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/gstreamer-1.0/libgsta52dec.so</Path>
@@ -1788,6 +1792,7 @@
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/gst-plugins-ugly-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/gst-plugins-ugly-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/gst-plugins-ugly-1.0.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/kk/LC_MESSAGES/gst-plugins-ugly-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lt/LC_MESSAGES/gst-plugins-ugly-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lv/LC_MESSAGES/gst-plugins-ugly-1.0.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ms/LC_MESSAGES/gst-plugins-ugly-1.0.mo</Path>
@@ -1821,13 +1826,13 @@
         <Description xml:lang="en">GStreamer&apos;s RTSP server (gst-rtsp-server) is a featureful and easy-to-use library that allows applications to implement a complete RTSP server with just a couple of lines of code.</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="134">gstreamer-plugins-base</Dependency>
-            <Dependency release="134">gstreamer</Dependency>
+            <Dependency release="135">gstreamer-plugins-base</Dependency>
+            <Dependency release="135">gstreamer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/girepository-1.0/GstRtspServer-1.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libgstrtspserver-1.0.so.0</Path>
-            <Path fileType="library">/usr/lib64/libgstrtspserver-1.0.so.0.2801.0</Path>
+            <Path fileType="library">/usr/lib64/libgstrtspserver-1.0.so.0.2802.0</Path>
         </Files>
         <Replaces>
             <Package>gst-rtsp-server</Package>
@@ -1839,11 +1844,11 @@
         <Description xml:lang="en">Development files for gstreamer-1.0-plugins-ugly</Description>
         <PartOf>multimedia.gstreamer</PartOf>
         <RuntimeDependencies>
-            <Dependency release="134">gstreamer-plugins-base-devel</Dependency>
-            <Dependency release="134">gstreamer-rtsp-server</Dependency>
-            <Dependency release="134">gstreamer-devel</Dependency>
-            <Dependency release="134">gstreamer-plugins-base</Dependency>
-            <Dependency release="134">gstreamer</Dependency>
+            <Dependency release="135">gstreamer</Dependency>
+            <Dependency release="135">gstreamer-devel</Dependency>
+            <Dependency release="135">gstreamer-plugins-base</Dependency>
+            <Dependency release="135">gstreamer-plugins-base-devel</Dependency>
+            <Dependency release="135">gstreamer-rtsp-server</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/gstreamer-1.0/gst/rtsp-server/rtsp-address-pool.h</Path>
@@ -1881,12 +1886,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="134">
-            <Date>2026-04-25</Date>
-            <Version>1.28.1</Version>
+        <Update release="135">
+            <Date>2026-05-01</Date>
+            <Version>1.28.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://gstreamer.freedesktop.org/releases/1.28/#1.28.2).

**Security**
- CVE-2026-5056

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Play audio.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
