### PR TITLE
kirigami-addons: Update to 1.12.0

### DIFF
--- a/packages/k/kirigami-addons/abi_libs
+++ b/packages/k/kirigami-addons/abi_libs
@@ -1,3 +1,4 @@
+libKirigamiAddonsComponents.so.6
 libKirigamiAddonsStatefulApp.so.6
 libKirigamiAddonsStatefulAppplugin.so
 libKirigamiApp.so.6

--- a/packages/k/kirigami-addons/abi_symbols
+++ b/packages/k/kirigami-addons/abi_symbols
@@ -1,3 +1,6 @@
+libKirigamiAddonsComponents.so.6:_ZN9NameUtils16colorsFromStringERK7QString
+libKirigamiAddonsComponents.so.6:_ZN9NameUtils18initialsFromStringERK7QString
+libKirigamiAddonsComponents.so.6:_ZN9NameUtils29isStringUnsuitableForInitialsERK7QString
 libKirigamiAddonsStatefulApp.so.6:_Z53qml_register_types_org_kde_kirigamiaddons_statefulappv
 libKirigamiAddonsStatefulApp.so.6:_ZN24KirigamiActionCollection10addActionsERK5QListIP7QActionE
 libKirigamiAddonsStatefulApp.so.6:_ZN24KirigamiActionCollection10takeActionEP7QAction
@@ -80,6 +83,7 @@ libKirigamiApp.so.6:_ZN11KirigamiAppC2Ev
 libKirigamiApp.so.6:_ZN11KirigamiAppD0Ev
 libKirigamiApp.so.6:_ZN11KirigamiAppD1Ev
 libKirigamiApp.so.6:_ZN11KirigamiAppD2Ev
+libKirigamiApp.so.6:_ZN19KirigamiAppDefaults5applyEP15QGuiApplication
 libKirigamiApp.so.6:_ZTI11KirigamiApp
 libKirigamiApp.so.6:_ZTS11KirigamiApp
 libKirigamiApp.so.6:_ZTV11KirigamiApp

--- a/packages/k/kirigami-addons/abi_used_libs
+++ b/packages/k/kirigami-addons/abi_used_libs
@@ -12,6 +12,7 @@ libQt6Gui.so.6
 libQt6Qml.so.6
 libQt6Quick.so.6
 libQt6QuickControls2.so.6
+libQt6Widgets.so.6
 libc.so.6
 libm.so.6
 libstdc++.so.6

--- a/packages/k/kirigami-addons/abi_used_symbols
+++ b/packages/k/kirigami-addons/abi_used_symbols
@@ -101,6 +101,7 @@ libQt6Core.so.6:_ZN14QStandardPaths17standardLocationsENS_16StandardLocationE
 libQt6Core.so.6:_ZN15QtSharedPointer20ExternalRefCountData9getAndRefEPK7QObject
 libQt6Core.so.6:_ZN16QCoreApplication15applicationNameEv
 libQt6Core.so.6:_ZN16QCoreApplication4exitEi
+libQt6Core.so.6:_ZN16QCoreApplication4selfE
 libQt6Core.so.6:_ZN16QDebugStateSaverC1ER6QDebug
 libQt6Core.so.6:_ZN16QDebugStateSaverD1Ev
 libQt6Core.so.6:_ZN16QLoggingCategoryC1EPKc9QtMsgType
@@ -538,6 +539,8 @@ libQt6Quick.so.6:_ZN12QQuickWindow16staticMetaObjectE
 libQt6Quick.so.6:_ZN19QQuickRenderControl15renderWindowForEP12QQuickWindowP6QPoint
 libQt6QuickControls2.so.6:_ZN11QQuickStyle4nameEv
 libQt6QuickControls2.so.6:_ZN11QQuickStyle8setStyleERK7QString
+libQt6Widgets.so.6:_ZN12QApplication8setStyleEP6QStyle
+libQt6Widgets.so.6:_ZN13QStyleFactory6createERK7QString
 libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_tolower_loc
 libc.so.6:__cxa_atexit

--- a/packages/k/kirigami-addons/package.yml
+++ b/packages/k/kirigami-addons/package.yml
@@ -1,11 +1,21 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : kirigami-addons
-version    : 1.10.0
-release    : 21
+version    : 1.12.0
+release    : 22
 source     :
-    - https://download.kde.org/stable/kirigami-addons/kirigami-addons-1.10.0.tar.xz : c98f92bf7c452e12f6dc403404215413db3959fe904ad830ead0db6bb09b3d11
+    - https://download.kde.org/stable/kirigami-addons/kirigami-addons-1.12.0.tar.xz : 513051dff8417da1819d6ae89d6c21a03654c9a60891df60df6aba13df19d21b
 homepage   : https://invent.kde.org/libraries/kirigami-addons
