### PR TITLE
dua-cli: Update to v2.37.1

### DIFF
--- a/packages/d/dua-cli/package.yml
+++ b/packages/d/dua-cli/package.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : dua-cli
-version    : 2.37.0
-release    : 4
+version    : 2.37.1
+release    : 5
 source     :
-    - https://github.com/Byron/dua-cli/archive/refs/tags/v2.37.0.tar.gz : 9373b85fbf626afe7de27d209b1ed9775825b89b211c8480255ac38b1e3e270c
+    - https://github.com/Byron/dua-cli/archive/refs/tags/v2.37.1.tar.gz : 309194f35a6cabe8a91046641680862cbe1e1379f55c88c94337b541ce987969
 homepage   : https://github.com/Byron/dua-cli
 license    : MIT
 component  : system.utils

--- a/packages/d/dua-cli/pspec_x86_64.xml
+++ b/packages/d/dua-cli/pspec_x86_64.xml
@@ -28,9 +28,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="4">
-            <Date>2026-06-21</Date>
-            <Version>2.37.0</Version>
+        <Update release="5">
+            <Date>2026-06-29</Date>
+            <Version>2.37.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Jared Cervantes</Name>
             <Email>jared@jaredcervantes.com</Email>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://github.com/Byron/dua-cli/releases/tag/v2.37.1).
- Bug fix

**Test Plan**

Tested the bug fix with `dua i`

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
