### PR TITLE
docker security updates

### DIFF
--- a/packages/b/buildkit/package.yml
+++ b/packages/b/buildkit/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : buildkit
-version    : 0.29.0
-release    : 9
+version    : 0.30.0
+release    : 10
 source     :
-    - https://github.com/moby/buildkit/archive/refs/tags/v0.29.0.tar.gz : 243d6ba77404467f90087a9141af5f755f1e8aa22d4b4c42ce87a1b898d9b8b2
+    - https://github.com/moby/buildkit/archive/refs/tags/v0.30.0.tar.gz : d7ec8c8657ad0c8b1b29219d923afb693b3a6321748aac034c3afee2973b07c8
 homepage   : https://github.com/moby/buildkit
 license    : Apache-2.0
 component  : virt

--- a/packages/b/buildkit/pspec_x86_64.xml
+++ b/packages/b/buildkit/pspec_x86_64.xml
@@ -30,9 +30,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2026-04-18</Date>
-            <Version>0.29.0</Version>
+        <Update release="10">
+            <Date>2026-05-20</Date>
+            <Version>0.30.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>

--- a/packages/d/docker-buildx/package.yml
+++ b/packages/d/docker-buildx/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : docker-buildx
-version    : 0.33.0
-release    : 27
+version    : 0.34.1
+release    : 28
 source     :
-    - https://github.com/docker/buildx/archive/refs/tags/v0.33.0.tar.gz : 00b5d5093f6b6cb75fd687988fb395253d10a5ca4d7e4c6b26af3914c219d2d7
+    - https://github.com/docker/buildx/archive/refs/tags/v0.34.1.tar.gz : 907846895a843d1dc4fb6962f05567b0c279a2eca83be7461b5928125ebdcc51
 homepage   : https://www.docker.com
 license    : Apache-2.0
 component  : virt

--- a/packages/d/docker-buildx/pspec_x86_64.xml
+++ b/packages/d/docker-buildx/pspec_x86_64.xml
@@ -25,9 +25,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2026-04-18</Date>
-            <Version>0.33.0</Version>
+        <Update release="28">
+            <Date>2026-05-20</Date>
+            <Version>0.34.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>

--- a/packages/d/docker/package.yml
+++ b/packages/d/docker/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : docker
-version    : 29.4.2
-release    : 74
+version    : 29.5.1
+release    : 75
 source     :
-    - https://github.com/docker/cli/archive/refs/tags/v29.4.2.tar.gz : 87d5f01a880bdd329af5fb57120b83b7e3bd215d8046b67a0b6d303293e91a1f
+    - https://github.com/docker/cli/archive/refs/tags/v29.5.1.tar.gz : de3cdd74a66f4cfe843983e4ca8d2133cf5eecc8ad8b5450cec0b7ccd59f921d
 homepage   : https://www.docker.com
 license    : Apache-2.0
 component  : virt

--- a/packages/d/docker/pspec_x86_64.xml
+++ b/packages/d/docker/pspec_x86_64.xml
@@ -218,9 +218,9 @@ Docker containers are both hardware-agnostic and platform-agnostic. This means t
         </Files>
     </Package>
     <History>
-        <Update release="74">
-            <Date>2026-05-04</Date>
-            <Version>29.4.2</Version>
+        <Update release="75">
+            <Date>2026-05-20</Date>
+            <Version>29.5.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>

--- a/packages/m/moby/package.yml
+++ b/packages/m/moby/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : moby
-version    : 29.4.2
-release    : 30
+version    : 29.5.1
+release    : 31
 source     :
-    - https://github.com/moby/moby/archive/refs/tags/docker-v29.4.2.tar.gz : f2d4d892f5439ac8b3b28a2ba03d29db1a377f8dd5d057ca941cdbba92f6ed7f
+    - https://github.com/moby/moby/archive/refs/tags/docker-v29.5.1.tar.gz : 26646ad2a39a41ecdc85261f32c491188c995f95130f487332b4c64afaf4cdb4
 homepage   : https://www.docker.com
 license    : Apache-2.0
 component  : virt

--- a/packages/m/moby/pspec_x86_64.xml
+++ b/packages/m/moby/pspec_x86_64.xml
@@ -32,9 +32,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="30">
-            <Date>2026-05-04</Date>
-            <Version>29.4.2</Version>
+        <Update release="31">
+            <Date>2026-05-20</Date>
+            <Version>29.5.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://docs.docker.com/engine/release-notes/29/).

**Security**
Includes fixes for:
- CVE-2026-41567
- CVE-2026-41568
- CVE-2026-42306
- CVE-2026-32288
- CVE-2026-31431

**Test Plan**

`docker` still works. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
