### PR TITLE
i2c-tools: Update to 4.4

### DIFF
--- a/packages/i/i2c-tools/abi_used_symbols
+++ b/packages/i/i2c-tools/abi_used_symbols
@@ -1,6 +1,8 @@
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoul
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
@@ -18,10 +20,13 @@ libc.so.6:fopen
 libc.so.6:fputc
 libc.so.6:free
 libc.so.6:fwrite
+libc.so.6:getopt
 libc.so.6:ioctl
 libc.so.6:malloc
 libc.so.6:open
 libc.so.6:opendir
+libc.so.6:optarg
+libc.so.6:optind
 libc.so.6:putchar
 libc.so.6:puts
 libc.so.6:qsort
@@ -39,5 +44,3 @@ libc.so.6:strerror
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:strrchr
-libc.so.6:strtol
-libc.so.6:strtoul

--- a/packages/i/i2c-tools/package.yml
+++ b/packages/i/i2c-tools/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : i2c-tools
-version    : '4.3'
-release    : 4
+version    : '4.4'
+release    : 5
 source     :
-    - https://git.kernel.org/pub/scm/utils/i2c-tools/i2c-tools.git/snapshot/i2c-tools-4.3.tar.gz : b4f63b9f8d74e89a010f1d6e4748659df2f556717dfa273cedc144be451758b9
+    - https://git.kernel.org/pub/scm/utils/i2c-tools/i2c-tools.git/snapshot/i2c-tools-4.4.tar.gz : af01d0fbe78e109a2db7137c7e9bfda3f3fb236c3177744c0f2695d1056cde71
 homepage   : https://archive.kernel.org/oldwiki/i2c.wiki.kernel.org/index.php/I2C_Tools.html
 license    :
     - GPL-2.0-or-later
@@ -17,3 +17,4 @@ build      : |
 install    : |
     # Don't ask why, but BUILD_STATIC_LIB doesn't work in build phase
     %make_install PREFIX="/usr" DESTDIR=$installdir libdir=%libdir% BUILD_STATIC_LIB=0
+    %install_license COPYING

--- a/packages/i/i2c-tools/pspec_x86_64.xml
+++ b/packages/i/i2c-tools/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>i2c-tools</Name>
         <Homepage>https://archive.kernel.org/oldwiki/i2c.wiki.kernel.org/index.php/I2C_Tools.html</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -33,14 +33,15 @@
             <Path fileType="executable">/usr/sbin/i2cget</Path>
             <Path fileType="executable">/usr/sbin/i2cset</Path>
             <Path fileType="executable">/usr/sbin/i2ctransfer</Path>
-            <Path fileType="man">/usr/share/man/man1/decode-dimms.1</Path>
-            <Path fileType="man">/usr/share/man/man1/decode-vaio.1</Path>
-            <Path fileType="man">/usr/share/man/man8/i2c-stub-from-dump.8</Path>
-            <Path fileType="man">/usr/share/man/man8/i2cdetect.8</Path>
-            <Path fileType="man">/usr/share/man/man8/i2cdump.8</Path>
-            <Path fileType="man">/usr/share/man/man8/i2cget.8</Path>
-            <Path fileType="man">/usr/share/man/man8/i2cset.8</Path>
-            <Path fileType="man">/usr/share/man/man8/i2ctransfer.8</Path>
+            <Path fileType="data">/usr/share/licenses/i2c-tools/COPYING</Path>
+            <Path fileType="man">/usr/share/man/man1/decode-dimms.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man1/decode-vaio.1.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/i2c-stub-from-dump.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/i2cdetect.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/i2cdump.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/i2cget.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/i2cset.8.zst</Path>
+            <Path fileType="man">/usr/share/man/man8/i2ctransfer.8.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -50,21 +51,21 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="4">i2c-tools</Dependency>
+            <Dependency release="5">i2c-tools</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/i2c/smbus.h</Path>
             <Path fileType="library">/usr/lib64/libi2c.so</Path>
-            <Path fileType="man">/usr/share/man/man3/libi2c.3</Path>
+            <Path fileType="man">/usr/share/man/man3/libi2c.3.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2024-04-25</Date>
-            <Version>4.3</Version>
+        <Update release="5">
+            <Date>2026-06-03</Date>
+            <Version>4.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Bump to latest. Not new, just the latest
- Maintenance release
- Add License

[4.4 Change Log](https://git.kernel.org/pub/scm/utils/i2c-tools/i2c-tools.git/tree/CHANGES?h=v4.4)

**Test Plan**

Install, test  checking bus information, basic probes

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
