### PR TITLE
libreoffice: Update to v25.8.7.3

### DIFF
--- a/packages/l/libreoffice/abi_used_symbols
+++ b/packages/l/libreoffice/abi_used_symbols
@@ -485,9 +485,9 @@ libQt6Gui.so.6:_ZN8QPainter18setCompositionModeENS_15CompositionModeE
 libQt6Gui.so.6:_ZN8QPainter4saveEv
 libQt6Gui.so.6:_ZN8QPainter5beginEP12QPaintDevice
 libQt6Gui.so.6:_ZN8QPainter6setPenEN2Qt8PenStyleE
-libQt6Gui.so.6:_ZN8QPainter6setPenERK4QPen
 libQt6Gui.so.6:_ZN8QPainter6setPenERK6QColor
 libQt6Gui.so.6:_ZN8QPainter7restoreEv
+libQt6Gui.so.6:_ZN8QPainter8doSetPenERK4QPenPS0_
 libQt6Gui.so.6:_ZN8QPainter8drawPathERK12QPainterPath
 libQt6Gui.so.6:_ZN8QPainter8fillRectERK5QRectRK6QBrush
 libQt6Gui.so.6:_ZN8QPainter8fillRectERK5QRectRK6QColor

--- a/packages/l/libreoffice/package.yml
+++ b/packages/l/libreoffice/package.yml
@@ -1,12 +1,12 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libreoffice
-version    : 25.8.6.2
-release    : 205
+version    : 25.8.7.3
+release    : 206
 source     :
-    - https://download.documentfoundation.org/libreoffice/src/25.8.6/libreoffice-25.8.6.2.tar.xz : 601969fe95deaab4b1f1f1a16eb8b7fe6af990f33363c5bca23e657b037a7c0f
-    - https://download.documentfoundation.org/libreoffice/src/25.8.6/libreoffice-dictionaries-25.8.6.2.tar.xz : b5a84f37169a3700491422e085d2452eafb8a40258058a060471a53794aa9c9d
-    - https://download.documentfoundation.org/libreoffice/src/25.8.6/libreoffice-help-25.8.6.2.tar.xz : 3c0ffa249b1fac4041b88437f6c5feb6b2badd2cf1f5de23f531937e6ddbaf5b
-    - https://download.documentfoundation.org/libreoffice/src/25.8.6/libreoffice-translations-25.8.6.2.tar.xz : 8aee64da391822afce797306eb4a45b44b438082d00a1c681bddc02471baee55
+    - https://download.documentfoundation.org/libreoffice/src/25.8.7/libreoffice-25.8.7.3.tar.xz : aff5817dabecab65c16eb641ef2799339df29d75d15544ebd8f8c57605fca02d
+    - https://download.documentfoundation.org/libreoffice/src/25.8.7/libreoffice-dictionaries-25.8.7.3.tar.xz : 3402fbd31aa121cb498e2c9aedfbcfcfc24fcbf885916f925e7060692cd2a290
+    - https://download.documentfoundation.org/libreoffice/src/25.8.7/libreoffice-help-25.8.7.3.tar.xz : 26aafc8ae7a283b146ec2b9fedb9afc0728dfbcddf233c007562c222f0be15a6
+    - https://download.documentfoundation.org/libreoffice/src/25.8.7/libreoffice-translations-25.8.7.3.tar.xz : 92eefdb667a7d0227b37e1254abbee0de64e05d23616682d0b57817d50ecb22d
     - https://dev-www.libreoffice.org/src/box2d-2.4.1.tar.gz : d6b4650ff897ee1ead27cf77a5933ea197cbeef6705638dd181adc2e816b23c2
     - https://dev-www.libreoffice.org/src/bsh-2.1.1-src.zip : 2248387ceaa319840434a3547a8b2fec12f95a8418ee039ce5ff5726053a139c
     - https://dev-www.libreoffice.org/src/culmus-0.133.tar.gz : c0c6873742d07544f6bacf2ad52eb9cb392974d56427938dc1dfbc8399c64d05

--- a/packages/l/libreoffice/pspec_x86_64.xml
+++ b/packages/l/libreoffice/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libreoffice</Name>
         <Homepage>https://www.libreoffice.org/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>BSD-2-Clause</License>
