### PR TITLE
pandoc-crossref: Update to v0.3.24

### DIFF
--- a/packages/p/pandoc-crossref/package.yml
+++ b/packages/p/pandoc-crossref/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : pandoc-crossref
-version    : 0.3.23
-release    : 13
+version    : 0.3.24
+release    : 14
 source     :
-    - https://github.com/lierdakil/pandoc-crossref/archive/refs/tags/v0.3.23a.tar.gz : 7b3638c8b8d416f28e950cf650c52d3e961f53ce6cc640133caf8ee99b2efade
+    - https://github.com/lierdakil/pandoc-crossref/archive/refs/tags/v0.3.24a.tar.gz : 5b478c94b67d5b972c7b3d867a345be982d3af12475e2261dd9b37fc17e225d1
 homepage   : https://lierdakil.github.io/pandoc-crossref/
 license    : GPL-2.0-only
 component  : office

--- a/packages/p/pandoc-crossref/pspec_x86_64.xml
+++ b/packages/p/pandoc-crossref/pspec_x86_64.xml
@@ -25,9 +25,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2026-05-10</Date>
-            <Version>0.3.23</Version>
+        <Update release="14">
+            <Date>2026-05-24</Date>
+            <Version>0.3.24</Version>
             <Comment>Packaging update</Comment>
             <Name>Ivan Trepakov</Name>
             <Email>liontiger23@gmail.com</Email>


### PR DESCRIPTION
**Summary**

Release notes:

- [v0.3.24](https://github.com/lierdakil/pandoc-crossref/releases/tag/v0.3.24)

**Test Plan**

- Build pandoc-crossref [demo](https://github.com/lierdakil/pandoc-crossref/tree/v0.3.24/docs/demo) with `make`
- Check that all references resolve correctly

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
