### PR TITLE
gdb: Update to v17.2

### DIFF
--- a/packages/g/gdb/abi_symbols
+++ b/packages/g/gdb/abi_symbols
@@ -78,7 +78,6 @@ libinproctrace.so:gdb_agent_traceframe_write_count
 libinproctrace.so:gdb_agent_traceframes_created
 libinproctrace.so:gdb_agent_tracepoints
 libinproctrace.so:gdb_agent_tracing
-libinproctrace.so:gdb_agent_ust_loaded
 libinproctrace.so:gdb_collect
 libinproctrace.so:get_trace_state_variable_value
 libinproctrace.so:set_trace_state_variable_value

--- a/packages/g/gdb/abi_used_symbols
+++ b/packages/g/gdb/abi_used_symbols
@@ -23,6 +23,7 @@ libc.so.6:__longjmp_chk
 libc.so.6:__mbrlen
 libc.so.6:__memcpy_chk
 libc.so.6:__memmove_chk
+libc.so.6:__memset_chk
 libc.so.6:__printf_chk
 libc.so.6:__read_chk
 libc.so.6:__realpath_chk
@@ -30,6 +31,7 @@ libc.so.6:__sigsetjmp
 libc.so.6:__snprintf_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
+libc.so.6:__stpcpy_chk
 libc.so.6:__strcat_chk
 libc.so.6:__strcpy_chk
 libc.so.6:__strncpy_chk
@@ -62,6 +64,7 @@ libc.so.6:connect
 libc.so.6:ctime
 libc.so.6:ctime_r
 libc.so.6:dcgettext
+libc.so.6:dcngettext
 libc.so.6:dirfd
 libc.so.6:dl_iterate_phdr
 libc.so.6:dladdr
@@ -110,6 +113,7 @@ libc.so.6:getenv
 libc.so.6:getgid
 libc.so.6:getgrgid
 libc.so.6:getnameinfo
+libc.so.6:getopt_long
 libc.so.6:getopt_long_only
 libc.so.6:getpagesize
 libc.so.6:getpgid
@@ -132,6 +136,7 @@ libc.so.6:iconv
 libc.so.6:iconv_close
 libc.so.6:iconv_open
 libc.so.6:in6addr_any
+libc.so.6:inet_ntop
 libc.so.6:ioctl
 libc.so.6:isalnum
 libc.so.6:isalpha
@@ -173,7 +178,9 @@ libc.so.6:open
 libc.so.6:openat
 libc.so.6:opendir
 libc.so.6:optarg
+libc.so.6:opterr
 libc.so.6:optind
+libc.so.6:optopt
 libc.so.6:pclose
 libc.so.6:perror
 libc.so.6:personality
@@ -204,6 +211,8 @@ libc.so.6:pthread_setname_np
 libc.so.6:pthread_sigmask
 libc.so.6:ptrace
 libc.so.6:putc
+libc.so.6:putchar
+libc.so.6:puts
 libc.so.6:pwrite
 libc.so.6:pwrite64
 libc.so.6:qsort
@@ -249,6 +258,7 @@ libc.so.6:sleep
 libc.so.6:snprintf
 libc.so.6:socket
 libc.so.6:socketpair
+libc.so.6:sprintf
 libc.so.6:stat
 libc.so.6:stderr
 libc.so.6:stdin
@@ -275,6 +285,7 @@ libc.so.6:strnlen
 libc.so.6:strpbrk
 libc.so.6:strrchr
 libc.so.6:strsignal
+libc.so.6:strspn
 libc.so.6:strstr
 libc.so.6:strtok_r
 libc.so.6:syscall
@@ -335,6 +346,7 @@ libexpat.so.1:XML_UseForeignDTD
 libgcc_s.so.1:_Unwind_Backtrace
 libgcc_s.so.1:_Unwind_GetIPInfo
 libgcc_s.so.1:_Unwind_Resume
+libgcc_s.so.1:__popcountdi2
 libgmp.so.10:__gmp_set_memory_functions
 libgmp.so.10:__gmp_vsnprintf
 libgmp.so.10:__gmp_vsprintf
@@ -397,7 +409,9 @@ libm.so.6:fmod
 libm.so.6:frexp
 libm.so.6:ldexp
 libm.so.6:log10
+libm.so.6:log2
 libm.so.6:pow
+libm.so.6:sqrt
 libmpfr.so.6:__gmpfr_mpfr_get_sj
 libmpfr.so.6:__gmpfr_set_sj
 libmpfr.so.6:__gmpfr_set_uj
