### PR TITLE
python-urllib3: Update to v2.7.0

### DIFF
--- a/packages/py/python-urllib3/package.yml
+++ b/packages/py/python-urllib3/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-urllib3
-version    : 2.6.3
-release    : 22
+version    : 2.7.0
+release    : 23
 source     :
-    - https://pypi.debian.net/urllib3/urllib3-2.6.3.tar.gz : 1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed
+    - https://pypi.debian.net/urllib3/urllib3-2.7.0.tar.gz : 231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c
 homepage   : https://urllib3.readthedocs.io/
 license    : MIT
 component  : programming.python

--- a/packages/py/python-urllib3/pspec_x86_64.xml
+++ b/packages/py/python-urllib3/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-urllib3</Name>
         <Homepage>https://urllib3.readthedocs.io/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.python</PartOf>
@@ -20,10 +20,10 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.6.3.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.6.3.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.6.3.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.6.3.dist-info/licenses/LICENSE.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.7.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.7.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.7.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3-2.7.0.dist-info/licenses/LICENSE.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/urllib3/__pycache__/__init__.cpython-312.pyc</Path>
@@ -138,12 +138,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2026-01-24</Date>
-            <Version>2.6.3</Version>
+        <Update release="23">
+            <Date>2026-05-15</Date>
+            <Version>2.7.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst).

**Security**
Includes fixes for:
- CVE-2026-44431
- CVE-2026-44432

**Test Plan**

`python3 -c "import urllib3; print(urllib3.__version__)"` and read correct version. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
