### PR TITLE
pdfsam: Update to v6.0.1

### DIFF
--- a/packages/p/pdfsam/files/org.pdfsam.pdfsam_basic.metainfo.xml
+++ b/packages/p/pdfsam/files/org.pdfsam.pdfsam_basic.metainfo.xml
@@ -7,6 +7,7 @@
 
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>AGPL-3.0-only</project_license>
+  <url type="homepage">https://pdfsam.org/</url>
 
   <description>
     <p>

--- a/packages/p/pdfsam/files/pdfsam.sh
+++ b/packages/p/pdfsam/files/pdfsam.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ -z "$JAVA_HOME" ]; then
-    export JAVA_HOME=/usr/lib64/openjdk-21
+    export JAVA_HOME=/usr/lib64/openjdk-25
 fi
 
 exec "$JAVA_HOME/bin/java" --enable-preview \

--- a/packages/p/pdfsam/package.yml
+++ b/packages/p/pdfsam/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : pdfsam
-version    : 5.3.2
-release    : 11
+version    : 6.0.1
+release    : 12
 source     :
-    - https://github.com/torakiki/pdfsam/archive/refs/tags/v5.3.2.tar.gz : e576743fd6e291a96e4d3e376fae69d5f1cdb9a09981137aabfc5fc4c955900e
+    - https://github.com/torakiki/pdfsam/archive/refs/tags/v6.0.1.tar.gz : c9594bafb71f2cbf96ae3405a8da4077f64367cb77f1386d7f2cc1b688107d91
 homepage   : https://pdfsam.org/
 license    : AGPL-3.0-only
 component  : office
@@ -12,25 +12,27 @@ description: |
     PDFsam Basic, a free, open source, multi-platform software designed to split, merge, extract pages, mix and rotate PDF files.
 builddeps  :
     - apache-maven
-    - openjdk-21-devel
+    - openjdk-25-devel
 rundeps    :
-    - openjdk-21
+    - openjdk-25
 networking : true
 environment: |
-    export JAVA_HOME=/usr/lib64/openjdk-21
-    export PATH=$JAVA_HOME/bin:$PATH
-setup      : |
-    sed 's|http://|https://|' -i pom.xml
-    sed -i 's|<argument>--vm=server</argument>||' pdfsam-basic/pom.xml
+    export JAVA_HOME=/usr/lib64/openjdk-25
+    export PATH=${JAVA_HOME}/bin:${PATH}
 build      : |
-    export MAVEN_OPTS="-Dmaven.repo.local=./m2"
-    mvn -DskipTests=true -Drelease -Dgpg.skip package
+    export MAVEN_OPTS="-Dmaven.repo.local=${workdir}/m2"
+    # Skip bundled runtime/image generation; Solus installs the assembled jars and uses the system JDK.
+    mvn -DskipTests=true -Drelease -Dgpg.skip -Dexec.skip=true -Dmaven.antrun.skip=true package
 install    : |
