### PR TITLE
unbound: Update to v1.25.1

### DIFF
--- a/packages/u/unbound/abi_libs
+++ b/packages/u/unbound/abi_libs
@@ -1,1 +1,6 @@
 libunbound.so.8
+unbound
+unbound-anchor
+unbound-checkconf
+unbound-control
+unbound-host

--- a/packages/u/unbound/abi_symbols
+++ b/packages/u/unbound/abi_symbols
@@ -34,3 +34,8 @@ libunbound.so.8:ub_resolve_free
 libunbound.so.8:ub_strerror
 libunbound.so.8:ub_version
 libunbound.so.8:ub_wait
+unbound:_IO_stdin_used
+unbound-anchor:_IO_stdin_used
+unbound-checkconf:_IO_stdin_used
+unbound-control:_IO_stdin_used
+unbound-host:_IO_stdin_used

--- a/packages/u/unbound/abi_used_symbols
+++ b/packages/u/unbound/abi_used_symbols
@@ -8,6 +8,7 @@ libc.so.6:__fgets_chk
 libc.so.6:__fprintf_chk
 libc.so.6:__isoc23_sscanf
 libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoll
 libc.so.6:__isoc23_strtoul
 libc.so.6:__libc_start_main
 libc.so.6:__memcpy_chk
@@ -117,6 +118,7 @@ libc.so.6:pthread_rwlock_init
 libc.so.6:pthread_rwlock_rdlock
 libc.so.6:pthread_rwlock_unlock
 libc.so.6:pthread_rwlock_wrlock
+libc.so.6:pthread_setname_np
 libc.so.6:pthread_setspecific
 libc.so.6:pthread_sigmask
 libc.so.6:pthread_spin_destroy
@@ -209,9 +211,8 @@ libcrypto.so.3:EVP_DigestVerifyInit
 libcrypto.so.3:EVP_EncryptInit_ex
 libcrypto.so.3:EVP_MAC_CTX_set_params
 libcrypto.so.3:EVP_MD_CTX_free
-libcrypto.so.3:EVP_MD_CTX_get0_md
+libcrypto.so.3:EVP_MD_CTX_get_size_ex
 libcrypto.so.3:EVP_MD_CTX_new
-libcrypto.so.3:EVP_MD_get_size
 libcrypto.so.3:EVP_PKEY_CTX_free
 libcrypto.so.3:EVP_PKEY_CTX_new_from_name
 libcrypto.so.3:EVP_PKEY_free

--- a/packages/u/unbound/package.yml
+++ b/packages/u/unbound/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : unbound
-version    : 1.24.2
-release    : 21
+version    : 1.25.1
+release    : 22
 source     :
-    - https://nlnetlabs.nl/downloads/unbound/unbound-1.24.2.tar.gz : 44e7b53e008a6dcaec03032769a212b46ab5c23c105284aa05a4f3af78e59cdb
+    - https://nlnetlabs.nl/downloads/unbound/unbound-1.25.1.tar.gz : 0fe8b6277b0959cfd17562debac0aa5f71e0b02dc4ffa9c60271c583edab586f
 homepage   : https://nlnetlabs.nl/projects/unbound/about/
 license    : BSD-3-Clause
 component  : network.util
@@ -13,7 +13,8 @@ description: |
 builddeps  :
     - pkgconfig(libevent)
 setup      : |
-    %configure --disable-static \
+    %configure \
+        --disable-static \
         --enable-event-api \
         --enable-pie \
         --enable-relro-now \
@@ -26,14 +27,15 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license LICENSE
 
-    install -Dm00644 contrib/unbound.{service,socket} -t $installdir/%libdir%/systemd/system
-    install -Dm00644 contrib/libunbound.pc -t $installdir/%libdir%/pkgconfig
-    install -Dm00644 $pkgfiles/unbound.tmpfiles $installdir/%libdir%/tmpfiles.d/unbound.conf
-    install -Dm00644 $pkgfiles/unbound.sysusers $installdir/%libdir%/sysusers.d/unbound.conf
+    install -Dm00644 contrib/unbound.{service,socket} -t ${installdir}/%libdir%/systemd/system
+    install -Dm00644 contrib/libunbound.pc -t ${installdir}/%libdir%/pkgconfig
+    install -Dm00644 ${pkgfiles}/unbound.tmpfiles ${installdir}/%libdir%/tmpfiles.d/unbound.conf
+    install -Dm00644 ${pkgfiles}/unbound.sysusers ${installdir}/%libdir%/sysusers.d/unbound.conf
 
     # Use our own settings (lot of work is still required to provide sane config but at least this allows to start the service)
-    install -Dm00644 $pkgfiles/unbound.service $installdir/%libdir%/systemd/system/unbound.service
-    install -Dm00644 $pkgfiles/unbound.conf $installdir/%libdir%/unbound/unbound.conf
+    install -Dm00644 ${pkgfiles}/unbound.service ${installdir}/%libdir%/systemd/system/unbound.service
+    install -Dm00644 ${pkgfiles}/unbound.conf ${installdir}/%libdir%/unbound/unbound.conf
 check      : |
     %make check

--- a/packages/u/unbound/pspec_x86_64.xml
+++ b/packages/u/unbound/pspec_x86_64.xml
@@ -21,7 +21,7 @@
         <PartOf>network.util</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libunbound.so.8</Path>
-            <Path fileType="library">/usr/lib64/libunbound.so.8.1.34</Path>
+            <Path fileType="library">/usr/lib64/libunbound.so.8.1.37</Path>
             <Path fileType="library">/usr/lib64/systemd/system/unbound.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/unbound.socket</Path>
             <Path fileType="library">/usr/lib64/sysusers.d/unbound.conf</Path>
@@ -33,6 +33,7 @@
             <Path fileType="executable">/usr/sbin/unbound-control</Path>
             <Path fileType="executable">/usr/sbin/unbound-control-setup</Path>
             <Path fileType="executable">/usr/sbin/unbound-host</Path>
+            <Path fileType="data">/usr/share/licenses/unbound/LICENSE</Path>
             <Path fileType="man">/usr/share/man/man1/unbound-host.1.zst</Path>
             <Path fileType="man">/usr/share/man/man5/unbound.conf.5.zst</Path>
             <Path fileType="man">/usr/share/man/man8/unbound-anchor.8.zst</Path>
@@ -49,7 +50,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="21">unbound</Dependency>
+            <Dependency release="22">unbound</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/unbound-event.h</Path>
@@ -90,9 +91,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2025-11-27</Date>
-            <Version>1.24.2</Version>
+        <Update release="22">
+            <Date>2026-05-20</Date>
+            <Version>1.25.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
- [1.25.0](https://nlnetlabs.nl/news/2026/Apr/29/unbound-1.25.0-released/)
- [1.25.1](https://nlnetlabs.nl/news/2026/May/20/unbound-1.25.1-released/)

**Security**
- CVE-2026-33278
- CVE-2026-42944
- CVE-2026-42959
- CVE-2026-32792
- CVE-2026-40622
- CVE-2026-41292
- CVE-2026-42534
- CVE-2026-42923
- CVE-2026-42960
- CVE-2026-44390
- CVE-2026-44608

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebuild `getdns` against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
