### PR TITLE
cryptomator: switch to openjdk-25

### DIFF
--- a/packages/c/cryptomator/files/java-shim.txt
+++ b/packages/c/cryptomator/files/java-shim.txt
@@ -1,3 +1,3 @@
 if [ -z "$JAVA_HOME" ]; then
-    export JAVA_HOME=/usr/lib64/openjdk-21
+    export JAVA_HOME=/usr/lib64/openjdk-25
 fi

--- a/packages/c/cryptomator/package.yml
+++ b/packages/c/cryptomator/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : cryptomator
 version    : 1.6.8
-release    : 6
+release    : 7
 source     :
     - https://github.com/cryptomator/cryptomator/archive/1.6.8.tar.gz : 04030072574d85ec3d6b17a103e342ee961d21bcca1dfe982fbbdca72e2c81f4
 homepage   : https://cryptomator.org/
@@ -13,11 +13,11 @@ description: |
 networking : true
 builddeps  :
     - apache-maven
-    - openjdk-21
+    - openjdk-25
 rundeps    :
-    - openjdk-21
+    - openjdk-25
 environment: |
-    export JAVA_HOME=/usr/lib64/openjdk-21
+    export JAVA_HOME=/usr/lib64/openjdk-25
     export PATH=$JAVA_HOME/bin:$PATH
 setup      : |
     %apply_patches

--- a/packages/c/cryptomator/pspec_x86_64.xml
+++ b/packages/c/cryptomator/pspec_x86_64.xml
@@ -88,8 +88,8 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2026-01-10</Date>
+        <Update release="7">
+            <Date>2026-06-13</Date>
             <Version>1.6.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Jakob Gezelius</Name>


### PR DESCRIPTION
**Summary**
- Switch to openjdk-25

**Test Plan**
- Built it.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
