### PR TITLE
openexr: Update to v3.4.12

### DIFF
--- a/packages/o/openexr/abi_used_symbols
+++ b/packages/o/openexr/abi_used_symbols
@@ -108,6 +108,7 @@ libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strncpy
+libc.so.6:strnlen
 libc.so.6:strrchr
 libc.so.6:strtod
 libc.so.6:sysconf

--- a/packages/o/openexr/package.yml
+++ b/packages/o/openexr/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : openexr
-version    : 3.4.11
-release    : 14
+version    : 3.4.12
+release    : 15
 source     :
-    - https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.4.11.tar.gz : 63730442f5fd6c5a79395bdd199040ab3821c229066049f52a57424a984b16ed
+    - https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.4.12.tar.gz : a455779c389f65c64220d45b63ead2900081e5f6337cdf93431cb1032c3e2686
 homepage   : https://www.openexr.com/
 license    : BSD-3-Clause
 component  :

--- a/packages/o/openexr/pspec_x86_64.xml
+++ b/packages/o/openexr/pspec_x86_64.xml
@@ -28,7 +28,7 @@ OpenEXR is widely used in host application software where accuracy is critical, 
 </Description>
         <PartOf>multimedia.library</PartOf>
         <RuntimeDependencies>
-            <Dependency release="14">openexr-libs</Dependency>
+            <Dependency release="15">openexr-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/exr2aces</Path>
@@ -56,8 +56,8 @@ OpenEXR is widely used in host application software where accuracy is critical, 
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="14">openexr</Dependency>
-            <Dependency releaseFrom="14">openexr-libs</Dependency>
+            <Dependency release="15">openexr</Dependency>
+            <Dependency releaseFrom="15">openexr-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/OpenEXR/Iex.h</Path>
@@ -272,21 +272,21 @@ OpenEXR is widely used in host application software where accuracy is critical, 
         <PartOf>multimedia.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libIex-3_4.so.33</Path>
-            <Path fileType="library">/usr/lib64/libIex-3_4.so.33.3.4.11</Path>
+            <Path fileType="library">/usr/lib64/libIex-3_4.so.33.3.4.12</Path>
             <Path fileType="library">/usr/lib64/libIlmThread-3_4.so.33</Path>
-            <Path fileType="library">/usr/lib64/libIlmThread-3_4.so.33.3.4.11</Path>
+            <Path fileType="library">/usr/lib64/libIlmThread-3_4.so.33.3.4.12</Path>
             <Path fileType="library">/usr/lib64/libOpenEXR-3_4.so.33</Path>
-            <Path fileType="library">/usr/lib64/libOpenEXR-3_4.so.33.3.4.11</Path>
+            <Path fileType="library">/usr/lib64/libOpenEXR-3_4.so.33.3.4.12</Path>
             <Path fileType="library">/usr/lib64/libOpenEXRCore-3_4.so.33</Path>
-            <Path fileType="library">/usr/lib64/libOpenEXRCore-3_4.so.33.3.4.11</Path>
+            <Path fileType="library">/usr/lib64/libOpenEXRCore-3_4.so.33.3.4.12</Path>
             <Path fileType="library">/usr/lib64/libOpenEXRUtil-3_4.so.33</Path>
-            <Path fileType="library">/usr/lib64/libOpenEXRUtil-3_4.so.33.3.4.11</Path>
+            <Path fileType="library">/usr/lib64/libOpenEXRUtil-3_4.so.33.3.4.12</Path>
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2026-05-01</Date>
-            <Version>3.4.11</Version>
+        <Update release="15">
+            <Date>2026-05-25</Date>
+            <Version>3.4.12</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/AcademySoftwareFoundation/openexr/releases/tag/v3.4.12).

**Security**
Includes fixes for:
- CVE-2026-45696
- CVE-2026-44663

**Test Plan**

Revdep `blender` works. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
