### PR TITLE
firewalld: Update to v2.4.2

### DIFF
--- a/packages/f/firewalld/package.yml
+++ b/packages/f/firewalld/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : firewalld
-version    : 2.4.1
-release    : 22
+version    : 2.4.2
+release    : 23
 source     :
-    - https://github.com/firewalld/firewalld/releases/download/v2.4.1/firewalld-2.4.1.tar.bz2 : 453230c49b961853144dd7614d59e82fafbcc52c314c39ec66d1316274a33001
+    - https://github.com/firewalld/firewalld/releases/download/v2.4.2/firewalld-2.4.2.tar.bz2 : 1917b5d77d3c1106c425d49be568bb0728130a5a08766b11c979874fe4f61bc6
 homepage   : https://firewalld.org/
 license    : GPL-2.0-or-later
 component  :
@@ -26,7 +26,8 @@ builddeps  :
 rundeps    :
     - applet :
         - firewalld-config
-        - python3-qt5
+        - python-qt6
+        - shiboken6
     - config :
         - firewalld
         - libgtk-3

--- a/packages/f/firewalld/pspec_x86_64.xml
+++ b/packages/f/firewalld/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>firewalld</Name>
         <Homepage>https://firewalld.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>security</PartOf>
@@ -358,6 +358,7 @@
             <Path fileType="library">/usr/lib/firewalld/xmlschema/helper.xsd</Path>
             <Path fileType="library">/usr/lib/firewalld/xmlschema/icmptype.xsd</Path>
             <Path fileType="library">/usr/lib/firewalld/xmlschema/ipset.xsd</Path>
+            <Path fileType="library">/usr/lib/firewalld/xmlschema/policy.xsd</Path>
             <Path fileType="library">/usr/lib/firewalld/xmlschema/service.xsd</Path>
             <Path fileType="library">/usr/lib/firewalld/xmlschema/zone.xsd</Path>
             <Path fileType="library">/usr/lib/firewalld/zones/block.xml</Path>
@@ -529,7 +530,7 @@
 </Description>
         <PartOf>security</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="22">firewalld-config</Dependency>
+            <Dependency releaseFrom="23">firewalld-config</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/firewall-applet</Path>
@@ -562,7 +563,7 @@
 </Description>
         <PartOf>security</PartOf>
         <RuntimeDependencies>
-            <Dependency releaseFrom="22">firewalld</Dependency>
+            <Dependency releaseFrom="23">firewalld</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/firewall-config</Path>
@@ -581,12 +582,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="22">
-            <Date>2026-06-07</Date>
-            <Version>2.4.1</Version>
+        <Update release="23">
+            <Date>2026-06-22</Date>
+            <Version>2.4.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Changelog available [here](https://github.com/firewalld/firewalld/releases/tag/v2.4.2).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Successfully start the `firewalld` service, and the applet.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
