### PR TITLE
Remove usr-merge compat symlinks in nvidia drivers

### DIFF
--- a/packages/n/nvidia-470-glx-driver/package.yml
+++ b/packages/n/nvidia-470-glx-driver/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : nvidia-470-glx-driver
 version    : 470.256.02
-release    : 137
+release    : 138
 source     :
     - https://us.download.nvidia.com/XFree86/Linux-x86_64/470.256.02/NVIDIA-Linux-x86_64-470.256.02.run : d6451862deb695bb0447f3b7cd6268f73e81168c10e2c10597ff3fa01349b1de
 extract    : false
@@ -265,20 +265,3 @@ install    : |
 
     # Compress modules with zstd. TODO fix this so that we're able to capture the debug symbols (needs ypkg changes)
     find "$installdir" -name '*.ko' -exec strip --strip-unneeded {} \; -exec zstd -19 {} \; -exec rm -v {} \;
-
-    # Usr-merge
-    install -dm00755 $installdir/lib64
-    pushd $installdir/usr
-    file_list=()
-    while IFS=  read -r -d $'\0'; do
-        file_list+=("$REPLY")
-    done < <(find lib64/modules -type f -print0)
-    while IFS=  read -r -d $'\0'; do
-        file_list+=("$REPLY")
-    done < <(find lib64/firmware -type f -print0)
-    for file in "${file_list[@]}"; do
-        parent=$(dirname "$file")
-        install -dm00755 "$installdir/$parent"
-        ln -srv "$installdir/usr/$file" "$installdir/$file"
-    done
-    popd

--- a/packages/n/nvidia-470-glx-driver/pspec_x86_64.xml
+++ b/packages/n/nvidia-470-glx-driver/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nvidia-470-glx-driver</Name>
         <Homepage>https://nvidia.com</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>EULA</License>
         <PartOf>kernel.drivers</PartOf>
@@ -18,14 +18,9 @@
         <Description xml:lang="en">NVIDIA 470.xx Binary Driver (LTS Kernel)</Description>
         <PartOf>kernel.drivers</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="137">nvidia-470-glx-driver-common</Dependency>
+            <Dependency releaseFrom="138">nvidia-470-glx-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
-            <Path fileType="data">/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia-drm.ko.zst</Path>
-            <Path fileType="data">/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia-modeset.ko.zst</Path>
-            <Path fileType="data">/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia-peermem.ko.zst</Path>
-            <Path fileType="data">/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia-uvm.ko.zst</Path>
-            <Path fileType="data">/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia.ko.zst</Path>
             <Path fileType="library">/usr/lib64/kernel/initrd-com.solus-project.lts.6.18.28-287.nvidia</Path>
             <Path fileType="library">/usr/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia-drm.ko.zst</Path>
             <Path fileType="library">/usr/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia-modeset.ko.zst</Path>
@@ -47,7 +42,7 @@
         <Description xml:lang="en">32-bit libraries for NVIDIA 470.xx Binary Driver</Description>
         <PartOf>xorg.driver</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="137">nvidia-470-glx-driver-common</Dependency>
+            <Dependency releaseFrom="138">nvidia-470-glx-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libEGL_nvidia.so</Path>
@@ -259,12 +254,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="137">
-            <Date>2026-05-08</Date>
+        <Update release="138">
+            <Date>2026-05-09</Date>
             <Version>470.256.02</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/n/nvidia-beta-driver/package.yml
+++ b/packages/n/nvidia-beta-driver/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : nvidia-beta-driver
 version    : 590.48.01
-release    : 343
+release    : 344
 source     :
     - https://in.download.nvidia.com/XFree86/Linux-x86_64/590.48.01/NVIDIA-Linux-x86_64-590.48.01.run : b9e2f80693781431cc87f4cd29109e133dcecb50a50d6b68d4b3bf2d696bd689
 extract    : false
@@ -296,20 +296,3 @@ install    : |
 
     # Compress modules with zstd. TODO fix this so that we're able to capture the debug symbols (needs ypkg changes)
     find "$installdir" -name '*.ko' -exec strip --strip-unneeded {} \; -exec zstd -19 {} \; -exec rm -v {} \;
-
-    # Usr-merge
-    install -dm00755 $installdir/lib64
-    pushd $installdir/usr
-    file_list=()
-    while IFS=  read -r -d $'\0'; do
-        file_list+=("$REPLY")
-    done < <(find lib64/modules -type f -print0)
-    while IFS=  read -r -d $'\0'; do
-        file_list+=("$REPLY")
-    done < <(find lib64/firmware -type f -print0)
-    for file in "${file_list[@]}"; do
-        parent=$(dirname "$file")
-        install -dm00755 "$installdir/$parent"
-        ln -srv "$installdir/usr/$file" "$installdir/$file"
-    done
-    popd

