### PR TITLE
podman: Update to 5.8.3

### DIFF
--- a/packages/p/podman/package.yml
+++ b/packages/p/podman/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : podman
-version    : 5.8.2
-release    : 47
+version    : 5.8.3
+release    : 48
 source     :
-    - https://github.com/containers/podman/archive/refs/tags/v5.8.2.tar.gz : b20ea65afc5a58ea1cea019bd51a5d84eb9042d25d3eb82c55010c8815732d84
+    - https://github.com/containers/podman/archive/refs/tags/v5.8.3.tar.gz : c54a2ec4b4fb5577288992aaa78684397ec3552fb2d1234d910ec50097d05c0f
     - https://github.com/openSUSE/catatonit/releases/download/v0.2.1/catatonit.tar.xz#catatonit.tar.gz : 9950425501af862e12f618bdc930ea755c46db6a16072a1462b4fc93b2bd59bc
 license    :
     - Apache-2.0 # podman

--- a/packages/p/podman/pspec_x86_64.xml
+++ b/packages/p/podman/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>podman</Name>
         <Homepage>https://podman.io/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>GPL-2.0-or-later</License>
@@ -293,12 +293,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="47">
-            <Date>2026-05-14</Date>
-            <Version>5.8.2</Version>
+        <Update release="48">
+            <Date>2026-06-15</Date>
+            <Version>5.8.3</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Clint Eschberger</Name>
+            <Email>clint@eschberger.info</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Security update

**Security**
- CVE-2026-44517

[Change Log](https://github.com/podman-container-tools/podman/releases/tag/v5.8.3)

**Test Plan**
- Test adding/managing container
- Test with distrobox

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
