### PR TITLE
libvncserver: Update to v0.9.15

### DIFF
--- a/packages/l/libvncserver/abi_symbols
+++ b/packages/l/libvncserver/abi_symbols
@@ -28,6 +28,7 @@ libvncclient.so.1:ReadFromRFBServer
 libvncclient.so.1:ReadFromTLS
 libvncclient.so.1:SameMachine
 libvncclient.so.1:SendClientCutText
+libvncclient.so.1:SendClientCutTextUTF8
 libvncclient.so.1:SendExtDesktopSize
 libvncclient.so.1:SendExtendedKeyEvent
 libvncclient.so.1:SendFramebufferUpdateRequest
@@ -89,9 +90,11 @@ libvncclient.so.1:rfbClientEncryptBytes2
 libvncclient.so.1:rfbClientErr
 libvncclient.so.1:rfbClientExtensions
 libvncclient.so.1:rfbClientGetClientData
+libvncclient.so.1:rfbClientGetUpdateRect
 libvncclient.so.1:rfbClientLog
 libvncclient.so.1:rfbClientRegisterExtension
 libvncclient.so.1:rfbClientSetClientData
+libvncclient.so.1:rfbClientSetUpdateRect
 libvncclient.so.1:rfbEnableClientLogging
 libvncclient.so.1:rfbGetClient
 libvncclient.so.1:rfbHandleAuthResult

--- a/packages/l/libvncserver/abi_used_symbols
+++ b/packages/l/libvncserver/abi_used_symbols
@@ -6,6 +6,7 @@ libc.so.6:__isoc99_sscanf
 libc.so.6:__longjmp_chk
 libc.so.6:__memcpy_chk
 libc.so.6:__printf_chk
+libc.so.6:__read_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail

--- a/packages/l/libvncserver/files/CVE-2026-32853.patch
+++ b/packages/l/libvncserver/files/CVE-2026-32853.patch
@@ -1,0 +1,70 @@
+From 009008e2f4d5a54dd71f422070df3af7b3dbc931 Mon Sep 17 00:00:00 2001
+From: Kazuma Matsumoto <269371721+y637F9QQ2x@users.noreply.github.com>
+Date: Sun, 22 Mar 2026 20:35:49 +0100
+Subject: [PATCH] libvncclient: add bounds checks to UltraZip subrectangle
+ parsing
+
+HandleUltraZipBPP() iterates over sub-rectangles using numCacheRects
+(derived from the attacker-controlled rect.r.x) without validating
+that the pointer stays within the decompressed data buffer. A malicious
+server can set a large numCacheRects value, causing heap out-of-bounds
+reads via the memcpy calls in the parsing loop.
+
+Add bounds checks before reading the 12-byte subrect header and before
+advancing the pointer by the raw pixel data size. Use uint64_t for the
+raw data size calculation to prevent integer overflow on 32-bit platforms.
+---
+ src/libvncclient/ultra.c | 16 +++++++++++++++-
+ 1 file changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/src/libvncclient/ultra.c b/src/libvncclient/ultra.c
+index 1d3aaba..5633b8c 100644
+--- a/src/libvncclient/ultra.c
++++ b/src/libvncclient/ultra.c
+@@ -126,6 +126,7 @@ HandleUltraZipBPP (rfbClient* client, int rx, int ry, int rw, int rh)
+   int toRead=0;
+   int inflateResult=0;
+   unsigned char *ptr=NULL;
++  unsigned char *ptr_end=NULL;
+   lzo_uint uncompressedBytes = ry + (rw * 65535);
+   unsigned int numCacheRects = rx;
+ 
+@@ -194,11 +195,18 @@ HandleUltraZipBPP (rfbClient* client, int rx, int ry, int rw, int rh)
+   
+   /* Put the uncompressed contents of the update on the screen. */
+   ptr = (unsigned char *)client->raw_buffer;
++  ptr_end = ptr + uncompressedBytes;
+   for (i=0; i<numCacheRects; i++)
+   {
+     unsigned short sx, sy, sw, sh;
+     unsigned int se;
+ 
++    /* subrect header: sx(2) + sy(2) + sw(2) + sh(2) + se(4) = 12 bytes */
++    if (ptr + 12 > ptr_end) {
++      rfbClientLog("UltraZip: subrect %d header exceeds decompressed data bounds\n", i);
++      return FALSE;
++    }
++
+     memcpy((char *)&sx, ptr, 2); ptr += 2;
+     memcpy((char *)&sy, ptr, 2); ptr += 2;
+     memcpy((char *)&sw, ptr, 2); ptr += 2;
+@@ -213,8 +221,13 @@ HandleUltraZipBPP (rfbClient* client, int rx, int ry, int rw, int rh)
+ 
+     if (se == rfbEncodingRaw)
+     {
++        uint64_t rawBytes = (uint64_t)sw * sh * (BPP / 8);
++        if (rawBytes > (size_t)(ptr_end - ptr)) {
++          rfbClientLog("UltraZip: subrect %d raw data exceeds decompressed data bounds\n", i);
++          return FALSE;
++        }
+         client->GotBitmap(client, (unsigned char *)ptr, sx, sy, sw, sh);
+-        ptr += ((sw * sh) * (BPP / 8));
++        ptr += (size_t)rawBytes;
+     }
+   }  
+ 
+@@ -222,3 +235,4 @@ HandleUltraZipBPP (rfbClient* client, int rx, int ry, int rw, int rh)
+ }
+ 
+ #undef CARDBPP
++

