### PR TITLE
eopkg: Cleanup package post-epoch

### DIFF
--- a/packages/e/eopkg/files/0001-Rename-eopkg.py3-eopkg.py.patch
+++ b/packages/e/eopkg/files/0001-Rename-eopkg.py3-eopkg.py.patch
@@ -1,0 +1,142 @@
+From d450c01bea346148012b39f5bee72106373ece3d Mon Sep 17 00:00:00 2001
+From: Joey Riches <josephriches@gmail.com>
+Date: Sat, 9 May 2026 14:09:20 +0100
+Subject: [PATCH 1/1] Rename eopkg.py3 -> eopkg.py
+
+.py3 is not a recognized file extension, now that we no longer care
+about python2 we can use the standard extension.
+---
+ README.md                 |  6 +++---
+ build_chroot.sh           | 12 ++++++------
+ eopkg.py3 => eopkg.py     |  0
+ eopkg_venv_functions.bash |  4 ++--
+ pisi/cli/build.py         |  2 +-
+ pisi/db/filesdb.py        |  2 +-
+ pisi/scripts/eopkg.py     |  2 +-
+ 7 files changed, 14 insertions(+), 14 deletions(-)
+ rename eopkg.py3 => eopkg.py (100%)
+
+diff --git a/README.md b/README.md
+index 69f42216..47eb25e5 100644
+--- a/README.md
++++ b/README.md
+@@ -53,7 +53,7 @@ To build the eopkg.1 man-page, the `pandoc` executable needs to be available.
+ - Execute `./prepare_eopkg_venv.sh`
+ - Depending on the shell you use, `source` one of `eopkg_venv/bin/activate`, `eopkg_venv/bin/activate.fish`, or `eopkg_venv/bin/activate.zsh`.
+ 
+-Now you should be able to execute `eopkg.py3 --version` successfully, independently of whether your host system is running Solus or not.
++Now you should be able to execute `eopkg.py --version` successfully, independently of whether your host system is running Solus or not.
+ 
+ ### Running commands with sudo inside the venv
+ 
+@@ -64,10 +64,10 @@ To run a command with elevated privileges via sudo inside the venv, execute:
+ **Example:**
+ 
+     source eopkg_venv/bin/activate
+-    sudo -E env PATH="${PATH}" eopkg.py3 --version
++    sudo -E env PATH="${PATH}" eopkg.py --version
+     deactivate
+ 
+-### Building a Solus chroot using the eopkg_venv eopkg.py3 version
++### Building a Solus chroot using the eopkg_venv eopkg.py version
+ 
+ After setting up and activating the venv as above, run `./build_chroot.sh` followed by `./start_systemd_nspawn.sh` (recommended) or `/start_chroot.sh`.
+ 
+diff --git a/build_chroot.sh b/build_chroot.sh
+index 5caf1998..7ee33aca 100755
+--- a/build_chroot.sh
++++ b/build_chroot.sh
+@@ -58,7 +58,7 @@ SOLROOT="${PWD}/${SOLNAME}"
+ checkPrereqs () {
+     # prerequisite checks
+     test -x $(command -v chroot) || die "\n${0} assumes that chroot is available\n"
+-    test -x $(command -v eopkg.py3) || die "\n${0} assumes that eopkg.py3 is available\n"
++    test -x $(command -v eopkg.py) || die "\n${0} assumes that eopkg.py is available\n"
+     test -x $(command -v find) || die "\n${0} assumes that find is available\n"
+     test -x $(command -v groupadd) || die "\n${0} assumes that groupadd is available\n"
+     test -x $(command -v passwd) || die "\n${0} assumes that passwd is available\n"
+@@ -133,14 +133,14 @@ basicSetup () {
+     local chroot="sudo systemd-nspawn --as-pid2 --quiet -D ${SOLROOT}" # better chroot essentially
+     #local chroot="sudo chroot ${SOLROOT}"
+     # necessary cruft for sudo to work with the eopkg_venv
+-    local eopkg_py3="sudo -E env PATH=${PATH} eopkg.py3 --debug"
++    local eopkg_py3="sudo -E env PATH=${PATH} eopkg.py --debug"
+     local eopkg_bin='eopkg.bin --debug'
+     local mkdir='sudo mkdir -pv'
+ 
+-    local eopkg_py3_path="$(command -v eopkg.py3)"
+-    MSG="Path to eopkg.py3: ${eopkg_py3_path}"
++    local eopkg_py3_path="$(command -v eopkg.py)"
++    MSG="Path to eopkg.py: ${eopkg_py3_path}"
+     printInfo "${MSG}"
+-    MSG="Elevated eopkg.py3 command: ${eopkg_py3}"
++    MSG="Elevated eopkg.py command: ${eopkg_py3}"
+     printInfo "${MSG}"
+ 
+     # should no longer be necessary
+@@ -177,7 +177,7 @@ basicSetup () {
+     #MSG="Installing baselayout ..."
+     #${eopkg_py3} install -y -D "${SOLROOT}" --ignore-safety --ignore-comar baselayout || die "${MSG}"
+ 
+-    # Since we're testing eopkg.py3 from a venv, let's use that instead for creating the root
++    # Since we're testing eopkg.py from a venv, let's use that instead for creating the root
+     #MSG="Installing packages to act as a seed for systemd-nspawn chroot runs ..."
+     #printInfo "${MSG}"
+     #${eopkg_py3} install -y -D "${SOLROOT}" --ignore-safety "${SELFHOSTINGEOPKG[@]}" || die "${MSG}"
+diff --git a/eopkg.py3 b/eopkg.py
+similarity index 100%
+rename from eopkg.py3
+rename to eopkg.py
+diff --git a/eopkg_venv_functions.bash b/eopkg_venv_functions.bash
+index abc49b73..b3808f62 100644
+--- a/eopkg_venv_functions.bash
++++ b/eopkg_venv_functions.bash
+@@ -26,8 +26,8 @@ function prepare_venv () {
+     ${PY3} -m pip install -r requirements.txt
+     compile_iksemel_cleanly
+ 
+-    printInfo "Symlink eopkg-cli into the eopkg_venv bin/ directory so it can be executed as eopkg.py3 ..."
+-    ln -srvf ./eopkg-cli eopkg_venv/bin/eopkg.py3
++    printInfo "Symlink eopkg-cli into the eopkg_venv bin/ directory so it can be executed as eopkg.py ..."
++    ln -srvf ./eopkg-cli eopkg_venv/bin/eopkg.py
+ 
+     # get rid of any existing lines w/git ref version info
+     sed "/__version__ += /d" -i pisi/__init__.py
+diff --git a/pisi/cli/build.py b/pisi/cli/build.py
+index 88efdb19..97491422 100644
+--- a/pisi/cli/build.py
++++ b/pisi/cli/build.py
+@@ -185,7 +185,7 @@ class Build(command.Command, metaclass=command.autocommand):
+ 
+     def run(self):
+         if "__compiled__" in globals():
+-            raise pisi.Error(_("Building packages is not supported when eopkg is compiled with nuitka. Please use eopkg.py3 instead."))
++            raise pisi.Error(_("Building packages is not supported when eopkg is compiled with nuitka. Please use eopkg.py instead."))
+ 
+         if not self.options.quiet:
+             self.options.debug = True
+diff --git a/pisi/db/filesdb.py b/pisi/db/filesdb.py
+index 968819e9..aba7e1be 100644
+--- a/pisi/db/filesdb.py
++++ b/pisi/db/filesdb.py
+@@ -296,7 +296,7 @@ class FilesDB(lazydb.LazyDB):
+ 
+         # This block implies that the state is invalid
+         if please_rebuild_manually:
+-            ctx.ui.warning(_("FilesDB is invalid. Please rebuild it with 'sudo eopkg.py3 -y rdb'"))
++            ctx.ui.warning(_("FilesDB is invalid. Please rebuild it with 'sudo eopkg.py -y rdb'"))
+             ctx.ui.warning(_("Falling back to slow and inaccurate XML search..."))
+ 
+         if force_rebuild or needs_rebuild:
+diff --git a/pisi/scripts/eopkg.py b/pisi/scripts/eopkg.py
+index 4de07ae0..5c7a93b6 120000
+--- a/pisi/scripts/eopkg.py
++++ b/pisi/scripts/eopkg.py
+@@ -1 +1 @@
+-../../eopkg.py3
+\ No newline at end of file
++../../eopkg.py
+\ No newline at end of file
+-- 
+2.54.0
+

--- a/packages/e/eopkg/package.yml
+++ b/packages/e/eopkg/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : eopkg
 version    : 4.4.2
-release    : 36
+release    : 37
 source     :
     - https://github.com/getsolus/eopkg/archive/refs/tags/v4.4.2.tar.gz : bc2073bdad9f011aeb865ceb7e5e8ed5f5f5f6b6227465099d93913e84d1c603
     - git|https://github.com/PackageKit/PackageKit.git : d9cae13b326238488bf06fb5bf458cfeeaf71869 # v1.3.5
@@ -11,17 +11,13 @@ component  :
     - system.base
     - ^python-eopkg : programming.python
 summary    :
-    - The Solus package manager (python3 eopkg.bin nuitka-compiled version)
-    - ^python-eopkg : The Solus package manager (pure python3 eopkg.py3 version)
+    - The Solus package manager (nuitka-compiled version)
+    - ^python-eopkg : The Solus package manager (python version)
 description:
-    - The Solus package manager (python3 eopkg.bin nuitka-compiled version)
-    - ^python-eopkg : The Solus package manager (pure python3 eopkg.py3 version)
-strip      : false
-debug      : false
-# Sadly necessary for now to deal with rel8 having the bad "reorder eopkg code"
-# AND depending on an updated, versioned glibc version.
-# FIXME: Remove `autodep: false` for the eopkg package in the epoch bumped repo
-autodep    : false
+    - The Solus package manager (nuitka-compiled version)
+    - ^python-eopkg : The Solus package manager (python version)
+strip      : false # strip breaks nuitka compiled binaries
+debug      : false # debug breaks nuitka compiled binaries
 builddeps  :
     - pkgconfig(packagekit-glib2)
     - pkgconfig(python3)
@@ -45,28 +41,16 @@ rundeps    :
         - python-jeepney
         - python-ordered-set
         - python-xattr
-    - glibc
-setup      : |
-    # Uncomment the following in case of future extended testing with a git ref:
-    # # get rid of any existing lines w/git ref version info
-    # sed "/__version__ += /d" -i pisi/__init__.py
-    # # Show clean version info
-    # grep -Hn version pisi/__init__.py
-    # # append the git ref to __version__ on a new line
-    # gawk -i inplace \
-    #     'BEGIN { "git rev-parse --short HEAD" | getline gitref } { print };
-    #      /__version__ = / { printf "%s %s\n", $1, "+= \" (" gitref ")\"" };' \
-    #     pisi/__init__.py
-    # # Verify added git ref version info for build introspection purposes
-    # grep -Hn version pisi/__init__.py
-
-    %python3_setup
-build      : |
+environment: |
     # This prevents the dynamic loader and glibc from attempting to resolve shared objects via hwcaps,
     # and effectively forces nuitka to build with x86_64-v1 (OG AMD64). Note that more flags may need
     # to be added in the future to guard against either x86_64-v2, x86_64-v3 or x86_64-v4 hwcaps being used.
     export GLIBC_TUNABLES=glibc.cpu.hwcaps=-AVX
+setup      : |
+    %patch -p1 -i $pkgfiles/0001-Rename-eopkg.py3-eopkg.py.patch
 
+    %python3_setup
+build      : |
     # Note: we need to ensure that ca-certs, libmagic, openssl, and zlib are included
     #       in the standalone package (all are part of system.base, so not listed in
     #       builddeps for now).
@@ -74,33 +58,28 @@ build      : |
     #       ca-certs to be able to check https connections.
 
     # We're not actually using self-execution. In this case, eopkg is using the -c flag as shorthand for --component, rather than for passing the program as a string (as is default python behavior).
-    nuitka3 --onefile --include-module=dbm.gnu --include-data-dir=build/lib/pisi/data/locale=pisi/data/locale --show-scons --no-deployment-flag=self-execution eopkg.py3
+    nuitka3 --onefile --include-module=dbm.gnu --include-data-dir=build/lib/pisi/data/locale=pisi/data/locale --show-scons --no-deployment-flag=self-execution eopkg.py
     nuitka3 --onefile --include-data-dir=build/lib/pisi/data/locale=pisi/data/locale --show-scons --include-module=dbm.gnu pisi/scripts/lseopkg.py
     nuitka3 --onefile --include-data-dir=build/lib/pisi/data/locale=pisi/data/locale --show-scons --include-module=dbm.gnu pisi/scripts/uneopkg.py
     nuitka3 --onefile --include-module=dbm.gnu $sources/PackageKit.git/backends/eopkg/eopkgBackend.py
 install    : |
-    # install the normal pure py3 stuff
     %python3_install
 
-    # .py3 ensures no conflict w/eopkg py2 stuff (shuffle it into the ^python-eopkg pattern later)
+    # Add .py extension
     for exe in eopkg lseopkg uneopkg; do
-        mv -v $installdir/usr/bin/${exe} $installdir/usr/bin/${exe}.py3
+        mv -v $installdir/usr/bin/${exe} $installdir/usr/bin/${exe}.py
     done
 
     # install the nuitka-compiled eopkg PackageKit backend (TODO: move this to packagekit)
     install -Dm0755 ./eopkgBackend.bin $installdir/usr/share/PackageKit/helpers/eopkg/eopkgBackend.bin
 
     # install the compiled eopkg.bin nuitka standalone thing
-    install -Dm0755 ./eopkg.py3.bin $installdir/usr/bin/eopkg.bin
+    install -Dm0755 ./eopkg.bin $installdir/usr/bin/eopkg.bin
 
     # install nuitka compiled lseopkg and uneopkg
     for exe in lseopkg uneopkg; do
       install -Dm0755 ./${exe}.bin $installdir/usr/bin/${exe}.bin
     done
-
-    # Install the usr-merge marker file
-    install -dm0755 $installdir/var/solus/usr-merge
-    touch $installdir/var/solus/usr-merge/eopkg-ready
 
     # Install Bash completions
     install -Dm0755 $workdir/dist/completions/bash/eopkg $installdir/usr/share/bash-completion/completions/eopkg
@@ -123,13 +102,8 @@ install    : |
     install -Dm0644 $installdir/usr/lib/python3.12/site-packages/pisi/data/eopkg.conf $installdir/usr/share/defaults/eopkg/eopkg.conf
     install -Dm0644 $pkgfiles/mirrors.conf $installdir/usr/share/defaults/eopkg/mirrors.conf
     install -Dm0644 $pkgfiles/mirrors.conf $installdir/usr/share/defaults/eopkg/sandbox.conf
-    ## END post epoch ownership changes
-replaces   :
-    - eopkg4-bin
 patterns   :
-    # This patterns follows our established practice of using python-<something> for pure python stuff
-    # It also conveniently replaces the existing python-eopkg standalone package (thanks for the idea Joey!)
     - ^python-eopkg :
         - /usr/lib/python3.*/site-packages/eopkg*
         - /usr/lib/python3.*/site-packages/pisi
-        - /usr/bin/*eopkg.py3
+        - /usr/bin/*eopkg.py

--- a/packages/e/eopkg/pspec_x86_64.xml
+++ b/packages/e/eopkg/pspec_x86_64.xml
@@ -8,14 +8,14 @@
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.base</PartOf>
-        <Summary xml:lang="en">The Solus package manager (python3 eopkg.bin nuitka-compiled version)</Summary>
-        <Description xml:lang="en">The Solus package manager (python3 eopkg.bin nuitka-compiled version)</Description>
+        <Summary xml:lang="en">The Solus package manager (nuitka-compiled version)</Summary>
+        <Description xml:lang="en">The Solus package manager (nuitka-compiled version)</Description>
         <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>eopkg</Name>
-        <Summary xml:lang="en">The Solus package manager (python3 eopkg.bin nuitka-compiled version)</Summary>
-        <Description xml:lang="en">The Solus package manager (python3 eopkg.bin nuitka-compiled version)</Description>
+        <Summary xml:lang="en">The Solus package manager (nuitka-compiled version)</Summary>
+        <Description xml:lang="en">The Solus package manager (nuitka-compiled version)</Description>
         <PartOf>system.base</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/eopkg</Path>
@@ -34,21 +34,17 @@
             <Path fileType="data">/usr/share/defaults/eopkg/sandbox.conf</Path>
             <Path fileType="man">/usr/share/man/man1/eopkg.1.zst</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_eopkg</Path>
-            <Path fileType="data">/var/solus/usr-merge/eopkg-ready</Path>
         </Files>
-        <Replaces>
-            <Package>eopkg4-bin</Package>
-        </Replaces>
     </Package>
     <Package>
         <Name>python-eopkg</Name>
-        <Summary xml:lang="en">The Solus package manager (pure python3 eopkg.py3 version)</Summary>
-        <Description xml:lang="en">The Solus package manager (pure python3 eopkg.py3 version)</Description>
+        <Summary xml:lang="en">The Solus package manager (python version)</Summary>
+        <Description xml:lang="en">The Solus package manager (python version)</Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="executable">/usr/bin/eopkg.py3</Path>
-            <Path fileType="executable">/usr/bin/lseopkg.py3</Path>
-            <Path fileType="executable">/usr/bin/uneopkg.py3</Path>
+            <Path fileType="executable">/usr/bin/eopkg.py</Path>
+            <Path fileType="executable">/usr/bin/lseopkg.py</Path>
+            <Path fileType="executable">/usr/bin/uneopkg.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.4.0.dist-info/METADATA</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.4.0.dist-info/RECORD</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/eopkg-4.4.0.dist-info/WHEEL</Path>
@@ -463,8 +459,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2026-05-02</Date>
+        <Update release="37">
+            <Date>2026-05-09</Date>
             <Version>4.4.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Joey Riches</Name>


### PR DESCRIPTION
**Summary**
- Reenable autodep
- Use standard .py extension
- Remove a few unneccessary comments
- Remove replaces key which is unneccessary post-epoch (polaris repo)
- Remove unneeded usr-merge marker

**Test Plan**

Shove to local repo and update as normal

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
