### PR TITLE
python-ujson: Update to v5.12.1

### DIFF
--- a/packages/py/python-ujson/package.yml
+++ b/packages/py/python-ujson/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-ujson
-version    : 5.12.0
-release    : 16
+version    : 5.12.1
+release    : 17
 source     :
-    - https://files.pythonhosted.org/packages/source/u/ujson/ujson-5.12.0.tar.gz : 14b2e1eb528d77bc0f4c5bd1a7ebc05e02b5b41beefb7e8567c9675b8b13bcf4
+    - https://files.pythonhosted.org/packages/source/u/ujson/ujson-5.12.1.tar.gz : 5b7e96406c301a1366534479a7352ec40ec68bb327c0c119091635acd5925e35
 homepage   : https://github.com/ultrajson/ultrajson
 license    : BSD-3-Clause
 component  : programming.python

--- a/packages/py/python-ujson/pspec_x86_64.xml
+++ b/packages/py/python-ujson/pspec_x86_64.xml
@@ -20,19 +20,19 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-5.12.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-5.12.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-5.12.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-5.12.0.dist-info/licenses/LICENSE.txt</Path>
-            <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-5.12.0.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-5.12.1.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-5.12.1.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-5.12.1.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-5.12.1.dist-info/licenses/LICENSE.txt</Path>
+            <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-5.12.1.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ujson-stubs/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.12/site-packages/ujson.cpython-312-x86_64-linux-gnu.so</Path>
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2026-03-29</Date>
-            <Version>5.12.0</Version>
+        <Update release="17">
+            <Date>2026-06-03</Date>
+            <Version>5.12.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/ultrajson/ultrajson/releases/tag/5.12.1).

**Security**
Includes fixes for:
- CVE-2026-44660

**Test Plan**

Passed python tests. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
