### PR TITLE
autoconf: Update to v2.73

### DIFF
--- a/packages/a/autoconf/package.yml
+++ b/packages/a/autoconf/package.yml
@@ -1,20 +1,36 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : autoconf
-version    : '2.72'
-release    : 13
+version    : '2.73'
+release    : 14
 source     :
-    - https://ftpmirror.gnu.org/gnu/autoconf/autoconf-2.72.tar.xz : ba885c1319578d6c94d46e9b0dceb4014caafe2490e437a0dbca3f270a223f5a
+    - https://ftp.gnu.org/gnu/autoconf/autoconf-2.73.tar.xz : 9fd672b1c8425fac2fa67fa0477b990987268b90ff36d5f016dae57be0d6b52e
 homepage   : https://www.gnu.org/software/autoconf/
-license    : GPL-2.0-or-later
+license    :
+    - GPL-2.0-or-later
+    - GPL-3.0-with-autoconf-exception
 summary    : Autoconf is an extensible package of M4 macros that produce shell scripts to automatically configure software source code packages.
 component  : system.devel
 description: |
     Autoconf creates a configuration script for a package from a template file that lists the operating system features that the package can use, in the form of M4 macro calls.
+optimize   :
+    - lto
+    - speed
+builddeps  :
+    - m4
+    - perl
+rundeps    :
+    - m4
+    - perl
 setup      : |
     %configure
 build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING*
+
+    # Remove unwanted file
+    rm -v ${installdir}/usr/share/info/standards.info
 check      : |
-    %make check
+    # Run `make check` without broken tests 227 and 294.
+    %make check TESTSUITEFLAGS="1-226 228-293 295-"

--- a/packages/a/autoconf/pspec_x86_64.xml
+++ b/packages/a/autoconf/pspec_x86_64.xml
@@ -3,10 +3,11 @@
         <Name>autoconf</Name>
         <Homepage>https://www.gnu.org/software/autoconf/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
+        <License>GPL-3.0-with-autoconf-exception</License>
         <PartOf>system.devel</PartOf>
         <Summary xml:lang="en">Autoconf is an extensible package of M4 macros that produce shell scripts to automatically configure software source code packages.</Summary>
         <Description xml:lang="en">Autoconf creates a configuration script for a package from a template file that lists the operating system features that the package can use, in the form of M4 macro calls.
@@ -38,6 +39,7 @@
             <Path fileType="data">/usr/share/autoconf/Autom4te/Request.pm</Path>
             <Path fileType="data">/usr/share/autoconf/Autom4te/XFile.pm</Path>
             <Path fileType="data">/usr/share/autoconf/INSTALL</Path>
+            <Path fileType="data">/usr/share/autoconf/autoconf/a68.m4</Path>
             <Path fileType="data">/usr/share/autoconf/autoconf/autoconf.m4</Path>
             <Path fileType="data">/usr/share/autoconf/autoconf/autoconf.m4f</Path>
             <Path fileType="data">/usr/share/autoconf/autoconf/autoheader.m4</Path>
@@ -59,6 +61,7 @@
             <Path fileType="data">/usr/share/autoconf/autoconf/status.m4</Path>
             <Path fileType="data">/usr/share/autoconf/autoconf/trailer.m4</Path>
             <Path fileType="data">/usr/share/autoconf/autoconf/types.m4</Path>
+            <Path fileType="data">/usr/share/autoconf/autoconf_version.m4</Path>
             <Path fileType="data">/usr/share/autoconf/autom4te.cfg</Path>
             <Path fileType="data">/usr/share/autoconf/autoscan/autoscan.list</Path>
             <Path fileType="data">/usr/share/autoconf/autotest/autotest.m4</Path>
@@ -73,9 +76,10 @@
             <Path fileType="data">/usr/share/autoconf/m4sugar/m4sh.m4f</Path>
             <Path fileType="data">/usr/share/autoconf/m4sugar/m4sugar.m4</Path>
             <Path fileType="data">/usr/share/autoconf/m4sugar/m4sugar.m4f</Path>
-            <Path fileType="data">/usr/share/autoconf/version.m4</Path>
             <Path fileType="info">/usr/share/info/autoconf.info.zst</Path>
-            <Path fileType="info">/usr/share/info/standards.info.zst</Path>
+            <Path fileType="data">/usr/share/licenses/autoconf/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/autoconf/COPYING.EXCEPTION</Path>
+            <Path fileType="data">/usr/share/licenses/autoconf/COPYINGv3</Path>
             <Path fileType="man">/usr/share/man/man1/autoconf.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/autoheader.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/autom4te.1.zst</Path>
@@ -86,12 +90,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2025-10-27</Date>
-            <Version>2.72</Version>
+        <Update release="14">
+            <Date>2026-05-09</Date>
+            <Version>2.73</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- autoreconf has a new option to exclude certain steps
- AC_PROG_GO and AC_PROG_A68 now honor GOFLAGS and A68FLAGS set by the user
- autoheader takes more care not to overwrite hand-written config.h.in
- AC_OUTPUT issues an error if called with more than three arguments
- AC_PROG_CC now prefers C23 if available
- AC_PROG_CC no longer checks __STDC__ or variable length arrays (VLAs)
- AC_PROG_CXX no longer attempts to switch to C++98 or C++11
- autoheader and autoreconf preserve hand-written template files
- Programs now recognize `#elifdef` and `#elifndef`
- Support for the Algol 68 programming language has been added
- AC_PROG_AWK now also checks for busybox awk
- AC_USE_SYSTEM_EXTENSIONS now defines _COSMO_SOURCE for Cosmopolitan Libc
- AC_CHECK_DECL and AC_CHECK_DECLS will, on macOS, now report "no" for
  functions that are declared as existing in future macOS versions only
- AC_DEFINE_UNQUOTED no longer mishandles double-quotes inside `$(...)`
- AC_DEFINE and similar macros no longer emit trailing whitespace
- AC_FUNC_STRNLEN now detects Android 5.0's broken strnlen
- AC_PROG_OBJC now finds the GNU Objective-C compiler
- Autoconf no longer generates `${1+"$@"}` in scripts
- config.status now fails with a diagnostic if awk is missing
- autoreconf handles projects using GNU Gettext and/or gtk-doc better
- autoconf no longer installs a file named "version.m4"

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebuild `pinentry` with this version of autoconf.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
