### PR TITLE
python-ujson: Update to v5.13.0

### DIFF
--- a/packages/py/python-ujson/package.yml
+++ b/packages/py/python-ujson/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-ujson
-version    : 5.12.1
-release    : 18
+version    : 5.13.0
+release    : 19
 source     :
-    - https://files.pythonhosted.org/packages/source/u/ujson/ujson-5.12.1.tar.gz : 5b7e96406c301a1366534479a7352ec40ec68bb327c0c119091635acd5925e35
+    - https://files.pythonhosted.org/packages/source/u/ujson/ujson-5.13.0.tar.gz : d62e3d7625384c08082abad81a077af587fdef2761bb14c3822f4234b8d07d75
 homepage   : https://github.com/ultrajson/ultrajson
 license    : BSD-3-Clause
 component  : programming.python

--- a/packages/py/python-ujson/pspec_x86_64.xml
+++ b/packages/py/python-ujson/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>python-ujson</Name>
         <Homepage>https://github.com/ultrajson/ultrajson</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>BSD-3-Clause</License>
         <PartOf>programming.python</PartOf>
@@ -20,22 +20,22 @@
 </Description>
         <PartOf>programming.python</PartOf>
         <Files>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/ujson-5.12.1.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/ujson-5.12.1.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/ujson-5.12.1.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/ujson-5.12.1.dist-info/licenses/LICENSE.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/ujson-5.12.1.dist-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/ujson-5.13.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/ujson-5.13.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/ujson-5.13.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/ujson-5.13.0.dist-info/licenses/LICENSE.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/ujson-5.13.0.dist-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/ujson-stubs/__init__.pyi</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/ujson.cpython-314-x86_64-linux-gnu.so</Path>
         </Files>
     </Package>
     <History>
-        <Update release="18">
-            <Date>2026-06-07</Date>
-            <Version>5.12.1</Version>
+        <Update release="19">
+            <Date>2026-06-28</Date>
+            <Version>5.13.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/ultrajson/ultrajson/releases/tag/5.13.0).

**Security**
Includes fixes for:
- CVE-2026-54911

**Test Plan**

Passed python checks. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
