### PR TITLE
miriway: Update to v26.06.3

### DIFF
--- a/packages/m/miriway/package.yml
+++ b/packages/m/miriway/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : miriway
-version    : '26.06'
-release    : 8
+version    : 26.06.3
+release    : 9
 source     :
-    - https://github.com/Miriway/Miriway/archive/refs/tags/v26.06.tar.gz : 10cdee48f1bcb1091d68383e6e5c8f67b286dab58a34dd25ff7c9d6a08545575
+    - https://github.com/Miriway/Miriway/archive/refs/tags/v26.06.3.tar.gz : effefeea00c3b6859072058c335832dec06c3f30467cc1b3886c2bea7ff93ebf
 homepage   : https://github.com/Miriway/Miriway
 license    : GPL-3.0-only
 component  :

--- a/packages/m/miriway/pspec_x86_64.xml
+++ b/packages/m/miriway/pspec_x86_64.xml
@@ -45,7 +45,7 @@ Miriway has been tested with shell components from several desktop environments 
 </Description>
         <PartOf>desktop</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="8">miriway</Dependency>
+            <Dependency releaseFrom="9">miriway</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="data">/usr/share/sddm/sddm.conf.d/miriway.conf</Path>
@@ -60,7 +60,7 @@ Miriway has been tested with shell components from several desktop environments 
 </Description>
         <PartOf>desktop</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="8">miriway</Dependency>
+            <Dependency releaseFrom="9">miriway</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/miriway-session</Path>
@@ -71,9 +71,9 @@ Miriway has been tested with shell components from several desktop environments 
         </Files>
     </Package>
     <History>
-        <Update release="8">
-            <Date>2026-06-14</Date>
-            <Version>26.06</Version>
+        <Update release="9">
+            <Date>2026-06-21</Date>
+            <Version>26.06.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Evan Maddock</Name>
             <Email>maddock.evan@vivaldi.net</Email>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/Miriway/Miriway/releases/tag/v26.06.3).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Start a Budgie Miriway session.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
