### PR TITLE
sqlite3: Update to v3.53.2

### DIFF
--- a/packages/s/sqlite3/package.yml
+++ b/packages/s/sqlite3/package.yml
@@ -1,15 +1,14 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : sqlite3
-version    : 3.53.1
-release    : 66
+version    : 3.53.2
+release    : 67
 source     :
-    - https://www.sqlite.org/2026/sqlite-src-3530000.zip : fbc30cdbfcfa42c78fe7bddd3fd37ab8995369a31d39097a5d0633296c0b6e65
+    - https://www.sqlite.org/2026/sqlite-src-3530200.zip : cafff764c03f6d720968f746e2f47a986bbf12bf4c18904f1eb131c0b0b592d3
+homepage   : https://www.sqlite.org
 license    : Public-Domain
 component  :
     - system.base
     - lemon : programming.tools
-emul32     : true
-homepage   : https://www.sqlite.org
 summary    :
     - Self contained SQL package
     - lemon : A parser generator
@@ -17,6 +16,7 @@ description:
     - The SQLite package is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.
     - lemon : The Lemon program is an LALR(1) parser generator. It takes a context free grammar and converts it into a subroutine that will parse a file using that grammar.
 clang      : true
+emul32     : true
 optimize   :
     - speed
     - thin-lto

--- a/packages/s/sqlite3/pspec_x86_64.xml
+++ b/packages/s/sqlite3/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>sqlite3</Name>
         <Homepage>https://www.sqlite.org</Homepage>
         <Packager>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Public-Domain</License>
         <PartOf>system.base</PartOf>
@@ -20,7 +20,7 @@
         <Files>
             <Path fileType="executable">/usr/bin/sqlite3</Path>
             <Path fileType="library">/usr/lib64/libsqlite3.so.0</Path>
-            <Path fileType="library">/usr/lib64/libsqlite3.so.3.53.0</Path>
+            <Path fileType="library">/usr/lib64/libsqlite3.so.3.53.2</Path>
             <Path fileType="data">/usr/share/licenses/sqlite3/LICENSE.md</Path>
             <Path fileType="man">/usr/share/man/man1/sqlite3.1.zst</Path>
         </Files>
@@ -31,11 +31,11 @@
         <Description xml:lang="en">The SQLite package is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.</Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="66">sqlite3</Dependency>
+            <Dependency release="67">sqlite3</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libsqlite3.so.0</Path>
-            <Path fileType="library">/usr/lib32/libsqlite3.so.3.53.0</Path>
+            <Path fileType="library">/usr/lib32/libsqlite3.so.3.53.2</Path>
         </Files>
     </Package>
     <Package>
@@ -44,8 +44,8 @@
         <Description xml:lang="en">The SQLite package is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="66">sqlite3-devel</Dependency>
-            <Dependency release="66">sqlite3-32bit</Dependency>
+            <Dependency release="67">sqlite3-32bit</Dependency>
+            <Dependency release="67">sqlite3-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libsqlite3.so</Path>
@@ -58,7 +58,7 @@
         <Description xml:lang="en">The SQLite package is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.</Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="66">sqlite3</Dependency>
+            <Dependency release="67">sqlite3</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/sqlite3.h</Path>
@@ -78,12 +78,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="66">
-            <Date>2026-05-18</Date>
-            <Version>3.53.1</Version>
+        <Update release="67">
+            <Date>2026-06-11</Date>
+            <Version>3.53.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Robert Gonzalez</Name>
-            <Email>uni.dos12@outlook.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://www.sqlite.org/releaselog/3_53_2.html).

**Security**
Includes fixes for:
- CVE-2026-11822
- CVE-2026-11824

**Test Plan**

Passed smoke tests. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
