### PR TITLE
python-jupyter-server: Update to v2.18.2

### DIFF
--- a/packages/py/python-jupyter-server/package.yml
+++ b/packages/py/python-jupyter-server/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-jupyter-server
-version    : 2.15.0
-release    : 7
+version    : 2.18.2
+release    : 8
 source     :
-    - https://files.pythonhosted.org/packages/source/j/jupyter_server/jupyter_server-2.15.0.tar.gz : 9d446b8697b4f7337a1b7cdcac40778babdd93ba614b6d68ab1c0c918f1c4084
+    - https://files.pythonhosted.org/packages/source/j/jupyter_server/jupyter_server-2.18.2.tar.gz : 06b4f40d8a7a00bb39d5216859c81374a0e7cfefe6d8a5a7facc5a5c37c679a7
 homepage   : https://github.com/jupyter-server/jupyter_server
 license    : BSD-3-Clause
 component  : programming.python

--- a/packages/py/python-jupyter-server/pspec_x86_64.xml
+++ b/packages/py/python-jupyter-server/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-jupyter-server</Name>
         <Homepage>https://github.com/jupyter-server/jupyter_server</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -21,11 +21,11 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/jupyter-server</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/jupyter_server-2.15.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/jupyter_server-2.15.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/jupyter_server-2.15.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/jupyter_server-2.15.0.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/jupyter_server-2.15.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/jupyter_server-2.18.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/jupyter_server-2.18.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/jupyter_server-2.18.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/jupyter_server-2.18.2.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/jupyter_server-2.18.2.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/jupyter_server/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/jupyter_server/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/jupyter_server/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -328,12 +328,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2025-05-17</Date>
-            <Version>2.15.0</Version>
+        <Update release="8">
+            <Date>2026-05-11</Date>
+            <Version>2.18.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://jupyter-server.readthedocs.io/en/latest/other/changelog.html).

**Security**
Includes fixes for:
- CVE-2025-61669
- CVE-2026-35397
- CVE-2026-40110
- CVE-2026-40934

**Test Plan**

`python -m jupyter_server --ServerApp.port=8888 --ServerApp.open_browser=False &` and see server running. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
