### PR TITLE
Fix CVE-2026-46529

### DIFF
--- a/packages/a/atril/abi_libs
+++ b/packages/a/atril/abi_libs
@@ -1,3 +1,6 @@
+atril
+atril-previewer
+atril-thumbnailer
 libatril-properties-page.so
 libatrildocument.so.3
 libatrilview.so.3

--- a/packages/a/atril/abi_symbols
+++ b/packages/a/atril/abi_symbols
@@ -1,3 +1,6 @@
+atril:_IO_stdin_used
+atril-previewer:_IO_stdin_used
+atril-thumbnailer:_IO_stdin_used
 libatril-properties-page.so:caja_module_initialize
 libatril-properties-page.so:caja_module_list_types
 libatril-properties-page.so:caja_module_shutdown

--- a/packages/a/atril/abi_used_symbols
+++ b/packages/a/atril/abi_used_symbols
@@ -511,6 +511,7 @@ libglib-2.0.so.0:g_filename_from_uri
 libglib-2.0.so.0:g_filename_to_uri
 libglib-2.0.so.0:g_find_program_in_path
 libglib-2.0.so.0:g_free
+libglib-2.0.so.0:g_free_sized
 libglib-2.0.so.0:g_get_application_name
 libglib-2.0.so.0:g_get_charset
 libglib-2.0.so.0:g_get_home_dir