-    install -Dm00644 $workdir/pdfsam-basic/target/assembled/lib/pdfsam-basic-$version.jar $installdir/usr/share/pdfsam/pdfsam.jar
-    install -Dm00644 $workdir/pdfsam-docs/graphics/splash.png $installdir/usr/share/pdfsam/splash.png
-    install -dm00755 $installdir/usr/share/pdfsam/lib/
-    install -Dm00644 pdfsam-basic/target/assembled/lib/* $installdir/usr/share/pdfsam/lib/
-    install -Dm00644 pdfsam-basic/src/deb/icon.svg $installdir/usr/share/icons/hicolor/scalable/apps/pdfsam.svg
-    install -Dm00755 $pkgfiles/pdfsam.sh $installdir/usr/bin/pdfsam
-    install -Dm00644 $pkgfiles/pdfsam.desktop $installdir/usr/share/applications/org.pdfsam.gui.PdfsamApp.desktop
-    install -Dm00644 $pkgfiles/org.pdfsam.pdfsam_basic.metainfo.xml -t $installdir/usr/share/metainfo
+    # Application jars and runtime assets
+    install -Dm00644 ${workdir}/pdfsam-basic/target/assembled/lib/pdfsam-basic-${version}.jar ${installdir}/usr/share/pdfsam/pdfsam.jar
+    install -Dm00644 ${workdir}/pdfsam-docs/graphics/splash.png ${installdir}/usr/share/pdfsam/splash.png
+    install -dm00755 ${installdir}/usr/share/pdfsam/lib/
+    install -Dm00644 pdfsam-basic/target/assembled/lib/* ${installdir}/usr/share/pdfsam/lib/
+
+    # Desktop integration
+    install -Dm00644 pdfsam-basic/src/deb/icon.svg ${installdir}/usr/share/icons/hicolor/scalable/apps/pdfsam.svg
+    install -Dm00755 ${pkgfiles}/pdfsam.sh ${installdir}/usr/bin/pdfsam
+    install -Dm00644 ${pkgfiles}/pdfsam.desktop ${installdir}/usr/share/applications/org.pdfsam.gui.PdfsamApp.desktop
+    install -Dm00644 ${pkgfiles}/org.pdfsam.pdfsam_basic.metainfo.xml -t ${installdir}/usr/share/metainfo
+    %install_license LICENSE

--- a/packages/p/pdfsam/pspec_x86_64.xml
+++ b/packages/p/pdfsam/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>pdfsam</Name>
         <Homepage>https://pdfsam.org/</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>AGPL-3.0-only</License>
         <PartOf>office</PartOf>
@@ -23,93 +23,96 @@
             <Path fileType="executable">/usr/bin/pdfsam</Path>
             <Path fileType="data">/usr/share/applications/org.pdfsam.gui.PdfsamApp.desktop</Path>
             <Path fileType="data">/usr/share/icons/hicolor/scalable/apps/pdfsam.svg</Path>
+            <Path fileType="data">/usr/share/licenses/pdfsam/LICENSE</Path>
             <Path fileType="data">/usr/share/metainfo/org.pdfsam.pdfsam_basic.metainfo.xml</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/bcmail-jdk18on-1.81.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/bcpkix-jdk18on-1.81.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/bcprov-jdk18on-1.81.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/bcutil-jdk18on-1.81.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/bcmail-jdk18on-1.84.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/bcpkix-jdk18on-1.84.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/bcprov-jdk18on-1.84.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/bcutil-jdk18on-1.84.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/lib/classmate-1.5.1.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/common-image-3.12.0.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/common-io-3.12.0.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/common-lang-3.12.0.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/commons-io-2.20.0.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/commons-lang3-3.18.0.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/eventstudio-4.0.1.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/fontbox-2.0.28.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/common-image-3.13.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/common-io-3.13.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/common-lang-3.13.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/commons-io-2.21.0.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/commons-lang3-3.20.0.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/eventstudio-5.0.0.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/fontbox-2.0.36.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/lib/hibernate-validator-7.0.5.Final.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/icu4j-71.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/icu4j-78.3.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/lib/ikonli-boxicons-pack-12.4.0.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/lib/ikonli-core-12.4.0.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/lib/ikonli-javafx-12.4.0.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/lib/ikonli-unicons-pack-12.4.0.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/imageio-core-3.12.0.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/imageio-jpeg-3.12.0.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/imageio-metadata-3.12.0.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/imageio-tiff-3.12.0.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/jackson-annotations-2.19.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/jackson-core-2.19.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/jackson-databind-2.19.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/jackson-datatype-jdk8-2.19.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/jackson-datatype-jsr310-2.19.2.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/imageio-core-3.13.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/imageio-jpeg-3.13.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/imageio-metadata-3.13.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/imageio-tiff-3.13.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/jackson-annotations-2.21.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/jackson-core-2.21.2.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/jackson-databind-2.21.2.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/jackson-datatype-jdk8-2.21.2.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/jackson-datatype-jsr310-2.21.2.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/lib/jakarta.el-4.0.2.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/lib/jakarta.el-api-4.0.0.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/lib/jakarta.inject-api-2.0.1.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/lib/jakarta.validation-api-3.0.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/javafx-base-23.0.2-linux.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/javafx-base-23.0.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/javafx-controls-23.0.2-linux.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/javafx-controls-23.0.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/javafx-graphics-23.0.2-linux.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/javafx-graphics-23.0.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/javafx-media-23.0.2-linux.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/javafx-media-23.0.2.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/javafx-base-25.0.2-linux.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/javafx-base-25.0.2.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/javafx-controls-25.0.2-linux.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/javafx-controls-25.0.2.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/javafx-graphics-25.0.2-linux.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/javafx-graphics-25.0.2.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/javafx-media-25.0.2-linux.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/javafx-media-25.0.2.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/lib/jboss-logging-3.4.1.Final.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/lib/jcl-over-slf4j-2.0.17.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/metadata-extractor-2.19.0.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-alternate-mix-5.3.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-backpages-5.3.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-basic-5.3.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-core-5.3.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-extract-5.3.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-gui-5.3.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-i18n-5.3.2.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/metadata-extractor-2.20.0.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-alternate-mix-6.0.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-backpages-6.0.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-basic-6.0.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-core-6.0.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-extract-6.0.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-fonts-6.0.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-gui-6.0.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-i18n-6.0.1.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-injector-5.0.0.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-merge-5.3.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-model-5.3.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-persistence-5.3.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-rotate-5.3.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-service-5.3.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-simple-split-5.3.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-split-by-bookmarks-5.3.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-split-by-size-5.3.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-themes-5.3.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-ui-components-5.3.2.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/sambox-3.0.23.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-merge-6.0.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-model-6.0.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-persistence-6.0.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-rotate-6.0.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-service-6.0.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-simple-split-6.0.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-split-by-bookmarks-6.0.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-split-by-size-6.0.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-themes-6.0.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/pdfsam-ui-components-6.0.1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/sambox-4.0.0.M4.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/lib/sejda-commons-3.0.1.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/sejda-conversion-5.1.13.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/sejda-core-5.1.13.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/sejda-fonts-5.1.13.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/sejda-image-writers-5.1.13.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/sejda-io-4.0.0.M4.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/sejda-model-5.1.13.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/sejda-sambox-5.1.13.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/sejda-conversion-6.0.0.M4.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/sejda-core-6.0.0.M4.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/sejda-fonts-6.0.0.M4.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/sejda-image-writers-6.0.0.M4.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/sejda-io-5.0.0.M1.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/sejda-model-6.0.0.M4.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/sejda-sambox-6.0.0.M4.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/lib/slf4j-api-2.0.17.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/lib/slf4j-tinylog-2.7.0.jar</Path>
-            <Path fileType="data">/usr/share/pdfsam/lib/thumbnailator-0.4.20.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/thumbnailator-0.4.21.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/lib/tinylog-api-2.7.0.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/lib/tinylog-impl-2.7.0.jar</Path>
+            <Path fileType="data">/usr/share/pdfsam/lib/xmpbox-3.0.7.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/lib/xmpcore-6.1.11.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/pdfsam.jar</Path>
             <Path fileType="data">/usr/share/pdfsam/splash.png</Path>
         </Files>
     </Package>
     <History>
-        <Update release="11">
-            <Date>2025-08-26</Date>
-            <Version>5.3.2</Version>
+        <Update release="12">
+            <Date>2026-06-14</Date>
+            <Version>6.0.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harveydevel@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/torakiki/pdfsam/releases).
- Switch to OpenJDK-25
- Part of #9232 

**Test Plan**

Split a pdf. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
