### PR TITLE
imagemagick: Update and Fix build

### DIFF
--- a/packages/a/aom/package.yml
+++ b/packages/a/aom/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : aom
 version    : 3.14.1
-release    : 27
+release    : 28
 source     :
     - git|https://aomedia.googlesource.com/aom.git : v3.14.1
 license    :
@@ -23,6 +23,8 @@ avx2       : true
 builddeps  :
     - yasm
 setup      : |
+    # Do not install/export the static target (matches stripped libaom.a); cf. AerynOS aom recipe.
+    sed -i 's/aom aom_static/aom/' cmake/aom_install.cmake
     %cmake_ninja \
                  -DBUILD_SHARED_LIBS=1 \
                  -DENABLE_TESTS=0
@@ -30,7 +32,5 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
-
-    rm -v $installdir/usr/lib64/libaom.a
 
     %install_license LICENSE PATENTS

--- a/packages/a/aom/pspec_x86_64.xml
+++ b/packages/a/aom/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>aom</Name>
         <Homepage>https://aomedia.googlesource.com/aom/</Homepage>
         <Packager>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>AOMPL-1.0</License>
         <License>BSD-2-Clause</License>
@@ -59,7 +59,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="27">aom</Dependency>
+            <Dependency release="28">aom</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/aom/aom.h</Path>
@@ -83,12 +83,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="27">
-            <Date>2026-05-25</Date>
+        <Update release="28">
+            <Date>2026-05-26</Date>
             <Version>3.14.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/i/imagemagick/package.yml
+++ b/packages/i/imagemagick/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : imagemagick
-version    : 7.1.2.23
-release    : 217
+version    : 7.1.2.24
+release    : 218
 source     :
-    - https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-23.tar.gz : f129f7d87fc21da453d032dd291b80ea13faf2497f13ef8279d97759ed7d5c46
+    - https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-24.tar.gz : 645f1dc68482ba952a02a854ffaf67efca42871b168e0cf702a043db2ec54638
 homepage   : https://imagemagick.org/
 license    : Apache-2.0
 component  : multimedia.graphics

--- a/packages/i/imagemagick/pspec_x86_64.xml
+++ b/packages/i/imagemagick/pspec_x86_64.xml
@@ -94,7 +94,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="217">imagemagick</Dependency>
+            <Dependency release="218">imagemagick</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/ImageMagick-7/Magick++.h</Path>
@@ -594,9 +594,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="217">
-            <Date>2026-05-17</Date>
-            <Version>7.1.2.23</Version>
+        <Update release="218">
+            <Date>2026-05-26</Date>
+            <Version>7.1.2.24</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>

--- a/packages/l/libheif/abi_symbols
+++ b/packages/l/libheif/abi_symbols
@@ -183,6 +183,7 @@ libheif.so.1:heif_image_extend_padding_to_size
 libheif.so.1:heif_image_extend_to_size_fill_with_zero
 libheif.so.1:heif_image_extract_area
 libheif.so.1:heif_image_get_bayer_pattern
+libheif.so.1:heif_image_get_bayer_pattern_size
 libheif.so.1:heif_image_get_bits_per_pixel
 libheif.so.1:heif_image_get_bits_per_pixel_range
 libheif.so.1:heif_image_get_chroma_format

--- a/packages/l/libheif/abi_used_libs
+++ b/packages/l/libheif/abi_used_libs
@@ -1,4 +1,3 @@
-UNKNOWN
 ld-linux-x86-64.so.2
 libSvtAv1Enc.so.4
 libaom.so.3

--- a/packages/l/libheif/abi_used_symbols
+++ b/packages/l/libheif/abi_used_symbols
@@ -1,4 +1,3 @@
-UNKNOWN:_Z19get_subsampled_sizejj12heif_channel11heif_chromaPjS1_
 ld-linux-x86-64.so.2:__tls_get_addr
 libSvtAv1Enc.so.4:svt_av1_enc_deinit
 libSvtAv1Enc.so.4:svt_av1_enc_deinit_handle

--- a/packages/l/libheif/package.yml
+++ b/packages/l/libheif/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libheif
-version    : 1.22.0
-release    : 60
+version    : 1.22.2
+release    : 61
 source     :
-    - https://github.com/strukturag/libheif/releases/download/v1.22.0/libheif-1.22.0.tar.gz : 8bd20cfa3201997b8f63266cddfabea2e1481467d7f992e6a2595e0bec691fc2
+    - https://github.com/strukturag/libheif/releases/download/v1.22.2/libheif-1.22.2.tar.gz : eea48e4841f83fbe51d029337ffd2d14512d0203015dad40b90213d872958af3
 homepage   : https://github.com/strukturag/libheif
 license    :
     - LGPL-3.0-or-later

--- a/packages/l/libheif/pspec_x86_64.xml
+++ b/packages/l/libheif/pspec_x86_64.xml
@@ -23,15 +23,15 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
 </Description>
         <PartOf>multimedia.codecs</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="60">libheif-plugin-dav1d</Dependency>
