### PR TITLE
Add monitoring.yaml to hunspell-* and hyphen-* dictionary packages

### DIFF
--- a/packages/h/hunspell-fr/monitoring.yaml
+++ b/packages/h/hunspell-fr/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 130209
+  rss: ~
+# No known CPE, checked 2026-06-19
+security:
+  cpe: ~

--- a/packages/h/hunspell-it/monitoring.yaml
+++ b/packages/h/hunspell-it/monitoring.yaml
@@ -1,0 +1,6 @@
+releases:
+  id: 390712
+  rss: ~
+# No known CPE, checked 2026-06-19
+security:
+  cpe: ~


### PR DESCRIPTION
**Summary**

<!-- Info on what this pull request updates/changes/etc --> 
Adds `monitoring.yaml` to 2 spell-checker dictionary packages that were missing it,
enabling automated release and CVE monitoring. Part of #4121.

- hunspell-fr — Anitya ID 130209 (grammalecte), no CPE
- hunspell-it — Anitya ID 390712, no CPE

Note: This PR originally covered 7 packages. Per review, the 5 packages without a working Anitya ID (hunspell-pt-br, hunspell-ru, hunspell-sl, hyphen-de, hyphen-fr) have been dropped and their template monitoring files removed. Only the two packages with verified, working Anitya IDs remain.

**Test Plan**

<!-- Short description of how the package was tested -->
- Verified each `monitoring.yaml` is valid YAML
- Confirmed both Anitya IDs (130209, 390712) resolve and return version info at https://release-monitoring.org
- Checked NVD CPE database for each package; neither has CVE entries

**Checklist**

- [ ] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.