### PR TITLE
feh: Update to v3.12.2

### DIFF
--- a/packages/f/feh/package.yml
+++ b/packages/f/feh/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : feh
-version    : 3.12.1
-release    : 54
+version    : 3.12.2
+release    : 55
 source     :
-    - https://feh.finalrewind.org/feh-3.12.1.tar.bz2 : 6772f48e7956a16736e4c165a8367f357efc413b895f5b04133366e01438f95d
+    - https://feh.finalrewind.org/feh-3.12.2.tar.bz2 : 7ce358b18a7f37bcc97a09b4efd89fdadd54cd8e7032db345f61e66dd04b1c3f
 homepage   : https://feh.finalrewind.org/
 license    : MIT
 component  : multimedia.graphics
@@ -18,8 +18,8 @@ builddeps  :
     - pkgconfig(xinerama)
     - pkgconfig(xt)
 build      : |
-    %make PREFIX=/usr app=1 exif=1 inotify=1
+    %make PREFIX=/usr exif=1 inotify=1
 install    : |
     %make_install PREFIX=/usr
     %install_license COPYING
-    install -Dm00644 $pkgfiles/org.finalrewind.feh.feh.metainfo.xml -t $installdir/usr/share/metainfo
+    install -Dm00644 ${pkgfiles}/org.finalrewind.feh.feh.metainfo.xml -t ${installdir}/usr/share/metainfo

--- a/packages/f/feh/pspec_x86_64.xml
+++ b/packages/f/feh/pspec_x86_64.xml
@@ -44,9 +44,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="54">
-            <Date>2026-04-07</Date>
-            <Version>3.12.1</Version>
+        <Update release="55">
+            <Date>2026-05-11</Date>
+            <Version>3.12.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://feh.finalrewind.org/archive/3.12.2/).

**Test Plan**

`feh example.png` See picture. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
