### PR TITLE
util-linux: Update to v2.41.4

### DIFF
--- a/packages/u/util-linux/abi_libs
+++ b/packages/u/util-linux/abi_libs
@@ -1,8 +1,14 @@
+agetty
 libblkid.so.1
 libfdisk.so.1
 liblastlog2.so.2
 libmount.so.1
 libsmartcols.so.1
 libuuid.so.1
+logger
+lslogins
 pam_lastlog2.so
 pylibmount.cpython-312-x86_64-linux-gnu.so
+uuidd
+wall
+write

--- a/packages/u/util-linux/abi_symbols
+++ b/packages/u/util-linux/abi_symbols
@@ -1,3 +1,4 @@
+agetty:_IO_stdin_used
 libblkid.so.1:BLKID_1.0
 libblkid.so.1:BLKID_2.15
 libblkid.so.1:BLKID_2.17
@@ -1023,9 +1024,14 @@ libuuid.so.1:uuid_unparse
 libuuid.so.1:uuid_unparse_lower
 libuuid.so.1:uuid_unparse_upper
 libuuid.so.1:uuid_variant
+logger:_IO_stdin_used
+lslogins:_IO_stdin_used
 pam_lastlog2.so:pam_sm_acct_mgmt
 pam_lastlog2.so:pam_sm_authenticate
 pam_lastlog2.so:pam_sm_close_session
 pam_lastlog2.so:pam_sm_open_session
 pam_lastlog2.so:pam_sm_setcred
 pylibmount.cpython-312-x86_64-linux-gnu.so:PyInit_pylibmount
+uuidd:_IO_stdin_used
+wall:_IO_stdin_used
+write:_IO_stdin_used

--- a/packages/u/util-linux/package.yml
+++ b/packages/u/util-linux/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : util-linux
-version    : 2.41.3
-release    : 56
+version    : 2.41.4
+release    : 57
 source     :
-    - https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.3.tar.xz : 3330d873f0fceb5560b89a7dc14e4f3288bbd880e96903ed9b50ec2b5799e58b
+    - https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.4.tar.xz : a8c213cc06048862602a42b2d299b340001f6d05c4407b549f3e03521df83688
 homepage   : https://github.com/util-linux/util-linux
 license    :
     - BSD-3-Clause

--- a/packages/u/util-linux/pspec_x86_64.xml
+++ b/packages/u/util-linux/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>util-linux</Name>
         <Homepage>https://github.com/util-linux/util-linux</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>BSD-4-Clause-UC</License>
@@ -1250,7 +1250,7 @@
         <Description xml:lang="en">Util-linux is a suite of essential tools for any Linux system, such as chsh, kill, cfdisk, mkfs, mount, and more.</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="56">util-linux</Dependency>
+            <Dependency release="57">util-linux</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libblkid.so.1</Path>
@@ -1271,8 +1271,8 @@
         <Description xml:lang="en">Util-linux is a suite of essential tools for any Linux system, such as chsh, kill, cfdisk, mkfs, mount, and more.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="56">util-linux-32bit</Dependency>
-            <Dependency release="56">util-linux-devel</Dependency>
+            <Dependency release="57">util-linux-32bit</Dependency>
+            <Dependency release="57">util-linux-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/lib_fdisk.a</Path>
@@ -1310,7 +1310,7 @@
         <Description xml:lang="en">Util-linux is a suite of essential tools for any Linux system, such as chsh, kill, cfdisk, mkfs, mount, and more.</Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="56">util-linux</Dependency>
+            <Dependency release="57">util-linux</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/blkid/blkid.h</Path>
@@ -1358,12 +1358,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="56">
-            <Date>2026-03-14</Date>
-            <Version>2.41.3</Version>
+        <Update release="57">
+            <Date>2026-05-17</Date>
+            <Version>2.41.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/log).

**Security**
Includes fixes for:
- CVE-2026-27456

**Test Plan**

tested `lsblk` and `fdisk`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
