### PR TITLE
replace paplay with pw cat

### DIFF
--- a/common/Scripts/buildserver-notification.sh
+++ b/common/Scripts/buildserver-notification.sh
@@ -4,7 +4,7 @@
 # Additionally, if a package successfully builds it will then check if it gets successfully indexed into the repo.
 
 # Check requirements before starting
-REQUIREMENTS="curl unxz notify-send paplay jq"
+REQUIREMENTS="curl unxz notify-send pipewire jq"
 for i in $REQUIREMENTS; do
     if ! which $i &> /dev/null; then
         echo "Missing requirement: $i. Install it to continue."
@@ -61,7 +61,7 @@ while [[ ! $(jq '.[] | select(.tag == $ARGS.positional[0]) | .status' "${JSONPAG
     if [[ $(jq '.[] | select(.tag == $ARGS.positional[0]) | .status' "${JSONPAGE}" --args "${TAG}" | grep "FAILED") ]] ; then
         echo "Failed on the build server!"
         notify-send -u critical "${TAG} failed on the build server!" -t 0
-        paplay /usr/share/sounds/freedesktop/stereo/suspend-error.oga
+        pw-cat --playback /usr/share/sounds/freedesktop/stereo/suspend-error.oga
         exit 1
     fi
 done
@@ -108,7 +108,7 @@ while [[ $(grep ${TAG} < ${INDEX_XML} | wc -l) -lt 1 ]] ; do
     if [[ $var == 18 ]]; then
         echo "Successfully built but hasn't been found in the index yet, please manually check."
         notify-send -u low "${TAG} successfully built but hasen't been found in the index yet, please manually check." -t 0
-        paplay /usr/share/sounds/freedesktop/stereo/dialog-warning.oga
+        pw-cat --playback /usr/share/sounds/freedesktop/stereo/dialog-warning.oga
         if [ -f "${INDEX_XML}" ]; then rm ${INDEX_XML}; fi
         exit 1
     fi
@@ -121,7 +121,7 @@ done
 echo "Successfully indexed into the repo!"
 if [[ -z "${DISABLE_BUILD_SUCCESS_NOTIFY}" ]]; then
     notify-send "${TAG} indexed into the repo!" -t 0
-    paplay /usr/share/sounds/freedesktop/stereo/complete.oga
+    pw-cat --playback /usr/share/sounds/freedesktop/stereo/complete.oga
 fi
 
 if [ -f "${INDEX_XML}" ]; then rm ${INDEX_XML}; fi

--- a/common/Scripts/publish_series.py
+++ b/common/Scripts/publish_series.py
@@ -209,7 +209,7 @@ class Publisher:
     def _notify_failed(self, build: APIBuild) -> None:
         self._run('notify-send', '--expire-time=0', '--urgency=critical', '--app-name=Solus Builds',
                   f'Build for {build.tag} failed!')
-        self._run('paplay', '/usr/share/sounds/freedesktop/stereo/suspend-error.oga')
+        self._run('pw-cat', '--playback', '/usr/share/sounds/freedesktop/stereo/suspend-error.oga')
 
     def _notify_finished(self) -> None:
         self._run('notify-send', '--expire-time=0', '--app-name=Solus Builds',

--- a/common/Scripts/rebuild-template-script.sh
+++ b/common/Scripts/rebuild-template-script.sh
@@ -42,7 +42,7 @@ then
 fi
 
 # Check requirements before starting
-REQUIREMENTS="curl unxz notify-send paplay solbuild git go-task"
+REQUIREMENTS="curl unxz notify-send pipewire solbuild git go-task"
 for i in $REQUIREMENTS; do
     if ! which $i &> /dev/null; then
         echo "Missing requirement: $i. Install it to continue."
@@ -193,7 +193,7 @@ build() {
 
     echo -e "${PROGRESS} > All packages built! ${NC}"
     notify-send "All rebuilds against ${MAINPAK} successfully built locally!" -t 0
-    paplay /usr/share/sounds/freedesktop/stereo/complete.oga
+    pw-cat --playback /usr/share/sounds/freedesktop/stereo/complete.oga
 }
 
 # Verify the change
@@ -337,7 +337,7 @@ publish() {
 
     echo -e "${PROGRESS} > All published packages successfully indexed into the repo! ${NC}"
     notify-send "All rebuilds against ${MAINPAK} successfully indexed into the repo!" -t 0
-    paplay /usr/share/sounds/freedesktop/stereo/complete.oga
+    pw-cat --playback /usr/share/sounds/freedesktop/stereo/complete.oga
 }
 
 NUKE() {

--- a/packages/i/i3/files/config
+++ b/packages/i/i3/files/config
@@ -50,9 +50,9 @@ bindsym Print exec scrot -q 100
 
 ### Sound ###
 # Raise Volume
-bindsym XF86AudioRaiseVolume exec --no-startup-id amixer -D pulse sset Master 5%+ && paplay /usr/share/sounds/freedesktop/stereo/audio-volume-change.oga
+bindsym XF86AudioRaiseVolume exec --no-startup-id amixer -D pulse sset Master 5%+ && pw-cat --playback /usr/share/sounds/freedesktop/stereo/audio-volume-change.oga
 # Lower Volume
-bindsym XF86AudioLowerVolume exec --no-startup-id amixer -D pulse sset Master 5%- && paplay /usr/share/sounds/freedesktop/stereo/audio-volume-change.oga
+bindsym XF86AudioLowerVolume exec --no-startup-id amixer -D pulse sset Master 5%- && pw-cat --playback /usr/share/sounds/freedesktop/stereo/audio-volume-change.oga
 bindsym XF86AudioMute exec --no-startup-id amixer -D pulse sset Master toggle-mute # Toggle muting
 
 # Use Mouse+Mod4 to drag floating windows to their wanted position

--- a/packages/i/i3/package.yml
+++ b/packages/i/i3/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : i3
 version    : 4.25.1
-release    : 54
+release    : 55
 source     :
     - https://github.com/i3/i3/archive/refs/tags/4.25.1.tar.gz : c4bc2a40796caf40e98deb968c26a48e2ed6e240d40384d4d0f68b4136b11cef
     - https://github.com/i3-gnome/i3-gnome/archive/refs/tags/40.4.tar.gz : 8cf578390ce98b4f7c14d7f49ce4eb2f7255119a685c99ded68b276521ab25f4

--- a/packages/i/i3/pspec_x86_64.xml
+++ b/packages/i/i3/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>i3</Name>
         <Homepage>https://i3wm.org/</Homepage>
         <Packager>
-            <Name>Ivan Trepakov</Name>
-            <Email>liontiger23@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>MIT</License>
@@ -107,7 +107,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="54">i3</Dependency>
+            <Dependency release="55">i3</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/i3/ipc.h</Path>
@@ -115,12 +115,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="54">
-            <Date>2026-05-09</Date>
+        <Update release="55">
+            <Date>2026-05-10</Date>
             <Version>4.25.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Ivan Trepakov</Name>
-            <Email>liontiger23@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Replace `paplay` with `pw-cat` to play audio files.

Fixes https://github.com/getsolus/packages/issues/8815

**Test Plan**

Run `pa-play --playback /usr/share/sounds/freedesktop/stereo/suspend-error.oga` to make sure that it plays the file as expected, without taking over the terminal.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
