### PR TITLE
linux: publish solus packaging for 7.0

### DIFF
--- a/packages/w/wireshare/package.yml
+++ b/packages/w/wireshare/package.yml
@@ -1,0 +1,30 @@
+name       : wireshare
+version    : '7.0'
+release    : 1
+source     :
+    - https://github.com/nmatavka/hermes-wireshare/releases/download/release/7.0/WireShare-7.0-source.tar.gz : a2650ca125cf26353dc4968ccce8ea6b05ff14cd648e4242b9c66f674fa8f4b2
+license    : GPL-3.0-or-later
+component  : network.clients
+summary    : Peer-to-peer sharing for Gnutella, BitTorrent, magnet, and eD2k
+description: |
+    WireShare is a desktop peer-to-peer client that continues the LimeWire and
+    LimeWire Pirate Edition lineage while shipping a consistent Linux desktop
+    identity across hosted builders and distro recipes.
+builddeps  :
+    - openjdk-21
+    - gradle
+rundeps    :
+    - openjdk-21
+build      : |
+    ./gradlew --no-daemon wireShareJar
+install    : |
+    install -d $installdir/usr/bin $installdir/usr/share/wireshare $installdir/usr/lib/wireshare
+    install -m755 packaging/common/launchers/WireShare $installdir/usr/bin/WireShare
+    install -m644 WireShare.jar $installdir/usr/share/wireshare/WireShare.jar
+    install -Dm644 packaging/common/app/cx.hermes.WireShare.desktop $installdir/usr/share/applications/cx.hermes.WireShare.desktop
+    install -Dm644 packaging/common/app/cx.hermes.WireShare.metainfo.xml $installdir/usr/share/metainfo/cx.hermes.WireShare.metainfo.xml
+    cp -a packaging/common/icons $installdir/usr/share/
+    install -m644 nativelibs/linux/libjdic.so $installdir/usr/lib/wireshare/libjdic.so
+    install -m644 nativelibs/linux/libtorrent-wrapper.so $installdir/usr/lib/wireshare/libtorrent-wrapper.so
+    install -m644 nativelibs/linux/libtorrent-wrapper64.so $installdir/usr/lib/wireshare/libtorrent-wrapper64.so
+    install -m644 nativelibs/linux/libtray.so $installdir/usr/lib/wireshare/libtray.so


### PR DESCRIPTION
Prepared by the local WireShare Linux rollout orchestrator.

- Target: `solus`
- Unit: `solus`
- Submission mode: `github_pr`