--- a/packages/n/nvidia-beta-driver/pspec_x86_64.xml
+++ b/packages/n/nvidia-beta-driver/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nvidia-beta-driver</Name>
         <Homepage>https://nvidia.com</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>EULA</License>
         <PartOf>kernel.drivers</PartOf>
@@ -24,14 +24,9 @@ NVIDIA Short-lived Binary Driver
 </Description>
         <PartOf>kernel.drivers</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="343">nvidia-beta-driver-common</Dependency>
+            <Dependency releaseFrom="344">nvidia-beta-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
-            <Path fileType="data">/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia-drm.ko.zst</Path>
-            <Path fileType="data">/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia-modeset.ko.zst</Path>
-            <Path fileType="data">/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia-peermem.ko.zst</Path>
-            <Path fileType="data">/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia-uvm.ko.zst</Path>
-            <Path fileType="data">/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia.ko.zst</Path>
             <Path fileType="library">/usr/lib64/kernel/initrd-com.solus-project.lts.6.18.28-287.nvidia</Path>
             <Path fileType="library">/usr/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia-drm.ko.zst</Path>
             <Path fileType="library">/usr/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia-modeset.ko.zst</Path>
@@ -54,7 +49,7 @@ NVIDIA Short-lived Binary Driver
 </Description>
         <PartOf>xorg.driver</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="343">nvidia-beta-driver-common</Dependency>
+            <Dependency releaseFrom="344">nvidia-beta-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libEGL_nvidia.so</Path>
@@ -132,8 +127,6 @@ NVIDIA Short-lived Binary Driver
 </Description>
         <PartOf>xorg.driver</PartOf>
         <Files>
-            <Path fileType="data">/lib64/firmware/nvidia/590.48.01/gsp_ga10x.bin</Path>
-            <Path fileType="data">/lib64/firmware/nvidia/590.48.01/gsp_tu10x.bin</Path>
             <Path fileType="executable">/usr/bin/nvidia-bug-report.sh</Path>
             <Path fileType="executable">/usr/bin/nvidia-cuda-mps-control</Path>
             <Path fileType="executable">/usr/bin/nvidia-cuda-mps-server</Path>
@@ -297,14 +290,9 @@ NVIDIA Short-lived Binary Driver
 </Description>
         <PartOf>kernel.drivers</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="343">nvidia-beta-driver-common</Dependency>
+            <Dependency releaseFrom="344">nvidia-beta-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
-            <Path fileType="data">/lib64/modules/7.0.5-337.current/extra/drivers/video/nvidia-drm.ko.zst</Path>
-            <Path fileType="data">/lib64/modules/7.0.5-337.current/extra/drivers/video/nvidia-modeset.ko.zst</Path>
-            <Path fileType="data">/lib64/modules/7.0.5-337.current/extra/drivers/video/nvidia-peermem.ko.zst</Path>
-            <Path fileType="data">/lib64/modules/7.0.5-337.current/extra/drivers/video/nvidia-uvm.ko.zst</Path>
-            <Path fileType="data">/lib64/modules/7.0.5-337.current/extra/drivers/video/nvidia.ko.zst</Path>
             <Path fileType="library">/usr/lib64/kernel/initrd-com.solus-project.current.7.0.5-337.nvidia</Path>
             <Path fileType="library">/usr/lib64/modules/7.0.5-337.current/extra/drivers/video/nvidia-drm.ko.zst</Path>
             <Path fileType="library">/usr/lib64/modules/7.0.5-337.current/extra/drivers/video/nvidia-modeset.ko.zst</Path>
@@ -319,12 +307,12 @@ NVIDIA Short-lived Binary Driver
         </Conflicts>
     </Package>
     <History>
-        <Update release="343">
-            <Date>2026-05-08</Date>
+        <Update release="344">
+            <Date>2026-05-09</Date>
             <Version>590.48.01</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/n/nvidia-glx-driver/package.yml
+++ b/packages/n/nvidia-glx-driver/package.yml
@@ -3,7 +3,7 @@
 # nvidia-beta-driver should always be ahead of nvidia-glx-driver version-wise or at the same version, never behind.
 name       : nvidia-glx-driver
 version    : 580.159.03
-release    : 601
+release    : 602
 source     :
     - https://us.download.nvidia.com/XFree86/Linux-x86_64/580.159.03/NVIDIA-Linux-x86_64-580.159.03.run : 32c85d99b0f640c9501f61b39ddad208fd0288d015c4fbc5fd0435c07783fa77
 extract    : false
@@ -330,20 +330,3 @@ install    : |
 
     # Compress modules with zstd. TODO fix this so that we're able to capture the debug symbols (needs ypkg changes)
     find "$installdir" -name '*.ko' -exec strip --strip-unneeded {} \; -exec zstd -19 {} \; -exec rm -v {} \;
