### PR TITLE
libjxl: Backport security patch

### DIFF
--- a/packages/l/libjxl/abi_used_symbols
+++ b/packages/l/libjxl/abi_used_symbols
@@ -96,6 +96,7 @@ libc.so.6:strstr
 libc.so.6:strtod
 libc.so.6:strtof
 libc.so.6:vsnprintf
+libc.so.6:wcslen
 libgcc_s.so.1:_Unwind_Resume
 libgif.so.7:DGifCloseFile
 libgif.so.7:DGifOpen

--- a/packages/l/libjxl/files/CVE-2025-70103.patch
+++ b/packages/l/libjxl/files/CVE-2025-70103.patch
@@ -1,0 +1,113 @@
+From 9a3952d3adfadcfb24f742ce46dec2961153bd5d Mon Sep 17 00:00:00 2001
+From: Evgenii Kliuchnikov <eustas@google.com>
+Date: Thu, 7 Aug 2025 12:08:18 +0000
+Subject: [PATCH] Take EC into accound when checking required PNM inmput length
+
+Based on #4338
+---
+ lib/extras/dec/pnm.cc | 66 +++++++++++++++++++++++++++----------------
+ 1 file changed, 42 insertions(+), 24 deletions(-)
+
+diff --git a/lib/extras/dec/pnm.cc b/lib/extras/dec/pnm.cc
+index 6d857fbc617..8b6dcd847f8 100644
+--- a/lib/extras/dec/pnm.cc
++++ b/lib/extras/dec/pnm.cc
+@@ -514,13 +514,26 @@ Status DecodeImagePNM(const Span<const uint8_t> bytes,
+     }
+   }
+ 
++  // No align - pixels are tightly packed.
++  constexpr size_t kAlign = 0;
++  size_t twidth = PackedImage::BitsPerChannel(data_type) / 8;
+   const JxlPixelFormat format{
+       /*num_channels=*/num_interleaved_channels,
+       /*data_type=*/data_type,
+       /*endianness=*/header.big_endian ? JXL_BIG_ENDIAN : JXL_LITTLE_ENDIAN,
+-      /*align=*/0,
++      kAlign,
+   };
+-  const JxlPixelFormat ec_format{1, format.data_type, format.endianness, 0};
++  // EC format is same as color, but 1-channel.
++  JxlPixelFormat ec_format = format;
++  ec_format.num_channels = 1;
++  size_t required_pnm_size =
++      header.ysize * header.xsize *
++      (num_interleaved_channels + header.ec_types.size()) * twidth;
++  size_t pnm_remaining_size = bytes.data() + bytes.size() - pos;
++  if (pnm_remaining_size < required_pnm_size) {
++    return JXL_FAILURE("PNM file too small");
++  }
++
+   ppf->frames.clear();
+   {
+     JXL_ASSIGN_OR_RETURN(
+@@ -529,42 +542,47 @@ Status DecodeImagePNM(const Span<const uint8_t> bytes,
+     ppf->frames.emplace_back(std::move(frame));
+   }
+   auto* frame = &ppf->frames.back();
++  uint8_t* out = reinterpret_cast<uint8_t*>(frame->color.pixels());
++  std::vector<uint8_t*> ec_out;
+   for (size_t i = 0; i < header.ec_types.size(); ++i) {
+     JXL_ASSIGN_OR_RETURN(
+         PackedImage ec,
+         PackedImage::Create(header.xsize, header.ysize, ec_format));
+     frame->extra_channels.emplace_back(std::move(ec));
++    ec_out.emplace_back(
++        reinterpret_cast<uint8_t*>(frame->extra_channels.back().pixels()));
++    JXL_DASSERT(frame->extra_channels.back().stride == header.xsize * twidth);
+   }
+-  size_t pnm_remaining_size = bytes.data() + bytes.size() - pos;
+-  if (pnm_remaining_size < frame->color.pixels_size) {
+-    return JXL_FAILURE("PNM file too small");
+-  }
+-
+-  uint8_t* out = reinterpret_cast<uint8_t*>(frame->color.pixels());
+-  std::vector<uint8_t*> ec_out(header.ec_types.size());
+-  for (size_t i = 0; i < ec_out.size(); ++i) {
+-    ec_out[i] = reinterpret_cast<uint8_t*>(frame->extra_channels[i].pixels());
+-  }
++  JXL_DASSERT(frame->color.stride ==
++              header.xsize * num_interleaved_channels * twidth);
+   if (ec_out.empty()) {
+-    const bool flipped_y = header.bits_per_sample == 32;  // PFMs are flipped
+-    for (size_t y = 0; y < header.ysize; ++y) {
+-      size_t y_in = flipped_y ? header.ysize - 1 - y : y;
+-      const uint8_t* row_in = &pos[y_in * frame->color.stride];
+-      uint8_t* row_out = &out[y * frame->color.stride];
+-      memcpy(row_out, row_in, frame->color.stride);
++    const bool flipped_y = (header.bits_per_sample == 32);  // PFMs are flipped
++    if (!flipped_y) {
++    // When there are no EC and input is not flipped we can copy the whole
++    // image at once.
++      memcpy(out, pos, header.ysize * frame->color.stride);
++    } else {
++      // Otherwise copy row-by-row.
++      for (size_t y = 0; y < header.ysize; ++y) {
++        size_t y_out = header.ysize - 1 - y;
++        const uint8_t* row_in = pos + y * frame->color.stride;
++        uint8_t* row_out = out + y_out * frame->color.stride;
++        memcpy(row_out, row_in, frame->color.stride);
++      }
+     }
+   } else {
++    // In case there are EC, we have to deinterleave data pixel-wise.
+     JXL_RETURN_IF_ERROR(PackedImage::ValidateDataType(data_type));
+-    size_t pwidth = PackedImage::BitsPerChannel(data_type) / 8;
++    size_t color_stride = twidth * num_interleaved_channels;
+     for (size_t y = 0; y < header.ysize; ++y) {
+       for (size_t x = 0; x < header.xsize; ++x) {
+         memcpy(out, pos, frame->color.pixel_stride());
+-        out += frame->color.pixel_stride();
+-        pos += frame->color.pixel_stride();
++        out += color_stride;
++        pos += color_stride;
+         for (auto& p : ec_out) {
+-          memcpy(p, pos, pwidth);
+-          pos += pwidth;
+-          p += pwidth;
++          memcpy(p, pos, twidth);
++          pos += twidth;
++          p += twidth;
+         }
+       }
+     }

--- a/packages/l/libjxl/package.yml
+++ b/packages/l/libjxl/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libjxl
 version    : 0.11.2
-release    : 9
+release    : 10
 source     :
     - https://github.com/libjxl/libjxl/archive/refs/tags/v0.11.2.tar.gz : ab38928f7f6248e2a98cc184956021acb927b16a0dee71b4d260dc040a4320ea
     - git|https://skia.googlesource.com/skcms.git : b2e692629c1fb19342517d7fb61f1cf83d075492
@@ -38,19 +38,23 @@ setup      : |
     rm -rfv third_party/skcms && cp -a $sources/skcms.git third_party/skcms
     rm -rfv testdata && cp -a $sources/testdata.git testdata
     tar -xf $sources/sjpeg.tar.gz -C third_party/sjpeg --strip-components 1
+
+    %patch -p1 -i ${pkgfiles}/CVE-2025-70103.patch
+
     %cmake_ninja \
-                 -DBUILD_SHARED_LIBS=ON \
-                 -DJPEGXL_ENABLE_BENCHMARK=OFF \
-                 -DJPEGXL_ENABLE_PLUGINS=ON \
-                 -DJPEGXL_BUNDLE_LIBPNG=OFF \
-                 -DJPEGXL_FORCE_SYSTEM_BROTLI=ON \
-                 -DJPEGXL_FORCE_SYSTEM_GTEST=ON \
-                 -DJPEGXL_FORCE_SYSTEM_HWY=ON \
-                 -DJPEGXL_VERSION=$version
+        -DBUILD_SHARED_LIBS=ON \
+        -DJPEGXL_ENABLE_BENCHMARK=OFF \
+        -DJPEGXL_ENABLE_PLUGINS=ON \
+        -DJPEGXL_BUNDLE_LIBPNG=OFF \
+        -DJPEGXL_FORCE_SYSTEM_BROTLI=ON \
+        -DJPEGXL_FORCE_SYSTEM_GTEST=ON \
+        -DJPEGXL_FORCE_SYSTEM_HWY=ON \
+        -DJPEGXL_VERSION=$version
 build      : |
     %ninja_build
 install    : |
     %ninja_install
+    %install_license LICENSE
 check      : |
     %ninja_check
 patterns   :

--- a/packages/l/libjxl/pspec_x86_64.xml
+++ b/packages/l/libjxl/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libjxl</Name>
         <Homepage>https://jpeg.org/jpegxl</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>multimedia.codecs</PartOf>
@@ -26,6 +26,7 @@
             <Path fileType="library">/usr/lib64/libjxl_cms.so.0.11.2</Path>
             <Path fileType="library">/usr/lib64/libjxl_threads.so.0.11</Path>
             <Path fileType="library">/usr/lib64/libjxl_threads.so.0.11.2</Path>
+            <Path fileType="data">/usr/share/licenses/libjxl/LICENSE</Path>
             <Path fileType="data">/usr/share/mime/packages/image-jxl.xml</Path>
         </Files>
     </Package>
@@ -36,7 +37,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="9">libjxl</Dependency>
+            <Dependency release="10">libjxl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/jxl/cms.h</Path>
@@ -76,7 +77,7 @@
         <Description xml:lang="en">JPEG XL offers significantly better image quality and compression ratios than legacy JPEG
 </Description>
         <RuntimeDependencies>
-            <Dependency release="9">libjxl</Dependency>
+            <Dependency release="10">libjxl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/cjxl</Path>
@@ -87,12 +88,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2026-04-21</Date>
+        <Update release="10">
+            <Date>2026-05-31</Date>
             <Version>0.11.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Backport security patch.

**Security**
- CVE-2025-70103

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build `pix` against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
