### PR TITLE
caddy: Update to v2.11.4

### DIFF
--- a/packages/c/caddy/package.yml
+++ b/packages/c/caddy/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : caddy
-version    : 2.11.3
-release    : 26
+version    : 2.11.4
+release    : 27
 source     :
-    - https://github.com/caddyserver/caddy/archive/refs/tags/v2.11.3.tar.gz : de751e6b7ca769f0dc1f9b0a1949c7b149c115efde3aaf53182da2bf6a94c825
+    - https://github.com/caddyserver/caddy/archive/refs/tags/v2.11.4.tar.gz : 2c3d02078286a6282cdb4d1d8744077788d556659dac0b64d8ed5886a7e5aeb9
     - git|https://github.com/caddyserver/dist.git : 836ff569ed513837874a3aa5441f6719622bb08c
 homepage   : https://caddyserver.com
 license    : Apache-2.0

--- a/packages/c/caddy/pspec_x86_64.xml
+++ b/packages/c/caddy/pspec_x86_64.xml
@@ -59,9 +59,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2026-05-12</Date>
-            <Version>2.11.3</Version>
+        <Update release="27">
+            <Date>2026-06-03</Date>
+            <Version>2.11.4</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/caddyserver/caddy/releases/tag/v2.11.4).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start and stop a Caddy webserver.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
