### PR TITLE
fastfetch: Update to v2.65.2

### DIFF
--- a/packages/f/fastfetch/package.yml
+++ b/packages/f/fastfetch/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : fastfetch
-version    : 2.65.1
-release    : 77
+version    : 2.65.2
+release    : 78
 source     :
-    - https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/2.65.1.tar.gz : c4a9d191601bae302cfa9939f2b5666d2565e83229840cd00554c4913646f0ad
+    - https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/2.65.2.tar.gz : d0b318c33cf6c8bbae1162325f91624762a040a60f748941cbf1b4b99a75fa30
 homepage   : https://github.com/fastfetch-cli/fastfetch
 license    : MIT
 component  : system.utils

--- a/packages/f/fastfetch/pspec_x86_64.xml
+++ b/packages/f/fastfetch/pspec_x86_64.xml
@@ -67,9 +67,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="77">
-            <Date>2026-06-24</Date>
-            <Version>2.65.1</Version>
+        <Update release="78">
+            <Date>2026-06-28</Date>
+            <Version>2.65.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/fastfetch-cli/fastfetch/releases/tag/2.65.2).

**Test Plan**

See `fastfetch` output

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
