### PR TITLE
element: Fix desktop file mime type permiting callbacks

### DIFF
--- a/packages/e/element/abi_used_symbols
+++ b/packages/e/element/abi_used_symbols
@@ -342,6 +342,7 @@ libc.so.6:chroot
 libc.so.6:clock
 libc.so.6:clock_getres
 libc.so.6:clock_gettime
+libc.so.6:clock_nanosleep
 libc.so.6:clone
 libc.so.6:close
 libc.so.6:closedir

--- a/packages/e/element/files/im.riot.Riot.desktop
+++ b/packages/e/element/files/im.riot.Riot.desktop
@@ -6,5 +6,5 @@ Terminal=false
 Type=Application
 Categories=Network;InstantMessaging;Chat;VideoConference;
 Icon=element-desktop
-MimeType=x-scheme-handler/riot;x-scheme-handler/element;
+MimeType=x-scheme-handler/io.element.desktop;x-scheme-handler/element;
 Keywords=Matrix;matrix.org;chat;irc;communications;talk;riot;vector;

--- a/packages/e/element/package.yml
+++ b/packages/e/element/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : element
 version    : 1.12.18
-release    : 216
+release    : 217
 homepage   : https://element.io/
 source     :
     - git|https://github.com/element-hq/element-web.git : 0793747d68daeee149eddf2b378a723b19057c44

--- a/packages/e/element/pspec_x86_64.xml
+++ b/packages/e/element/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>element</Name>
         <Homepage>https://element.io/</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Trevor Busk</Name>
+            <Email>trevor@tbusk.com</Email>
         </Packager>
         <License>AGPL-3.0-or-later</License>
         <License>GPL-3.0-or-later</License>
@@ -793,12 +793,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="216">
-            <Date>2026-05-13</Date>
+        <Update release="217">
+            <Date>2026-06-06</Date>
             <Version>1.12.18</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Trevor Busk</Name>
+            <Email>trevor@tbusk.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
Fixes getsolus/packages#9165

**Summary**

This addresses the OIDC browser to app callback issue I was facing in #9165 which is exclusive to this packaging. The flatpack version works.

**Test Plan**

<!-- Short description of how the package was tested -->

- [X] rebuilt existing package and tried to login
- [X] authenticated with existing flatpack without issue
- [X] updated desktop file, rebuilt, and logged in

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
