### PR TITLE
solseek: Update to 1.3.3

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 1.3.2
-release    : 33
+version    : 1.3.3
+release    : 34
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v1.3.2.tar.gz : 2ec453fdf4eb59e009167bdd771db1129b2bea2da93f949805d0f5590cd1f7f7
+    - https://github.com/clintre/solseek/archive/refs/tags/v1.3.3.tar.gz : 4542cf1b5fcd947e1f4ae6029494f090350fbfcd3169823f56e8ba23791920f1
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -3,7 +3,7 @@
         <Name>solseek</Name>
         <Homepage>https://github.com/clintre/solseek</Homepage>
         <Packager>
-            <Name>clintre</Name>
+            <Name>Clint Eschberger</Name>
             <Email>clint@eschberger.info</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
@@ -71,11 +71,11 @@
         </Files>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2026-04-30</Date>
-            <Version>1.3.2</Version>
+        <Update release="34">
+            <Date>2026-05-01</Date>
+            <Version>1.3.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>clintre</Name>
+            <Name>Clint Eschberger</Name>
             <Email>clint@eschberger.info</Email>
         </Update>
     </History>


### PR DESCRIPTION
**Summary**

Bugfixes:
- Fix bonehead mistake, leaving test code in flatpak install manager

Full Changelog:
https://github.com/clintre/solseek/compare/v1.3.0...v1.3.3

**Test Plan**

Install, make sure I corrected my bonehead mistake by installing flatpak 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
