### PR TITLE
sddm: Backport fix for kmscon

### DIFF
--- a/packages/s/sddm/files/sddm-0.21.0-kmscon-fix.patch
+++ b/packages/s/sddm/files/sddm-0.21.0-kmscon-fix.patch
@@ -1,0 +1,28 @@
+From 6d395d02180e483bf57248948c13529cac39e8d2 Mon Sep 17 00:00:00 2001
+From: Jocelyn Falempe <jfalempe@redhat.com>
+Date: Thu, 26 Mar 2026 19:43:51 +0100
+Subject: [PATCH] sddm.service: conflicts with kmsconvt@ttyX
+
+To prevent kmscon to start on the same tty as sddm, add kmsconvt
+to the conflicts list, like getty.
+
+Signed-off-by: Jocelyn Falempe <jfalempe@redhat.com>
+---
+ services/sddm.service.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/services/sddm.service.in b/services/sddm.service.in
+index 0b464439c..a84874fae 100644
+--- a/services/sddm.service.in
++++ b/services/sddm.service.in
+@@ -1,8 +1,8 @@
+ [Unit]
+ Description=Simple Desktop Display Manager
+ Documentation=man:sddm(1) man:sddm.conf(5)
+-Conflicts=getty@tty${SDDM_INITIAL_VT}.service
+-After=systemd-user-sessions.service getty@tty${SDDM_INITIAL_VT}.service plymouth-quit.service systemd-logind.service
++Conflicts=getty@tty${SDDM_INITIAL_VT}.service kmsconvt@tty${SDDM_INITIAL_VT}.service
++After=systemd-user-sessions.service getty@tty${SDDM_INITIAL_VT}.service kmsconvt@tty${SDDM_INITIAL_VT}.service plymouth-quit.service systemd-logind.service
+ PartOf=graphical.target
+ StartLimitIntervalSec=30
+ StartLimitBurst=2

--- a/packages/s/sddm/files/series
+++ b/packages/s/sddm/files/series
@@ -3,3 +3,4 @@
 0001-Support-stateless-dir-for-xinitrc.d-files.patch
 qt6-themes.patch
 make-qt6-themes-default.patch
+sddm-0.21.0-kmscon-fix.patch

--- a/packages/s/sddm/package.yml
+++ b/packages/s/sddm/package.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : sddm
 version    : 0.21.0
-release    : 59
+release    : 60
 source     :
     - https://github.com/sddm/sddm/archive/refs/tags/v0.21.0.tar.gz : f895de2683627e969e4849dbfbbb2b500787481ca5ba0de6d6dfdae5f1549abf
 license    :
@@ -41,6 +41,7 @@ build      : |
     %ninja_build
 install    : |
     %ninja_install
+
     # Start by default
     ln -s sddm.service $installdir/%libdir%/systemd/system/display-manager.service
 
@@ -57,6 +58,9 @@ install    : |
 
     # Allow us to forward xorg logs to the journal
     install -Dm 00755 $pkgfiles/xserver-wrapper $installdir/%libdir%/%PKGNAME%/xserver-wrapper
+
+    # License files
+    %install_license LICENSE LICENSE.CC-BY-3.0
 
     # Stateless
     rmdir $installdir/etc/pam.d

--- a/packages/s/sddm/pspec_x86_64.xml
+++ b/packages/s/sddm/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>sddm</Name>
         <Homepage>https://github.com/sddm/sddm</Homepage>
         <Packager>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Packager>
         <License>CC-BY-3.0</License>
         <License>GPL-2.0-or-later</License>
@@ -48,6 +48,8 @@
             <Path fileType="data">/usr/share/defaults/etc/pam.d/sddm</Path>
             <Path fileType="data">/usr/share/defaults/etc/pam.d/sddm-autologin</Path>
             <Path fileType="data">/usr/share/defaults/etc/pam.d/sddm-greeter</Path>
+            <Path fileType="data">/usr/share/licenses/sddm/LICENSE</Path>
+            <Path fileType="data">/usr/share/licenses/sddm/LICENSE.CC-BY-3.0</Path>
             <Path fileType="man">/usr/share/man/man1/sddm-greeter.1.zst</Path>
             <Path fileType="man">/usr/share/man/man1/sddm.1.zst</Path>
             <Path fileType="man">/usr/share/man/man5/sddm-state.conf.5.zst</Path>
@@ -225,12 +227,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="59">
-            <Date>2026-05-12</Date>
+        <Update release="60">
+            <Date>2026-06-24</Date>
             <Version>0.21.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Troy Harvey</Name>
-            <Email>harvey@getsol.us</Email>
+            <Name>Evan Maddock</Name>
+            <Email>maddock.evan@vivaldi.net</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
Backport fix for kmscon.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

**Test Plan**

Install this package and `kmscon`, reboot, log in, and successfully switch to a tty and back.

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
