### PR TITLE
openssl: Update to v3.6.3

### DIFF
--- a/packages/o/openssl/package.yml
+++ b/packages/o/openssl/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : openssl
-version    : 3.6.2
-release    : 58
+version    : 3.6.3
+release    : 59
 source     :
-    - https://github.com/openssl/openssl/releases/download/openssl-3.6.2/openssl-3.6.2.tar.gz : aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f
+    - https://github.com/openssl/openssl/releases/download/openssl-3.6.3/openssl-3.6.3.tar.gz : 243a86649cf6f23eeb6a2ff2456e09e5d77dd9018a54d3d96b0c6bdd6ba6c7f1
 homepage   : https://www.openssl.org/
 license    : OpenSSL
 summary    : Cryptographic tools required by many packages

--- a/packages/o/openssl/pspec_x86_64.xml
+++ b/packages/o/openssl/pspec_x86_64.xml
@@ -415,7 +415,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="58">openssl</Dependency>
+            <Dependency release="59">openssl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/engines-3/afalg.so</Path>
@@ -434,8 +434,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="58">openssl-32bit</Dependency>
-            <Dependency release="58">openssl-devel</Dependency>
+            <Dependency release="59">openssl-devel</Dependency>
+            <Dependency release="59">openssl-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/cmake/OpenSSL/OpenSSLConfig.cmake</Path>
@@ -456,7 +456,7 @@
 </Description>
         <PartOf>system.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="58">openssl</Dependency>
+            <Dependency release="59">openssl</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/openssl/aes.h</Path>
@@ -966,6 +966,10 @@
             <Path fileType="man">/usr/share/man/man3/BIO_new_ssl.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_new_ssl_connect.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_next.3ossl</Path>
+            <Path fileType="man">/usr/share/man/man3/BIO_nread.3ossl</Path>
+            <Path fileType="man">/usr/share/man/man3/BIO_nread0.3ossl</Path>
+            <Path fileType="man">/usr/share/man/man3/BIO_nwrite.3ossl</Path>
+            <Path fileType="man">/usr/share/man/man3/BIO_nwrite0.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_parse_hostserv.3ossl.zst</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_pending.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/BIO_pop.3ossl</Path>
@@ -1401,10 +1405,12 @@
             <Path fileType="man">/usr/share/man/man3/CRYPTO_mem_leaks_cb.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/CRYPTO_mem_leaks_fp.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/CRYPTO_memcmp.3ossl.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/CRYPTO_memdup.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/CRYPTO_new_ex_data.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/CRYPTO_realloc.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/CRYPTO_realloc_array.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/CRYPTO_realloc_fn.3ossl</Path>
+            <Path fileType="man">/usr/share/man/man3/CRYPTO_secure_actual_size.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/CRYPTO_secure_allocated.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/CRYPTO_secure_calloc.3ossl</Path>
             <Path fileType="man">/usr/share/man/man3/CRYPTO_secure_clear_free.3ossl</Path>
@@ -6805,9 +6811,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="58">
-            <Date>2026-04-07</Date>
-            <Version>3.6.2</Version>
+        <Update release="59">
+            <Date>2026-06-09</Date>
+            <Version>3.6.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/openssl/openssl/releases/tag/openssl-3.6.3).

**Security**
- CVE-2026-45447
- CVE-2026-34182
- CVE-2026-34183
- CVE-2026-35188
- CVE-2026-42764
- CVE-2026-45445
- CVE-2026-7383
- CVE-2026-9076
- CVE-2026-34180
- CVE-2026-34181
- CVE-2026-42765
- CVE-2026-42766
- CVE-2026-42767
- CVE-2026-42768
- CVE-2026-42769
- CVE-2026-42770
- CVE-2026-45446

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Build `wget` against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
