### PR TITLE
anoise: Add StartupWMClass to desktop file to fix window mapping under wayland

### DIFF
--- a/packages/a/anoise/package.yml
+++ b/packages/a/anoise/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : anoise
 version    : 0.0.29
-release    : 14
+release    : 15
 source     :
     - https://launchpad.net/~costales/+archive/ubuntu/anoise/+files/anoise_0.0.29.tar.gz : 6357cb2459ba0ffc2563f9d10d596a14a456e37f3cbc12915cca95b046d19c07
 homepage   : https://costales.github.io/projects/anoise/
@@ -11,6 +11,7 @@ summary    : Minimal and integrated ambient noise player for boosting productivi
 description: Minimal and integrated ambient noise player for boosting productivity
 builddeps  :
     - pkgconfig(python3)
+    - desktop-file-utils
     - python-distutils-extra
 rundeps    :
     - anoise-media
@@ -21,3 +22,6 @@ build      : |
 install    : |
     %python3_install
     rm -r $installdir/usr/share/doc
+
+    # Add StartupWMClass to desktop file to fix window mapping under wayland
+    desktop-file-edit --set-key='StartupWMClass' --set-value='anoise.py' ${installdir}/usr/share/applications/anoise.desktop

--- a/packages/a/anoise/pspec_x86_64.xml
+++ b/packages/a/anoise/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>anoise</Name>
         <Homepage>https://costales.github.io/projects/anoise/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>multimedia.audio</PartOf>
@@ -68,12 +68,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2026-06-07</Date>
+        <Update release="15">
+            <Date>2026-06-13</Date>
             <Version>0.0.29</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Add StartupWMClass to desktop file via desktop-file-edit command in package.yml

**Test Plan**
- launch anoise in wayland and check for presence of anoise icon instead of generic icon in panel
