### PR TITLE
containerd: Update to v2.3.2

### DIFF
--- a/packages/c/containerd/package.yml
+++ b/packages/c/containerd/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : containerd
-version    : 2.3.1
-release    : 73
+version    : 2.3.2
+release    : 74
 source     :
-    - https://github.com/containerd/containerd/archive/refs/tags/v2.3.1.tar.gz : 9de4cb8bfb27964a8ffd95e35326b7279ea2e2a6506da16c2533d3f523f12c11
+    - https://github.com/containerd/containerd/archive/refs/tags/v2.3.2.tar.gz : 1a215ae4acb184192668b21f8b8375ceb6e86f8832a97fe6f7ab53ad79bb2cee
 license    : Apache-2.0
 component  : virt
 homepage   : https://containerd.io/

--- a/packages/c/containerd/pspec_x86_64.xml
+++ b/packages/c/containerd/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>containerd</Name>
         <Homepage>https://containerd.io/</Homepage>
         <Packager>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>virt</PartOf>
@@ -36,12 +36,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="73">
-            <Date>2026-05-22</Date>
-            <Version>2.3.1</Version>
+        <Update release="74">
+            <Date>2026-06-19</Date>
+            <Version>2.3.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jared Cervantes</Name>
-            <Email>jared@jaredcervantes.com</Email>
+            <Name>David Harder</Name>
+            <Email>david@davidjharder.ca</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

- Release notes [here](https://github.com/containerd/containerd/releases/tag/v2.3.2)

**Security**

- CVE-2026-50195
- CVE-2026-53488
- CVE-2026-53492
- CVE-2026-53489
- CVE-2026-47262

**Test Plan**

- Built, installed

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
