### PR TITLE
httpd: Update to v2.4.68

### DIFF
--- a/packages/h/httpd/abi_used_symbols
+++ b/packages/h/httpd/abi_used_symbols
@@ -995,9 +995,12 @@ libcrypt.so.2:crypt
 libcrypto.so.3:ASN1_INTEGER_to_BN
 libcrypto.so.3:ASN1_OBJECT_free
 libcrypto.so.3:ASN1_STRING_free
+libcrypto.so.3:ASN1_STRING_get0_data
+libcrypto.so.3:ASN1_STRING_length
 libcrypto.so.3:ASN1_STRING_new
 libcrypto.so.3:ASN1_STRING_print_ex
 libcrypto.so.3:ASN1_TIME_check
+libcrypto.so.3:ASN1_TIME_diff
 libcrypto.so.3:ASN1_TIME_print
 libcrypto.so.3:ASN1_UTCTIME_print
 libcrypto.so.3:ASN1_d2i_bio
@@ -1209,6 +1212,9 @@ libcrypto.so.3:X509_cmp_current_time
 libcrypto.so.3:X509_digest
 libcrypto.so.3:X509_email_free
 libcrypto.so.3:X509_free
+libcrypto.so.3:X509_get0_notAfter
+libcrypto.so.3:X509_get0_notBefore
+libcrypto.so.3:X509_get0_serialNumber
 libcrypto.so.3:X509_get0_tbs_sigalg
 libcrypto.so.3:X509_get1_ocsp
 libcrypto.so.3:X509_get_X509_PUBKEY

--- a/packages/h/httpd/package.yml
+++ b/packages/h/httpd/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : httpd
-version    : 2.4.67
-release    : 37
+version    : 2.4.68
+release    : 38
 source     :
-    - https://dlcdn.apache.org/httpd/httpd-2.4.67.tar.gz : 10a578d199c3930250534fac629995f34ef7571709a7c88c45239e1fdc88cf77
+    - https://dlcdn.apache.org/httpd/httpd-2.4.68.tar.gz : ed9a9d4500fb48bb28eaffb3ba71d06ccf86d498fa13ab9f781da010cc488498
 homepage   : https://httpd.apache.org/
 license    : Apache-2.0
 component  : programming

--- a/packages/h/httpd/pspec_x86_64.xml
+++ b/packages/h/httpd/pspec_x86_64.xml
@@ -186,6 +186,7 @@ Based on the the public domain HTTP daemon devloped by Rob McCool at the Nationa
             <Path fileType="data">/usr/share/httpd/error/HTTP_BAD_GATEWAY.html.var</Path>
             <Path fileType="data">/usr/share/httpd/error/HTTP_BAD_REQUEST.html.var</Path>
             <Path fileType="data">/usr/share/httpd/error/HTTP_FORBIDDEN.html.var</Path>
+            <Path fileType="data">/usr/share/httpd/error/HTTP_GATEWAY_TIME_OUT.html.var</Path>
             <Path fileType="data">/usr/share/httpd/error/HTTP_GONE.html.var</Path>
             <Path fileType="data">/usr/share/httpd/error/HTTP_INTERNAL_SERVER_ERROR.html.var</Path>
             <Path fileType="data">/usr/share/httpd/error/HTTP_LENGTH_REQUIRED.html.var</Path>
@@ -453,6 +454,7 @@ Based on the the public domain HTTP daemon devloped by Rob McCool at the Nationa
             <Path fileType="data">/usr/share/httpd/manual/bind.html.fr.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/bind.html.ja.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/bind.html.ko.euc-kr</Path>
+            <Path fileType="data">/usr/share/httpd/manual/bind.html.pt-br.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/bind.html.tr.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/caching.html</Path>
             <Path fileType="data">/usr/share/httpd/manual/caching.html.en</Path>
@@ -541,6 +543,7 @@ Based on the the public domain HTTP daemon devloped by Rob McCool at the Nationa
             <Path fileType="data">/usr/share/httpd/manual/filter.html.fr.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/filter.html.ja.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/filter.html.ko.euc-kr</Path>
+            <Path fileType="data">/usr/share/httpd/manual/filter.html.pt-br.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/filter.html.tr.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/getting-started.html</Path>
             <Path fileType="data">/usr/share/httpd/manual/getting-started.html.en</Path>
