### PR TITLE
zellij: Update to v0.44.3

### DIFF
--- a/packages/z/zellij/package.yml
+++ b/packages/z/zellij/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : zellij
-version    : 0.44.2
-release    : 19
+version    : 0.44.3
+release    : 20
 source     :
-    - https://github.com/zellij-org/zellij/archive/refs/tags/v0.44.2.tar.gz : 8a4c1558135e4dc7375fce8db3524c60289fa5eb5877068fcdeed9650140964d
+    - https://github.com/zellij-org/zellij/archive/refs/tags/v0.44.3.tar.gz : 33ae61fc802b59462fed49b424893596d3aa819646bdce53d5602f714c1264fe
 homepage   : https://zellij.dev
 license    : MIT
 component  : system.utils

--- a/packages/z/zellij/pspec_x86_64.xml
+++ b/packages/z/zellij/pspec_x86_64.xml
@@ -32,9 +32,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2026-05-05</Date>
-            <Version>0.44.2</Version>
+        <Update release="20">
+            <Date>2026-05-14</Date>
+            <Version>0.44.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/zellij-org/zellij/releases/tag/v0.44.3).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new zellij session.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
