### PR TITLE
quickshell: Don't disable crash reporter

### DIFF
--- a/packages/q/quickshell/package.yml
+++ b/packages/q/quickshell/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : quickshell
 version    : 0.3.0
-release    : 8
+release    : 9
 source     :
     - https://git.outfoxxed.me/quickshell/quickshell/archive/v0.3.0.tar.gz : f4821f9084cab04bd2b5384cc92b9726aecc4ce3eb27200dca24edc67da3b6e5
 homepage   : https://quickshell.org/
@@ -25,7 +25,6 @@ rundeps    :
     - upower
 setup      : |
     %cmake_ninja \
-        -DCRASH_REPORTER=OFF \
         -DINSTALL_QMLDIR="lib/qt6/qml" \
         -DDISTRIBUTOR="Solus" \
         -DNO_PCH=ON

--- a/packages/q/quickshell/pspec_x86_64.xml
+++ b/packages/q/quickshell/pspec_x86_64.xml
@@ -101,8 +101,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2026-05-19</Date>
+        <Update release="9">
+            <Date>2026-05-27</Date>
             <Version>0.3.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
This actually doesn't change anything for us, because the option for
this changed with 0.3, and I didn't update it.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a new Niri/DMS session.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
