### PR TITLE
uv: update to 0.11.25

### DIFF
--- a/packages/u/uv/abi_used_symbols
+++ b/packages/u/uv/abi_used_symbols
@@ -76,7 +76,6 @@ libc.so.6:kill
 libc.so.6:linkat
 libc.so.6:lseek64
 libc.so.6:lstat64
-libc.so.6:lutimes
 libc.so.6:madvise
 libc.so.6:malloc
 libc.so.6:memchr
@@ -85,6 +84,7 @@ libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:memset
 libc.so.6:mkdir
+libc.so.6:mlock
 libc.so.6:mmap
 libc.so.6:mmap64
 libc.so.6:mprotect
@@ -200,7 +200,6 @@ libc.so.6:tcgetattr
 libc.so.6:tcsetattr
 libc.so.6:unlink
 libc.so.6:unlinkat
-libc.so.6:utimensat
 libc.so.6:waitid
 libc.so.6:waitpid
 libc.so.6:write

--- a/packages/u/uv/package.yml
+++ b/packages/u/uv/package.yml
@@ -2,10 +2,10 @@
 #
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : uv
-version    : 0.11.15
-release    : 16
+version    : 0.11.25
+release    : 17
 source     :
-    - https://github.com/astral-sh/uv/archive/refs/tags/0.11.15.tar.gz : 78d3070b6add2d8f5a28d5781c938b75d2e861736cfe6bf7a88757c395f10a2e
+    - https://github.com/astral-sh/uv/archive/refs/tags/0.11.25.tar.gz : c59d0903cb163fdd50f3284c3d1d4cfc927d83ca0314f5a443fcc1d3c906cb62
 homepage   : https://docs.astral.sh/uv
 license    :
     - Apache-2.0
@@ -52,6 +52,8 @@ install    : |
     install -Dm00644 "completions/$package.bash" -t "$installdir/usr/share/bash-completion/completions/"
     install -Dm00644 "completions/$package.fish" -t "$installdir/usr/share/fish/vendor_completions.d/"
     install -Dm00644 "completions/_$package" -t "$installdir/usr/share/zsh/site-functions/"
+
+    %install_license LICENSE*
 check      : |
     # Run smoke tests
     cd /tmp

--- a/packages/u/uv/pspec_x86_64.xml
+++ b/packages/u/uv/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>uv</Name>
         <Homepage>https://docs.astral.sh/uv</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Matthias Homann</Name>
+            <Email>palto@mailbox.org</Email>
         </Packager>
         <License>Apache-2.0</License>
         <License>MIT</License>
@@ -23,12 +23,12 @@
         <Files>
             <Path fileType="executable">/usr/bin/uv</Path>
             <Path fileType="executable">/usr/bin/uvx</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.15.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.15.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.15.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.15.dist-info/licenses/LICENSE-APACHE</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.15.dist-info/licenses/LICENSE-MIT</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.15.dist-info/sboms/uv.cyclonedx.json</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.25.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.25.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.25.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.25.dist-info/licenses/LICENSE-APACHE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.25.dist-info/licenses/LICENSE-MIT</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/uv-0.11.25.dist-info/sboms/uv.cyclonedx.json</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/uv/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
@@ -42,16 +42,18 @@
             <Path fileType="data">/usr/share/bash-completion/completions/uv.bash</Path>
             <Path fileType="doc">/usr/share/doc/uv/README.md</Path>
             <Path fileType="data">/usr/share/fish/vendor_completions.d/uv.fish</Path>
+            <Path fileType="data">/usr/share/licenses/uv/LICENSE-APACHE</Path>
+            <Path fileType="data">/usr/share/licenses/uv/LICENSE-MIT</Path>
             <Path fileType="data">/usr/share/zsh/site-functions/_uv</Path>
         </Files>
     </Package>
     <History>
-        <Update release="16">
-            <Date>2026-06-08</Date>
-            <Version>0.11.15</Version>
+        <Update release="17">
+            <Date>2026-06-27</Date>
+            <Version>0.11.25</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Matthias Homann</Name>
+            <Email>palto@mailbox.org</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
## Summary

- **Security**: Updates `astral-tokio-tar` to v0.6.3 which hardens tar handling against parser differentials.
- Improve Python version compatibility and interpreter management.
- Enhance support for relocatable project environments.
- Improve performance and fix package management edge cases.

- Release notes:
    - [0.11.25](https://github.com/astral-sh/uv/releases/tag/0.11.25)
    - [0.11.24](https://github.com/astral-sh/uv/releases/tag/0.11.24)

## Test Plan

- Run smoke tests defined in source
- Installed locally and run some commands.

**Summary**

<!-- Info on what this pull request updates/changes/etc -->

**Test Plan**

<!-- Short description of how the package was tested -->

**Checklist**

- [X] Package was built and tested against unstable
- [X] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [X] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
