### PR TITLE
sshfs-fuse: Update to v3.7.6

### DIFF
--- a/packages/s/sshfs-fuse/abi_used_symbols
+++ b/packages/s/sshfs-fuse/abi_used_symbols
@@ -109,6 +109,7 @@ libfuse3.so.4:fuse_session_fd
 libfuse3.so.4:fuse_set_signal_handlers
 libfuse3.so.4:fuse_unmount
 libglib-2.0.so.0:g_free
+libglib-2.0.so.0:g_free_sized
 libglib-2.0.so.0:g_hash_table_foreach_remove
 libglib-2.0.so.0:g_hash_table_insert
 libglib-2.0.so.0:g_hash_table_lookup
@@ -127,9 +128,9 @@ libglib-2.0.so.0:g_malloc0_n
 libglib-2.0.so.0:g_ptr_array_add
 libglib-2.0.so.0:g_ptr_array_free
 libglib-2.0.so.0:g_ptr_array_new
+libglib-2.0.so.0:g_ptr_array_set_free_func
 libglib-2.0.so.0:g_str_equal
 libglib-2.0.so.0:g_str_hash
 libglib-2.0.so.0:g_strdup
 libglib-2.0.so.0:g_strdup_printf
-libglib-2.0.so.0:g_strfreev
 libglib-2.0.so.0:g_strndup

--- a/packages/s/sshfs-fuse/package.yml
+++ b/packages/s/sshfs-fuse/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : sshfs-fuse
-version    : 3.7.3
-release    : 11
+version    : 3.7.6
+release    : 12
 source     :
-    - https://github.com/libfuse/sshfs/archive/refs/tags/sshfs-3.7.3.tar.gz : 52a1a1e017859dfe72a550e6fef8ad4f8703ce312ae165f74b579fd7344e3a26
+    - https://github.com/libfuse/sshfs/releases/download/sshfs-3.7.6/sshfs-3.7.6.tar.xz : 6a1bcb31450a077e9cb1b7ff158c71de34db697c3c0da6cb362502131e495893
 homepage   : https://github.com/libfuse/sshfs
 license    : GPL-2.0-only
 component  : network.util
@@ -18,3 +18,4 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license COPYING

--- a/packages/s/sshfs-fuse/pspec_x86_64.xml
+++ b/packages/s/sshfs-fuse/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>sshfs-fuse</Name>
         <Homepage>https://github.com/libfuse/sshfs</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>network.util</PartOf>
@@ -23,15 +23,16 @@
             <Path fileType="executable">/usr/bin/sshfs</Path>
             <Path fileType="executable">/usr/sbin/mount.fuse.sshfs</Path>
             <Path fileType="executable">/usr/sbin/mount.sshfs</Path>
+            <Path fileType="data">/usr/share/licenses/sshfs-fuse/COPYING</Path>
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2025-04-09</Date>
-            <Version>3.7.3</Version>
+        <Update release="12">
+            <Date>2026-05-30</Date>
+            <Version>3.7.6</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/libfuse/sshfs/blob/sshfs-3.7.6/ChangeLog.rst).

**Security**
- CVE-2026-47187
- CVE-2026-48711

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Transfer file with KDEConnect.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
