### PR TITLE
glibc: Update to 2.43+git.4070d808

### DIFF
--- a/packages/g/glibc/package.yml
+++ b/packages/g/glibc/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : glibc
 version    : '2.43'
-release    : 140
+release    : 141
 source     :
     # release/2.43/master
-    - git|https://sourceware.org/git/glibc.git : 8362e8ce10b24068bacc19552c128dd10e082fd9
+    - git|https://sourceware.org/git/glibc.git : 4070d808bea1c077eb7e7d52b52b91cae98205d5
 homepage   : https://www.gnu.org/software/libc/
 license    :
     - GPL-2.0-or-later

--- a/packages/g/glibc/pspec_x86_64.xml
+++ b/packages/g/glibc/pspec_x86_64.xml
@@ -7020,7 +7020,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="140">glibc</Dependency>
+            <Dependency release="141">glibc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib32/ld-linux.so.2</Path>
@@ -7321,8 +7321,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="140">glibc-32bit</Dependency>
-            <Dependency release="140">glibc-devel</Dependency>
+            <Dependency release="141">glibc-devel</Dependency>
+            <Dependency release="141">glibc-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/Mcrt1.o</Path>
@@ -7856,7 +7856,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="140">glibc</Dependency>
+            <Dependency release="141">glibc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/mtrace</Path>
@@ -7880,6 +7880,7 @@
             <Path fileType="header">/usr/include/bits/argp-ldbl.h</Path>
             <Path fileType="header">/usr/include/bits/atomic_wide_counter.h</Path>
             <Path fileType="header">/usr/include/bits/byteswap.h</Path>
+            <Path fileType="header">/usr/include/bits/cloexec.h</Path>
             <Path fileType="header">/usr/include/bits/cmathcalls.h</Path>
             <Path fileType="header">/usr/include/bits/confname.h</Path>
             <Path fileType="header">/usr/include/bits/cpu-set.h</Path>
@@ -8376,8 +8377,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="140">
-            <Date>2026-04-20</Date>
+        <Update release="141">
+            <Date>2026-05-10</Date>
             <Version>2.43</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
- include: isolate __O_CLOEXEC flag for sys/mount.h and fcntl.h
- Linux: Only define OPEN_TREE_* macros in <sys/mount.h> if undefined
- abilist.awk: Handle weak unversioned defined symbols
- libio: Fix ungetwc operating on byte stream
- stdio-common: Fix buffer overflow in scanf %mc

**Security**
- CVE-2026-5450
- CVE-2026-5928

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build `nano`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
