### PR TITLE
python-pyjwt: Update to v2.13.0

### DIFF
--- a/packages/py/python-pyjwt/package.yml
+++ b/packages/py/python-pyjwt/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-pyjwt
-version    : 2.12.1
-release    : 17
+version    : 2.13.0
+release    : 18
 source     :
-    - https://files.pythonhosted.org/packages/source/P/PyJWT/pyjwt-2.12.1.tar.gz : c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b
+    - https://files.pythonhosted.org/packages/source/P/PyJWT/pyjwt-2.13.0.tar.gz : 41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423
 homepage   : https://github.com/jpadilla/pyjwt
 license    : MIT
 component  : programming.python

--- a/packages/py/python-pyjwt/pspec_x86_64.xml
+++ b/packages/py/python-pyjwt/pspec_x86_64.xml
@@ -57,18 +57,18 @@
             <Path fileType="library">/usr/lib/python3.12/site-packages/jwt/types.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/jwt/utils.py</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/jwt/warnings.py</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.12.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.12.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.12.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.12.1.dist-info/licenses/AUTHORS.rst</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.12.1.dist-info/licenses/LICENSE</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.12.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.13.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.13.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.13.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.13.0.dist-info/licenses/AUTHORS.rst</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.13.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/pyjwt-2.13.0.dist-info/top_level.txt</Path>
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2026-03-29</Date>
-            <Version>2.12.1</Version>
+        <Update release="18">
+            <Date>2026-06-03</Date>
+            <Version>2.13.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/jpadilla/pyjwt/releases/tag/2.13.0).

**Security**
Includes fixes for:
- CVE-2026-48526
- CVE-2026-48523
- CVE-2026-48525
- CVE-2026-48522
- CVE-2026-48524

**Test Plan**

Passed python checks. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