@@ -586,6 +589,7 @@ Based on the the public domain HTTP daemon devloped by Rob McCool at the Nationa
             <Path fileType="data">/usr/share/httpd/manual/howto/htaccess.html.ja.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/howto/htaccess.html.ko.euc-kr</Path>
             <Path fileType="data">/usr/share/httpd/manual/howto/htaccess.html.pt-br</Path>
+            <Path fileType="data">/usr/share/httpd/manual/howto/htaccess.html.pt-br.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/howto/http2.html</Path>
             <Path fileType="data">/usr/share/httpd/manual/howto/http2.html.en</Path>
             <Path fileType="data">/usr/share/httpd/manual/howto/http2.html.es</Path>
@@ -630,24 +634,27 @@ Based on the the public domain HTTP daemon devloped by Rob McCool at the Nationa
             <Path fileType="data">/usr/share/httpd/manual/images/feather.gif</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/feather.png</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/filter_arch.png</Path>
+            <Path fileType="data">/usr/share/httpd/manual/images/filter_arch.pt-br.png</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/filter_arch.tr.png</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/home.gif</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/index.gif</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/left.gif</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/mod_filter_new.gif</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/mod_filter_new.png</Path>
+            <Path fileType="data">/usr/share/httpd/manual/images/mod_filter_new.pt-br.png</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/mod_filter_new.tr.png</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/mod_filter_old.gif</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/mod_filter_old.png</Path>
-            <Path fileType="data">/usr/share/httpd/manual/images/mod_rewrite_fig1.gif</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/mod_rewrite_fig1.png</Path>
-            <Path fileType="data">/usr/share/httpd/manual/images/mod_rewrite_fig2.gif</Path>
+            <Path fileType="data">/usr/share/httpd/manual/images/mod_rewrite_fig1.svg</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/mod_rewrite_fig2.png</Path>
+            <Path fileType="data">/usr/share/httpd/manual/images/mod_rewrite_fig2.svg</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/pixel.gif</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/reverse-proxy-arch.png</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/rewrite_backreferences.png</Path>
+            <Path fileType="data">/usr/share/httpd/manual/images/rewrite_backreferences.svg</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/rewrite_process_uri.png</Path>
-            <Path fileType="data">/usr/share/httpd/manual/images/rewrite_rule_flow.png</Path>
+            <Path fileType="data">/usr/share/httpd/manual/images/rewrite_process_uri.svg</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/right.gif</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/ssl_intro_fig1.gif</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/ssl_intro_fig1.png</Path>
@@ -657,7 +664,9 @@ Based on the the public domain HTTP daemon devloped by Rob McCool at the Nationa
             <Path fileType="data">/usr/share/httpd/manual/images/ssl_intro_fig3.png</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/sub.gif</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/syntax_rewritecond.png</Path>
+            <Path fileType="data">/usr/share/httpd/manual/images/syntax_rewritecond.svg</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/syntax_rewriterule.png</Path>
+            <Path fileType="data">/usr/share/httpd/manual/images/syntax_rewriterule.svg</Path>
             <Path fileType="data">/usr/share/httpd/manual/images/up.gif</Path>
             <Path fileType="data">/usr/share/httpd/manual/index.html</Path>
             <Path fileType="data">/usr/share/httpd/manual/index.html.da</Path>
@@ -668,6 +677,7 @@ Based on the the public domain HTTP daemon devloped by Rob McCool at the Nationa
             <Path fileType="data">/usr/share/httpd/manual/index.html.ja.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/index.html.ko.euc-kr</Path>
             <Path fileType="data">/usr/share/httpd/manual/index.html.pt-br</Path>
+            <Path fileType="data">/usr/share/httpd/manual/index.html.pt-br.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/index.html.ru.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/index.html.tr.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/index.html.zh-cn.utf8</Path>
@@ -678,6 +688,7 @@ Based on the the public domain HTTP daemon devloped by Rob McCool at the Nationa
             <Path fileType="data">/usr/share/httpd/manual/install.html.fr.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/install.html.ja.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/install.html.ko.euc-kr</Path>
