### PR TITLE
usysconf-epoch: Fix non-standard desktop environments not transitioning

### DIFF
--- a/packages/u/usysconf-epoch/files/20-usysconf-epoch.preset
+++ b/packages/u/usysconf-epoch/files/20-usysconf-epoch.preset
@@ -1,2 +1,0 @@
-enable usr-merge.service
-enable epoch.service

--- a/packages/u/usysconf-epoch/files/epoch.sh
+++ b/packages/u/usysconf-epoch/files/epoch.sh
@@ -27,13 +27,14 @@ declare -A DESKTOP_SOFTWARE_CENTRE=(
     ["kde"]="discover"
     ["xfce"]="discover"
     ["mate"]="discover"
+    ["other"]=""
 )
 declare -A SC_DESKTOP_FILES=(
     ["discover"]="/usr/share/applications/org.kde.discover.desktop"
     ["gnome-software"]="/usr/share/applications/org.gnome.Software.desktop"
 )
 
-desktop=""
+desktop="other"
 replaced_sc=false
 switched_repo=false
 
@@ -228,15 +229,18 @@ done
 sc_package="${DESKTOP_SOFTWARE_CENTRE[$desktop]}"
 echo "Detected desktop: ${desktop}"
 
-if ! is_installed "${sc_package}"
+if [[ "${sc_package}" != "" ]]
 then
-    echo "Installing new SC: ${sc_package}"
-    while ! eopkg install --yes-all "${DESKTOP_SOFTWARE_CENTRE[$desktop]}"
-    do
-        echo "Install failed, will retry."
-        sleep 10
-    done
-    replaced_sc=true
+    if ! is_installed "${sc_package}"
+    then
+        echo "Installing new SC: ${sc_package}"
+        while ! eopkg install --yes-all "${DESKTOP_SOFTWARE_CENTRE[$desktop]}"
+        do
+            echo "Install failed, will retry."
+            sleep 10
+        done
+        replaced_sc=true
+    fi
 fi
 
 if is_installed solus-sc

--- a/packages/u/usysconf-epoch/package.yml
+++ b/packages/u/usysconf-epoch/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : usysconf-epoch
 version    : 1.0.0
-release    : 26
+release    : 27
 source     :
     # We need something for a source
     - https://getsol.us/sources/hotspot.txt : a12b7cb43c9d9134b5bb1b35e9096b66775d9e92e7611d1cc92b02edd6782a87
@@ -13,6 +13,9 @@ summary    : Temporary package for hosting epoch and usr-merge scripts
 description: |
     Temporary package for hosting the epoch script
 install    : |
-    install -Dm00755 -t ${installdir}/%libdir%/usysconf/              ${pkgfiles}/*.sh
-    install -Dm00644 -t ${installdir}/%libdir%/systemd/system/        ${pkgfiles}/*.service
-    install -Dm00644 -t ${installdir}/%libdir%/systemd/system-preset/ ${pkgfiles}/20-usysconf-epoch.preset
+    install -Dm00755 -t $installdir/usr/lib64/usysconf/      $pkgfiles/*.sh
+    install -Dm00644 -t $installdir/%libdir%/systemd/system/ $pkgfiles/*.service
+
+    install -Ddm00755 $installdir/%libdir%/systemd/system/{sysinit,multi-user}.target.wants
+    ln -srv $installdir/%libdir%/systemd/system/usr-merge.service $installdir/%libdir%/systemd/system/sysinit.target.wants/usr-merge.service
+    ln -srv $installdir/%libdir%/systemd/system/epoch.service     $installdir/%libdir%/systemd/system/multi-user.target.wants/epoch.service

--- a/packages/u/usysconf-epoch/pspec_x86_64.xml
+++ b/packages/u/usysconf-epoch/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>usysconf-epoch</Name>
         <Homepage>https://github.com/getsolus/usysconf/</Homepage>
         <Packager>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>GPL-2.0-only</License>
         <PartOf>system.base</PartOf>
@@ -20,20 +20,21 @@
 </Description>
         <PartOf>system.base</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib64/systemd/system-preset/20-usysconf-epoch.preset</Path>
             <Path fileType="library">/usr/lib64/systemd/system/epoch.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/system/multi-user.target.wants/epoch.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/system/sysinit.target.wants/usr-merge.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/usr-merge.service</Path>
             <Path fileType="library">/usr/lib64/usysconf/epoch.sh</Path>
             <Path fileType="library">/usr/lib64/usysconf/usr-merge.sh</Path>
         </Files>
     </Package>
     <History>
-        <Update release="26">
-            <Date>2026-03-14</Date>
+        <Update release="27">
+            <Date>2026-06-21</Date>
             <Version>1.0.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Evan Maddock</Name>
-            <Email>maddock.evan@vivaldi.net</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**

Fix an issue where non-standard desktops would not transition because there is no defined software center to transition them to. Such desktop environments will now result in having no UI alternative: users doing such tinkering should be able to use `eopkg` to install their desired alternative.

Resolves #9349

**Test Plan**

1. Budgie:
   1. Install on a Shannon VM.
   2. Verify that the VM is transitioned correctly.
2. No desktop:
   1. Remove Budgie from a Shannon VM.
   2. Verify that the VM is transitioned correctly.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
