### PR TITLE
aerion: Update to v0.2.5

### DIFF
--- a/packages/a/aerion/package.yml
+++ b/packages/a/aerion/package.yml
@@ -1,9 +1,11 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : aerion
-version    : 0.2.4
-release    : 2
+version    : 0.2.5
+release    : 3
 source     :
-    - https://github.com/hkdb/aerion/archive/refs/tags/v0.2.4.tar.gz : 639ba99e1c5a5dc6d059a1148682e015f8928cc9ec437ae2428e2d96aac29f75
+    - https://github.com/hkdb/aerion/archive/refs/tags/v0.2.5.tar.gz : 315a30b852580f36f32e46a8453585a9739d491a391545d652a7614dcb43f1bc
+    # Keep this OAuth credentials shim version in sync with the Aerion source tag.
+    - https://github.com/hkdb/aerion/releases/download/v0.2.5/flathub-build-env-v0.2.5-linux-x86_64 : 5a7d218ff2fc0baf4a3650851f19951204e922e0659ac35ec214d76b2308576b
 homepage   : https://aerion.3df.io/
 license    : Apache-2.0
 component  : network.mail
@@ -37,6 +39,7 @@ build      : |
     go build -tags desktop,webkit2_41,production -ldflags "-w -s -linkmode=external" -o aerion .
 install    : |
     install -Dm00755 aerion ${installdir}/usr/bin/aerion
+    install -Dm00755 ${sources}/flathub-build-env-v%version%-linux-x86_64 ${installdir}/usr/bin/aerion-creds
     install -Dm00644 build/appicon.png ${installdir}/usr/share/icons/hicolor/256x256/apps/io.github.hkdb.Aerion.png
     install -Dm00644 build/linux/aerion.desktop ${installdir}/usr/share/applications/io.github.hkdb.Aerion.desktop
 

--- a/packages/a/aerion/pspec_x86_64.xml
+++ b/packages/a/aerion/pspec_x86_64.xml
@@ -27,6 +27,7 @@ composition, contact sync, PGP/S/MIME, and multiple color themes.
         <PartOf>network.mail</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/aerion</Path>
+            <Path fileType="executable">/usr/bin/aerion-creds</Path>
             <Path fileType="data">/usr/share/applications/io.github.hkdb.Aerion.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/256x256/apps/io.github.hkdb.Aerion.png</Path>
             <Path fileType="data">/usr/share/licenses/aerion/LICENSE</Path>
@@ -34,9 +35,9 @@ composition, contact sync, PGP/S/MIME, and multiple color themes.
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2026-05-21</Date>
-            <Version>0.2.4</Version>
+        <Update release="3">
+            <Date>2026-05-27</Date>
+            <Version>0.2.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/hkdb/aerion/releases/tag/v0.2.5).
- Adds OAuth credentials
- Bug fixes
- Resolves: #9047 

**Test Plan**

<!-- Short description of how the package was tested -->

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
