### PR TITLE
openjfx-21: Fix dependency issue

### DIFF
--- a/packages/o/openjfx-21/abi_used_symbols
+++ b/packages/o/openjfx-21/abi_used_symbols
@@ -1236,7 +1236,6 @@ libm.so.6:nextafterf
 libm.so.6:pow
 libm.so.6:powf
 libm.so.6:remainder
-libm.so.6:rintf
 libm.so.6:round
 libm.so.6:roundf
 libm.so.6:sin

--- a/packages/o/openjfx-21/package.yml
+++ b/packages/o/openjfx-21/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : openjfx-21
 version    : 21.0.5
-release    : 6
+release    : 7
 source     :
     - https://github.com/openjdk/jfx21u/archive/refs/tags/21.0.5+0.tar.gz : 5766291a589fb7a5334b266016f5b47a6fe35b71c39346896385ecd449cd0274
 license    : GPL-2.0-only WITH Classpath-exception-2.0
@@ -23,7 +23,7 @@ builddeps  :
     - gradle
     - openjdk-21-devel
 rundeps    :
-    - libwebkit-gtk
+    - libwebkit-gtk41
     - openjdk-21
 mancompress: true
 clang      : true

--- a/packages/o/openjfx-21/pspec_x86_64.xml
+++ b/packages/o/openjfx-21/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>openjfx-21</Name>
         <Homepage>https://wiki.openjdk.java.net/display/OpenJFX/Main</Homepage>
         <Packager>
-            <Name>Ivan Trepakov</Name>
-            <Email>liontiger23@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>GPL-2.0-only WITH Classpath-exception-2.0</License>
         <PartOf>programming.java</PartOf>
@@ -55,12 +55,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2026-05-16</Date>
+        <Update release="7">
+            <Date>2026-06-04</Date>
             <Version>21.0.5</Version>
             <Comment>Packaging update</Comment>
-            <Name>Ivan Trepakov</Name>
-            <Email>liontiger23@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changed rundep libwebkit-gtk to libwebkit-gtk41

**Test Plan**
Make sure it installs properly with new dependency
Create a OpenJFX 21 Test script
Complie it
Launch app

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
