### PR TITLE
libssh2: Backport CVE patches

### DIFF
--- a/packages/l/libssh2/abi_used_symbols
+++ b/packages/l/libssh2/abi_used_symbols
@@ -3,6 +3,8 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__explicit_bzero_chk
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoll
 libc.so.6:__memcpy_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
@@ -40,8 +42,6 @@ libc.so.6:strncmp
 libc.so.6:strncpy
 libc.so.6:strrchr
 libc.so.6:strstr
-libc.so.6:strtol
-libc.so.6:strtoll
 libc.so.6:time
 libcrypto.so.3:BIO_ctrl
 libcrypto.so.3:BIO_free

--- a/packages/l/libssh2/abi_used_symbols32
+++ b/packages/l/libssh2/abi_used_symbols32
@@ -3,6 +3,8 @@ libc.so.6:__ctype_b_loc
 libc.so.6:__errno_location
 libc.so.6:__explicit_bzero_chk
 libc.so.6:__fprintf_chk
+libc.so.6:__isoc23_strtol
+libc.so.6:__isoc23_strtoll
 libc.so.6:__memcpy_chk
 libc.so.6:__snprintf_chk
 libc.so.6:__stack_chk_fail
@@ -40,8 +42,6 @@ libc.so.6:strncmp
 libc.so.6:strncpy
 libc.so.6:strrchr
 libc.so.6:strstr
-libc.so.6:strtol
-libc.so.6:strtoll
 libc.so.6:time
 libcrypto.so.3:BIO_ctrl
 libcrypto.so.3:BIO_free

