### PR TITLE
liblcms2: Update to v2.19.1

### DIFF
--- a/packages/l/liblcms2/package.yml
+++ b/packages/l/liblcms2/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : liblcms2
-version    : '2.19'
-release    : 21
+version    : 2.19.1
+release    : 22
 source     :
-    - https://github.com/mm2/Little-CMS/archive/refs/tags/lcms2.19.tar.gz : 6acc3eb5fac194acc85331194133ad1d4a60419dad16b3bc225a7d27380a5b3a
+    - https://github.com/mm2/Little-CMS/archive/refs/tags/lcms2.19.1.tar.gz : 267705e278e2f7c2fb886c259dadcbaeb2be52748bcbc71c79f08aacacb7a709
 homepage   : https://www.littlecms.com/
 license    :
     - GPL-3.0-or-later

--- a/packages/l/liblcms2/pspec_x86_64.xml
+++ b/packages/l/liblcms2/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>liblcms2</Name>
         <Homepage>https://www.littlecms.com/</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <License>MIT</License>
@@ -37,7 +37,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="21">liblcms2</Dependency>
+            <Dependency release="22">liblcms2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/liblcms2.so.2</Path>
@@ -55,8 +55,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="21">liblcms2-devel</Dependency>
-            <Dependency release="21">liblcms2-32bit</Dependency>
+            <Dependency release="22">liblcms2-32bit</Dependency>
+            <Dependency release="22">liblcms2-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/liblcms2.so</Path>
@@ -72,7 +72,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="21">liblcms2</Dependency>
+            <Dependency release="22">liblcms2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/lcms2.h</Path>
@@ -92,7 +92,7 @@
 </Description>
         <PartOf>desktop.core</PartOf>
         <RuntimeDependencies>
-            <Dependency release="21">liblcms2</Dependency>
+            <Dependency release="22">liblcms2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/jpgicc</Path>
@@ -109,12 +109,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="21">
-            <Date>2026-04-26</Date>
-            <Version>2.19</Version>
+        <Update release="22">
+            <Date>2026-05-26</Date>
+            <Version>2.19.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- lcms2-2.19.1 is a hot-fix release
-  Added building instructions on root folder
- Fixed sonames generation when using autotools
- Recovered an undocumented memory write feature lost because a "security" report.
- Fixed documentation pointers on visual studio project.

**Test Plan**

- Open a few of the rev-dep applications, krita, kitty, libreoffice

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
