### PR TITLE
bisq: Switch to openjdk-25

### DIFF
--- a/packages/b/bisq/files/0001-Gradle-9.x.x-fixes.patch
+++ b/packages/b/bisq/files/0001-Gradle-9.x.x-fixes.patch
@@ -1,0 +1,39 @@
+From b7a8df0ec08cbd7b0ca1be7f5f5e8bc03e31fbd2 Mon Sep 17 00:00:00 2001
+From: Ivan Trepakov <liontiger23@gmail.com>
+Date: Sun, 14 Jun 2026 09:52:28 +0700
+Subject: [PATCH] Gradle 9.x.x fixes
+
+---
+ build.gradle                      | 2 ++
+ code-coverage-report/build.gradle | 2 +-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/build.gradle b/build.gradle
+index b2746a2..8e255cf 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -6,6 +6,8 @@ buildscript {
+     }
+ }
+ 
++import groovy.xml.XmlSlurper
++
+ import org.gradle.jvm.tasks.Jar
+ import org.gradle.api.tasks.bundling.Zip
+ 
+diff --git a/code-coverage-report/build.gradle b/code-coverage-report/build.gradle
+index 5bb79db..e1c88bf 100644
+--- a/code-coverage-report/build.gradle
++++ b/code-coverage-report/build.gradle
+@@ -20,7 +20,7 @@ dependencies {
+ reporting {
+     reports {
+         testCodeCoverageReport(JacocoCoverageReport) {
+-            testType = TestSuiteType.UNIT_TEST
++            testSuiteName = "test"
+         }
+     }
+ }
+-- 
+2.54.0
+

--- a/packages/b/bisq/files/java-shim.sh
+++ b/packages/b/bisq/files/java-shim.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 if [ -z "$JAVA_HOME" ]; then
-    export JAVA_HOME=/usr/lib64/openjdk-21
+    export JAVA_HOME=/usr/lib64/openjdk-25
 fi
 

--- a/packages/b/bisq/package.yml
+++ b/packages/b/bisq/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : bisq
 version    : 1.10.1
-release    : 10
+release    : 11
 source     :
     # Using git tag because source.tar.gz does not contain submodule sources
     - git|https://github.com/bisq-network/bisq.git : v1.10.1
@@ -13,20 +13,22 @@ description: |
     Bisq is an open-source desktop application that allows you to buy and sell Bitcoins in exchange for national currencies, or alternative cryptocurrencies.
 networking : true
 builddeps  :
-    - openjdk-21
+    - gradle
+    - openjdk-25
 rundeps    :
-    - openjdk-21
+    - openjdk-25
 environment: |
-    JAVA_HOME=/usr/lib64/openjdk-21
+    JAVA_HOME=/usr/lib64/openjdk-25
     PATH=$JAVA_HOME/bin:$PATH
 setup      : |
     sed -i '/vendor = JvmVendorSpec.AZUL/d' build-logic/commons/src/main/groovy/bisq.java-conventions.gradle
     sed -i '/implementation = JvmImplementation.VENDOR_SPECIFIC/d' build-logic/commons/src/main/groovy/bisq.java-conventions.gradle
+    %patch -p1 -i $pkgfiles/0001-Gradle-9.x.x-fixes.patch
 build      : |
     export GRADLE_USER_HOME=$workdir/.gradle
 
     # tests will always fail, so disable them with -x test
-    ./gradlew --no-daemon build -x test
+    gradle --no-daemon build -x test --dependency-verification lenient
 install    : |
     # Install all build folder
     install -dm00755 $installdir/usr/share/bisq/

--- a/packages/b/bisq/pspec_x86_64.xml
+++ b/packages/b/bisq/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>bisq</Name>
         <Homepage>https://bisq.network/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Ivan Trepakov</Name>
+            <Email>liontiger23@gmail.com</Email>
         </Packager>
         <License>AGPL-3.0-or-later</License>
         <PartOf>network.web</PartOf>
@@ -473,12 +473,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2026-06-13</Date>
+        <Update release="11">
+            <Date>2026-06-14</Date>
             <Version>1.10.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Ivan Trepakov</Name>
+            <Email>liontiger23@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Switch to system gradle package
- Part of https://github.com/getsolus/packages/issues/9232

**Test Plan**

- Started bisq-desktop

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
