### PR TITLE
golang: Update to v1.26.3

### DIFF
--- a/packages/g/golang/package.yml
+++ b/packages/g/golang/package.yml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 # If you're updating this package to a new major version of golang, please update gopls to a version with support for that golang version
 name       : golang
-version    : 1.26.2
-release    : 141
+version    : 1.26.3
+release    : 142
 homepage   : https://golang.org
 source     :
-    - https://golang.org/dl/go1.26.2.src.tar.gz : 2e91ebb6947a96e9436fb2b3926a8802efe63a6d375dffec4f82aa9dbd6fd43b
+    - https://golang.org/dl/go1.26.3.src.tar.gz : 1c646875d0aa8799133184ed57cf79ff24bdefe8c8820470602a9d3d6d9192b8
 license    : BSD-3-Clause
 summary    : The Go programming language
 description: Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.

--- a/packages/g/golang/pspec_x86_64.xml
+++ b/packages/g/golang/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>golang</Name>
         <Homepage>https://golang.org</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming</PartOf>
@@ -75,6 +75,7 @@
             <Path fileType="library">/usr/lib64/golang/go.env</Path>
             <Path fileType="library">/usr/lib64/golang/lib/fips140/Makefile</Path>
             <Path fileType="library">/usr/lib64/golang/lib/fips140/README.md</Path>
+            <Path fileType="library">/usr/lib64/golang/lib/fips140/certified.txt</Path>
             <Path fileType="library">/usr/lib64/golang/lib/fips140/fips140.sum</Path>
             <Path fileType="library">/usr/lib64/golang/lib/fips140/inprocess.txt</Path>
             <Path fileType="library">/usr/lib64/golang/lib/fips140/v1.0.0-c2097c7c.zip</Path>
@@ -1668,6 +1669,7 @@
             <Path fileType="library">/usr/lib64/golang/src/cmd/compile/internal/loopvar/testdata/opt.go</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/compile/internal/loopvar/testdata/range_esc_address.go</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/compile/internal/loopvar/testdata/range_esc_closure.go</Path>
+            <Path fileType="library">/usr/lib64/golang/src/cmd/compile/internal/loopvar/testdata/range_esc_closure_linedir.go</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/compile/internal/loopvar/testdata/range_esc_method.go</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/compile/internal/loopvar/testdata/range_esc_minimal_closure.go</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/compile/internal/mips/galign.go</Path>
@@ -3021,6 +3023,7 @@
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/cover_single_vs_multiple.txt</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/cover_statements.txt</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/cover_swig.txt</Path>
+            <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/cover_switch_toolchain.txt</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/cover_sync_atomic_import.txt</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/cover_test_localpkg_filepath.txt</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/cover_test_pkgselect.txt</Path>
@@ -3048,6 +3051,7 @@
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/fileline.txt</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/fips.txt</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/fipssnap.txt</Path>
+            <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/fix_diff_exitcode.txt</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/fix_suite.txt</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/fix_vendor.txt</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/fmt_load_errors.txt</Path>
@@ -3461,6 +3465,7 @@
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/mod_stale.txt</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/mod_std_vendor.txt</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/mod_string_alias.txt</Path>
+            <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/mod_sum_absent.txt</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/mod_sum_ambiguous.txt</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/mod_sum_issue56222.txt</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/mod_sum_lookup.txt</Path>
@@ -3574,6 +3579,8 @@
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/test_buildinfo.txt</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/test_buildinfo_godebug_issue68053.txt</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/test_buildvcs.txt</Path>
+            <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/test_cache_coverpkg_bug.txt</Path>
+            <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/test_cache_coverpkg_no_profile.txt</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/test_cache_inputs.txt</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/test_chatty_fail.txt</Path>
             <Path fileType="library">/usr/lib64/golang/src/cmd/go/testdata/script/test_chatty_parallel_fail.txt</Path>
@@ -5638,6 +5645,8 @@
             <Path fileType="library">/usr/lib64/golang/src/crypto/internal/fips140/check/checktest/test.go</Path>
             <Path fileType="library">/usr/lib64/golang/src/crypto/internal/fips140/drbg/cast.go</Path>
             <Path fileType="library">/usr/lib64/golang/src/crypto/internal/fips140/drbg/ctrdrbg.go</Path>
+            <Path fileType="library">/usr/lib64/golang/src/crypto/internal/fips140/drbg/entropy_fips140.go</Path>
+            <Path fileType="library">/usr/lib64/golang/src/crypto/internal/fips140/drbg/entropy_wasm.go</Path>
             <Path fileType="library">/usr/lib64/golang/src/crypto/internal/fips140/drbg/rand.go</Path>
             <Path fileType="library">/usr/lib64/golang/src/crypto/internal/fips140/drbg/rand_test.go</Path>
             <Path fileType="library">/usr/lib64/golang/src/crypto/internal/fips140/ecdh/cast.go</Path>
@@ -9070,6 +9079,7 @@
             <Path fileType="library">/usr/lib64/golang/src/internal/types/testdata/fixedbugs/issue76383.go</Path>
             <Path fileType="library">/usr/lib64/golang/src/internal/types/testdata/fixedbugs/issue76384.go</Path>
             <Path fileType="library">/usr/lib64/golang/src/internal/types/testdata/fixedbugs/issue76478.go</Path>
+            <Path fileType="library">/usr/lib64/golang/src/internal/types/testdata/fixedbugs/issue78163.go</Path>
             <Path fileType="library">/usr/lib64/golang/src/internal/types/testdata/spec/assignability.go</Path>
             <Path fileType="library">/usr/lib64/golang/src/internal/types/testdata/spec/comparable.go</Path>
             <Path fileType="library">/usr/lib64/golang/src/internal/types/testdata/spec/comparable1.19.go</Path>
@@ -14832,7 +14842,9 @@
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue77815.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue77919.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue7794.go</Path>
+            <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue78404.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue7863.go</Path>
+            <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue78641.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue7867.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue7884.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue7921.go</Path>
@@ -15747,12 +15759,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="141">
-            <Date>2026-04-08</Date>
-            <Version>1.26.2</Version>
+        <Update release="142">
+            <Date>2026-05-09</Date>
+            <Version>1.26.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://groups.google.com/g/golang-announce/c/qcCIEXso47M)

**Security**

- CVE-2026-42501
- CVE-2026-39825
- CVE-2026-39836
- CVE-2026-42499
- CVE-2026-39820
- CVE-2026-39819
- CVE-2026-39817
- CVE-2026-33814
- CVE-2026-39826
- CVE-2026-33811
- CVE-2026-39823

**Test Plan**

- Build a go package (doctl)

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
