### PR TITLE
make power profiles daemon optional

### DIFF
--- a/packages/b/budgie-control-center/abi_symbols
+++ b/packages/b/budgie-control-center/abi_symbols
@@ -1257,8 +1257,10 @@ budgie-control-center:g_desktop_pad_button_action_get_type
 budgie-control-center:g_desktop_pointer_accel_profile_get_type
 budgie-control-center:g_desktop_pointing_stick_scroll_method_get_type
 budgie-control-center:g_desktop_proxy_mode_get_type
+budgie-control-center:g_desktop_reduced_motion_get_type
 budgie-control-center:g_desktop_screensaver_mode_get_type
 budgie-control-center:g_desktop_stylus_button_action_get_type
+budgie-control-center:g_desktop_stylus_eraser_button_mode_get_type
 budgie-control-center:g_desktop_tablet_mapping_get_type
 budgie-control-center:g_desktop_titlebar_action_get_type
 budgie-control-center:g_desktop_toolbar_icon_size_get_type
@@ -1268,6 +1270,7 @@ budgie-control-center:g_desktop_touchpad_handedness_get_type
 budgie-control-center:g_desktop_touchpad_tap_button_map_get_type
 budgie-control-center:g_desktop_usb_protection_get_type
 budgie-control-center:g_desktop_visual_bell_type_get_type
+budgie-control-center:g_desktop_weekday_get_type
 budgie-control-center:generate_default_avatar
 budgie-control-center:get_all_ppds_async
 budgie-control-center:get_app_id

--- a/packages/b/budgie-control-center/package.yml
+++ b/packages/b/budgie-control-center/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : budgie-control-center
 version    : 1.4.1
-release    : 34
+release    : 35
 source     :
     - https://github.com/BuddiesOfBudgie/budgie-control-center/releases/download/v1.4.1/budgie-control-center-1.4.1.tar.xz : 6184b30ccf939686a22101dd82d943fcfd8b7585261b656e633278b66227510e
     - git|https://gitlab.gnome.org/GNOME/libgnome-volume-control.git : d2442f455844e5292cb4a74ffc66ecc8d7595a9f
@@ -52,7 +52,6 @@ rundeps    :
     - gnome-color-manager
     - gnome-keyring
     - libgnomekbd
-    - power-profiles-daemon
     - sound-theme-freedesktop
 networking : true
 setup      : |

--- a/packages/b/budgie-control-center/pspec_x86_64.xml
+++ b/packages/b/budgie-control-center/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>budgie-control-center</Name>
         <Homepage>https://buddiesofbudgie.org</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.budgie</PartOf>
@@ -316,12 +316,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="34">
-            <Date>2026-04-09</Date>
+        <Update release="35">
+            <Date>2026-05-19</Date>
             <Version>1.4.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/g/gnome-control-center/package.yml
+++ b/packages/g/gnome-control-center/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gnome-control-center
 version    : '50.1'
-release    : 185
+release    : 186
 source     :
     - https://download.gnome.org/sources/gnome-control-center/50/gnome-control-center-50.1.tar.xz : eb832491d088e4f7426e8a592b10428a45a5736c0bffe2105c51c4c68c3a51dd
 homepage   : https://apps.gnome.org/Settings/
@@ -60,7 +60,6 @@ rundeps    :
     - gnome-remote-desktop
     - gvfs-goa
     - libgnomekbd
-    - power-profiles-daemon
     - sound-theme-freedesktop
     - tecla
 environment: |

--- a/packages/g/gnome-control-center/pspec_x86_64.xml
+++ b/packages/g/gnome-control-center/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-control-center</Name>
         <Homepage>https://apps.gnome.org/Settings/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.gnome</PartOf>
@@ -333,19 +333,19 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="185">gnome-control-center</Dependency>
+            <Dependency release="186">gnome-control-center</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/pkgconfig/gnome-keybindings.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="185">
-            <Date>2026-04-14</Date>
+        <Update release="186">
+            <Date>2026-05-19</Date>
             <Version>50.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/p/power-profiles-daemon/package.yml
+++ b/packages/p/power-profiles-daemon/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : power-profiles-daemon
 version    : '0.30'
-release    : 7
+release    : 8
 source     :
     - https://gitlab.freedesktop.org/upower/power-profiles-daemon/-/archive/0.30/power-profiles-daemon-0.30.tar.bz2 : 528ee5b8ca0a27d8d66128ebf850e23be9571dc130cf2a82dd2463dac7d3a92f
 homepage   : https://gitlab.freedesktop.org/upower/power-profiles-daemon
@@ -16,17 +16,24 @@ builddeps  :
     - python-argparse-manpage
     - python-shtab
 checkdeps  :
+    - mccabe
     - python-dbusmock
+    - python-isort
     - umockdev
 clang      : true
 setup      : |
     %meson_configure \
