### PR TITLE
labwc: Update to v0.20.1

### DIFF
--- a/packages/l/labwc/package.yml
+++ b/packages/l/labwc/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : labwc
-version    : 0.20.0
-release    : 17
+version    : 0.20.1
+release    : 18
 source     :
-    - https://github.com/labwc/labwc/archive/refs/tags/0.20.0.tar.gz : 3e0b7cfd8e371ed4826f2d5467749edc7f9d6c06491dd943a55ed1c0b49a369a
+    - https://github.com/labwc/labwc/archive/refs/tags/0.20.1.tar.gz : 2c95d8c19cc50ce0dd5cf3e412932ebb4d3353bc4a5d11e2405d124e6c77dcd2
 homepage   : https://labwc.github.io/
 license    : GPL-2.0-or-later
 component  : desktop

--- a/packages/l/labwc/pspec_x86_64.xml
+++ b/packages/l/labwc/pspec_x86_64.xml
@@ -83,7 +83,7 @@
         <Summary xml:lang="en">Labwc session</Summary>
         <Description xml:lang="en">Labwc session</Description>
         <RuntimeDependencies>
-            <Dependency releaseFrom="17">labwc</Dependency>
+            <Dependency releaseFrom="18">labwc</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib/systemd/user/labwc-session.target</Path>
@@ -93,9 +93,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2026-05-27</Date>
-            <Version>0.20.0</Version>
+        <Update release="18">
+            <Date>2026-06-17</Date>
+            <Version>0.20.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/labwc/labwc/releases/tag/0.20.1).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a Budgie labwc session.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
