### PR TITLE
dash: Update to v0.5.13.4

### DIFF
--- a/packages/d/dash/package.yml
+++ b/packages/d/dash/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : dash
-version    : 0.5.13.3
-release    : 19
+version    : 0.5.13.4
+release    : 20
 source     :
-    - https://git.kernel.org/pub/scm/utils/dash/dash.git/snapshot/dash-0.5.13.3.tar.gz : f7ab491177d696e42f93342abe9eb6d183adbd066e37e26056e0fa91e2f29c00
+    - https://git.kernel.org/pub/scm/utils/dash/dash.git/snapshot/dash-0.5.13.4.tar.gz : 652e95024b75758dcd141b64a0d3973a026cc6aaee1aec81ce03e76dc3e6a267
 homepage   : https://git.kernel.org/pub/scm/utils/dash/dash.git/
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/d/dash/pspec_x86_64.xml
+++ b/packages/d/dash/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>dash</Name>
         <Homepage>https://git.kernel.org/pub/scm/utils/dash/dash.git/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.utils</PartOf>
@@ -26,12 +26,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2026-04-20</Date>
-            <Version>0.5.13.3</Version>
+        <Update release="20">
+            <Date>2026-05-11</Date>
+            <Version>0.5.13.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://git.kernel.org/pub/scm/utils/dash/dash.git/log/?showmsg=1).

**Test Plan**

Pushed this commit in `dash`. Moved around file system. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
