### PR TITLE
gnome-sushi: Add libgtksourceview4 to rundeps

### DIFF
--- a/packages/g/gnome-sushi/package.yml
+++ b/packages/g/gnome-sushi/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gnome-sushi
 version    : '50.0'
-release    : 22
+release    : 23
 source     :
     - https://download.gnome.org/sources/sushi/50/sushi-50.0.tar.xz : ab25177908d5ccc58568769a81eb9b4f32306786e6c73618193ebf61a127ee00
 homepage   : https://gitlab.gnome.org/GNOME/sushi
@@ -19,6 +19,7 @@ builddeps  :
     - pkgconfig(webkit2gtk-4.1)
 rundeps    :
     - gjs
+    - libgtksourceview4
 setup      : |
     %meson_configure
 build      : |

--- a/packages/g/gnome-sushi/pspec_x86_64.xml
+++ b/packages/g/gnome-sushi/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>gnome-sushi</Name>
         <Homepage>https://gitlab.gnome.org/GNOME/sushi</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>desktop.gnome</PartOf>
@@ -118,12 +118,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2026-05-18</Date>
+        <Update release="23">
+            <Date>2026-06-20</Date>
             <Version>50.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>sebo505</Name>
+            <Email>sebastian.spree@web.de</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Add libgtksourceview4 to rundeps
Fixes gnome-sushi not showing previews

**Test Plan**
- install gnome-sushi on a system without libgtksourceview4 installed
- check that libgtksourceview4 gets installed along gnome-sushi
- check that gnome-sushi shows previews

**Checklist**
- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes
once merged <!-- Write an appropriate message in the Summary section,
then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous
contributions under the licensing terms in
[LICENSE.md](../blob/main/LICENSE.md) and have the power and authority
to grant those licenses.
