### PR TITLE
i3lock: Update to v2.16

### DIFF
--- a/packages/i/i3lock/MAINTAINERS.md
+++ b/packages/i/i3lock/MAINTAINERS.md
@@ -1,0 +1,5 @@
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+
+- Ivan Trepakov
+  - Matrix: @liontiger23:matrix.org
+  - Email: liontiger23@gmail.com

--- a/packages/i/i3lock/abi_used_symbols
+++ b/packages/i/i3lock/abi_used_symbols
@@ -1,9 +1,11 @@
 libc.so.6:__asprintf_chk
 libc.so.6:__errno_location
+libc.so.6:__explicit_bzero_chk
 libc.so.6:__fprintf_chk
 libc.so.6:__isoc23_sscanf
 libc.so.6:__isoc23_strtol
 libc.so.6:__libc_start_main
+libc.so.6:__memcpy_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:calloc
@@ -23,7 +25,6 @@ libc.so.6:getpwuid
 libc.so.6:gettimeofday
 libc.so.6:getuid
 libc.so.6:malloc
-libc.so.6:memcpy
 libc.so.6:mlock
 libc.so.6:optarg
 libc.so.6:perror

--- a/packages/i/i3lock/package.yml
+++ b/packages/i/i3lock/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : i3lock
-version    : '2.15'
-release    : 18
+version    : '2.16'
+release    : 19
 source     :
-    - https://github.com/i3/i3lock/archive/refs/tags/2.15.tar.gz : b3253dfc42b6fa3879498310b536d42224d3a492f9a957a5652e6ff6c91862dc
+    - https://github.com/i3/i3lock/archive/refs/tags/2.16.tar.gz : d62e81d3ab0bdd66363eec3671f2da24c7f662775705e4b33fd712796ba7e257
 license    : BSD-3-Clause
 component  : desktop.i3
 homepage   : https://i3wm.org/i3lock/

--- a/packages/i/i3lock/pspec_x86_64.xml
+++ b/packages/i/i3lock/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>i3lock</Name>
         <Homepage>https://i3wm.org/i3lock/</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Ivan Trepakov</Name>
+            <Email>liontiger23@gmail.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>desktop.i3</PartOf>
@@ -22,16 +22,16 @@
         <Files>
             <Path fileType="executable">/usr/bin/i3lock</Path>
             <Path fileType="data">/usr/share/defaults/etc/pam.d/i3lock</Path>
-            <Path fileType="man">/usr/share/man/man1/i3lock.1</Path>
+            <Path fileType="man">/usr/share/man/man1/i3lock.1.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2024-11-06</Date>
-            <Version>2.15</Version>
+        <Update release="19">
+            <Date>2026-06-14</Date>
+            <Version>2.16</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Ivan Trepakov</Name>
+            <Email>liontiger23@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- fix crash when the user changes the XKB configuration
- when started on Wayland, display an error and usage
- switch to clang-format 15 (with InsertBraces)
- fix -Werror=calloc-transposed-args by swapping calloc args
- reword: remove "dynamic" TWM
- update meson setup command in README
- do not increase failed_attempts beyond 999
- i3lock.1 man page: fix acute accent
- declare a development shell in flake.nix
- fix in_dpi variable checking
- meson: use explicit_bzero if it is available

**Test Plan**

- Checked that it successfully locks and unlocks screen

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
