### PR TITLE
libphonenumber: Update to v9.0.32

### DIFF
--- a/packages/l/libphonenumber/package.yml
+++ b/packages/l/libphonenumber/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libphonenumber
-version    : 9.0.30
-release    : 13
+version    : 9.0.32
+release    : 14
 source     :
-    - https://github.com/google/libphonenumber/archive/refs/tags/v9.0.30.tar.gz : 677dd2a555e467073e5c6ef7eaa75ecd7d0d6b2c0e71a231d0a70b730bd0f0c6
+    - https://github.com/google/libphonenumber/archive/refs/tags/v9.0.32.tar.gz : fef1a587ff4793d02cf10dc87d083e7a230e0caf56e8dfdf0da6a15f78420ed8
 homepage   : https://github.com/googlei18n/libphonenumber
 license    :
     - Apache-2.0
@@ -16,7 +16,7 @@ builddeps  :
     - pkgconfig(absl_base)
     - pkgconfig(protobuf)
     - libboost-devel
-    - openjdk-21
+    - openjdk-25-devel
 checkdeps  :
     - pkgconfig(gtest)
 rundeps    :
@@ -28,11 +28,11 @@ clang      : true
 optimize   :
     - thin-lto
 environment: |
-    export JAVA_HOME=/usr/lib64/openjdk-21
+    export JAVA_HOME=/usr/lib64/openjdk-25
     export PATH=$JAVA_HOME/bin:$PATH
     export CLANG_IGNORE_WERROR=1
 setup      : |
-    %patch -p1 -i $pkgfiles/0001-Fix-BUILD_STATIC_LIB-OFF.patch
+    %patch -p1 -i ${pkgfiles}/0001-Fix-BUILD_STATIC_LIB-OFF.patch
     %cmake_ninja -S cpp -DBUILD_STATIC_LIB=OFF
 build      : |
     %ninja_build

--- a/packages/l/libphonenumber/pspec_x86_64.xml
+++ b/packages/l/libphonenumber/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libphonenumber</Name>
         <Homepage>https://github.com/googlei18n/libphonenumber</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>BSD-3-Clause</License>
@@ -36,7 +36,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="13">libphonenumber</Dependency>
+            <Dependency release="14">libphonenumber</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/phonenumbers/asyoutypeformatter.h</Path>
@@ -81,12 +81,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="13">
-            <Date>2026-05-18</Date>
-            <Version>9.0.30</Version>
+        <Update release="14">
+            <Date>2026-06-14</Date>
+            <Version>9.0.32</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/google/libphonenumber/blob/master/release_notes.txt).
- Switch to OpenJDK-25
- Part of #9232 

**Test Plan**

Passed checks. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
