### PR TITLE
xorg security updates

### DIFF
--- a/packages/t/tigervnc/package.yml
+++ b/packages/t/tigervnc/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : tigervnc
 version    : 1.16.2
-release    : 31
+release    : 32
 source     :
     - https://github.com/TigerVNC/tigervnc/archive/refs/tags/v1.16.2.tar.gz : b107c0c8b8a962594281690366c24186e95c2ea4a169acbc0076aa62ed01f467
-    - https://www.x.org/releases/individual/xserver/xorg-server-21.1.22.tar.xz : 1a242c8917c49ba29ccc1f6021613d8a2b9805dd0d271a66ae9d09f4b0bb06b3
+    - https://www.x.org/releases/individual/xserver/xorg-server-21.1.23.tar.xz : e39832e5617dadaf072fdf9f0e19e5d2e1c2a13607ac280bac1aba9f8fe14634
 homepage   : https://tigervnc.org/
 license    :
     - GPL-2.0-or-later

--- a/packages/t/tigervnc/pspec_x86_64.xml
+++ b/packages/t/tigervnc/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>tigervnc</Name>
         <Homepage>https://tigervnc.org/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harvey@getsol.us</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>MIT</License>
@@ -82,12 +82,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="31">
-            <Date>2026-04-15</Date>
+        <Update release="32">
+            <Date>2026-06-02</Date>
             <Version>1.16.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harvey@getsol.us</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/x/xorg-server/package.yml
+++ b/packages/x/xorg-server/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 # Updating this package? Make sure to update the bundled xorg-server in tigervnc too
 name       : xorg-server
-version    : 21.1.22
-release    : 111
+version    : 21.1.23
+release    : 112
 source     :
-    - https://www.x.org/releases/individual/xserver/xorg-server-21.1.22.tar.xz : 1a242c8917c49ba29ccc1f6021613d8a2b9805dd0d271a66ae9d09f4b0bb06b3
+    - https://www.x.org/releases/individual/xserver/xorg-server-21.1.23.tar.xz : e39832e5617dadaf072fdf9f0e19e5d2e1c2a13607ac280bac1aba9f8fe14634
 homepage   : https://xorg.freedesktop.org/wiki/
 license    : MIT
 component  :

--- a/packages/x/xorg-server/pspec_x86_64.xml
+++ b/packages/x/xorg-server/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xorg-server</Name>
         <Homepage>https://xorg.freedesktop.org/wiki/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harvey@getsol.us</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>xorg.server</PartOf>
@@ -67,7 +67,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="111">xorg-server</Dependency>
+            <Dependency release="112">xorg-server</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/xorg/XIstubs.h</Path>
@@ -244,12 +244,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="111">
-            <Date>2026-04-14</Date>
-            <Version>21.1.22</Version>
+        <Update release="112">
+            <Date>2026-06-02</Date>
+            <Version>21.1.23</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harvey@getsol.us</Email>
         </Update>
     </History>
 </PISI>

--- a/packages/x/xorg-xwayland/package.yml
+++ b/packages/x/xorg-xwayland/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : xorg-xwayland
-version    : 24.1.11
-release    : 39
+version    : 24.1.12
+release    : 40
 source     :
-    - https://www.x.org/releases/individual/xserver/xwayland-24.1.11.tar.xz : 27115a1a8819078409bf6fecfeb7724e8137bd36426de7005a5b3aae0a2138ff
+    - https://www.x.org/releases/individual/xserver/xwayland-24.1.12.tar.xz : 6df02c511b92c1b9848734d9d1b03a4c24f8375ba3cada44e9684a21b5f78e21
 license    : MIT
 component  : xorg.server
 homepage   : https://www.x.org/

--- a/packages/x/xorg-xwayland/pspec_x86_64.xml
+++ b/packages/x/xorg-xwayland/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>xorg-xwayland</Name>
         <Homepage>https://www.x.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harvey@getsol.us</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>xorg.server</PartOf>
@@ -27,12 +27,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="39">
-            <Date>2026-05-18</Date>
-            <Version>24.1.11</Version>
+        <Update release="40">
+            <Date>2026-06-02</Date>
+            <Version>24.1.12</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harvey@getsol.us</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

xorg-server: Update to [v21.1.23](https://lists.x.org/archives/xorg-announce/2026-June/003702.html)
xorg-xwayland: Update to [v24.1.12](https://lists.x.org/archives/xorg-announce/2026-June/003702.html)
tigervnc: Update bundled xorg

CVEs not yet assigned.

**Test Plan**

- Boot into Budgie x11 session, use firefox.
- Boot into Plasma x11 session, use firefox.
- Boot into Plasma Wayland session, force firefox to use xwayland.

**Checklist**

- [X] Package was built and tested against unstable
- [X] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
