### PR TITLE
anki: Update to 25.09.4

### DIFF
--- a/packages/a/anki/abi_used_symbols
+++ b/packages/a/anki/abi_used_symbols
@@ -115,7 +115,6 @@ libc.so.6:ftruncate64
 libc.so.6:futimens
 libc.so.6:gai_strerror
 libc.so.6:getaddrinfo
-libc.so.6:getauxval
 libc.so.6:getcwd
 libc.so.6:getenv
 libc.so.6:geteuid
@@ -190,7 +189,6 @@ libc.so.6:send
 libc.so.6:setsockopt
 libc.so.6:shutdown
 libc.so.6:sigaction
-libc.so.6:sigaltstack
 libc.so.6:socket
 libc.so.6:socketpair
 libc.so.6:stat64

--- a/packages/a/anki/package.yml
+++ b/packages/a/anki/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : anki
-version    : '25.09.2'
-release    : 52
+version    : '25.09.4'
+release    : 53
 source     :
-    - git|https://github.com/ankitects/anki.git : 25.09.2
+    - git|https://github.com/ankitects/anki.git : 25.09.4
 homepage   : https://apps.ankiweb.net
 license    : AGPL-3.0-or-later
 component  : office.notes
@@ -52,5 +52,6 @@ install    : |
     install -Dm00644 $workdir/qt/launcher/lin/anki.desktop $installdir/usr/share/applications/anki.desktop
     install -Dm00644 $pkgfiles/net.ankiweb.Anki.appdata.xml -t $installdir/usr/share/metainfo
     install -Dm00644 $pkgfiles/anki.svg -t $installdir/usr/share/icons/hicolor/scalable/apps
+    %install_license LICENSE
     #Windows-only
     rm $installdir/usr/bin/ankiw

--- a/packages/a/anki/pspec_x86_64.xml
+++ b/packages/a/anki/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>anki</Name>
         <Homepage>https://apps.ankiweb.net</Homepage>
         <Packager>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>AGPL-3.0-or-later</License>
         <PartOf>office.notes</PartOf>
@@ -229,17 +229,16 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/CPuIZvQd.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/CQ-9KGf5.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/CcaWrs5J.mjs</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/Cd6aGhTc.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/Cfg-5ksk.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/Ch7ZtZmv.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/CmYyQsAK.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/CtwPNh8B.mjs</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/CyTsZL-R.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/D0Kcqh4a.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/D1slsF82.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/D3ZK_B5Q.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/DB8w6JNV.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/DDmBsGOt.mjs</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/DUn2kAr0.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/DYn6QD_Z.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/Dbye-yJ_.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/Dg4D5_bH.mjs</Path>
@@ -251,16 +250,17 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/dPqBMmTD.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/eu2iBpjS.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/jkNgFhw5.mjs</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/oIEOMeNB.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/pYEVaWiA.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/chunks/xV9jLUMk.mjs</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/entry/app.trhiyFpT.mjs</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/entry/start.FpRVTpLv.mjs</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/entry/app.CHFIqkrN.mjs</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/entry/start.DyduPMxl.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/0.DHbGSFfX.mjs</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/1.CxyjeeTf.mjs</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/1.BuVTYRdb.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/10.TdgkMK5f.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/11.D6MvdDJk.mjs</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/2.Cgp2tt_o.mjs</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/3.BZcMcu4H.mjs</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/2.BgEQOqhz.mjs</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/3.BsKvhRBP.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/4.D_KsvzH5.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/5.DZqivpEk.mjs</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/data/web/sveltekit/_app/immutable/nodes/6.DOPo5mhD.mjs</Path>
@@ -398,9 +398,9 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/hooks.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/props.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/_aqt/py.typed</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/anki-25.9.2.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/anki-25.9.2.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/anki-25.9.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/anki-25.9.4.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/anki-25.9.4.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/anki-25.9.4.dist-info/WHEEL</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/anki/__pycache__/_backend.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/anki/__pycache__/_backend.cpython-312.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/anki/__pycache__/_backend_generated.cpython-312.opt-1.pyc</Path>
@@ -653,10 +653,10 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/anki/template.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/anki/types.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/anki/utils.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/aqt-25.9.2.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/aqt-25.9.2.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/aqt-25.9.2.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/aqt-25.9.2.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/aqt-25.9.4.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/aqt-25.9.4.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/aqt-25.9.4.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/aqt-25.9.4.dist-info/entry_points.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/aqt/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/aqt/__pycache__/__init__.cpython-312.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/aqt/__pycache__/__init__.cpython-312.pyc</Path>
@@ -1074,16 +1074,17 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/aqt/winpaths.py</Path>
             <Path fileType="data">/usr/share/applications/anki.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/anki.svg</Path>
+            <Path fileType="data">/usr/share/licenses/anki/LICENSE</Path>
             <Path fileType="data">/usr/share/metainfo/net.ankiweb.Anki.appdata.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="52">
-            <Date>2025-09-20</Date>
-            <Version>25.09.2</Version>
+        <Update release="53">
+            <Date>2026-05-19</Date>
+            <Version>25.09.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Thomas Staudinger</Name>
-            <Email>Staudi.Kaos@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Both releases are security related, but no CVEs
Added License

Security:
- Importing untrusted decks (.apkg files) had the ability to read local files. This has now been fixed.
- Ankis local media server did not sufficiently validate requests, which could allow a malicious website to read local files while Anki was running. This had the potential to affect mostly Firefox and Safari users. Chrome already restricts local network access.

[25.09.4 Release Notes](https://github.com/ankitects/anki/releases/tag/25.09.4)
[25.09.3 Release Notes](https://github.com/ankitects/anki/releases/tag/25.09.3)

**Test Plan**

Install, open, and test features

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
