### PR TITLE
usysconf: Add mandb no chroot patch

### DIFF
--- a/packages/u/usysconf/files/0001-handlers-mandb-Don-t-run-in-chroot.patch
+++ b/packages/u/usysconf/files/0001-handlers-mandb-Don-t-run-in-chroot.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Evan Maddock <maddock.evan@vivaldi.net>
+Date: Fri, 8 May 2026 21:11:54 -0400
+Subject: [PATCH] handlers/mandb: Don't run in chroot
+
+The current behaviour breaks building ISO images because in our setup,
+systemd is not PID 1, so it can't run the task. There is really no
+reason to run this trigger in a chroot environment; it only builds the
+caches for `whatis` and `apropos`.
+
+Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
+---
+ src/handlers/mandb.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/handlers/mandb.c b/src/handlers/mandb.c
+index c5cf241..7d7958c 100644
+--- a/src/handlers/mandb.c
++++ b/src/handlers/mandb.c
+@@ -39,6 +39,11 @@ static UscHandlerStatus usc_handler_mandb_exec(UscContext *ctx, const char *path
+                 return USC_HANDLER_SKIP;
+         }
+ 
++        if (usc_context_has_flag(ctx, USC_FLAGS_CHROOTED)) {
++                usc_context_emit_task_finish(ctx, USC_HANDLER_SKIP);
++                return USC_HANDLER_SKIP | USC_HANDLER_BREAK;
++        }
++
+         usc_context_emit_task_start(ctx, "Updating manpages database");
+         int ret = usc_exec_command(command);
+         if (ret != 0) {

--- a/packages/u/usysconf/package.yml
+++ b/packages/u/usysconf/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : usysconf
 version    : 0.5.15
-release    : 51
+release    : 52
 source     :
     - https://github.com/getsolus/usysconf/releases/download/v0.5.15/usysconf-v0.5.15.tar.xz : cc2dc9cebb98714b0b7935e7d7a853a5656559a545e22847558acb4dc89a8fd5
 homepage   : https://github.com/getsolus/usysconf/
@@ -23,6 +23,8 @@ optimize   :
     - size
     - lto
 setup      : |
+    %patch -p1 -i ${pkgfiles}/0001-handlers-mandb-Don-t-run-in-chroot.patch
+
     export CC=musl-gcc
     %meson_configure \
         -Dwith-static-binary=true \

--- a/packages/u/usysconf/pspec_x86_64.xml
+++ b/packages/u/usysconf/pspec_x86_64.xml
@@ -40,8 +40,8 @@ usysconf is a Solus project.
         </Files>
     </Package>
     <History>
-        <Update release="51">
-            <Date>2026-05-04</Date>
+        <Update release="52">
+            <Date>2026-05-09</Date>
             <Version>0.5.15</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
- Don't run the mandb trigger in chroot environments

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Built a couple packages, saw that the trigger did not run.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
