### PR TITLE
mariadb: Update to v11.8.8

### DIFF
--- a/packages/m/mariadb/package.yml
+++ b/packages/m/mariadb/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : mariadb
-version    : 11.8.7
-release    : 38
+version    : 11.8.8
+release    : 39
 source     :
-    - https://archive.mariadb.org/mariadb-11.8.7/source/mariadb-11.8.7.tar.gz : 1a23a21549ce6e4803f0f149159e5c76b925f6fa4c955a4064f9c472b4b79a05
+    - https://archive.mariadb.org/mariadb-11.8.8/source/mariadb-11.8.8.tar.gz : bd023a4959faf012db7f0ebfc0d276729e67e5443df193163f98d80fdfc524c9
 homepage   : https://mariadb.org/
 license    :
     - BSD-3-Clause

--- a/packages/m/mariadb/pspec_x86_64.xml
+++ b/packages/m/mariadb/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mariadb</Name>
         <Homepage>https://mariadb.org/</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <License>GPL-2.0-or-later</License>
@@ -35,12 +35,12 @@
             <Path fileType="executable">/usr/bin/mysqlshow</Path>
             <Path fileType="executable">/usr/bin/mysqlslap</Path>
             <Path fileType="executable">/usr/bin/mytop</Path>
-            <Path fileType="doc">/usr/share/doc/mariadb-11.8.7/COPYING</Path>
-            <Path fileType="doc">/usr/share/doc/mariadb-11.8.7/CREDITS</Path>
-            <Path fileType="doc">/usr/share/doc/mariadb-11.8.7/INSTALL-BINARY</Path>
-            <Path fileType="doc">/usr/share/doc/mariadb-11.8.7/README.md</Path>
-            <Path fileType="doc">/usr/share/doc/mariadb-11.8.7/THIRDPARTY</Path>
-            <Path fileType="doc">/usr/share/doc/mariadb-11.8.7/hashicorp_key_management.txt</Path>
+            <Path fileType="doc">/usr/share/doc/mariadb-11.8.8/COPYING</Path>
+            <Path fileType="doc">/usr/share/doc/mariadb-11.8.8/CREDITS</Path>
+            <Path fileType="doc">/usr/share/doc/mariadb-11.8.8/INSTALL-BINARY</Path>
+            <Path fileType="doc">/usr/share/doc/mariadb-11.8.8/README.md</Path>
+            <Path fileType="doc">/usr/share/doc/mariadb-11.8.8/THIRDPARTY</Path>
+            <Path fileType="doc">/usr/share/doc/mariadb-11.8.8/hashicorp_key_management.txt</Path>
             <Path fileType="data">/usr/share/licenses/mariadb/COPYING</Path>
             <Path fileType="data">/usr/share/licenses/mariadb/COPYING.LIB</Path>
             <Path fileType="man">/usr/share/man/man1/mariabackup.1.zst</Path>
@@ -105,9 +105,9 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="38">mariadb</Dependency>
-            <Dependency release="38">mariadb-common</Dependency>
-            <Dependency release="38">mariadb-server</Dependency>
+            <Dependency release="39">mariadb-common</Dependency>
+            <Dependency release="39">mariadb-server</Dependency>
+            <Dependency release="39">mariadb</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/mariadb-config</Path>
@@ -730,8 +730,8 @@
 </Description>
         <PartOf>database</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="38">mariadb-common</Dependency>
-            <Dependency releaseFrom="38">mariadb-errmsg</Dependency>
+            <Dependency releaseFrom="39">mariadb-common</Dependency>
+            <Dependency releaseFrom="39">mariadb-errmsg</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/mariadb-embedded</Path>
@@ -784,9 +784,9 @@
 </Description>
         <PartOf>database</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="38">mariadb</Dependency>
-            <Dependency releaseFrom="38">mariadb-common</Dependency>
-            <Dependency releaseFrom="38">mariadb-errmsg</Dependency>
+            <Dependency releaseFrom="39">mariadb</Dependency>
+            <Dependency releaseFrom="39">mariadb-common</Dependency>
+            <Dependency releaseFrom="39">mariadb-errmsg</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/aria_chk</Path>
@@ -1042,12 +1042,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="38">
-            <Date>2026-05-24</Date>
-            <Version>11.8.7</Version>
+        <Update release="39">
+            <Date>2026-06-06</Date>
+            <Version>11.8.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Jakob Gezelius</Name>
+            <Email>jakob@knugen.nu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://mariadb.com/docs/release-notes/community-server/11.8/11.8.8).

**Security**
Includes fixes for:
CVE-2026-49261
CVE-2026-48165
CVE-2026-48163

**Test Plan**
- Ran some sql-commands.

**Checklist**

- [X] Package was built and tested against unstable
- [X] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