@@ -580,6 +594,7 @@ libpython3.12.so.1.0:PyLong_AsSsize_t
 libpython3.12.so.1.0:PyLong_AsUnsignedLongLong
 libpython3.12.so.1.0:PyLong_FromLong
 libpython3.12.so.1.0:PyLong_FromUnsignedLong
+libpython3.12.so.1.0:PyLong_Type
 libpython3.12.so.1.0:PyMem_RawMalloc
 libpython3.12.so.1.0:PyMemoryView_FromObject
 libpython3.12.so.1.0:PyModule_AddIntConstant
@@ -603,7 +618,6 @@ libpython3.12.so.1.0:PyObject_GetBuffer
 libpython3.12.so.1.0:PyObject_GetIter
 libpython3.12.so.1.0:PyObject_HasAttr
 libpython3.12.so.1.0:PyObject_HasAttrString
-libpython3.12.so.1.0:PyObject_IsInstance
 libpython3.12.so.1.0:PyObject_IsTrue
 libpython3.12.so.1.0:PyObject_Repr
 libpython3.12.so.1.0:PyObject_RichCompareBool
@@ -652,8 +666,6 @@ libpython3.12.so.1.0:_Py_FalseStruct
 libpython3.12.so.1.0:_Py_NoneStruct
 libpython3.12.so.1.0:_Py_NotImplementedStruct
 libpython3.12.so.1.0:_Py_TrueStruct
-libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE13find_first_ofEPKcmm
-libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE17find_first_not_ofEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE17find_first_not_ofEcm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEPKcmm
 libstdc++.so.6:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEcm
@@ -683,6 +695,8 @@ libstdc++.so.6:_ZNSt28__atomic_futex_unsigned_base19_M_futex_notify_allEPj
 libstdc++.so.6:_ZNSt28__atomic_futex_unsigned_base19_M_futex_wait_untilEPjjbNSt6chrono8durationIlSt5ratioILl1ELl1EEEENS2_IlS3_ILl1ELl1000000000EEEE
 libstdc++.so.6:_ZNSt6chrono3_V212steady_clock3nowEv
 libstdc++.so.6:_ZNSt6chrono3_V212system_clock3nowEv
+libstdc++.so.6:_ZNSt6localeC1Ev
+libstdc++.so.6:_ZNSt6localeD1Ev
 libstdc++.so.6:_ZNSt6thread15_M_start_threadESt10unique_ptrINS_6_StateESt14default_deleteIS1_EEPFvvE
 libstdc++.so.6:_ZNSt6thread20hardware_concurrencyEv
 libstdc++.so.6:_ZNSt6thread6_StateD2Ev
@@ -703,14 +717,20 @@ libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createER
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_mutateEmmPKcm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1EOS4_
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev
+libstdc++.so.6:_ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEED1Ev
 libstdc++.so.6:_ZNSt8__detail15_List_node_base7_M_hookEPS0_
 libstdc++.so.6:_ZNSt8__detail15_List_node_base9_M_unhookEv
+libstdc++.so.6:_ZNSt8ios_baseC2Ev
+libstdc++.so.6:_ZNSt8ios_baseD2Ev
 libstdc++.so.6:_ZNSt9bad_allocD2Ev
+libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE4initEPSt15basic_streambufIcS1_E
+libstdc++.so.6:_ZNSt9basic_iosIcSt11char_traitsIcEE5clearESt12_Ios_Iostate
 libstdc++.so.6:_ZNSt9exceptionD2Ev
 libstdc++.so.6:_ZSt11_Hash_bytesPKvmm
 libstdc++.so.6:_ZSt11__once_call
 libstdc++.so.6:_ZSt15__once_callable
 libstdc++.so.6:_ZSt15future_categoryv
+libstdc++.so.6:_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
 libstdc++.so.6:_ZSt17__throw_bad_allocv
 libstdc++.so.6:_ZSt17current_exceptionv
 libstdc++.so.6:_ZSt17rethrow_exceptionNSt15__exception_ptr13exception_ptrE
@@ -737,13 +757,18 @@ libstdc++.so.6:_ZTISt12system_error
 libstdc++.so.6:_ZTISt14overflow_error
 libstdc++.so.6:_ZTISt9bad_alloc
 libstdc++.so.6:_ZTISt9exception
+libstdc++.so.6:_ZTTNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEE
 libstdc++.so.6:_ZTVN10__cxxabiv117__class_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv119__pointer_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv120__function_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv120__si_class_type_infoE
 libstdc++.so.6:_ZTVN10__cxxabiv121__vmi_class_type_infoE
