### PR TITLE
ldns: Update to v1.9.1

### DIFF
--- a/packages/l/ldns/package.yml
+++ b/packages/l/ldns/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : ldns
-version    : 1.9.0
-release    : 9
+version    : 1.9.2
+release    : 10
 source     :
-    - https://github.com/NLnetLabs/ldns/archive/refs/tags/1.9.0.tar.gz : e882cdb6b30504623a799e724f77273c14d5f265c925a2884de9fbc94aa88d19
+    - https://github.com/NLnetLabs/ldns/archive/refs/tags/1.9.2.tar.gz : 29ed8cf10fb098291cbcbcf1725b480867035b59347ee03ec55d683d47a430f1
 homepage   : https://nlnetlabs.nl/projects/ldns/
 license    : BSD-3-Clause
 component  :
@@ -13,13 +13,6 @@ summary    : ldns library for DNS programming
 description:
     - The goal of ldns is to simplify DNS programming, it supports recent RFCs like the DNSSEC documents, and allows developers to easily create software conforming to current RFCs, and experimental software for current Internet Drafts.
     - utils : Drill and ldns examples. Drill is a tool to designed to get all sorts of information out of the DNS. It is specificly designed to be used with DNSSEC. The examples are example programs of ldns usage.
-patterns   :
-    - utils :
-        - /usr/bin
-        - /usr/share/man/man1
-    - devel :
-        - /usr/bin/ldns-config
-        - /usr/share/man/man1/ldns-config.1
 environment: |
     unset CFLAGS
 setup      : |
@@ -33,4 +26,12 @@ build      : |
     %make
 install    : |
     %make_install
+    %install_license LICENSE
     install -D -m00644 packaging/libldns.pc $installdir/usr/lib64/pkgconfig/libldns.pc
+patterns   :
+    - utils :
+        - /usr/bin
+        - /usr/share/man/man1
+    - devel :
+        - /usr/bin/ldns-config
+        - /usr/share/man/man1/ldns-config.1

--- a/packages/l/ldns/pspec_x86_64.xml
+++ b/packages/l/ldns/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ldns</Name>
         <Homepage>https://nlnetlabs.nl/projects/ldns/</Homepage>
         <Packager>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.library</PartOf>
@@ -19,7 +19,8 @@
         <PartOf>programming.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libldns.so.3</Path>
-            <Path fileType="library">/usr/lib64/libldns.so.3.6.0</Path>
+            <Path fileType="library">/usr/lib64/libldns.so.3.9.0</Path>
+            <Path fileType="data">/usr/share/licenses/ldns/LICENSE</Path>
         </Files>
     </Package>
     <Package>
@@ -28,7 +29,7 @@
         <Description xml:lang="en">The goal of ldns is to simplify DNS programming, it supports recent RFCs like the DNSSEC documents, and allows developers to easily create software conforming to current RFCs, and experimental software for current Internet Drafts.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="9">ldns</Dependency>
+            <Dependency release="10">ldns</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/ldns-config</Path>
@@ -546,7 +547,7 @@
         <Description xml:lang="en">Drill and ldns examples. Drill is a tool to designed to get all sorts of information out of the DNS. It is specificly designed to be used with DNSSEC. The examples are example programs of ldns usage.</Description>
         <PartOf>network.util</PartOf>
         <RuntimeDependencies>
-            <Dependency release="9">ldns</Dependency>
+            <Dependency release="10">ldns</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/drill</Path>
@@ -605,12 +606,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="9">
-            <Date>2025-12-27</Date>
-            <Version>1.9.0</Version>
+        <Update release="10">
+            <Date>2026-06-12</Date>
+            <Version>1.9.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Silke Hofstra</Name>
-            <Email>silke@slxh.eu</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/NLnetLabs/ldns/blob/1.9.1/Changelog).

**Security**
- CVE-2026-10846

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebuild reverse dependencies against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
