### PR TITLE
fastfetch: Update to v2.64.0

### DIFF
--- a/packages/f/fastfetch/abi_used_symbols
+++ b/packages/f/fastfetch/abi_used_symbols
@@ -86,7 +86,6 @@ libc.so.6:localtime
 libc.so.6:localtime_r
 libc.so.6:malloc
 libc.so.6:malloc_usable_size
-libc.so.6:mbrtowc
 libc.so.6:memchr
 libc.so.6:memcmp
 libc.so.6:memcpy
@@ -164,7 +163,6 @@ libc.so.6:ttyname
 libc.so.6:uname
 libc.so.6:unlink
 libc.so.6:waitpid
-libc.so.6:wcwidth
 libc.so.6:wordexp
 libc.so.6:wordfree
 libc.so.6:write

--- a/packages/f/fastfetch/package.yml
+++ b/packages/f/fastfetch/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : fastfetch
-version    : 2.63.1
-release    : 73
+version    : 2.64.0
+release    : 74
 source     :
-    - https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/2.63.1.tar.gz : 6e124699ea20fb02c5bc402c0012543303ee75ca55ad664f96bc6cd414d7e6b3
+    - https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/2.64.0.tar.gz : cb2d5a1207c9ca9c6a5a25592c0b6064db2efe41dd88094972be9b7611694d8a
 homepage   : https://github.com/fastfetch-cli/fastfetch
 license    : MIT
 component  : system.utils
@@ -21,8 +21,11 @@ builddeps  :
     - pkgconfig(libelf)
     - pkgconfig(libpci)
     - pkgconfig(libpulse)
+    - pkgconfig(libva)
     - pkgconfig(libxfconf-0)
+    - pkgconfig(lua)
     - pkgconfig(sqlite3)
+    - pkgconfig(vdpau)
     - pkgconfig(vulkan)
     - pkgconfig(wayland-client)
     - pkgconfig(xrandr)

--- a/packages/f/fastfetch/pspec_x86_64.xml
+++ b/packages/f/fastfetch/pspec_x86_64.xml
@@ -67,9 +67,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="73">
-            <Date>2026-05-13</Date>
-            <Version>2.63.1</Version>
+        <Update release="74">
+            <Date>2026-06-03</Date>
+            <Version>2.64.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/fastfetch-cli/fastfetch/releases/tag/2.64.0).
- Add optional VA-API, VDPAU, and Lua 5.4 support

**Test Plan**

`fastfetch` `fastfetch --list-features` and see va, vapau, and lua features. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
