### PR TITLE
python-jupyter-server: Update to v2.20.0

### DIFF
--- a/packages/py/python-jupyter-server/package.yml
+++ b/packages/py/python-jupyter-server/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : python-jupyter-server
-version    : 2.19.0
-release    : 10
+version    : 2.20.0
+release    : 11
 source     :
-    - https://files.pythonhosted.org/packages/source/j/jupyter_server/jupyter_server-2.19.0.tar.gz : 1731236bc32b680223e1ceb9d68209a845203475012ef68773a81434b46a31a7
+    - https://files.pythonhosted.org/packages/source/j/jupyter_server/jupyter_server-2.20.0.tar.gz : b5778ba337d8015a3dc2b80803ecdd5ac18d3797fddf61a50ea5fb472b4ebe14
 homepage   : https://github.com/jupyter-server/jupyter_server
 license    : BSD-3-Clause
 component  : programming.python

--- a/packages/py/python-jupyter-server/pspec_x86_64.xml
+++ b/packages/py/python-jupyter-server/pspec_x86_64.xml
@@ -21,11 +21,11 @@
         <PartOf>programming.python</PartOf>
         <Files>
             <Path fileType="executable">/usr/bin/jupyter-server</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/jupyter_server-2.19.0.dist-info/METADATA</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/jupyter_server-2.19.0.dist-info/RECORD</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/jupyter_server-2.19.0.dist-info/WHEEL</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/jupyter_server-2.19.0.dist-info/entry_points.txt</Path>
-            <Path fileType="library">/usr/lib/python3.14/site-packages/jupyter_server-2.19.0.dist-info/licenses/LICENSE</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/jupyter_server-2.20.0.dist-info/METADATA</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/jupyter_server-2.20.0.dist-info/RECORD</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/jupyter_server-2.20.0.dist-info/WHEEL</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/jupyter_server-2.20.0.dist-info/entry_points.txt</Path>
+            <Path fileType="library">/usr/lib/python3.14/site-packages/jupyter_server-2.20.0.dist-info/licenses/LICENSE</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/jupyter_server/__init__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/jupyter_server/__main__.py</Path>
             <Path fileType="library">/usr/lib/python3.14/site-packages/jupyter_server/__pycache__/__init__.cpython-314.opt-1.pyc</Path>
@@ -328,9 +328,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="10">
-            <Date>2026-06-13</Date>
-            <Version>2.19.0</Version>
+        <Update release="11">
+            <Date>2026-06-28</Date>
+            <Version>2.20.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/jupyter-server/jupyter_server/releases/tag/v2.20.0).

**Security**
Includes fixes for:
- CVE-2026-44727

**Test Plan**

See jupyter server running on port. 

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
