### PR TITLE
dua-cli: Update to v2.36.0

### DIFF
--- a/packages/d/dua-cli/abi_used_symbols
+++ b/packages/d/dua-cli/abi_used_symbols
@@ -10,6 +10,7 @@ libc.so.6:cfmakeraw
 libc.so.6:chdir
 libc.so.6:chroot
 libc.so.6:clock_gettime
+libc.so.6:clock_nanosleep
 libc.so.6:close
 libc.so.6:closedir
 libc.so.6:dirfd
@@ -36,9 +37,11 @@ libc.so.6:fstatat64
 libc.so.6:getauxval
 libc.so.6:getcwd
 libc.so.6:getenv
+libc.so.6:geteuid
 libc.so.6:getmntent
 libc.so.6:getpeername
 libc.so.6:getpid
+libc.so.6:getpwnam
 libc.so.6:getpwuid_r
 libc.so.6:getsockname
 libc.so.6:getuid
@@ -56,7 +59,6 @@ libc.so.6:mkdir
 libc.so.6:mmap64
 libc.so.6:mprotect
 libc.so.6:munmap
-libc.so.6:nanosleep
 libc.so.6:open64
 libc.so.6:openat64
 libc.so.6:opendir
@@ -90,6 +92,7 @@ libc.so.6:pthread_setspecific
 libc.so.6:read
 libc.so.6:readdir64
 libc.so.6:readlink
+libc.so.6:readv
 libc.so.6:realloc
 libc.so.6:realpath
 libc.so.6:recv

--- a/packages/d/dua-cli/package.yml
+++ b/packages/d/dua-cli/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : dua-cli
-version    : 2.34.0
-release    : 2
+version    : 2.36.0
+release    : 3
 source     :
-    - https://github.com/Byron/dua-cli/archive/refs/tags/v2.34.0.tar.gz : eaa924f50efb425302c124f170644e95a08f8dad1f627b86f50d033ca5feb0c1
+    - https://github.com/Byron/dua-cli/archive/refs/tags/v2.36.0.tar.gz : feb4f0e3cdb2abf2dfd8ab9bdfbc7c43b07f0278b0ad6b02e9909149265aadf6
 homepage   : https://github.com/Byron/dua-cli
 license    : MIT
 component  : system.utils
@@ -20,9 +20,11 @@ build      : |
 install    : |
     %cargo_install dua
     %install_license LICENSE
-    install -dm00644 $installdir/usr/share/{bash-completion/completions,fish/vendor_completions.d,zsh/site-functions}
-    ./target/release/dua completions bash > $installdir/usr/share/bash-completion/completions/dua
-    ./target/release/dua completions zsh  > $installdir/usr/share/zsh/site-functions/_dua
-    ./target/release/dua completions fish > $installdir/usr/share/fish/vendor_completions.d/dua.fish
+
+    # Shell completions
+    install -dm00644 ${installdir}/usr/share/{bash-completion/completions,fish/vendor_completions.d,zsh/site-functions}
+    ./target/release/dua completions bash > ${installdir}/usr/share/bash-completion/completions/dua
+    ./target/release/dua completions zsh  > ${installdir}/usr/share/zsh/site-functions/_dua
+    ./target/release/dua completions fish > ${installdir}/usr/share/fish/vendor_completions.d/dua.fish
 check      : |
     %cargo_test -- --skip interactive

--- a/packages/d/dua-cli/pspec_x86_64.xml
+++ b/packages/d/dua-cli/pspec_x86_64.xml
@@ -28,9 +28,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2026-02-20</Date>
-            <Version>2.34.0</Version>
+        <Update release="3">
+            <Date>2026-06-17</Date>
+            <Version>2.36.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/Byron/dua-cli/releases/tag/v2.35.0).

**Test Plan**

See file sizes using `dua`. Go around file system using `dua i`. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