--- a/packages/l/libssh2/files/libssh2-1.11.1-CVE-2026-55199.patch
+++ b/packages/l/libssh2/files/libssh2-1.11.1-CVE-2026-55199.patch
@@ -1,0 +1,39 @@
+From 17626857d20b3c9a1addfa45979dadcee1cd84a4 Mon Sep 17 00:00:00 2001
+From: TristanInSec <tristan.mtn@gmail.com>
+Date: Wed, 15 Apr 2026 14:51:08 -0400
+Subject: [PATCH] packet: check `_libssh2_get_string()` return in `EXT_INFO`
+ handler
+
+The `SSH_MSG_EXT_INFO` handler discards the return values from
+`_libssh2_get_string()` when parsing extension name/value pairs. When
+the buffer is exhausted before all claimed extensions are parsed,
+the loop continues with no-op iterations until `nr_extensions` reaches
+zero.
+
+The `nr_extensions >= 1024` cap limits the worst case, but the loop
+should still break on parse failure for correctness and consistency
+with other parsers in this file (e.g. `SSH_MSG_CHANNEL_OPEN`,
+`SSH_MSG_KEXINIT`) that check `_libssh2_get_string()` return values.
+
+Closes #1864
+---
+ src/packet.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/packet.c b/src/packet.c
+index ae86365d2a..8a7a0d2690 100644
+--- a/src/packet.c
++++ b/src/packet.c
+@@ -890,8 +890,10 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
+ 
+                     nr_extensions -= 1;
+ 
+-                    _libssh2_get_string(&buf, &name, &name_len);
+-                    _libssh2_get_string(&buf, &value, &value_len);
++                    if(_libssh2_get_string(&buf, &name, &name_len))
++                        break;
++                    if(_libssh2_get_string(&buf, &value, &value_len))
++                        break;
+ 
+                     if(name && value) {
+                         _libssh2_debug((session,

--- a/packages/l/libssh2/files/libssh2-1.11.1-CVE-2026-55200.patch
+++ b/packages/l/libssh2/files/libssh2-1.11.1-CVE-2026-55200.patch
@@ -1,0 +1,33 @@
+From 97acf3dfda80c91c3a8c9f2372546301d4a1a7a8 Mon Sep 17 00:00:00 2001
+From: Will Cosgrove <will@panic.com>
+Date: Fri, 12 Jun 2026 15:57:44 -0700
+Subject: [PATCH] transport.c: Additional boundary checks for packet length
+ (#2052)
+
+Add additional bounds checking on packet length to prevent OOB write.
+
+Credit: [TristanInSec](https://github.com/TristanInSec)
+
+Backported to libssh2 1.11.1.
+---
+ src/transport.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/transport.c b/src/transport.c
+index 87b5e74..3b953df 100644
+--- a/src/transport.c
++++ b/src/transport.c
+@@ -640,8 +640,12 @@ int _libssh2_transport_read(LIBSSH2_SESSION * session)
+                 total_num = 4;
+ 
+                 p->packet_length = _libssh2_ntohu32(block);
+-                if(p->packet_length < 1)
++                if(p->packet_length < 1) {
+                     return LIBSSH2_ERROR_DECRYPT;
++                }
++                else if(p->packet_length > LIBSSH2_PACKET_MAXPAYLOAD) {
++                    return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
++                }
+ 
+                 /* total_num may include size field, however due to existing
+                  * logic it needs to be removed after the entire packet is read

--- a/packages/l/libssh2/files/libssh2-1.11.1-CVE-2026-7598.patch
+++ b/packages/l/libssh2/files/libssh2-1.11.1-CVE-2026-7598.patch
@@ -1,0 +1,36 @@
+--- src/userauth.c
++++ src/userauth.c
+@@ -80,6 +80,12 @@ static char *userauth_list(LIBSSH2_SESSI
+         memset(&session->userauth_list_packet_requirev_state, 0,
+                sizeof(session->userauth_list_packet_requirev_state));
+ 
++        if(username_len > UINT32_MAX - 27) {
++            _libssh2_error(session, LIBSSH2_ERROR_PROTO,
++                           "username_len out of bounds");
++            return NULL;
++        }
++
+         session->userauth_list_data_len = username_len + 27;
+ 
+         s = session->userauth_list_data =
+@@ -307,6 +313,11 @@ userauth_password(LIBSSH2_SESSION *session
+          * 40 = packet_type(1) + username_len(4) + service_len(4) +
+          * service(14)"ssh-connection" + method_len(4) + method(8)"password" +
+          * chgpwdbool(1) + password_len(4) */
++        if(username_len > UINT32_MAX - 40) {
++            return _libssh2_error(session, LIBSSH2_ERROR_PROTO,
++                                  "username_len out of bounds");
++        }
++
+         session->userauth_pswd_data_len = username_len + 40;
+ 
+         session->userauth_pswd_data0 =
+@@ -447,7 +458,7 @@ password_response:
+                         }
+ 
+                         /* basic data_len + newpw_len(4) */
+-                        if(username_len + password_len + 44 <= UINT_MAX) {
++                        if(username_len <= UINT32_MAX - password_len - 44) {
+                             session->userauth_pswd_data_len =
+                                 username_len + password_len + 44;
+                             s = session->userauth_pswd_data =

--- a/packages/l/libssh2/package.yml
+++ b/packages/l/libssh2/package.yml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libssh2
 version    : 1.11.1
-release    : 14
+release    : 15
 source     :
     - https://github.com/libssh2/libssh2/releases/download/libssh2-1.11.1/libssh2-1.11.1.tar.xz : 9954cb54c4f548198a7cbebad248bdc87dd64bd26185708a294b2b50771e3769
 homepage   : https://libssh2.org/
-license    : MIT
+license    : BSD-3-Clause
 component  : system.base
 summary    : libssh2 is a client-side C library implementing the SSH2 protocol
 description: |
@@ -15,13 +15,18 @@ builddeps  :
     - pkgconfig32(libcrypto)
     - pkgconfig32(zlib)
 setup      : |
+    %patch -p0 -i ${pkgfiles}/libssh2-1.11.1-CVE-2026-7598.patch
+    %patch -p1 -i ${pkgfiles}/libssh2-1.11.1-CVE-2026-55200.patch
+    %patch -p1 -i ${pkgfiles}/libssh2-1.11.1-CVE-2026-55199.patch
+
     %configure \
-               --disable-docker-tests \
-               --disable-static \
-               --with-crypto=openssl
+        --disable-docker-tests \
+        --disable-static \
+        --with-crypto=openssl
 build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING
 check      : |
     %make check

--- a/packages/l/libssh2/pspec_x86_64.xml
+++ b/packages/l/libssh2/pspec_x86_64.xml
@@ -3,10 +3,10 @@
         <Name>libssh2</Name>
         <Homepage>https://libssh2.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
-        <License>MIT</License>
+        <License>BSD-3-Clause</License>
         <PartOf>system.base</PartOf>
         <Summary xml:lang="en">libssh2 is a client-side C library implementing the SSH2 protocol</Summary>
         <Description xml:lang="en">libssh2 is a client-side C library implementing the SSH2 protocol
@@ -22,6 +22,7 @@
         <Files>
             <Path fileType="library">/usr/lib64/libssh2.so.1</Path>
             <Path fileType="library">/usr/lib64/libssh2.so.1.0.1</Path>
+            <Path fileType="data">/usr/share/licenses/libssh2/COPYING</Path>
         </Files>
     </Package>
     <Package>
@@ -31,7 +32,7 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="14">libssh2</Dependency>
+            <Dependency release="15">libssh2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libssh2.so.1</Path>
@@ -45,8 +46,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="14">libssh2-devel</Dependency>
-            <Dependency release="14">libssh2-32bit</Dependency>
+            <Dependency release="15">libssh2-devel</Dependency>
+            <Dependency release="15">libssh2-32bit</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libssh2.so</Path>
@@ -60,7 +61,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="14">libssh2</Dependency>
+            <Dependency release="15">libssh2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libssh2.h</Path>
@@ -68,201 +69,201 @@
             <Path fileType="header">/usr/include/libssh2_sftp.h</Path>
             <Path fileType="library">/usr/lib64/libssh2.so</Path>
             <Path fileType="data">/usr/lib64/pkgconfig/libssh2.pc</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_agent_connect.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_agent_disconnect.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_agent_free.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_agent_get_identity.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_agent_get_identity_path.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_agent_init.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_agent_list_identities.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_agent_set_identity_path.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_agent_sign.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_agent_userauth.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_banner_set.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_base64_decode.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_close.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_direct_streamlocal_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_direct_tcpip.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_direct_tcpip_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_eof.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_exec.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_flush.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_flush_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_flush_stderr.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_forward_accept.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_forward_cancel.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_forward_listen.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_forward_listen_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_free.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_get_exit_signal.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_get_exit_status.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_handle_extended_data.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_handle_extended_data2.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_ignore_extended_data.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_open_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_open_session.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_process_startup.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_read.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_read_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_read_stderr.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_receive_window_adjust.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_receive_window_adjust2.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_request_auth_agent.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_request_pty.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_request_pty_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_request_pty_size.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_request_pty_size_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_send_eof.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_set_blocking.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_setenv.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_setenv_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_shell.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_signal_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_subsystem.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_wait_closed.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_wait_eof.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_window_read.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_window_read_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_window_write.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_window_write_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_write.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_write_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_write_stderr.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_x11_req.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_channel_x11_req_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_crypto_engine.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_exit.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_free.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_hostkey_hash.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_init.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_keepalive_config.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_keepalive_send.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_add.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_addc.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_check.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_checkp.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_del.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_free.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_get.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_init.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_readfile.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_readline.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_writefile.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_writeline.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_poll.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_poll_channel_read.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_publickey_add.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_publickey_add_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_publickey_init.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_publickey_list_fetch.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_publickey_list_free.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_publickey_remove.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_publickey_remove_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_publickey_shutdown.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_scp_recv.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_scp_recv2.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_scp_send.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_scp_send64.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_scp_send_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_abstract.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_banner_get.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_banner_set.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_block_directions.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_callback_set.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_callback_set2.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_disconnect.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_disconnect_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_flag.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_free.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_get_blocking.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_get_read_timeout.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_get_timeout.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_handshake.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_hostkey.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_init.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_init_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_last_errno.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_last_error.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_method_pref.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_methods.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_set_blocking.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_set_last_error.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_set_read_timeout.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_set_timeout.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_startup.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_session_supported_algs.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_close.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_close_handle.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_closedir.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_fsetstat.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_fstat.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_fstat_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_fstatvfs.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_fsync.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_get_channel.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_init.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_last_error.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_lstat.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_mkdir.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_mkdir_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_open.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_open_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_open_ex_r.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_open_r.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_opendir.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_posix_rename.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_posix_rename_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_read.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_readdir.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_readdir_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_readlink.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_realpath.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_rename.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_rename_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_rewind.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_rmdir.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_rmdir_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_seek.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_seek64.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_setstat.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_shutdown.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_stat.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_stat_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_statvfs.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_symlink.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_symlink_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_tell.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_tell64.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_unlink.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_unlink_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_write.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_sign_sk.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_trace.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_trace_sethandler.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_authenticated.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_banner.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_hostbased_fromfile.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_hostbased_fromfile_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_keyboard_interactive.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_keyboard_interactive_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_list.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_password.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_password_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_publickey.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_publickey_fromfile.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_publickey_fromfile_ex.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_publickey_frommemory.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_publickey_sk.3</Path>
-            <Path fileType="man">/usr/share/man/man3/libssh2_version.3</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_agent_connect.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_agent_disconnect.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_agent_free.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_agent_get_identity.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_agent_get_identity_path.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_agent_init.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_agent_list_identities.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_agent_set_identity_path.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_agent_sign.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_agent_userauth.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_banner_set.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_base64_decode.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_close.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_direct_streamlocal_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_direct_tcpip.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_direct_tcpip_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_eof.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_exec.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_flush.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_flush_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_flush_stderr.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_forward_accept.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_forward_cancel.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_forward_listen.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_forward_listen_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_free.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_get_exit_signal.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_get_exit_status.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_handle_extended_data.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_handle_extended_data2.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_ignore_extended_data.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_open_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_open_session.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_process_startup.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_read.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_read_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_read_stderr.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_receive_window_adjust.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_receive_window_adjust2.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_request_auth_agent.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_request_pty.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_request_pty_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_request_pty_size.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_request_pty_size_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_send_eof.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_set_blocking.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_setenv.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_setenv_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_shell.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_signal_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_subsystem.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_wait_closed.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_wait_eof.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_window_read.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_window_read_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_window_write.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_window_write_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_write.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_write_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_write_stderr.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_x11_req.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_channel_x11_req_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_crypto_engine.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_exit.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_free.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_hostkey_hash.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_init.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_keepalive_config.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_keepalive_send.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_add.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_addc.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_check.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_checkp.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_del.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_free.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_get.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_init.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_readfile.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_readline.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_writefile.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_knownhost_writeline.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_poll.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_poll_channel_read.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_publickey_add.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_publickey_add_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_publickey_init.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_publickey_list_fetch.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_publickey_list_free.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_publickey_remove.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_publickey_remove_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_publickey_shutdown.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_scp_recv.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_scp_recv2.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_scp_send.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_scp_send64.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_scp_send_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_abstract.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_banner_get.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_banner_set.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_block_directions.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_callback_set.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_callback_set2.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_disconnect.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_disconnect_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_flag.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_free.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_get_blocking.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_get_read_timeout.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_get_timeout.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_handshake.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_hostkey.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_init.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_init_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_last_errno.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_last_error.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_method_pref.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_methods.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_set_blocking.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_set_last_error.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_set_read_timeout.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_set_timeout.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_startup.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_session_supported_algs.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_close.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_close_handle.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_closedir.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_fsetstat.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_fstat.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_fstat_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_fstatvfs.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_fsync.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_get_channel.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_init.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_last_error.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_lstat.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_mkdir.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_mkdir_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_open.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_open_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_open_ex_r.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_open_r.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_opendir.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_posix_rename.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_posix_rename_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_read.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_readdir.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_readdir_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_readlink.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_realpath.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_rename.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_rename_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_rewind.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_rmdir.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_rmdir_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_seek.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_seek64.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_setstat.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_shutdown.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_stat.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_stat_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_statvfs.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_symlink.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_symlink_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_tell.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_tell64.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_unlink.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_unlink_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sftp_write.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_sign_sk.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_trace.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_trace_sethandler.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_authenticated.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_banner.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_hostbased_fromfile.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_hostbased_fromfile_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_keyboard_interactive.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_keyboard_interactive_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_list.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_password.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_password_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_publickey.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_publickey_fromfile.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_publickey_fromfile_ex.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_publickey_frommemory.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_userauth_publickey_sk.3.zst</Path>
+            <Path fileType="man">/usr/share/man/man3/libssh2_version.3.zst</Path>
         </Files>
     </Package>
     <History>
-        <Update release="14">
-            <Date>2024-10-20</Date>
+        <Update release="15">
+            <Date>2026-06-23</Date>
             <Version>1.11.1</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Backport CVE patches.

**Security**
- CVE-2026-55199
- CVE-2026-55200
- CVE-2026-7598

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Rebuild `curl` against this version.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
