### PR TITLE
protonmail-bridge: Update to v3.24.2

### DIFF
--- a/packages/p/protonmail-bridge/abi_libs
+++ b/packages/p/protonmail-bridge/abi_libs
@@ -1,1 +1,2 @@
 proton-bridge
+protonmail-bridge

--- a/packages/p/protonmail-bridge/abi_symbols
+++ b/packages/p/protonmail-bridge/abi_symbols
@@ -10,3 +10,4 @@ proton-bridge:preUpdateHookTrampoline
 proton-bridge:rollbackHookTrampoline
 proton-bridge:stepTrampoline
 proton-bridge:updateHookTrampoline
+protonmail-bridge:_IO_stdin_used

--- a/packages/p/protonmail-bridge/files/0001-Solus-Fix-Wayland-AppID.patch
+++ b/packages/p/protonmail-bridge/files/0001-Solus-Fix-Wayland-AppID.patch
@@ -1,25 +1,12 @@
-From c27094ace35176cf78a4e41e5454d7f469901b55 Mon Sep 17 00:00:00 2001
-From: Reilly Brogan <reilly@reillybrogan.com>
-Date: Fri, 15 Dec 2023 13:10:26 -0600
-Subject: [PATCH] Solus: Fix Wayland AppID
-
-Signed-off-by: Reilly Brogan <reilly@reillybrogan.com>
----
- internal/frontend/bridge-gui/bridge-gui/main.cpp | 1 +
- 1 file changed, 1 insertion(+)
-
 diff --git a/internal/frontend/bridge-gui/bridge-gui/main.cpp b/internal/frontend/bridge-gui/bridge-gui/main.cpp
-index 38db9f6b..f9cff950 100644
+index ff017dd1..9075d78e 100644
 --- a/internal/frontend/bridge-gui/bridge-gui/main.cpp
 +++ b/internal/frontend/bridge-gui/bridge-gui/main.cpp
-@@ -86,6 +86,7 @@ void initQtApplication() {
+@@ -81,6 +81,7 @@ void initQtApplication() {
      QGuiApplication::setOrganizationName(PROJECT_VENDOR);
      QGuiApplication::setOrganizationDomain("proton.ch");
      QGuiApplication::setQuitOnLastWindowClosed(false);
 +    QGuiApplication::setDesktopFileName("ch.protonmail.protonmail-bridge");
- #ifdef Q_OS_MACOS
-     // on macOS, the app icon as it appears in the dock and file system is defined by in the app bundle plist, not here.
-     // We still use this copy (lock icon in white rectangle), so that devs that use the bridge-gui exe directly get a decent looking icon in the dock.
--- 
-2.43.0
-
+ 
+ #ifndef Q_OS_MACOS
+ 

--- a/packages/p/protonmail-bridge/package.yml
+++ b/packages/p/protonmail-bridge/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : protonmail-bridge
-version    : 3.22.0
-release    : 31
+version    : 3.24.2
+release    : 32
 source     :
-    - https://github.com/ProtonMail/proton-bridge/archive/refs/tags/v3.22.0.tar.gz : 15c9daa5bbb9db6e61d9644f346dc9d4df3bda59ccd3d73ae4b889d64f4874cf
+    - https://github.com/ProtonMail/proton-bridge/archive/refs/tags/v3.24.2.tar.gz : 17b9ac6d8556aabc1f53c41c8f3341fb9e774ec9557a44c36187aa5e4964c7d8
 homepage   : https://proton.me/mail/bridge
 license    : GPL-3.0-or-later
 component  : network.mail

--- a/packages/p/protonmail-bridge/pspec_x86_64.xml
+++ b/packages/p/protonmail-bridge/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>protonmail-bridge</Name>
         <Homepage>https://proton.me/mail/bridge</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jasper Behrensdorf</Name>
+            <Email>solus.citizen140@passmail.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.mail</PartOf>
@@ -29,12 +29,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2026-03-10</Date>
-            <Version>3.22.0</Version>
+        <Update release="32">
+            <Date>2026-05-06</Date>
+            <Version>3.24.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jasper Behrensdorf</Name>
+            <Email>solus.citizen140@passmail.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Release notes can be found [here](https://proton.me/download/bridge/stable_releases.html).

I've also submitted an upstream PR to potentially get rid of the Qt 6.10 patch in ProtonMail/proton-bridge#525.

**Test Plan**
Synced and sent mail through Thunderbird.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