-            <Dependency releaseFrom="60">libheif-plugin-ffmpeg</Dependency>
-            <Dependency releaseFrom="60">libheif-plugin-jpeg</Dependency>
-            <Dependency releaseFrom="60">libheif-plugin-rav1e</Dependency>
-            <Dependency releaseFrom="60">libheif-plugin-x265</Dependency>
+            <Dependency releaseFrom="61">libheif-plugin-dav1d</Dependency>
+            <Dependency releaseFrom="61">libheif-plugin-ffmpeg</Dependency>
+            <Dependency releaseFrom="61">libheif-plugin-jpeg</Dependency>
+            <Dependency releaseFrom="61">libheif-plugin-rav1e</Dependency>
+            <Dependency releaseFrom="61">libheif-plugin-x265</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/libheif.so.1</Path>
-            <Path fileType="library">/usr/lib64/libheif.so.1.22.0</Path>
+            <Path fileType="library">/usr/lib64/libheif.so.1.22.2</Path>
             <Path fileType="data">/usr/share/licenses/libheif/COPYING</Path>
         </Files>
     </Package>
@@ -43,18 +43,18 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="60">libheif</Dependency>
-            <Dependency releaseFrom="60">libheif-plugin-aom</Dependency>
-            <Dependency releaseFrom="60">libheif-plugin-dav1d</Dependency>
-            <Dependency releaseFrom="60">libheif-plugin-ffmpeg</Dependency>
-            <Dependency releaseFrom="60">libheif-plugin-j2k</Dependency>
-            <Dependency releaseFrom="60">libheif-plugin-jpeg</Dependency>
-            <Dependency releaseFrom="60">libheif-plugin-libde265</Dependency>
-            <Dependency releaseFrom="60">libheif-plugin-openh264</Dependency>
-            <Dependency releaseFrom="60">libheif-plugin-rav1e</Dependency>
-            <Dependency releaseFrom="60">libheif-plugin-svtav1</Dependency>
-            <Dependency releaseFrom="60">libheif-plugin-x264</Dependency>
-            <Dependency releaseFrom="60">libheif-plugin-x265</Dependency>
+            <Dependency release="61">libheif</Dependency>
+            <Dependency releaseFrom="61">libheif-plugin-aom</Dependency>
+            <Dependency releaseFrom="61">libheif-plugin-dav1d</Dependency>
+            <Dependency releaseFrom="61">libheif-plugin-ffmpeg</Dependency>
+            <Dependency releaseFrom="61">libheif-plugin-j2k</Dependency>
+            <Dependency releaseFrom="61">libheif-plugin-jpeg</Dependency>
+            <Dependency releaseFrom="61">libheif-plugin-libde265</Dependency>
+            <Dependency releaseFrom="61">libheif-plugin-openh264</Dependency>
+            <Dependency releaseFrom="61">libheif-plugin-rav1e</Dependency>
+            <Dependency releaseFrom="61">libheif-plugin-svtav1</Dependency>
+            <Dependency releaseFrom="61">libheif-plugin-x264</Dependency>
+            <Dependency releaseFrom="61">libheif-plugin-x265</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libheif/heif.h</Path>
@@ -198,7 +198,7 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
         <Description xml:lang="en">This package provides tools for manipulating HEIF files.</Description>
         <PartOf>multimedia.codecs</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="60">libheif</Dependency>
+            <Dependency releaseFrom="61">libheif</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/heif-convert</Path>
@@ -214,9 +214,9 @@ libheif makes use of libde265 for the actual image decoding and x265 for encodin
         </Files>
     </Package>
     <History>
-        <Update release="60">
-            <Date>2026-05-21</Date>
-            <Version>1.22.0</Version>
+        <Update release="61">
+            <Date>2026-05-26</Date>
+            <Version>1.22.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- aom: Stop exporting static AOM CMake target
- libheif: Update to 1.22.2 (fix broken headers)
- imagemagick: Update to 7.1.2.24

**Security**
`libheif`
- [GHSA-r7qj-cg5r-r6vf](https://github.com/strukturag/libheif/security/advisories/GHSA-r7qj-cg5r-r6vf)
- [GHSA-5hqq-636x-r3cr](https://github.com/strukturag/libheif/security/advisories/GHSA-5hqq-636x-r3cr)

`imagemagick`
- GHSA-vgh5-r42g-4j44
- GHSA-6mwj-rp89-6j5j
- GHSA-2hhq-c99x-492r
- GHSA-9hqg-xf93-ghfw
- GHSA-5v62-8fq6-cp9m
- GHSA-h36c-3666-h489
- GHSA-gm48-c7f2-v67p
- GHSA-8pj9-6897-74xc
- GHSA-xcjm-wqff-m669
- GHSA-4v89-6mgq-6rgc

**Test Plan**

`magick identify example.png`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
