### PR TITLE
xdg-desktop-portal-wlr: Update to 0.8.2

### DIFF
--- a/packages/x/xdg-desktop-portal-wlr/abi_libs
+++ b/packages/x/xdg-desktop-portal-wlr/abi_libs
@@ -1,0 +1,1 @@
+xdg-desktop-portal-wlr

--- a/packages/x/xdg-desktop-portal-wlr/abi_symbols
+++ b/packages/x/xdg-desktop-portal-wlr/abi_symbols
@@ -1,0 +1,1 @@
+xdg-desktop-portal-wlr:_IO_stdin_used

--- a/packages/x/xdg-desktop-portal-wlr/abi_used_symbols
+++ b/packages/x/xdg-desktop-portal-wlr/abi_used_symbols
@@ -6,6 +6,7 @@ libc.so.6:__libc_start_main
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__vfprintf_chk
+libc.so.6:__vsnprintf_chk
 libc.so.6:_exit
 libc.so.6:abort
 libc.so.6:access
@@ -18,6 +19,7 @@ libc.so.6:execvp
 libc.so.6:exit
 libc.so.6:fclose
 libc.so.6:fdopen
+libc.so.6:feof
 libc.so.6:fflush
 libc.so.6:fork
 libc.so.6:fread
@@ -27,6 +29,7 @@ libc.so.6:getenv
 libc.so.6:getline
 libc.so.6:getopt_long
 libc.so.6:localtime
+libc.so.6:malloc
 libc.so.6:memcpy
 libc.so.6:mmap64
 libc.so.6:munmap
@@ -55,10 +58,12 @@ libc.so.6:timerfd_create
 libc.so.6:timerfd_settime
 libc.so.6:waitpid
 libdrm.so.2:drmDevicesEqual
-libdrm.so.2:drmFreeDevices
+libdrm.so.2:drmFreeDevice
+libdrm.so.2:drmGetDevice
 libdrm.so.2:drmGetDevice2
 libdrm.so.2:drmGetDeviceFromDevId
-libdrm.so.2:drmGetDevices2
+libdrm.so.2:drmGetFormatModifierName
+libdrm.so.2:drmGetFormatName
 libgbm.so.1:gbm_bo_create
 libgbm.so.1:gbm_bo_create_with_modifiers2
 libgbm.so.1:gbm_bo_destroy
@@ -94,6 +99,7 @@ libpipewire-0.3.so.0:pw_stream_update_params
 libsystemd.so.0:sd_bus_add_match
 libsystemd.so.0:sd_bus_add_object_vtable
 libsystemd.so.0:sd_bus_close
+libsystemd.so.0:sd_bus_emit_signal
 libsystemd.so.0:sd_bus_flush
 libsystemd.so.0:sd_bus_get_events
 libsystemd.so.0:sd_bus_get_fd
@@ -114,6 +120,7 @@ libsystemd.so.0:sd_bus_open_user
 libsystemd.so.0:sd_bus_process
 libsystemd.so.0:sd_bus_request_name
 libsystemd.so.0:sd_bus_send
+libsystemd.so.0:sd_bus_slot_get_bus
 libsystemd.so.0:sd_bus_slot_unref
 libsystemd.so.0:sd_bus_unref
 libwayland-client.so.0:wl_array_add
@@ -133,6 +140,7 @@ libwayland-client.so.0:wl_list_insert
 libwayland-client.so.0:wl_list_length
 libwayland-client.so.0:wl_list_remove
 libwayland-client.so.0:wl_output_interface
+libwayland-client.so.0:wl_pointer_interface
 libwayland-client.so.0:wl_proxy_add_listener
 libwayland-client.so.0:wl_proxy_destroy
 libwayland-client.so.0:wl_proxy_get_version

--- a/packages/x/xdg-desktop-portal-wlr/package.yml
+++ b/packages/x/xdg-desktop-portal-wlr/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : xdg-desktop-portal-wlr
-version    : 0.7.1
-release    : 3
+version    : 0.8.2
+release    : 4
 source     :
-    - https://github.com/emersion/xdg-desktop-portal-wlr/releases/download/v0.7.1/xdg-desktop-portal-wlr-0.7.1.tar.gz : eec6e4be808e1a445e677dba1e20e5acb2f091825f5ff4c6ac49d5843b2185f9
+    - https://github.com/emersion/xdg-desktop-portal-wlr/releases/download/v0.8.2/xdg-desktop-portal-wlr-0.8.2.tar.gz : 5e6840d3326a4afb440c353ee19cf68d4e4fba40a5648224904b3a06612aae87
 license    : MIT
 component  : desktop.util
 homepage   : https://github.com/emersion/xdg-desktop-portal-wlr
@@ -30,6 +30,7 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license LICENSE
 
     # Install our portal configuration
     install -Dm00644 $pkgfiles/wlroots-portals.conf $installdir/usr/share/xdg-desktop-portal/wlroots-portals.conf

--- a/packages/x/xdg-desktop-portal-wlr/pspec_x86_64.xml
+++ b/packages/x/xdg-desktop-portal-wlr/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xdg-desktop-portal-wlr</Name>
         <Homepage>https://github.com/emersion/xdg-desktop-portal-wlr</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>desktop.util</PartOf>
@@ -23,18 +23,19 @@
             <Path fileType="library">/usr/lib/systemd/user/xdg-desktop-portal-wlr.service</Path>
             <Path fileType="library">/usr/lib64/xdg-desktop-portal-wlr/xdg-desktop-portal-wlr</Path>
             <Path fileType="data">/usr/share/dbus-1/services/org.freedesktop.impl.portal.desktop.wlr.service</Path>
-            <Path fileType="man">/usr/share/man/man5/xdg-desktop-portal-wlr.5</Path>
+            <Path fileType="data">/usr/share/licenses/xdg-desktop-portal-wlr/LICENSE</Path>
+            <Path fileType="man">/usr/share/man/man5/xdg-desktop-portal-wlr.5.zst</Path>
             <Path fileType="data">/usr/share/xdg-desktop-portal/portals/wlr.portal</Path>
             <Path fileType="data">/usr/share/xdg-desktop-portal/wlroots-portals.conf</Path>
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2025-04-05</Date>
-            <Version>0.7.1</Version>
+        <Update release="4">
+            <Date>2026-05-14</Date>
+            <Version>0.8.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Updated to current version.
- Added License

[0.8.2 Release Notes](https://github.com/emersion/xdg-desktop-portal-wlr/releases/tag/v0.8.2)
[0.8.1 Release Notes](https://github.com/emersion/xdg-desktop-portal-wlr/releases/tag/v0.8.1)
[0.8.0 Release Notes](https://github.com/emersion/xdg-desktop-portal-wlr/releases/tag/v0.8.0)

**Test Plan**

Installed on Sway or similar and test functionality with WebRTC getDisplayMedia test

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
