### PR TITLE
fastfetch: Update to v2.64.2

### DIFF
--- a/packages/f/fastfetch/package.yml
+++ b/packages/f/fastfetch/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : fastfetch
-version    : 2.64.1
-release    : 75
+version    : 2.64.2
+release    : 76
 source     :
-    - https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/2.64.1.tar.gz : a91b736e855847aa8803efdd328c076b0048278368238ea45519bd2164f4fb63
+    - https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/2.64.2.tar.gz : 28db81d6568f28281d9aab9e88d5a4c7892d519c54b8739eef17953cce6802d0
 homepage   : https://github.com/fastfetch-cli/fastfetch
 license    : MIT
 component  : system.utils

--- a/packages/f/fastfetch/pspec_x86_64.xml
+++ b/packages/f/fastfetch/pspec_x86_64.xml
@@ -67,9 +67,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="75">
-            <Date>2026-06-04</Date>
-            <Version>2.64.1</Version>
+        <Update release="76">
+            <Date>2026-06-05</Date>
+            <Version>2.64.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/fastfetch-cli/fastfetch/releases/tag/2.64.2).
- Fix Regressions

**Test Plan**

Ran fastfetch

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
