### PR TITLE
imagemagick: Update to v7.1.2.23

### DIFF
--- a/packages/i/imagemagick/abi_used_symbols
+++ b/packages/i/imagemagick/abi_used_symbols
@@ -292,6 +292,7 @@ libc.so.6:fstat
 libc.so.6:fsync
 libc.so.6:ftello
 libc.so.6:fwrite
+libc.so.6:gai_strerror
 libc.so.6:getaddrinfo
 libc.so.6:getc
 libc.so.6:getcwd
@@ -329,6 +330,7 @@ libc.so.6:posix_fallocate
 libc.so.6:posix_memalign
 libc.so.6:pread
 libc.so.6:pthread_attr_init
+libc.so.6:pthread_attr_setdetachstate
 libc.so.6:pthread_create
 libc.so.6:pthread_getspecific
 libc.so.6:pthread_key_create
@@ -550,6 +552,7 @@ libheif.so.1:heif_encoder_set_parameter
 libheif.so.1:heif_encoding_options_alloc
 libheif.so.1:heif_encoding_options_free
 libheif.so.1:heif_has_compatible_brand
+libheif.so.1:heif_has_compatible_filetype
 libheif.so.1:heif_have_decoder_for_format
 libheif.so.1:heif_have_encoder_for_format
 libheif.so.1:heif_image_add_plane

--- a/packages/i/imagemagick/package.yml
+++ b/packages/i/imagemagick/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : imagemagick
-version    : 7.1.2.21
-release    : 216
+version    : 7.1.2.23
+release    : 217
 source     :
-    - https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-21.tar.gz : 4ba5b81797910efa93e65fb5a02b496284b8069d64513c6d2687c80d180dd70f
+    - https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-23.tar.gz : f129f7d87fc21da453d032dd291b80ea13faf2497f13ef8279d97759ed7d5c46
 homepage   : https://imagemagick.org/
 license    : Apache-2.0
 component  : multimedia.graphics

--- a/packages/i/imagemagick/pspec_x86_64.xml
+++ b/packages/i/imagemagick/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>imagemagick</Name>
         <Homepage>https://imagemagick.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>multimedia.graphics</PartOf>
@@ -94,7 +94,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="216">imagemagick</Dependency>
+            <Dependency release="217">imagemagick</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/ImageMagick-7/Magick++.h</Path>
@@ -377,6 +377,7 @@
             <Path fileType="doc">/usr/share/doc/ImageMagick-7/images/t-shirt.png</Path>
             <Path fileType="doc">/usr/share/doc/ImageMagick-7/images/wand.ico</Path>
             <Path fileType="doc">/usr/share/doc/ImageMagick-7/images/wand.png</Path>
+            <Path fileType="doc">/usr/share/doc/ImageMagick-7/images/wand.svg</Path>
             <Path fileType="doc">/usr/share/doc/ImageMagick-7/images/white-highlight.png</Path>
             <Path fileType="doc">/usr/share/doc/ImageMagick-7/images/wizard.jpg</Path>
             <Path fileType="doc">/usr/share/doc/ImageMagick-7/images/wizard.png</Path>
@@ -593,12 +594,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="216">
-            <Date>2026-05-12</Date>
-            <Version>7.1.2.21</Version>
+        <Update release="217">
+            <Date>2026-05-17</Date>
+            <Version>7.1.2.23</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/ImageMagick/Website/blob/main/ChangeLog.md).

**Security**
Includes fixes for:
- CVE-2026-42326
- CVE-2026-40169
- CVE-2026-45359
- CVE-2026-45358
- CVE-2026-45624
- CVE-2026-45664
- GHSA-3rvp-mpr5-qjm9
- GHSA-36wm-hprc-mcf5
- GHSA-jcqp-6r6f-3mfx
- GHSA-7gg8-qqx7-92g5
- GHSA-533m-3wf6-c33v
- GHSA-88wq-x9gc-45h8
- GHSA-5r4x-w6p5-222q
- GHSA-xf64-q5rg-85g5
- GHSA-4g75-9r48-jf92
- GHSA-p93h-f2jc-477j
- GHSA-rcr6-g7jc-f57g
- GHSA-6gxq-f64p-5w6f
- GHSA-85r7-8qr6-54gh
- GHSA-rw3g-wvj6-3p7w
- GHSA-v6qj-8rm4-fpgj
- GHSA-j3pv-77gf-fw2g
- GHSA-hg5x-pmmv-4q7g
- GHSA-gj92-pwm7-jcmp

**Test Plan**

`magick identify example.png`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
