### PR TITLE
perl-dbi: Update to v1.648

### DIFF
--- a/packages/p/perl-dbi/package.yml
+++ b/packages/p/perl-dbi/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : perl-dbi
-version    : '1.647'
-release    : 16
+version    : '1.648'
+release    : 17
 source     :
-    - https://cpan.metacpan.org/authors/id/H/HM/HMBRAND/DBI-1.647.tgz : 0df16af8e5b3225a68b7b592ab531004ddb35a9682b50300ce50174ad867d9aa
+    - https://cpan.metacpan.org/authors/id/H/HM/HMBRAND/DBI-1.648.tgz : ef266aad6010ce2eabb7e465ebd73ca3020bc58150f6989bd89c2b8f9bac6a86
 homepage   : https://metacpan.org/pod/DBI
 license    : Artistic-1.0-Perl
 component  : programming.perl

--- a/packages/p/perl-dbi/pspec_x86_64.xml
+++ b/packages/p/perl-dbi/pspec_x86_64.xml
@@ -144,9 +144,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2026-04-07</Date>
-            <Version>1.647</Version>
+        <Update release="17">
+            <Date>2026-06-09</Date>
+            <Version>1.648</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://metacpan.org/dist/DBI/changes).

**Security**
Includes fixes for:
- CVE-2026-9698

**Test Plan**

`perl -MDBI -e 'print "DBI $DBI::VERSION\n"'` and see version

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
