### PR TITLE
python-qt6: Fix D-Bus bindings

### DIFF
--- a/packages/py/python-qt6/abi_libs
+++ b/packages/py/python-qt6/abi_libs
@@ -32,3 +32,4 @@ QtWidgets.abi3.so
 QtXml.abi3.so
 libpyqt6.so
 libpyqt6qmlplugin.so
+pyqt6.abi3.so

--- a/packages/py/python-qt6/abi_symbols
+++ b/packages/py/python-qt6/abi_symbols
@@ -69,3 +69,4 @@ libpyqt6qmlplugin.so:_ZThn16_N14PyQt6QmlPluginD0Ev
 libpyqt6qmlplugin.so:_ZThn16_N14PyQt6QmlPluginD1Ev
 libpyqt6qmlplugin.so:qt_plugin_instance
 libpyqt6qmlplugin.so:qt_plugin_query_metadata_v2
+pyqt6.abi3.so:PyInit_pyqt6

--- a/packages/py/python-qt6/abi_used_libs
+++ b/packages/py/python-qt6/abi_used_libs
@@ -31,6 +31,7 @@ libQt6WebSockets.so.6
 libQt6Widgets.so.6
 libQt6Xml.so.6
 libc.so.6
+libdbus-1.so.3
 libgcc_s.so.1
 libm.so.6
 libpython3.14.so.1.0

--- a/packages/py/python-qt6/abi_used_symbols
+++ b/packages/py/python-qt6/abi_used_symbols
@@ -19120,6 +19120,19 @@ libc.so.6:strcmp
 libc.so.6:strlen
 libc.so.6:strncmp
 libc.so.6:toupper
+libdbus-1.so.3:dbus_connection_dispatch
+libdbus-1.so.3:dbus_connection_set_timeout_functions
+libdbus-1.so.3:dbus_connection_set_wakeup_main_function
+libdbus-1.so.3:dbus_connection_set_watch_functions
+libdbus-1.so.3:dbus_server_set_timeout_functions
+libdbus-1.so.3:dbus_server_set_watch_functions
+libdbus-1.so.3:dbus_timeout_get_enabled
+libdbus-1.so.3:dbus_timeout_get_interval
+libdbus-1.so.3:dbus_timeout_handle
+libdbus-1.so.3:dbus_watch_get_enabled
+libdbus-1.so.3:dbus_watch_get_fd
+libdbus-1.so.3:dbus_watch_get_flags
+libdbus-1.so.3:dbus_watch_handle
 libgcc_s.so.1:_Unwind_Resume
 libm.so.6:fmod
 libm.so.6:hypotf
@@ -19137,6 +19150,7 @@ libpython3.14.so.1.0:PyCallable_Check
 libpython3.14.so.1.0:PyCapsule_GetContext
 libpython3.14.so.1.0:PyCapsule_GetPointer
 libpython3.14.so.1.0:PyCapsule_Import
+libpython3.14.so.1.0:PyCapsule_IsValid
 libpython3.14.so.1.0:PyCapsule_New
 libpython3.14.so.1.0:PyCapsule_SetContext
 libpython3.14.so.1.0:PyCapsule_Type

--- a/packages/py/python-qt6/package.yml
+++ b/packages/py/python-qt6/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-qt6
 version    : 6.11.0
-release    : 34
+release    : 35
 source     :
     - https://pypi.debian.net/PyQt6/pyqt6-6.11.0.tar.gz : 45dd60aa69976de1918b5ced6b4e7b6a25abd2a919ecef5fd5826ecc76718889
 homepage   : https://www.riverbankcomputing.com/software/pyqt/

--- a/packages/py/python-qt6/pspec_x86_64.xml
+++ b/packages/py/python-qt6/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-qt6</Name>
         <Homepage>https://www.riverbankcomputing.com/software/pyqt/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>programming.python</PartOf>
@@ -929,6 +929,7 @@
             <Path fileType="library">/usr/lib/python3.14/site-packages/PyQt6/uic/widget-plugins/qtprintsupport.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/PyQt6/uic/widget-plugins/qtquickwidgets.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/PyQt6/uic/widget-plugins/qtwebenginewidgets.py</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/dbus/mainloop/pyqt6.abi3.so</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/pyqt6-6.11.0.dist-info/INSTALLER</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/pyqt6-6.11.0.dist-info/METADATA</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/pyqt6-6.11.0.dist-info/RECORD</Path>
@@ -943,19 +944,19 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="34">python-qt6</Dependency>
+            <Dependency release="35">python-qt6</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib64/qt6/plugins/designer/libpyqt6.so</Path>
         </Files>
     </Package>
     <History>
-        <Update release="34">
-            <Date>2026-06-06</Date>
+        <Update release="35">
+            <Date>2026-06-22</Date>
             <Version>6.11.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Fix D-Bus bindings. Somehow. All I did was bump it.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Successfully launch `firewall-applet` from `firewalld`.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