--- a/packages/l/libvncserver/files/CVE-2026-32854.patch
+++ b/packages/l/libvncserver/files/CVE-2026-32854.patch
@@ -1,0 +1,60 @@
+From dc78dee51a7e270e537a541a17befdf2073f5314 Mon Sep 17 00:00:00 2001
+From: Kazuma Matsumoto <269371721+y637F9QQ2x@users.noreply.github.com>
+Date: Thu, 19 Mar 2026 17:42:00 +0900
+Subject: [PATCH] libvncserver: fix NULL pointer dereferences in httpd proxy
+ handlers
+
+httpProcessInput() passes the return value of strchr() to atoi()
+and strncmp() without checking for NULL. If a CONNECT request
+contains no colon, or a GET request contains no slash, strchr()
+returns NULL, leading to a segmentation fault.
+
+Add NULL checks before using the strchr() return values.
+---
+ src/libvncserver/httpd.c | 24 ++++++++++++++----------
+ 1 file changed, 14 insertions(+), 10 deletions(-)
+
+diff --git a/src/libvncserver/httpd.c b/src/libvncserver/httpd.c
+index f4fe51c..7cefadc 100644
+--- a/src/libvncserver/httpd.c
++++ b/src/libvncserver/httpd.c
+@@ -353,10 +353,11 @@ httpProcessInput(rfbScreenInfoPtr rfbScreen)
+ 
+ 
+     /* Process the request. */
+-    if(rfbScreen->httpEnableProxyConnect) {
++if(rfbScreen->httpEnableProxyConnect) {
+ 	const static char* PROXY_OK_STR = "HTTP/1.0 200 OK\r\nContent-Type: octet-stream\r\nPragma: no-cache\r\n\r\n";
+ 	if(!strncmp(buf, "CONNECT ", 8)) {
+-	    if(atoi(strchr(buf, ':')+1)!=rfbScreen->port) {
++	    char *colon = strchr(buf, ':');
++	    if(colon == NULL || atoi(colon+1)!=rfbScreen->port) {
+ 		rfbErr("httpd: CONNECT format invalid.\n");
+ 		rfbWriteExact(&cl,INVALID_REQUEST_STR, strlen(INVALID_REQUEST_STR));
+ 		httpCloseSock(rfbScreen);
+@@ -369,14 +370,17 @@ httpProcessInput(rfbScreenInfoPtr rfbScreen)
+ 	    rfbScreen->httpSock = RFB_INVALID_SOCKET;
+ 	    return;
+ 	}
+-	if (!strncmp(buf, "GET ",4) && !strncmp(strchr(buf,'/'),"/proxied.connection HTTP/1.", 27)) {
+-	    /* proxy connection */
+-	    rfbLog("httpd: client asked for /proxied.connection\n");
+-	    rfbWriteExact(&cl,PROXY_OK_STR,strlen(PROXY_OK_STR));
+-	    rfbNewClientConnection(rfbScreen,rfbScreen->httpSock);
+-	    rfbScreen->httpSock = RFB_INVALID_SOCKET;
+-	    return;
+-	}	   
++	if (!strncmp(buf, "GET ",4)) {
++	    char *slash = strchr(buf, '/');
++	    if (slash != NULL && !strncmp(slash,"/proxied.connection HTTP/1.", 27)) {
++		/* proxy connection */
++		rfbLog("httpd: client asked for /proxied.connection\n");
++		rfbWriteExact(&cl,PROXY_OK_STR,strlen(PROXY_OK_STR));
++		rfbNewClientConnection(rfbScreen,rfbScreen->httpSock);
++		rfbScreen->httpSock = RFB_INVALID_SOCKET;
++		return;
++	    }
++	}
+     }
+ 
+     if (strncmp(buf, "GET ", 4)) {

--- a/packages/l/libvncserver/package.yml
+++ b/packages/l/libvncserver/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libvncserver
-version    : 0.9.14
-release    : 10
+version    : 0.9.15
+release    : 11
 source     :
-    - https://github.com/LibVNC/libvncserver/archive/LibVNCServer-0.9.14.tar.gz : 83104e4f7e28b02f8bf6b010d69b626fae591f887e949816305daebae527c9a5
+    - https://github.com/LibVNC/libvncserver/archive/LibVNCServer-0.9.15.tar.gz : 62352c7795e231dfce044beb96156065a05a05c974e5de9e023d688d8ff675d7
 homepage   : https://github.com/LibVNC/libvncserver
 license    : GPL-2.0-or-later
 component  : programming.library
@@ -15,8 +15,11 @@ builddeps  :
     - pkgconfig(libgcrypt)
     - pkgconfig(libturbojpeg)
 setup      : |
-    %cmake
+    %patch -p1 -i ${pkgfiles}/CVE-2026-32854.patch
+    %patch -p1 -i ${pkgfiles}/CVE-2026-32853.patch
+    %cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING

--- a/packages/l/libvncserver/pspec_x86_64.xml
+++ b/packages/l/libvncserver/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>libvncserver</Name>
         <Homepage>https://github.com/LibVNC/libvncserver</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>programming.library</PartOf>
         <Summary xml:lang="en">VNC Server Library</Summary>
         <Description xml:lang="en">A library for easy implementation of a VNC server.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>libvncserver</Name>
@@ -20,10 +20,11 @@
 </Description>
         <PartOf>programming.library</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib64/libvncclient.so.0.9.14</Path>
+            <Path fileType="library">/usr/lib64/libvncclient.so.0.9.15</Path>
             <Path fileType="library">/usr/lib64/libvncclient.so.1</Path>
-            <Path fileType="library">/usr/lib64/libvncserver.so.0.9.14</Path>
+            <Path fileType="library">/usr/lib64/libvncserver.so.0.9.15</Path>
             <Path fileType="library">/usr/lib64/libvncserver.so.1</Path>
+            <Path fileType="data">/usr/share/licenses/libvncserver/COPYING</Path>
         </Files>
     </Package>
     <Package>
@@ -33,7 +34,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="10">libvncserver</Dependency>
+            <Dependency release="11">libvncserver</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/rfb/keysym.h</Path>
@@ -54,12 +55,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2023-08-21</Date>
-            <Version>0.9.14</Version>
+        <Update release="11">
+            <Date>2026-05-16</Date>
+            <Version>0.9.15</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/LibVNC/libvncserver/releases/tag/LibVNCServer-0.9.15).
- Patches for CVE's

**Security**
Includes fixes for:
- CVE-2026-32854
- CVE-2026-32853

**Test Plan**

Connect to other computer using `krdc`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
