### PR TITLE
repo_data: Deprecate vscode-dbginfo

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -3211,5 +3211,6 @@
 		<Package>p7zip-dbginfo</Package>
 		<Package>edk2-ovmf-i386</Package>
 		<Package>edk2-ovmf-aarch64</Package>
+		<Package>vscode-dbginfo</Package>
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -4421,5 +4421,7 @@
 		<!-- Renamed -->
 		<Package>edk2-ovmf-aarch64</Package>
 
+		<!-- Debug packages for vscode were disabled ages ago -->
+		<Package>vscode-dbginfo</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
**Summary**

Deprecate `vscode-dbginfo`

Debug package build for vscode was disabled [28th September 2025](https://github.com/getsolus/packages/commit/0178974544c7ed1f32fa30141e9322a7a016d088#diff-edd6257f10591f512f22fb09ac295512bd29f71973013aa57005d7cae859e781)