### PR TITLE
libtiff: Patch for CVE

### DIFF
--- a/packages/l/libtiff/abi_symbols
+++ b/packages/l/libtiff/abi_symbols
@@ -6,6 +6,7 @@ libtiff.so.6:LIBTIFF_4.4
 libtiff.so.6:LIBTIFF_4.5
 libtiff.so.6:LIBTIFF_4.6.1
 libtiff.so.6:LIBTIFF_4.7.1
+libtiff.so.6:LIBTIFF_4.7.2
 libtiff.so.6:TIFFAccessTagMethods
 libtiff.so.6:TIFFCIELabToRGBInit
 libtiff.so.6:TIFFCIELabToXYZ
@@ -62,6 +63,7 @@ libtiff.so.6:TIFFGetConfiguredCODECs
 libtiff.so.6:TIFFGetField
 libtiff.so.6:TIFFGetFieldDefaulted
 libtiff.so.6:TIFFGetMapFileProc
+libtiff.so.6:TIFFGetMaxCompressionRatio
 libtiff.so.6:TIFFGetMode
 libtiff.so.6:TIFFGetReadProc
 libtiff.so.6:TIFFGetSeekProc

--- a/packages/l/libtiff/abi_symbols32
+++ b/packages/l/libtiff/abi_symbols32
@@ -6,6 +6,7 @@ libtiff.so.6:LIBTIFF_4.4
 libtiff.so.6:LIBTIFF_4.5
 libtiff.so.6:LIBTIFF_4.6.1
 libtiff.so.6:LIBTIFF_4.7.1
+libtiff.so.6:LIBTIFF_4.7.2
 libtiff.so.6:TIFFAccessTagMethods
 libtiff.so.6:TIFFCIELabToRGBInit
 libtiff.so.6:TIFFCIELabToXYZ
@@ -62,6 +63,7 @@ libtiff.so.6:TIFFGetConfiguredCODECs
 libtiff.so.6:TIFFGetField
 libtiff.so.6:TIFFGetFieldDefaulted
 libtiff.so.6:TIFFGetMapFileProc
+libtiff.so.6:TIFFGetMaxCompressionRatio
 libtiff.so.6:TIFFGetMode
 libtiff.so.6:TIFFGetReadProc
 libtiff.so.6:TIFFGetSeekProc

