### PR TITLE
prism-launcher: Remove openjdk-17 dependency

### DIFF
--- a/packages/p/prism-launcher/abi_used_symbols
+++ b/packages/p/prism-launcher/abi_used_symbols
@@ -71,8 +71,8 @@ libQt6Core.so.6:_ZN10QJsonValueC1Ex
 libQt6Core.so.6:_ZN10QJsonValueC2ERK7QString
 libQt6Core.so.6:_ZN10QJsonValueD1Ev
 libQt6Core.so.6:_ZN11QBasicMutex12lockInternalEv
-libQt6Core.so.6:_ZN11QBasicMutex14unlockInternalEv
 libQt6Core.so.6:_ZN11QBasicMutex15destroyInternalEPv
+libQt6Core.so.6:_ZN11QBasicMutex19unlockInternalFutexEPv
 libQt6Core.so.6:_ZN11QDataStream10writeBytesEPKcx
 libQt6Core.so.6:_ZN11QDataStream11readRawDataEPcx
 libQt6Core.so.6:_ZN11QDataStream11resetStatusEv
@@ -165,10 +165,7 @@ libQt6Core.so.6:_ZN13QTemporaryDirC1Ev
 libQt6Core.so.6:_ZN13QTemporaryDirD1Ev
 libQt6Core.so.6:_ZN14QDeadlineTimerC1ExN2Qt9TimerTypeE
 libQt6Core.so.6:_ZN14QItemSelectionC1ERK11QModelIndexS2_
-libQt6Core.so.6:_ZN14QReadWriteLock14tryLockForReadE14QDeadlineTimer
-libQt6Core.so.6:_ZN14QReadWriteLock15tryLockForWriteE14QDeadlineTimer
 libQt6Core.so.6:_ZN14QReadWriteLock16destroyRecursiveEP21QReadWriteLockPrivate
-libQt6Core.so.6:_ZN14QReadWriteLock6unlockEv
 libQt6Core.so.6:_ZN14QStandardPaths14findExecutableERK7QStringRK5QListIS0_E
 libQt6Core.so.6:_ZN14QStandardPaths16writableLocationENS_16StandardLocationE
 libQt6Core.so.6:_ZN14QStandardPaths6locateENS_16StandardLocationERK7QString6QFlagsINS_12LocateOptionEE
@@ -304,6 +301,9 @@ libQt6Core.so.6:_ZN19QAbstractProxyModel7setDataERK11QModelIndexRK8QVarianti
 libQt6Core.so.6:_ZN19QAbstractProxyModel9fetchMoreERK11QModelIndex
 libQt6Core.so.6:_ZN19QAbstractProxyModelC2EP7QObject
 libQt6Core.so.6:_ZN19QAbstractProxyModelD2Ev
+libQt6Core.so.6:_ZN19QBasicReadWriteLock15contendedUnlockEPv
+libQt6Core.so.6:_ZN19QBasicReadWriteLock23contendedTryLockForReadE14QDeadlineTimerPv
+libQt6Core.so.6:_ZN19QBasicReadWriteLock24contendedTryLockForWriteE14QDeadlineTimerPv
 libQt6Core.so.6:_ZN19QIdentityProxyModel10insertRowsEiiRK11QModelIndex
 libQt6Core.so.6:_ZN19QIdentityProxyModel10removeRowsEiiRK11QModelIndex
 libQt6Core.so.6:_ZN19QIdentityProxyModel11moveColumnsERK11QModelIndexiiS2_i
@@ -478,7 +478,7 @@ libQt6Core.so.6:_ZN7QObject11qt_metacastEPKc
 libQt6Core.so.6:_ZN7QObject12blockSignalsEb
 libQt6Core.so.6:_ZN7QObject12moveToThreadEP7QThreadN2Qt15Disambiguated_tE
 libQt6Core.so.6:_ZN7QObject13connectNotifyERK11QMetaMethod
