### PR TITLE
byobu: Update to 6.14

### DIFF
--- a/packages/b/byobu/package.yml
+++ b/packages/b/byobu/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : byobu
-version    : '6.13'
-release    : 9
+version    : '6.14'
+release    : 10
 source     :
-    - https://github.com/dustinkirkland/byobu/archive/refs/tags/6.13.tar.gz : 9690c629588e8f95d16b2461950d39934faaf8005dd2a283886d4e3bd6c86df6
+    - https://github.com/dustinkirkland/byobu/archive/refs/tags/6.14.tar.gz : 478e15a38a57678e4bd2cd55994ea1edece2d10bb6bf0a3de8f0b2dd8df35485
 homepage   : https://www.byobu.org/
 license    : GPL-3.0-or-later
 component  : system.utils
@@ -18,4 +18,5 @@ setup      : |
 build      : |
     %make
 install    : |
-    %make_install
+    make -j1 install DESTDIR=%installroot%
+    %install_license COPYING

--- a/packages/b/byobu/pspec_x86_64.xml
+++ b/packages/b/byobu/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>byobu</Name>
         <Homepage>https://www.byobu.org/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>clintre</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -124,7 +124,14 @@
             <Path fileType="data">/usr/share/byobu/keybindings/mouse.tmux.enable</Path>
             <Path fileType="data">/usr/share/byobu/keybindings/none</Path>
             <Path fileType="data">/usr/share/byobu/keybindings/tmux-screen-keys.conf</Path>
+            <Path fileType="data">/usr/share/byobu/pixmaps/byobu-banner.svg</Path>
+            <Path fileType="data">/usr/share/byobu/pixmaps/byobu.14.png</Path>
+            <Path fileType="data">/usr/share/byobu/pixmaps/byobu.192.png</Path>
+            <Path fileType="data">/usr/share/byobu/pixmaps/byobu.64.png</Path>
+            <Path fileType="data">/usr/share/byobu/pixmaps/byobu.png</Path>
             <Path fileType="data">/usr/share/byobu/pixmaps/byobu.svg</Path>
+            <Path fileType="data">/usr/share/byobu/pixmaps/byobu_backup.svg</Path>
+            <Path fileType="data">/usr/share/byobu/pixmaps/highcontrast/byobu.svg</Path>
             <Path fileType="data">/usr/share/byobu/profiles/NONE</Path>
             <Path fileType="data">/usr/share/byobu/profiles/bashrc</Path>
             <Path fileType="data">/usr/share/byobu/profiles/byoburc</Path>
@@ -140,50 +147,52 @@
             <Path fileType="data">/usr/share/dbus-1/services/us.kirkland.terminals.byobu.service</Path>
             <Path fileType="doc">/usr/share/doc/byobu/help.screen.txt</Path>
             <Path fileType="doc">/usr/share/doc/byobu/help.tmux.txt</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-config.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-ctrl-a.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-disable-prompt.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-disable.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-enable-prompt.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-enable.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-export.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-janitor.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-keybindings.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-launch.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-launcher-install.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-launcher-uninstall.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-launcher.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-layout.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-prompt.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-quiet.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-reconnect-sockets.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-screen.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-select-backend.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-select-profile.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-select-session.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-shell.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-silent.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-status-detail.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-status.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-tmux.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-ugraph.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu-ulevel.1</Path>
-            <Path fileType="man">/usr/share/man/man1/byobu.1</Path>
-            <Path fileType="man">/usr/share/man/man1/col1.1</Path>
-            <Path fileType="man">/usr/share/man/man1/ctail.1</Path>
-            <Path fileType="man">/usr/share/man/man1/manifest.1</Path>
-            <Path fileType="man">/usr/share/man/man1/purge-old-kernels.1</Path>
-            <Path fileType="man">/usr/share/man/man1/vigpg.1</Path>
-            <Path fileType="man">/usr/share/man/man1/wifi-status.1</Path>
+            <Path fileType="data">/usr/share/licenses/byobu/COPYING</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-config.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-ctrl-a.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-disable-prompt.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-disable.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-enable-prompt.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-enable.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-export.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-janitor.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-keybindings.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-launch.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-launcher-install.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-launcher-uninstall.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-launcher.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-layout.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-prompt.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-quiet.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-reconnect-sockets.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-screen.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-select-backend.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-select-profile.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-select-session.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-shell.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-silent.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-status-detail.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-status.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-tmux.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-ugraph.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu-ulevel.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/byobu.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/col1.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/ctail.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/manifest.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/purge-old-kernels.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/vigpg.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/wifi-status.1.zst</Path>
+            <Path fileType="data">/usr/share/sounds/byobu/byobu.ogg</Path>
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2025-03-30</Date>
-            <Version>6.13</Version>
+        <Update release="10">
+            <Date>2026-05-11</Date>
+            <Version>6.14</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>clintre</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Fixed critical prompt issues affecting Ubuntu 24.04 users
- Added systemd support for modern Linux distributions
- Improved Arch Linux package detection
- Fixed byobu -v command output
- Better error handling outside byobu sessions
- Added license

[Full Release Notes](https://github.com/dustinkirkland/byobu/releases/tag/6.14)

**Test Plan**

Install and test with tmux

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
