### PR TITLE
gcstar: update to 1.8.1

### DIFF
--- a/packages/g/gcstar/package.yml
+++ b/packages/g/gcstar/package.yml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : gcstar
-version    : 1.8.0.2026.03.26
-release    : 6
+version    : 1.8.1
+release    : 7
 source     :
-    # - https://gitlab.com/GCstar/GCstar/-/archive/v1.8.0/GCstar-v1.8.0.tar.gz : 0c790f61a69d0aa2eadc5ef35c45cbfee71beedf
-    - git|https://gitlab.com/GCstar/GCstar.git : d68daa74f48f9c4f2fd092c99bd0789e2555948b
+    - https://gitlab.com/GCstar/GCstar/-/archive/v1.8.1/GCstar-v1.8.1.tar.gz : 4c2a4082d3d088a265c726143ba2046e656da4649b3d157543bdc4d3d6636d58
+    # - git|https://gitlab.com/GCstar/GCstar.git : 428f2f9d13c5937d81e27b6b5a91eed6721f3edf
 homepage   : https://gcstar.gitlab.io/gcstar_docs/en/
 license    : GPL-2.0-or-later
 component  : office
@@ -25,13 +25,17 @@ rundeps    :
     - perl-json
     - perl-xmlsimple
 install    : |
-    cd gcstar
     # If an interim version is used from git commit, patch the version shown in GCstar according to this YAML version definition
-    sed -i 's/\(\$VERSION = .\)[0-9\.]*/\1%version%/g' bin/gcstar
-    cd -
+    # cd gcstar
+    # sed -i 's/\(\$VERSION = .\)[0-9\.]*/\1%version%/g' bin/gcstar
+    # cd -
 
     ./gcstar/install --text --fhs --prefix $installdir/usr
     find $installdir/usr -type d -empty -delete
     find $installdir/usr/share/mime ! -name "*gcstar*" ! -type d -delete
     # Install AppStream metainfo
     install -Dm00644 $pkgfiles/io.gitlab.gcstar.gcstar.metainfo.xml -t $installdir/usr/share/metainfo
+
+    # Copy license files to standard location
+    %install_license gcstar/share/gcstar/LICENSE 
+    install -Dm0644 gcstar/share/gcstar/fonts/LICENSE -t $installdir/usr/share/licenses/gcstar/fonts

--- a/packages/g/gcstar/pspec_x86_64.xml
+++ b/packages/g/gcstar/pspec_x86_64.xml
@@ -1055,6 +1055,7 @@
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCTVseries/GCAllocine.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCTVseries/GCBeyazPerde.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCTVseries/GCImdb.pm</Path>
+            <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCTVseries/GCMyAnimeList.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCTVseries/GCTVseriesCommon.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCTVseries/GCThemoviedb.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCTVseries/GCThemoviedbDE.pm</Path>
@@ -1084,6 +1085,7 @@
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCbooks/GCBibliotekaNarodowa.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCbooks/GCBokkilden.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCbooks/GCBol.pm</Path>
+            <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCbooks/GCBookBrainz.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCbooks/GCCasadelibro.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCbooks/GCDoubanbook.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCbooks/GCFnacCommon.pm</Path>
@@ -1095,6 +1097,7 @@
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCbooks/GCLaLibrairie.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCbooks/GCLeyaOnline.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCbooks/GCNooSFere.pm</Path>
+            <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCbooks/GCOpenLibrary.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCbooks/GCbooksAdlibrisCommon.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCbooks/GCbooksCommon.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCbuildingtoys/GCBrickset.pm</Path>
@@ -1114,6 +1117,7 @@
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCcomics/GCAmazonUS.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCcomics/GCBdphile.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCcomics/GCBedetheque.pm</Path>
+            <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCcomics/GCMyAnimeList.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCcomics/GCSanctuary.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCcomics/GCcomicsCommon.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCcomics/GCmangasanctuary.pm</Path>
@@ -1177,10 +1181,7 @@
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCgames/GCAmazonUS.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCgames/GCGameSpot.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCgames/GCJeuxVideoCom.pm</Path>
-            <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCgames/GCJeuxVideoFr.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCgames/GCMobyGames.pm</Path>
-            <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCgames/GCNextGame.pm</Path>
-            <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCgames/GCTheLegacy.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCgames/GCVGCollect.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCgames/GCgamesCommon.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCmusiccourses/GCAlfred.pm</Path>
@@ -1191,6 +1192,7 @@
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCmusics/GCmusicsCommon.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCstar/GCAmazonCommon.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCstar/GCAmazonCommonBCGG.pm</Path>
+            <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCstar/GCMyAnimeListCommon.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCPlugins/GCstar/GCThemoviedbCommon.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCSplash.pm</Path>
             <Path fileType="data">/usr/share/gcstar/lib/GCStats.pm</Path>
@@ -1460,6 +1462,8 @@
             <Path fileType="data">/usr/share/icons/hicolor/72x72/mimetypes/application-x-gcstar.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/96x96/apps/gcstar.png</Path>
             <Path fileType="data">/usr/share/icons/hicolor/96x96/mimetypes/application-x-gcstar.png</Path>
+            <Path fileType="data">/usr/share/licenses/gcstar/LICENSE</Path>
+            <Path fileType="data">/usr/share/licenses/gcstar/fonts/LICENSE</Path>
             <Path fileType="man">/usr/share/man/man1/gcstar.1.gz</Path>
             <Path fileType="data">/usr/share/metainfo/io.gitlab.gcstar.gcstar.metainfo.xml</Path>
             <Path fileType="data">/usr/share/mime/application/x-gcstar.xml</Path>
@@ -1468,9 +1472,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2026-03-27</Date>
-            <Version>1.8.0.2026.03.26</Version>
+        <Update release="7">
+            <Date>2026-06-22</Date>
+            <Version>1.8.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>


### PR DESCRIPTION
**Summary**

- Improve compatibility with online metadata providers and collection plugins.
- Fix collection management and import/export issues.
- Resolve various GTK3 user interface and usability bugs.
- General stability improvements and bug fixes.

- Release notes:
    - [1.8.1](https://gitlab.com/GCstar/GCstar/-/releases)

**Test Plan**

- Opened library and edited some entries.

**Checklist**

- [X] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
