### PR TITLE
celluloid: Update to v0.30

### DIFF
--- a/packages/c/celluloid/abi_used_symbols
+++ b/packages/c/celluloid/abi_used_symbols
@@ -24,6 +24,7 @@ libadwaita-1.so.0:adw_clamp_set_child
 libadwaita-1.so.0:adw_clamp_set_maximum_size
 libadwaita-1.so.0:adw_clamp_set_tightening_threshold
 libadwaita-1.so.0:adw_dialog_present
+libadwaita-1.so.0:adw_dialog_set_content_height
 libadwaita-1.so.0:adw_entry_row_new
 libadwaita-1.so.0:adw_header_bar_new
 libadwaita-1.so.0:adw_header_bar_pack_end
@@ -52,6 +53,11 @@ libadwaita-1.so.0:adw_preferences_page_new
 libadwaita-1.so.0:adw_preferences_page_set_icon_name
 libadwaita-1.so.0:adw_preferences_page_set_title
 libadwaita-1.so.0:adw_preferences_row_set_title
+libadwaita-1.so.0:adw_shortcuts_dialog_add
+libadwaita-1.so.0:adw_shortcuts_dialog_get_type
+libadwaita-1.so.0:adw_shortcuts_item_new
+libadwaita-1.so.0:adw_shortcuts_section_add
+libadwaita-1.so.0:adw_shortcuts_section_new
 libadwaita-1.so.0:adw_show_about_dialog
 libadwaita-1.so.0:adw_status_page_new
 libadwaita-1.so.0:adw_status_page_set_description
@@ -155,6 +161,7 @@ libgio-2.0.so.0:g_file_enumerator_get_child
 libgio-2.0.so.0:g_file_enumerator_next_file
 libgio-2.0.so.0:g_file_equal
 libgio-2.0.so.0:g_file_get_basename
+libgio-2.0.so.0:g_file_get_parent
 libgio-2.0.so.0:g_file_get_path
 libgio-2.0.so.0:g_file_get_type
 libgio-2.0.so.0:g_file_get_uri
@@ -521,7 +528,6 @@ libgtk-4.so.1:gtk_box_get_type
 libgtk-4.so.1:gtk_box_new
 libgtk-4.so.1:gtk_box_prepend
 libgtk-4.so.1:gtk_box_set_homogeneous
-libgtk-4.so.1:gtk_buildable_get_type
 libgtk-4.so.1:gtk_button_get_type
 libgtk-4.so.1:gtk_button_new
 libgtk-4.so.1:gtk_button_new_from_icon_name
@@ -571,6 +577,8 @@ libgtk-4.so.1:gtk_file_filter_get_type
 libgtk-4.so.1:gtk_file_filter_new
 libgtk-4.so.1:gtk_file_filter_set_name
 libgtk-4.so.1:gtk_gesture_click_new
+libgtk-4.so.1:gtk_gesture_drag_get_start_point
+libgtk-4.so.1:gtk_gesture_drag_new
 libgtk-4.so.1:gtk_gesture_get_device
 libgtk-4.so.1:gtk_gesture_single_get_button
 libgtk-4.so.1:gtk_gesture_single_get_current_button
@@ -646,10 +654,6 @@ libgtk-4.so.1:gtk_search_bar_new
 libgtk-4.so.1:gtk_search_bar_set_child
 libgtk-4.so.1:gtk_search_entry_new
 libgtk-4.so.1:gtk_search_entry_set_placeholder_text
-libgtk-4.so.1:gtk_shortcuts_group_get_type
-libgtk-4.so.1:gtk_shortcuts_section_get_type
-libgtk-4.so.1:gtk_shortcuts_shortcut_get_type
-libgtk-4.so.1:gtk_shortcuts_window_get_type
 libgtk-4.so.1:gtk_size_group_add_widget
 libgtk-4.so.1:gtk_size_group_new
 libgtk-4.so.1:gtk_stack_add_child
@@ -691,6 +695,7 @@ libgtk-4.so.1:gtk_widget_realize
 libgtk-4.so.1:gtk_widget_remove_controller
 libgtk-4.so.1:gtk_widget_remove_css_class
 libgtk-4.so.1:gtk_widget_set_can_focus
+libgtk-4.so.1:gtk_widget_set_direction
 libgtk-4.so.1:gtk_widget_set_halign
 libgtk-4.so.1:gtk_widget_set_hexpand
 libgtk-4.so.1:gtk_widget_set_margin_bottom

