### PR TITLE
procs: Update to v0.14.12

### DIFF
--- a/packages/p/procs/abi_used_symbols
+++ b/packages/p/procs/abi_used_symbols
@@ -5,13 +5,14 @@ libc.so.6:__res_init
 libc.so.6:__xpg_strerror_r
 libc.so.6:_exit
 libc.so.6:abort
+libc.so.6:access
 libc.so.6:bcmp
 libc.so.6:bind
 libc.so.6:calloc
-libc.so.6:cfmakeraw
 libc.so.6:chdir
 libc.so.6:chroot
 libc.so.6:clock_gettime
+libc.so.6:clock_nanosleep
 libc.so.6:close
 libc.so.6:connect
 libc.so.6:dl_iterate_phdr
@@ -19,7 +20,6 @@ libc.so.6:dlsym
 libc.so.6:dup
 libc.so.6:dup2
 libc.so.6:environ
-libc.so.6:epoll_create
 libc.so.6:epoll_create1
 libc.so.6:epoll_ctl
 libc.so.6:epoll_wait
@@ -56,7 +56,6 @@ libc.so.6:memset
 libc.so.6:mmap64
 libc.so.6:mprotect
 libc.so.6:munmap
-libc.so.6:nanosleep
 libc.so.6:open64
 libc.so.6:pause
 libc.so.6:pipe

--- a/packages/p/procs/package.yml
+++ b/packages/p/procs/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : procs
-version    : 0.14.11
-release    : 2
+version    : 0.14.12
+release    : 3
 source     :
-    - https://github.com/dalance/procs/archive/refs/tags/v0.14.11.tar.gz : 3d6b3561ce05362a092ea8488458f552d6636d3a280290e21f841c432cadf91a
+    - https://github.com/dalance/procs/archive/refs/tags/v0.14.12.tar.gz : f2fab583fe98a9ae9505c5eecf4f3d9d4ad9bcb5d478a8222d52c87aa1ac602e
 homepage   : https://github.com/dalance/procs
 license    : MIT
 component  : system.utils
@@ -12,7 +12,6 @@ description: |
     procs is a replacement for ps written in Rust. It provides colored and human-readable output, multi-column keyword search, additional information not supported by ps (such as TCP/UDP ports, Docker container names), pager support, watch mode, and tree view.
 networking : true
 builddeps  :
-    - asciidoctor
     - rust
 setup      : |
     %cargo_fetch
@@ -24,13 +23,13 @@ build      : |
     target/release/procs --gen-completion fish
     target/release/procs --gen-completion zsh
 
-    # Generate man pages
-    asciidoctor -b manpage man/procs.1.adoc
+    # Generate man page
+    target/release/procs --gen-man-page > procs.1
 install    : |
     %cargo_install
     %install_license LICENSE
 
-    install -Dm00644 procs.bash $installdir/usr/share/bash-completion/completions/procs
-    install -Dm00644 procs.fish $installdir/usr/share/fish/vendor_completions.d/procs.fish
-    install -Dm00644 _procs $installdir/usr/share/zsh/site-functions/_procs
-    install -Dm00644 man/procs.1 $installdir/usr/share/man/man1/procs.1
+    install -Dm00644 procs.bash ${installdir}/usr/share/bash-completion/completions/procs
+    install -Dm00644 procs.fish ${installdir}/usr/share/fish/vendor_completions.d/procs.fish
+    install -Dm00644 _procs ${installdir}/usr/share/zsh/site-functions/_procs
+    install -Dm00644 procs.1 ${installdir}/usr/share/man/man1/procs.1

--- a/packages/p/procs/pspec_x86_64.xml
+++ b/packages/p/procs/pspec_x86_64.xml
@@ -29,9 +29,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="2">
-            <Date>2026-02-27</Date>
-            <Version>0.14.11</Version>
+        <Update release="3">
+            <Date>2026-06-25</Date>
+            <Version>0.14.12</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/dalance/procs/blob/master/CHANGELOG.md#v01412---2026-06-25).

**Test Plan**

See processes with `procs`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
