### PR TITLE
libssh: Update to v0.12.0

### DIFF
--- a/packages/l/libssh/abi_symbols
+++ b/packages/l/libssh/abi_symbols
@@ -1,4 +1,5 @@
 libssh.so.4:LIBSSH_4_10_0
+libssh.so.4:LIBSSH_4_11_0
 libssh.so.4:LIBSSH_4_5_0
 libssh.so.4:LIBSSH_4_6_0
 libssh.so.4:LIBSSH_4_7_0
@@ -85,6 +86,7 @@ libssh.so.4:sftp_fstatvfs
 libssh.so.4:sftp_fsync
 libssh.so.4:sftp_get_client_message
 libssh.so.4:sftp_get_error
+libssh.so.4:sftp_get_users_groups_by_id
 libssh.so.4:sftp_handle
 libssh.so.4:sftp_handle_alloc
 libssh.so.4:sftp_handle_remove
@@ -96,6 +98,8 @@ libssh.so.4:sftp_limits_free
 libssh.so.4:sftp_lsetstat
 libssh.so.4:sftp_lstat
 libssh.so.4:sftp_mkdir
+libssh.so.4:sftp_name_id_map_free
+libssh.so.4:sftp_name_id_map_new
 libssh.so.4:sftp_new
 libssh.so.4:sftp_new_channel
 libssh.so.4:sftp_open
@@ -254,6 +258,7 @@ libssh.so.4:ssh_get_random
 libssh.so.4:ssh_get_server_publickey
 libssh.so.4:ssh_get_serverbanner
 libssh.so.4:ssh_get_status
+libssh.so.4:ssh_get_supported_methods
 libssh.so.4:ssh_get_version
 libssh.so.4:ssh_getpass
 libssh.so.4:ssh_handle_key_exchange
@@ -264,6 +269,9 @@ libssh.so.4:ssh_is_server_known
 libssh.so.4:ssh_key_cmp
 libssh.so.4:ssh_key_dup
 libssh.so.4:ssh_key_free
+libssh.so.4:ssh_key_get_sk_application
+libssh.so.4:ssh_key_get_sk_flags
+libssh.so.4:ssh_key_get_sk_user_id
 libssh.so.4:ssh_key_is_private
 libssh.so.4:ssh_key_is_public
 libssh.so.4:ssh_key_new
@@ -329,6 +337,13 @@ libssh.so.4:ssh_pcap_file_free
 libssh.so.4:ssh_pcap_file_new
 libssh.so.4:ssh_pcap_file_open
 libssh.so.4:ssh_pki_copy_cert_to_privkey
+libssh.so.4:ssh_pki_ctx_free
+libssh.so.4:ssh_pki_ctx_get_sk_attestation_buffer
+libssh.so.4:ssh_pki_ctx_new
+libssh.so.4:ssh_pki_ctx_options_set
+libssh.so.4:ssh_pki_ctx_set_sk_pin_callback
+libssh.so.4:ssh_pki_ctx_sk_callbacks_option_set
+libssh.so.4:ssh_pki_ctx_sk_callbacks_options_clear
 libssh.so.4:ssh_pki_export_privkey_base64
 libssh.so.4:ssh_pki_export_privkey_base64_format
 libssh.so.4:ssh_pki_export_privkey_file
@@ -337,6 +352,7 @@ libssh.so.4:ssh_pki_export_privkey_to_pubkey
 libssh.so.4:ssh_pki_export_pubkey_base64
 libssh.so.4:ssh_pki_export_pubkey_file
 libssh.so.4:ssh_pki_generate
+libssh.so.4:ssh_pki_generate_key
 libssh.so.4:ssh_pki_import_cert_base64
 libssh.so.4:ssh_pki_import_cert_file
 libssh.so.4:ssh_pki_import_privkey_base64
@@ -399,12 +415,14 @@ libssh.so.4:ssh_set_pcap_file
 libssh.so.4:ssh_set_server_callbacks
 libssh.so.4:ssh_silent_disconnect
 libssh.so.4:ssh_string_burn
+libssh.so.4:ssh_string_cmp
 libssh.so.4:ssh_string_copy
 libssh.so.4:ssh_string_data
 libssh.so.4:ssh_string_fill
 libssh.so.4:ssh_string_free
 libssh.so.4:ssh_string_free_char
 libssh.so.4:ssh_string_from_char
+libssh.so.4:ssh_string_from_data
 libssh.so.4:ssh_string_get_char
 libssh.so.4:ssh_string_len
 libssh.so.4:ssh_string_new
@@ -439,6 +457,8 @@ libssh.so.4:ssh_userauth_try_publickey
 libssh.so.4:ssh_version
 libssh.so.4:ssh_vlog
 libssh.so.4:ssh_write_knownhost
+libssh.so.4:sshsig_sign
+libssh.so.4:sshsig_verify
 libssh.so.4:string_burn
 libssh.so.4:string_copy
 libssh.so.4:string_data

--- a/packages/l/libssh/abi_used_symbols
+++ b/packages/l/libssh/abi_used_symbols
@@ -2,11 +2,10 @@ ld-linux-x86-64.so.2:__tls_get_addr
 libc.so.6:__ctype_b_loc
 libc.so.6:__ctype_tolower_loc
 libc.so.6:__errno_location
