### PR TITLE
7zip: Update to 26.02

### DIFF
--- a/packages/7/7zip/package.yml
+++ b/packages/7/7zip/package.yml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : 7zip
-version    : 26.01
-release    : 1
+version    : '26.02'
+release    : 2
 source     :
-    - https://github.com/ip7z/7zip/archive/refs/tags/26.01.tar.gz : f4212b508641b3584f7089ab67bc0aba028c631f049b4dd603ff07853e72e749
+    - https://github.com/ip7z/7zip/archive/refs/tags/26.02.tar.gz : 7e5600ad0b21918bc41803bd84d0c2967e097fb7fbaa2e7aeb90beeb1121e54b
 homepage   : https://www.7-zip.org/
-license    : 
+license    :
     - LGPL-2.1-or-later
     - BSD-3-Clause
 component  : system.utils
@@ -20,28 +20,28 @@ setup      : |
 build      : |
     # 7zz
     %make -C CPP/7zip/Bundles/Alone2 -f ../../cmpl_gcc.mak CXX="$CXX $CXXFLAGS" CC="$CC $CFLAGS"
-    
+
     # 7za
     %make -C CPP/7zip/Bundles/Alone -f ../../cmpl_gcc.mak CXX="$CXX $CXXFLAGS" CC="$CC $CFLAGS"
-    
+
     # 7zr
     %make -C CPP/7zip/Bundles/Alone7z -f ../../cmpl_gcc.mak CXX="$CXX $CXXFLAGS" CC="$CC $CFLAGS"
-    
+
     # 7z.so
     %make -C CPP/7zip/Bundles/Format7zF -f ../../cmpl_gcc.mak CXX="$CXX $CXXFLAGS" CC="$CC $CFLAGS"
-    
+
     # 7z 
     %make -C CPP/7zip/UI/Console -f ../../cmpl_gcc.mak LOCAL_FLAGS="-DZ7_EXTERNAL_CODECS" CXX="$CXX $CXXFLAGS" CC="$CC $CFLAGS"
-    
+
 install    : |
     install -D -m 00755 CPP/7zip/UI/Console/b/g/7z $installdir/usr/bin/7z
     install -D -m 00755 CPP/7zip/Bundles/Alone/b/g/7za $installdir/usr/bin/7za
     install -D -m 00755 CPP/7zip/Bundles/Alone7z/b/g/7zr $installdir/usr/bin/7zr
     install -D -m 00755 CPP/7zip/Bundles/Alone2/b/g/7zz $installdir/usr/bin/7zz
-    
+
     # Install the plugin to /usr/lib64/7zip/
     install -D -m 00755 CPP/7zip/Bundles/Format7zF/b/g/7z.so $installdir%libdir%/7zip/7z.so
-    
+
     %install_license DOC/copying.txt
     %install_license DOC/License.txt
 

--- a/packages/7/7zip/pspec_x86_64.xml
+++ b/packages/7/7zip/pspec_x86_64.xml
@@ -34,9 +34,9 @@
         </Replaces>
     </Package>
     <History>
-        <Update release="1">
-            <Date>2026-05-30</Date>
-            <Version>26.01</Version>
+        <Update release="2">
+            <Date>2026-06-28</Date>
+            <Version>26.02</Version>
             <Comment>Packaging update</Comment>
             <Name>Clint Eschberger</Name>
             <Email>clint@eschberger.info</Email>


### PR DESCRIPTION
**Summary**
- Updated to latest
- Some bugs and vulnerabilities were fixed

[Change Log](https://github.com/ip7z/7zip/releases/tag/26.02)

**Test Plan**
- Test compression and decompression


**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