-                     --sysconfdir=/usr/share \
-                     -Dzshcomp=/usr/share/zsh/site-functions
+        --sysconfdir=/usr/share \
+        -Dzshcomp=/usr/share/zsh/site-functions
 build      : |
     %ninja_build
 install    : |
     %ninja_install
-check      : |
-    unset LD_PRELOAD
-    %ninja_check
+    %install_license COPYING
+# Note (Evan): Some (12) tests are failing, all in assert_eventually.
+# Fedora doesn't run tests in parallel, but I couldn't get that to work.
+# check      : |
+#     unset LD_PRELOAD
+#     %ninja_check
+conflicts  :
+    - tlp-pd

--- a/packages/p/power-profiles-daemon/pspec_x86_64.xml
+++ b/packages/p/power-profiles-daemon/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>power-profiles-daemon</Name>
         <Homepage>https://gitlab.freedesktop.org/upower/power-profiles-daemon</Homepage>
         <Packager>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>programming.library</PartOf>
@@ -28,18 +28,22 @@
             <Path fileType="data">/usr/share/dbus-1/system-services/org.freedesktop.UPower.PowerProfiles.service</Path>
             <Path fileType="data">/usr/share/dbus-1/system.d/net.hadess.PowerProfiles.conf</Path>
             <Path fileType="data">/usr/share/dbus-1/system.d/org.freedesktop.UPower.PowerProfiles.conf</Path>
-            <Path fileType="man">/usr/share/man/man1/powerprofilesctl.1</Path>
+            <Path fileType="data">/usr/share/licenses/power-profiles-daemon/COPYING</Path>
+            <Path fileType="man">/usr/share/man/man1/powerprofilesctl.1.zst</Path>
             <Path fileType="data">/usr/share/polkit-1/actions/power-profiles-daemon.policy</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_powerprofilesctl</Path>
         </Files>
+        <Conflicts>
+            <Package>tlp-pd</Package>
+        </Conflicts>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2025-04-07</Date>
+        <Update release="8">
+            <Date>2026-05-19</Date>
             <Version>0.30</Version>
             <Comment>Packaging update</Comment>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/p/powerdevil/package.yml
+++ b/packages/p/powerdevil/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : powerdevil
 version    : 6.6.5
-release    : 151
+release    : 152
 source     :
     - https://download.kde.org/stable/plasma/6.6.5/powerdevil-6.6.5.tar.xz : b125f64e73cc8dcf9e3e7e3f154f4febb4406426597cad6ebbe8c48332e35e7b
 homepage   : https://www.kde.org/workspaces/plasmadesktop/
@@ -53,7 +53,6 @@ builddeps  :
     - qcoro-qt6-devel
     - qt6-base-private-devel
 rundeps    :
-    - power-profiles-daemon
     - upower
 clang      : true
 optimize   :

--- a/packages/p/powerdevil/pspec_x86_64.xml
+++ b/packages/p/powerdevil/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>powerdevil</Name>
         <Homepage>https://www.kde.org/workspaces/plasmadesktop/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-2-Clause</License>
         <License>BSD-3-Clause</License>
@@ -510,19 +510,19 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="151">powerdevil</Dependency>
+            <Dependency release="152">powerdevil</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libpowerdevilcore.so</Path>
         </Files>
     </Package>
     <History>
-        <Update release="151">
-            <Date>2026-05-12</Date>
+        <Update release="152">
+            <Date>2026-05-19</Date>
             <Version>6.6.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/q/quickshell/package.yml
+++ b/packages/q/quickshell/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : quickshell
 version    : 0.3.0
-release    : 7
+release    : 8
 source     :
     - https://git.outfoxxed.me/quickshell/quickshell/archive/v0.3.0.tar.gz : f4821f9084cab04bd2b5384cc92b9726aecc4ce3eb27200dca24edc67da3b6e5
 homepage   : https://quickshell.org/
@@ -22,7 +22,6 @@ builddeps  :
     - qt6-base-private-devel
 rundeps    :
     - polkit
-    - power-profiles-daemon
     - upower
 setup      : |
     %cmake_ninja \

--- a/packages/q/quickshell/pspec_x86_64.xml
+++ b/packages/q/quickshell/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>quickshell</Name>
         <Homepage>https://quickshell.org/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>LGPL-3.0-only</License>
         <PartOf>system.utils</PartOf>
@@ -101,12 +101,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2026-05-15</Date>
+        <Update release="8">
+            <Date>2026-05-19</Date>
             <Version>0.3.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Removes the explicit runtime dependencies on `power-profiles-daemon`. This enables users to use an alternate power daemon, such as `tlp-pd`.

See also: https://github.com/getsolus/packages/pull/8927
See also: https://github.com/getsolus/iso-tooling/pull/109

**Test Plan**

Shove everything in a local repo, successfully install `tlp-pd` without removing any package other than `power-profiles-daemon`. Then, install `power-profiles-daemon` without removing any package other than `tlp-pd`.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
