### PR TITLE
lazarus: Fix rundeps and split gui

### DIFF
--- a/packages/l/lazarus/package.yml
+++ b/packages/l/lazarus/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : lazarus
 version    : '4.6'
-release    : 23
+release    : 24
 source     :
     - https://gitlab.com/freepascal.org/lazarus/lazarus/-/archive/lazarus_4_6/lazarus-lazarus_4_6.tar.gz : e13c74f87329467113f4ebdf7b9e7bf3b7eb4b76c94305372fb3cf99739ea886
 homepage   : https://www.lazarus-ide.org
@@ -9,8 +9,12 @@ license    :
     - GPL-2.0-or-later
     - LGPL-2.1-or-later
     - MPL-1.1
-component  : programming.tools
-summary    : Lazarus is a Rapid Application Development Tool for Free Pascal
+component  :
+    - qt6 : programming.ide
+    - programming.tools
+summary    :
+    - qt6 : Delphi-like IDE for FreePascal Qt6 version
+    - Lazarus is a Rapid Application Development Tool for Free Pascal
 description: |
     Lazarus is a Rapid Application Development Tool for Free Pascal.
 builddeps  :
@@ -20,12 +24,13 @@ builddeps  :
     - qt6pas-devel
     - rsync
 rundeps    :
+    - qt6 :
+        - lazarus
     - binutils
     - fpc
     - fpc-src
     - gdb
     - make
-    - qt5pas-devel # To compile qt5 apps
     - qt6pas-devel # To compile qt6 apps
 clang      : true
 setup      : |
@@ -85,3 +90,9 @@ install    : |
 
     # Licenses
     %install_license COPYING.*
+patterns    :
+    - qt6 :
+        - /usr/bin/lazarus
+        - /usr/bin/startlazarus
+        - /usr/share/applications/lazarus.desktop
+        - /usr/share/icons/hicolor/48x48/apps/lazarus.png

--- a/packages/l/lazarus/pspec_x86_64.xml
+++ b/packages/l/lazarus/pspec_x86_64.xml
@@ -22,9 +22,7 @@
 </Description>
         <PartOf>programming.tools</PartOf>
         <Files>
-            <Path fileType="executable">/usr/bin/lazarus</Path>
             <Path fileType="executable">/usr/bin/lazbuild</Path>
-            <Path fileType="executable">/usr/bin/startlazarus</Path>
             <Path fileType="library">/usr/lib64/lazarus/.gitattributes</Path>
             <Path fileType="library">/usr/lib64/lazarus/.gitignore</Path>
             <Path fileType="library">/usr/lib64/lazarus/.gitlab-ci.yml</Path>
@@ -22593,7 +22591,6 @@
             <Path fileType="library">/usr/lib64/lazarus/units/x86_64-linux/qt6/window_options.ppu</Path>
             <Path fileType="library">/usr/lib64/lazarus/units/x86_64-linux/qt6/wordcompletion.o</Path>
             <Path fileType="library">/usr/lib64/lazarus/units/x86_64-linux/qt6/wordcompletion.ppu</Path>
-            <Path fileType="data">/usr/share/applications/lazarus.desktop</Path>
             <Path fileType="doc">/usr/share/doc/lazarus/.gitignore</Path>
             <Path fileType="doc">/usr/share/doc/lazarus/BigIDE.txt</Path>
             <Path fileType="doc">/usr/share/doc/lazarus/Contributors.txt</Path>
@@ -22870,7 +22867,6 @@
             <Path fileType="doc">/usr/share/doc/lazarus/xml/mkhtml.bat</Path>
             <Path fileType="doc">/usr/share/doc/lazarus/xml/multi_makeskel.pl</Path>
             <Path fileType="doc">/usr/share/doc/lazarus/xml/updateXML.bat</Path>
-            <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/lazarus.png</Path>
             <Path fileType="data">/usr/share/licenses/lazarus/COPYING.GPL.txt</Path>
             <Path fileType="data">/usr/share/licenses/lazarus/COPYING.LGPL.txt</Path>
             <Path fileType="data">/usr/share/licenses/lazarus/COPYING.modifiedLGPL.txt</Path>
@@ -22884,9 +22880,25 @@
             <Path fileType="man">/usr/share/man/man1/updatepofiles.1.zst</Path>
         </Files>
     </Package>
+    <Package>
+        <Name>lazarus-qt6</Name>
+        <Summary xml:lang="en">Delphi-like IDE for FreePascal Qt6 version</Summary>
+        <Description xml:lang="en">Lazarus is a Rapid Application Development Tool for Free Pascal.
+</Description>
+        <PartOf>programming.ide</PartOf>
+        <RuntimeDependencies>
+            <Dependency releaseFrom="24">lazarus</Dependency>
+        </RuntimeDependencies>
+        <Files>
+            <Path fileType="executable">/usr/bin/lazarus</Path>
+            <Path fileType="executable">/usr/bin/startlazarus</Path>
+            <Path fileType="data">/usr/share/applications/lazarus.desktop</Path>
+            <Path fileType="data">/usr/share/icons/hicolor/48x48/apps/lazarus.png</Path>
+        </Files>
+    </Package>
     <History>
-        <Update release="23">
-            <Date>2026-05-31</Date>
+        <Update release="24">
+            <Date>2026-06-01</Date>
             <Version>4.6</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
- Fix rundep that doesn't exist.
- Split out the GUI editor launcher, in case packages (like peazip) need
  lazbuild, but not the full IDE.

Follow up to https://github.com/getsolus/packages/pull/9097
Ref https://github.com/getsolus/packages/issues/9088

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install `lazarus-qt6` from local repository, and launch the IDE.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
