### PR TITLE
qbittorrent: Update to 5.2.2

### DIFF
--- a/packages/q/qbittorrent/package.yml
+++ b/packages/q/qbittorrent/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : qbittorrent
-version    : 5.2.0
-release    : 109
+version    : 5.2.2
+release    : 110
 source     :
-    - https://github.com/qbittorrent/qBittorrent/archive/refs/tags/release-5.2.0.tar.gz : 543c657362d7aaf712ccb28e80236de3b7685235112122c06d69c6a8b68ef0e0
+    - https://github.com/qbittorrent/qBittorrent/archive/refs/tags/release-5.2.2.tar.gz : 177efdadcd66fa66c473e97ee8ed117ce33ccb9a0a25a0716b62245ce506d1d7
 homepage   : https://www.qbittorrent.org/
 license    : GPL-2.0-or-later
 component  : network.download


### PR DESCRIPTION
Updates qBittorrent to the latest upstream release, [5.2.2](https://github.com/qbittorrent/qBittorrent/releases/tag/release-5.2.2), published 2026-06-16.

- Bumped `version` 5.2.0 → 5.2.2 and `release` 109 → 110.
- Updated source URL and sha256 (`177efdadcd66fa66c473e97ee8ed117ce33ccb9a0a25a0716b62245ce506d1d7`), verified against the upstream release archive.
- No build recipe or dependency changes (same Qt6 / libtorrent-rasterbar / boost deps, same cmake+ninja build); 5.2.1 and 5.2.2 are bugfix releases.

### Test Plan
- [ ] Builds in solbuild / CI
- [ ] `qbittorrent --version` reports 5.2.2