### PR TITLE
xdg-desktop-portal: Update to v1.22.1

### DIFF
--- a/packages/x/xdg-desktop-portal/abi_used_symbols
+++ b/packages/x/xdg-desktop-portal/abi_used_symbols
@@ -49,6 +49,7 @@ libc.so.6:getenv
 libc.so.6:geteuid
 libc.so.6:getgid
 libc.so.6:getpid
+libc.so.6:getrandom
 libc.so.6:getrlimit64
 libc.so.6:getuid
 libc.so.6:getxattr
@@ -340,6 +341,7 @@ libglib-2.0.so.0:g_assertion_message_expr
 libglib-2.0.so.0:g_atomic_ref_count_dec
 libglib-2.0.so.0:g_atomic_ref_count_inc
 libglib-2.0.so.0:g_atomic_ref_count_init
+libglib-2.0.so.0:g_base64_encode
 libglib-2.0.so.0:g_build_filename
 libglib-2.0.so.0:g_bytes_equal
 libglib-2.0.so.0:g_bytes_get_data
@@ -609,7 +611,6 @@ libglib-2.0.so.0:g_utf8_skip
 libglib-2.0.so.0:g_utf8_strlen
 libglib-2.0.so.0:g_utf8_validate
 libglib-2.0.so.0:g_uuid_string_is_valid
-libglib-2.0.so.0:g_uuid_string_random
 libglib-2.0.so.0:g_variant_builder_add
 libglib-2.0.so.0:g_variant_builder_add_value
 libglib-2.0.so.0:g_variant_builder_clear

--- a/packages/x/xdg-desktop-portal/package.yml
+++ b/packages/x/xdg-desktop-portal/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : xdg-desktop-portal
-version    : 1.22.0
-release    : 35
+version    : 1.22.1
+release    : 36
 source     :
-    - https://github.com/flatpak/xdg-desktop-portal/releases/download/1.22.0/xdg-desktop-portal-1.22.0.tar.xz : a610393a123f9dbd0aed662e716f6f98362850283d2cc750399f12c8313e6564
+    - https://github.com/flatpak/xdg-desktop-portal/releases/download/1.22.1/xdg-desktop-portal-1.22.1.tar.xz : d4879ddb3d65ff1a8f19187497e6f13dc5d267bcac404a5d501218be355753d3
 homepage   : https://github.com/flatpak/xdg-desktop-portal
 license    : LGPL-2.1-or-later
 component  : desktop.util

--- a/packages/x/xdg-desktop-portal/pspec_x86_64.xml
+++ b/packages/x/xdg-desktop-portal/pspec_x86_64.xml
@@ -138,16 +138,16 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="35">xdg-desktop-portal</Dependency>
+            <Dependency release="36">xdg-desktop-portal</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/pkgconfig/xdg-desktop-portal.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="35">
-            <Date>2026-06-13</Date>
-            <Version>1.22.0</Version>
+        <Update release="36">
+            <Date>2026-06-17</Date>
+            <Version>1.22.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/flatpak/xdg-desktop-portal/releases/tag/1.22.1).

**Security**
- GHSA-c5cf-79w8-pvfh
- GHSA-cm83-2936-gxjm

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Reboot and see that the portal service is running.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
