### PR TITLE
runc: Update to v1.4.3

### DIFF
--- a/packages/r/runc/package.yml
+++ b/packages/r/runc/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : runc
-version    : 1.4.2
-release    : 39
+version    : 1.4.3
+release    : 40
 source     :
-    - https://github.com/opencontainers/runc/archive/refs/tags/v1.4.2.tar.gz : 9e1dcd513e28fac99e7b47fec38ce4f1969a9a9693b80619e9009286e2d0d584
+    - https://github.com/opencontainers/runc/archive/refs/tags/v1.4.3.tar.gz : e0a89f9e883ce93e740d14bb105b25c665f7d7beade4cfd0714fcafb38855d35
 homepage   : https://opencontainers.org/
 license    : Apache-2.0
 component  : virt

--- a/packages/r/runc/pspec_x86_64.xml
+++ b/packages/r/runc/pspec_x86_64.xml
@@ -43,9 +43,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="39">
-            <Date>2026-04-15</Date>
-            <Version>1.4.2</Version>
+        <Update release="40">
+            <Date>2026-06-18</Date>
+            <Version>1.4.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/opencontainers/runc/releases/tag/v1.4.3).

**Security**
Includes fixes for:
- CVE-2026-41579
- CVE-2025-31133

**Test Plan**

docker works. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
