### PR TITLE
httpd: Update to v2.4.67

### DIFF
--- a/packages/h/httpd/abi_symbols
+++ b/packages/h/httpd/abi_symbols
@@ -677,6 +677,7 @@ httpd:ap_hack_ap_md5_binary
 httpd:ap_hack_ap_md5contextTo64
 httpd:ap_hack_ap_md5digest
 httpd:ap_hack_ap_meets_conditions
+httpd:ap_hack_ap_memeq_timingsafe
 httpd:ap_hack_ap_merge_log_config
 httpd:ap_hack_ap_merge_per_dir_configs
 httpd:ap_hack_ap_method_in_list
@@ -988,7 +989,9 @@ httpd:ap_hack_ap_strcasestr
 httpd:ap_hack_ap_strchr
 httpd:ap_hack_ap_strchr_c
 httpd:ap_hack_ap_strcmp_match
+httpd:ap_hack_ap_streq_timingsafe
 httpd:ap_hack_ap_stripprefix
+httpd:ap_hack_ap_strneq_timingsafe
 httpd:ap_hack_ap_strrchr
 httpd:ap_hack_ap_strrchr_c
 httpd:ap_hack_ap_strstr
@@ -2111,6 +2114,7 @@ httpd:ap_md5_binary
 httpd:ap_md5contextTo64
 httpd:ap_md5digest
 httpd:ap_meets_conditions
+httpd:ap_memeq_timingsafe
 httpd:ap_merge_log_config
 httpd:ap_merge_per_dir_configs
 httpd:ap_method_in_list
@@ -2460,7 +2464,9 @@ httpd:ap_strcasestr
 httpd:ap_strchr
 httpd:ap_strchr_c
 httpd:ap_strcmp_match
+httpd:ap_streq_timingsafe
 httpd:ap_stripprefix
+httpd:ap_strneq_timingsafe
 httpd:ap_strrchr
 httpd:ap_strrchr_c
 httpd:ap_strstr

--- a/packages/h/httpd/package.yml
+++ b/packages/h/httpd/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : httpd
-version    : 2.4.66
-release    : 36
+version    : 2.4.67
+release    : 37
 source     :
-    - https://dlcdn.apache.org/httpd/httpd-2.4.66.tar.gz : 442184763b60936471b88a91275f79d2407733b7aac27e345f270e8bc31c3d49
+    - https://dlcdn.apache.org/httpd/httpd-2.4.67.tar.gz : 10a578d199c3930250534fac629995f34ef7571709a7c88c45239e1fdc88cf77
 homepage   : https://httpd.apache.org/
 license    : Apache-2.0
 component  : programming
@@ -67,6 +67,7 @@ build      : |
     %make
 install    : |
     %make_install -j1
+    %install_license LICENSE
     # Install httpd systemd stuff
     install -Dm00644 $pkgfiles/httpd.service $installdir/%libdir%/systemd/system/httpd.service
     install -Dm00644 $pkgfiles/httpd.sysusers $installdir/%libdir%/sysusers.d/httpd.conf

--- a/packages/h/httpd/pspec_x86_64.xml
+++ b/packages/h/httpd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>httpd</Name>
         <Homepage>https://httpd.apache.org/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming</PartOf>
@@ -493,6 +493,8 @@ Based on the the public domain HTTP daemon devloped by Rob McCool at the Nationa
             <Path fileType="data">/usr/share/httpd/manual/developer/index.html</Path>
             <Path fileType="data">/usr/share/httpd/manual/developer/index.html.en</Path>
             <Path fileType="data">/usr/share/httpd/manual/developer/index.html.zh-cn.utf8</Path>
+            <Path fileType="data">/usr/share/httpd/manual/developer/mod_example_1.c</Path>
+            <Path fileType="data">/usr/share/httpd/manual/developer/mod_example_2.c</Path>
             <Path fileType="data">/usr/share/httpd/manual/developer/modguide.html</Path>
             <Path fileType="data">/usr/share/httpd/manual/developer/modguide.html.en</Path>
             <Path fileType="data">/usr/share/httpd/manual/developer/modules.html</Path>
@@ -1317,10 +1319,6 @@ Based on the the public domain HTTP daemon devloped by Rob McCool at the Nationa
             <Path fileType="data">/usr/share/httpd/manual/platform/netware.html.en</Path>
             <Path fileType="data">/usr/share/httpd/manual/platform/netware.html.fr.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/platform/netware.html.ko.euc-kr</Path>
-            <Path fileType="data">/usr/share/httpd/manual/platform/perf-hp.html</Path>
-            <Path fileType="data">/usr/share/httpd/manual/platform/perf-hp.html.en</Path>
-            <Path fileType="data">/usr/share/httpd/manual/platform/perf-hp.html.fr.utf8</Path>
-            <Path fileType="data">/usr/share/httpd/manual/platform/perf-hp.html.ko.euc-kr</Path>
             <Path fileType="data">/usr/share/httpd/manual/platform/rpm.html</Path>
             <Path fileType="data">/usr/share/httpd/manual/platform/rpm.html.en</Path>
             <Path fileType="data">/usr/share/httpd/manual/platform/rpm.html.fr.utf8</Path>
@@ -1590,6 +1588,7 @@ Based on the the public domain HTTP daemon devloped by Rob McCool at the Nationa
             <Path fileType="data">/usr/share/httpd/manual/vhosts/name-based.html.ja.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/vhosts/name-based.html.ko.euc-kr</Path>
             <Path fileType="data">/usr/share/httpd/manual/vhosts/name-based.html.tr.utf8</Path>
+            <Path fileType="data">/usr/share/licenses/httpd/LICENSE</Path>
             <Path fileType="man">/usr/share/man/man1/ab.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/apxs.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/dbmmanage.1.zst</Path>
@@ -1617,7 +1616,7 @@ Based on the the public domain HTTP daemon devloped by Rob McCool at the Nationa
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="36">httpd</Dependency>
+            <Dependency release="37">httpd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/httpd/ap_compat.h</Path>
@@ -1688,12 +1687,12 @@ Based on the the public domain HTTP daemon devloped by Rob McCool at the Nationa
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2026-02-13</Date>
-            <Version>2.4.66</Version>
+        <Update release="37">
+            <Date>2026-05-07</Date>
+            <Version>2.4.67</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://dlcdn.apache.org/httpd/CHANGES_2.4.67).

**Security**
Includes fixes for:
- CVE-2026-23918
- CVE-2026-24072
- CVE-2026-28780
- CVE-2026-29168
- CVE-2026-29169
- CVE-2026-33006
- CVE-2026-33007
- CVE-2026-33523
- CVE-2026-33857
- CVE-2026-34032
- CVE-2026-34059

**Test Plan**

`httpd -v && httpd -t`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
