### PR TITLE
qt6-declarative: Symlink for ypkg macro

### DIFF
--- a/packages/q/qt6-declarative/package.yml
+++ b/packages/q/qt6-declarative/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : qt6-declarative
 version    : 6.11.1
-release    : 27
+release    : 28
 source     :
     - https://download.qt.io/official_releases/qt/6.11/6.11.1/submodules/qtdeclarative-everywhere-src-6.11.1.tar.xz : 52e670f670b0304f534b24f98c47ceb8a41bb710464414ebc9527ec71cc86aa4
 license    :
@@ -43,6 +43,8 @@ install    : |
             $installdir/usr/lib64/qt6/qmlcachegen -o "${i}"c "${i}" $*
         fi
     done
+    # Symlink for ypkg macro
+    ln -srv $installdir/usr/lib64/qt6/qmlcachegen $installdir/usr/bin/qmlcachegen6
 patterns   :
     - devel :
         - /usr/bin/qml*

--- a/packages/q/qt6-declarative/pspec_x86_64.xml
+++ b/packages/q/qt6-declarative/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>qt6-declarative</Name>
         <Homepage>https://www.qt.io</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GFDL-1.3-or-later</License>
         <License>GPL-3.0-or-later</License>
@@ -2239,7 +2239,7 @@
 </Description>
         <PartOf>programming.library</PartOf>
         <RuntimeDependencies>
-            <Dependency release="27">qt6-declarative</Dependency>
+            <Dependency release="28">qt6-declarative</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/qt6/examples/qml/tutorials/extending-qml/chapter1-basics/bin/chapter1-basics</Path>
@@ -2348,10 +2348,11 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="27">qt6-declarative</Dependency>
+            <Dependency release="28">qt6-declarative</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/qml6</Path>
+            <Path fileType="executable">/usr/bin/qmlcachegen6</Path>
             <Path fileType="executable">/usr/bin/qmleasing6</Path>
             <Path fileType="executable">/usr/bin/qmlls6</Path>
             <Path fileType="executable">/usr/bin/qmlpreview6</Path>
@@ -5742,12 +5743,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2026-05-12</Date>
+        <Update release="28">
+            <Date>2026-05-18</Date>
             <Version>6.11.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add a symlink for the ypkg macro to use

**Test Plan**

- build kstars, which failed previously

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
