### PR TITLE
usb-modeswitch: Update to v2.6.2

### DIFF
--- a/packages/u/usb-modeswitch/abi_used_symbols
+++ b/packages/u/usb-modeswitch/abi_used_symbols
@@ -1,5 +1,6 @@
 libc.so.6:__ctype_toupper_loc
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__sprintf_chk
@@ -39,7 +40,6 @@ libc.so.6:strrchr
 libc.so.6:strspn
 libc.so.6:strstr
 libc.so.6:strtok
-libc.so.6:strtol
 libc.so.6:usleep
 libusb-1.0.so.0:libusb_bulk_transfer
 libusb-1.0.so.0:libusb_claim_interface

--- a/packages/u/usb-modeswitch/files/usb-modeswitch-2.6.2-stateless.patch
+++ b/packages/u/usb-modeswitch/files/usb-modeswitch-2.6.2-stateless.patch
@@ -1,0 +1,24 @@
+diff '--color=auto' -pruN a/Makefile b/Makefile
+--- a/Makefile	2020-07-05 09:53:24.000000000 -0400
++++ b/Makefile	2026-05-08 16:44:01.808683971 -0400
+@@ -56,7 +56,7 @@ distclean: clean
+ install-common: $(PROG) $(DISPATCH)
+ 	install -D --mode=755 usb_modeswitch $(SBINDIR)/usb_modeswitch
+ 	install -D --mode=755 usb_modeswitch.sh $(UDEVDIR)/usb_modeswitch
+-	install -D --mode=644 usb_modeswitch.conf $(ETCDIR)/usb_modeswitch.conf
++	install -D --mode=644 usb_modeswitch.conf $(PREFIX)/share/defaults/usb_modeswitch/usb_modeswitch.conf
+ 	install -D --mode=644 usb_modeswitch.1 $(MANDIR)/usb_modeswitch.1
+ 	install -D --mode=644 usb_modeswitch_dispatcher.1 $(MANDIR)/usb_modeswitch_dispatcher.1
+ 	install -D --mode=755 usb_modeswitch_dispatcher $(SBINDIR)/usb_modeswitch_dispatcher
+diff '--color=auto' -pruN a/usb_modeswitch_dispatcher.tcl b/usb_modeswitch_dispatcher.tcl
+--- a/usb_modeswitch_dispatcher.tcl	2025-02-18 14:42:22.000000000 -0500
++++ b/usb_modeswitch_dispatcher.tcl	2026-05-08 16:44:09.936889369 -0400
+@@ -539,7 +539,7 @@ set configFile ""
+ if [string length $path] {
+ 	set places [list $path]
+ } else {
+-	set places [list /etc/usb_modeswitch.conf /etc/sysconfig/usb_modeswitch /etc/default/usb_modeswitch]
++	set places [list /etc/usb_modeswitch.conf /etc/sysconfig/usb_modeswitch /etc/default/usb_modeswitch /usr/share/defaults/usb_modeswitch/usb_modeswitch.conf]
+ }
+ foreach cfg $places {
+ 	if [file exists $cfg] {

--- a/packages/u/usb-modeswitch/files/usb_modeswitch.tmpfiles
+++ b/packages/u/usb-modeswitch/files/usb_modeswitch.tmpfiles
@@ -1,0 +1,1 @@
+d /etc/usb_modeswitch.d 0755 root root

--- a/packages/u/usb-modeswitch/package.yml
+++ b/packages/u/usb-modeswitch/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : usb-modeswitch
-version    : 2.6.0
-release    : 5
+version    : 2.6.2
+release    : 6
 source     :
-    - https://www.draisberghof.de/usb_modeswitch/usb-modeswitch-2.6.0.tar.bz2 : c215236e6bada6e659fc195a31d611ea298a4bdb4d57a0d68c553b56585f8ba3
-    - https://www.draisberghof.de/usb_modeswitch/usb-modeswitch-data-20191128.tar.bz2 : 3f039b60791c21c7cb15c7986cac89650f076dc274798fa242231b910785eaf9
+    - https://www.draisberghof.de/usb_modeswitch/usb-modeswitch-2.6.2.tar.bz2 : f7abd337784a9d1bd39cb8a587518aff6f2a43d916145eafd80b1b8b7146db66
+    - https://www.draisberghof.de/usb_modeswitch/usb-modeswitch-data-20251207.tar.bz2 : 0bb12d64aee5e467c31af61a53fb828ff7aa59c54a82ca85eeede4c5690bfa66
 homepage   : https://www.draisberghof.de/usb_modeswitch/
 license    : GPL-2.0-or-later
 component  : network.util
@@ -16,12 +16,31 @@ builddeps  :
 rundeps    :
     - tcl
 setup      : |
-    tar xf $sources/usb-modeswitch-data-*.tar.bz2
+    tar xf ${sources}/usb-modeswitch-data-*.tar.bz2
+
+    %patch -p1 -i ${pkgfiles}/usb-modeswitch-2.6.2-stateless.patch
 build      : |
     %make
 install    : |
-    install -dm00755 $installdir/%libdir%/systemd/system
-    %make_install UDEVDIR=$installdir/%libdir%/udev SYSDIR=$installdir/%libdir%/systemd/system
-    %make_install -C usb-modeswitch-data-* RULESDIR=$installdir/%libdir%/udev/rules.d
-    cd $installdir
-    rmdir -p var/lib/usb_modeswitch
+    %install_license COPYING
+
+    install -dm00755 ${installdir}/%libdir%/systemd/system
+
+    %make_install \
+        UDEVDIR=${installdir}/%libdir%/udev \
+        SYSDIR=${installdir}/%libdir%/systemd/system
+    %make_install -C usb-modeswitch-data-* \
+        RULESDIR=${installdir}/%libdir%/udev/rules.d
+
+    install -Dm00644 ${pkgfiles}/usb_modeswitch.tmpfiles ${installdir}/%libdir%/tmpfiles.d/usb_modeswitch.conf
+
+    # Stateless
+    rmdir \
+        ${installdir}/etc/usb_modeswitch.d \
+        ${installdir}/etc
+
+    # Not needed
+    rmdir \
+        ${installdir}/var/lib/usb_modeswitch \
+        ${installdir}/var/lib \
+        ${installdir}/var \

--- a/packages/u/usb-modeswitch/pspec_x86_64.xml
+++ b/packages/u/usb-modeswitch/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>usb-modeswitch</Name>
         <Homepage>https://www.draisberghof.de/usb_modeswitch/</Homepage>
         <Packager>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>network.util</PartOf>
@@ -20,15 +20,16 @@
 </Description>
         <PartOf>network.util</PartOf>
         <Files>
-            <Path fileType="config">/etc/usb_modeswitch.conf</Path>
-            <Path fileType="config">/etc/usb_modeswitch.d</Path>
             <Path fileType="library">/usr/lib64/systemd/system/usb_modeswitch@.service</Path>
+            <Path fileType="library">/usr/lib64/tmpfiles.d/usb_modeswitch.conf</Path>
             <Path fileType="library">/usr/lib64/udev/rules.d/40-usb_modeswitch.rules</Path>
             <Path fileType="library">/usr/lib64/udev/usb_modeswitch</Path>
             <Path fileType="executable">/usr/sbin/usb_modeswitch</Path>
             <Path fileType="executable">/usr/sbin/usb_modeswitch_dispatcher</Path>
-            <Path fileType="man">/usr/share/man/man1/usb_modeswitch.1</Path>
-            <Path fileType="man">/usr/share/man/man1/usb_modeswitch_dispatcher.1</Path>
+            <Path fileType="data">/usr/share/defaults/usb_modeswitch/usb_modeswitch.conf</Path>
+            <Path fileType="data">/usr/share/licenses/usb-modeswitch/COPYING</Path>
+            <Path fileType="man">/usr/share/man/man1/usb_modeswitch.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/usb_modeswitch_dispatcher.1.zst</Path>
             <Path fileType="data">/usr/share/usb_modeswitch/03f0:002a</Path>
             <Path fileType="data">/usr/share/usb_modeswitch/03f0:032a</Path>
             <Path fileType="data">/usr/share/usb_modeswitch/03f0:0857</Path>
@@ -176,6 +177,7 @@
             <Path fileType="data">/usr/share/usb_modeswitch/0b3c:f00c</Path>
             <Path fileType="data">/usr/share/usb_modeswitch/0b3c:f017</Path>
             <Path fileType="data">/usr/share/usb_modeswitch/0bda:1a2b</Path>
+            <Path fileType="data">/usr/share/usb_modeswitch/0bda:a192</Path>
             <Path fileType="data">/usr/share/usb_modeswitch/0bdb:190d</Path>
             <Path fileType="data">/usr/share/usb_modeswitch/0bdb:1910</Path>
             <Path fileType="data">/usr/share/usb_modeswitch/0cf3:20ff</Path>
@@ -541,16 +543,15 @@
             <Path fileType="data">/usr/share/usb_modeswitch/6000:1000</Path>
             <Path fileType="data">/usr/share/usb_modeswitch/8888:6500</Path>
             <Path fileType="data">/usr/share/usb_modeswitch/ed09:1021</Path>
-            <Path fileType="data">/usr/share/usb_modeswitch/new.lst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2023-10-18</Date>
-            <Version>2.6.0</Version>
+        <Update release="6">
+            <Date>2026-05-08</Date>
+            <Version>2.6.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Muhammad Alfi Syahrin</Name>
-            <Email>ems1000.syahrin@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://www.draisberghof.de/usb_modeswitch/ChangeLog).

Made package stateless.

Fixes https://github.com/getsolus/packages/issues/8797

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Ran some `usb_modeswitch` commands.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
