### PR TITLE
clr-boot-manager: Update to v3.7.0

### DIFF
--- a/packages/c/clr-boot-manager/package.yml
+++ b/packages/c/clr-boot-manager/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : clr-boot-manager
-version    : 3.6.0
-release    : 39
+version    : 3.7.0
+release    : 40
 source     :
-    - https://github.com/getsolus/clr-boot-manager/releases/download/solus-3.6.0/clr-boot-manager-3.6.0.tar.xz : f05cafc9fe808adbe9532a734551497d4810a163877cb316cb2fb12613fdc49e
-homepage   : https://www.clearlinux.org
+    - https://github.com/getsolus/clr-boot-manager/releases/download/solus-3.7.0/clr-boot-manager-3.7.0.tar.xz : ea924d4796b380ac0041279c83d579a2b576c13c9351ad8b612339a0cd43dc41
+homepage   : https://github.com/getsolus/clr-boot-manager
 license    : LGPL-2.1-or-later
 component  : system.base
 summary    : Kernel & Boot Loader Management

--- a/packages/c/clr-boot-manager/pspec_x86_64.xml
+++ b/packages/c/clr-boot-manager/pspec_x86_64.xml
@@ -1,10 +1,10 @@
 <PISI>
     <Source>
         <Name>clr-boot-manager</Name>
-        <Homepage>https://www.clearlinux.org</Homepage>
+        <Homepage>https://github.com/getsolus/clr-boot-manager</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>system.base</PartOf>
@@ -39,12 +39,12 @@ Most importantly, clr-boot-manager provides a simple mechanism to provide kernel
         </Files>
     </Package>
     <History>
-        <Update release="39">
-            <Date>2026-03-14</Date>
-            <Version>3.6.0</Version>
+        <Update release="40">
+            <Date>2026-05-06</Date>
+            <Version>3.7.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

This release buys users with 512 MiB EFI partitions some time by doing the cleanup before installing the new kernel. This is safe because the currently running kernel (ie. last known working) is never removed.

The default update flow now goes from 1) install new kernel, 2) install current kernel, 3) remove oldest kernel (three kernels installed at most) to 1) install current kernel, 2) remove oldest kernel, 3) install new kernel (two kernels installed at most.

**Test Plan**

- Install
- Run `sudo clr-boot-manager update`
- Verify system:
  ```
  $ sudo clr-boot-manager mount-boot
  $ sudo bootctl
  <snip>
  Default Boot Loader Entry:
         type: Boot Loader Specification Type #1 (.conf)
        title: Solus 4.9 Serenity
           id: Solus-current-7.0.3-336.conf
  ```

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](LICENSE.md) and have the power and authority to grant those licenses.
