### PR TITLE
libidn: Update to v1.44

### DIFF
--- a/packages/l/libidn/abi_used_symbols
+++ b/packages/l/libidn/abi_used_symbols
@@ -1,11 +1,11 @@
 libc.so.6:__errno_location
 libc.so.6:__fprintf_chk
-libc.so.6:__getdelim
 libc.so.6:__libc_start_main
 libc.so.6:__printf_chk
 libc.so.6:__progname
 libc.so.6:__progname_full
 libc.so.6:__stack_chk_fail
+libc.so.6:__uflow
 libc.so.6:abort
 libc.so.6:bindtextdomain
 libc.so.6:calloc
@@ -17,11 +17,12 @@ libc.so.6:feof
 libc.so.6:ferror
 libc.so.6:fflush
 libc.so.6:fileno
+libc.so.6:flockfile
 libc.so.6:fopen
 libc.so.6:fputc
 libc.so.6:fputs
 libc.so.6:free
-libc.so.6:fwrite
+libc.so.6:funlockfile
 libc.so.6:getenv
 libc.so.6:getopt_long
 libc.so.6:iconv
@@ -29,6 +30,7 @@ libc.so.6:iconv_close
 libc.so.6:iconv_open
 libc.so.6:isatty
 libc.so.6:malloc
+libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:nl_langinfo
@@ -49,7 +51,6 @@ libc.so.6:strcmp
 libc.so.6:strcpy
 libc.so.6:strdup
 libc.so.6:strlen
-libc.so.6:strncmp
 libc.so.6:strrchr
 libc.so.6:strverscmp
 libc.so.6:textdomain

--- a/packages/l/libidn/abi_used_symbols32
+++ b/packages/l/libidn/abi_used_symbols32
@@ -10,6 +10,7 @@ libc.so.6:iconv
 libc.so.6:iconv_close
 libc.so.6:iconv_open
 libc.so.6:malloc
+libc.so.6:memcmp
 libc.so.6:memcpy
 libc.so.6:memmove
 libc.so.6:nl_langinfo

--- a/packages/l/libidn/package.yml
+++ b/packages/l/libidn/package.yml
@@ -1,23 +1,25 @@
 # yaml-language-server: $schema=/usr/share/ypkg/schema/schema.json
 name       : libidn
-version    : '1.43'
-release    : 12
+version    : '1.44'
+release    : 13
 source     :
-    - https://ftpmirror.gnu.org/gnu/libidn/libidn-1.43.tar.gz : bdc662c12d041b2539d0e638f3a6e741130cdb33a644ef3496963a443482d164
+    - https://ftp.gnu.org/gnu/libidn/libidn-1.44.tar.gz : 499608bab3a65650a0ea52888c13a8deebe3f71408e319acd9ec52e02eb13959
+homepage   : https://www.gnu.org/software/libidn
 license    :
     - GPL-2.0-or-later
     - LGPL-3.0-or-later
 component  : network.library
-homepage   : https://www.gnu.org/software/libidn
 summary    : Internationalized domain name support library
 description: |
     GNU library implementing Stringprep, Punycode and IDNA specifications.
 emul32     : true
 setup      : |
-    %configure --disable-static
+    %configure \
+        --disable-static
 build      : |
     %make
 install    : |
     %make_install
+    %install_license COPYING*
 check      : |
     %make check

--- a/packages/l/libidn/pspec_x86_64.xml
+++ b/packages/l/libidn/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libidn</Name>
         <Homepage>https://www.gnu.org/software/libidn</Homepage>
         <Packager>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-3.0-or-later</License>
@@ -23,11 +23,15 @@
         <Files>
             <Path fileType="executable">/usr/bin/idn</Path>
             <Path fileType="library">/usr/lib64/libidn.so.12</Path>
-            <Path fileType="library">/usr/lib64/libidn.so.12.6.6</Path>
+            <Path fileType="library">/usr/lib64/libidn.so.12.6.7</Path>
             <Path fileType="data">/usr/share/emacs/site-lisp/idna.el</Path>
             <Path fileType="data">/usr/share/emacs/site-lisp/punycode.el</Path>
             <Path fileType="info">/usr/share/info/libidn-components.png</Path>
             <Path fileType="info">/usr/share/info/libidn.info.zst</Path>
+            <Path fileType="data">/usr/share/licenses/libidn/COPYING</Path>
+            <Path fileType="data">/usr/share/licenses/libidn/COPYING.LESSERv2</Path>
+            <Path fileType="data">/usr/share/licenses/libidn/COPYING.LESSERv3</Path>
+            <Path fileType="data">/usr/share/licenses/libidn/COPYINGv2</Path>
             <Path fileType="localedata">/usr/share/locale/cs/LC_MESSAGES/libidn.mo</Path>
             <Path fileType="localedata">/usr/share/locale/da/LC_MESSAGES/libidn.mo</Path>
             <Path fileType="localedata">/usr/share/locale/de/LC_MESSAGES/libidn.mo</Path>
@@ -61,11 +65,11 @@
 </Description>
         <PartOf>emul32</PartOf>
         <RuntimeDependencies>
-            <Dependency release="12">libidn</Dependency>
+            <Dependency release="13">libidn</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libidn.so.12</Path>
-            <Path fileType="library">/usr/lib32/libidn.so.12.6.6</Path>
+            <Path fileType="library">/usr/lib32/libidn.so.12.6.7</Path>
         </Files>
     </Package>
     <Package>
@@ -75,8 +79,8 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="12">libidn-devel</Dependency>
-            <Dependency release="12">libidn-32bit</Dependency>
+            <Dependency release="13">libidn-32bit</Dependency>
+            <Dependency release="13">libidn-devel</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32/libidn.so</Path>
@@ -90,7 +94,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="12">libidn</Dependency>
+            <Dependency release="13">libidn</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/idn-free.h</Path>
@@ -152,12 +156,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="12">
-            <Date>2025-10-30</Date>
-            <Version>1.43</Version>
+        <Update release="13">
+            <Date>2026-06-30</Date>
+            <Version>1.44</Version>
             <Comment>Packaging update</Comment>
-            <Name>Jakob Gezelius</Name>
-            <Email>jakob@knugen.nu</Email>
+            <Name>Jared Cervantes</Name>
+            <Email>jared@jaredcervantes.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Summary**
- Release notes can be found [here](https://lists.gnu.org/archive/html/help-libidn/2026-06/msg00000.html).

**Security**
Includes fixes for:
- CVE-2026-57053

**Test Plan**

Passed make checks

**Checklist**

- [x] Package was built and tested against unstable
- [ ] This change could gainfully be listed in the weekly sync notes once merged  <!-- Write an appropriate message in the Summary section, then add the "Topic: Sync Notes" label -->
- [x] I agree to license this contribution and all my previous contributions under the licensing terms in [LICENSE.md](../blob/main/LICENSE.md) and have the power and authority to grant those licenses.
