### PR TITLE
solseek: Update to 1.4.5

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 1.4.1
-release    : 36
+version    : 1.4.5
+release    : 37
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v1.4.1.tar.gz : aab6802af880667846c30f794c37485748985d1bd16978093fb1f7c7eaf5b7a7
+    - https://github.com/clintre/solseek/archive/refs/tags/v1.4.5.tar.gz : bbdca70f43b49b4266e402c640f354186f556910419bd614e567897aeba69702
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -3,7 +3,7 @@
         <Name>solseek</Name>
         <Homepage>https://github.com/clintre/solseek</Homepage>
         <Packager>
-            <Name>Clint Eschberger</Name>
+            <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
@@ -73,11 +73,11 @@
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2026-05-12</Date>
-            <Version>1.4.1</Version>
+        <Update release="37">
+            <Date>2026-05-18</Date>
+            <Version>1.4.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Clint Eschberger</Name>
+            <Name>clintre</Name>
             <Email>clint@eschberger.info</Email>
         </Update>
     </History>


### PR DESCRIPTION
**Summary**

Bugfixes:
- Fixed helper cache script to retry if eopkg index file is not ready yet.
- Fixed issue where solseek was sending too many notifications in a short period. Created a method to limit the calls.
- Fixed a minor formatting issue when using some export tools.
- Fixed an "on load" issue where the Welcome panel would not show the update count due to the update check not being finished by adding a limited retry loop. This may cause a small delay on the help panel load but will not stop use from using solseek.

Enhancements:
- Changed the welcome page to have information up front about the repository settings.
- Change the welcome page layout to accommodate additional information.
- Small performance bump on load

Full Changelog:
https://github.com/clintre/solseek/releases/tag/v1.4.5

**Test Plan**

Install and run

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