@@ -25,13 +25,13 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="205">libreoffice-base</Dependency>
-            <Dependency releaseFrom="205">libreoffice-calc</Dependency>
-            <Dependency releaseFrom="205">libreoffice-common</Dependency>
-            <Dependency releaseFrom="205">libreoffice-common-dictionaries</Dependency>
-            <Dependency releaseFrom="205">libreoffice-draw</Dependency>
-            <Dependency releaseFrom="205">libreoffice-impress</Dependency>
-            <Dependency releaseFrom="205">libreoffice-math</Dependency>
+            <Dependency releaseFrom="206">libreoffice-base</Dependency>
+            <Dependency releaseFrom="206">libreoffice-calc</Dependency>
+            <Dependency releaseFrom="206">libreoffice-common</Dependency>
+            <Dependency releaseFrom="206">libreoffice-common-dictionaries</Dependency>
+            <Dependency releaseFrom="206">libreoffice-draw</Dependency>
+            <Dependency releaseFrom="206">libreoffice-impress</Dependency>
+            <Dependency releaseFrom="206">libreoffice-math</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="doc">/usr/share/doc/libreoffice-all</Path>
@@ -43,8 +43,8 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency release="205">libreoffice-common</Dependency>
-            <Dependency releaseFrom="205">libreoffice-writer</Dependency>
+            <Dependency release="206">libreoffice-common</Dependency>
+            <Dependency releaseFrom="206">libreoffice-writer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/lobase</Path>
@@ -73,7 +73,7 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="205">libreoffice-common-help</Dependency>
+            <Dependency releaseFrom="206">libreoffice-common-help</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/help/am/sdatabase.cfg</Path>
@@ -696,7 +696,7 @@
         <Description xml:lang="en">Calc is the spreadsheet program you&apos;ve always needed.</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="205">libreoffice-writer</Dependency>
+            <Dependency releaseFrom="206">libreoffice-writer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/localc</Path>
@@ -974,7 +974,7 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="205">libreoffice-common-help</Dependency>
+            <Dependency releaseFrom="206">libreoffice-common-help</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/help/am/scalc.cfg</Path>
@@ -1597,7 +1597,7 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="205">libreoffice-common-dictionaries</Dependency>
+            <Dependency releaseFrom="206">libreoffice-common-dictionaries</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/libreoffice</Path>
@@ -15027,7 +15027,7 @@
         <Description xml:lang="en">KDE integration for LibreOffice.</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency release="205">libreoffice-common</Dependency>
+            <Dependency release="206">libreoffice-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/program/libvclplug_kf6lo.so</Path>
@@ -15041,7 +15041,7 @@
         <Description xml:lang="en">Draw lets you produce anything from a quick sketch to a complex plan and gives you the means to communicate with graphics and diagrams.</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="205">libreoffice-writer</Dependency>
+            <Dependency releaseFrom="206">libreoffice-writer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/lodraw</Path>
@@ -15171,7 +15171,7 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="205">libreoffice-common-help</Dependency>
+            <Dependency releaseFrom="206">libreoffice-common-help</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/help/am/sdraw.cfg</Path>
@@ -15794,8 +15794,8 @@
         <Description xml:lang="en">Impress is a truly outstanding tool for creating effective multimedia presentations.</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="205">libreoffice-draw</Dependency>
-            <Dependency releaseFrom="205">libreoffice-writer</Dependency>
+            <Dependency releaseFrom="206">libreoffice-draw</Dependency>
+            <Dependency releaseFrom="206">libreoffice-writer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/loimpress</Path>
@@ -15980,7 +15980,7 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="205">libreoffice-common-help</Dependency>
+            <Dependency releaseFrom="206">libreoffice-common-help</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/help/am/simpress.cfg</Path>
@@ -16603,7 +16603,7 @@
         <Description xml:lang="en">Math is LibreOffice&apos;s formula editor.</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="205">libreoffice-writer</Dependency>
+            <Dependency releaseFrom="206">libreoffice-writer</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/lomath</Path>
@@ -16651,7 +16651,7 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="205">libreoffice-common-help</Dependency>
+            <Dependency releaseFrom="206">libreoffice-common-help</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/help/am/smath.cfg</Path>
@@ -17274,7 +17274,7 @@
         <Description xml:lang="en">Writer has all the features you need from a modern, full-featured word processing and desktop publishing tool.</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="205">libreoffice-common</Dependency>
+            <Dependency releaseFrom="206">libreoffice-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/loweb</Path>
@@ -17616,7 +17616,7 @@
         <Description xml:lang="en">LibreOffice Office Suite</Description>
         <PartOf>office</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="205">libreoffice-common-help</Dependency>
+            <Dependency releaseFrom="206">libreoffice-common-help</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libreoffice/help/am/swriter.cfg</Path>
@@ -18234,12 +18234,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="205">
-            <Date>2026-05-14</Date>
-            <Version>25.8.6.2</Version>
+        <Update release="206">
+            <Date>2026-05-16</Date>
+            <Version>25.8.7.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://www.libreoffice.org/release-notes/).

**Security**
Includes fixes for:
- CVE-2026-4430

**Test Plan**

Wrote a novel in `writer` and saved. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
