### PR TITLE
platformio: update to 6.1.19

### DIFF
--- a/packages/p/platformio/package.yml
+++ b/packages/p/platformio/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : platformio
-version    : 6.1.17
-release    : 20
+version    : 6.1.19
+release    : 21
 source     :
-    - https://github.com/platformio/platformio-core/archive/refs/tags/v6.1.17.tar.gz : 8876df773b262e7c5ec6784537dba10c0f305b448da11631f0142da4b288c3f3
+    - https://github.com/platformio/platformio-core/archive/refs/tags/v6.1.19.tar.gz : b4c197b41191d5f853c4751ad5116fc0ad2ad74081df57ce20502084c6d60c81
 homepage   : https://platformio.org/
 license    : Apache-2.0
 component  : programming.python
@@ -30,3 +30,5 @@ build      : |
 install    : |
     %python3_install
     install -Dm00644 platformio/assets/system/99-platformio-udev.rules -t $installdir/usr/lib/udev/rules.d/
+
+    %install_license LICENSE

--- a/packages/p/platformio/pspec_x86_64.xml
+++ b/packages/p/platformio/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>platformio</Name>
         <Homepage>https://platformio.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Matthias Homann</Name>
+            <Email>palto@mailbox.org</Email>
         </Packager>
         <License>Apache-2.0</License>
         <PartOf>programming.python</PartOf>
@@ -23,12 +23,12 @@
             <Path fileType="executable">/usr/bin/pio</Path>
             <Path fileType="executable">/usr/bin/piodebuggdb</Path>
             <Path fileType="executable">/usr/bin/platformio</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/platformio-6.1.17-py3.14.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/platformio-6.1.17-py3.14.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/platformio-6.1.17-py3.14.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/platformio-6.1.17-py3.14.egg-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/platformio-6.1.17-py3.14.egg-info/requires.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/platformio-6.1.17-py3.14.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/platformio-6.1.19-py3.14.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/platformio-6.1.19-py3.14.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/platformio-6.1.19-py3.14.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/platformio-6.1.19-py3.14.egg-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/platformio-6.1.19-py3.14.egg-info/requires.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/platformio-6.1.19-py3.14.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/platformio/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/platformio/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/platformio/__pycache__/__init__.cpython-314.pyc</Path>
@@ -567,15 +567,16 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/platformio/test/runners/unity.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/platformio/util.py</Path>
             <Path fileType="library">/usr/lib/udev/rules.d/99-platformio-udev.rules</Path>
+            <Path fileType="data">/usr/share/licenses/platformio/LICENSE</Path>
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2026-06-07</Date>
-            <Version>6.1.17</Version>
+        <Update release="21">
+            <Date>2026-06-21</Date>
+            <Version>6.1.19</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Matthias Homann</Name>
+            <Email>palto@mailbox.org</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Add support for Python 3.14.
- Improve compatibility with development tools and editor integrations.
- Fix package installation, dependency cleanup, and path-handling issues.
- Release notes:
    - [6.1.19](https://github.com/platformio/platformio-core/releases/tag/v6.1.19)
    - [6.1.18](https://github.com/platformio/platformio-core/releases/tag/v6.1.18)

**Test Plan**

Installed locally and used with VScode extension to compile a project.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
