### PR TITLE
libde265: Update to v1.1.0

### DIFF
--- a/packages/l/libde265/abi_symbols
+++ b/packages/l/libde265/abi_symbols
@@ -572,6 +572,7 @@ libde265.so.0:de265_get_bits_per_pixel
 libde265.so.0:de265_get_chroma_format
 libde265.so.0:de265_get_current_TID
 libde265.so.0:de265_get_default_image_allocation_functions
+libde265.so.0:de265_get_disabled_security_limits
 libde265.so.0:de265_get_error_text
 libde265.so.0:de265_get_highest_TID
 libde265.so.0:de265_get_image_NAL_header
@@ -589,6 +590,7 @@ libde265.so.0:de265_get_next_picture
 libde265.so.0:de265_get_number_of_NAL_units_pending
 libde265.so.0:de265_get_number_of_input_bytes_pending
 libde265.so.0:de265_get_parameter_bool
+libde265.so.0:de265_get_security_limits
 libde265.so.0:de265_get_version
 libde265.so.0:de265_get_version_number
 libde265.so.0:de265_get_version_number_maintenance
@@ -612,6 +614,7 @@ libde265.so.0:de265_set_image_user_data
 libde265.so.0:de265_set_limit_TID
 libde265.so.0:de265_set_parameter_bool
 libde265.so.0:de265_set_parameter_int
+libde265.so.0:de265_set_security_limits
 libde265.so.0:de265_set_verbosity
 libde265.so.0:de265_start_worker_threads
 libde265.so.0:draw_CB_grid

--- a/packages/l/libde265/package.yml
+++ b/packages/l/libde265/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libde265
-version    : 1.0.19
-release    : 15
+version    : 1.1.0
+release    : 16
 source     :
-    - https://github.com/strukturag/libde265/releases/download/v1.0.19/libde265-1.0.19.tar.gz : bb19a0b485d2643e0eeb7e91f3ab32d1ad617e7c487dbedc91214ca3dbd8d7eb
+    - https://github.com/strukturag/libde265/releases/download/v1.1.0/libde265-1.1.0.tar.gz : afc19dd28e2fc523de5952bba5224ee1d28e286c72436d2843df126cca1181fd
 homepage   : https://www.libde265.org/
 license    : LGPL-3.0-or-later
 component  : multimedia.codecs

--- a/packages/l/libde265/pspec_x86_64.xml
+++ b/packages/l/libde265/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libde265</Name>
         <Homepage>https://www.libde265.org/</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>LGPL-3.0-or-later</License>
         <PartOf>multimedia.codecs</PartOf>
@@ -21,7 +21,7 @@
         <PartOf>multimedia.codecs</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libde265.so.0</Path>
-            <Path fileType="library">/usr/lib64/libde265.so.0.1.12</Path>
+            <Path fileType="library">/usr/lib64/libde265.so.0.2.0</Path>
             <Path fileType="data">/usr/share/licenses/libde265/COPYING</Path>
         </Files>
     </Package>
@@ -32,7 +32,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="15">libde265</Dependency>
+            <Dependency release="16">libde265</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libde265/de265-version.h</Path>
@@ -45,12 +45,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2026-05-20</Date>
-            <Version>1.0.19</Version>
+        <Update release="16">
+            <Date>2026-05-26</Date>
+            <Version>1.1.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Added de265_security_limits parameters to limit the maximum image size and memory that libde265 will use during decoding.

**Security**

- GHSA-g2rg-wj66-w594 - Out-of-bounds write in process_reference_picture_set via predicted short-term RPS
- GHSA-vv8h-932h-7r86 - Heap buffer overflow in de265_image_get_buffer via SPS dimension integer overflow
- GHSA-g5hj-rf9f-7vxm - Unbounded memory accumulation via orphaned slice headers in read_slice_NAL
- GHSA-x27c-jp65-g395 - Quadratic CPU consumption in NAL parser (remove_stuffing_bytes, resize)

**Test Plan**

- ?

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