--- a/packages/c/celluloid/package.yml
+++ b/packages/c/celluloid/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : celluloid
-version    : '0.29'
-release    : 44
+version    : '0.30'
+release    : 45
 source     :
-    - https://github.com/celluloid-player/celluloid/archive/refs/tags/v0.29.tar.gz : c4fa8e21647f39253709bad1939fe3d376abd07e05c2c02fb235c23375aa810a
+    - https://github.com/celluloid-player/celluloid/archive/refs/tags/v0.30.tar.gz : 75ff83f650180cf9fa2458a7015fa84fd3be014e9478d670f9cf94367720313e
 license    : GPL-3.0-or-later
 homepage   : https://celluloid-player.github.io/
 component  : multimedia.video
@@ -24,3 +24,4 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING

--- a/packages/c/celluloid/pspec_x86_64.xml
+++ b/packages/c/celluloid/pspec_x86_64.xml
@@ -26,6 +26,7 @@
             <Path fileType="data">/usr/share/glib-2.0/schemas/io.github.celluloid_player.Celluloid.gschema.xml</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/io.github.celluloid_player.Celluloid.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/symbolic/apps/io.github.celluloid_player.Celluloid-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/licenses/celluloid/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/celluloid.mo</Path>
             <Path fileType="localedata">/usr/share/locale/bg/LC_MESSAGES/celluloid.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/celluloid.mo</Path>
@@ -40,6 +41,8 @@
             <Path fileType="localedata">/usr/share/locale/fa/LC_MESSAGES/celluloid.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fi/LC_MESSAGES/celluloid.mo</Path>
             <Path fileType="localedata">/usr/share/locale/fr/LC_MESSAGES/celluloid.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/ga/LC_MESSAGES/celluloid.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/hi/LC_MESSAGES/celluloid.mo</Path>
             <Path fileType="localedata">/usr/share/locale/hr/LC_MESSAGES/celluloid.mo</Path>
             <Path fileType="localedata">/usr/share/locale/hu/LC_MESSAGES/celluloid.mo</Path>
             <Path fileType="localedata">/usr/share/locale/id/LC_MESSAGES/celluloid.mo</Path>
@@ -48,7 +51,9 @@
             <Path fileType="localedata">/usr/share/locale/it/LC_MESSAGES/celluloid.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ja/LC_MESSAGES/celluloid.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ka/LC_MESSAGES/celluloid.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/kk/LC_MESSAGES/celluloid.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ko/LC_MESSAGES/celluloid.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/kw/LC_MESSAGES/celluloid.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lt/LC_MESSAGES/celluloid.mo</Path>
             <Path fileType="localedata">/usr/share/locale/lv/LC_MESSAGES/celluloid.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ms/LC_MESSAGES/celluloid.mo</Path>
@@ -70,6 +75,7 @@
             <Path fileType="localedata">/usr/share/locale/tr/LC_MESSAGES/celluloid.mo</Path>
             <Path fileType="localedata">/usr/share/locale/uk/LC_MESSAGES/celluloid.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ur/LC_MESSAGES/celluloid.mo</Path>
+            <Path fileType="localedata">/usr/share/locale/uz/LC_MESSAGES/celluloid.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_CN/LC_MESSAGES/celluloid.mo</Path>
             <Path fileType="localedata">/usr/share/locale/zh_TW/LC_MESSAGES/celluloid.mo</Path>
             <Path fileType="man">/usr/share/man/man1/celluloid.1.zst</Path>
@@ -80,9 +86,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="44">
-            <Date>2026-04-27</Date>
-            <Version>0.29</Version>
+        <Update release="45">
+            <Date>2026-05-09</Date>
+            <Version>0.30</Version>
             <Comment>Packaging update</Comment>
             <Name>David Harder</Name>
             <Email>david@davidjharder.ca</Email>


### PR DESCRIPTION
**Summary**

- Fix the file chooser not remembering the location of last opened file.
- Prevent the seek bar and playback buttons from becoming reversed under RTL locales.
- Updated the shortcuts dialog to use libadwaita.
- Fix the timestamp popover that appears when hovering the seek bar not appearing at the right location.
- Fix Blu-ray discs not being detected.

**Test Plan**

- Play a video

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
