### PR TITLE
postgresql: Update to v18.4

### DIFF
--- a/packages/p/postgresql/abi_symbols
+++ b/packages/p/postgresql/abi_symbols
@@ -3822,6 +3822,7 @@ postgres:GetWalRcvFlushRecPtr
 postgres:GetWalRcvWriteRecPtr
 postgres:GetWalSummaries
 postgres:GetWalSummarizerState
+postgres:GetXLogInsertEndRecPtr
 postgres:GetXLogInsertRecPtr
 postgres:GetXLogReceiptTime
 postgres:GetXLogReplayRecPtr
@@ -3855,6 +3856,7 @@ postgres:HandleNotifyInterrupt
 postgres:HandleParallelApplyMessageInterrupt
 postgres:HandleParallelMessageInterrupt
 postgres:HandleRecoveryConflictInterrupt
+postgres:HandleSlotSyncMessageInterrupt
 postgres:HandleWalSndInitStopping
 postgres:HasSubscriptionRelations
 postgres:HaveNFreeProcs
@@ -4569,6 +4571,7 @@ postgres:ProcessNotifyInterrupt
 postgres:ProcessParallelApplyMessages
 postgres:ProcessParallelMessages
 postgres:ProcessProcSignalBarrier
+postgres:ProcessSlotSyncMessage
 postgres:ProcessStartupProcInterrupts
 postgres:ProcessSyncRequests
 postgres:ProcessUtility
@@ -5200,6 +5203,7 @@ postgres:SlabStats
 postgres:SlotExistsInSyncStandbySlots
 postgres:SlotSyncShmemInit
 postgres:SlotSyncShmemSize
+postgres:SlotSyncShutdownPending
 postgres:SlotSyncWorkerCanRestart
 postgres:SlruDeleteSegment
 postgres:SlruScanDirCbDeleteAll
@@ -6917,6 +6921,7 @@ postgres:coerce_to_specific_type_typmod
 postgres:coerce_to_target_type
 postgres:coerce_type
 postgres:colNameToVar
+postgres:collations_agree_on_equality
 postgres:command_tag_display_rowcount
 postgres:command_tag_event_trigger_ok
 postgres:command_tag_table_rewrite_ok
@@ -9150,6 +9155,7 @@ postgres:isQueryUsingTempRelation
 postgres:isTempNamespace
 postgres:isTempOrTempToastNamespace
 postgres:isTempToastNamespace
+postgres:isValidTarHeader
 postgres:is_admin_of_role
 postgres:is_dummy_rel
 postgres:is_encoding_supported_by_icu
@@ -10227,8 +10233,11 @@ postgres:pairingheap_remove
 postgres:pairingheap_remove_first
 postgres:palloc
 postgres:palloc0
+postgres:palloc0_mul
 postgres:palloc_aligned
 postgres:palloc_extended
+postgres:palloc_mul
+postgres:palloc_mul_extended
 postgres:parallel_leader_participation
 postgres:parallel_setup_cost
 postgres:parallel_tuple_cost
@@ -10290,6 +10299,7 @@ postgres:path_inter
 postgres:path_is_prefix_of_path
 postgres:path_is_relative_and_below_cwd
 postgres:path_is_reparameterizable_by_child
+postgres:path_is_safe_for_extraction
 postgres:path_isclosed
 postgres:path_isopen
 postgres:path_length
@@ -11844,6 +11854,8 @@ postgres:repalloc
 postgres:repalloc0
 postgres:repalloc_extended
 postgres:repalloc_huge
+postgres:repalloc_mul
+postgres:repalloc_mul_extended
 postgres:reparameterize_path
 postgres:reparameterize_path_by_child
 postgres:repeat
@@ -12322,6 +12334,7 @@ postgres:string_agg_serialize
 postgres:string_agg_transfn
 postgres:string_hash
 postgres:strip_implicit_coercions
+postgres:strip_noop_phvs
 postgres:strip_phvs_in_index_operand
 postgres:strlist_to_textarray
 postgres:strlower_builtin
@@ -13130,6 +13143,7 @@ postgres:visibilitymap_pin
 postgres:visibilitymap_pin_ok
 postgres:visibilitymap_prepare_truncate
 postgres:visibilitymap_set
+postgres:visibilitymap_truncation_length
 postgres:void_in
 postgres:void_out
 postgres:void_recv

--- a/packages/p/postgresql/abi_used_symbols
+++ b/packages/p/postgresql/abi_used_symbols
@@ -24,7 +24,6 @@ libc.so.6:__read_chk
 libc.so.6:__sigsetjmp
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
-libc.so.6:__stpcpy_chk
 libc.so.6:__strcat_chk
 libc.so.6:__strcpy_chk
 libc.so.6:__strlcpy_chk
@@ -358,9 +357,9 @@ libcrypto.so.3:EVP_EncryptInit_ex
 libcrypto.so.3:EVP_EncryptUpdate
 libcrypto.so.3:EVP_MD_CTX_free
 libcrypto.so.3:EVP_MD_CTX_get0_md
+libcrypto.so.3:EVP_MD_CTX_get_size_ex
 libcrypto.so.3:EVP_MD_CTX_new
 libcrypto.so.3:EVP_MD_get_block_size
