### PR TITLE
ocaml: Update to v4.14.4

### DIFF
--- a/packages/o/ocaml/package.yml
+++ b/packages/o/ocaml/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : ocaml
-version    : 4.14.3
-release    : 23
+version    : 4.14.4
+release    : 24
 source     :
-    - https://github.com/ocaml/ocaml/archive/refs/tags/4.14.3.tar.gz : e510689183b2d62b0a7513ea7e47be80ddb9173377a2df436dbc1ca927a64689
+    - https://github.com/ocaml/ocaml/archive/refs/tags/4.14.4.tar.gz : 71415c000ebfce604defafaa584ab5ed10ad81ff180897db4e6fea8dac6e4b0d
 homepage   : https://ocaml.org/
 license    : LGPL-2.1-only WITH OCaml-LGPL-linking-exception
 component  : programming

--- a/packages/o/ocaml/pspec_x86_64.xml
+++ b/packages/o/ocaml/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>ocaml</Name>
         <Homepage>https://ocaml.org/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>LGPL-2.1-only WITH OCaml-LGPL-linking-exception</License>
         <PartOf>programming</PartOf>
@@ -2954,12 +2954,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2026-02-27</Date>
-            <Version>4.14.3</Version>
+        <Update release="24">
+            <Date>2026-06-17</Date>
+            <Version>4.14.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://ocaml.org/releases/4.14.4).

**Security**
Includes fixes for:
- CVE-2026-34353
- CVE-2026-41083

**Test Plan**

Hello world in ocaml.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
