### PR TITLE
jq: Update to 1.8.2

### DIFF
--- a/packages/j/jq/abi_used_libs
+++ b/packages/j/jq/abi_used_libs
@@ -1,3 +1,4 @@
+ld-linux-x86-64.so.2
 libc.so.6
 libm.so.6
 libonig.so.5

--- a/packages/j/jq/abi_used_symbols
+++ b/packages/j/jq/abi_used_symbols
@@ -1,3 +1,4 @@
+ld-linux-x86-64.so.2:__tls_get_addr
 libc.so.6:__assert_fail
 libc.so.6:__ctype_b_loc
 libc.so.6:__cxa_atexit
@@ -12,6 +13,7 @@ libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
 libc.so.6:__vsnprintf_chk
 libc.so.6:abort
+libc.so.6:arc4random
 libc.so.6:calloc
 libc.so.6:clearerr
 libc.so.6:close
@@ -59,7 +61,6 @@ libc.so.6:putchar
 libc.so.6:puts
 libc.so.6:qsort
 libc.so.6:raise
-libc.so.6:rand
 libc.so.6:realloc
 libc.so.6:realpath
 libc.so.6:setlocale
@@ -77,7 +78,6 @@ libc.so.6:strerror
 libc.so.6:strftime
 libc.so.6:strlen
 libc.so.6:strncmp
-libc.so.6:strncpy
 libc.so.6:strptime
 libc.so.6:strrchr
 libc.so.6:strspn

--- a/packages/j/jq/package.yml
+++ b/packages/j/jq/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : jq
-version    : 1.8.1
-release    : 12
+version    : 1.8.2
+release    : 13
 source     :
-    - https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-1.8.1.tar.gz : 2be64e7129cecb11d5906290eba10af694fb9e3e7f9fc208a311dc33ca837eb0
+    - https://github.com/jqlang/jq/releases/download/jq-1.8.2/jq-1.8.2.tar.gz : 71b8d6e8f5fe81f6c6d0d110e3892251f6ce76ed095abd315e26e6e1193af3af
 homepage   : https://stedolan.github.io/jq/
 license    : MIT
 component  : programming.tools

--- a/packages/j/jq/pspec_x86_64.xml
+++ b/packages/j/jq/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>jq</Name>
         <Homepage>https://stedolan.github.io/jq/</Homepage>
         <Packager>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Matt Staude</Name>
+            <Email>mattstaude_dev@icloud.com</Email>
         </Packager>
         <License>MIT</License>
         <PartOf>programming.tools</PartOf>
@@ -27,7 +27,7 @@
             <Path fileType="doc">/usr/share/doc/jq/COPYING</Path>
             <Path fileType="doc">/usr/share/doc/jq/NEWS.md</Path>
             <Path fileType="doc">/usr/share/doc/jq/README.md</Path>
-            <Path fileType="man">/usr/share/man/man1/jq.1</Path>
+            <Path fileType="man">/usr/share/man/man1/jq.1.zst</Path>
         </Files>
     </Package>
     <Package>
@@ -37,7 +37,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="12">jq</Dependency>
+            <Dependency release="13">jq</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/jq.h</Path>
@@ -47,12 +47,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2025-08-14</Date>
-            <Version>1.8.1</Version>
+        <Update release="13">
+            <Date>2026-06-21</Date>
+            <Version>1.8.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>David Harder</Name>
-            <Email>david@davidjharder.ca</Email>
+            <Name>Matt Staude</Name>
+            <Email>mattstaude_dev@icloud.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Updates jq to the latest upstream release, [1.8.2](https://github.com/jqlang/jq/releases/tag/jq-1.8.2), published 2026-06-20.

- Bumped `version` 1.8.1 → 1.8.2 and `release` 12 → 13.
- Updated source URL and sha256 (`71b8d6e8f5fe81f6c6d0d110e3892251f6ce76ed095abd315e26e6e1193af3af`), verified against the official release tarball.
- No build recipe or dependency changes; same `oniguruma` build dep.
- Rebuilt with solbuild; regenerated `pspec_x86_64.xml` and the `abi_*` reports are included.

**Test Plan**

Built against unstable with `solbuild build` and exercised the resulting binary:

```
$ jq --version
jq-1.8.2

$ echo '{"package":"jq","version":"1.8.2","deps":["oniguruma"]}' | jq '{name: .package, ver: .version, first_dep: .deps[0]}'
{
  "name": "jq",
  "ver": "1.8.2",
  "first_dep": "oniguruma"
}

$ echo '[1,2,3,4,5]' | jq 'map(. * 2) | add'
30

$ echo '"jq-1.8.2"' | jq 'capture("(?<ver>[0-9.]+)$").ver'
"1.8.2"
```

The regex `capture` test confirms the oniguruma linkage works.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
