### PR TITLE
asusctl: Update to 6.3.8

### DIFF
--- a/packages/a/asusctl/files/asusd.preset
+++ b/packages/a/asusctl/files/asusd.preset
@@ -1,0 +1,2 @@
+enable asusd.service
+enable asus-shutdown.service

--- a/packages/a/asusctl/package.yml
+++ b/packages/a/asusctl/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : asusctl
-version    : 6.3.7
-release    : 1
+version    : 6.3.8
+release    : 2
 source     :
-    - https://gitlab.com/asus-linux/asusctl/-/archive/6.3.7/asusctl-6.3.7.tar.gz : e971665c6bb8b81f125304574d1a0568997cd23ad67a048d595abdde6ba8d63a
+    - https://gitlab.com/asus-linux/asusctl/-/archive/6.3.8/asusctl-6.3.8.tar.gz : 7f767da78a8efd6b67632172c643c005330dee897cc380604f6ae09eba5c7e7a
 homepage   : https://asus-linux.org/
 license    : MPL-2.0
 component  : hardware.power
@@ -33,6 +33,7 @@ build      : |
     %make
 install    : |
     %make_install prefix=/usr
+    install -Dm00644 ${pkgfiles}/asusd.preset ${installdir}/usr/lib/systemd/system-preset/60-asusd.preset
     install -Dm00644 ${pkgfiles}/asusctl.tmpfiles ${installdir}/usr/lib/tmpfiles.d/asusctl.conf
     install -dm00755 ${installdir}/usr/share/licenses/${package}
     mv ${installdir}/usr/share/asusctl/LICENSE ${installdir}/usr/share/licenses/${package}/LICENSE

--- a/packages/a/asusctl/pspec_x86_64.xml
+++ b/packages/a/asusctl/pspec_x86_64.xml
@@ -31,6 +31,7 @@ charge limit, fan curves, and GPU MUX where supported.
             <Path fileType="executable">/usr/bin/asusd</Path>
             <Path fileType="executable">/usr/bin/asusd-user</Path>
             <Path fileType="executable">/usr/bin/rog-control-center</Path>
+            <Path fileType="library">/usr/lib/systemd/system-preset/60-asusd.preset</Path>
             <Path fileType="library">/usr/lib/systemd/system/asus-shutdown.service</Path>
             <Path fileType="library">/usr/lib/systemd/system/asusd.service</Path>
             <Path fileType="library">/usr/lib/tmpfiles.d/asusctl.conf</Path>
@@ -120,9 +121,9 @@ charge limit, fan curves, and GPU MUX where supported.
         </Files>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2026-05-22</Date>
-            <Version>6.3.7</Version>
+        <Update release="2">
+            <Date>2026-06-08</Date>
+            <Version>6.3.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Marc Van Giel</Name>
             <Email>marc@nalolabs.be</Email>


### PR DESCRIPTION
**Summary**

- Update asusctl to 6.3.8

**Test Plan**

Built against unstable on Solus 4.9. Installed on ASUS ROG laptop, started asusd, confirmed asusctl info and asusctl profile -p.

**Checklist**

- [x] Package was built and tested against unstable
- [x] This change could gainfully be listed in the weekly sync notes once merged
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