-libQt6Core.so.6:_ZN7QObject13doSetPropertyEPKcPK8QVariantPS2_
+libQt6Core.so.6:_ZN7QObject13doSetPropertyEPKcRK8QVariantPS2_
 libQt6Core.so.6:_ZN7QObject13setObjectNameE14QAnyStringView
 libQt6Core.so.6:_ZN7QObject14disconnectImplEPKS_PPvS1_S3_PK11QMetaObject
 libQt6Core.so.6:_ZN7QObject15doSetObjectNameERK7QString
@@ -659,8 +659,8 @@ libQt6Core.so.6:_ZN9QSaveFile4openE6QFlagsIN13QIODeviceBase12OpenModeFlagEE
 libQt6Core.so.6:_ZN9QSaveFile5closeEv
 libQt6Core.so.6:_ZN9QSaveFile6commitEv
 libQt6Core.so.6:_ZN9QSaveFile9writeDataEPKcx
-libQt6Core.so.6:_ZN9QSaveFileC1ERK7QString
-libQt6Core.so.6:_ZN9QSaveFileC2ERK7QString
+libQt6Core.so.6:_ZN9QSaveFileC1ERK7QStringP7QObject
+libQt6Core.so.6:_ZN9QSaveFileC2ERK7QStringP7QObject
 libQt6Core.so.6:_ZN9QSaveFileD1Ev
 libQt6Core.so.6:_ZN9QSaveFileD2Ev
 libQt6Core.so.6:_ZN9QSettings10beginGroupE14QAnyStringView
@@ -865,6 +865,7 @@ libQt6Core.so.6:_ZNK20QFutureInterfaceBase10queryStateENS_5StateE
 libQt6Core.so.6:_ZNK20QFutureInterfaceBase12hasExceptionEv
 libQt6Core.so.6:_ZNK20QFutureInterfaceBase15resultStoreBaseEv
 libQt6Core.so.6:_ZNK20QFutureInterfaceBase15runContinuationEv
+libQt6Core.so.6:_ZNK20QFutureInterfaceBase29isAddResultsIfCanceledEnabledEv
 libQt6Core.so.6:_ZNK20QFutureInterfaceBase4refTEv
 libQt6Core.so.6:_ZNK20QFutureInterfaceBase5mutexEv
 libQt6Core.so.6:_ZNK20QFutureInterfaceBase6derefTEv
@@ -922,7 +923,7 @@ libQt6Core.so.6:_ZNK4QDir5countEN2Qt15Disambiguated_tE
 libQt6Core.so.6:_ZNK4QDir6existsERK7QString
 libQt6Core.so.6:_ZNK4QDir6existsEv
 libQt6Core.so.6:_ZNK4QDir6isRootEv
-libQt6Core.so.6:_ZNK4QDir6mkpathERK7QString
+libQt6Core.so.6:_ZNK4QDir6mkpathERK7QStringSt8optionalI6QFlagsIN11QFileDevice10PermissionEEE
 libQt6Core.so.6:_ZNK4QDir7dirNameEv
 libQt6Core.so.6:_ZNK4QDir7refreshEv
 libQt6Core.so.6:_ZNK4QDir8filePathERK7QString
@@ -973,6 +974,7 @@ libQt6Core.so.6:_ZNK7QObject6threadEv
 libQt6Core.so.6:_ZNK7QString10startsWithE5QCharN2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString10startsWithERKS_N2Qt15CaseSensitivityE
 libQt6Core.so.6:_ZNK7QString11lastIndexOfERKS_xN2Qt15CaseSensitivityE
+libQt6Core.so.6:_ZNK7QString11toStdStringB5cxx11Ev
 libQt6Core.so.6:_ZNK7QString13toHtmlEscapedEv
 libQt6Core.so.6:_ZNK7QString18localeAwareCompareERKS_
 libQt6Core.so.6:_ZNK7QString5countERKS_N2Qt15CaseSensitivityE
