### PR TITLE
common: Add package check for metainfo file name

### DIFF
--- a/common/CI/package_checks.py
+++ b/common/CI/package_checks.py
@@ -782,6 +782,30 @@ class StaticLibs(PullRequestCheck):
                     for pattern in self.config.static_libs.allowed_files])
 
 
+class MetainfoFile(PullRequestCheck):
+    """
+    Checks that AppStream metainfo files have a correct name.
+    """
+    _level = Level.WARNING
+
+    def run(self) -> List[Result]:
+        return [self._result(pspec, file)
+                for pspec in self.filter_files('pspec_x86_64.xml')
+                for file in self.load_pspec_xml(pspec).files
+                if self._check(file)]
+
+    def _result(self, pspec: str, file: str) -> Result:
+        return Result(message=f'An AppStream metainfo file is misnamed in the package: `{file}`. '
+                      'File name should be in the format `id.metainfo.xml`, e.g. `org.gnome.Software.metainfo.xml`, '
+                      'or `id.appdata.xml`, e.g. `org.kde.discover.appdata.xml`.',
+                      file=pspec, line=self.file_line(pspec, f'.*{file}.*'), level=self._level)
+
+    def _check(self, file: str) -> bool:
+        return (file.startswith('/usr/share/metainfo') and
+                (not file.endswith('.appdata.xml') and
+                not file.endswith('.metainfo.xml')))
+
+
 class SystemDependencies(PullRequestCheck):
     _components = ['system.base', 'system.devel']
 
@@ -871,6 +895,7 @@ class Checker:
         CommitMessage,
         FrozenPackage,
         Homepage,
+        MetainfoFile,
         Monitoring,
         License,
         PackageBumped,


### PR DESCRIPTION
**Summary**
We want to be able to catch when a package contains AppStream metainfo files that don't follow the correct naming convention. If they don't, they may not be picked up during the generation of the AppStream catalog.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

1. Modify by hand the `package.yml` and `pspec_x86_64` files for `gnome-software` and `discover` to bump the package release.
2. Run `go-task check` and see no warnings.
3. Modify the name of a metainfo file in one of the pspec files to be an invalid name.
4. Run `go-task check` and see a warning about the metainfo file name.

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
