### PR TITLE
repo_data: Deprecate qscintilla

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -3201,5 +3201,6 @@
 		<Package>gpgme-qt-devel</Package>
 		<Package>VTK-qt6</Package>
 		<Package>python-qscintilla</Package>
+		<Package>qscintilla</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -4399,5 +4399,7 @@
 		<!-- Replaced by python-qscintilla-qt5 -->
 		<Package>python-qscintilla</Package>
 
+		<!-- Everything has been Split into subpackages -->
+		<Package>qscintilla</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
**Summary**

Deprecate qscintilla as it has been split into subpackages as of getsolus/packages#8992