+libstdc++.so.6:_ZTVNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEEE
+libstdc++.so.6:_ZTVNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEE
 libstdc++.so.6:_ZTVSt12bad_weak_ptr
 libstdc++.so.6:_ZTVSt12future_error
+libstdc++.so.6:_ZTVSt15basic_streambufIcSt11char_traitsIcEE
+libstdc++.so.6:_ZTVSt9basic_iosIcSt11char_traitsIcEE
 libstdc++.so.6:_ZdlPvm
 libstdc++.so.6:_Znwm
 libstdc++.so.6:__cxa_allocate_exception
@@ -765,11 +790,8 @@ libxxhash.so.0:XXH64
 libz.so.1:compress
 libz.so.1:compressBound
 libz.so.1:gzwrite
-libz.so.1:inflate
-libz.so.1:inflateEnd
-libz.so.1:inflateInit_
-libz.so.1:inflateReset
 libz.so.1:uncompress
+libz.so.1:uncompress2
 libz.so.1:zError
 libzstd.so.1:ZSTD_compress
 libzstd.so.1:ZSTD_decompress

--- a/packages/g/gdb/package.yml
+++ b/packages/g/gdb/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gdb
-version    : '16.3'
-release    : 33
+version    : '17.2'
+release    : 34
 source     :
-    - https://ftpmirror.gnu.org/gnu/gdb/gdb-16.3.tar.xz : bcfcd095528a987917acf9fff3f1672181694926cc18d609c99d0042c00224c5
+    - https://ftpmirror.gnu.org/gnu/gdb/gdb-17.2.tar.xz : 1c036c0d72e4b3d1fb5c94c88632add6f9d76f4d7c4d2ea793c12a9f19a3228c
 homepage   : https://www.gnu.org/software/gdb/
 license    : GPL-3.0-or-later
 component  : programming.tools
@@ -14,6 +14,7 @@ patterns   :
     - /usr/include
     - /usr/lib64
 builddeps  :
+    - pkgconfig(expat)
     - pkgconfig(libdebuginfod)
     - pkgconfig(liblzma)
     - pkgconfig(libxxhash)
@@ -21,8 +22,10 @@ builddeps  :
     - pkgconfig(python3)
 setup      : |
     %configure_no_runstatedir \
+        --enable-targets=all \
         --with-python=/usr/bin/python3 \
-        --with-system-zlib
+        --with-system-zlib \
+        --with-expat
 build      : |
     %make
 install    : |

--- a/packages/g/gdb/pspec_x86_64.xml
+++ b/packages/g/gdb/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gdb</Name>
         <Homepage>https://www.gnu.org/software/gdb/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Leon Lombar</Name>
+            <Email>leon@makase.ro</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>programming.tools</PartOf>
@@ -42,6 +42,7 @@
             <Path fileType="data">/usr/share/gdb/python/gdb/dap/__init__.py</Path>
             <Path fileType="data">/usr/share/gdb/python/gdb/dap/breakpoint.py</Path>
             <Path fileType="data">/usr/share/gdb/python/gdb/dap/bt.py</Path>
+            <Path fileType="data">/usr/share/gdb/python/gdb/dap/completions.py</Path>
             <Path fileType="data">/usr/share/gdb/python/gdb/dap/disassemble.py</Path>
             <Path fileType="data">/usr/share/gdb/python/gdb/dap/evaluate.py</Path>
             <Path fileType="data">/usr/share/gdb/python/gdb/dap/events.py</Path>
@@ -119,12 +120,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="33">
-            <Date>2026-01-13</Date>
-            <Version>16.3</Version>
+        <Update release="34">
+            <Date>2026-05-13</Date>
+            <Version>17.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Leon Lombar</Name>
+            <Email>leon@makase.ro</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Now builds with the `--enable-targets=all` flag, adding multi-arch debugging support

Full release notes:

- [17.1](https://sourceware.org/pipermail/gdb-announce/2025/000147.html)
- [17.2](https://sourceware.org/pipermail/gdb-announce/2026/000148.html)

**Test Plan**

- Compile a barebones ELF for R3000
```sh
❯ file test.elf
test.elf: ELF 32-bit LSB executable, MIPS, MIPS-I version 1 (SYSV), statically linked, with debug_info, not stripped
❯ gdb test.elf
(gdb) show architecture
The target architecture is set to "auto" (currently "mips:3000").
```
- Run some commands (`info functions`, `disassemble __start`) and make sure they work now

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