-
-    # Usr-merge
-    install -dm00755 $installdir/lib64
-    pushd $installdir/usr
-    file_list=()
-    while IFS=  read -r -d $'\0'; do
-        file_list+=("$REPLY")
-    done < <(find lib64/modules -type f -print0)
-    while IFS=  read -r -d $'\0'; do
-        file_list+=("$REPLY")
-    done < <(find lib64/firmware -type f -print0)
-    for file in "${file_list[@]}"; do
-        parent=$(dirname "$file")
-        install -dm00755 "$installdir/$parent"
-        ln -srv "$installdir/usr/$file" "$installdir/$file"
-    done
-    popd

--- a/packages/n/nvidia-glx-driver/pspec_x86_64.xml
+++ b/packages/n/nvidia-glx-driver/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>nvidia-glx-driver</Name>
         <Homepage>https://nvidia.com</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Packager>
         <License>EULA</License>
         <PartOf>kernel.drivers</PartOf>
@@ -18,14 +18,9 @@
         <Description xml:lang="en">NVIDIA Binary Driver (LTS Kernel)</Description>
         <PartOf>kernel.drivers</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="601">nvidia-glx-driver-common</Dependency>
+            <Dependency releaseFrom="602">nvidia-glx-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
-            <Path fileType="data">/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia-drm.ko.zst</Path>
-            <Path fileType="data">/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia-modeset.ko.zst</Path>
-            <Path fileType="data">/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia-peermem.ko.zst</Path>
-            <Path fileType="data">/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia-uvm.ko.zst</Path>
-            <Path fileType="data">/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia.ko.zst</Path>
             <Path fileType="library">/usr/lib64/kernel/initrd-com.solus-project.lts.6.18.28-287.nvidia</Path>
             <Path fileType="library">/usr/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia-drm.ko.zst</Path>
             <Path fileType="library">/usr/lib64/modules/6.18.28-287.lts/extra/drivers/video/nvidia-modeset.ko.zst</Path>
@@ -46,7 +41,7 @@
         <Description xml:lang="en">32-bit libraries for NVIDIA Binary Driver</Description>
         <PartOf>xorg.driver</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="601">nvidia-glx-driver-common</Dependency>
+            <Dependency releaseFrom="602">nvidia-glx-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libEGL_nvidia.so</Path>
@@ -120,8 +115,6 @@
         <Description xml:lang="en">Shared assets for the NVIDIA GLX Driver</Description>
         <PartOf>xorg.driver</PartOf>
         <Files>
-            <Path fileType="data">/lib64/firmware/nvidia/580.159.03/gsp_ga10x.bin</Path>
-            <Path fileType="data">/lib64/firmware/nvidia/580.159.03/gsp_tu10x.bin</Path>
             <Path fileType="executable">/usr/bin/nvidia-bug-report.sh</Path>
             <Path fileType="executable">/usr/bin/nvidia-cuda-mps-control</Path>
             <Path fileType="executable">/usr/bin/nvidia-cuda-mps-server</Path>
@@ -280,14 +273,9 @@
         <Description xml:lang="en">NVIDIA Binary Driver (Current Kernel)</Description>
         <PartOf>kernel.drivers</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="601">nvidia-glx-driver-common</Dependency>
+            <Dependency releaseFrom="602">nvidia-glx-driver-common</Dependency>
         </RuntimeDependencies>
         <Files>
-            <Path fileType="data">/lib64/modules/7.0.5-337.current/extra/drivers/video/nvidia-drm.ko.zst</Path>
-            <Path fileType="data">/lib64/modules/7.0.5-337.current/extra/drivers/video/nvidia-modeset.ko.zst</Path>
-            <Path fileType="data">/lib64/modules/7.0.5-337.current/extra/drivers/video/nvidia-peermem.ko.zst</Path>
-            <Path fileType="data">/lib64/modules/7.0.5-337.current/extra/drivers/video/nvidia-uvm.ko.zst</Path>
-            <Path fileType="data">/lib64/modules/7.0.5-337.current/extra/drivers/video/nvidia.ko.zst</Path>
             <Path fileType="library">/usr/lib64/kernel/initrd-com.solus-project.current.7.0.5-337.nvidia</Path>
             <Path fileType="library">/usr/lib64/modules/7.0.5-337.current/extra/drivers/video/nvidia-drm.ko.zst</Path>
             <Path fileType="library">/usr/lib64/modules/7.0.5-337.current/extra/drivers/video/nvidia-modeset.ko.zst</Path>
@@ -313,12 +301,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="601">
-            <Date>2026-05-08</Date>
+        <Update release="602">
+            <Date>2026-05-09</Date>
             <Version>580.159.03</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Joey Riches</Name>
+            <Email>josephriches@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

We've epoched now, we can remove these

**Test Plan**

Install, update, nvidia driver still works as expected

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [ ] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
