### PR TITLE
mercurial: Update to v7.2.2

### DIFF
--- a/packages/m/mercurial/abi_used_symbols
+++ b/packages/m/mercurial/abi_used_symbols
@@ -146,6 +146,7 @@ libc.so.6:__assert_fail
 libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_sscanf
 libc.so.6:__memcpy_chk
 libc.so.6:__sprintf_chk
 libc.so.6:__stack_chk_fail
@@ -156,8 +157,11 @@ libc.so.6:clock
 libc.so.6:close
 libc.so.6:closedir
 libc.so.6:exit
+libc.so.6:fclose
 libc.so.6:fdopendir
 libc.so.6:fflush
+libc.so.6:fgets
+libc.so.6:fopen64
 libc.so.6:fputc
 libc.so.6:free
 libc.so.6:fstatat64
@@ -189,9 +193,11 @@ libc.so.6:realloc
 libc.so.6:sigaddset
 libc.so.6:sigemptyset
 libc.so.6:sigprocmask
+libc.so.6:snprintf
 libc.so.6:statfs64
 libc.so.6:stderr
 libc.so.6:strcmp
 libc.so.6:strlen
 libc.so.6:strncpy
+libc.so.6:strrchr
 libc.so.6:sysconf

--- a/packages/m/mercurial/package.yml
+++ b/packages/m/mercurial/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : mercurial
-version    : 7.0.1
-release    : 48
+version    : 7.2.2
+release    : 49
 source     :
-    - https://www.mercurial-scm.org/release/mercurial-7.0.1.tar.gz : 0f4cde42ec6c15f7ff93d421e7a842fdb30ee7951b1dbc4aacaac06eac764b48
+    - https://www.mercurial-scm.org/release/mercurial-7.2.2.tar.gz : f2ec8e7eeef0500591706d374555f0ceb118822068e75fa3b32be07dd2184f6c
 homepage   : https://www.mercurial-scm.org/
 license    : GPL-2.0-or-later
 summary    : Mercurial is a free, distributed source control management tool.
@@ -21,17 +21,21 @@ build      : |
     %python3_setup
 install    : |
     %python3_install
+    %install_license COPYING
+
     # Docs
-    install -d $installdir/usr/share/man/{man1,man5}
+    install -dm 00755 $installdir/usr/share/man/{man1,man5}
     install -m00644 doc/hg.1 $installdir/usr/share/man/man1
     install -m00644 doc/{hgrc.5,hgignore.5} $installdir/usr/share/man/man5
     install -m00755 contrib/hgk $installdir/usr/bin
+
     # Completions
     install -Dm00644 contrib/zsh_completion $installdir/usr/share/zsh/site-functions/_hg
     install -Dm00644 contrib/bash_completion $installdir/usr/share/bash-completion/completions/hg
-    install -d $installdir/usr/share/emacs/site-lisp
+    install -dm 00755 $installdir/usr/share/emacs/site-lisp
     install -m00644 contrib/{mq.el,mercurial.el} $installdir/usr/share/emacs/site-lisp
     install -Dm00644 contrib/vim/HGAnnotate.vim $installdir/usr/share/vim/vimfiles/syntax/HGAnnotate.vim
-#check      : |
-#    TESTFLAGS="%JOBS% --tmpdir tmp --blacklist blacklists/failed-tests" \
-#    make check
+# TODO: Disable for now, tests don't work
+# check      : |
+#     TESTFLAGS="%JOBS% --tmpdir tmp --blacklist blacklists/failed-tests" \
+#     make check

--- a/packages/m/mercurial/pspec_x86_64.xml
+++ b/packages/m/mercurial/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>mercurial</Name>
         <Homepage>https://www.mercurial-scm.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>programming.tools</PartOf>
