### PR TITLE
taskfile.yml: Add "info" helper utility

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -179,6 +179,16 @@ tasks:
       - sed -i 's/{{.CURRENT_VERSION}}/{{.LATEST_VERSION}}/g' package.yml # Up to here it works for single source git
       - go-task update -- {{.LATEST_VERSION}} $(yq '.source[0] | keys' package.yml | cut -c 3-) # use yq to get the "source" key from package.yml, then trim the leading characters
 
+  info:
+    desc: >-
+      Return "eopkg info" for the package associated with the current folder.
+    dir: '{{ .USER_WORKING_DIR }}'
+    preconditions:
+      - sh: test -f package.yml
+        msg: "`package.yml` must exist in the current directory"
+    cmds:
+      - eopkg info $(basename $PWD)
+
   # For staff and packagers with push access
   publish:
     desc: >-


### PR DESCRIPTION
**Summary**

This utility returns "eopkg info" for the package associated with the current directory. Does not know or understand sub-packages.

**Test Plan**

- Go to folder, get info

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
