### PR TITLE
zellij: Update to v0.44.2

### DIFF
--- a/packages/z/zellij/package.yml
+++ b/packages/z/zellij/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : zellij
-version    : 0.44.1
-release    : 18
+version    : 0.44.2
+release    : 19
 source     :
-    - https://github.com/zellij-org/zellij/archive/refs/tags/v0.44.1.tar.gz : a7fb97e7d32c7be977cdc977d4f03a3b6bdb054251b3f2c36bf143671e4a7f08
+    - https://github.com/zellij-org/zellij/archive/refs/tags/v0.44.2.tar.gz : 8a4c1558135e4dc7375fce8db3524c60289fa5eb5877068fcdeed9650140964d
 homepage   : https://zellij.dev
 license    : MIT
 component  : system.utils

--- a/packages/z/zellij/pspec_x86_64.xml
+++ b/packages/z/zellij/pspec_x86_64.xml
@@ -32,9 +32,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2026-04-07</Date>
-            <Version>0.44.1</Version>
+        <Update release="19">
+            <Date>2026-05-05</Date>
+            <Version>0.44.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/zellij-org/zellij/releases/tag/v0.44.2).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new Zellij session.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](LICENSE.md) and have the power and authority to grant those licenses.
