### PR TITLE
xdg-desktop-portal: Backport patch for autostart on non-systemd DEs

### DIFF
--- a/packages/x/xdg-desktop-portal/abi_libs
+++ b/packages/x/xdg-desktop-portal/abi_libs
@@ -1,3 +1,5 @@
 xdg-desktop-portal
+xdg-desktop-portal-rewrite-launchers
+xdg-desktop-portal-validate-icon
 xdg-document-portal
 xdg-permission-store

--- a/packages/x/xdg-desktop-portal/abi_symbols
+++ b/packages/x/xdg-desktop-portal/abi_symbols
@@ -1,3 +1,5 @@
 xdg-desktop-portal:_IO_stdin_used
+xdg-desktop-portal-rewrite-launchers:_IO_stdin_used
+xdg-desktop-portal-validate-icon:_IO_stdin_used
 xdg-document-portal:_IO_stdin_used
 xdg-permission-store:_IO_stdin_used

--- a/packages/x/xdg-desktop-portal/files/xdp-1.22.1-start-service-withouut-graphical-session.patch
+++ b/packages/x/xdg-desktop-portal/files/xdp-1.22.1-start-service-withouut-graphical-session.patch
@@ -1,0 +1,36 @@
+From 77e837f0034d1b9237e09244fb17fed81c9c9e45 Mon Sep 17 00:00:00 2001
+From: Alessandro Astone <alessandro.astone@canonical.com>
+Date: Sun, 29 Mar 2026 23:10:03 +0200
+Subject: [PATCH] Allow service's start even if graphical-session is not
+ reached
+
+While this is not ideal, we need to support desktop environments that do not
+bind to graphical-session.target, at least as a temporary measure.
+
+We keep the After=graphical-session.target stanza, since 'After' will only
+affect the ordering of start operations if both are queued up to start, while
+it is a no-op if graphical-session.target is not pending start.
+
+This partially reverts commit 4d284de29d1d0740c9b80b634631a8f253287680.
+
+Resolves: https://github.com/flatpak/xdg-desktop-portal/issues/1983
+Bug-Fedora: https://bugzilla.redhat.com/show_bug.cgi?id=2481764
+Bug-Ubuntu: https://launchpad.net/bugs/2144855
+---
+ desktop-portal/xdg-desktop-portal.service.in | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/xdg-desktop-portal.service.in b/src/xdg-desktop-portal.service.in
+index 1029f5901..d7a9e8b55 100644
+--- a/src/xdg-desktop-portal.service.in
++++ b/src/xdg-desktop-portal.service.in
+@@ -4,7 +4,8 @@
+ [Unit]
+ Description=Portal service
+ PartOf=graphical-session.target
+-Requisite=graphical-session.target
++Requires=dbus.service
++After=dbus.service
+ After=graphical-session.target
+ 
+ [Service]

--- a/packages/x/xdg-desktop-portal/package.yml
+++ b/packages/x/xdg-desktop-portal/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : xdg-desktop-portal
 version    : 1.22.1
-release    : 36
+release    : 37
 source     :
     - https://github.com/flatpak/xdg-desktop-portal/releases/download/1.22.1/xdg-desktop-portal-1.22.1.tar.xz : d4879ddb3d65ff1a8f19187497e6f13dc5d267bcac404a5d501218be355753d3
 homepage   : https://github.com/flatpak/xdg-desktop-portal
@@ -23,6 +23,8 @@ builddeps  :
     - docbook-xml
     - xmlto
 setup      : |
+    %patch -p1 -i ${pkgfiles}/xdp-1.22.1-start-service-withouut-graphical-session.patch
+
     %meson_configure -Dtests=disabled
 build      : |
     %ninja_build

--- a/packages/x/xdg-desktop-portal/pspec_x86_64.xml
+++ b/packages/x/xdg-desktop-portal/pspec_x86_64.xml
@@ -138,15 +138,15 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="36">xdg-desktop-portal</Dependency>
+            <Dependency release="37">xdg-desktop-portal</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/pkgconfig/xdg-desktop-portal.pc</Path>
         </Files>
     </Package>
     <History>
-        <Update release="36">
-            <Date>2026-06-17</Date>
+        <Update release="37">
+            <Date>2026-06-19</Date>
             <Version>1.22.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>


### PR DESCRIPTION
**Summary**
- Fixes the portal services not starting if the DE never reaches
  graphical-session.target, such as Budgie and Xfce.

See https://github.com/flatpak/xdg-desktop-portal/pull/2027

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install the package in both Budgie and Xfce VMs, and see that the portals start as expected.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