@@ -458,11 +458,11 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/hgext3rd/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/hgext3rd/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/hgext3rd/__pycache__/__init__.cpython-314.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial-7.0.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial-7.0.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial-7.0.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial-7.0.1.dist-info/licenses/COPYING</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial-7.0.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial-7.2.2.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial-7.2.2.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial-7.2.2.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial-7.2.2.dist-info/licenses/COPYING</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial-7.2.2.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__modulepolicy__.py</Path>
@@ -486,6 +486,8 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/branchmap.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/bundle2.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/bundle2.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/bundle2_part_handlers.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/bundle2_part_handlers.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/bundlecaches.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/bundlecaches.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/bundlerepo.cpython-314.opt-1.pyc</Path>
@@ -578,6 +580,8 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/httppeer.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/i18n.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/i18n.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/initialization.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/initialization.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/keepalive.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/keepalive.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/linelog.cpython-314.opt-1.pyc</Path>
@@ -662,6 +666,8 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/revlog.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/revset.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/revset.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/revset_predicates.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/revset_predicates.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/revsetlang.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/revsetlang.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/rewriteutil.cpython-314.opt-1.pyc</Path>
@@ -676,6 +682,8 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/server.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/setdiscovery.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/setdiscovery.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/shape.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/shape.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/shelve.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/shelve.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/similar.cpython-314.opt-1.pyc</Path>
@@ -708,6 +716,8 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/subrepo.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/subrepoutil.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/subrepoutil.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/tables.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/tables.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/tagmerge.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/tagmerge.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/__pycache__/tags.cpython-314.opt-1.pyc</Path>
@@ -784,6 +794,7 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/branching/rev_cache.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/branchmap.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/bundle2.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/bundle2_part_handlers.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/bundlecaches.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/bundlerepo.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cacheutil.py</Path>
@@ -828,9 +839,24 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/__pycache__/bundle.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/__pycache__/bundle.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/__pycache__/clone.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/__pycache__/clone.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/__pycache__/graft.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/__pycache__/graft.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/__pycache__/incoming.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/__pycache__/incoming.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/__pycache__/outgoing.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/__pycache__/outgoing.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/__pycache__/update.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/__pycache__/update.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/bundle.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/clone.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/graft.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/incoming.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/outgoing.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmd_impls/update.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/cmdutil.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/color.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/commands.py</Path>
@@ -881,6 +907,18 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/encoding.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/error.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/exchange.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/exchanges/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/exchanges/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/exchanges/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/exchanges/__pycache__/bundle_cache.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/exchanges/__pycache__/bundle_cache.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/exchanges/__pycache__/bundle_caps.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/exchanges/__pycache__/bundle_caps.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/exchanges/__pycache__/peer.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/exchanges/__pycache__/peer.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/exchanges/bundle_cache.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/exchanges/bundle_caps.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/exchanges/peer.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/extensions.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/exthelper.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/fancyopts.py</Path>
@@ -927,6 +965,7 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/helptext/internals/config.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/helptext/internals/dirstate-v2.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/helptext/internals/extensions.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/helptext/internals/file-index.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/helptext/internals/linelog.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/helptext/internals/mergestate.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/helptext/internals/requirements.txt</Path>
@@ -952,8 +991,12 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/__pycache__/common.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/__pycache__/hgweb_mod.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/__pycache__/hgweb_mod.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/__pycache__/hgweb_mod_inner.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/__pycache__/hgweb_mod_inner.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/__pycache__/hgwebdir_mod.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/__pycache__/hgwebdir_mod.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/__pycache__/hgwebdir_mod_inner.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/__pycache__/hgwebdir_mod_inner.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/__pycache__/request.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/__pycache__/request.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/__pycache__/server.cpython-314.opt-1.pyc</Path>
@@ -964,28 +1007,48 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/__pycache__/webutil.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/__pycache__/wsgicgi.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/__pycache__/wsgicgi.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/__pycache__/wsgicgi_inner.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/__pycache__/wsgicgi_inner.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/__pycache__/wsgiheaders.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/__pycache__/wsgiheaders.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/common.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/hgweb_mod.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/hgweb_mod_inner.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/hgwebdir_mod.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/hgwebdir_mod_inner.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/request.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/server.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/webcommands.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/webutil.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/wsgicgi.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/wsgicgi_inner.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hgweb/wsgiheaders.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/hook.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/httpconnection.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/httppeer.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/i18n.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/initialization.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/__init__.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/_basetypes.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/_basetypes.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/bundle.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/bundle.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/changegroup.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/changegroup.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/compression.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/compression.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/config.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/config.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/context.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/context.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/dirstate.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/dirstate.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/exchange.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/exchange.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/file_index.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/file_index.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/matcher.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/matcher.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/misc.cpython-314.opt-1.pyc</Path>
@@ -994,21 +1057,34 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/modules.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/repository.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/repository.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/revlog.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/revlog.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/status.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/status.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/transaction.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/transaction.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/types.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/types.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/ui.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/__pycache__/ui.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/_basetypes.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/bundle.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/changegroup.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/compression.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/config.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/context.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/dirstate.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/exchange.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/file_index.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/matcher.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/misc.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/modules.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/repository.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/revlog.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/status.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/transaction.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/types.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/interfaces/ui.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/keepalive.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/linelog.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/locale/da/LC_MESSAGES/hg.mo</Path>
@@ -1031,16 +1107,43 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/lsprof.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/lsprofcalltree.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/mail.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/main_script/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/main_script/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/main_script/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/main_script/__pycache__/cmd_finder.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/main_script/__pycache__/cmd_finder.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/main_script/__pycache__/options.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/main_script/__pycache__/options.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/main_script/__pycache__/paths.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/main_script/__pycache__/paths.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/main_script/cmd_finder.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/main_script/options.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/main_script/paths.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/manifest.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/match.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/mdiff.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/merge.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/merge_utils/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/merge_utils/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/merge_utils/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/merge_utils/__pycache__/diff.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/merge_utils/__pycache__/diff.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/merge_utils/__pycache__/update.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/merge_utils/__pycache__/update.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/merge_utils/diff.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/merge_utils/update.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/mergestate.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/mergeutil.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/metadata.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/minifileset.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/minirst.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/namespaces.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/narrow/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/narrow/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/narrow/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/narrow/__pycache__/working_copy.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/narrow/__pycache__/working_copy.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/narrow/working_copy.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/narrowspec.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/node.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/obsolete.py</Path>
@@ -1062,6 +1165,8 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/pure/__pycache__/bdiff.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/pure/__pycache__/charencode.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/pure/__pycache__/charencode.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/pure/__pycache__/deltas.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/pure/__pycache__/deltas.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/pure/__pycache__/mpatch.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/pure/__pycache__/mpatch.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/pure/__pycache__/osutil.cpython-314.opt-1.pyc</Path>
@@ -1071,6 +1176,7 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/pure/base85.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/pure/bdiff.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/pure/charencode.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/pure/deltas.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/pure/mpatch.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/pure/osutil.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/pure/parsers.py</Path>
@@ -1079,6 +1185,21 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/pycompat.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/registrar.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/repair.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/repo/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/repo/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/repo/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/repo/__pycache__/creation.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/repo/__pycache__/creation.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/repo/__pycache__/factory.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/repo/__pycache__/factory.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/repo/__pycache__/requirements.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/repo/__pycache__/requirements.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/repo/__pycache__/vfs_options.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/repo/__pycache__/vfs_options.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/repo/creation.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/repo/factory.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/repo/requirements.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/repo/vfs_options.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/repocache.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/repoview.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/requirements.py</Path>
@@ -1088,6 +1209,8 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/revlogutils/__pycache__/__init__.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/revlogutils/__pycache__/concurrency_checker.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/revlogutils/__pycache__/concurrency_checker.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/revlogutils/__pycache__/config.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/revlogutils/__pycache__/config.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/revlogutils/__pycache__/constants.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/revlogutils/__pycache__/constants.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/revlogutils/__pycache__/debug.cpython-314.opt-1.pyc</Path>
@@ -1109,6 +1232,7 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/revlogutils/__pycache__/sidedata.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/revlogutils/__pycache__/sidedata.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/revlogutils/concurrency_checker.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/revlogutils/config.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/revlogutils/constants.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/revlogutils/debug.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/revlogutils/deltas.py</Path>
@@ -1120,6 +1244,7 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/revlogutils/rewrite.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/revlogutils/sidedata.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/revset.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/revset_predicates.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/revsetlang.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/rewriteutil.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/scmposix.py</Path>
@@ -1127,6 +1252,7 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/scmwindows.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/server.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/setdiscovery.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/shape.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/shelve.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/similar.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/simplemerge.py</Path>
@@ -1145,10 +1271,20 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/statichttprepo.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/statprof.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/store.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/store_utils/__init__.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/store_utils/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/store_utils/__pycache__/__init__.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/store_utils/__pycache__/file_index.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/store_utils/__pycache__/file_index.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/store_utils/__pycache__/file_index_util.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/store_utils/__pycache__/file_index_util.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/store_utils/file_index.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/store_utils/file_index_util.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/streamclone.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/strip.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/subrepo.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/subrepoutil.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/tables.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/tagmerge.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/tags.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/templatefilters.py</Path>
@@ -1354,13 +1490,10 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/testing/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/testing/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/testing/__pycache__/__init__.cpython-314.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/testing/__pycache__/ps_util.cpython-314.opt-1.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/testing/__pycache__/ps_util.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/testing/__pycache__/revlog.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/testing/__pycache__/revlog.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/testing/__pycache__/storage.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/testing/__pycache__/storage.cpython-314.pyc</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/testing/ps_util.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/testing/revlog.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/testing/storage.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/thirdparty/__init__.py</Path>
@@ -1444,9 +1577,12 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/upgrade_utils/__pycache__/auto_upgrade.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/upgrade_utils/__pycache__/engine.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/upgrade_utils/__pycache__/engine.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/upgrade_utils/__pycache__/share_safe.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/upgrade_utils/__pycache__/share_safe.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/upgrade_utils/actions.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/upgrade_utils/auto_upgrade.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/upgrade_utils/engine.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/upgrade_utils/share_safe.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/url.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/urllibcompat.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/util.py</Path>
@@ -1457,8 +1593,12 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/__pycache__/cborutil.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/__pycache__/compression.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/__pycache__/compression.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/__pycache__/dag_util.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/__pycache__/dag_util.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/__pycache__/dateutil.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/__pycache__/dateutil.cpython-314.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/__pycache__/docket.cpython-314.opt-1.pyc</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/__pycache__/docket.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/__pycache__/hashutil.cpython-314.opt-1.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/__pycache__/hashutil.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/__pycache__/memorytop.cpython-314.opt-1.pyc</Path>
@@ -1477,7 +1617,9 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/__pycache__/urlutil.cpython-314.pyc</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/cborutil.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/compression.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/dag_util.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/dateutil.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/docket.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/hashutil.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/memorytop.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/mercurial/utils/procutil.py</Path>
@@ -1500,6 +1642,7 @@
             <Path fileType="data">/usr/share/bash-completion/completions/hg</Path>
             <Path fileType="data">/usr/share/emacs/site-lisp/mercurial.el</Path>
             <Path fileType="data">/usr/share/emacs/site-lisp/mq.el</Path>
+            <Path fileType="data">/usr/share/licenses/mercurial/COPYING</Path>
             <Path fileType="man">/usr/share/man/man1/hg.1.zst</Path>
             <Path fileType="man">/usr/share/man/man5/hgignore.5.zst</Path>
             <Path fileType="man">/usr/share/man/man5/hgrc.5.zst</Path>
@@ -1508,12 +1651,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="48">
-            <Date>2026-06-07</Date>
-            <Version>7.0.1</Version>
+        <Update release="49">
+            <Date>2026-06-12</Date>
+            <Version>7.2.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelogs:
- [7.1](https://www.mercurial-scm.org/relnotes/7.1.html)
- [7.2](https://www.mercurial-scm.org/relnotes/7.2.html#mercurial-7-2-2026-01-29)
- [7.2.1](https://www.mercurial-scm.org/relnotes/7.2.html#mercurial-7-2-1-2026-04-01)
- [7.2.2](https://www.mercurial-scm.org/relnotes/7.2#mercurial-7-2-2-2026-05-07)

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Run the `reuse` test suite, see that the mercurial tests pass.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
