### PR TITLE
openrazer: Remove xaut rundep

### DIFF
--- a/packages/o/openrazer/package.yml
+++ b/packages/o/openrazer/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : openrazer
 version    : 3.12.3
-release    : 381
+release    : 382
 source     :
     - https://github.com/openrazer/openrazer/archive/refs/tags/v3.12.3.tar.gz : d569700a71ca0dd2ec7a578c5fb986b16c89a298fb281ca1da2f33480b542e42
 license    : GPL-2.0-or-later
@@ -52,7 +52,6 @@ rundeps    :
         - python-setproctitle
         - python-pyudev
         - python3-dbus
-        - xaut
         - xdotool
     - current :
         - openrazer-common

--- a/packages/o/openrazer/pspec_x86_64.xml
+++ b/packages/o/openrazer/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>openrazer</Name>
         <Homepage>https://openrazer.github.io</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>kernel.drivers</PartOf>
@@ -20,7 +20,7 @@
 </Description>
         <PartOf>kernel.drivers</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="381">openrazer-common</Dependency>
+            <Dependency releaseFrom="382">openrazer-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/6.18.35-294.lts/extra/drivers/hid/razeraccessory.ko.zst</Path>
@@ -176,7 +176,7 @@
 </Description>
         <PartOf>kernel.drivers</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="381">openrazer-common</Dependency>
+            <Dependency releaseFrom="382">openrazer-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/lib64/modules/7.0.12-344.current/extra/drivers/hid/razeraccessory.ko.zst</Path>
@@ -206,12 +206,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="381">
-            <Date>2026-06-10</Date>
+        <Update release="382">
+            <Date>2026-06-12</Date>
             <Version>3.12.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Removing xaut dependency which is only used for a deprecated feature that only works on X11


**Test Plan**
Install and test with Razergenie + Razer mouse


**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
