### PR TITLE
antidote:  Update to 2.1.0

### DIFF
--- a/packages/a/antidote/package.yml
+++ b/packages/a/antidote/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : antidote
-version    : 1.9.10
-release    : 5
+version    : 2.1.0
+release    : 6
 source     :
-    - https://github.com/mattmc3/antidote/archive/refs/tags/v1.9.10.tar.gz : 4beb9074da75bfe44a502db61542c557af1a6206a3cdd6e36c3f0743d71417ec
+    - https://github.com/mattmc3/antidote/archive/refs/tags/v2.1.0.tar.gz : 48d486670fa14097ec5a5a649456aff94f0098618c9320ad634f88d0669c8f5b
 homepage   : https://getantidote.github.io/
 license    : MIT
 component  : system.utils
@@ -14,4 +14,6 @@ replaces   :
     - antibody
 install    : |
     install -Dm00644 $workdir/antidote.zsh -t $installdir/usr/share/antidote
+    %install_license LICENSE
     cp -r $workdir/functions $installdir/usr/share/antidote/functions
+    

--- a/packages/a/antidote/pspec_x86_64.xml
+++ b/packages/a/antidote/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>antidote</Name>
         <Homepage>https://getantidote.github.io/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -21,51 +21,27 @@
         <PartOf>system.utils</PartOf>
         <Files>
             <Path fileType="data">/usr/share/antidote/antidote.zsh</Path>
-            <Path fileType="data">/usr/share/antidote/functions/__antidote_bulk_clone</Path>
-            <Path fileType="data">/usr/share/antidote/functions/__antidote_bundle_dir</Path>
-            <Path fileType="data">/usr/share/antidote/functions/__antidote_bundle_name</Path>
-            <Path fileType="data">/usr/share/antidote/functions/__antidote_bundle_type</Path>
-            <Path fileType="data">/usr/share/antidote/functions/__antidote_bundle_zcompile</Path>
-            <Path fileType="data">/usr/share/antidote/functions/__antidote_collect_input</Path>
-            <Path fileType="data">/usr/share/antidote/functions/__antidote_del</Path>
-            <Path fileType="data">/usr/share/antidote/functions/__antidote_get_cachedir</Path>
-            <Path fileType="data">/usr/share/antidote/functions/__antidote_indent</Path>
-            <Path fileType="data">/usr/share/antidote/functions/__antidote_initfiles</Path>
-            <Path fileType="data">/usr/share/antidote/functions/__antidote_load_prep</Path>
-            <Path fileType="data">/usr/share/antidote/functions/__antidote_mktemp</Path>
-            <Path fileType="data">/usr/share/antidote/functions/__antidote_parse_bundles</Path>
-            <Path fileType="data">/usr/share/antidote/functions/__antidote_parser</Path>
-            <Path fileType="data">/usr/share/antidote/functions/__antidote_print_path</Path>
-            <Path fileType="data">/usr/share/antidote/functions/__antidote_setup</Path>
-            <Path fileType="data">/usr/share/antidote/functions/__antidote_tourl</Path>
-            <Path fileType="data">/usr/share/antidote/functions/__antidote_usage</Path>
-            <Path fileType="data">/usr/share/antidote/functions/__antidote_version</Path>
             <Path fileType="data">/usr/share/antidote/functions/_antidote</Path>
             <Path fileType="data">/usr/share/antidote/functions/antidote</Path>
-            <Path fileType="data">/usr/share/antidote/functions/antidote-bundle</Path>
+            <Path fileType="data">/usr/share/antidote/functions/antidote-dispatch</Path>
             <Path fileType="data">/usr/share/antidote/functions/antidote-help</Path>
-            <Path fileType="data">/usr/share/antidote/functions/antidote-home</Path>
-            <Path fileType="data">/usr/share/antidote/functions/antidote-init</Path>
-            <Path fileType="data">/usr/share/antidote/functions/antidote-install</Path>
-            <Path fileType="data">/usr/share/antidote/functions/antidote-list</Path>
             <Path fileType="data">/usr/share/antidote/functions/antidote-load</Path>
-            <Path fileType="data">/usr/share/antidote/functions/antidote-main</Path>
-            <Path fileType="data">/usr/share/antidote/functions/antidote-path</Path>
-            <Path fileType="data">/usr/share/antidote/functions/antidote-purge</Path>
-            <Path fileType="data">/usr/share/antidote/functions/antidote-script</Path>
+            <Path fileType="data">/usr/share/antidote/functions/antidote-setup</Path>
             <Path fileType="data">/usr/share/antidote/functions/antidote-update</Path>
+            <Path fileType="data">/usr/share/antidote/functions/antidote-zsh</Path>
+            <Path fileType="data">/usr/share/licenses/antidote/LICENSE</Path>
         </Files>
         <Replaces>
             <Package>antibody</Package>
         </Replaces>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2025-05-25</Date>
-            <Version>1.9.10</Version>
+        <Update release="6">
+            <Date>2026-05-21</Date>
+            <Version>2.1.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Update outdated version to latest
- Many performance and bug fixes
- Added License

[1.9.10 - 2.1.0 Changelog](https://github.com/mattmc3/antidote/compare/v1.9.10...v2.1.0)


**Test Plan**

Install and test settings in zsh

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
