### PR TITLE
python-setuptools-git-versioning: Update to v3.1.0

### DIFF
--- a/packages/py/python-setuptools-git-versioning/package.yml
+++ b/packages/py/python-setuptools-git-versioning/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-setuptools-git-versioning
-version    : 3.0.1
-release    : 2
+version    : 3.1.0
+release    : 3
 source     :
-    - https://files.pythonhosted.org/packages/source/s/setuptools-git-versioning/setuptools_git_versioning-3.0.1.tar.gz : c8a599bacf163b5d215552b5701faf5480ffc4d65426a5711a010b802e1590eb
+    - https://files.pythonhosted.org/packages/source/s/setuptools-git-versioning/setuptools_git_versioning-3.1.0.tar.gz : 612dfcf184addac9e1c2216f4f229724b2390e5bf613fb925ae80b84f2529172
 homepage   : https://pypi.org/project/setuptools-git-versioning/
 license    : MIT
 component  : programming.python

--- a/packages/py/python-setuptools-git-versioning/pspec_x86_64.xml
+++ b/packages/py/python-setuptools-git-versioning/pspec_x86_64.xml
@@ -21,18 +21,20 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/setuptools-git-versioning</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-3.0.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-3.0.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-3.0.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-3.0.1.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-3.0.1.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-3.0.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-3.1.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-3.1.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-3.1.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-3.1.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-3.1.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning-3.1.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/__init__.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/__main__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/__main__.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/archival.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/archival.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/cli.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/cli.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/defaults.cpython-312.opt-1.pyc</Path>
@@ -43,26 +45,30 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/git.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/log.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/log.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/scikit_metadata.cpython-312.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/scikit_metadata.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/setup.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/setup.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/subst.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/subst.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/version.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/__pycache__/version.cpython-312.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/archival.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/cli.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/defaults.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/factories.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/git.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/log.py</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/scikit_metadata.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/setup.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/subst.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/setuptools_git_versioning/version.py</Path>
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2026-01-16</Date>
-            <Version>3.0.1</Version>
+        <Update release="3">
+            <Date>2026-05-16</Date>
+            <Version>3.1.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Changes:
- Added a dynamic-metadata provider compatible with scikit-build-core
- Add support for git archive builds via a tracked .git_archival.txt file

Full release notes available [here](https://github.com/dolfinus/setuptools-git-versioning/releases/tag/v3.1.0)

**Test Plan**

Successfully built `python-toolz`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [ ] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
