### PR TITLE
liblo: Update to v0.35

### DIFF
--- a/packages/l/liblo/abi_symbols
+++ b/packages/l/liblo/abi_symbols
@@ -30,6 +30,7 @@ liblo.so.7:lo_blob_new
 liblo.so.7:lo_blobsize
 liblo.so.7:lo_bundle_add_bundle
 liblo.so.7:lo_bundle_add_message
+liblo.so.7:lo_bundle_clear
 liblo.so.7:lo_bundle_count
 liblo.so.7:lo_bundle_free
 liblo.so.7:lo_bundle_free_messages
@@ -43,6 +44,7 @@ liblo.so.7:lo_bundle_length
 liblo.so.7:lo_bundle_new
 liblo.so.7:lo_bundle_pp
 liblo.so.7:lo_bundle_serialise
+liblo.so.7:lo_bundle_set_timestamp
 liblo.so.7:lo_client_sockets
 liblo.so.7:lo_coerce
 liblo.so.7:lo_error_context
@@ -69,7 +71,9 @@ liblo.so.7:lo_message_add_symbol
 liblo.so.7:lo_message_add_timetag
 liblo.so.7:lo_message_add_true
 liblo.so.7:lo_message_add_varargs_internal
+liblo.so.7:lo_message_clear
 liblo.so.7:lo_message_clone
+liblo.so.7:lo_message_decref
 liblo.so.7:lo_message_deserialise
 liblo.so.7:lo_message_free
 liblo.so.7:lo_message_get_argc
@@ -109,6 +113,7 @@ liblo.so.7:lo_server_get_socket_fd
 liblo.so.7:lo_server_get_url
 liblo.so.7:lo_server_max_msg_size
 liblo.so.7:lo_server_new
+liblo.so.7:lo_server_new_from_config
 liblo.so.7:lo_server_new_from_url
 liblo.so.7:lo_server_new_multicast
 liblo.so.7:lo_server_new_multicast_iface
@@ -117,7 +122,6 @@ liblo.so.7:lo_server_next_event_delay
 liblo.so.7:lo_server_pp
 liblo.so.7:lo_server_recv
 liblo.so.7:lo_server_recv_noblock
-liblo.so.7:lo_server_recv_raw
 liblo.so.7:lo_server_set_error_context
 liblo.so.7:lo_server_should_coerce_args
 liblo.so.7:lo_server_thread_add_method
@@ -129,6 +133,7 @@ liblo.so.7:lo_server_thread_get_port
 liblo.so.7:lo_server_thread_get_server
 liblo.so.7:lo_server_thread_get_url
 liblo.so.7:lo_server_thread_new
+liblo.so.7:lo_server_thread_new_from_config
 liblo.so.7:lo_server_thread_new_from_url
 liblo.so.7:lo_server_thread_new_multicast
 liblo.so.7:lo_server_thread_new_multicast_iface
@@ -141,6 +146,7 @@ liblo.so.7:lo_server_thread_stop
 liblo.so.7:lo_server_wait
 liblo.so.7:lo_servers_recv_noblock
 liblo.so.7:lo_servers_wait
+liblo.so.7:lo_string_contains_pattern
 liblo.so.7:lo_strsize
 liblo.so.7:lo_throw
 liblo.so.7:lo_timetag_diff

--- a/packages/l/liblo/abi_used_symbols
+++ b/packages/l/liblo/abi_used_symbols
@@ -2,7 +2,11 @@ libc.so.6:__assert_fail
 libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__isoc99_sscanf
+libc.so.6:__inet_pton_chk
+libc.so.6:__isoc23_sscanf
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoll
+libc.so.6:__isoc23_strtoul
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__snprintf_chk
@@ -30,7 +34,6 @@ libc.so.6:gethostname
 libc.so.6:getifaddrs
 libc.so.6:getnameinfo
 libc.so.6:gettimeofday
-libc.so.6:index
 libc.so.6:inet_pton
 libc.so.6:listen
 libc.so.6:malloc
@@ -75,9 +78,6 @@ libc.so.6:strtod
 libc.so.6:strtof
 libc.so.6:strtok
 libc.so.6:strtok_r
-libc.so.6:strtol
-libc.so.6:strtoll
-libc.so.6:strtoul
 libc.so.6:time
 libc.so.6:unlink
 libc.so.6:usleep

--- a/packages/l/liblo/package.yml
+++ b/packages/l/liblo/package.yml
@@ -1,18 +1,21 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : liblo
-version    : '0.31'
-release    : 4
+version    : '0.35'
+release    : 5
 source     :
-    - https://github.com/radarsat1/liblo/archive/0.31.tar.gz : 71d1819bcd18be66bd80c95a2d3159b9ca6f13746ddbaf1e489128f3bf46d231
+    - https://github.com/radarsat1/liblo/archive/0.35.tar.gz : d3d807faa89fc42a5f2468246d212decfa7d2775da879d6aaaa97768aaf8e183
 homepage   : https://github.com/radarsat1/liblo
 license    : LGPL-2.1-or-later
 component  : multimedia.library
 summary    : Lightweight Open Sound Control (OSC) implementation
 description: |
     A lightweight library to handle the receiving and sending of messages according to the Open Sound Control (OSC) protocol.
+builddeps  :
+    - doxygen
 setup      : |
     %autogen --disable-static
 build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING

--- a/packages/l/liblo/pspec_x86_64.xml
+++ b/packages/l/liblo/pspec_x86_64.xml
@@ -3,15 +3,15 @@
         <Name>liblo</Name>
         <Homepage>https://github.com/radarsat1/liblo</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>multimedia.library</PartOf>
         <Summary xml:lang="en">Lightweight Open Sound Control (OSC) implementation</Summary>
         <Description xml:lang="en">A lightweight library to handle the receiving and sending of messages according to the Open Sound Control (OSC) protocol.
 </Description>
-        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://getsol.us/sources/README.Solus</Archive>
+        <Archive type="binary" sha1sum="79eb0752a961b8e0d15c77d298c97498fbc89c5a">https://sources.getsol.us/README.Solus</Archive>
     </Source>
     <Package>
         <Name>liblo</Name>
@@ -24,7 +24,8 @@
             <Path fileType="executable">/usr/bin/oscsend</Path>
             <Path fileType="executable">/usr/bin/oscsendfile</Path>
             <Path fileType="library">/usr/lib64/liblo.so.7</Path>
-            <Path fileType="library">/usr/lib64/liblo.so.7.4.1</Path>
+            <Path fileType="library">/usr/lib64/liblo.so.7.7.0</Path>
+            <Path fileType="data">/usr/share/licenses/liblo/COPYING</Path>
         </Files>
     </Package>
     <Package>
@@ -34,7 +35,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="4">liblo</Dependency>
+            <Dependency release="5">liblo</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/lo/lo.h</Path>
@@ -52,12 +53,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2022-07-09</Date>
-            <Version>0.31</Version>
+        <Update release="5">
+            <Date>2026-06-17</Date>
+            <Version>0.35</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- [0.35](https://github.com/radarsat1/liblo/releases/tag/0.35)
- [0.34](https://github.com/radarsat1/liblo/releases/tag/0.34)
- *No 0.33 notes*
- [0.32](https://github.com/radarsat1/liblo/releases/tag/0.32)

**Test Plan**

- Run ardour, one of the revdeps

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
