### PR TITLE
golang: Update to v1.26.4

### DIFF
--- a/packages/g/golang/package.yml
+++ b/packages/g/golang/package.yml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 # If you're updating this package to a new major version of golang, please update gopls to a version with support for that golang version
 name       : golang
-version    : 1.26.3
-release    : 142
+version    : 1.26.4
+release    : 143
 homepage   : https://golang.org
 source     :
-    - https://golang.org/dl/go1.26.3.src.tar.gz : 1c646875d0aa8799133184ed57cf79ff24bdefe8c8820470602a9d3d6d9192b8
+    - https://golang.org/dl/go1.26.4.src.tar.gz : 4f668a32fbfc1132e6a881fb968c2f1dada631492a339211735fbb255a42602d
 license    : BSD-3-Clause
 summary    : The Go programming language
 description: Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.

--- a/packages/g/golang/pspec_x86_64.xml
+++ b/packages/g/golang/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>golang</Name>
         <Homepage>https://golang.org</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harvey@getsol.us</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming</PartOf>
@@ -14847,6 +14847,7 @@
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue78641.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue7867.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue7884.go</Path>
+            <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue79182.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue7921.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue7944.go</Path>
             <Path fileType="library">/usr/lib64/golang/test/fixedbugs/issue7995.go</Path>
@@ -15759,12 +15760,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="142">
-            <Date>2026-05-09</Date>
-            <Version>1.26.3</Version>
+        <Update release="143">
+            <Date>2026-06-03</Date>
+            <Version>1.26.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Troy Harvey</Name>
+            <Email>harvey@getsol.us</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

**Security**

- CVE-2026-27145
- CVE-2026-42504
- CVE-2026-42507

Release notes available [here](https://groups.google.com/g/golang-announce/c/tKs3rmcBcKw)

**Test Plan**

- Build doctl against local

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