--- a/packages/l/libtiff/files/CVE-2026-36849.patch
+++ b/packages/l/libtiff/files/CVE-2026-36849.patch
@@ -1,0 +1,646 @@
+From eedba405d3695b52faae65994c5904f228eca0bf Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Tue, 21 Apr 2026 19:52:02 +0200
+Subject: [PATCH] Add TIFFGetMaxCompressionRatio() and use it in
+ _TIFFReadEncoded[Tile|Strip)AndAllocBuffer()
+
+```rst
+
+.. c:function:: uint64_t TIFFGetMaxCompressionRatio(TIFF *tif);
+
+Description
+-----------
+
+:c:func:`TIFFGetMaxCompressionRatio` returns the maximum compression ratio
+for the current codec, which is typically achieved for a uncompressed buffer
+with all bytes at zero.
+
+This function can be used to determine if the compressed size of a strip or tile
+is realistic compared to the expected uncompressed size, to prevent some
+denial-of-service scenarios.
+
+Depending on the codec, it may take into account the strip or tile size,
+number of samples per pixel, etc.
+
+Some codecs don't implement that method, or only for a subset of configurations,
+and may return 0 when the maximum compression ratio is unknown.
+
+Return values
+-------------
+
+0 is returned if no maximum compression ratio is known.
+1 is returned when there is no compression.
+Values strictly bigger than 1 are returned when a maximum compression ratio is
+known.
+```
+
+Fixes #781
+---
+ doc/Makefile.am                              |  1 +
+ doc/conf.py                                  |  1 +
+ doc/functions/TIFFGetMaxCompressionRatio.rst | 40 ++++++++++++++++++++
+ doc/functions/libtiff.rst                    |  2 +
+ libtiff/libtiff.def                          |  1 +
+ libtiff/libtiff.map                          |  4 ++
+ libtiff/tif_compress.c                       | 22 +++++++++++
+ libtiff/tif_fax3.c                           | 34 +++++++++++++++++
+ libtiff/tif_jpeg.c                           | 25 ++++++++++++
+ libtiff/tif_lerc.c                           | 11 ++++++
+ libtiff/tif_lzma.c                           | 13 +++++++
+ libtiff/tif_lzw.c                            | 12 ++++++
+ libtiff/tif_packbits.c                       |  8 ++++
+ libtiff/tif_pixarlog.c                       | 10 +++++
+ libtiff/tif_read.c                           | 37 +++++++++++-------
+ libtiff/tif_webp.c                           |  9 +++++
+ libtiff/tif_zip.c                            |  8 ++++
+ libtiff/tiffio.h                             |  1 +
+ libtiff/tiffiop.h                            |  5 ++-
+ 19 files changed, 230 insertions(+), 14 deletions(-)
+ create mode 100644 doc/functions/TIFFGetMaxCompressionRatio.rst
+
+diff --git a/doc/Makefile.am b/doc/Makefile.am
+index 543e6c9b..8db4e1f5 100644
+--- a/doc/Makefile.am
++++ b/doc/Makefile.am
+@@ -191,6 +191,7 @@ rst_sources = \
+ 	functions/TIFFReadFromUserBuffer.rst \
+ 	functions/TIFFSetTagExtender.rst \
+ 	functions/TIFFStrileQuery.rst \
++	functions/TIFFGetMaxCompressionRatio.rst \
+ 	libtiff.rst \
+ 	multi_page.rst \
+ 	images.rst
+diff --git a/doc/conf.py b/doc/conf.py
+index 343eeef3..2fd31cf0 100644
+--- a/doc/conf.py
++++ b/doc/conf.py
+@@ -137,6 +137,7 @@ man_pages = [
+     ('functions/TIFFFieldWriteCount', 'TIFFFieldWriteCount', 'get number of values to be written to field', author, '3tiff'),
+     ('functions/TIFFFlush', 'TIFFFlush', 'flush pending writes to an open TIFF file', author, '3tiff'),
+     ('functions/TIFFGetField', 'TIFFGetField', 'get the value(s) of a tag in an open TIFF file', author, '3tiff'),
++    ('functions/TIFFGetMaxCompressionRatio', 'TIFFGetMaxCompressionRatio', 'return maximum compression ratio for current codec', author, '3tiff'),
+     ('functions/TIFFmemory', 'TIFFmemory', 'memory management-related functions for use with TIFF files', author, '3tiff'),
+     ('functions/TIFFMergeFieldInfo', 'TIFFMergeFieldInfo', 'add application-defined TIFF tags to the list of known libtiff tags', author, '3tiff'),
+     ('functions/TIFFOpen', 'TIFFOpen', 'open a TIFF file for reading or writing', author, '3tiff'),
+diff --git a/doc/functions/TIFFGetMaxCompressionRatio.rst b/doc/functions/TIFFGetMaxCompressionRatio.rst
+new file mode 100644
+index 00000000..274788cd
+--- /dev/null
++++ b/doc/functions/TIFFGetMaxCompressionRatio.rst
+@@ -0,0 +1,40 @@
++TIFFGetMaxCompressionRatio
++==========================
++
++.. versionadded:: 4.7.2
++
++Synopsis
++--------
++
++.. highlight:: c
++
++::
++
++    #include <tiffio.h>
++
++.. c:function:: uint64_t TIFFGetMaxCompressionRatio(TIFF *tif);
++
++Description
++-----------
++
++:c:func:`TIFFGetMaxCompressionRatio` returns the maximum compression ratio
++for the current codec, which is typically achieved for a uncompressed buffer
++with all bytes at zero.
++
++This function can be used to determine if the compressed size of a strip or tile
++is realistic compared to the expected uncompressed size, to prevent some
++denial-of-service scenarios.
++
++Depending on the codec, it may take into account the strip or tile size,
++number of samples per pixel, etc.
++
++Some codecs don't implement that method, or only for a subset of configurations,
++and may return 0 when the maximum compression ratio is unknown.
++
++Return values
++-------------
++
++0 is returned if no maximum compression ratio is known.
++1 is returned when there is no compression.
++Values strictly bigger than 1 are returned when a maximum compression ratio is
++known.
+diff --git a/doc/functions/libtiff.rst b/doc/functions/libtiff.rst
+index bfc13bce..5fafb57c 100644
+--- a/doc/functions/libtiff.rst
++++ b/doc/functions/libtiff.rst
+@@ -268,6 +268,8 @@ will work.
+     * - :c:func:`TIFFGetFieldDefaulted`
+       - return tag value in current directory with default value set if the
+         value is not already set and a default is defined
++    * - :c:func:`TIFFGetMaxCompressionRatio`
++      - return maximum compression ratio for current codec
+     * - :c:func:`TIFFGetMapFileProc`
+       - returns a pointer to memory mapping method
+     * - :c:func:`TIFFGetMode`
+diff --git a/libtiff/libtiff.def b/libtiff/libtiff.def
+index 20f1ff56..a9f18ca2 100644
+--- a/libtiff/libtiff.def
++++ b/libtiff/libtiff.def
+@@ -54,6 +54,7 @@ EXPORTS	TIFFAccessTagMethods
+ 	TIFFGetField
+ 	TIFFGetFieldDefaulted
+ 	TIFFGetMapFileProc
++	TIFFGetMaxCompressionRatio
+ 	TIFFGetMode
+ 	TIFFGetReadProc
+ 	TIFFGetSeekProc
+diff --git a/libtiff/libtiff.map b/libtiff/libtiff.map
+index 45641920..a9a767b8 100644
+--- a/libtiff/libtiff.map
++++ b/libtiff/libtiff.map
+@@ -222,3 +222,7 @@ LIBTIFF_4.6.1 {
+ LIBTIFF_4.7.1 {
+     TIFFOpenOptionsSetWarnAboutUnknownTags;
+ } LIBTIFF_4.6.1;
++
++LIBTIFF_4.7.2 {
++    TIFFGetMaxCompressionRatio;
++} LIBTIFF_4.7.1;
+diff --git a/libtiff/tif_compress.c b/libtiff/tif_compress.c
+index e76d9652..d62bf59e 100644
+--- a/libtiff/tif_compress.c
++++ b/libtiff/tif_compress.c
+@@ -169,6 +169,18 @@ void _TIFFSetDefaultPostDecode(TIFF *tif)
+     }
+ }
+ 
++static uint64_t _TIFFDefaultGetMaxCompressionRatio(TIFF *tif)
++{
++    (void)tif;
++    return 0; /* unknown */
++}
++
++static uint64_t _TIFFGetMaxCompressionRatioOne(TIFF *tif)
++{
++    (void)tif;
++    return 1; /* no compression */
++}
++
+ void _TIFFSetDefaultCompressionState(TIFF *tif)
+ {
+     tif->tif_fixuptags = _TIFFNoFixupTags;
+@@ -191,6 +203,7 @@ void _TIFFSetDefaultCompressionState(TIFF *tif)
+     tif->tif_cleanup = _TIFFvoid;
+     tif->tif_defstripsize = _TIFFDefaultStripSize;
+     tif->tif_deftilesize = _TIFFDefaultTileSize;
++    tif->tif_getmaxcompressionratio = _TIFFDefaultGetMaxCompressionRatio;
+     tif->tif_flags &= ~(TIFF_NOBITREV | TIFF_NOREADRAW);
+ }
+ 
+@@ -199,6 +212,8 @@ int TIFFSetCompressionScheme(TIFF *tif, int scheme)
+     const TIFFCodec *c = TIFFFindCODEC((uint16_t)scheme);
+ 
+     _TIFFSetDefaultCompressionState(tif);
++    if (scheme == COMPRESSION_NONE)
++        tif->tif_getmaxcompressionratio = _TIFFGetMaxCompressionRatioOne;
+     /*
+      * Don't treat an unknown compression scheme as an error.
+      * This permits applications to open files with data that
+@@ -208,6 +223,13 @@ int TIFFSetCompressionScheme(TIFF *tif, int scheme)
+     return (c ? (*c->init)(tif, scheme) : 1);
+ }
+ 
++uint64_t TIFFGetMaxCompressionRatio(TIFF *tif)
++{
++    if (tif->tif_getmaxcompressionratio)
++        return tif->tif_getmaxcompressionratio(tif);
++    return 0;
++}
++
+ /*
+  * Other compression schemes may be registered.  Registered
+  * schemes can also override the builtin versions provided
+diff --git a/libtiff/tif_fax3.c b/libtiff/tif_fax3.c
+index 2799af9e..143147e4 100644
+--- a/libtiff/tif_fax3.c
++++ b/libtiff/tif_fax3.c
+@@ -1518,6 +1518,18 @@ static void Fax3PrintDir(TIFF *tif, FILE *fd, long flags)
+         (*sp->printdir)(tif, fd, flags);
+ }
+ 
++static uint64_t Fax3GetMaxCompressionRatio(TIFF *tif)
++{
++    (void)tif;
++    /* 1024x1024: 36 */
++    /* 4096x4096: 100 */
++    /* 16383x16383: 163 */
++    /* 65536x65536: 200 */
++    /* 200000x200000: 208 */
++
++    return 250;
++}
++
+ static int InitCCITTFax3(TIFF *tif)
+ {
+     static const char module[] = "InitCCITTFax3";
+@@ -1582,6 +1594,7 @@ static int InitCCITTFax3(TIFF *tif)
+     tif->tif_encodetile = Fax3Encode;
+     tif->tif_close = Fax3Close;
+     tif->tif_cleanup = Fax3Cleanup;
++    tif->tif_getmaxcompressionratio = Fax3GetMaxCompressionRatio;
+ 
+     return (1);
+ }
+@@ -1731,6 +1744,12 @@ static int Fax4PostEncode(TIFF *tif)
+     return (1);
+ }
+ 
++static uint64_t Fax4GetMaxCompressionRatio(TIFF *tif)
++{
++    return isTiled(tif) ? tif->tif_dir.td_tilewidth
++                        : tif->tif_dir.td_imagewidth;
++}
++
+ int TIFFInitCCITTFax4(TIFF *tif, int scheme)
+ {
+     (void)scheme;
+@@ -1753,6 +1772,7 @@ int TIFFInitCCITTFax4(TIFF *tif, int scheme)
+         tif->tif_encodestrip = Fax4Encode;
+         tif->tif_encodetile = Fax4Encode;
+         tif->tif_postencode = Fax4PostEncode;
++        tif->tif_getmaxcompressionratio = Fax4GetMaxCompressionRatio;
+         /*
+          * Suppress RTC at the end of each strip.
+          */
+@@ -1824,6 +1844,18 @@ static int Fax3DecodeRLE(TIFF *tif, uint8_t *buf, tmsize_t occ, uint16_t s)
+     return (1);
+ }
+ 
++static uint64_t Fax3RLEGetMaxCompressionRatio(TIFF *tif)
++{
++    (void)tif;
++    /* 1024x1024: 43 */
++    /* 4096x4096: 128 */
++    /* 16383x16383: 171 */
++    /* 65536x65536: 205 */
++    /* 200000x200000: 211 */
++
++    return 250;
++}
++
+ int TIFFInitCCITTRLE(TIFF *tif, int scheme)
+ {
+     (void)scheme;
+@@ -1832,6 +1864,7 @@ int TIFFInitCCITTRLE(TIFF *tif, int scheme)
+         tif->tif_decoderow = Fax3DecodeRLE;
+         tif->tif_decodestrip = Fax3DecodeRLE;
+         tif->tif_decodetile = Fax3DecodeRLE;
++        tif->tif_getmaxcompressionratio = Fax3RLEGetMaxCompressionRatio;
+         /*
+          * Suppress RTC+EOLs when encoding and byte-align data.
+          */
+@@ -1850,6 +1883,7 @@ int TIFFInitCCITTRLEW(TIFF *tif, int scheme)
+         tif->tif_decoderow = Fax3DecodeRLE;
+         tif->tif_decodestrip = Fax3DecodeRLE;
+         tif->tif_decodetile = Fax3DecodeRLE;
++        tif->tif_getmaxcompressionratio = Fax3RLEGetMaxCompressionRatio;
+         /*
+          * Suppress RTC+EOLs when encoding and word-align data.
+          */
+diff --git a/libtiff/tif_jpeg.c b/libtiff/tif_jpeg.c
+index a0b06461..272fee6f 100644
+--- a/libtiff/tif_jpeg.c
++++ b/libtiff/tif_jpeg.c
+@@ -2809,6 +2809,30 @@ static int JPEGInitializeLibJPEG(TIFF *tif, int decompress)
+     return 1;
+ }
+ 
++static uint64_t JPEGGetMaxCompressionRatio(TIFF *tif)
++{
++    JPEGState *sp = JState(tif);
++    if ((tif->tif_dir.td_photometric == PHOTOMETRIC_YCBCR) &&
++        (tif->tif_dir.td_planarconfig == PLANARCONFIG_CONTIG) &&
++        (tif->tif_dir.td_samplesperpixel == 3))
++    {
++        if (sp->h_sampling == 2 && sp->v_sampling == 2)
++        {
++            if (tif->tif_dir.td_bitspersample == 12)
++                return 768;
++            else
++                return 512;
++        }
++
++        return 0; /* unknown */
++    }
++
++    if (tif->tif_dir.td_bitspersample == 12)
++        return 384;
++    else
++        return 256;
++}
++
+ /* Common to tif_jpeg.c and tif_jpeg_12.c */
+ static void TIFFInitJPEGCommon(TIFF *tif)
+ {
+@@ -2845,6 +2869,7 @@ static void TIFFInitJPEGCommon(TIFF *tif)
+     tif->tif_encoderow = JPEGEncode;
+     tif->tif_encodestrip = JPEGEncode;
+     tif->tif_encodetile = JPEGEncode;
++    tif->tif_getmaxcompressionratio = JPEGGetMaxCompressionRatio;
+     tif->tif_cleanup = JPEGCleanup;
+ 
+     tif->tif_defstripsize = JPEGDefaultStripSize;
+diff --git a/libtiff/tif_lerc.c b/libtiff/tif_lerc.c
+index 2b7ab87b..44f88d06 100644
+--- a/libtiff/tif_lerc.c
++++ b/libtiff/tif_lerc.c
+@@ -1488,6 +1488,16 @@ static int LERCVGetField(TIFF *tif, uint32_t tag, va_list ap)
+     return 1;
+ }
+ 
++static uint64_t LERCGetMaxCompressionRatio(TIFF *tif)
++{
++    (void)tif;
++
++    /* LERC compression ratio can grow to several millions */
++    /* eg. 5703725 for Lerc deflate on 16383x16383 array */
++    /* or 3829644 for regular Lerc */
++    return 0;
++}
++
+ int TIFFInitLERC(TIFF *tif, int scheme)
+ {
+     static const char module[] = "TIFFInitLERC";
+@@ -1538,6 +1548,7 @@ int TIFFInitLERC(TIFF *tif, int scheme)
+     tif->tif_encodestrip = LERCEncode;
+     tif->tif_encodetile = LERCEncode;
+ #endif
++    tif->tif_getmaxcompressionratio = LERCGetMaxCompressionRatio;
+     tif->tif_cleanup = LERCCleanup;
+ 
+     /* Default values for codec-specific fields */
+diff --git a/libtiff/tif_lzma.c b/libtiff/tif_lzma.c
+index 9b4f66cf..57acbd69 100644
+--- a/libtiff/tif_lzma.c
++++ b/libtiff/tif_lzma.c
+@@ -486,6 +486,17 @@ static const TIFFField lzmaFields[] = {
+      FALSE, "LZMA2 Compression Preset", NULL},
+ };
+ 
++static uint64_t LZMAGetMaxCompressionRatio(TIFF *tif)
++{
++    (void)tif;
++    /* 1024x1024: 3800 */
++    /* 4096x4096: 6534 */
++    /* 16383x16383: 6846 */
++    /* 65536x65536: 6874 */
++
++    return 7000;
++}
++
+ int TIFFInitLZMA(TIFF *tif, int scheme)
+ {
+     static const char module[] = "TIFFInitLZMA";
+@@ -561,6 +572,8 @@ int TIFFInitLZMA(TIFF *tif, int scheme)
+     tif->tif_encodestrip = LZMAEncode;
+     tif->tif_encodetile = LZMAEncode;
+     tif->tif_cleanup = LZMACleanup;
++    tif->tif_getmaxcompressionratio = LZMAGetMaxCompressionRatio;
++
+     /*
+      * Setup predictor setup.
+      */
+diff --git a/libtiff/tif_lzw.c b/libtiff/tif_lzw.c
+index 8b9af237..8129a4fd 100644
+--- a/libtiff/tif_lzw.c
++++ b/libtiff/tif_lzw.c
+@@ -1399,6 +1399,17 @@ static void LZWCleanup(TIFF *tif)
+     _TIFFSetDefaultCompressionState(tif);
+ }
+ 
++static uint64_t LZWGetMaxCompressionRatio(TIFF *tif)
++{
++    (void)tif;
++    /* 1024x1024: 562 */
++    /* 4096x4096: 1243 */
++    /* 16383x16383: 1353 */
++    /* 65536x65536: 1362 */
++
++    return 1400;
++}
++
+ int TIFFInitLZW(TIFF *tif, int scheme)
+ {
+     static const char module[] = "TIFFInitLZW";
+@@ -1432,6 +1443,7 @@ int TIFFInitLZW(TIFF *tif, int scheme)
+     tif->tif_encodestrip = LZWEncode;
+     tif->tif_encodetile = LZWEncode;
+ #endif
++    tif->tif_getmaxcompressionratio = LZWGetMaxCompressionRatio;
+     tif->tif_cleanup = LZWCleanup;
+     /*
+      * Setup predictor setup.
+diff --git a/libtiff/tif_packbits.c b/libtiff/tif_packbits.c
+index c8053001..883b5084 100644
+--- a/libtiff/tif_packbits.c
++++ b/libtiff/tif_packbits.c
+@@ -317,6 +317,12 @@ static int PackBitsDecode(TIFF *tif, uint8_t *op, tmsize_t occ, uint16_t s)
+     return (1);
+ }
+ 
++static uint64_t PackBitsGetMaxCompressionRatio(TIFF *tif)
++{
++    (void)tif;
++    return 64;
++}
++
+ int TIFFInitPackBits(TIFF *tif, int scheme)
+ {
+     (void)scheme;
+@@ -330,6 +336,8 @@ int TIFFInitPackBits(TIFF *tif, int scheme)
+     tif->tif_encodestrip = PackBitsEncodeChunk;
+     tif->tif_encodetile = PackBitsEncodeChunk;
+ #endif
++    tif->tif_getmaxcompressionratio = PackBitsGetMaxCompressionRatio;
++
+     return (1);
+ }
+ #endif /* PACKBITS_SUPPORT */
+diff --git a/libtiff/tif_pixarlog.c b/libtiff/tif_pixarlog.c
+index 8bc1529d..71cd2a2b 100644
+--- a/libtiff/tif_pixarlog.c
++++ b/libtiff/tif_pixarlog.c
+@@ -1619,6 +1619,15 @@ static const TIFFField pixarlogFields[] = {
+     {TIFFTAG_PIXARLOGQUALITY, 0, 0, TIFF_ANY, 0, TIFF_SETGET_INT, FIELD_PSEUDO,
+      FALSE, FALSE, "", NULL}};
+ 
++static uint64_t PixarLogGetMaxCompressionRatio(TIFF *tif)
++{
++    (void)tif;
++    /* cf https://zlib.net/zlib_tech.html */
++    const uint64_t MAX_DEFLATE_RATIO = 1032;
++
++    /* security margin as I don't understand what this codec does */
++    return MAX_DEFLATE_RATIO * (uint64_t)4;
++}
+ int TIFFInitPixarLog(TIFF *tif, int scheme)
+ {
+     static const char module[] = "TIFFInitPixarLog";
+@@ -1666,6 +1675,7 @@ int TIFFInitPixarLog(TIFF *tif, int scheme)
+     tif->tif_encodetile = PixarLogEncode;
+     tif->tif_close = PixarLogClose;
+     tif->tif_cleanup = PixarLogCleanup;
++    tif->tif_getmaxcompressionratio = PixarLogGetMaxCompressionRatio;
+ 
+     /* Override SetField so we can handle our private pseudo-tag */
+     sp->vgetparent = tif->tif_tagmethods.vgetfield;
+diff --git a/libtiff/tif_read.c b/libtiff/tif_read.c
+index b47168da..a74e591c 100644
+--- a/libtiff/tif_read.c
++++ b/libtiff/tif_read.c
+@@ -618,13 +618,31 @@ tmsize_t _TIFFReadEncodedStripAndAllocBuffer(TIFF *tif, uint32_t strip,
+     if (!TIFFFillStrip(tif, strip))
+         return ((tmsize_t)(-1));
+ 
+-    *buf = _TIFFmallocExt(tif, bufsizetoalloc);
++    /* Sanity checks to avoid excessive memory allocation */
++    /* Max compression ratio experimentally determined. Might be fragile...
++     * Only apply this heuristics to situations where the memory allocation
++     * would be big, to avoid breaking nominal use cases.
++     */
++    const uint64_t maxCompressionRatio = TIFFGetMaxCompressionRatio(tif);
++    if (maxCompressionRatio > 0 && bufsizetoalloc > 100 * 1000 * 1000 &&
++        (uint64_t)tif->tif_rawdatasize <
++            (uint64_t)this_stripsize / maxCompressionRatio)
++    {
++        TIFFErrorExtR(tif, TIFFFileName(tif),
++                      "Likely invalid strip byte count for strip %u. "
++                      "Uncompressed strip size is %" PRIu64 ", "
++                      "compressed one is %" PRIu64,
++                      strip, (uint64_t)this_stripsize,
++                      (uint64_t)tif->tif_rawdatasize);
++        return ((tmsize_t)(-1));
++    }
++
++    *buf = _TIFFcallocExt(tif, 1, bufsizetoalloc);
+     if (*buf == NULL)
+     {
+         TIFFErrorExtR(tif, TIFFFileName(tif), "No space for strip buffer");
+         return ((tmsize_t)(-1));
+     }
+-    _TIFFmemset(*buf, 0, bufsizetoalloc);
+ 
+     if ((*tif->tif_decodestrip)(tif, (uint8_t *)*buf, this_stripsize, plane) <=
+         0)
+@@ -1088,17 +1106,10 @@ tmsize_t _TIFFReadEncodedTileAndAllocBuffer(TIFF *tif, uint32_t tile,
+          * Only apply this heuristics to situations where the memory allocation
+          * would be big, to avoid breaking nominal use cases.
+          */
+-        const int maxCompressionRatio =
+-            td->td_compression == COMPRESSION_ZSTD ? 33000
+-            : td->td_compression == COMPRESSION_JXL
+-                ?
+-                /* Evaluated on a 8000x8000 tile */
+-                25000 * (td->td_planarconfig == PLANARCONFIG_CONTIG
+-                             ? td->td_samplesperpixel
+-                             : 1)
+-                : td->td_compression == COMPRESSION_LZMA ? 7000 : 1000;
+-        if (bufsizetoalloc > 100 * 1000 * 1000 &&
+-            tif->tif_rawdatasize < tilesize / maxCompressionRatio)
++        const uint64_t maxCompressionRatio = TIFFGetMaxCompressionRatio(tif);
++        if (maxCompressionRatio > 0 && bufsizetoalloc > 100 * 1000 * 1000 &&
++            (uint64_t)tif->tif_rawdatasize <
++                (uint64_t)tilesize / maxCompressionRatio)
+         {
+             TIFFErrorExtR(tif, TIFFFileName(tif),
+                           "Likely invalid tile byte count for tile %u. "
+diff --git a/libtiff/tif_webp.c b/libtiff/tif_webp.c
+index 0725cebb..0545ec03 100644
+--- a/libtiff/tif_webp.c
++++ b/libtiff/tif_webp.c
+@@ -847,6 +847,14 @@ static const TIFFField TWebPFields[] = {
+      FIELD_PSEUDO, TRUE, FALSE, "WEBP exact lossless", NULL},
+ };
+ 
++static uint64_t TWebPGetMaxCompressionRatio(TIFF *tif)
++{
++    /* lossy compression: */
++    /* return (tif->tif_dir.td_samplesperpixel == 4) ? 2199 : 1685; */
++    /* lossless compression: */
++    return (tif->tif_dir.td_samplesperpixel == 4) ? 104194 : 78146;
++}
++
+ int TIFFInitWebP(TIFF *tif, int scheme)
+ {
+     static const char module[] = "TIFFInitWebP";
+@@ -910,6 +918,7 @@ int TIFFInitWebP(TIFF *tif, int scheme)
+     tif->tif_encodestrip = TWebPEncode;
+     tif->tif_encodetile = TWebPEncode;
+     tif->tif_cleanup = TWebPCleanup;
++    tif->tif_getmaxcompressionratio = TWebPGetMaxCompressionRatio;
+ 
+     return 1;
+ bad:
+diff --git a/libtiff/tif_zip.c b/libtiff/tif_zip.c
+index 36f93a75..4081e7f1 100644
+--- a/libtiff/tif_zip.c
++++ b/libtiff/tif_zip.c
+@@ -700,6 +700,13 @@ static void TIFF_zfree(void *opaque, void *ptr)
+     _TIFFfreeExt((TIFF *)opaque, ptr);
+ }
+ 
++static uint64_t ZIPGetMaxCompressionRatio(TIFF *tif)
++{
++    (void)tif;
++    /* cf https://zlib.net/zlib_tech.html */
++    return 1032;
++}
++
+ int TIFFInitZIP(TIFF *tif, int scheme)
+ {
+     static const char module[] = "TIFFInitZIP";
+@@ -766,6 +773,7 @@ int TIFFInitZIP(TIFF *tif, int scheme)
+     tif->tif_encodestrip = ZIPEncode;
+     tif->tif_encodetile = ZIPEncode;
+     tif->tif_cleanup = ZIPCleanup;
++    tif->tif_getmaxcompressionratio = ZIPGetMaxCompressionRatio;
+     /*
+      * Setup predictor setup.
+      */
+diff --git a/libtiff/tiffio.h b/libtiff/tiffio.h
+index 117ec241..bb8fbde2 100644
+--- a/libtiff/tiffio.h
++++ b/libtiff/tiffio.h
+@@ -584,6 +584,7 @@ extern int TIFFReadRGBAImageOriented(TIFF *, uint32_t, uint32_t, uint32_t *,
+                                          tmsize_t cc);
+     extern tmsize_t TIFFWriteRawTile(TIFF *tif, uint32_t tile, void *data,
+                                      tmsize_t cc);
++    extern uint64_t TIFFGetMaxCompressionRatio(TIFF *tif);
+     extern int TIFFDataWidth(
+         TIFFDataType); /* table of tag datatype widths within TIFF file. */
+     extern void TIFFSetWriteOffset(TIFF *tif, toff_t off);
+diff --git a/libtiff/tiffiop.h b/libtiff/tiffiop.h
+index 2a4265ba..1667a421 100644
+--- a/libtiff/tiffiop.h
++++ b/libtiff/tiffiop.h
+@@ -95,6 +95,7 @@ typedef int (*TIFFSeekMethod)(TIFF *, uint32_t);
+ typedef void (*TIFFPostMethod)(TIFF *tif, uint8_t *buf, tmsize_t size);
+ typedef uint32_t (*TIFFStripMethod)(TIFF *, uint32_t);
+ typedef void (*TIFFTileMethod)(TIFF *, uint32_t *, uint32_t *);
++typedef uint64_t (*TIFFGetMaxCompressionRatioMethod)(TIFF *);
+ 
+ struct TIFFOffsetAndDirNumber
+ {
+@@ -216,7 +217,9 @@ struct tiff
+     TIFFVoidMethod tif_cleanup;       /* cleanup state routine */
+     TIFFStripMethod tif_defstripsize; /* calculate/constrain strip size */
+     TIFFTileMethod tif_deftilesize;   /* calculate/constrain tile size */
+-    uint8_t *tif_data;                /* compression scheme private data */
++    /* returns maximum compression ratio for current compression method */
++    TIFFGetMaxCompressionRatioMethod tif_getmaxcompressionratio;
++    uint8_t *tif_data; /* compression scheme private data */
+     /* input/output buffering */
+     uint8_t *tif_rawdata;       /* raw data buffer */
+     tmsize_t tif_rawdatasize;   /* # of bytes in raw data buffer */
+-- 
+GitLab
+

--- a/packages/l/libtiff/package.yml
+++ b/packages/l/libtiff/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libtiff
 version    : 4.7.1
-release    : 45
+release    : 46
 source     :
     - https://download.osgeo.org/libtiff/tiff-4.7.1.tar.xz : b92017489bdc1db3a4c97191aa4b75366673cb746de0dce5d7a749d5954681ba
 homepage   : https://libtiff.gitlab.io/libtiff/
@@ -25,10 +25,13 @@ patterns   :
         - /usr/bin
         - /usr/share/man/man1
 setup      : |
+    # Remove patch next upstream release
+    %patch -p1 -i ${pkgfiles}/CVE-2026-36849.patch
     %configure --disable-static
 build      : |
     %make
 install    : |
     %make_install
+    %install_license LICENSE.md
 check      : |
-    %make check || :
+    %make check

--- a/packages/l/libtiff/pspec_x86_64.xml
+++ b/packages/l/libtiff/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libtiff</Name>
         <Homepage>https://libtiff.gitlab.io/libtiff/</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>libtiff</License>
         <PartOf>desktop.library</PartOf>
@@ -24,6 +24,7 @@
             <Path fileType="library">/usr/lib64/libtiff.so.6.2.0</Path>
             <Path fileType="library">/usr/lib64/libtiffxx.so.6</Path>
             <Path fileType="library">/usr/lib64/libtiffxx.so.6.2.0</Path>
+            <Path fileType="data">/usr/share/licenses/libtiff/LICENSE.md</Path>
         </Files>
     </Package>
     <Package>
@@ -33,7 +34,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="45">libtiff</Dependency>
+            <Dependency release="46">libtiff</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libtiff.so.6</Path>
@@ -49,8 +50,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="45">libtiff-32bit</Dependency>
-            <Dependency release="45">libtiff-devel</Dependency>
+            <Dependency release="46">libtiff-32bit</Dependency>
+            <Dependency release="46">libtiff-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libtiff.so</Path>
@@ -65,7 +66,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="45">libtiff</Dependency>
+            <Dependency release="46">libtiff</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/tiff.h</Path>
@@ -524,7 +525,7 @@
 </Description>
         <PartOf>multimedia.graphics</PartOf>
         <RuntimeDependencies>
-            <Dependency release="45">libtiff</Dependency>
+            <Dependency release="46">libtiff</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/fax2ps</Path>
@@ -569,12 +570,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="45">
-            <Date>2025-11-10</Date>
+        <Update release="46">
+            <Date>2026-06-17</Date>
             <Version>4.7.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Resolves this upstream issue https://gitlab.com/libtiff/libtiff/-/work_items/781

**Security**

- CVE-2026-36849

**Test Plan**

- Build a couple of the revdeps

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