+            <Path fileType="data">/usr/share/httpd/manual/install.html.pt-br.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/install.html.tr.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/invoking.html</Path>
             <Path fileType="data">/usr/share/httpd/manual/invoking.html.de</Path>
@@ -686,6 +697,7 @@ Based on the the public domain HTTP daemon devloped by Rob McCool at the Nationa
             <Path fileType="data">/usr/share/httpd/manual/invoking.html.fr.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/invoking.html.ja.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/invoking.html.ko.euc-kr</Path>
+            <Path fileType="data">/usr/share/httpd/manual/invoking.html.pt-br.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/invoking.html.tr.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/license.html</Path>
             <Path fileType="data">/usr/share/httpd/manual/license.html.en</Path>
@@ -1296,16 +1308,19 @@ Based on the the public domain HTTP daemon devloped by Rob McCool at the Nationa
             <Path fileType="data">/usr/share/httpd/manual/new_features_2_0.html.ja.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/new_features_2_0.html.ko.euc-kr</Path>
             <Path fileType="data">/usr/share/httpd/manual/new_features_2_0.html.pt-br</Path>
+            <Path fileType="data">/usr/share/httpd/manual/new_features_2_0.html.pt-br.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/new_features_2_0.html.tr.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/new_features_2_2.html</Path>
             <Path fileType="data">/usr/share/httpd/manual/new_features_2_2.html.en</Path>
             <Path fileType="data">/usr/share/httpd/manual/new_features_2_2.html.fr.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/new_features_2_2.html.ko.euc-kr</Path>
             <Path fileType="data">/usr/share/httpd/manual/new_features_2_2.html.pt-br</Path>
+            <Path fileType="data">/usr/share/httpd/manual/new_features_2_2.html.pt-br.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/new_features_2_2.html.tr.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/new_features_2_4.html</Path>
             <Path fileType="data">/usr/share/httpd/manual/new_features_2_4.html.en</Path>
             <Path fileType="data">/usr/share/httpd/manual/new_features_2_4.html.fr.utf8</Path>
+            <Path fileType="data">/usr/share/httpd/manual/new_features_2_4.html.pt-br.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/new_features_2_4.html.tr.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/platform/ebcdic.html</Path>
             <Path fileType="data">/usr/share/httpd/manual/platform/ebcdic.html.en</Path>
@@ -1539,6 +1554,7 @@ Based on the the public domain HTTP daemon devloped by Rob McCool at the Nationa
             <Path fileType="data">/usr/share/httpd/manual/upgrading.html</Path>
             <Path fileType="data">/usr/share/httpd/manual/upgrading.html.en</Path>
             <Path fileType="data">/usr/share/httpd/manual/upgrading.html.fr.utf8</Path>
+            <Path fileType="data">/usr/share/httpd/manual/upgrading.html.pt-br.utf8</Path>
             <Path fileType="data">/usr/share/httpd/manual/urlmapping.html</Path>
             <Path fileType="data">/usr/share/httpd/manual/urlmapping.html.en</Path>
             <Path fileType="data">/usr/share/httpd/manual/urlmapping.html.fr.utf8</Path>
@@ -1616,7 +1632,7 @@ Based on the the public domain HTTP daemon devloped by Rob McCool at the Nationa
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="37">httpd</Dependency>
+            <Dependency release="38">httpd</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/httpd/ap_compat.h</Path>
@@ -1687,9 +1703,9 @@ Based on the the public domain HTTP daemon devloped by Rob McCool at the Nationa
         </Files>
     </Package>
     <History>
-        <Update release="37">
-            <Date>2026-05-07</Date>
-            <Version>2.4.67</Version>
+        <Update release="38">
+            <Date>2026-06-09</Date>
+            <Version>2.4.68</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://downloads.apache.org/httpd/CHANGES_2.4.68).

**Security**
Includes fixes for:
- CVE-2026-49975
- CVE-2026-48913
- CVE-2026-44631
- CVE-2026-44186
- CVE-2026-44185
- CVE-2026-44119
- CVE-2026-43951
- CVE-2026-42536
- CVE-2026-42535
- CVE-2026-34356
- CVE-2026-34355
- CVE-2026-29170
- CVE-2026-29167

**Test Plan**

`curl -I http://localhost/` and see successful test. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