@@ -1008,7 +1010,6 @@ libQt6Core.so.6:_ZNK8QVariant6toBoolEv
 libQt6Core.so.6:_ZNK8QVariant6toDateEv
 libQt6Core.so.6:_ZNK8QVariant6toUIntEPb
 libQt6Core.so.6:_ZNK8QVariant7toFloatEPb
-libQt6Core.so.6:_ZNK8QVariant8metaTypeEv
 libQt6Core.so.6:_ZNK8QVariant8toDoubleEPb
 libQt6Core.so.6:_ZNK8QVariant8toStringEv
 libQt6Core.so.6:_ZNK9QCollator7compareE11QStringViewS0_
@@ -1209,6 +1210,7 @@ libQt6Gui.so.6:_ZN15QGuiApplication7paletteEv
 libQt6Gui.so.6:_ZN15QGuiApplication9clipboardEv
 libQt6Gui.so.6:_ZN15QPointingDevice21primaryPointingDeviceERK7QString
 libQt6Gui.so.6:_ZN15QTextCharFormat7setFontERK5QFontNS_33FontPropertiesInheritanceBehaviorE
+libQt6Gui.so.6:_ZN16QAccessibleEvent8setChildEi
 libQt6Gui.so.6:_ZN16QAccessibleEventD1Ev
 libQt6Gui.so.6:_ZN16QDesktopServices7openUrlERK4QUrl
 libQt6Gui.so.6:_ZN16QFileSystemModel11setReadOnlyEb
@@ -1266,6 +1268,7 @@ libQt6Gui.so.6:_ZN5QFontD1Ev
 libQt6Gui.so.6:_ZN5QFontaSERKS_
 libQt6Gui.so.6:_ZN5QIcon12hasThemeIconERK7QString
 libQt6Gui.so.6:_ZN5QIcon12setThemeNameERK7QString
+libQt6Gui.so.6:_ZN5QIcon16staticMetaObjectE
 libQt6Gui.so.6:_ZN5QIcon16themeSearchPathsEv
 libQt6Gui.so.6:_ZN5QIcon19setThemeSearchPathsERK5QListI7QStringE
 libQt6Gui.so.6:_ZN5QIcon20setFallbackThemeNameERK7QString
@@ -1338,6 +1341,7 @@ libQt6Gui.so.6:_ZN7QRegionC1Ev
 libQt6Gui.so.6:_ZN7QRegionD1Ev
 libQt6Gui.so.6:_ZN7QRegionpLERK5QRect
 libQt6Gui.so.6:_ZN7QWindow5closeEv
+libQt6Gui.so.6:_ZN8QPainter10doSetBrushERK6QBrushPS0_
 libQt6Gui.so.6:_ZN8QPainter10drawPixmapERK7QPointFRK7QPixmap
 libQt6Gui.so.6:_ZN8QPainter10setOpacityEd
 libQt6Gui.so.6:_ZN8QPainter11setClipRectERK5QRectN2Qt13ClipOperationE
@@ -1347,16 +1351,15 @@ libQt6Gui.so.6:_ZN8QPainter15drawRoundedRectERK6QRectFddN2Qt8SizeModeE
 libQt6Gui.so.6:_ZN8QPainter3endEv
 libQt6Gui.so.6:_ZN8QPainter4saveEv
 libQt6Gui.so.6:_ZN8QPainter5beginEP12QPaintDevice
-libQt6Gui.so.6:_ZN8QPainter6setPenERK4QPen
 libQt6Gui.so.6:_ZN8QPainter6setPenERK6QColor
 libQt6Gui.so.6:_ZN8QPainter7drawPieERK6QRectFii
 libQt6Gui.so.6:_ZN8QPainter7restoreEv
 libQt6Gui.so.6:_ZN8QPainter7setFontERK5QFont
+libQt6Gui.so.6:_ZN8QPainter8doSetPenERK4QPenPS0_
 libQt6Gui.so.6:_ZN8QPainter8drawTextERK5QRectiRK7QStringPS0_
 libQt6Gui.so.6:_ZN8QPainter8drawTextERK7QPointFRK7QString
 libQt6Gui.so.6:_ZN8QPainter8fillRectERK5QRectRK6QBrush
 libQt6Gui.so.6:_ZN8QPainter8setBrushE6QColor
