### PR TITLE
openexr: Update to v3.4.13

### DIFF
--- a/packages/o/openexr/package.yml
+++ b/packages/o/openexr/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : openexr
-version    : 3.4.12
-release    : 15
+version    : 3.4.13
+release    : 16
 source     :
-    - https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.4.12.tar.gz : a455779c389f65c64220d45b63ead2900081e5f6337cdf93431cb1032c3e2686
+    - https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.4.13.tar.gz : 1ed0cee48ac8c77da235c8ca8ab85d031d43cd790eda36af87fed4cf316cf2df
 homepage   : https://www.openexr.com/
 license    : BSD-3-Clause
 component  :

--- a/packages/o/openexr/pspec_x86_64.xml
+++ b/packages/o/openexr/pspec_x86_64.xml
@@ -28,7 +28,7 @@ OpenEXR is widely used in host application software where accuracy is critical, 
 </Description>
         <PartOf>multimedia.library</PartOf>
         <RuntimeDependencies>
-            <Dependency release="15">openexr-libs</Dependency>
+            <Dependency release="16">openexr-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/exr2aces</Path>
@@ -56,8 +56,8 @@ OpenEXR is widely used in host application software where accuracy is critical, 
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="15">openexr</Dependency>
-            <Dependency releaseFrom="15">openexr-libs</Dependency>
+            <Dependency release="16">openexr</Dependency>
+            <Dependency releaseFrom="16">openexr-libs</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/OpenEXR/Iex.h</Path>
@@ -272,21 +272,21 @@ OpenEXR is widely used in host application software where accuracy is critical, 
         <PartOf>multimedia.library</PartOf>
         <Files>
             <Path fileType="library">/usr/lib64/libIex-3_4.so.33</Path>
-            <Path fileType="library">/usr/lib64/libIex-3_4.so.33.3.4.12</Path>
+            <Path fileType="library">/usr/lib64/libIex-3_4.so.33.3.4.13</Path>
             <Path fileType="library">/usr/lib64/libIlmThread-3_4.so.33</Path>
-            <Path fileType="library">/usr/lib64/libIlmThread-3_4.so.33.3.4.12</Path>
+            <Path fileType="library">/usr/lib64/libIlmThread-3_4.so.33.3.4.13</Path>
             <Path fileType="library">/usr/lib64/libOpenEXR-3_4.so.33</Path>
-            <Path fileType="library">/usr/lib64/libOpenEXR-3_4.so.33.3.4.12</Path>
+            <Path fileType="library">/usr/lib64/libOpenEXR-3_4.so.33.3.4.13</Path>
             <Path fileType="library">/usr/lib64/libOpenEXRCore-3_4.so.33</Path>
-            <Path fileType="library">/usr/lib64/libOpenEXRCore-3_4.so.33.3.4.12</Path>
+            <Path fileType="library">/usr/lib64/libOpenEXRCore-3_4.so.33.3.4.13</Path>
             <Path fileType="library">/usr/lib64/libOpenEXRUtil-3_4.so.33</Path>
-            <Path fileType="library">/usr/lib64/libOpenEXRUtil-3_4.so.33.3.4.12</Path>
+            <Path fileType="library">/usr/lib64/libOpenEXRUtil-3_4.so.33.3.4.13</Path>
         </Files>
     </Package>
     <History>
-        <Update release="15">
-            <Date>2026-05-25</Date>
-            <Version>3.4.12</Version>
+        <Update release="16">
+            <Date>2026-06-19</Date>
+            <Version>3.4.13</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/AcademySoftwareFoundation/openexr/releases/tag/v3.4.13).

**Security**
Includes fixes for:
- CVE-2026-55373
- CVE-2026-55371
- CVE-2026-55059
- CVE-2026-54920
- CVE-2026-53532

**Test Plan**

Passed ninja checks.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
