### PR TITLE
openexr: Update to v3.4.11

### DIFF
--- a/packages/o/openexr/package.yml
+++ b/packages/o/openexr/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : openexr
-version    : 3.4.10
-release    : 13
+version    : 3.4.11
+release    : 14
 source     :
-    - https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.4.10.tar.gz : b61ae2d0fa4872c5f5fc45618f107945df37c0eba4853263091b949c513d3319
+    - https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.4.11.tar.gz : 63730442f5fd6c5a79395bdd199040ab3821c229066049f52a57424a984b16ed
 homepage   : https://www.openexr.com/
 license    : BSD-3-Clause
 component  :

--- a/packages/o/openexr/pspec_x86_64.xml
+++ b/packages/o/openexr/pspec_x86_64.xml
@@ -28,7 +28,7 @@ OpenEXR is widely used in host application software where accuracy is critical, 
 </Description>
         <PartOf>multimedia.library</PartOf>
         <RuntimeDependencies>
-            <Dependency release="13">openexr-libs</Dependency>
+            <Dependency release="14">openexr-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/exr2aces</Path>
@@ -56,8 +56,8 @@ OpenEXR is widely used in host application software where accuracy is critical, 
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="13">openexr</Dependency>
-            <Dependency releaseFrom="13">openexr-libs</Dependency>
+            <Dependency release="14">openexr</Dependency>
+            <Dependency releaseFrom="14">openexr-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/OpenEXR/Iex.h</Path>
@@ -272,21 +272,21 @@ OpenEXR is widely used in host application software where accuracy is critical, 
         <PartOf>multimedia.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libIex-3_4.so.33</Path>
-            <Path fileType="library">/usr/lib64/libIex-3_4.so.33.3.4.10</Path>
+            <Path fileType="library">/usr/lib64/libIex-3_4.so.33.3.4.11</Path>
             <Path fileType="library">/usr/lib64/libIlmThread-3_4.so.33</Path>
-            <Path fileType="library">/usr/lib64/libIlmThread-3_4.so.33.3.4.10</Path>
+            <Path fileType="library">/usr/lib64/libIlmThread-3_4.so.33.3.4.11</Path>
             <Path fileType="library">/usr/lib64/libOpenEXR-3_4.so.33</Path>
-            <Path fileType="library">/usr/lib64/libOpenEXR-3_4.so.33.3.4.10</Path>
+            <Path fileType="library">/usr/lib64/libOpenEXR-3_4.so.33.3.4.11</Path>
             <Path fileType="library">/usr/lib64/libOpenEXRCore-3_4.so.33</Path>
-            <Path fileType="library">/usr/lib64/libOpenEXRCore-3_4.so.33.3.4.10</Path>
+            <Path fileType="library">/usr/lib64/libOpenEXRCore-3_4.so.33.3.4.11</Path>
             <Path fileType="library">/usr/lib64/libOpenEXRUtil-3_4.so.33</Path>
-            <Path fileType="library">/usr/lib64/libOpenEXRUtil-3_4.so.33.3.4.10</Path>
+            <Path fileType="library">/usr/lib64/libOpenEXRUtil-3_4.so.33.3.4.11</Path>
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2026-04-25</Date>
-            <Version>3.4.10</Version>
+        <Update release="14">
+            <Date>2026-05-01</Date>
+            <Version>3.4.11</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/AcademySoftwareFoundation/openexr/releases/tag/v3.4.11).

**Security**
Includes fixes for:
- CVE-2026-42217
- CVE-2026-42216
- CVE-2026-41142

**Test Plan**

Opened `gimp`. Did `magick identify example.png` against `openexr` v3.4.11

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