-license    : GPL-2.0-or-later
+license    : 
+    - BSD-3-Clause
+    - CC0-1.0
+    - CC-BY-SA-4.0
+    - GPL-2.0-or-later
+    - LGPL-2.0-only
+    - LGPL-2.0-or-later
+    - LGPL-2.1-only
+    - LGPL-2.1-or-later
+    - LGPL-3.0-only
+    - MIT
 component  : programming.library
 summary    : Convergent visual components ("widgets") for Kirigami-based applications
 description: |
@@ -32,6 +42,7 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license LICENSES/*
 patterns   :
     - devel :
         - /usr/share/kdevappwizard/

--- a/packages/k/kirigami-addons/pspec_x86_64.xml
+++ b/packages/k/kirigami-addons/pspec_x86_64.xml
@@ -3,10 +3,19 @@
         <Name>kirigami-addons</Name>
         <Homepage>https://invent.kde.org/libraries/kirigami-addons</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
+        <License>BSD-3-Clause</License>
+        <License>CC0-1.0</License>
+        <License>CC-BY-SA-4.0</License>
         <License>GPL-2.0-or-later</License>
+        <License>LGPL-2.0-only</License>
+        <License>LGPL-2.0-or-later</License>
+        <License>LGPL-2.1-only</License>
+        <License>LGPL-2.1-or-later</License>
+        <License>LGPL-3.0-only</License>
+        <License>MIT</License>
         <PartOf>programming.library</PartOf>
         <Summary xml:lang="en">Convergent visual components (&quot;widgets&quot;) for Kirigami-based applications</Summary>
         <Description xml:lang="en">A set of &quot;widgets&quot; i.e visual end user components along with a code to support them. Components are usable by both touch and desktop experiences providing a native experience on both, and look native with any QQC2 style (qqc2-desktop-theme, Material or Plasma)
@@ -20,9 +29,11 @@
 </Description>
         <PartOf>programming.library</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib64/libKirigamiAddonsStatefulApp.so.1.10.0</Path>
+            <Path fileType="library">/usr/lib64/libKirigamiAddonsComponents.so.1.12.0</Path>
+            <Path fileType="library">/usr/lib64/libKirigamiAddonsComponents.so.6</Path>
+            <Path fileType="library">/usr/lib64/libKirigamiAddonsStatefulApp.so.1.12.0</Path>
             <Path fileType="library">/usr/lib64/libKirigamiAddonsStatefulApp.so.6</Path>
-            <Path fileType="library">/usr/lib64/libKirigamiApp.so.1.10.0</Path>
+            <Path fileType="library">/usr/lib64/libKirigamiApp.so.1.12.0</Path>
             <Path fileType="library">/usr/lib64/libKirigamiApp.so.6</Path>
             <Path fileType="library">/usr/lib64/qt6/qml/org/kde/kirigamiaddons/components/Avatar.qml</Path>
             <Path fileType="library">/usr/lib64/qt6/qml/org/kde/kirigamiaddons/components/AvatarButton.qml</Path>
@@ -176,6 +187,19 @@
             <Path fileType="library">/usr/lib64/qt6/qml/org/kde/kirigamiaddons/treeview/qmldir</Path>
             <Path fileType="library">/usr/lib64/qt6/qml/org/kde/kirigamiaddons/treeview/styles/org.kde.desktop/TreeViewDecoration.qml</Path>
             <Path fileType="library">/usr/lib64/qt6/qml/org/kde/kirigamiaddons/treeview/treeviewplugin.qmltypes</Path>
+            <Path fileType="data">/usr/share/licenses/kirigami-addons/BSD-2-Clause.txt</Path>
+            <Path fileType="data">/usr/share/licenses/kirigami-addons/BSD-3-Clause.txt</Path>
+            <Path fileType="data">/usr/share/licenses/kirigami-addons/CC-BY-SA-4.0.txt</Path>
+            <Path fileType="data">/usr/share/licenses/kirigami-addons/CC0-1.0.txt</Path>
+            <Path fileType="data">/usr/share/licenses/kirigami-addons/GPL-2.0-or-later.txt</Path>
+            <Path fileType="data">/usr/share/licenses/kirigami-addons/LGPL-2.0-only.txt</Path>
+            <Path fileType="data">/usr/share/licenses/kirigami-addons/LGPL-2.0-or-later.txt</Path>
+            <Path fileType="data">/usr/share/licenses/kirigami-addons/LGPL-2.1-only.txt</Path>
+            <Path fileType="data">/usr/share/licenses/kirigami-addons/LGPL-2.1-or-later.txt</Path>
+            <Path fileType="data">/usr/share/licenses/kirigami-addons/LGPL-3.0-only.txt</Path>
+            <Path fileType="data">/usr/share/licenses/kirigami-addons/LicenseRef-KDE-Accepted-GPL.txt</Path>
+            <Path fileType="data">/usr/share/licenses/kirigami-addons/LicenseRef-KDE-Accepted-LGPL.txt</Path>
+            <Path fileType="data">/usr/share/licenses/kirigami-addons/MIT.txt</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/kirigami-addons6.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ast/LC_MESSAGES/kirigami-addons6.mo</Path>
             <Path fileType="localedata">/usr/share/locale/az/LC_MESSAGES/kirigami-addons6.mo</Path>
@@ -191,6 +215,7 @@
             <Path fileType="localedata">/usr/share/locale/eu/LC_MESSAGES/kirigami-addons6.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fi/LC_MESSAGES/kirigami-addons6.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/kirigami-addons6.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ga/LC_MESSAGES/kirigami-addons6.mo</Path>
             <Path fileType="localedata">/usr/share/locale/gl/LC_MESSAGES/kirigami-addons6.mo</Path>
             <Path fileType="localedata">/usr/share/locale/he/LC_MESSAGES/kirigami-addons6.mo</Path>
             <Path fileType="localedata">/usr/share/locale/hi/LC_MESSAGES/kirigami-addons6.mo</Path>
@@ -229,13 +254,19 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="21">kirigami-addons</Dependency>
+            <Dependency release="22">kirigami-addons</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/KirigamiAddons/App/KirigamiApp</Path>
+            <Path fileType="header">/usr/include/KirigamiAddons/App/KirigamiAppDefaults</Path>
             <Path fileType="header">/usr/include/KirigamiAddons/App/kirigamiapp.h</Path>
             <Path fileType="header">/usr/include/KirigamiAddons/App/kirigamiapp_export.h</Path>
             <Path fileType="header">/usr/include/KirigamiAddons/App/kirigamiapp_version.h</Path>
+            <Path fileType="header">/usr/include/KirigamiAddons/App/kirigamiappdefaults.h</Path>
+            <Path fileType="header">/usr/include/KirigamiAddons/Components/NameUtils</Path>
+            <Path fileType="header">/usr/include/KirigamiAddons/Components/kirigamiaddonscomponents_export.h</Path>
+            <Path fileType="header">/usr/include/KirigamiAddons/Components/kirigamiaddonscomponents_version.h</Path>
+            <Path fileType="header">/usr/include/KirigamiAddons/Components/nameutils.h</Path>
             <Path fileType="header">/usr/include/KirigamiAddonsStatefulApp/AbstractKirigamiApplication</Path>
             <Path fileType="header">/usr/include/KirigamiAddonsStatefulApp/KirigamiActionCollection</Path>
             <Path fileType="header">/usr/include/KirigamiAddonsStatefulApp/abstractkirigamiapplication.h</Path>
@@ -246,6 +277,7 @@
             <Path fileType="library">/usr/lib64/cmake/KF6KirigamiAddons/KirigamiAddonsMacros.cmake</Path>
             <Path fileType="library">/usr/lib64/cmake/KF6KirigamiAddons/KirigamiAddonsTargets-relwithdebinfo.cmake</Path>
             <Path fileType="library">/usr/lib64/cmake/KF6KirigamiAddons/KirigamiAddonsTargets.cmake</Path>
+            <Path fileType="library">/usr/lib64/libKirigamiAddonsComponents.so</Path>
             <Path fileType="library">/usr/lib64/libKirigamiAddonsStatefulApp.so</Path>
             <Path fileType="library">/usr/lib64/libKirigamiApp.so</Path>
             <Path fileType="data">/usr/share/kdevappwizard/templates/kirigamiaddons6.tar.bz2</Path>
@@ -253,12 +285,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2026-04-02</Date>
-            <Version>1.10.0</Version>
+        <Update release="22">
+            <Date>2026-05-05</Date>
+            <Version>1.12.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Updated to latest for better compatibility with newer KDE Framework and QT versions

Bugfixes:
- Bug Reporting Fix: Resolved an issue where the "Report Bug" button in the standard About pages would fail to open the appropriate bug report URL.
- Brought various component stability improvements and QML binding refinements, ensuring that context menus and form cards behave more consistently across desktop and mobile.

Enhancements:
- Stack Upgrades: Rebuilt and optimized to ensure compatibility with the updated Qt 6.10+ and KDE Frameworks (KF6) 6.22+ stacks.

[Full Change Log](https://invent.kde.org/libraries/kirigami-addons/-/tags)

**Test Plan**

Install test with widgets 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](LICENSE.md) and have the power and authority to grant those licenses.
