### PR TITLE
xdg-terminal-exec: Add at v0.14.2

### DIFF
--- a/packages/x/xdg-terminal-exec/monitoring.yaml
+++ b/packages/x/xdg-terminal-exec/monitoring.yaml
@@ -1,0 +1,5 @@
+releases:
+  id: 377182
+  rss: https://github.com/Vladimir-csp/xdg-terminal-exec/releases.atom
+security:
+  cpe: ~ # No CPE found, last checked (2026-05-09)

--- a/packages/x/xdg-terminal-exec/package.yml
+++ b/packages/x/xdg-terminal-exec/package.yml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
+name       : xdg-terminal-exec
+version    : 0.14.2
+release    : 1
+source     :
+    - https://github.com/Vladimir-csp/xdg-terminal-exec/archive/refs/tags/v0.14.2.tar.gz : ed62746efc425226e5a44aa98a048178b53344d562dc673da65e9a96a47f3489
+homepage   : https://github.com/Vladimir-csp/xdg-terminal-exec
+license    : GPL-3.0-or-later
+component  : desktop.core
+summary    : Proposal for XDG Default Terminal Execution Specification and shell-based reference implementation.
+description: |
+    Proposal for XDG Default Terminal Execution Specification and reference shell-based implementation.
+builddeps:
+    - scdoc
+build      : |
+    %make prefix=/usr
+install    : |
+    %make_install prefix=/usr
+    %install_license LICENSE

--- a/packages/x/xdg-terminal-exec/pspec_x86_64.xml
+++ b/packages/x/xdg-terminal-exec/pspec_x86_64.xml
@@ -1,0 +1,38 @@
+<PISI>
+    <Source>
+        <Name>xdg-terminal-exec</Name>
+        <Homepage>https://github.com/Vladimir-csp/xdg-terminal-exec</Homepage>
+        <Packager>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
+        </Packager>
+        <License>GPL-3.0-or-later</License>
+        <PartOf>desktop.core</PartOf>
+        <Summary xml:lang="en">Proposal for XDG Default Terminal Execution Specification and shell-based reference implementation.</Summary>
+        <Description xml:lang="en">Proposal for XDG Default Terminal Execution Specification and reference shell-based implementation.
+</Description>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
+    </Source>
+    <Package>
+        <Name>xdg-terminal-exec</Name>
+        <Summary xml:lang="en">Proposal for XDG Default Terminal Execution Specification and shell-based reference implementation.</Summary>
+        <Description xml:lang="en">Proposal for XDG Default Terminal Execution Specification and reference shell-based implementation.
+</Description>
+        <PartOf>desktop.core</PartOf>
+        <Files>
+            <Path fileType="executable">/usr/bin/xdg-terminal-exec</Path>
+            <Path fileType="data">/usr/share/licenses/xdg-terminal-exec/LICENSE</Path>
+            <Path fileType="man">/usr/share/man/man1/xdg-terminal-exec.1.zst</Path>
+            <Path fileType="data">/usr/share/xdg-terminal-exec/xdg-terminals.list</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2026-05-09</Date>
+            <Version>0.14.2</Version>
+            <Comment>Packaging update</Comment>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**Summary**

New XDG proposal specification for setting and finding terminal emulators

https://gitlab.freedesktop.org/terminal-wg/specifications/-/merge_requests/3/diffs

Some terminal emulators such as ghostty only support this and having it installed fixes launching terminal .desktop files such as btop/zellij via GNOME Shell when only ghostty is installed.

**Test Plan**

Attempt to launch btop and zellij from GNOME with only ghostty the only terminal emulator installed. Previously, they would fail to launch, now they launch as expected in ghostty.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [ ] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
