### PR TITLE
fastfetch: Update to v2.63.1

### DIFF
--- a/packages/f/fastfetch/abi_used_symbols
+++ b/packages/f/fastfetch/abi_used_symbols
@@ -19,6 +19,7 @@ libc.so.6:__realpath_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
+libc.so.6:__strcpy_chk
 libc.so.6:__vasprintf_chk
 libc.so.6:__vfprintf_chk
 libc.so.6:__vsnprintf_chk

--- a/packages/f/fastfetch/package.yml
+++ b/packages/f/fastfetch/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : fastfetch
-version    : 2.62.1
-release    : 72
+version    : 2.63.1
+release    : 73
 source     :
-    - https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/2.62.1.tar.gz : 8c4833e55b8b445a32c7cb7570007b5e10a9ee4cee74a494004ba61e88b12b26
+    - https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/2.63.1.tar.gz : 6e124699ea20fb02c5bc402c0012543303ee75ca55ad664f96bc6cd414d7e6b3
 homepage   : https://github.com/fastfetch-cli/fastfetch
 license    : MIT
 component  : system.utils

--- a/packages/f/fastfetch/pspec_x86_64.xml
+++ b/packages/f/fastfetch/pspec_x86_64.xml
@@ -67,9 +67,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="72">
-            <Date>2026-04-26</Date>
-            <Version>2.62.1</Version>
+        <Update release="73">
+            <Date>2026-05-13</Date>
+            <Version>2.63.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/fastfetch-cli/fastfetch/releases/tag/2.63.0).
- Release notes can be found [here](https://github.com/fastfetch-cli/fastfetch/releases/tag/2.63.1).

**Test Plan**

View output of `fastfetch`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
