### PR TITLE
solseek: Update to 1.4.8

### DIFF
--- a/packages/s/solseek/package.yml
+++ b/packages/s/solseek/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : solseek
-version    : 1.4.7
-release    : 39
+version    : 1.4.8
+release    : 40
 source     :
-    - https://github.com/clintre/solseek/archive/refs/tags/v1.4.7.tar.gz : b04b80b2bbd70dfc945ff564baf51ca05f155e044009e30e24bd0f241834c2e8
+    - https://github.com/clintre/solseek/archive/refs/tags/v1.4.8.tar.gz : cebb19508a057f8f39850b94394fcec905580f19c80cd7b1ab67b5397999f021
 homepage   : https://github.com/clintre/solseek
 license    : GPL-3.0-or-later
 component  : system.utils

--- a/packages/s/solseek/pspec_x86_64.xml
+++ b/packages/s/solseek/pspec_x86_64.xml
@@ -74,9 +74,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="39">
-            <Date>2026-05-27</Date>
-            <Version>1.4.7</Version>
+        <Update release="40">
+            <Date>2026-06-03</Date>
+            <Version>1.4.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Clint Eschberger</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**

Bugfixes:
- Fix issue where sometimes you get double entries in the update list
- Fix lock file issue where you have both the service and user checking updates at the same time

Full Changelog:
https://github.com/clintre/solseek/releases/tag/v1.4.8


**Test Plan**

Install and run

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
