### PR TITLE
dua-cli: Update to v2.37.0

### DIFF
--- a/packages/d/dua-cli/package.yml
+++ b/packages/d/dua-cli/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : dua-cli
-version    : 2.36.0
-release    : 3
+version    : 2.37.0
+release    : 4
 source     :
-    - https://github.com/Byron/dua-cli/archive/refs/tags/v2.36.0.tar.gz : feb4f0e3cdb2abf2dfd8ab9bdfbc7c43b07f0278b0ad6b02e9909149265aadf6
+    - https://github.com/Byron/dua-cli/archive/refs/tags/v2.37.0.tar.gz : 9373b85fbf626afe7de27d209b1ed9775825b89b211c8480255ac38b1e3e270c
 homepage   : https://github.com/Byron/dua-cli
 license    : MIT
 component  : system.utils

--- a/packages/d/dua-cli/pspec_x86_64.xml
+++ b/packages/d/dua-cli/pspec_x86_64.xml
@@ -28,9 +28,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="3">
-            <Date>2026-06-17</Date>
-            <Version>2.36.0</Version>
+        <Update release="4">
+            <Date>2026-06-21</Date>
+            <Version>2.37.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/Byron/dua-cli/releases/tag/v2.37.0).

**Test Plan**

Use `dua` and `dua i`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
