### PR TITLE
azahar: Update to v2125.1.2

### DIFF
--- a/packages/a/azahar/package.yml
+++ b/packages/a/azahar/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : azahar
-version    : 2125.1.1
-release    : 15
+version    : 2125.1.2
+release    : 16
 source     :
-    - https://github.com/azahar-emu/azahar/releases/download/2125.1.1/azahar-unified-source-2125.1.1.tar.xz : a1379f408a8d23825dd8adcd51a621a74719bd25c1a85db58ef2b61e96fba298
+    - https://github.com/azahar-emu/azahar/releases/download/2125.1.2/azahar-unified-source-2125.1.2.tar.xz : 688db108137fa6f4c29b48b187325a622afef7e3147e5f0b83c6996d96f7328f
 homepage   : https://azahar-emu.org/
 license    : GPL-2.0-or-later
 component  : games.emulator

--- a/packages/a/azahar/pspec_x86_64.xml
+++ b/packages/a/azahar/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>azahar</Name>
         <Homepage>https://azahar-emu.org/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>games.emulator</PartOf>
@@ -36,12 +36,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2026-05-15</Date>
-            <Version>2125.1.1</Version>
+        <Update release="16">
+            <Date>2026-05-19</Date>
+            <Version>2125.1.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/azahar-emu/azahar/releases/tag/2125.1.2).
- This is an unscheduled release to put into action new security policies we have enabled for Azahar after the recent TeamPCP supply chain attacks, which affected big open source projects like CEMU Emulator.

This release contains no user-facing changes when compared with 2125.1.1 outside of the security policy changes. We decided to publish this release now so that the new policies are applied as soon as possible. Users may choose to skip this release if they wish.

Please keep in mind that Azahar was NOT compromised by the attacks and our users are safe. We are just being proactive and adding security measures to our release distribution process as a preventative measure.

**Test Plan**
- Played a game.

**Checklist**

- [X] Package was built and tested against unstable
- [X] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
