### PR TITLE
apostrophe: Fix Python 3.14 breakages

### DIFF
--- a/packages/a/apostrophe/files/0001-HACK-Fix-multiprocessing-with-Python-3.14.patch
+++ b/packages/a/apostrophe/files/0001-HACK-Fix-multiprocessing-with-Python-3.14.patch
@@ -1,0 +1,34 @@
+From 210276f1a10be7f38ac34513832cce4225ae5bdd Mon Sep 17 00:00:00 2001
+From: "Alexander F. Lent" <lx@xanderlent.com>
+Date: Mon, 30 Mar 2026 23:45:19 -0400
+Subject: [PATCH] HACK: Fix multiprocessing with Python 3.14+
+
+---
+ apostrophe/text_view_markup_handler.py | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/apostrophe/text_view_markup_handler.py b/apostrophe/text_view_markup_handler.py
+index a4ca14e..aa6b080 100644
+--- a/apostrophe/text_view_markup_handler.py
++++ b/apostrophe/text_view_markup_handler.py
+@@ -15,6 +15,7 @@
+ 
+ import regex as re
+ from multiprocessing import Pipe, Process
++import multiprocessing
+ 
+ import gi
+ from gi.repository import GLib, Gtk, Pango
+@@ -139,6 +140,10 @@ class MarkupHandler:
+         self.parsing = False
+         self.apply_pending = False
+         self.parent_conn, child_conn = Pipe()
++        # HACK: The following line preserves the old behavior in Python 3.14+ (requires 3.4+)
++        # With the new forkserver default on Linux (and spawn default on other platforms) we can
++        # only use pickleable objects across processes.
++        multiprocessing.set_start_method('fork')
+         Process(target=self.parse, args=(child_conn,), daemon=True).start()
+         GLib.io_add_watch(
+             self.parent_conn.fileno(),
+-- 
+2.53.0

--- a/packages/a/apostrophe/package.yml
+++ b/packages/a/apostrophe/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : apostrophe
 version    : '3.4'
-release    : 18
+release    : 19
 source     :
     - https://gitlab.gnome.org/World/apostrophe/-/archive/v3.4/apostrophe-v3.4.tar.gz : daee484d02f67e03d9c46a0f3ce1ae7828afc7b9946868f6b057267ed591918a
 homepage   : https://world.pages.gitlab.gnome.org/apostrophe/
@@ -26,6 +26,7 @@ rundeps    :
     - python-pypandoc
     - python-regex
 setup      : |
+    %patch -p1 -i $pkgfiles/0001-HACK-Fix-multiprocessing-with-Python-3.14.patch
     %meson_configure
 build      : |
     %ninja_build

--- a/packages/a/apostrophe/pspec_x86_64.xml
+++ b/packages/a/apostrophe/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>apostrophe</Name>
         <Homepage>https://world.pages.gitlab.gnome.org/apostrophe/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>office.notes</PartOf>
@@ -170,12 +170,12 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2026-06-07</Date>
+        <Update release="19">
+            <Date>2026-06-18</Date>
             <Version>3.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Muhammad Alfi Syahrin</Name>
+            <Email>alfi@getsol.us</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Fix this [issue](https://gitlab.gnome.org/World/apostrophe/-/work_items/669)

**Test Plan**

<!-- Short description of how the package was tested -->
App launches

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