-libc.so.6:__explicit_bzero_chk
 libc.so.6:__fdelt_chk
 libc.so.6:__fprintf_chk
 libc.so.6:__isoc99_fscanf
-libc.so.6:__memcpy_chk
+libc.so.6:__memset_explicit_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__strcat_chk
@@ -74,7 +73,7 @@ libc.so.6:inet_pton
 libc.so.6:isatty
 libc.so.6:kill
 libc.so.6:listen
-libc.so.6:localtime
+libc.so.6:localtime_r
 libc.so.6:lseek
 libc.so.6:lstat
 libc.so.6:malloc
@@ -201,6 +200,7 @@ libcrypto.so.3:EVP_DecryptFinal
 libcrypto.so.3:EVP_DecryptInit_ex
 libcrypto.so.3:EVP_DecryptUpdate
 libcrypto.so.3:EVP_DigestFinal
+libcrypto.so.3:EVP_DigestInit
 libcrypto.so.3:EVP_DigestInit_ex
 libcrypto.so.3:EVP_DigestSign
 libcrypto.so.3:EVP_DigestSignFinal
@@ -226,6 +226,8 @@ libcrypto.so.3:EVP_MAC_init
 libcrypto.so.3:EVP_MAC_update
 libcrypto.so.3:EVP_MD_CTX_free
 libcrypto.so.3:EVP_MD_CTX_new
+libcrypto.so.3:EVP_MD_fetch
+libcrypto.so.3:EVP_MD_free
 libcrypto.so.3:EVP_PKEY_CTX_free
 libcrypto.so.3:EVP_PKEY_CTX_new
 libcrypto.so.3:EVP_PKEY_CTX_new_from_name
@@ -233,9 +235,13 @@ libcrypto.so.3:EVP_PKEY_CTX_new_from_pkey
 libcrypto.so.3:EVP_PKEY_CTX_new_id
 libcrypto.so.3:EVP_PKEY_CTX_set_params
 libcrypto.so.3:EVP_PKEY_Q_keygen
+libcrypto.so.3:EVP_PKEY_decapsulate
+libcrypto.so.3:EVP_PKEY_decapsulate_init
 libcrypto.so.3:EVP_PKEY_derive
 libcrypto.so.3:EVP_PKEY_derive_init
 libcrypto.so.3:EVP_PKEY_derive_set_peer
+libcrypto.so.3:EVP_PKEY_encapsulate
+libcrypto.so.3:EVP_PKEY_encapsulate_init
 libcrypto.so.3:EVP_PKEY_eq
 libcrypto.so.3:EVP_PKEY_free
 libcrypto.so.3:EVP_PKEY_fromdata
@@ -253,6 +259,7 @@ libcrypto.so.3:EVP_PKEY_keygen_init
 libcrypto.so.3:EVP_PKEY_new_mac_key
 libcrypto.so.3:EVP_PKEY_new_raw_private_key
 libcrypto.so.3:EVP_PKEY_new_raw_public_key
+libcrypto.so.3:EVP_PKEY_new_raw_public_key_ex
 libcrypto.so.3:EVP_PKEY_todata
 libcrypto.so.3:EVP_PKEY_up_ref
 libcrypto.so.3:EVP_aes_128_cbc

--- a/packages/l/libssh/package.yml
+++ b/packages/l/libssh/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libssh
-version    : 0.11.4
-release    : 19
+version    : 0.12.0
+release    : 20
 source     :
-    - https://www.libssh.org/files/0.11/libssh-0.11.4.tar.xz : 002ac320e3d66c9e100ec6576e3e84aa0c48949efde3bf5b40a2802992297701
+    - https://www.libssh.org/files/0.12/libssh-0.12.0.tar.xz : 1a6af424d8327e5eedef4e5fe7f5b924226dd617ac9f3de80f217d82a36a7121
 homepage   : https://www.libssh.org/
 license    : LGPL-2.1-or-later
 component  : programming.library

--- a/packages/l/libssh/pspec_x86_64.xml
+++ b/packages/l/libssh/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libssh</Name>
         <Homepage>https://www.libssh.org/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>programming.library</PartOf>
@@ -21,7 +21,7 @@
         <PartOf>programming.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libssh.so.4</Path>
-            <Path fileType="library">/usr/lib64/libssh.so.4.10.4</Path>
+            <Path fileType="library">/usr/lib64/libssh.so.4.11.0</Path>
             <Path fileType="data">/usr/share/licenses/libssh/COPYING</Path>
         </Files>
     </Package>
@@ -32,7 +32,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="19">libssh</Dependency>
+            <Dependency release="20">libssh</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libssh/callbacks.h</Path>
@@ -52,12 +52,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2026-03-11</Date>
-            <Version>0.11.4</Version>
+        <Update release="20">
+            <Date>2026-05-08</Date>
+            <Version>0.12.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://www.libssh.org/).

**Security**
Includes fixes for:
- CVE-2025-14821
- CVE-2026-0964
- CVE-2026-0965
- CVE-2026-0966
- CVE-2026-0967
- CVE-2026-0968

**Test Plan**

Passed the ninja_checks

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
