### PR TITLE
solseek: Update to 1.4.6

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 1.4.5
-release    : 37
+version    : 1.4.6
+release    : 38
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v1.4.5.tar.gz : bbdca70f43b49b4266e402c640f354186f556910419bd614e567897aeba69702
+    - https://github.com/clintre/solseek/archive/refs/tags/v1.4.6.tar.gz : ca2611e5f5a70e2ac9c48da370af815817e4e0421dd30a87173caffffefc08bb
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils
@@ -24,7 +24,13 @@ install    : |-
     cp -r $workdir/package/share/solseek $installdir/usr/share/
     chmod 00755 $installdir/usr/share/solseek/helpers/eopkg-info.py
     chmod 00755 $installdir/usr/share/solseek/helpers/solseek-tray.py
+
     install -Dm00644 $workdir/package/share/applications/Solseek.desktop $installdir/usr/share/applications/Solseek.desktop
     install -Dm00644 $workdir/package/share/icons/hicolor/scalable/apps/solseek.svg $installdir/usr/share/icons/hicolor/scalable/apps/solseek.svg
     install -Dm00644 $workdir/package/share/metainfo/solseek.metainfo.xml $installdir/usr/share/metainfo/solseek.metainfo.xml
+
+    install -Dm00644 $workdir/package/share/applications/solseek-uc.service $installdir/%libdir%/systemd/user/solseek-uc.service
+    install -Dm00644 $workdir/package/share/applications/solseek-uc.timer $installdir/%libdir%/systemd/user/solseek-uc.timer
+    install -Dm00644 $workdir/package/share/applications/60-solseek-uc.preset $installdir/%libdir%/systemd/user-preset/60-solseek-uc.preset
+
     %install_license LICENSE

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -3,7 +3,7 @@
         <Name>solseek</Name>
         <Homepage>https://github.com/clintre/solseek</Homepage>
         <Packager>
-            <Name>clintre</Name>
+            <Name>Clint Eschberger</Name>
             <Email>clint@eschberger.info</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
@@ -21,6 +21,9 @@
         <PartOf>system.utils</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/solseek</Path>
+            <Path fileType="library">/usr/lib64/systemd/user-preset/60-solseek-uc.preset</Path>
+            <Path fileType="library">/usr/lib64/systemd/user/solseek-uc.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/user/solseek-uc.timer</Path>
             <Path fileType="data">/usr/share/applications/Solseek.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/solseek.svg</Path>
             <Path fileType="data">/usr/share/licenses/solseek/LICENSE</Path>
@@ -60,8 +63,6 @@
             <Path fileType="data">/usr/share/solseek/modules/ui_tools</Path>
             <Path fileType="data">/usr/share/solseek/modules/ui_update</Path>
             <Path fileType="data">/usr/share/solseek/modules/update-runner</Path>
-            <Path fileType="data">/usr/share/solseek/solseek-uc.service</Path>
-            <Path fileType="data">/usr/share/solseek/solseek-uc.timer</Path>
             <Path fileType="data">/usr/share/solseek/solseek_fastfetch_1.jsonc</Path>
             <Path fileType="data">/usr/share/solseek/solseek_fastfetch_2.jsonc</Path>
             <Path fileType="data">/usr/share/solseek/solseek_fastfetch_3.jsonc</Path>
@@ -73,11 +74,11 @@
         </Files>
     </Package>
     <History>
-        <Update release="37">
-            <Date>2026-05-18</Date>
-            <Version>1.4.5</Version>
+        <Update release="38">
+            <Date>2026-05-26</Date>
+            <Version>1.4.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>clintre</Name>
+            <Name>Clint Eschberger</Name>
             <Email>clint@eschberger.info</Email>
         </Update>
     </History>


### PR DESCRIPTION
**Summary**

Bugfixes:
- Fixed additional issue (second) sending too many notifications in a short period. Created a method to limit the calls.
- Fixed incomplete metadata info missing author info, causing missing info in Gnome Software and Discover.

Enhancements:
- Created preset file for solseek update service.
- Update metadata info data with current features and added rating

Other:
- Moved the update service and timer to /usr/lib/systemd/user from ~/.config/systemd/user

Full Changelog:
https://github.com/clintre/solseek/releases/tag/v1.4.6

**Test Plan**

Install and test

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
