### PR TITLE
tetro-tui: Update to v3.6.1

### DIFF
--- a/packages/t/tetro-tui/package.yml
+++ b/packages/t/tetro-tui/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : tetro-tui
-version    : 3.5.2
-release    : 3
+version    : 3.6.1
+release    : 4
 source     :
-    - https://github.com/Strophox/tetro-tui/archive/refs/tags/v3.5.2.tar.gz : 5302435075bc4b4b8880dc820fdcea5021458a67ec5f0fe845785c4dafaf4898
+    - https://github.com/Strophox/tetro-tui/archive/refs/tags/v3.6.1.tar.gz : 3b08e3087ef24fb79bad373408b67e6391093e3aea368698d9b994aeb7c491ff
 homepage   : https://github.com/Strophox/tetro-tui
 license    : MIT
 component  : games.puzzle

--- a/packages/t/tetro-tui/pspec_x86_64.xml
+++ b/packages/t/tetro-tui/pspec_x86_64.xml
@@ -32,9 +32,9 @@ keybinds, scoreboards, replays, and statistics.
         </Replaces>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2026-05-21</Date>
-            <Version>3.5.2</Version>
+        <Update release="4">
+            <Date>2026-05-31</Date>
+            <Version>3.6.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/Strophox/tetro-tui/releases/tag/v3.6.1).
- Release notes can be found [here](https://github.com/Strophox/tetro-tui/releases/tag/v3.6.0).

**Test Plan**

Played a game. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
