### PR TITLE
ack: Update to 3.10.0

### DIFF
--- a/packages/a/ack/package.yml
+++ b/packages/a/ack/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : ack
-version    : 3.9.0
-release    : 22
+version    : 3.10.0
+release    : 23
 source     :
-    - https://github.com/beyondgrep/ack3/archive/refs/tags/v3.9.0.tar.gz : b2233b9f30b7099db2bad9d6b7e7f7e1003a73ce24353b92b8e904d5b44fedf7
+    - https://github.com/beyondgrep/ack3/archive/refs/tags/v3.10.0.tar.gz : ef1df66e8bd5cee004473231423cf2033450b8f2955f2020628361ff80a5675e
 homepage   : https://beyondgrep.com/
 license    : Artistic-2.0
 component  : system.utils
@@ -18,3 +18,4 @@ build      : |
     %perl_build
 install    : |
     %perl_install
+    %install_license LICENSE.md

--- a/packages/a/ack/pspec_x86_64.xml
+++ b/packages/a/ack/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ack</Name>
         <Homepage>https://beyondgrep.com/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>Artistic-2.0</License>
         <PartOf>system.utils</PartOf>
@@ -41,16 +41,17 @@
             <Path fileType="library">/usr/lib64/perl5/vendor_perl/5.38/App/Ack/Filter/Match.pm</Path>
             <Path fileType="library">/usr/lib64/perl5/vendor_perl/5.38/App/Ack/Filter/MatchGroup.pm</Path>
             <Path fileType="library">/usr/lib64/perl5/vendor_perl/5.38/x86_64-linux-thread-multi/auto/ack/.packlist</Path>
-            <Path fileType="man">/usr/share/man/man1/ack.1</Path>
+            <Path fileType="data">/usr/share/licenses/ack/LICENSE.md</Path>
+            <Path fileType="man">/usr/share/man/man1/ack.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2025-05-28</Date>
-            <Version>3.9.0</Version>
+        <Update release="23">
+            <Date>2026-06-08</Date>
+            <Version>3.10.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Security update
Add License

**Security Updates**
- CVE-2026-49147
- CVE-2026-49146
- CVE-2026-49145

[Full Change Log](https://beyondgrep.com/changes.txt)

**Test Plan**

Install and test

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
