### PR TITLE
imagemagick: Update to v7.1.2.25

### DIFF
--- a/packages/i/imagemagick/abi_symbols
+++ b/packages/i/imagemagick/abi_symbols
@@ -3612,6 +3612,7 @@ libMagickCore-7.Q16HDRI.so.10:SetPixelMetaChannels
 libMagickCore-7.Q16HDRI.so.10:SetQuantumAlphaType
 libMagickCore-7.Q16HDRI.so.10:SetQuantumDepth
 libMagickCore-7.Q16HDRI.so.10:SetQuantumEndian
+libMagickCore-7.Q16HDRI.so.10:SetQuantumExtent
 libMagickCore-7.Q16HDRI.so.10:SetQuantumFormat
 libMagickCore-7.Q16HDRI.so.10:SetQuantumImageType
 libMagickCore-7.Q16HDRI.so.10:SetQuantumMetaChannel

--- a/packages/i/imagemagick/package.yml
+++ b/packages/i/imagemagick/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : imagemagick
-version    : 7.1.2.24
-release    : 218
+version    : 7.1.2.25
+release    : 219
 source     :
-    - https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-24.tar.gz : 645f1dc68482ba952a02a854ffaf67efca42871b168e0cf702a043db2ec54638
+    - https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-25.tar.gz : ff33d227d2e1744327280e956ec9f7abaebbd8f48277d16cdad906e05e4794b6
 homepage   : https://imagemagick.org/
 license    : Apache-2.0
 component  : multimedia.graphics

--- a/packages/i/imagemagick/pspec_x86_64.xml
+++ b/packages/i/imagemagick/pspec_x86_64.xml
@@ -94,7 +94,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="218">imagemagick</Dependency>
+            <Dependency release="219">imagemagick</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/ImageMagick-7/Magick++.h</Path>
@@ -594,9 +594,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="218">
-            <Date>2026-05-26</Date>
-            <Version>7.1.2.24</Version>
+        <Update release="219">
+            <Date>2026-06-05</Date>
+            <Version>7.1.2.25</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/ImageMagick/Website/blob/main/ChangeLog.md).

**Security**
Includes fixes for:
- GHSA-q62c-h75r-2xhc
- GHSA-g22q-f7gc-5jhr
- GHSA-px7q-ggqj-hcf2
- GHSA-p9rq-q46c-g4x6
- GHSA-j989-f892-2335
- GHSA-44cp-c3ww-9rv5

**Test Plan**

`magick identify example.png`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