--- a/packages/a/atril/files/cve-2026-46529.patch
+++ b/packages/a/atril/files/cve-2026-46529.patch
@@ -1,0 +1,64 @@
+From b989b7922a454ed81f8bb14786a958828513f576 Mon Sep 17 00:00:00 2001
+From: Victor Kareh <vkareh@redhat.com>
+Date: Thu, 14 May 2026 20:56:31 -0400
+Subject: [PATCH] ev-application: Quote user-supplied strings in ev_spawn
+ command line
+
+When spawning a new atril instance for cross-document links, the
+destination and search parameters from the document were interpolated
+directly into the command line without shell quoting. Values containing
+spaces or special characters could be split into separate arguments by
+the shell parser, potentially being interpreted as unintended flags by
+the child process.
+
+Apply shell quoting to page label, named destination, and search string
+values before appending them to the command line, consistent with how
+other spawn sites in the codebase already handle this.
+---
+ shell/ev-application.c | 20 +++++++++++++-------
+ 1 file changed, 13 insertions(+), 7 deletions(-)
+
+diff --git a/shell/ev-application.c b/shell/ev-application.c
+index 57f1b9225..37d35eaa7 100644
+--- a/shell/ev-application.c
++++ b/shell/ev-application.c
+@@ -221,18 +221,22 @@ ev_spawn (const char     *uri,
+ 	/* Page label or index */
+ 	if (dest) {
+ 		switch (ev_link_dest_get_dest_type (dest)) {
+-		case EV_LINK_DEST_TYPE_PAGE_LABEL:
+-			g_string_append_printf (cmd, " --page-label=%s",
+-			                        ev_link_dest_get_page_label (dest));
++		case EV_LINK_DEST_TYPE_PAGE_LABEL: {
++			gchar *quoted = g_shell_quote (ev_link_dest_get_page_label (dest));
++			g_string_append_printf (cmd, " --page-label=%s", quoted);
++			g_free (quoted);
+ 			break;
++		}
+ 		case EV_LINK_DEST_TYPE_PAGE:
+ 			g_string_append_printf (cmd, " --page-index=%d",
+ 			                        ev_link_dest_get_page (dest) + 1);
+ 			break;
+-		case EV_LINK_DEST_TYPE_NAMED:
+-		g_string_append_printf (cmd, " --named-dest=%s",
+-			                    ev_link_dest_get_named_dest (dest));
++		case EV_LINK_DEST_TYPE_NAMED: {
++			gchar *quoted = g_shell_quote (ev_link_dest_get_named_dest (dest));
++			g_string_append_printf (cmd, " --named-dest=%s", quoted);
++			g_free (quoted);
+ 			break;
++		}
+ 		default:
+ 			break;
+ 		}
+@@ -240,7 +244,9 @@ ev_spawn (const char     *uri,
+ 
+ 	/* Find string */
+ 	if (search_string) {
+-		g_string_append_printf (cmd, " --find=%s", search_string);
++		gchar *quoted = g_shell_quote (search_string);
++		g_string_append_printf (cmd, " --find=%s", quoted);
++		g_free (quoted);
+ 	}
+ 
+ 	/* Mode */

--- a/packages/a/atril/package.yml
+++ b/packages/a/atril/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : atril
 version    : 1.28.3
-release    : 47
+release    : 48
 source     :
     - https://github.com/mate-desktop/atril/releases/download/v1.28.3/atril-1.28.3.tar.xz : 1a89724cdfb8af83fa44f08d89d66049f9aac053b28be9cef13eb27148a970da
 homepage   : https://mate-desktop.org/
@@ -25,10 +25,14 @@ builddeps  :
     - pkgconfig(webkit2gtk-4.1)
     - itstool
 setup      : |
-    %configure --disable-static \
+    %patch -p1 -i ${pkgfiles}/cve-2026-46529.patch
+
+    %configure \
+        --disable-static \
         --enable-epub \
         --enable-gtk-doc
 build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING

--- a/packages/a/atril/pspec_x86_64.xml
+++ b/packages/a/atril/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>atril</Name>
         <Homepage>https://mate-desktop.org/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.mate</PartOf>
@@ -5755,6 +5755,7 @@
             <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/atril.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/64x64/apps/atril.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/atril.svg</Path>
+            <Path fileType="data">/usr/share/licenses/atril/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/atril.mo</Path>
             <Path fileType="localedata">/usr/share/locale/am/LC_MESSAGES/atril.mo</Path>
             <Path fileType="localedata">/usr/share/locale/ar/LC_MESSAGES/atril.mo</Path>
@@ -5904,7 +5905,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="47">atril</Dependency>
+            <Dependency release="48">atril</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/atril/1.5.0/atril-document.h</Path>
@@ -6091,12 +6092,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="47">
-            <Date>2026-02-15</Date>
+        <Update release="48">
+            <Date>2026-05-19</Date>
             <Version>1.28.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/e/evince/abi_used_symbols
+++ b/packages/e/evince/abi_used_symbols
@@ -552,6 +552,7 @@ libglib-2.0.so.0:g_filename_to_uri
 libglib-2.0.so.0:g_find_program_in_path
 libglib-2.0.so.0:g_format_size
 libglib-2.0.so.0:g_free
+libglib-2.0.so.0:g_free_sized
 libglib-2.0.so.0:g_get_application_name
 libglib-2.0.so.0:g_get_charset
 libglib-2.0.so.0:g_get_home_dir

--- a/packages/e/evince/package.yml
+++ b/packages/e/evince/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : evince
-version    : '48.1'
-release    : 69
+version    : '48.4'
+release    : 70
 source     :
-    - https://download.gnome.org/sources/evince/48/evince-48.1.tar.xz : 7d8b9a6fa3a05d3f5b9048859027688c73a788ff6e923bc3945126884943fa10
+    - https://download.gnome.org/sources/evince/48/evince-48.4.tar.xz : f296c5c662886635d4cd597e8ac0afcde7982be4486533c2b7f095b268be8668
 homepage   : https://apps.gnome.org/Evince/
 license    : GPL-2.0-or-later
 component  : office.viewers

--- a/packages/e/evince/pspec_x86_64.xml
+++ b/packages/e/evince/pspec_x86_64.xml
@@ -2913,7 +2913,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="69">evince</Dependency>
+            <Dependency release="70">evince</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/evince/3.0/evince-document.h</Path>
@@ -2975,9 +2975,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="69">
-            <Date>2026-03-17</Date>
-            <Version>48.1</Version>
+        <Update release="70">
+            <Date>2026-05-19</Date>
+            <Version>48.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>

--- a/packages/p/papers/files/cve-2026-46529.patch
+++ b/packages/p/papers/files/cve-2026-46529.patch
@@ -1,0 +1,44 @@
+From 1b82bf627b4d8b414a57b55a9095e6d361799d6c Mon Sep 17 00:00:00 2001
+From: Lucas Baudin <lbaudin@gnome.org>
+Date: Sat, 16 May 2026 00:25:31 +0200
+Subject: [PATCH] shell: escape link arguments before spawning a new process
+
+---
+ shell/src/application.rs | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/shell/src/application.rs b/shell/src/application.rs
+index f0b9b2887..f12c20308 100644
+--- a/shell/src/application.rs
++++ b/shell/src/application.rs
+@@ -494,7 +494,12 @@ pub fn spawn(file: Option<&gio::File>, dest: Option<&LinkDest>, mode: Option<Win
+                 match dest.dest_type() {
+                     LinkDestType::PageLabel => {
+                         cmd.push_str(" --page-label=");
+-                        cmd.push_str(&dest.page_label().unwrap_or_default());
++                        cmd.push_str(
++                            glib::shell_quote(dest.page_label().unwrap_or_default())
++                                .as_os_str()
++                                .to_str()
++                                .unwrap_or_default(),
++                        );
+                     }
+                     LinkDestType::Page
+                     | LinkDestType::Xyz
+@@ -506,7 +511,12 @@ pub fn spawn(file: Option<&gio::File>, dest: Option<&LinkDest>, mode: Option<Win
+                     }
+                     LinkDestType::Named => {
+                         cmd.push_str(" --named-dest=");
+-                        cmd.push_str(&dest.named_dest().unwrap_or_default())
++                        cmd.push_str(
++                            glib::shell_quote(dest.named_dest().unwrap_or_default())
++                                .as_os_str()
++                                .to_str()
++                                .unwrap_or_default(),
++                        );
+                     }
+                     _ => (),
+                 }
+-- 
+GitLab
+

--- a/packages/p/papers/package.yml
+++ b/packages/p/papers/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : papers
 version    : '50.1'
-release    : 19
+release    : 20
 source     :
     - https://download.gnome.org/sources/papers/50/papers-50.1.tar.xz : f79ce4b950cf5111dc48e8b7dc1728b1651c80f32f0e24dce55371993ccab270
 homepage   : https://apps.gnome.org/Papers/
@@ -25,11 +25,14 @@ builddeps  :
     - itstool
     - rust-devel
 setup      : |
+    %patch -p1 -i ${pkgfiles}/cve-2026-46529.patch
+
     %meson_configure -Ddocumentation=false
 build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING
 check      : |
     # Failed on appdata validation but it doesn't affect function, disable test for now
     #ninja_check

--- a/packages/p/papers/pspec_x86_64.xml
+++ b/packages/p/papers/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>papers</Name>
         <Homepage>https://apps.gnome.org/Papers/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>office.viewers</PartOf>
@@ -2522,6 +2522,7 @@
             <Path fileType="doc">/usr/share/help/zh_TW/papers/translate.page</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/org.gnome.Papers.svg</Path>
             <Path fileType="data">/usr/share/icons/hicolor/symbolic/apps/org.gnome.Papers-symbolic.svg</Path>
+            <Path fileType="data">/usr/share/licenses/papers/COPYING</Path>
             <Path fileType="localedata">/usr/share/locale/ab/LC_MESSAGES/papers.mo</Path>
             <Path fileType="localedata">/usr/share/locale/af/LC_MESSAGES/papers.mo</Path>
             <Path fileType="localedata">/usr/share/locale/an/LC_MESSAGES/papers.mo</Path>
@@ -2642,7 +2643,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="19">papers</Dependency>
+            <Dependency release="20">papers</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/papers/4.0/libdocument/pps-annotation.h</Path>
@@ -2716,12 +2717,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2026-04-14</Date>
+        <Update release="20">
+            <Date>2026-05-19</Date>
             <Version>50.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/x/xreader/package.yml
+++ b/packages/x/xreader/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : xreader
-version    : 4.6.3
-release    : 8
+version    : 4.6.5
+release    : 9
 source     :
-    - https://github.com/linuxmint/xreader/archive/refs/tags/4.6.3.tar.gz : fefcee0ea9810b4039e5150145a126545c731ab47cc7bad76c04cde139ed5a71
+    - https://github.com/linuxmint/xreader/archive/refs/tags/4.6.5.tar.gz : 502e069c9f20861544067433ec81a3859c9453b931b58f38e5e442381dc39528
 homepage   : https://github.com/linuxmint/xreader
 license    : GPL-2.0-or-later
 component  : office.viewers
@@ -28,6 +28,8 @@ builddeps  :
     - itstool
     - mathjax2
     - yelp-tools
+rundeps    :
+    - xapp-symbolic-icons
 setup      : |
     %meson_configure \
         -Ddjvu=true \

--- a/packages/x/xreader/pspec_x86_64.xml
+++ b/packages/x/xreader/pspec_x86_64.xml
@@ -287,7 +287,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="8">xreader</Dependency>
+            <Dependency release="9">xreader</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/xreader/1.5/libdocument/ev-annotation.h</Path>
@@ -348,9 +348,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2026-03-31</Date>
-            <Version>4.6.3</Version>
+        <Update release="9">
+            <Date>2026-05-19</Date>
+            <Version>4.6.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**

- **evince: Update to v48.4**
- **xreader: Update to v4.6.5**
- **papers: Backport security patch**
- **atril: Backport security patch**

Note that while Atril has a new release, we can't really use it. The tarball is missing the configure file, reconfigure doesn't work (build failure), and the Meson build needs at least one other MATE dep that we don't have. I opted to just backport the patch instead.

**Test Plan**

Open a PDF file in each program.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
