### PR TITLE
weechat: Update to v4.9.2

### DIFF
--- a/packages/w/weechat/package.yml
+++ b/packages/w/weechat/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : weechat
-version    : 4.9.1
-release    : 105
+version    : 4.9.2
+release    : 106
 source     :
-    - https://github.com/weechat/weechat/archive/refs/tags/v4.9.1.tar.gz : edf1bfb20fcecc64e23dca609dae18d7fe7e7545ed1c7e8a05bf3b7571087036
+    - https://github.com/weechat/weechat/archive/refs/tags/v4.9.2.tar.gz : 355c2ac3ffe038bbcd9dac8b1f5250278cb4978ca3bc4fcbbc8b7ffefc1669b2
 homepage   : https://weechat.org
 license    : GPL-3.0-or-later
 summary    : WeeChat is a fast, light and extensible chat client.

--- a/packages/w/weechat/pspec_x86_64.xml
+++ b/packages/w/weechat/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>weechat</Name>
         <Homepage>https://weechat.org</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>network.irc</PartOf>
@@ -92,7 +92,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="105">weechat</Dependency>
+            <Dependency release="106">weechat</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/weechat/weechat-plugin.h</Path>
@@ -100,12 +100,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="105">
-            <Date>2026-06-08</Date>
-            <Version>4.9.1</Version>
+        <Update release="106">
+            <Date>2026-06-13</Date>
+            <Version>4.9.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/weechat/weechat/releases/tag/v4.9.2).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Connect to Libera chat.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
