### PR TITLE
m4: Update to 1.4.21

### DIFF
--- a/packages/m/m4/abi_used_symbols
+++ b/packages/m/m4/abi_used_symbols
@@ -6,10 +6,8 @@ libc.so.6:__environ
 libc.so.6:__errno_location
 libc.so.6:__fpending
 libc.so.6:__fprintf_chk
-libc.so.6:__freading
 libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
-libc.so.6:__memcpy_chk
 libc.so.6:__overflow
 libc.so.6:__printf_chk
 libc.so.6:__progname
@@ -37,6 +35,7 @@ libc.so.6:ferror
 libc.so.6:fflush
 libc.so.6:fflush_unlocked
 libc.so.6:fileno
+libc.so.6:fileno_unlocked
 libc.so.6:fopen
 libc.so.6:fputc
 libc.so.6:fputc_unlocked
@@ -56,6 +55,7 @@ libc.so.6:getrandom
 libc.so.6:iconv
 libc.so.6:iconv_close
 libc.so.6:iconv_open
+libc.so.6:ioctl
 libc.so.6:iswalnum
 libc.so.6:iswprint
 libc.so.6:iswspace
@@ -134,7 +134,6 @@ libc.so.6:strdup
 libc.so.6:strerror_r
 libc.so.6:strerrorname_np
 libc.so.6:strlen
-libc.so.6:strncmp
 libc.so.6:strnlen
 libc.so.6:strrchr
 libc.so.6:strsignal

--- a/packages/m/m4/package.yml
+++ b/packages/m/m4/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : m4
-version    : 1.4.20
-release    : 9
+version    : 1.4.21
+release    : 10
 source     :
-    - https://mirror.team-cymru.com/gnu/m4/m4-1.4.20.tar.gz : 6ac4fc31ce440debe63987c2ebbf9d7b6634e67a7c3279257dc7361de8bdb3ef
+    - https://mirror.team-cymru.com/gnu/m4/m4-1.4.21.tar.gz : 38ae59f7a30bf9c108193cc5c25fbb06014f21e230c7ede2eff614f7b7c37ed8
 homepage   : https://www.gnu.org/software/m4/
 license    :
     - GPL-3.0-or-later
@@ -17,6 +17,7 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING
 check      : |
     # test-execute failing,
     # passes if you chroot in and run testsuite...

--- a/packages/m/m4/pspec_x86_64.xml
+++ b/packages/m/m4/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>m4</Name>
         <Homepage>https://www.gnu.org/software/m4/</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>clintre</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>system.devel</PartOf>
@@ -24,6 +24,7 @@
             <Path fileType="info">/usr/share/info/m4.info-1.zst</Path>
             <Path fileType="info">/usr/share/info/m4.info-2.zst</Path>
             <Path fileType="info">/usr/share/info/m4.info.zst</Path>
+            <Path fileType="data">/usr/share/licenses/m4/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/bg/LC_MESSAGES/m4.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/m4.mo</Path>
             <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/m4.mo</Path>
@@ -55,12 +56,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2025-10-28</Date>
-            <Version>1.4.20</Version>
+        <Update release="10">
+            <Date>2026-05-15</Date>
+            <Version>1.4.21</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>clintre</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- glibc 2.43 Support
- fixes regressions in 1.4.20
- Added license

[Full Release Notes](https://lists.gnu.org/archive/html/m4-announce/2026-02/msg00000.html)

**Test Plan**

Ran test suite plus test script

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
