### PR TITLE
dos2unix: Update to v7.5.6

### DIFF
--- a/packages/d/dos2unix/package.yml
+++ b/packages/d/dos2unix/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : dos2unix
-version    : 7.5.5
-release    : 10
+version    : 7.5.6
+release    : 11
 source     :
-    - https://sourceforge.net/projects/dos2unix/files/dos2unix/7.5.5/dos2unix-7.5.5.tar.gz : 75f692b8484c8c24579a2ffd87df16b9c9428ed95497e3393a21d1ba0697ac33
-homepage   : https://dos2unix.sourceforge.io/
+    - https://sourceforge.net/projects/dos2unix/files/dos2unix/7.5.6/dos2unix-7.5.6.tar.gz : 63650acbd0c7fa8623429bcbf93a888e3351a1cad0f556cf41876f5673dd7d0b
+homepage   : https://waterlander.net/dos2unix/
 license    : BSD-2-Clause-FreeBSD
 component  : system.utils
 summary    : DOS/Mac to Unix and vice versa text file format converter
@@ -14,5 +14,7 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING.txt
+    rm ${installdir}/usr/share/doc/dos2unix-${version}/COPYING.txt
 check      : |
     %make test

--- a/packages/d/dos2unix/pspec_x86_64.xml
+++ b/packages/d/dos2unix/pspec_x86_64.xml
@@ -1,7 +1,7 @@
 <PISI>
     <Source>
         <Name>dos2unix</Name>
-        <Homepage>https://dos2unix.sourceforge.io/</Homepage>
+        <Homepage>https://waterlander.net/dos2unix/</Homepage>
         <Packager>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>
@@ -24,39 +24,39 @@
             <Path fileType="executable">/usr/bin/mac2unix</Path>
             <Path fileType="executable">/usr/bin/unix2dos</Path>
             <Path fileType="executable">/usr/bin/unix2mac</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/BUGS.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/COPYING.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/ChangeLog.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/INSTALL.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/NEWS.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/README.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/TODO.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/de/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/de/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/es/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/es/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/fr/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/fr/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/ko/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/ko/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/nl/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/nl/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/pl/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/pl/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/pt_BR/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/pt_BR/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/ro/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/ro/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/sr/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/sr/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/sv/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/sv/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/uk/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/uk/dos2unix.txt</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/zh_CN/dos2unix.htm</Path>
-            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.5/zh_CN/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/BUGS.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/ChangeLog.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/INSTALL.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/NEWS.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/README.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/TODO.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/de/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/de/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/es/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/es/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/fr/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/fr/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/ko/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/ko/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/nl/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/nl/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/pl/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/pl/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/pt_BR/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/pt_BR/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/ro/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/ro/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/sr/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/sr/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/sv/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/sv/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/uk/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/uk/dos2unix.txt</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/zh_CN/dos2unix.htm</Path>
+            <Path fileType="doc">/usr/share/doc/dos2unix-7.5.6/zh_CN/dos2unix.txt</Path>
+            <Path fileType="data">/usr/share/licenses/dos2unix/COPYING.txt</Path>
             <Path fileType="localedata">/usr/share/locale/ca/LC_MESSAGES/dos2unix.mo</Path>
             <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/dos2unix.mo</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/dos2unix.mo</Path>
@@ -135,9 +135,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2026-05-11</Date>
-            <Version>7.5.5</Version>
+        <Update release="11">
+            <Date>2026-05-30</Date>
+            <Version>7.5.6</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://dos2unix.sourceforge.io/dos2unix/ChangeLog.txt).
- New homepage

**Test Plan**

Converted crlf to lf and back.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
