### PR TITLE
weechat: Update to v4.9.1

### DIFF
--- a/packages/w/weechat/abi_symbols
+++ b/packages/w/weechat/abi_symbols
@@ -1634,6 +1634,7 @@ irc.so:irc_protocol_recv_command
 irc.so:irc_protocol_string_params
 irc.so:irc_protocol_tags
 irc.so:irc_protocol_tags_add_cb
+irc.so:irc_protocol_tags_cmd
 irc.so:irc_raw_add_to_infolist
 irc.so:irc_raw_buffer
 irc.so:irc_raw_end
@@ -2757,6 +2758,7 @@ relay.so:relay_auth_check_salt
 relay.so:relay_auth_generate_nonce
 relay.so:relay_auth_parse_pbkdf2
 relay.so:relay_auth_parse_sha
+relay.so:relay_auth_password_equals
 relay.so:relay_auth_password_hash
 relay.so:relay_auth_password_hash_algo_name
 relay.so:relay_auth_password_hash_algo_search

--- a/packages/w/weechat/package.yml
+++ b/packages/w/weechat/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : weechat
-version    : 4.9.0
-release    : 103
+version    : 4.9.1
+release    : 104
 source     :
-    - https://github.com/weechat/weechat/archive/refs/tags/v4.9.0.tar.gz : 337fc24c0a4c00aa2c47262f123014b23d55c5cf02785ecfdf204f96ccef5c65
+    - https://github.com/weechat/weechat/archive/refs/tags/v4.9.1.tar.gz : edf1bfb20fcecc64e23dca609dae18d7fe7e7545ed1c7e8a05bf3b7571087036
 homepage   : https://weechat.org
 license    : GPL-3.0-or-later
 summary    : WeeChat is a fast, light and extensible chat client.

--- a/packages/w/weechat/pspec_x86_64.xml
+++ b/packages/w/weechat/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>weechat</Name>
         <Homepage>https://weechat.org</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.irc</PartOf>
@@ -92,7 +92,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="103">weechat</Dependency>
+            <Dependency release="104">weechat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/weechat/weechat-plugin.h</Path>
@@ -100,12 +100,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="103">
-            <Date>2026-05-03</Date>
-            <Version>4.9.0</Version>
+        <Update release="104">
+            <Date>2026-06-03</Date>
+            <Version>4.9.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/weechat/weechat/releases/tag/v4.9.1).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Connect to Libera, receive messages.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
