### PR TITLE
common/Scripts: Use extended grep in bash helpers

### DIFF
--- a/common/Scripts/helpers.sh
+++ b/common/Scripts/helpers.sh
@@ -45,12 +45,12 @@ function localrepo_reindex() {
 
 # What provides a lib
 function whatprovides() {
-    grep "$1" "$(git rev-parse --show-toplevel)"/packages/*/*/abi_libs
+    grep -E "$1" "$(git rev-parse --show-toplevel)"/packages/*/*/abi_libs
 }
 
 # What uses a lib
 function whatuses() {
-    grep "$1" "$(git rev-parse --show-toplevel)"/packages/*/*/abi_used_libs
+    grep -E "$1" "$(git rev-parse --show-toplevel)"/packages/*/*/abi_used_libs
 }
 
 function quickfixup() {


### PR DESCRIPTION
**Summary**
- Allows 'foo|bar' syntax

**Test Plan**

whatuses 'libraw.so|libraw_r.so'

**Checklist**

- [n/a] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
