### PR TITLE
firewalld: Update to 2.4.1

### DIFF
--- a/packages/f/firewalld/package.yml
+++ b/packages/f/firewalld/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : firewalld
-version    : 2.4.0
-release    : 20
+version    : 2.4.1
+release    : 21
 source     :
-    - https://github.com/firewalld/firewalld/releases/download/v2.4.0/firewalld-2.4.0.tar.bz2 : 992853451a58d229068c0ed10c3e007b2032c0fb654f27d656bfa3c120a2f132
+    - https://github.com/firewalld/firewalld/releases/download/v2.4.1/firewalld-2.4.1.tar.bz2 : 453230c49b961853144dd7614d59e82fafbcc52c314c39ec66d1316274a33001
 homepage   : https://firewalld.org/
 license    : GPL-2.0-or-later
 component  :
@@ -73,6 +73,6 @@ patterns   :
         - /usr/share/firewalld/gtk3_chooserbutton.py*
         - /usr/share/firewalld/gtk3_niceexpander.py*
         - /usr/share/applications/firewall-config.desktop
-        - /usr/share/metainfo/firewall-config.appdata.xml
+        - /usr/share/metainfo/org.firewalld.firewall-config.metainfo.xml
         - /usr/share/icons/hicolor/*/apps/firewall-config*.*
         - /usr/share/man/man1/firewall-config*.1*

--- a/packages/f/firewalld/pspec_x86_64.xml
+++ b/packages/f/firewalld/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>firewalld</Name>
         <Homepage>https://firewalld.org/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>security</PartOf>
@@ -529,7 +529,7 @@
 </Description>
         <PartOf>security</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="20">firewalld-config</Dependency>
+            <Dependency releaseFrom="21">firewalld-config</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/firewall-applet</Path>
@@ -562,7 +562,7 @@
 </Description>
         <PartOf>security</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="20">firewalld</Dependency>
+            <Dependency releaseFrom="21">firewalld</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/firewall-config</Path>
@@ -577,16 +577,16 @@
             <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/firewall-config.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/firewall-config.svg</Path>
             <Path fileType="man">/usr/share/man/man1/firewall-config.1.zst</Path>
-            <Path fileType="data">/usr/share/metainfo/firewall-config.appdata.xml</Path>
+            <Path fileType="data">/usr/share/metainfo/org.firewalld.firewall-config.metainfo.xml</Path>
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2026-03-24</Date>
-            <Version>2.4.0</Version>
+        <Update release="21">
+            <Date>2026-05-20</Date>
+            <Version>2.4.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Bugfix only release

[2.4.1 Release Notes](https://github.com/firewalld/firewalld/releases/tag/v2.4.1)


**Test Plan**

Install firewalld, applet, and config
Start firewalld services
Lunch config and ensure management
Test firewall status

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
