### PR TITLE
faugus-launcher: Update to v1.22.6

### DIFF
--- a/packages/f/faugus-launcher/package.yml
+++ b/packages/f/faugus-launcher/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : faugus-launcher
-version    : 1.22.4
-release    : 6
+version    : 1.22.6
+release    : 7
 source     :
-    - https://github.com/Faugus/faugus-launcher/archive/refs/tags/1.22.4.tar.gz : e5b055e2109fd897a7b1638c9065bcf653218f517ccec2fc0edb691453be5928
+    - https://github.com/Faugus/faugus-launcher/archive/refs/tags/1.22.6.tar.gz : f073c03a7624a5b894e928a5c02e500887fcc95214e97c96f0d26df7f2960670
 homepage   : https://github.com/Faugus/faugus-launcher
 license    : MIT
 component  : games

--- a/packages/f/faugus-launcher/pspec_x86_64.xml
+++ b/packages/f/faugus-launcher/pspec_x86_64.xml
@@ -139,9 +139,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="6">
-            <Date>2026-06-19</Date>
-            <Version>1.22.4</Version>
+        <Update release="7">
+            <Date>2026-06-25</Date>
+            <Version>1.22.6</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/Faugus/faugus-launcher/releases/tag/1.22.5).
- Release notes can be found [here](https://github.com/Faugus/faugus-launcher/releases/tag/1.22.6).

**Test Plan**

Play a game. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
