### PR TITLE
dos2unix: Update to v7.5.5

### DIFF
--- a/packages/d/dos2unix/package.yml
+++ b/packages/d/dos2unix/package.yml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : dos2unix
-version    : 7.5.4
-release    : 9
+version    : 7.5.5
+release    : 10
 source     :
-    - https://sourceforge.net/projects/dos2unix/files/dos2unix/7.5.4/dos2unix-7.5.4.tar.gz : f811a2b9e4a0c936c61ef7c1732993d1820e5cf011f4d93861885ccb8101ca21
-license    : BSD-2-Clause-FreeBSD
+    - https://sourceforge.net/projects/dos2unix/files/dos2unix/7.5.5/dos2unix-7.5.5.tar.gz : 75f692b8484c8c24579a2ffd87df16b9c9428ed95497e3393a21d1ba0697ac33
 homepage   : https://dos2unix.sourceforge.io/
+license    : BSD-2-Clause-FreeBSD
 component  : system.utils
 summary    : DOS/Mac to Unix and vice versa text file format converter
 description: |

--- a/packages/d/dos2unix/pspec_x86_64.xml
+++ b/packages/d/dos2unix/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>dos2unix</Name>
         <Homepage>https://dos2unix.sourceforge.io/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>BSD-2-Clause-FreeBSD</License>
         <PartOf>system.utils</PartOf>
@@ -24,39 +24,39 @@
             <Path fileType="executable">/usr/bin/mac2unix</Path>
             <Path fileType="executable">/usr/bin/unix2dos</Path>
             <Path fileType="executable">/usr/bin/unix2mac</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/BUGS.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/COPYING.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/ChangeLog.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/INSTALL.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/NEWS.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/README.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/TODO.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/de/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/de/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/es/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/es/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/fr/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/fr/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/ko/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/ko/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/nl/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/nl/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/pl/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/pl/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/pt_BR/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/pt_BR/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/ro/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/ro/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/sr/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/sr/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/sv/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/sv/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/uk/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/uk/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/zh_CN/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.4/zh_CN/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/BUGS.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/COPYING.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/ChangeLog.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/INSTALL.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/NEWS.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/README.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/TODO.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/de/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/de/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/es/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/es/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/fr/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/fr/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/ko/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/ko/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/nl/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/nl/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/pl/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/pl/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/pt_BR/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/pt_BR/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/ro/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/ro/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/sr/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/sr/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/sv/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/sv/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/uk/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/uk/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/zh_CN/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/zh_CN/dos2unix.txt</Path>
             <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/dos2unix.mo</Path>
             <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/dos2unix.mo</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/dos2unix.mo</Path>
@@ -135,12 +135,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2026-02-25</Date>
-            <Version>7.5.4</Version>
+        <Update release="10">
+            <Date>2026-05-11</Date>
+            <Version>7.5.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://dos2unix.sourceforge.io/).
- Fixed dos2unix error on empty input. New option --error-binary: Return an error if a binary file is skipped.

**Test Plan**

Converted crlf to lf and back. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
