### PR TITLE
docker stack security update

### DIFF
--- a/packages/c/containerd/package.yml
+++ b/packages/c/containerd/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : containerd
-version    : 2.3.0
-release    : 72
+version    : 2.3.1
+release    : 73
 source     :
-    - https://github.com/containerd/containerd/archive/refs/tags/v2.3.0.tar.gz : 915ef1d9fab5fbd8e3726bfb80c901fd87aa25e938bed5194df132853036ed58
+    - https://github.com/containerd/containerd/archive/refs/tags/v2.3.1.tar.gz : 9de4cb8bfb27964a8ffd95e35326b7279ea2e2a6506da16c2533d3f523f12c11
 license    : Apache-2.0
 component  : virt
 homepage   : https://containerd.io/

--- a/packages/c/containerd/pspec_x86_64.xml
+++ b/packages/c/containerd/pspec_x86_64.xml
@@ -36,9 +36,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="72">
-            <Date>2026-05-04</Date>
-            <Version>2.3.0</Version>
+        <Update release="73">
+            <Date>2026-05-22</Date>
+            <Version>2.3.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>

--- a/packages/d/docker-compose/package.yml
+++ b/packages/d/docker-compose/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : docker-compose
-version    : 5.1.3
-release    : 61
+version    : 5.1.4
+release    : 62
 source     :
-    - https://github.com/docker/compose/archive/refs/tags/v5.1.3.tar.gz : 19c7219c97390473bb96530153e64fce98d4b05ecf6f73016e564201d99512e7
+    - https://github.com/docker/compose/archive/refs/tags/v5.1.4.tar.gz : 363ce6ccca46f836648f5f4ec9ecfdb6f631daa126570cc3fc69140edeed6794
 homepage   : https://docs.docker.com/compose/
 license    : Apache-2.0
 component  : virt

--- a/packages/d/docker-compose/pspec_x86_64.xml
+++ b/packages/d/docker-compose/pspec_x86_64.xml
@@ -28,9 +28,9 @@ With Compose, you use a Compose file to configure your application&#x2019;s serv
         </Files>
     </Package>
     <History>
-        <Update release="61">
-            <Date>2026-04-24</Date>
-            <Version>5.1.3</Version>
+        <Update release="62">
+            <Date>2026-05-22</Date>
+            <Version>5.1.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>

--- a/packages/d/docker/package.yml
+++ b/packages/d/docker/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : docker
-version    : 29.5.1
-release    : 75
+version    : 29.5.2
+release    : 76
 source     :
-    - https://github.com/docker/cli/archive/refs/tags/v29.5.1.tar.gz : de3cdd74a66f4cfe843983e4ca8d2133cf5eecc8ad8b5450cec0b7ccd59f921d
+    - https://github.com/docker/cli/archive/refs/tags/v29.5.2.tar.gz : e5cf80d9e0b6630bb2e97decf664ad5f0c732b296b7c47030044c3a7287bbddb
 homepage   : https://www.docker.com
 license    : Apache-2.0
 component  : virt

--- a/packages/d/docker/pspec_x86_64.xml
+++ b/packages/d/docker/pspec_x86_64.xml
@@ -218,9 +218,9 @@ Docker containers are both hardware-agnostic and platform-agnostic. This means t
         </Files>
     </Package>
     <History>
-        <Update release="75">
-            <Date>2026-05-20</Date>
-            <Version>29.5.1</Version>
+        <Update release="76">
+            <Date>2026-05-22</Date>
+            <Version>29.5.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>

--- a/packages/m/moby/package.yml
+++ b/packages/m/moby/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : moby
-version    : 29.5.1
-release    : 31
+version    : 29.5.2
+release    : 32
 source     :
-    - https://github.com/moby/moby/archive/refs/tags/docker-v29.5.1.tar.gz : 26646ad2a39a41ecdc85261f32c491188c995f95130f487332b4c64afaf4cdb4
+    - https://github.com/moby/moby/archive/refs/tags/docker-v29.5.2.tar.gz : 1235ed325d324c76f52e52beaa1dac85c92a073bf2f9fcc5bb9f67e35a668028
 homepage   : https://www.docker.com
 license    : Apache-2.0
 component  : virt

--- a/packages/m/moby/pspec_x86_64.xml
+++ b/packages/m/moby/pspec_x86_64.xml
@@ -32,9 +32,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2026-05-20</Date>
-            <Version>29.5.1</Version>
+        <Update release="32">
+            <Date>2026-05-22</Date>
+            <Version>29.5.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/containerd/containerd/releases/tag/v2.3.1).

**Security**
Includes fixes for:
- CVE-2026-46680

**Test Plan**

Docker still works. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
