### PR TITLE
gettext: Add missing rundep on envsubst

### DIFF
--- a/packages/g/gettext/package.yml
+++ b/packages/g/gettext/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gettext
 version    : '1.0'
-release    : 22
+release    : 23
 source     :
     - https://ftp.gnu.org/pub/gnu/gettext/gettext-1.0.tar.gz : 85d99b79c981a404874c02e0342176cf75c7698e2b51fe41031cf6526d974f1a
 homepage   : https://www.gnu.org/software/gettext
@@ -9,7 +9,7 @@ license    : GPL-3.0-or-later
 component  :
     - devel : system.devel
     - docs : programming.docs
-    - ^envsubst : system.utils
+    - ^envsubst : system.base
     - libs : system.base
     - ^libtextstyle : system.base
     - ^libtextstyle-devel : system.devel
@@ -34,14 +34,13 @@ builddeps  :
     - pkgconfig(ncursesw)
     - libunistring-devel
 rundeps    :
-    - ^envsubst :
-        - glibc
     - ^libtextstyle-devel :
         - libtextstyle
     - devel :
         - gettext
         - gettext-libs
         - libtextstyle-devel
+    - envsubst
     - gettext-libs
     - libtextstyle
 setup      : |

--- a/packages/g/gettext/pspec_x86_64.xml
+++ b/packages/g/gettext/pspec_x86_64.xml
@@ -18,8 +18,9 @@
         <Description xml:lang="en">The Gettext package contains utilities for internationalization and localization. These allow programs to be compiled with NLS (Native Language Support), enabling them to output messages in the user&apos;s native language.</Description>
         <PartOf>system.base</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="22">gettext-libs</Dependency>
-            <Dependency releaseFrom="22">libtextstyle</Dependency>
+            <Dependency releaseFrom="23">envsubst</Dependency>
+            <Dependency releaseFrom="23">gettext-libs</Dependency>
+            <Dependency releaseFrom="23">libtextstyle</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/gettext</Path>
@@ -195,7 +196,7 @@
         <Name>envsubst</Name>
         <Summary xml:lang="en">Substitutes the values of environment variables</Summary>
         <Description xml:lang="en">Substitutes the values of environment variables</Description>
-        <PartOf>system.utils</PartOf>
+        <PartOf>system.base</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/envsubst</Path>
             <Path fileType="man">/usr/share/man/man1/envsubst.1.zst</Path>
@@ -217,7 +218,7 @@
         <Description xml:lang="en">Development files for libtextstyle</Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="22">libtextstyle</Dependency>
+            <Dependency releaseFrom="23">libtextstyle</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/textstyle.h</Path>
@@ -242,9 +243,9 @@
         <Description xml:lang="en">The Gettext package contains utilities for internationalization and localization. These allow programs to be compiled with NLS (Native Language Support), enabling them to output messages in the user&apos;s native language.</Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="22">gettext</Dependency>
-            <Dependency releaseFrom="22">gettext-libs</Dependency>
-            <Dependency releaseFrom="22">libtextstyle-devel</Dependency>
+            <Dependency release="23">gettext</Dependency>
+            <Dependency releaseFrom="23">gettext-libs</Dependency>
+            <Dependency releaseFrom="23">libtextstyle-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/autopoint</Path>
@@ -411,8 +412,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2026-05-06</Date>
+        <Update release="23">
+            <Date>2026-05-12</Date>
             <Version>1.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
Add missing rundep on `envsubst`.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Upgrade packages without dependency errors.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