-libQt6Gui.so.6:_ZN8QPainter8setBrushERK6QBrush
 libQt6Gui.so.6:_ZN8QPainter9drawImageERK6QRectFRK6QImageS2_6QFlagsIN2Qt19ImageConversionFlagEE
 libQt6Gui.so.6:_ZN8QPainter9drawImageERK7QPointFRK6QImage
 libQt6Gui.so.6:_ZN8QPainter9drawRectsEPK5QRecti

--- a/packages/p/prism-launcher/package.yml
+++ b/packages/p/prism-launcher/package.yml
@@ -1,9 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : prism-launcher
 version    : '9.4'
-release    : 12
+release    : 13
 source     :
     - https://github.com/PrismLauncher/PrismLauncher/releases/download/9.4/PrismLauncher-9.4.tar.gz : 77ab52239c2a2a9f77d7c4607e1d9cf40970f9240d2f5061b116a7b1b8fd0277
+    - https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_x64_linux_hotspot_17.0.19_10.tar.gz : d8afc263758141a66e0e3aafc321e783f7016696f4eaea067d340a269037d331
 license    : GPL-3.0-or-later
 homepage   : https://prismlauncher.org/
 component  : games
@@ -19,16 +20,19 @@ builddeps  :
     - pkgconfig(scdoc)
     - pkgconfig(tomlplusplus)
     - extra-cmake-modules
-    - openjdk-17
 rundeps    :
     # This package should always have a rundep on whatever version of Java the latest stable Minecraft version requires
     - openjdk-21
 clang      : true
 optimize   : thin-lto
 environment: |
-    export JAVA_HOME=/usr/lib64/openjdk-17
+    export JAVA_HOME=$workdir/jdk-17.0.19+10
     export PATH=$JAVA_HOME/bin:$PATH
 setup      : |
+    # This package requires Java <= 17 to build - https://github.com/PrismLauncher/PrismLauncher/issues/2208
+    # Because OpenJDK 17 is EOL, we have to download pre-built binary version that is still being supported by adoptium.net
+    tar xvf $sources/OpenJDK17U-jdk_x64_linux_hotspot_17.0.19_10.tar.gz
+
     %cmake_ninja \
                  -DLauncher_BUILD_PLATFORM="solus" \
                  -DLauncher_QT_VERSION_MAJOR="6"

--- a/packages/p/prism-launcher/pspec_x86_64.xml
+++ b/packages/p/prism-launcher/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>prism-launcher</Name>
         <Homepage>https://prismlauncher.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Ivan Trepakov</Name>
+            <Email>liontiger23@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>games</PartOf>
@@ -27,19 +27,19 @@
             <Path fileType="data">/usr/share/PrismLauncher/qtlogging.ini</Path>
             <Path fileType="data">/usr/share/applications/org.prismlauncher.PrismLauncher.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/org.prismlauncher.PrismLauncher.svg</Path>
-            <Path fileType="man">/usr/share/man/man6/prismlauncher.6</Path>
+            <Path fileType="man">/usr/share/man/man6/prismlauncher.6.zst</Path>
             <Path fileType="data">/usr/share/metainfo/org.prismlauncher.PrismLauncher.metainfo.xml</Path>
             <Path fileType="data">/usr/share/mime/packages/modrinth-mrpack-mime.xml</Path>
             <Path fileType="data">/usr/share/qlogging-categories6/prismlauncher.categories</Path>
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2025-09-06</Date>
+        <Update release="13">
+            <Date>2026-05-24</Date>
             <Version>9.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Ivan Trepakov</Name>
+            <Email>liontiger23@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Switch build pre-built binary of OpenJDK 17
- Part of https://github.com/getsolus/packages/issues/7692

**Test Plan**

- Run launcher and went through a couple of dialog choices, but did not run any Minecraft instances

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
