### PR TITLE
usysconf: Update to v0.5.15

### DIFF
--- a/packages/u/usysconf/package.yml
+++ b/packages/u/usysconf/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : usysconf
-version    : 0.5.14
-release    : 50
+version    : 0.5.15
+release    : 51
 source     :
-    - https://github.com/getsolus/usysconf/releases/download/v0.5.14/usysconf-v0.5.14.tar.xz : 97b84cebcf62cb0a9622cc23632fe63a9c4cc8fb4c72b58d6000a6d2cb38e76a
+    - https://github.com/getsolus/usysconf/releases/download/v0.5.15/usysconf-v0.5.15.tar.xz : cc2dc9cebb98714b0b7935e7d7a853a5656559a545e22847558acb4dc89a8fd5
 homepage   : https://github.com/getsolus/usysconf/
 license    : GPL-2.0-only
 component  : system.base

--- a/packages/u/usysconf/pspec_x86_64.xml
+++ b/packages/u/usysconf/pspec_x86_64.xml
@@ -40,9 +40,9 @@ usysconf is a Solus project.
         </Files>
     </Package>
     <History>
-        <Update release="50">
-            <Date>2026-05-01</Date>
-            <Version>0.5.14</Version>
+        <Update release="51">
+            <Date>2026-05-04</Date>
+            <Version>0.5.15</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/getsolus/usysconf/releases/tag/v0.5.15).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install packages with manpages, see that the  trigger still seems to work.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](LICENSE.md) and have the power and authority to grant those licenses.
