### PR TITLE
libtpms: Update to v0.10.2

### DIFF
--- a/packages/l/libtpms/abi_used_symbols
+++ b/packages/l/libtpms/abi_used_symbols
@@ -133,6 +133,7 @@ libcrypto.so.3:EVP_DecryptUpdate
 libcrypto.so.3:EVP_EncryptFinal_ex
 libcrypto.so.3:EVP_EncryptInit_ex
 libcrypto.so.3:EVP_EncryptUpdate
+libcrypto.so.3:EVP_KDF_CTX_free
 libcrypto.so.3:EVP_KDF_CTX_new
 libcrypto.so.3:EVP_KDF_derive
 libcrypto.so.3:EVP_KDF_fetch

--- a/packages/l/libtpms/package.yml
+++ b/packages/l/libtpms/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libtpms
-version    : 0.10.0
-release    : 5
+version    : 0.10.2
+release    : 6
 source     :
-    - https://github.com/stefanberger/libtpms/archive/refs/tags/v0.10.0.tar.gz : 6da9a527b3afa7b1470acd4cd17157b8646c31a2c7ff3ba2dfc50c81ba413426
+    - https://github.com/stefanberger/libtpms/archive/refs/tags/v0.10.2.tar.gz : edac03680f8a4a1c5c1d609a10e3f41e1a129e38ff5158f0c8deaedc719fb127
 homepage   : https://github.com/stefanberger/libtpms
 license    :
     - BSD-3-Clause
@@ -19,3 +19,6 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license LICENSE
+check      : |
+    %make check

--- a/packages/l/libtpms/pspec_x86_64.xml
+++ b/packages/l/libtpms/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libtpms</Name>
         <Homepage>https://github.com/stefanberger/libtpms</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>TCGL</License>
@@ -22,7 +22,8 @@
         <PartOf>virt</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libtpms.so.0</Path>
-            <Path fileType="library">/usr/lib64/libtpms.so.0.10.0</Path>
+            <Path fileType="library">/usr/lib64/libtpms.so.0.10.2</Path>
+            <Path fileType="data">/usr/share/licenses/libtpms/LICENSE</Path>
         </Files>
     </Package>
     <Package>
@@ -32,7 +33,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="5">libtpms</Dependency>
+            <Dependency release="6">libtpms</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libtpms/tpm_error.h</Path>
@@ -43,43 +44,43 @@
             <Path fileType="header">/usr/include/libtpms/tpm_types.h</Path>
             <Path fileType="library">/usr/lib64/libtpms.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/libtpms.pc</Path>
-            <Path fileType="man">/usr/share/man/man3/TPMLIB_CancelCommand.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPMLIB_ChooseTPMVersion.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPMLIB_DecodeBlob.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPMLIB_GetInfo.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPMLIB_GetState.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPMLIB_GetTPMProperty.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPMLIB_GetVersion.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPMLIB_MainInit.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPMLIB_Process.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPMLIB_RegisterCallbacks.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPMLIB_SetBufferSize.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPMLIB_SetDebugFD.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPMLIB_SetDebugLevel.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPMLIB_SetDebugPrefix.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPMLIB_SetProfile.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPMLIB_SetState.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPMLIB_Terminate.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPMLIB_ValidateState.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPMLIB_VolatileAll_Store.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPMLIB_WasManufactured.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPM_Free.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPM_IO_Hash_Data.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPM_IO_Hash_End.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPM_IO_Hash_Start.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPM_IO_TpmEstablished_Get.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPM_IO_TpmEstablished_Reset.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPM_Malloc.3</Path>
-            <Path fileType="man">/usr/share/man/man3/TPM_Realloc.3</Path>
+            <Path fileType="man">/usr/share/man/man3/TPMLIB_CancelCommand.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPMLIB_ChooseTPMVersion.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPMLIB_DecodeBlob.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPMLIB_GetInfo.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPMLIB_GetState.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPMLIB_GetTPMProperty.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPMLIB_GetVersion.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPMLIB_MainInit.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPMLIB_Process.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPMLIB_RegisterCallbacks.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPMLIB_SetBufferSize.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPMLIB_SetDebugFD.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPMLIB_SetDebugLevel.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPMLIB_SetDebugPrefix.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPMLIB_SetProfile.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPMLIB_SetState.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPMLIB_Terminate.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPMLIB_ValidateState.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPMLIB_VolatileAll_Store.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPMLIB_WasManufactured.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPM_Free.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPM_IO_Hash_Data.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPM_IO_Hash_End.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPM_IO_Hash_Start.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPM_IO_TpmEstablished_Get.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPM_IO_TpmEstablished_Reset.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPM_Malloc.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/TPM_Realloc.3.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2024-12-07</Date>
-            <Version>0.10.0</Version>
+        <Update release="6">
+            <Date>2026-05-08</Date>
+            <Version>0.10.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/stefanberger/libtpms/releases/tag/v0.10.2).

**Security**
Includes fixes for:
- CVE-2025-49133
- CVE-2026-21444

**Test Plan**

Passed make checks

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
