### PR TITLE
broot: Update to v1.56.3

### DIFF
--- a/packages/b/broot/abi_used_symbols
+++ b/packages/b/broot/abi_used_symbols
@@ -134,6 +134,7 @@ libc.so.6:strlen
 libc.so.6:symlink
 libc.so.6:syscall
 libc.so.6:sysconf
+libc.so.6:tcflush
 libc.so.6:unlink
 libc.so.6:unlinkat
 libc.so.6:waitid

--- a/packages/b/broot/package.yml
+++ b/packages/b/broot/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : broot
-version    : 1.56.2
-release    : 33
+version    : 1.56.3
+release    : 34
 source     :
-    - https://github.com/Canop/broot/archive/refs/tags/v1.56.2.tar.gz : 3e7be4252c76565f6d71b34bd07d26e1444b9ac2e1c8271c724f6e866fe75565
+    - https://github.com/Canop/broot/archive/refs/tags/v1.56.3.tar.gz : 48f7fdc6e68539a951207d892916824bb08e8752d2c6aa414ef994f08b6ba43c
 homepage   : https://dystroy.org/broot/
 license    : MIT
 component  : system.utils

--- a/packages/b/broot/pspec_x86_64.xml
+++ b/packages/b/broot/pspec_x86_64.xml
@@ -27,9 +27,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2026-03-26</Date>
-            <Version>1.56.2</Version>
+        <Update release="34">
+            <Date>2026-05-13</Date>
+            <Version>1.56.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/Canop/broot/releases/tag/v1.56.3).

**Test Plan**

Ran `broot`. Looked around file system. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
