### PR TITLE
reuse: Re-enable tests

### DIFF
--- a/packages/r/reuse/package.yml
+++ b/packages/r/reuse/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : reuse
 version    : 6.2.0
-release    : 2
+release    : 3
 source     :
     - https://codeberg.org/fsfe/reuse-tool/archive/v6.2.0.tar.gz : beff91ef9a138d830a6562808a3fb1c5411101988136062784d7e50bdb65023e
 homepage   : https://reuse.software/
@@ -74,9 +74,8 @@ install    : |
     install -Dm00644 completions/bash ${installdir}/usr/share/bash-completion/completions/reuse
     install -Dm00644 completions/fish ${installdir}/usr/share/fish/vendor_completions.d/reuse.fish
     install -Dm00644 completions/zsh ${installdir}/usr/share/zsh/site-functions/_reuse
-# TODO 3.14
-#check      : |
-#    # The de-selected tests don't work in solbuild containers
-#    %python3_test pytest -v \
-#        -k "not test_to_read_only_file_forbidden and not test_lint_read_errors and not test_read_errors and not test_read_error" \
-#        tests/ "${installdir}/usr/lib/python%python3_version%/site-packages/reuse"
+check      : |
+    # The de-selected tests don't work in solbuild containers
+    %python3_test pytest -v \
+        -k "not test_to_read_only_file_forbidden and not test_lint_read_errors and not test_read_errors and not test_read_error" \
+        tests/ "${installdir}/usr/lib/python%python3_version%/site-packages/reuse"

--- a/packages/r/reuse/pspec_x86_64.xml
+++ b/packages/r/reuse/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>reuse</Name>
         <Homepage>https://reuse.software/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>CC-BY-SA-4.0</License>
@@ -165,12 +165,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2026-06-08</Date>
+        <Update release="3">
+            <Date>2026-06-12</Date>
             <Version>6.2.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Re-enable tests.

Depends on https://github.com/getsolus/packages/pull/9230

**Test Plan**

See that the test suite passes.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
