### PR TITLE
uv: update to 0.11.15

### DIFF
--- a/packages/u/uv/abi_used_symbols
+++ b/packages/u/uv/abi_used_symbols
@@ -200,7 +200,6 @@ libc.so.6:tcsetattr
 libc.so.6:unlink
 libc.so.6:unlinkat
 libc.so.6:utimensat
-libc.so.6:utimes
 libc.so.6:waitid
 libc.so.6:waitpid
 libc.so.6:write
@@ -219,6 +218,5 @@ libgcc_s.so.1:_Unwind_RaiseException
 libgcc_s.so.1:_Unwind_Resume
 libgcc_s.so.1:_Unwind_SetGR
 libgcc_s.so.1:_Unwind_SetIP
-libm.so.6:log2
 libm.so.6:log2f
 libm.so.6:pow

--- a/packages/u/uv/package.yml
+++ b/packages/u/uv/package.yml
@@ -2,10 +2,10 @@
 #
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : uv
-version    : 0.11.14
-release    : 14
+version    : 0.11.15
+release    : 15
 source     :
-    - https://github.com/astral-sh/uv/archive/refs/tags/0.11.14.tar.gz : 17e2cca308b31247079e732f21ca43ac07ee44657dc947560beb0ddbca9121e0
+    - https://github.com/astral-sh/uv/archive/refs/tags/0.11.15.tar.gz : 78d3070b6add2d8f5a28d5781c938b75d2e861736cfe6bf7a88757c395f10a2e
 homepage   : https://docs.astral.sh/uv
 license    :
     - Apache-2.0

--- a/packages/u/uv/pspec_x86_64.xml
+++ b/packages/u/uv/pspec_x86_64.xml
@@ -23,12 +23,12 @@
         <Files>
             <Path fileType="executable">/usr/bin/uv</Path>
             <Path fileType="executable">/usr/bin/uvx</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.14.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.14.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.14.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.14.dist-info/licenses/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.14.dist-info/licenses/LICENSE-MIT</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.14.dist-info/sboms/uv.cyclonedx.json</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.15.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.15.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.15.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.15.dist-info/licenses/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.15.dist-info/licenses/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/uv-0.11.15.dist-info/sboms/uv.cyclonedx.json</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/uv/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/uv/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/uv/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
@@ -46,9 +46,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2026-05-14</Date>
-            <Version>0.11.14</Version>
+        <Update release="15">
+            <Date>2026-05-19</Date>
+            <Version>0.11.15</Version>
             <Comment>Packaging update</Comment>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>


### PR DESCRIPTION
## Summary

- **Security** (moderate)
  - Fix a TAR partial differential, see GHSA-3cv2-h65g-fgmm (#19463)
  - Enforce that entry points cannot escape in the scripts directory, see GHSA-4gg8-gxpx-9rph (#19464)
- Enhancements, Bugfixes
- Release notes:
    - [v0.11.15](https://github.com/astral-sh/uv/releases/tag/0.11.15)

Sync note for security updates:

- uv was updated to 0.11.15-15 (@palto42). Includes security fixes for GHSA-3cv2-h65g-fgmm and GHSA-4gg8-gxpx-9rph.

## Test Plan

- Run smoke tests defined in source
- Installed locally and run some commands.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
