### PR TITLE
thefuck: Backport patch for Pytest 9

### DIFF
--- a/packages/t/thefuck/files/thefuck-3.32-pytest-9.patch
+++ b/packages/t/thefuck/files/thefuck-3.32-pytest-9.patch
@@ -1,0 +1,27 @@
+From 606ec7d539c255716c26399d63afd294b36e3923 Mon Sep 17 00:00:00 2001
+From: Stanislav Levin <slev@altlinux.org>
+Date: Tue, 24 Feb 2026 18:29:45 +0300
+Subject: [PATCH] tests: make tests compatible with Pytest 9
+
+https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
+
+> Applying a mark to a fixture function never had any effect, but it is a common user error.
+
+Fixes: https://github.com/nvbn/thefuck/issues/1549
+Signed-off-by: Stanislav Levin <slev@altlinux.org>
+---
+ tests/shells/conftest.py | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/tests/shells/conftest.py b/tests/shells/conftest.py
+index 069673fcc..783442ae0 100644
+--- a/tests/shells/conftest.py
++++ b/tests/shells/conftest.py
+@@ -12,7 +12,6 @@ def isfile(mocker):
+ 
+ 
+ @pytest.fixture
+-@pytest.mark.usefixtures('isfile')
+ def history_lines(mocker):
+     def aux(lines):
+         mock = mocker.patch('io.open')

--- a/packages/t/thefuck/package.yml
+++ b/packages/t/thefuck/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : thefuck
 version    : '3.32'
-release    : 25
+release    : 26
 source     :
     - https://github.com/nvbn/thefuck/archive/3.32.tar.gz : 76cbb014473672d1c384922857f8fbc1f6f7774f74f784149ad88751854ecfdf
 homepage   : https://github.com/nvbn/thefuck
@@ -18,6 +18,7 @@ checkdeps  :
     - python-colorama
     - python-decorator
     - python-mock
+    - python-pexpect
     - python-psutil
     - python-pyte
     - python-pytest-mock
@@ -33,6 +34,7 @@ setup      : |
     %patch -p1 -i $pkgfiles/remove-imp-usage.patch
     %patch -p1 -i $pkgfiles/remove-mock-usage.patch
     %patch -p1 -i $pkgfiles/pytest-8.patch
+    %patch -p1 -i ${pkgfiles}/thefuck-3.32-pytest-9.patch
     %patch -p1 -i ${pkgfiles}/thefuck-3.32-replace-pkg_resources.patch
 build      : |
     %python3_setup

--- a/packages/t/thefuck/pspec_x86_64.xml
+++ b/packages/t/thefuck/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>thefuck</Name>
         <Homepage>https://github.com/nvbn/thefuck</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>system.utils</PartOf>
@@ -656,12 +656,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="25">
-            <Date>2026-06-09</Date>
+        <Update release="26">
+            <Date>2026-06-12</Date>
             <Version>3.32</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Backport patch fixing compatibility with Pytest 9.

Ref https://github.com/nvbn/thefuck/issues/1549

**Test Plan**

See that the test suite runs successfully.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
