### PR TITLE
fop: Switch to openjdk-25

### DIFF
--- a/packages/f/fop/files/fop.conf
+++ b/packages/f/fop/files/fop.conf
@@ -1,4 +1,4 @@
-JAVACMD="/usr/lib64/openjdk-21/bin/java"
+JAVACMD="/usr/lib64/openjdk-25/bin/java"
 
 FOP_HOME="/usr/share/java/fop"
 CLASSPATH="$FOP_HOME/fop.jar"

--- a/packages/f/fop/package.yml
+++ b/packages/f/fop/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : fop
 version    : '2.8'
-release    : 5
+release    : 6
 source     :
     - https://archive.apache.org/dist/xmlgraphics/fop/source/fop-2.8-src.tar.gz : 6fb02fd7bc2ee80aff9e928e8b062ace5bc115222e5d3a6a4da70cd6cc6d06f7
 license    : Apache-2.0
@@ -15,11 +15,11 @@ description: |
 networking : true
 builddeps  :
     - apache-maven
-    - openjdk-21
+    - openjdk-25
 rundeps    :
-    - openjdk-21
+    - openjdk-25
 environment: |
-    JAVA_HOME=/usr/lib64/openjdk-21
+    JAVA_HOME=/usr/lib64/openjdk-25
     PATH=$JAVA_HOME/bin:$PATH
 build      : |
     mkdir -p fop-events/target/test-classes

--- a/packages/f/fop/pspec_x86_64.xml
+++ b/packages/f/fop/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>fop</Name>
         <Homepage>https://xmlgraphics.apache.org/fop/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Ivan Trepakov</Name>
+            <Email>liontiger23@gmail.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.java</PartOf>
@@ -35,12 +35,12 @@ Output formats currently supported include PDF, PS and PNG.
         </Files>
     </Package>
     <History>
-        <Update release="5">
-            <Date>2026-01-11</Date>
+        <Update release="6">
+            <Date>2026-06-14</Date>
             <Version>2.8</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Ivan Trepakov</Name>
+            <Email>liontiger23@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Part of https://github.com/getsolus/packages/issues/9232

**Test Plan**

- Rendered first example from https://xmlgraphics.apache.org/fop/examples.html
  ```bash
  fop fonts.fo fonts.pdf
  ```

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