-libcrypto.so.3:EVP_MD_get_size
 libcrypto.so.3:EVP_aes_128_cbc
 libcrypto.so.3:EVP_aes_128_cfb128
 libcrypto.so.3:EVP_aes_128_ecb

--- a/packages/p/postgresql/package.yml
+++ b/packages/p/postgresql/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : postgresql
-version    : '18.3'
-release    : 63
-homepage   : https://www.postgresql.org/
+version    : '18.4'
+release    : 64
 source     :
-    - https://ftp.postgresql.org/pub/source/v18.3/postgresql-18.3.tar.bz2 : d95663fbbf3a80f81a9d98d895266bdcb74ba274bcc04ef6d76630a72dee016f
+    - https://ftp.postgresql.org/pub/source/v18.4/postgresql-18.4.tar.bz2 : 81a81ec695fb0c7901407defaa1d2f7973617154cf27ba74e3a7ab8e64436094
+homepage   : https://www.postgresql.org/
 license    :
     - PostgreSQL
     - TCL
@@ -12,13 +12,13 @@ component  :
     - database
     - libpq : programming.library
     - contrib : database
-optimize   : speed
 summary    :
     - PostgreSQL is an object-relational database system
     - libpq : PostgreSQL C client library
     - contrib : Extension modules distributed with PostgreSQL
 description: |
     PostgreSQL is an object-relational database system that has the features of traditional proprietary database systems with enhancements to be found in next-generation DBMS systems.
+optimize   : speed
 patterns   :
     - libpq :
         - /usr/lib64/libpq.so.*
@@ -91,10 +91,11 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYRIGHT
 
     find $installdir -name "*.a" -delete
 
-    install -Dm 00644 $pkgfiles/postgresql.sysusers $installdir/%libdir%/sysusers.d/postgresql.conf
-    install -Dm 00644 $pkgfiles/postgresql.tmpfiles $installdir/%libdir%/tmpfiles.d/postgresql.conf
-    install -Dm 00644 $pkgfiles/postgresql.service $installdir/%libdir%/systemd/system/postgresql.service
-    install -Dm 00755 $pkgfiles/postgresql_first_install $installdir/usr/share/postgresql/postgresql_first_install
+    install -Dm 00644 ${pkgfiles}/postgresql.sysusers ${installdir}/%libdir%/sysusers.d/postgresql.conf
+    install -Dm 00644 ${pkgfiles}/postgresql.tmpfiles ${installdir}/%libdir%/tmpfiles.d/postgresql.conf
+    install -Dm 00644 ${pkgfiles}/postgresql.service ${installdir}/%libdir%/systemd/system/postgresql.service
+    install -Dm 00755 ${pkgfiles}/postgresql_first_install ${installdir}/usr/share/postgresql/postgresql_first_install

--- a/packages/p/postgresql/pspec_x86_64.xml
+++ b/packages/p/postgresql/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>postgresql</Name>
         <Homepage>https://www.postgresql.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>PostgreSQL</License>
         <License>TCL</License>
@@ -21,7 +21,7 @@
 </Description>
         <PartOf>database</PartOf>
         <RuntimeDependencies>
-            <Dependency release="63">postgresql-libpq</Dependency>
+            <Dependency release="64">postgresql-libpq</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/clusterdb</Path>
@@ -134,6 +134,7 @@
             <Path fileType="doc">/usr/share/doc/postgresql/extension/insert_username.example</Path>
             <Path fileType="doc">/usr/share/doc/postgresql/extension/moddatetime.example</Path>
             <Path fileType="doc">/usr/share/doc/postgresql/extension/refint.example</Path>
+            <Path fileType="data">/usr/share/licenses/postgresql/COPYRIGHT</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/ecpg-18.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/ecpglib6-18.mo</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/initdb-18.mo</Path>
@@ -883,7 +884,7 @@
 </Description>
         <PartOf>database</PartOf>
         <RuntimeDependencies>
-            <Dependency release="63">postgresql-libpq</Dependency>
+            <Dependency release="64">postgresql-libpq</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/postgresql/_int.so</Path>
@@ -941,7 +942,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="63">postgresql</Dependency>
+            <Dependency release="64">postgresql</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/ecpg_config.h</Path>
@@ -1902,12 +1903,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="63">
-            <Date>2026-03-05</Date>
-            <Version>18.3</Version>
+        <Update release="64">
+            <Date>2026-05-22</Date>
+            <Version>18.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://www.postgresql.org/about/news/postgresql-184-1710-1614-1518-and-1423-released-3297/).

**Security**
Includes fixes for:
- CVE-2026-6472
- CVE-2026-6473
- CVE-2026-6474
- CVE-2026-6475
- CVE-2026-6476
- CVE-2026-6477
- CVE-2026-6478
- CVE-2026-6479
- CVE-2026-6575
- CVE-2026-6637
- CVE-2026-6638

**Test Plan**

`sudo -u postgres psql -d smoketest -c "CREATE TABLE t (id int); INSERT INTO t VALUES (1); SELECT * FROM t;"`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
