### PR TITLE
os-prober: Update to v1.84

### DIFF
--- a/packages/o/os-prober/package.yml
+++ b/packages/o/os-prober/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : os-prober
-version    : 1.81
-release    : 7
+version    : '1.84'
+release    : 8
 source     :
-    - https://ftp.debian.org/debian/pool/main/o/os-prober/os-prober_1.81.tar.xz : 2fd928ec86538227711e2adf49cfd6a1ef74f6bb3555c5dad4e0425ccd978883
+    - https://ftp.debian.org/debian/pool/main/o/os-prober/os-prober_1.84.tar.xz : 42e48245986d8ec9491a07a74522c7b78e685ddc9b4f801045c62cd03dd7b067
 license    : GPL-2.0-or-later
 component  : system.boot
 homepage   : https://joeyh.name/code/os-prober
@@ -29,3 +29,5 @@ install    : |
     install -Dm00755 os-probes/mounted/powerpc/20macosx -t $installdir/%libdir%/os-probes/mounted
 
     install -Dm00644 $pkgfiles/os-prober.tmpfiles $installdir/%libdir%/tmpfiles.d/os-prober.conf
+
+    %install_license debian/copyright

--- a/packages/o/os-prober/pspec_x86_64.xml
+++ b/packages/o/os-prober/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>os-prober</Name>
         <Homepage>https://joeyh.name/code/os-prober</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>system.boot</PartOf>
@@ -45,16 +45,17 @@
             <Path fileType="library">/usr/lib64/os-probes/mounted/efi/10elilo</Path>
             <Path fileType="library">/usr/lib64/os-probes/mounted/efi/20microsoft</Path>
             <Path fileType="library">/usr/lib64/tmpfiles.d/os-prober.conf</Path>
+            <Path fileType="data">/usr/share/licenses/os-prober/copyright</Path>
             <Path fileType="data">/usr/share/os-prober/common.sh</Path>
         </Files>
     </Package>
     <History>
-        <Update release="7">
-            <Date>2023-12-20</Date>
-            <Version>1.81</Version>
+        <Update release="8">
+            <Date>2026-05-29</Date>
+            <Version>1.84</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Change install path, to make package usrmerge-compliant.
- Support the noudeb profile
- Refactor windows version detection (+ adding ver 12).
- Make gbp tag produce the right tag format.

Full changelog [here](https://tracker.debian.org/media/packages/o/os-prober/changelog-1.84)

**Test Plan**

- Run `os-prober` see windows install listed

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
