### PR TITLE
uv: update to 0.11.14

### DIFF
--- a/packages/u/uv/abi_used_symbols
+++ b/packages/u/uv/abi_used_symbols
@@ -41,7 +41,6 @@ libc.so.6:eventfd
 libc.so.6:execvp
 libc.so.6:exit
 libc.so.6:fchmod
-libc.so.6:fchown
 libc.so.6:fcntl
 libc.so.6:fdatasync
 libc.so.6:fdopendir
@@ -53,7 +52,6 @@ libc.so.6:fstat64
 libc.so.6:fstatat64
 libc.so.6:ftruncate64
 libc.so.6:futimens
-libc.so.6:futimes
 libc.so.6:gai_strerror
 libc.so.6:getaddrinfo
 libc.so.6:getauxval
@@ -74,7 +72,6 @@ libc.so.6:gnu_get_libc_version
 libc.so.6:ioctl
 libc.so.6:isatty
 libc.so.6:kill
-libc.so.6:lchown
 libc.so.6:linkat
 libc.so.6:lseek64
 libc.so.6:lstat64

--- a/packages/u/uv/package.yml
+++ b/packages/u/uv/package.yml
@@ -1,9 +1,11 @@
+# SPDX-License-Identifier: MPL-2.0
+#
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : uv
-version    : 0.11.2
-release    : 13
+version    : 0.11.14
+release    : 14
 source     :
-    - https://github.com/astral-sh/uv/archive/refs/tags/0.11.2.tar.gz : 12f5f6ce0c4e1e80424329098786dd33195df1c342c926f499f8599d1d2ec694
+    - https://github.com/astral-sh/uv/archive/refs/tags/0.11.14.tar.gz : 17e2cca308b31247079e732f21ca43ac07ee44657dc947560beb0ddbca9121e0
 homepage   : https://docs.astral.sh/uv
 license    :
     - Apache-2.0

--- a/packages/u/uv/pspec_x86_64.xml
+++ b/packages/u/uv/pspec_x86_64.xml
@@ -23,11 +23,12 @@
         <Files>
             <Path fileType="executable">/usr/bin/uv</Path>
             <Path fileType="executable">/usr/bin/uvx</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.2.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.2.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.2.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.2.dist-info/licenses/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.2.dist-info/licenses/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.14.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.14.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.14.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.14.dist-info/licenses/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.14.dist-info/licenses/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.14.dist-info/sboms/uv.cyclonedx.json</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/uv/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/uv/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/uv/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -45,9 +46,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2026-03-29</Date>
-            <Version>0.11.2</Version>
+        <Update release="14">
+            <Date>2026-05-14</Date>
+            <Version>0.11.14</Version>
             <Comment>Packaging update</Comment>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>


### PR DESCRIPTION
## Summary

- Resolves a low severity security advisory in which wheels with malformed RECORD entries could delete arbitrary files on uninstall. See GHSA-pjjw-68hj-v9mw for details.
- Ban external symlinks in .tar.zst wheels
- Improve TLS certificate handling and fix a panic when certificate validation fails
- Normalize paths more consistently by removing trailing separators
- Add `--upgrade-group` and refine `--exclude-newer` behavior in `uv tool list --outdated`
- Respect --require-hashes when installing from pylock.toml files
- Bug fixes
- Release notes:
    - [v0.11.14](https://github.com/astral-sh/uv/releases/tag/0.11.14)
    - [v0.11.13](https://github.com/astral-sh/uv/releases/tag/0.11.13)
    - [v0.11.12](https://github.com/astral-sh/uv/releases/tag/0.11.12)
    - [v0.11.11](https://github.com/astral-sh/uv/releases/tag/0.11.11)
    - [v0.11.10](https://github.com/astral-sh/uv/releases/tag/0.11.10)
    - [v0.11.9](https://github.com/astral-sh/uv/releases/tag/0.11.9)
    - [v0.11.8](https://github.com/astral-sh/uv/releases/tag/0.11.8)
    - [v0.11.7](https://github.com/astral-sh/uv/releases/tag/0.11.7)
    - [v0.11.6](https://github.com/astral-sh/uv/releases/tag/0.11.6)
    - [v0.11.5](https://github.com/astral-sh/uv/releases/tag/0.11.5)
    - [v0.11.4](https://github.com/astral-sh/uv/releases/tag/0.11.4)
    - [v0.11.3](https://github.com/astral-sh/uv/releases/tag/0.11.3)

## Test Plan

- Run smoke tests defined in source
- Installed locally and run some commands.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
