### PR TITLE
protobuf: Bump release to be higher than python-protobuf

### DIFF
--- a/packages/p/protobuf/package.yml
+++ b/packages/p/protobuf/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : protobuf
 version    : '35.1'
-release    : 20
+release    : 30
 source     :
     - https://github.com/protocolbuffers/protobuf/releases/download/v35.1/protobuf-35.1.tar.gz : f0b6838e7522a8da96126d487068c959bc624926368f3024ac8fd03abd0a1ac4
 homepage   : https://developers.google.com/protocol-buffers/

--- a/packages/p/protobuf/pspec_x86_64.xml
+++ b/packages/p/protobuf/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>protobuf</Name>
         <Homepage>https://developers.google.com/protocol-buffers/</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming</PartOf>
@@ -35,7 +35,7 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="20">protobuf</Dependency>
+            <Dependency releaseFrom="30">protobuf</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib/python3.14/site-packages/google/_upb/_message.cpython-314-x86_64-linux-gnu.so</Path>
@@ -214,7 +214,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="20">protobuf</Dependency>
+            <Dependency release="30">protobuf</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/protoc</Path>
@@ -545,12 +545,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2026-06-14</Date>
+        <Update release="30">
+            <Date>2026-06-16</Date>
             <Version>35.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Bump release to be higher than python-protobuf.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

See number go up.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
